### PR TITLE
fix(typeck): support ability type parameters in effect rows (#26)

### DIFF
--- a/crates/trunk-ir/src/types.rs
+++ b/crates/trunk-ir/src/types.rs
@@ -83,6 +83,21 @@ impl<'db> Type<'db> {
     }
 }
 
+// Implement Ord for Type using salsa's interned ID.
+// This provides a stable ordering for types in collections like BTreeSet.
+impl<'db> PartialOrd for Type<'db> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'db> Ord for Type<'db> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use salsa::plumbing::AsId;
+        self.as_id().cmp(&other.as_id())
+    }
+}
+
 /// IR attribute values.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
 pub enum Attribute<'db> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison logic for parameterized abilities, ensuring distinct types are correctly distinguished in equality and ordering contexts.

* **Chores**
  * Enhanced type system infrastructure with expanded API support and improved ordering capabilities for better type handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->