### PR TITLE
fix(resolve): resolve primitive types in enum/struct field definitions

### DIFF
--- a/crates/tribute-passes/src/resolve.rs
+++ b/crates/tribute-passes/src/resolve.rs
@@ -1668,7 +1668,6 @@ impl<'db> Resolver<'db> {
         let binding = if path.is_simple() {
             let name = *path;
             if let Some(local) = self.lookup_local(name) {
-                dbg!(local);
                 let callee = match local {
                     LocalBinding::Parameter { value, .. }
                     | LocalBinding::LetBinding { value, .. } => *value,


### PR DESCRIPTION
## Summary

Fixes #227

- Add `resolve_primitive_type()` helper function that resolves `tribute.type(name=X)` to concrete types during environment building
- Update `collect_struct_fields()` and `collect_enum_constructors()` to resolve field types

## Problem

Variant pattern field types like `Num(Int)` were not being resolved to concrete types (`tribute_rt.int`). This caused `tribute.type(name=Int)` references to propagate through the IR pipeline to the wasm backend.

## Solution

Resolve primitive types (Int, Bool, Float, Nat, String, Bytes, Nil) during environment building phase. User-defined types remain unresolved and are handled by the full resolve pass.

## Test Plan

- [x] All existing tests pass
- [x] `test_calc_eval` (which uses enum patterns) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resolution of primitive types in struct and enum definitions, ensuring proper handling of type parameters throughout environment construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->