### PR TITLE
fix(wasm): handle region result values from outside the region

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -77,13 +77,30 @@ Two-phase resolution:
    - `expr.method(args)` → `Type::method(expr, args)`
    - Requires inferred type information
 
-## Dialect Operation Matching
+## Dialect Operations
+
+### Creating Operations
+
+When creating dialect operations, prefer typed helper functions over `Operation::of_name`:
+
+```rust
+// ✅ Preferred: Use typed helper functions
+let yield_op = wasm::r#yield(db, location, value);
+let call_op = func::call(db, location, callee, args, result_ty);
+
+// ❌ Avoid: Manual operation construction
+let yield_op = Operation::of_name(db, location, "wasm.yield")
+    .operands(idvec![value])
+    .build();
+```
+
+### Matching Operations
 
 When matching dialect operations, prefer typed wrappers over manual dialect/name comparison:
 
 ```rust
 // ✅ Preferred: Use from_operation for type-safe matching
-if let Ok(bind_op) = pat::Bind::from_operation(db, op) {
+if let Ok(bind_op) = tribute_pat::Bind::from_operation(db, op) {
     let name = bind_op.name(db);
     // ...
 }
@@ -91,13 +108,13 @@ if let Ok(bind_op) = pat::Bind::from_operation(db, op) {
 // ❌ Avoid: Manual dialect and name comparison
 let dialect = op.dialect(db);
 let op_name = op.name(db);
-if dialect == pat::DIALECT_NAME() && op_name == pat::BIND() {
+if dialect == tribute_pat::DIALECT_NAME() && op_name == tribute_pat::BIND() {
     // ...
 }
 ```
 
-Benefits of typed wrappers:
-- Type-safe access to operation attributes
+Benefits of typed helpers and wrappers:
+- Type-safe access to operation attributes and operands
 - Compile-time verification of operation structure
 - Cleaner, more readable code
 

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -38,6 +38,12 @@ dialect! {
         /// `wasm.return` operation: return from function.
         fn r#return(#[rest] values);
 
+        /// `wasm.yield` operation: marks the region's result value.
+        /// This is not a real Wasm instruction - it's used to track which value
+        /// should be left on the stack at the end of a block/if region.
+        /// At emit time, this is handled specially to emit local.get for the operand.
+        fn r#yield(value);
+
         /// `wasm.drop` operation: drop a value on the stack.
         fn drop(value);
 


### PR DESCRIPTION
## Summary

- Add `wasm.yield` operation to track which value should be the result of a region
- Fix "wasm.if else region missing result value" error for handler dispatch

## Problem

When compiling ability system code, the handler dispatch lowering would fail with:
```
wasm.if else region missing result value
```

This occurred because the done_body in handler case (`{ result } -> result`) would become empty after lowering:
1. `tribute.var` is erased (maps to scrutinee value)
2. `scf.yield` was completely erased in `scf_to_wasm`

The emit code expected the last operation in the region to produce the result value, but the region was empty.

## Solution

Instead of erasing `scf.yield`, convert it to `wasm.yield`:
- `wasm.yield` is an IR-level pseudo-operation (no real Wasm instruction)
- `region_result_value` looks for `wasm.yield` to find which value is the region's result
- `emit_region_ops` skips `wasm.yield` since it's handled by `region_result_value` + `emit_value_get`

This correctly handles cases where the result value is defined outside the region (like the scrutinee in handler dispatch).

## Test plan

- [x] All existing tests pass
- [x] `cargo run -- compile --target=wasm lang-examples/ability_core.trb` now compiles successfully

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a wasm.yield operation to explicitly track region result values, supporting results produced inside regions but defined externally.

* **Improvements**
  * Updated compilation flow to emit region-result yields as local value accesses while skipping a dedicated instruction for yield.
  * Improved detection and handling of region termination and yielded values for more accurate WebAssembly generation.

* **Documentation**
  * Expanded conventions with guidance on creating and matching typed operation helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->