### PR TITLE
ci: Use exit code 2 for lint check failures

### DIFF
--- a/.ci/lint.sh
+++ b/.ci/lint.sh
@@ -7,7 +7,7 @@ if ! cargo fmt --all --check; then
     echo ""
     echo "❌ Code formatting check failed."
     echo "   Run 'cargo fmt --all' to fix formatting issues."
-    exit 1
+    exit 2
 fi
 
 echo "Running clippy..."
@@ -15,7 +15,7 @@ if ! cargo clippy --workspace --all-targets --message-format=short -- -D warning
     echo ""
     echo "❌ Clippy failed with warnings/errors. Fix the issues above and try again."
     echo "   Run 'cargo clippy --workspace --all-targets' to see all issues."
-    exit 1
+    exit 2
 fi
 
 echo "✅ Lint checks passed!"


### PR DESCRIPTION
## Summary
Updated the CI lint script to use exit code 2 instead of exit code 1 when lint checks fail, allowing for better distinction between different types of CI failures.

## Changes
- Changed exit code from 1 to 2 for `cargo fmt` formatting check failures
- Changed exit code from 1 to 2 for `cargo clippy` linting check failures

## Details
Exit code 2 is now used to specifically indicate lint/formatting failures, which can help distinguish these failures from other types of CI errors (exit code 1). This follows common Unix conventions where different exit codes represent different error categories, making it easier for CI systems and scripts to handle different failure modes appropriately.

https://claude.ai/code/session_0152aNjitqTQ66NQE1LwXRVi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configuration for lint checks.

---

**Note:** This release contains internal infrastructure updates with no user-visible changes or impact to functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->