### PR TITLE
feat(wasm): implement live local analysis for continuations

### DIFF
--- a/crates/tribute-wasm-backend/src/passes/cont_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/cont_to_wasm.rs
@@ -1775,18 +1775,18 @@ mod tests {
         let ops = body.blocks(db)[0].operations(db);
 
         // The first operation should be the resume function (wasm.func)
-        if let Some(resume_fn) = ops.first() {
-            if resume_fn.full_name(db) == "wasm.func" {
-                // Check if the resume function body contains struct_get
-                let fn_body = resume_fn.regions(db);
-                if let Some(region) = fn_body.first() {
-                    if let Some(block) = region.blocks(db).first() {
-                        return block
-                            .operations(db)
-                            .iter()
-                            .any(|op| op.full_name(db) == "wasm.struct_get");
-                    }
-                }
+        if let Some(resume_fn) = ops.first()
+            && resume_fn.full_name(db) == "wasm.func"
+        {
+            // Check if the resume function body contains struct_get
+            let fn_body = resume_fn.regions(db);
+            if let Some(region) = fn_body.first()
+                && let Some(block) = region.blocks(db).first()
+            {
+                return block
+                    .operations(db)
+                    .iter()
+                    .any(|op| op.full_name(db) == "wasm.struct_get");
             }
         }
         false


### PR DESCRIPTION
Add live local analysis to identify variables that need to be captured
at shift points for continuation state restoration.

Changes:
- Add `value` field to `LiveLocal` to track the SSA value
- Implement `compute_live_locals()` in ContinuationAnalyzer
- Track function arguments and their types for proper analysis
- Change state_type to return `structref` instead of `anyref`
- Update ShiftPattern to generate `wasm.struct_new` for state capture

The live local analysis identifies values that are:
1. Defined before the shift point (including function parameters)
2. Used after the shift point (in subsequent code)

This is analogous to what Rust's async/await compiler does for
capturing variables in Future state machines.

Note: Full integration with ShiftPattern requires architecture changes
due to lifetime constraints. Currently generates empty state structs
but the analysis infrastructure is in place.

Relates to: #112, #113, #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked continuation/state representation and resume generation to materialize captured locals and remap continuation bodies during lowering; shift lowering now emits explicit state/continuation objects and yield sequencing.

* **Tests**
  * Added validations for live-local capture, resume contents, and continuation wiring.

* **Documentation**
  * Updated docs describing the new state/continuation model, live-local capture, and lowering flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->