### PR TITLE
feat(examples): implement AST-based calculator (calc.trb)

### DIFF
--- a/lang-examples/calc.trb
+++ b/lang-examples/calc.trb
@@ -1,8 +1,32 @@
-// Calculator example - will need more advanced features
-// This is a placeholder for now as it requires pattern matching
-// and string operations not yet implemented in modern syntax
+// AST-based Calculator
+// Demonstrates: enum, pattern matching, recursive functions
 
-fn main() {
-    print_line("Calculator example - to be implemented")
-    print_line("Requires pattern matching and string operations")
+enum Expr {
+    Num(Int),
+    Add(Expr, Expr),
+    Sub(Expr, Expr),
+    Mul(Expr, Expr),
+    Div(Expr, Expr),
+}
+
+fn eval(e: Expr) -> Int {
+    case e {
+        Num(n) -> n,
+        Add(l, r) -> eval(l) + eval(r),
+        Sub(l, r) -> eval(l) - eval(r),
+        Mul(l, r) -> eval(l) * eval(r),
+        Div(l, r) -> eval(l) / eval(r),
+    }
+}
+
+fn main() -> Int {
+    // (1 + 2) * (10 - 4) / 2 = 9
+    let expr = Div(
+        Mul(
+            Add(Num(1), Num(2)),
+            Sub(Num(10), Num(4))
+        ),
+        Num(2)
+    )
+    eval(expr)
 }


### PR DESCRIPTION
## Summary

Implements a fully functional AST-based calculator example demonstrating Tribute's algebraic data types (enums), pattern matching, and recursive function evaluation. The calculator evaluates arithmetic expressions with support for addition, subtraction, multiplication, and division operations.

## Changes

- **Enhanced calc.trb example**: Replaced placeholder with complete implementation featuring:
  - Expr enum with variants: Num(Int), Add, Sub, Mul, Div
  - eval() recursive function using pattern matching
  - Example computation: (1 + 2) * (10 - 4) / 2 = 9

- **E2E test for calc.trb**: Added test_calc_eval() in tests/e2e_add.rs
  - Currently ignored due to issue #80 (WASM struct field count mismatch for enum variants)
  - Will be enabled once #80 is resolved
  - Verifies end-to-end compilation and execution via WasmGC backend

- **Syntax improvements**: Updated tree-sitter-tribute to v0.3.0 with function type syntax support
- **Highlighting fixes**: Removed duplicate spread operator in Zed syntax highlighting

## Testing

- E2E test test_calc_eval() is marked with #[ignore] pending resolution of #80
- All other tests pass, including function type syntax tests (a0e9ec7)

## Relates To

- Milestone: #1 (AST-based Calculator)
- Blocked by: #80 (WASM struct field count mismatch for enum variants)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced calculator example with improved expression evaluation capabilities.

* **Tests**
  * Added end-to-end test for calculator functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->