### PR TITLE
feat(typeck): add type checking for Bytes literals

### DIFF
--- a/crates/tribute-passes/src/typeck/checker.rs
+++ b/crates/tribute-passes/src/typeck/checker.rs
@@ -422,6 +422,8 @@ impl<'db> TypeChecker<'db> {
         } else if dialect == adt::DIALECT_NAME() {
             if name == adt::STRING_CONST() {
                 self.check_string_const(op);
+            } else if name == adt::BYTES_CONST() {
+                self.check_bytes_const(op);
             } else if name == adt::STRUCT_NEW() || name == adt::VARIANT_NEW() {
                 // For struct/variant construction, the result type is already set correctly
                 // to the struct/enum type. Just record this type for the result value.
@@ -931,6 +933,12 @@ impl<'db> TypeChecker<'db> {
         let string_type = core::String::new(self.db);
         let value = op.result(self.db, 0);
         self.record_type(value, *string_type);
+    }
+
+    fn check_bytes_const(&mut self, op: &Operation<'db>) {
+        let bytes_type = core::Bytes::new(self.db);
+        let value = op.result(self.db, 0);
+        self.record_type(value, *bytes_type);
     }
 
     // === list dialect checking ===


### PR DESCRIPTION
## Summary

- Add type checking support for `adt.bytes_const` operations
- The `check_bytes_const` function assigns `core::Bytes` type to Bytes literals

This is part of #88 (Implement Bytes type). The WasmGC representation has been split into a separate issue (#124).

## Test plan

- [x] `cargo test -p tribute-passes` passes
- [x] Manual test: `b"hello"` literal compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced type checking system to properly handle byte constant operations with appropriate type assignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->