### PR TITLE
Implement shift value passing and handler preparation

### DIFF
--- a/crates/trunk-ir/src/dialect/cont.rs
+++ b/crates/trunk-ir/src/dialect/cont.rs
@@ -8,17 +8,17 @@ use crate::dialect;
 dialect! {
     mod cont {
         /// `cont.push_prompt` operation: installs a prompt and executes body.
-        #[attr(tag: any)]
+        #[attr(tag: u32)]
         fn push_prompt() -> result {
             #[region(body)] {}
         };
 
         /// `cont.shift` operation: captures continuation and jumps to handler.
         ///
-        /// The optional `value` operand is passed to the handler along with
-        /// the captured continuation.
-        #[attr(tag: any)]
-        fn shift(#[rest] values) {
+        /// The optional `value` operands are passed to the handler along with
+        /// the captured continuation. Currently only the first value is used.
+        #[attr(tag: u32)]
+        fn shift(#[rest] value) {
             #[region(handler)] {}
         };
 


### PR DESCRIPTION
- Add `values` operand to cont.shift dialect for passing yield value
- Modify expand_shift_operation to use shift's operand for $yield_value instead of always passing null
- Enhance push_prompt handling to load continuation and yield value from globals in preparation for handler invocation
- Add detailed comments documenting the handler invocation flow and what upstream changes are needed (handler_lower.rs integration)

The actual handler function call (step 4 of handler invocation) requires handler_lower.rs to populate the shift's handler region with actual code. This is tracked in TODO(#100).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Shift operation updated to accept optional values that are forwarded to handlers along with captured continuations.
  * Continuation setup and push-prompt handling now derive and propagate yield values from operands instead of using placeholders, making value flow and continuation preparation explicit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->