### PR TITLE
fix(typeck): match handler patterns by ability name against effect row

### DIFF
--- a/crates/tribute-passes/src/typeck/checker.rs
+++ b/crates/tribute-passes/src/typeck/checker.rs
@@ -173,6 +173,44 @@ impl<'db> TypeChecker<'db> {
         self.current_effect = self.current_effect.union(&effect, fresh_var);
     }
 
+    /// Check for conflicting abilities in the current effect row and report an error.
+    ///
+    /// Conflicting abilities are abilities with the same name but different type parameters
+    /// (e.g., `State(Int)` and `State(Text)`). Handler patterns match by name only, so having
+    /// multiple parameterizations of the same ability would be ambiguous.
+    ///
+    /// This restriction may be lifted in the future with named effects.
+    fn check_ability_conflicts(&self, span: trunk_ir::Span) {
+        if let Some((name, abilities)) = self.current_effect.find_conflicting_abilities() {
+            let ability_strs: Vec<String> = abilities
+                .iter()
+                .map(|a| {
+                    if a.params.is_empty() {
+                        a.name.to_string()
+                    } else {
+                        let params: Vec<String> =
+                            a.params.iter().map(|ty| format!("{:?}", ty)).collect();
+                        format!("{}({})", a.name, params.join(", "))
+                    }
+                })
+                .collect();
+
+            Diagnostic {
+                message: format!(
+                    "conflicting ability parameterizations for `{}`: {} are all in scope. \
+                     Handler patterns match abilities by name only, so mixing different \
+                     parameterizations is not allowed.",
+                    name,
+                    ability_strs.join(" and ")
+                ),
+                span,
+                severity: DiagnosticSeverity::Error,
+                phase: CompilationPhase::TypeChecking,
+            }
+            .accumulate(self.db);
+        }
+    }
+
     /// Check a module.
     pub fn check_module(&mut self, module: &core::Module<'db>) {
         self.seed_var_counters(module);
@@ -959,6 +997,11 @@ impl<'db> TypeChecker<'db> {
     /// the effect row may contain parameterized abilities (e.g., `State(Int)`).
     /// This function matches pattern ability names against the current effect row
     /// to find the fully parameterized abilities that are being handled.
+    ///
+    /// Note: When the effect row contains multiple parameterizations of the same
+    /// ability (e.g., both `State(Int)` and `State(String)`), a handler pattern
+    /// without explicit type parameters will handle ALL of them. Future work may
+    /// add type inference from handler bodies to disambiguate.
     fn extract_handled_abilities(
         &self,
         pattern_region: &Region<'db>,
@@ -1026,6 +1069,9 @@ impl<'db> TypeChecker<'db> {
                 // Create an effect row with this ability and merge it
                 let effect = EffectRow::concrete([ability]);
                 self.merge_effect(effect);
+
+                // Check for conflicting abilities (same name with different type parameters)
+                self.check_ability_conflicts(op.location(self.db).span);
             } else {
                 trace!(
                     ?ability_ty,
@@ -1065,6 +1111,9 @@ impl<'db> TypeChecker<'db> {
         // (pat.handler_suspend in pattern regions).
         let body_effect = std::mem::replace(&mut self.current_effect, outer_effect);
         self.merge_effect(body_effect);
+
+        // Check for conflicting abilities after merging body effects
+        self.check_ability_conflicts(op.location(self.db).span);
 
         let value = op.result(self.db, 0);
         self.record_type(value, result_type);


### PR DESCRIPTION
## Summary
- Fixes handler pattern matching to correctly match parameterized abilities from effect rows

## Problem
Handler patterns currently match abilities by name only (e.g., `State::get()`), but the effect row may contain parameterized abilities (e.g., `State(Int)`). Previously, this caused a mismatch because the pattern's `AbilityRef` had no type parameters while the effect row's `AbilityRef` did.

## Solution
This change modifies `extract_handled_abilities()` to:
1. Extract the ability name from handler patterns
2. Find matching abilities in the current effect row by name
3. Use the fully parameterized abilities for effect row removal

This ensures that `State::get()` in a handler correctly matches and removes `State(Int)` from the effect row.

## Changes
- Add `EffectRow::find_by_name()` method for name-based ability lookup
- Modify `extract_handled_abilities()` to use name-based matching against current effect row
- Add unit tests for the new functionality

## Test plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all` passes
- [x] New tests verify name-based matching

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handler pattern matching so parameterized abilities are correctly aligned with effect rows; adds detection and reporting of conflicting ability variants.

* **New Features**
  * Added name-based ability lookup in effect rows to retrieve all type-parameter variants for a given ability name.

* **Tests**
  * Expanded tests covering name-based lookup, multiple parameterizations, and conflict detection.

* **Documentation**
  * Updated docs to explain matching behavior and conflict outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->