### PR TITLE
refactor(emit): extract GC type collection to gc_types_collection.rs

### DIFF
--- a/crates/tribute-wasm-backend/src/emit.rs
+++ b/crates/tribute-wasm-backend/src/emit.rs
@@ -33,9 +33,11 @@ use wasm_encoder::{
 };
 
 use crate::errors;
+#[cfg(test)]
+use crate::gc_types::FIRST_USER_TYPE_IDX;
 use crate::gc_types::{
     ATTR_FIELD_IDX, ATTR_TYPE, ATTR_TYPE_IDX, BOXED_F64_IDX, BYTES_ARRAY_IDX, BYTES_STRUCT_IDX,
-    CLOSURE_STRUCT_IDX, FIRST_USER_TYPE_IDX, GcTypeDef, STEP_IDX,
+    CLOSURE_STRUCT_IDX, GcTypeDef, STEP_IDX,
 };
 use crate::{CompilationError, CompilationResult};
 


### PR DESCRIPTION
## Summary
- Extract `collect_gc_types` function and related code from emit.rs to a dedicated gc_types_collection.rs module
- Reduces emit.rs from ~5,040 to ~4,254 lines (~786 lines moved)
- New module gc_types_collection.rs is 854 lines

## Changes
- **GcTypesResult** type definition
- **GcKind and GcTypeBuilder** internal types
- Helper functions: `is_builtin_type`, `try_get_builder`, `register_type`, `record_struct_field`, `record_array_elem`, `attr_u32`, `attr_field_idx`
- Main function: `collect_gc_types` with internal `visit_op` closure
- Visitor functions: `visit_all_ops_recursive`, `visit_region`

## Test plan
- [x] `cargo build -p tribute-wasm-backend` passes
- [x] `cargo test -p tribute-wasm-backend` passes (71/73 tests)
- [x] All pre-commit checks pass

This completes Phase 1.3 of the emit.rs refactoring plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved GC-related type-collection logic into a dedicated internal module to improve maintainability and modularity. Behavior and external outputs remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->