### PR TITLE
feat(ir): use ability.op operations in region for ability definitions

### DIFF
--- a/crates/trunk-ir/src/dialect/ability.rs
+++ b/crates/trunk-ir/src/dialect/ability.rs
@@ -24,6 +24,16 @@ use crate::dialect;
 
 dialect! {
     mod ability {
+        /// `ability.op` operation: declares an operation signature within an ability.
+        ///
+        /// Used inside `ty.ability` operations region to define what operations the ability provides.
+        ///
+        /// Attributes:
+        /// - `sym_name`: The operation name
+        /// - `type`: The operation's function type (func.Fn)
+        #[attr(sym_name: Symbol, r#type: Type)]
+        fn op();
+
         /// `ability.perform` operation: performs an ability operation.
         ///
         /// Invokes an operation from an ability, capturing the current continuation

--- a/crates/trunk-ir/src/dialect/ty.rs
+++ b/crates/trunk-ir/src/dialect/ty.rs
@@ -38,11 +38,14 @@ dialect! {
 
         /// `type.ability` operation: defines an ability (effect) type.
         ///
+        /// The operations region contains `ability.op` operations defining the signatures.
+        ///
         /// Attributes:
         /// - `sym_name`: The name of the ability
-        /// - `operations`: Operation signatures as [(name, signature)] pairs
-        #[attr(sym_name, operations)]
-        fn ability() -> result;
+        #[attr(sym_name)]
+        fn ability() -> result {
+            #[region(operations)] {}
+        };
 
         // === Tribute language primitive types ===
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed how ability operations are represented so operation signatures carry concrete parameter and return types, improving type accuracy and environment population.

* **Tests**
  * Updated and added tests to verify ability operation parameter and return types are correctly parsed and stored.

* **Documentation**
  * Added documentation notes clarifying that ability definitions include an operations region containing operation declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->