### PR TITLE
refactor: move resolve_type_references to tribute-passes

### DIFF
--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -20,6 +20,7 @@ pub mod handler_lower;
 pub mod lambda_lift;
 pub mod live_vars;
 pub mod resolve;
+pub mod resolve_type_references;
 pub mod tdnr;
 pub mod tribute_to_cont;
 pub mod tribute_to_scf;

--- a/crates/tribute-wasm-backend/src/passes/mod.rs
+++ b/crates/tribute-wasm-backend/src/passes/mod.rs
@@ -9,7 +9,6 @@
 pub mod const_to_wasm;
 pub mod intrinsic_to_wasm;
 pub mod normalize_primitive_types;
-pub mod resolve_type_references;
 pub mod tribute_rt_to_wasm;
 pub mod wasm_gc_type_assign;
 pub mod wasm_type_concrete;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -719,6 +719,9 @@ pub fn compile_to_wasm_binary<'db>(
     // Resolve any unrealized_conversion_cast operations from earlier passes
     let module = stage_resolve_casts(db, module);
 
+    // Resolve tribute.type references to ADT types (backend-agnostic)
+    let module = tribute_passes::resolve_type_references::lower(db, module);
+
     // Lower to WebAssembly
     stage_lower_to_wasm(db, module)
 }


### PR DESCRIPTION
## Summary

- Make `resolve_type_references` pass backend-agnostic by reordering passes to run before `func_to_wasm`
- Move pass from `tribute-wasm-backend` to `tribute-passes`
- Call from `pipeline.rs` before `compile_to_wasm` for clearer pipeline ordering

## Changes

- Reorder passes: `resolve_type_references` now runs before `func_to_wasm`
- Update to handle `func.func` instead of `wasm.func`
- Remove `NormalizeWasmFuncPattern` from `normalize_primitive_types` (no longer needed)
- Net reduction of ~50 lines of code

## Test plan

- [x] All 324 tests pass
- [x] Pre-commit checks pass (clippy, fmt, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized type reference resolution in the compilation pipeline for improved code structure and eliminated redundant processing steps within the lowering stage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->