### PR TITLE
fix(wasm): add type support for core.func, closure.Closure and wasm types

### DIFF
--- a/crates/tribute-wasm-backend/src/emit.rs
+++ b/crates/tribute-wasm-backend/src/emit.rs
@@ -2428,17 +2428,9 @@ fn type_to_valtype<'db>(
         // In Tribute, function-typed parameters receive closures at runtime
         Ok(ValType::Ref(RefType::ANYREF))
     } else if closure::Closure::from_type(db, ty).is_some() {
-        // Closure types - these are WasmGC structs
-        // If registered in type_idx_by_type, use concrete ref; otherwise anyref
-        if let Some(&type_idx) = type_idx_by_type.get(&ty) {
-            Ok(ValType::Ref(RefType {
-                nullable: true,
-                heap_type: HeapType::Concrete(type_idx),
-            }))
-        } else {
-            // Fallback to anyref for unregistered closure types
-            Ok(ValType::Ref(RefType::ANYREF))
-        }
+        // Closure types - use anyref for unregistered closures
+        // (registered closures are handled earlier by the generic type_idx_by_type lookup)
+        Ok(ValType::Ref(RefType::ANYREF))
     } else if ty.dialect(db) == wasm::DIALECT_NAME() {
         // WASM dialect types (e.g., wasm.structref for continuation frames)
         let name = ty.name(db);


### PR DESCRIPTION
## Summary
- Add handling in `type_to_valtype` for `core.func` → `anyref` (function types passed as closure structs)
- Add handling for `closure.Closure` → concrete ref or `anyref` (WasmGC structs)
- Add handling for `wasm.structref` → abstract struct reference
- Add handling for `wasm.funcref` → funcref
- Add handling for `wasm.anyref` → anyref

This fixes the "unsupported wasm value type: core.func" error when compiling files that use closures or abilities.

Closes #138

## Test plan
- [x] `cargo build -p tribute-wasm-backend` succeeds
- [x] All existing tests pass
- [ ] Manual test: `cargo run -- compile --target wasm lang-examples/ability_core.trb` (progresses further, now blocked by case_lowering issue)
- [ ] Manual test: `cargo run -- compile --target wasm lang-examples/lambda.trb` (progresses further, now blocked by struct field type mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## WASM Backend Enhancements

* **Improvements**
  * Broader support for function and closure value types in WASM output.
  * Better handling of WASM-specific reference types and structured references.
  * Improved fallback behavior for unrecognized value types.

* **Bug Fixes**
  * Clearer validation and explicit errors for unsupported WASM value types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->