### PR TITLE
fix(wasm): clean up compilation tests and enable passing e2e tests

### DIFF
--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -13,7 +13,7 @@
 //! ## Remaining Work
 //!
 //! The following features need additional lowering passes:
-//! - `tribute.block` → block expressions in if/else branches
+//! - `tribute.block` → block expressions in case branches
 //! - String literals in pattern matching (case expressions)
 
 use salsa_test_macros::salsa_test;


### PR DESCRIPTION
## Summary

- Update doc comments to use current dialect names (`tribute.*` instead of `src.*`)
- Update ignore reasons for consistency
- Add Testing Strategy section to clarify purpose of e2e tests

## Changes

| Old Name | New Name |
|----------|----------|
| `src.var` | `tribute.var` |
| `src.type` | type inference |
| `src.block` | `tribute.block` |
| `case.case` | `tribute.case` |

## Test plan

- [x] All existing tests still pass
- [x] Clippy clean

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and reorganized end-to-end tests: added targeted scenarios for printing and local variables, added a placeholder for case-expression behavior, and adjusted previously ignored tests; introduced a section flagging tests that require additional lowering passes (control-flow and string-literal handling).

* **Documentation**
  * Updated testing docs to clarify current validated scenarios and added a "Remaining Work" section outlining outstanding pipeline passes and next test targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->