### PR TITLE
refactor(trunk-ir)\!: consolidate PatternApplicator API with required type converter

### DIFF
--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -21,7 +21,9 @@
 
 use tribute_ir::dialect::{adt, closure};
 use trunk_ir::dialect::{core, func};
-use trunk_ir::rewrite::{OpAdaptor, PatternApplicator, RewritePattern, RewriteResult};
+use trunk_ir::rewrite::{
+    OpAdaptor, PatternApplicator, RewritePattern, RewriteResult, TypeConverter,
+};
 use trunk_ir::{Attribute, DialectOp, DialectType, Operation, Type, Value, ValueDef};
 
 /// Lower closure operations in the module.
@@ -36,7 +38,7 @@ pub fn lower_closures<'db>(
     db: &'db dyn salsa::Database,
     module: core::Module<'db>,
 ) -> core::Module<'db> {
-    let applicator = PatternApplicator::new()
+    let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern(LowerClosureCallPattern)
         .add_pattern(LowerClosureNewPattern)
         .add_pattern(LowerClosureFuncPattern)

--- a/crates/tribute-passes/src/evidence.rs
+++ b/crates/tribute-passes/src/evidence.rs
@@ -44,7 +44,9 @@ use std::collections::HashSet;
 
 use tribute_ir::dialect::ability;
 use trunk_ir::dialect::{core, func};
-use trunk_ir::rewrite::{OpAdaptor, PatternApplicator, RewritePattern, RewriteResult};
+use trunk_ir::rewrite::{
+    OpAdaptor, PatternApplicator, RewritePattern, RewriteResult, TypeConverter,
+};
 use trunk_ir::{
     Block, BlockArg, DialectOp, DialectType, IdVec, Operation, Region, Symbol, Type, Value,
 };
@@ -71,7 +73,7 @@ pub fn insert_evidence<'db>(
     // Both phases use PatternApplicator
     // Phase 1: Add evidence parameters to function signatures
     // Phase 2: Transform calls inside effectful functions to pass evidence
-    PatternApplicator::new()
+    PatternApplicator::new(TypeConverter::new())
         .add_pattern(AddEvidenceParamPattern::new(effectful_fns.clone()))
         .add_pattern(TransformCallsPattern::new(effectful_fns))
         .apply(db, module)

--- a/crates/tribute-passes/src/handler_lower.rs
+++ b/crates/tribute-passes/src/handler_lower.rs
@@ -27,7 +27,9 @@ use tribute_ir::dialect::{ability, tribute};
 use trunk_ir::dialect::{cont, core};
 #[cfg(test)]
 use trunk_ir::rewrite::RewriteContext;
-use trunk_ir::rewrite::{OpAdaptor, PatternApplicator, RewritePattern, RewriteResult};
+use trunk_ir::rewrite::{
+    OpAdaptor, PatternApplicator, RewritePattern, RewriteResult, TypeConverter,
+};
 use trunk_ir::{Attribute, Block, BlockId, DialectOp, IdVec, Operation, Region};
 
 /// Lower handler operations from ability dialect to cont dialect.
@@ -38,7 +40,7 @@ pub fn lower_handlers<'db>(
     db: &'db dyn salsa::Database,
     module: core::Module<'db>,
 ) -> core::Module<'db> {
-    let applicator = PatternApplicator::new()
+    let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern(LowerPromptPattern::new())
         .add_pattern(LowerPerformPattern::new())
         .add_pattern(LowerResumePattern)

--- a/crates/tribute-wasm-backend/src/passes/adt_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/adt_to_wasm.rs
@@ -51,7 +51,7 @@ use crate::type_converter::wasm_type_converter;
 
 /// Lower adt dialect to wasm dialect.
 pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'db> {
-    PatternApplicator::with_type_converter(wasm_type_converter())
+    PatternApplicator::new(wasm_type_converter())
         .add_pattern(StructNewPattern)
         .add_pattern(StructGetPattern)
         .add_pattern(StructSetPattern)

--- a/crates/tribute-wasm-backend/src/passes/arith_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/arith_to_wasm.rs
@@ -19,7 +19,7 @@ use crate::type_converter::wasm_type_converter;
 
 /// Lower arith dialect to wasm dialect.
 pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'db> {
-    PatternApplicator::with_type_converter(wasm_type_converter())
+    PatternApplicator::new(wasm_type_converter())
         .add_pattern(ArithConstPattern)
         .add_pattern(ArithBinOpPattern)
         .add_pattern(ArithCmpPattern)

--- a/crates/tribute-wasm-backend/src/passes/closure_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/closure_to_wasm.rs
@@ -33,7 +33,7 @@ const CLOSURE_FIELD_COUNT: u64 = 2;
 
 /// Lower closure dialect to wasm dialect.
 pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'db> {
-    PatternApplicator::with_type_converter(wasm_type_converter())
+    PatternApplicator::new(wasm_type_converter())
         .add_pattern(ClosureNewPattern)
         .add_pattern(ClosureFuncPattern)
         .add_pattern(ClosureEnvPattern)

--- a/crates/tribute-wasm-backend/src/passes/const_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/const_to_wasm.rs
@@ -175,7 +175,7 @@ pub fn lower<'db>(
     let string_allocations = analysis.string_allocations(db).clone();
     let bytes_allocations = analysis.bytes_allocations(db).clone();
 
-    PatternApplicator::with_type_converter(wasm_type_converter())
+    PatternApplicator::new(wasm_type_converter())
         .add_pattern(StringConstPattern::new(string_allocations))
         .add_pattern(BytesConstPattern::new(bytes_allocations))
         .apply(db, module)

--- a/crates/tribute-wasm-backend/src/passes/cont_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/cont_to_wasm.rs
@@ -859,7 +859,7 @@ pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'
     let resume_fn_names = resume_gen::generate_resume_fn_names(db, &analysis);
 
     // Apply pattern transformations for non-shift operations
-    let module = PatternApplicator::with_type_converter(wasm_type_converter())
+    let module = PatternApplicator::new(wasm_type_converter())
         .add_pattern(PushPromptPattern)
         .add_pattern(HandlerDispatchPattern)
         .add_pattern(ResumePattern)

--- a/crates/tribute-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/func_to_wasm.rs
@@ -18,7 +18,7 @@ use crate::type_converter::wasm_type_converter;
 
 /// Lower func dialect to wasm dialect.
 pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'db> {
-    PatternApplicator::with_type_converter(wasm_type_converter())
+    PatternApplicator::new(wasm_type_converter())
         .add_pattern(FuncFuncPattern)
         .add_pattern(FuncCallPattern)
         .add_pattern(FuncCallIndirectPattern)

--- a/crates/tribute-wasm-backend/src/passes/intrinsic_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/intrinsic_to_wasm.rs
@@ -176,7 +176,7 @@ pub fn lower<'db>(
     module: Module<'db>,
     analysis: IntrinsicAnalysis<'db>,
 ) -> Module<'db> {
-    let mut applicator = PatternApplicator::with_type_converter(wasm_type_converter());
+    let mut applicator = PatternApplicator::new(wasm_type_converter());
 
     // Add __print_line pattern if needed
     if analysis.needs_fd_write(db) {

--- a/crates/tribute-wasm-backend/src/passes/scf_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/scf_to_wasm.rs
@@ -19,7 +19,7 @@ use crate::type_converter::wasm_type_converter;
 
 /// Lower scf dialect to wasm dialect.
 pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'db> {
-    PatternApplicator::with_type_converter(wasm_type_converter())
+    PatternApplicator::new(wasm_type_converter())
         .add_pattern(ScfIfPattern)
         .add_pattern(ScfLoopPattern)
         .add_pattern(ScfYieldPattern)

--- a/crates/tribute-wasm-backend/src/passes/tribute_rt_to_wasm.rs
+++ b/crates/tribute-wasm-backend/src/passes/tribute_rt_to_wasm.rs
@@ -20,7 +20,7 @@ use crate::type_converter::wasm_type_converter;
 
 /// Lower tribute_rt dialect to wasm dialect.
 pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'db> {
-    PatternApplicator::with_type_converter(wasm_type_converter())
+    PatternApplicator::new(wasm_type_converter())
         .add_pattern(BoxIntPattern)
         .add_pattern(UnboxIntPattern)
         .apply(db, module)

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -49,7 +49,8 @@
 //! # }
 //! # #[salsa::tracked]
 //! # fn apply_rename(db: &dyn salsa::Database, module: Module<'_>) -> bool {
-//! #     let applicator = PatternApplicator::new()
+//! #     use trunk_ir::rewrite::TypeConverter;
+//! #     let applicator = PatternApplicator::new(TypeConverter::new())
 //! #         .add_pattern(RenamePattern)
 //! #         .with_max_iterations(50);
 //! #     let result = applicator.apply(db, module);


### PR DESCRIPTION
Consolidates the PatternApplicator API to make type conversion configuration explicit and required. The TypeConverter must now be provided when creating a PatternApplicator, eliminating implicit type conversion behavior.

## Key Changes

- Introduces MLIR-style TypeConverter infrastructure for systematic type transformations
- Implements tribute_rt dialect for boxing/unboxing primitives
- Updates all PatternApplicator instantiations to provide TypeConverter

## Breaking Change

PatternApplicator::new() now requires a TypeConverter parameter. All call sites must be updated to provide the appropriate type converter strategy.

## Benefits

- **Explicit API**: Type conversion configuration is now explicit rather than implicit
- **Systematic**: Centralizes type conversion logic using proven MLIR patterns
- **Extensible**: Easier to add new type conversion strategies in the future
- **Clear dependencies**: Each applicator declares its type conversion requirements upfront

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized pattern applicator initialization across internal rewriting passes to require explicit type converter specification, improving consistency in code transformation pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->