### PR TITLE
fix(cont): add result to cont.shift to preserve SSA value chain

### DIFF
--- a/crates/tribute-passes/src/handler_lower.rs
+++ b/crates/tribute-passes/src/handler_lower.rs
@@ -176,6 +176,14 @@ impl RewritePattern for LowerPerformPattern {
 
         let location = op.location(db);
 
+        // Get the result type from ability.perform to pass to cont.shift.
+        // This is the type that will be returned when the continuation is resumed.
+        let result_ty = op
+            .results(db)
+            .first()
+            .copied()
+            .unwrap_or_else(|| *core::Nil::new(db));
+
         // TODO: Create handler region with actual handler logic.
         // The handler region should contain the code that runs when the continuation
         // is captured. In the full implementation, this will be populated based on
@@ -195,6 +203,7 @@ impl RewritePattern for LowerPerformPattern {
             .attr("tag", Attribute::IntBits(tag as u64))
             .attr("op_idx", Attribute::IntBits(0)) // Placeholder, resolved by handler dispatch
             .attr("op_name", Attribute::Symbol(op_name))
+            .result(result_ty)
             .region(handler_region)
             .build();
 

--- a/crates/tribute-wasm-backend/src/passes/cont_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/cont_to_wasm.rs
@@ -1728,14 +1728,17 @@ mod tests {
     #[salsa::tracked]
     fn make_module_with_shift(db: &dyn salsa::Database) -> Module<'_> {
         let location = test_location(db);
+        let i32_ty = core::I32::new(db).as_type();
 
         // Create empty handler region for shift
         let handler_block = Block::new(db, BlockId::fresh(), location, IdVec::new(), idvec![]);
         let handler_region = Region::new(db, location, idvec![handler_block]);
 
+        // cont.shift now has a result (the value passed when continuation is resumed)
         let shift = Operation::of_name(db, location, "cont.shift")
             .attr("tag", Attribute::IntBits(42))
             .attr("op_idx", Attribute::IntBits(0)) // Required attribute for multi-op dispatch
+            .result(i32_ty)
             .region(handler_region)
             .build();
 
@@ -1916,8 +1919,10 @@ mod tests {
         let handler_block = Block::new(db, BlockId::fresh(), shift_loc, IdVec::new(), idvec![]);
         let handler_region = Region::new(db, shift_loc, idvec![handler_block]);
 
+        // cont.shift now has a result (the value passed when continuation is resumed)
         let shift = Operation::of_name(db, shift_loc, "cont.shift")
             .attr("tag", Attribute::IntBits(99))
+            .result(i32_ty)
             .region(handler_region)
             .build();
 
@@ -1994,8 +1999,11 @@ mod tests {
         // Create shift
         let handler_block = Block::new(db, BlockId::fresh(), shift_loc, IdVec::new(), idvec![]);
         let handler_region = Region::new(db, shift_loc, idvec![handler_block]);
+        // cont.shift now has a result (the value passed when continuation is resumed)
         let shift = Operation::of_name(db, shift_loc, "cont.shift")
             .attr("tag", Attribute::IntBits(1))
+            .attr("op_idx", Attribute::IntBits(0))
+            .result(i32_ty)
             .region(handler_region)
             .build();
 

--- a/crates/trunk-ir/src/dialect/cont.rs
+++ b/crates/trunk-ir/src/dialect/cont.rs
@@ -18,10 +18,13 @@ dialect! {
         /// The optional `value` operands are passed to the handler along with
         /// the captured continuation. Currently only the first value is used.
         ///
+        /// The result is the value passed when the continuation is resumed.
+        /// This corresponds to the value returned by `ability.perform`.
+        ///
         /// - `tag`: prompt tag for matching handler
         /// - `op_idx`: index of the ability operation (for multi-op abilities)
         #[attr(tag: u32, op_idx: u32)]
-        fn shift(#[rest] value) {
+        fn shift(#[rest] value) -> result {
             #[region(handler)] {}
         };
 


### PR DESCRIPTION
## Summary

- Add `-> result` to `cont.shift` in the dialect definition so it produces a value
- Pass result type from `ability.perform` when lowering to `cont.shift`
- Update tests to include result when creating `cont.shift`

`ability.perform` returns a value (the value passed to `resume(k, value)`), but `cont.shift` had no result. This caused `PatternApplicator` to fail when mapping the old result to a new one, leaving stale SSA references.

Fixes #165

## Test plan

- [x] All existing tests pass
- [x] Stale reference warning for `ability.perform` is gone

Note: `tribute.case` stale references remain - this is a separate issue tracked in #166 (IsolatedFromAbove trait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type propagation in shift operations to ensure result types are properly declared and carried throughout the system for improved type safety and consistency.

* **Tests**
  * Updated test suite to validate type handling in shift operations across various execution scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->