### PR TITLE
refactor(ast): remove redundant TypeAnnotationKind::WithEffects

### DIFF
--- a/crates/tribute-front/src/ast/types.rs
+++ b/crates/tribute-front/src/ast/types.rs
@@ -398,11 +398,6 @@ pub enum TypeAnnotationKind {
     },
     /// A tuple type: `(Int, String)`
     Tuple(Vec<TypeAnnotation>),
-    /// A type with effects: `() ->{IO} ()`
-    WithEffects {
-        inner: Box<TypeAnnotation>,
-        effects: Vec<TypeAnnotation>,
-    },
     /// Inferred type (omitted annotation): `_`
     Infer,
     /// Error in parsing

--- a/crates/tribute-front/src/typeck/checker.rs
+++ b/crates/tribute-front/src/typeck/checker.rs
@@ -239,10 +239,6 @@ impl<'db> TypeChecker<'db> {
                     elems.iter().map(|e| self.annotation_to_type(e)).collect();
                 self.ctx.tuple_type(elem_types)
             }
-            TypeAnnotationKind::WithEffects { inner, effects: _ } => {
-                // TODO: Proper effect handling
-                self.annotation_to_type(inner)
-            }
             TypeAnnotationKind::Infer => self.ctx.fresh_type_var(),
             TypeAnnotationKind::Path(_) | TypeAnnotationKind::Error => self.ctx.error_type(),
         }

--- a/src/lsp/completion_index.rs
+++ b/src/lsp/completion_index.rs
@@ -293,11 +293,6 @@ fn print_type_annotation(ty: &TypeAnnotation) -> String {
             let elems_str: Vec<_> = elems.iter().map(print_type_annotation).collect();
             format!("({})", elems_str.join(", "))
         }
-        TypeAnnotationKind::WithEffects { inner, effects } => {
-            let inner_str = print_type_annotation(inner);
-            let effects_str: Vec<_> = effects.iter().map(print_type_annotation).collect();
-            format!("{} ->{{{}}}", inner_str, effects_str.join(", "))
-        }
         TypeAnnotationKind::Infer => "_".to_string(),
         TypeAnnotationKind::Error => "?".to_string(),
     }


### PR DESCRIPTION
## Summary

Removes the redundant `TypeAnnotationKind::WithEffects` variant from the AST type annotation enum. This variant became obsolete after the `Func` variant was updated to include effect annotations directly via its `abilities` field.

## Changes

- **`crates/tribute-front/src/ast/types.rs`**: Removed `WithEffects` variant from `TypeAnnotationKind` enum
- **`crates/tribute-front/src/typeck/checker.rs`**: Removed obsolete match arm that was just unwrapping the inner type
- **`src/lsp/completion_index.rs`**: Removed formatting logic for the now-unused variant

## Technical Details

Previously, effect annotations were represented as a separate `WithEffects` wrapper around function types. After the refactoring to add the `abilities` field directly to the `Func` variant, this wrapper became redundant. Effect annotations are now handled inline within function type annotations, making the type representation simpler and more consistent.

## Test Plan

- All existing tests pass (`cargo nextest run --workspace`)
- No compilation errors or warnings
- Code successfully builds and LSP features work correctly
- Type checker handles function types with effects correctly via the `Func` variant

Generated with Claude Code