### PR TITLE
feat(wasm): implement Float boxing for polymorphic contexts (#52)

### DIFF
--- a/tests/e2e_add.rs
+++ b/tests/e2e_add.rs
@@ -1,10 +1,17 @@
-//! End-to-end test for add.trb compilation and execution with wasmtime.
+//! End-to-end tests for compilation and execution with wasmtime.
 
 use ropey::Rope;
 use salsa::Database;
 use tribute::TributeDatabaseImpl;
 use tribute::pipeline::stage_lower_to_wasm;
 use tribute_front::SourceCst;
+
+/// Helper to create a wasmtime engine with GC support
+fn create_gc_engine() -> wasmtime::Engine {
+    let mut config = wasmtime::Config::new();
+    config.wasm_gc(true);
+    wasmtime::Engine::new(&config).expect("Failed to create engine")
+}
 
 #[test]
 fn test_add_compiles_and_runs() {
@@ -22,7 +29,7 @@ fn test_add_compiles_and_runs() {
         let wasm_binary = stage_lower_to_wasm(db, source_file).expect("WASM compilation failed");
 
         // Execute with wasmtime (no WASI needed for add.trb)
-        let engine = wasmtime::Engine::default();
+        let engine = create_gc_engine();
         let module = wasmtime::Module::new(&engine, wasm_binary.bytes(db)).unwrap();
         let mut store = wasmtime::Store::new(&engine, ());
         let instance =
@@ -38,5 +45,85 @@ fn test_add_compiles_and_runs() {
 
         // Verify the result: add(40, 2) = 42
         assert_eq!(result, 42, "Expected main to return 42, got {}", result);
+    });
+}
+
+/// Test that Int boxing/unboxing works correctly in polymorphic contexts.
+/// This verifies PR #61 (uniform representation for generics).
+#[test]
+fn test_generic_int_identity() {
+    use tribute::database::parse_with_thread_local;
+
+    // Generic identity function that boxes Int to i31ref and unboxes back
+    let source_code = Rope::from_str(
+        r#"
+fn identity(x: a) -> a { x }
+fn main() -> Int { identity(42) }
+"#,
+    );
+
+    TributeDatabaseImpl::default().attach(|db| {
+        let tree = parse_with_thread_local(&source_code, None);
+        let source_file = SourceCst::from_path(db, "int_identity.trb", source_code.clone(), tree);
+
+        let wasm_binary = stage_lower_to_wasm(db, source_file).expect("WASM compilation failed");
+
+        let engine = create_gc_engine();
+        let module = wasmtime::Module::new(&engine, wasm_binary.bytes(db)).unwrap();
+        let mut store = wasmtime::Store::new(&engine, ());
+        let instance =
+            wasmtime::Instance::new(&mut store, &module, &[]).expect("Failed to instantiate");
+
+        // Int compiles to i64 in WASM
+        let main = instance
+            .get_typed_func::<(), i64>(&mut store, "main")
+            .expect("main function not found");
+
+        let result = main.call(&mut store, ()).expect("Execution failed");
+
+        // Verify the result is 42 (Int identity should preserve the value)
+        assert_eq!(result, 42, "Expected main to return 42, got {}", result);
+    });
+}
+
+/// Test that Float boxing/unboxing works correctly in polymorphic contexts.
+/// This verifies issue #52 (Float boxing for generic type parameters).
+#[test]
+fn test_generic_float_identity() {
+    use tribute::database::parse_with_thread_local;
+
+    // Generic identity function that boxes Float to anyref and unboxes back
+    let source_code = Rope::from_str(
+        r#"
+fn identity(x: a) -> a { x }
+fn main() -> Float { identity(3.125) }
+"#,
+    );
+
+    TributeDatabaseImpl::default().attach(|db| {
+        let tree = parse_with_thread_local(&source_code, None);
+        let source_file = SourceCst::from_path(db, "float_identity.trb", source_code.clone(), tree);
+
+        let wasm_binary = stage_lower_to_wasm(db, source_file).expect("WASM compilation failed");
+
+        let engine = create_gc_engine();
+        let module = wasmtime::Module::new(&engine, wasm_binary.bytes(db)).unwrap();
+        let mut store = wasmtime::Store::new(&engine, ());
+        let instance =
+            wasmtime::Instance::new(&mut store, &module, &[]).expect("Failed to instantiate");
+
+        // Float compiles to f64 in WASM
+        let main = instance
+            .get_typed_func::<(), f64>(&mut store, "main")
+            .expect("main function not found");
+
+        let result = main.call(&mut store, ()).expect("Execution failed");
+
+        // Verify the result (Float identity should preserve the value)
+        assert!(
+            (result - 3.125).abs() < 0.0001,
+            "Expected main to return 3.125, got {}",
+            result
+        );
     });
 }


### PR DESCRIPTION
## Summary

This PR implements Float boxing for polymorphic (generic) contexts in the WebAssembly backend, completing the uniform representation strategy for generics. Floats are now boxed as `BoxedF64` (a struct wrapper) when used in generic type parameters, complementing the existing Int→i31ref boxing mechanism.

### Key Changes

- **BoxedF64 struct type**: Added a dedicated GC struct type (always at index 0 in the type section) to wrap Float values in generic contexts
- **Emit boxing/unboxing**: Implemented `emit_boxing` and `emit_unboxing` for Float support
  - Boxing: `f64` → `struct.new` with BoxedF64 index
  - Unboxing: `struct.get` with `ref.cast` from anyref to BoxedF64
- **Inference helper**: Added `infer_call_result_type` to determine concrete return types for generic function calls, ensuring locals are allocated with correct types
- **End-to-end tests**: Added comprehensive tests for generic Int and Float identity functions

### Test Coverage

- `test_generic_int_identity`: Verifies Int boxing/unboxing in polymorphic identity function
- `test_generic_float_identity`: Verifies Float boxing/unboxing in polymorphic identity function

### Related Issues

- Closes #52 (Float boxing for polymorphic contexts)
- Builds on #61 (uniform representation for generics - Int→i31ref)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced support for generic and polymorphic functions with improved type handling in the WASM compilation backend.

* **Tests**
  * Added end-to-end tests for generic function compilation and execution, validating integer and floating-point polymorphic operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->