### PR TITLE
refactor(ir): migrate name_span to name_location and remove Attribute::Span

### DIFF
--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -104,7 +104,8 @@ impl<'db> Func<'db> {
             .region(region);
 
         if let Some(span) = name_span {
-            builder = builder.attr("name_span", Attribute::Span(span));
+            let name_loc = crate::Location::new(location.path, span);
+            builder = builder.attr("name_location", Attribute::Location(name_loc));
         }
 
         Func::from_operation(db, builder.build()).expect("valid func.func operation")
@@ -149,7 +150,8 @@ impl<'db> Func<'db> {
             .region(region);
 
         if let Some(span) = name_span {
-            builder = builder.attr("name_span", Attribute::Span(span));
+            let name_loc = crate::Location::new(location.path, span);
+            builder = builder.attr("name_location", Attribute::Location(name_loc));
         }
 
         Func::from_operation(db, builder.build()).expect("valid func.func operation")

--- a/crates/trunk-ir/src/types.rs
+++ b/crates/trunk-ir/src/types.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::{IdVec, Location, QualifiedName, Span, Symbol, dialect::core};
+use crate::{IdVec, Location, QualifiedName, Symbol, dialect::core};
 
 /// Trait for dialect-specific type wrappers.
 ///
@@ -117,8 +117,6 @@ pub enum Attribute<'db> {
     QualifiedName(QualifiedName),
     /// List of attributes (for arrays of values like switch cases).
     List(Vec<Attribute<'db>>),
-    /// Source span (for tracking source locations in attributes).
-    Span(Span),
     /// Full source location (file path + span).
     Location(Location<'db>),
 }

--- a/src/lsp/definition_index.rs
+++ b/src/lsp/definition_index.rs
@@ -100,11 +100,13 @@ impl DefinitionIndex {
         let attrs = op.attributes(db);
         let op_span = op.location(db).span;
 
-        // Helper to get name_span attribute from attrs
-        let name_span = attrs.get(&Symbol::new("name_span")).and_then(|a| match a {
-            Attribute::Span(s) => Some(*s),
-            _ => None,
-        });
+        // Helper to get name_location attribute from attrs
+        let name_span = attrs
+            .get(&Symbol::new("name_location"))
+            .and_then(|a| match a {
+                Attribute::Location(loc) => Some(loc.span),
+                _ => None,
+            });
 
         // Collect definitions using typed wrappers
         if let Ok(func_op) = func::Func::from_operation(db, *op) {

--- a/src/lsp/type_index.rs
+++ b/src/lsp/type_index.rs
@@ -93,15 +93,15 @@ impl<'db> TypeIndex<'db> {
         };
 
         // Special case for func.func: use the 'type' attribute since it has no results
-        // and use 'name_span' if available for precise hover targeting
+        // and use 'name_location' if available for precise hover targeting
         if dialect == "func" && name == "func" {
             let type_key = trunk_ir::Symbol::new("type");
-            let name_span_key = trunk_ir::Symbol::new("name_span");
+            let name_location_key = trunk_ir::Symbol::new("name_location");
 
             if let Some(Attribute::Type(func_ty)) = op.attributes(db).get(&type_key) {
-                // Use name_span if available, otherwise fall back to operation span
-                let hover_span = match op.attributes(db).get(&name_span_key) {
-                    Some(Attribute::Span(s)) => *s,
+                // Use name_location if available, otherwise fall back to operation span
+                let hover_span = match op.attributes(db).get(&name_location_key) {
+                    Some(Attribute::Location(loc)) => loc.span,
                     _ => span,
                 };
                 entries.push(TypeEntry {


### PR DESCRIPTION
## Summary

Migrate existing `Attribute::Span` usage to `Attribute::Location` and remove the deprecated variant.

## Changes

- Change `func.func`'s `name_span` attribute to `name_location` using `Attribute::Location`
- Update LSP `definition_index` and `type_index` to read `Attribute::Location`
- Remove unused `Attribute::Span` variant from the enum

## Context

This follows up on #133 which added `Attribute::Location`. Now that the new type is available, we migrate all usages and remove the old `Attribute::Span`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified location tracking in function definitions by consolidating attributes used in definition indexing and IDE language services, ensuring consistent source location handling across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->