### PR TITLE
fix: prevent explosive unrealized_conversion_cast chains (#331)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,6 @@
+{
+  "ignores": [
+    "node_modules/",
+    "target/"
+  ]
+}

--- a/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
@@ -55,8 +55,9 @@ pub fn lower<'db>(
     module: Module<'db>,
     type_converter: TypeConverter,
 ) -> Module<'db> {
-    // No specific conversion target - adt lowering is a dialect transformation
-    let target = ConversionTarget::new();
+    let target = ConversionTarget::new()
+        .legal_dialect("wasm")
+        .illegal_dialect("adt");
     PatternApplicator::new(type_converter)
         .add_pattern(StructNewPattern)
         .add_pattern(StructGetPattern)

--- a/crates/trunk-ir-wasm-backend/src/passes/arith_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/arith_to_wasm.rs
@@ -26,8 +26,9 @@ pub fn lower<'db>(
     module: Module<'db>,
     type_converter: TypeConverter,
 ) -> Module<'db> {
-    // No specific conversion target - arith lowering is a dialect transformation
-    let target = ConversionTarget::new();
+    let target = ConversionTarget::new()
+        .legal_dialect("wasm")
+        .illegal_dialect("arith");
     let applicator = PatternApplicator::new(type_converter)
         .add_pattern(ArithConstPattern)
         .add_pattern(ArithBinOpPattern)

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -37,8 +37,9 @@ pub fn lower<'db>(
     // 1. Collect all functions referenced by func.constant operations
     let func_refs = collect_func_constant_refs(db, &module);
 
-    // No specific conversion target - func lowering is a dialect transformation
-    let target = ConversionTarget::new();
+    let target = ConversionTarget::new()
+        .legal_dialect("wasm")
+        .illegal_dialect("func");
 
     if func_refs.is_empty() {
         // No func.constant operations - just apply patterns without table generation

--- a/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
@@ -24,8 +24,9 @@ pub fn lower<'db>(
     module: Module<'db>,
     type_converter: TypeConverter,
 ) -> Module<'db> {
-    // No specific conversion target - scf lowering is a dialect transformation
-    let target = ConversionTarget::new();
+    let target = ConversionTarget::new()
+        .legal_dialect("wasm")
+        .illegal_dialect("scf");
     let applicator = PatternApplicator::new(type_converter)
         .add_pattern(ScfIfPattern)
         .add_pattern(ScfLoopPattern)

--- a/crates/trunk-ir-wasm-backend/src/passes/trampoline_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/trampoline_to_wasm.rs
@@ -70,8 +70,9 @@ pub fn lower<'db>(db: &'db dyn salsa::Database, module: Module<'db>) -> Module<'
         .add_pattern(LowerYieldContinuationAccessPattern)
         .add_pattern(LowerYieldGlobalGetPattern);
 
-    // No specific conversion target - trampoline lowering is a dialect transformation
-    let target = ConversionTarget::new();
+    let target = ConversionTarget::new()
+        .legal_dialect("wasm")
+        .illegal_dialect("trampoline");
     applicator.apply_partial(db, module, target).module
 }
 


### PR DESCRIPTION
## Summary
- **PatternApplicator restructure**: Move legality check before cast insertion so legal operations skip conversion casts entirely
- **ConversionTarget constraints**: Add `legal_dialect("wasm")`/`illegal_dialect(X)` to all 5 WASM backend passes (arith, scf, func, adt, trampoline)
- **markdownlint config**: Add `.markdownlint-cli2.jsonc` to exclude `node_modules/` from lint

## Test plan
- [x] `cargo nextest run -p trunk-ir` — 58 tests passed
- [x] `cargo nextest run -p trunk-ir-wasm-backend` — 70 tests passed
- [x] `cargo nextest run --workspace` — 881 tests passed (including `e2e_ability_core`)
- [x] Pre-commit hook (fmt, clippy, markdownlint, tests) all passed

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added markdown linting configuration to maintain consistent code quality standards.

* **Performance**
  * Enhanced IR transformation pipeline with optimized pattern matching logic, reducing compilation overhead and improving overall build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->