### PR TITLE
fix(wasm): handle struct type field count mismatch for placeholder types

### DIFF
--- a/crates/tribute-wasm-backend/src/emit.rs
+++ b/crates/tribute-wasm-backend/src/emit.rs
@@ -836,7 +836,9 @@ fn collect_gc_types<'db>(
                     let idx = next_type_idx;
                     next_type_idx += 1;
                     placeholder_struct_type_idx.insert(key, idx);
-                    type_idx_by_type.entry(ty).or_insert(idx);
+                    // Note: Placeholder types are NOT inserted into type_idx_by_type
+                    // They are only stored in placeholder_struct_type_idx to avoid
+                    // confusion and ensure proper lookup via (type, field_count) key
                     debug!(
                         "GC: struct_new allocated type_idx={} for placeholder (field_count={})",
                         idx, field_count


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for placeholder struct-reference types in WebAssembly compilation, allowing multiple field-count variants and reusing allocated type slots. Emission now resolves these placeholders when creating, reading, and writing struct values while preserving strict field-count checks for non-placeholder types.

* **Tests**
  * Updated tests to validate placeholder behavior, distinct field-count variants, and allocation/reuse of type slots.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->