### PR TITLE
Refactor lint checks into separate script for reusability

### DIFF
--- a/.ci/githooks/pre-commit
+++ b/.ci/githooks/pre-commit
@@ -2,24 +2,11 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "Running pre-commit checks..."
 
-echo "Running clippy..."
-# Limit clippy output to first 20 errors and use compact format
-if ! cargo clippy --workspace --all-targets --message-format=short -- -D warnings 2>&1 | head -n 40; then
-    echo ""
-    echo "❌ Clippy failed with warnings/errors. Fix the issues above and try again."
-    echo "   Run 'cargo clippy --workspace --all-targets' to see all issues."
-    exit 1
-fi
-
-echo "Running cargo fmt..."
-if ! cargo fmt --all --check; then
-    echo ""
-    echo "❌ Code formatting check failed."
-    echo "   Run 'cargo fmt --all' to fix formatting issues."
-    exit 1
-fi
+"$SCRIPT_DIR/../../.ci/lint.sh"
 
 echo "Running tests..."
 # Use nextest for faster test execution

--- a/.ci/lint.sh
+++ b/.ci/lint.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-echo "Running pre-commit-lite checks..."
-
 echo "Running cargo fmt..."
 if ! cargo fmt --all --check; then
     echo ""
@@ -20,4 +18,4 @@ if ! cargo clippy --workspace --all-targets --message-format=short -- -D warning
     exit 1
 fi
 
-echo "✅ All pre-commit-lite checks passed!"
+echo "✅ Lint checks passed!"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": ".ci/githooks/pre-commit-lite"
+                        "command": ".ci/lint.sh"
                     }
                 ]
             }


### PR DESCRIPTION
## Summary
Extracted lint checks (cargo fmt and clippy) from the pre-commit hook into a standalone script to enable reuse across different CI/development contexts.

## Key Changes
- Created new `.ci/lint.sh` script containing cargo fmt and clippy checks
- Updated `.ci/githooks/pre-commit` to call the new lint script instead of running checks inline
- Added lint script invocation to Claude settings for IDE integration
- Improved script portability by using `SCRIPT_DIR` for relative path resolution

## Implementation Details
- The new `lint.sh` script runs formatting checks before linting (fmt → clippy order)
- Added success message (`✅ Lint checks passed!`) to the lint script
- Pre-commit hook now delegates to the shared lint script, reducing duplication
- Claude IDE settings configured to run lint checks on "Stop" hook event
- Both scripts use `set -e` to fail fast on any errors

https://claude.ai/code/session_01QXQMq5FBPTnTVzqPBVmMux