### PR TITLE
fix(wasm-backend): preserve SSA form for nil constant values

### DIFF
--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -56,6 +56,10 @@ dialect! {
         /// `wasm.unreachable` operation: trap / unreachable code.
         fn unreachable();
 
+        /// `wasm.nop` operation: no-op placeholder for nil constants.
+        /// Preserves SSA form without runtime effect.
+        fn nop() -> result;
+
         // === Module-level Definitions ===
 
         /// `wasm.func` operation: define a function.


### PR DESCRIPTION
## Summary

Fixes issue #47 by replacing nil constant erasure with wasm.nop placeholder operations to maintain SSA form validity. Nil values have no runtime representation but were previously being erased without replacement, causing stale SSA value errors in downstream operations.

## Changes

- **Add wasm.nop operation**: New no-op operation in wasm dialect that preserves SSA value references without runtime effect
- **Update nil constant handling**: Changed arith_to_wasm pass from Erase to Replace with wasm.nop for nil constants
- **Add wasm.nop skip logic**: emit.rs now skips wasm.nop operations (emits no WASM instruction)
- **Add nil type value skipping**: emit.rs emit_operands now skips nil type values (nil values not mapped to locals)

This ensures operations referencing nil constants maintain valid SSA references while producing no runtime overhead.

## Files Changed

- `crates/trunk-ir/src/dialect/wasm.rs` - Added wasm.nop operation definition
- `crates/tribute-wasm-backend/src/passes/arith_to_wasm.rs` - Changed nil constant handling from Erase to Replace with wasm.nop
- `crates/tribute-wasm-backend/src/emit.rs` - Added wasm.nop skip logic and nil type value skipping

## Testing

All tests pass including test_add_compiles_and_runs.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced nil value handling in WASM compilation: nil constants now use no-op placeholders instead of being erased, preserving intermediate representation while maintaining runtime efficiency.
  * Optimized operand emission to skip nil-typed values during code generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->