### PR TITLE
feat(wasm): add memory load/store operations (#40)

### DIFF
--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -554,6 +554,118 @@ dialect! {
         /// `wasm.f64_reinterpret_i64` operation: reinterpret i64 bits as f64.
         fn f64_reinterpret_i64(operand) -> result;
 
+        // === Linear Memory Management ===
+
+        /// `wasm.memory_size` operation: returns current memory size in pages.
+        #[attr(memory: u32)]
+        fn memory_size() -> result;
+
+        /// `wasm.memory_grow` operation: grows memory by delta pages, returns previous size or -1.
+        #[attr(memory: u32)]
+        fn memory_grow(delta) -> result;
+
+        // === Linear Memory Loads (Full Width) ===
+
+        /// `wasm.i32_load` operation: load i32 from linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_load(addr) -> result;
+
+        /// `wasm.i64_load` operation: load i64 from linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_load(addr) -> result;
+
+        /// `wasm.f32_load` operation: load f32 from linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn f32_load(addr) -> result;
+
+        /// `wasm.f64_load` operation: load f64 from linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn f64_load(addr) -> result;
+
+        // === Linear Memory Loads (Partial Width - i32) ===
+
+        /// `wasm.i32_load8_s` operation: load 8-bit value, sign-extend to i32.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_load8_s(addr) -> result;
+
+        /// `wasm.i32_load8_u` operation: load 8-bit value, zero-extend to i32.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_load8_u(addr) -> result;
+
+        /// `wasm.i32_load16_s` operation: load 16-bit value, sign-extend to i32.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_load16_s(addr) -> result;
+
+        /// `wasm.i32_load16_u` operation: load 16-bit value, zero-extend to i32.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_load16_u(addr) -> result;
+
+        // === Linear Memory Loads (Partial Width - i64) ===
+
+        /// `wasm.i64_load8_s` operation: load 8-bit value, sign-extend to i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_load8_s(addr) -> result;
+
+        /// `wasm.i64_load8_u` operation: load 8-bit value, zero-extend to i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_load8_u(addr) -> result;
+
+        /// `wasm.i64_load16_s` operation: load 16-bit value, sign-extend to i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_load16_s(addr) -> result;
+
+        /// `wasm.i64_load16_u` operation: load 16-bit value, zero-extend to i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_load16_u(addr) -> result;
+
+        /// `wasm.i64_load32_s` operation: load 32-bit value, sign-extend to i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_load32_s(addr) -> result;
+
+        /// `wasm.i64_load32_u` operation: load 32-bit value, zero-extend to i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_load32_u(addr) -> result;
+
+        // === Linear Memory Stores (Full Width) ===
+
+        /// `wasm.i32_store` operation: store i32 to linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_store(addr, value);
+
+        /// `wasm.i64_store` operation: store i64 to linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_store(addr, value);
+
+        /// `wasm.f32_store` operation: store f32 to linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn f32_store(addr, value);
+
+        /// `wasm.f64_store` operation: store f64 to linear memory.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn f64_store(addr, value);
+
+        // === Linear Memory Stores (Partial Width) ===
+
+        /// `wasm.i32_store8` operation: store low 8 bits of i32.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_store8(addr, value);
+
+        /// `wasm.i32_store16` operation: store low 16 bits of i32.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i32_store16(addr, value);
+
+        /// `wasm.i64_store8` operation: store low 8 bits of i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_store8(addr, value);
+
+        /// `wasm.i64_store16` operation: store low 16 bits of i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_store16(addr, value);
+
+        /// `wasm.i64_store32` operation: store low 32 bits of i64.
+        #[attr(offset: u32, align: u32, memory: u32)]
+        fn i64_store32(addr, value);
+
         // === WasmGC Types ===
 
         /// `wasm.anyref` type: top reference type (all GC references).


### PR DESCRIPTION
## Summary

Implements 25 WebAssembly linear memory operations for the wasm dialect to support dynamic WASI I/O and FFI operations:

- **Memory Management**: `memory_size`, `memory_grow`
- **Full-width Loads**: `i32_load`, `i64_load`, `f32_load`, `f64_load`
- **Partial-width Loads**: `i32_load8_s/u`, `i32_load16_s/u`, `i64_load8_s/u`, `i64_load16_s/u`, `i64_load32_s/u`
- **Full-width Stores**: `i32_store`, `i64_store`, `f32_store`, `f64_store`
- **Partial-width Stores**: `i32_store8/16`, `i64_store8/16/32`

## Implementation Details

### New Wasm Dialect Operations
Added 25 operations to `crates/trunk-ir/src/dialect/wasm.rs` with proper attributes:
- MemArg attributes: `offset` (u32), `align` (u32), `memory` (u32 index)
- Return types for load operations
- Operand requirements (address for loads/stores, delta for memory_grow)

### Emission Logic
Implemented emit functions in `crates/tribute-wasm-backend/src/emit.rs`:
- `extract_memarg()`: Constructs MemArg from operation attributes with proper offset/align/memory handling
- `extract_memory_index()`: Extracts memory index with default fallback
- Comprehensive match arms for all 25 operations with proper Wasmtime encoding

### Test Coverage
Added comprehensive test suite:
- `test_memory_load_store_emit()`: Validates load/store operations compile correctly
- `test_memory_grow_emit()`: Validates memory_size and memory_grow operations
- Both tests verify WASM magic number in output and full compilation pipeline

## Related Issue
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>