### PR TITLE
refactor(passes): rename case_lowering to tribute_to_scf and add block lowering

### DIFF
--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -11,7 +11,6 @@
 pub mod diagnostic;
 
 // === TrunkIR passes ===
-pub mod case_lowering;
 pub mod closure_lower;
 pub mod const_inline;
 pub mod evidence;
@@ -19,10 +18,10 @@ pub mod handler_lower;
 pub mod lambda_lift;
 pub mod resolve;
 pub mod tdnr;
+pub mod tribute_to_scf;
 pub mod typeck;
 
 // Re-exports
-pub use case_lowering::lower_case_to_scf;
 pub use closure_lower::lower_closures;
 pub use const_inline::{ConstInliner, inline_module};
 pub use diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
@@ -31,6 +30,7 @@ pub use handler_lower::lower_handlers;
 pub use lambda_lift::lift_lambdas;
 pub use resolve::{ModuleEnv, Resolver, resolve_module};
 pub use tdnr::{TdnrResolver, resolve_tdnr};
+pub use tribute_to_scf::lower_tribute_to_scf;
 pub use trunk_ir::rewrite::{
     ApplyResult, PatternApplicator, RewriteContext, RewritePattern, RewriteResult,
 };

--- a/crates/tribute-passes/src/resolve.rs
+++ b/crates/tribute-passes/src/resolve.rs
@@ -1392,12 +1392,12 @@ impl<'db> Resolver<'db> {
                 }
                 LocalBinding::PatternBinding { ty } => {
                     // Pattern binding - keep tribute.var with resolved type
-                    // case_lowering will remap the result to the bound value
+                    // tribute_to_scf will remap the result to the bound value
                     let resolved_ty = self.resolve_type(*ty);
                     let new_op = tribute::var(self.db, location, resolved_ty, *sym);
                     let new_operation = self.mark_resolved_local(new_op.as_operation());
 
-                    // Map old result to new tribute.var result (will be remapped in case_lowering)
+                    // Map old result to new tribute.var result (will be remapped in tribute_to_scf)
                     let old_result = op.result(self.db, 0);
                     let new_result = new_operation.result(self.db, 0);
                     self.ctx.map_value(old_result, new_result);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -79,7 +79,7 @@ use tribute_passes::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverit
 use tribute_passes::evidence::insert_evidence;
 use tribute_passes::handler_lower::lower_handlers;
 use tribute_passes::lambda_lift::lift_lambdas;
-use tribute_passes::lower_case_to_scf;
+use tribute_passes::lower_tribute_to_scf;
 use tribute_passes::resolve::{Resolver, build_env};
 use tribute_passes::tdnr::resolve_tdnr;
 use tribute_passes::typeck::{TypeChecker, TypeSolver, apply_subst_to_module};
@@ -404,11 +404,11 @@ pub fn stage_handler_lower<'db>(db: &'db dyn salsa::Database, source: SourceCst)
     lower_handlers(db, module)
 }
 
-/// Stage 10: Lower `case.case` to `scf.if` chains.
+/// Stage 10: Lower tribute dialect to scf dialect.
 #[salsa::tracked]
 pub fn stage_lower_case<'db>(db: &'db dyn salsa::Database, source: SourceCst) -> Module<'db> {
     let module = stage_handler_lower(db, source);
-    lower_case_to_scf(db, module)
+    lower_tribute_to_scf(db, module)
 }
 
 /// Stage 11: Dead Code Elimination (DCE).


### PR DESCRIPTION
## Summary

Rename `case_lowering.rs` to `tribute_to_scf.rs` to better reflect the pass's purpose of lowering tribute dialect operations to scf dialect. This refactor also adds support for lowering block expressions (`tribute.block`) to structured control flow, fixing the "Found non-wasm operation: tribute.block" error that occurred in ability handlers.

**Key improvements:**
- **Better naming**: `tribute_to_scf` more clearly expresses what the pass does (transforms tribute operations to scf)
- **Block expression support**: Block expressions `{ statements; result }` are now converted to `scf.if` with an always-true condition
- **Unified lowering**: The pass now handles `tribute.case` → `scf.if` chains, `tribute.block` → `scf.if`, and `tribute.yield` → `scf.yield` in one place

## Technical Details

The new `lower_block_expr` function:
- Creates an `arith.const true` to form the always-true condition
- Wraps the lowered block body in an `scf.if` operation
- Maps the block result to the scf.if result

Block expressions without results are inlined directly, skipping any `scf.yield` operations since there's no value to yield.

## Related Issues

Fixes #140 (tribute.case lowering for ability handlers)
Follow-up: #162 (closure type inference issue discovered during testing)

## Test Plan

- [x] All existing tests pass (pattern matching and case lowering unchanged)
- [x] Block expressions in ability handlers are properly lowered to scf dialect
- [x] No stale references or dangling operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced compiler lowering infrastructure to support additional dialect operations and improved internal module organization. The transformation capabilities now handle expanded language construct coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->