### PR TITLE
Add Cranelift native backend design documentation

### DIFF
--- a/.claude/rules/crates.md
+++ b/.claude/rules/crates.md
@@ -66,6 +66,20 @@ separated responsibilities.
 
 **Location**: `crates/tribute-cranelift/`
 
+## trunk-ir-cranelift-backend
+
+**Role**: Native code generation via Cranelift (language-agnostic)
+
+**Key Modules**:
+
+- `lib.rs` - Public API: `emit_module_to_native`
+- `translate.rs` - Module-level orchestration (ObjectModule → object file)
+- `function.rs` - `clif.*` → Cranelift FunctionBuilder emit
+- `validation.rs` - Pre-emit validation (all ops must be `clif.*`)
+- `passes/` - Lowering passes (`func_to_clif`, `arith_to_clif`, etc.)
+
+**Location**: `crates/trunk-ir-cranelift-backend/`
+
 ## tribute (main crate)
 
 **Role**: CLI entry point, LSP server, and pipeline orchestration
@@ -87,6 +101,10 @@ tribute (main)
 ├── tribute-passes
 │   ├── trunk-ir
 ├── trunk-ir
+├── trunk-ir-wasm-backend
+│   └── trunk-ir
+├── trunk-ir-cranelift-backend
+│   └── trunk-ir
 └── tree-sitter-tribute
 
 tribute-front
@@ -96,3 +114,5 @@ tribute-front
 
 Note: `trunk-ir` is now fully independent with no dependencies on other
 tribute crates (not even as dev-dependencies). It's a standalone IR system.
+Both `trunk-ir-wasm-backend` and `trunk-ir-cranelift-backend` depend only
+on `trunk-ir`, keeping them language-agnostic.

--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -6,11 +6,14 @@ See the detailed pipeline diagram in the doc comment at the top of `src/pipeline
 
 ## Pipeline Overview
 
-The pipeline is divided into two main phases:
+The pipeline is divided into three main phases:
 
 1. **Frontend (tribute-front)**: CST → AST → resolve → typecheck → TDNR → TrunkIR
 2. **TrunkIR Passes (tribute-passes)**:
-   Boxing → Evidence → Closures → Continuations → Backend
+   Boxing → Evidence → Closures → Continuations
+3. **Backend** (target-specific):
+   - **WASM**: cont_to_trampoline → lower_to_wasm → emit_wasm
+   - **Native**: cont_to_libmprompt → lower_to_clif → emit_native (Cranelift)
 
 ## Frontend Stages (tribute-front)
 
@@ -36,6 +39,14 @@ The pipeline is divided into two main phases:
 | dce | `eliminate_dead_functions(db, module)` | Dead code elimination |
 | resolve_casts | `resolve_unrealized_casts(db, module, ...)` | Resolve type casts |
 
+## Native Pipeline (trunk-ir-cranelift-backend)
+
+| Stage | Function | Description |
+| ----- | -------- | ----------- |
+| cont_to_libmprompt | `lower_cont_to_libmprompt(db, module)` | Lower `cont.*` via libmprompt FFI calls |
+| lower_to_clif | `lower_to_clif(db, module)` | Lower `func.*`/`arith.*`/`scf.*`/`adt.*` to `clif.*` |
+| compile_to_native | `emit_module_to_native(db, module)` | Emit `clif.*` to native object file via Cranelift |
+
 ## Entry Point
 
 The main compilation entry points are:
@@ -43,6 +54,7 @@ The main compilation entry points are:
 ```rust
 pub fn compile_ast(db: &dyn salsa::Database, source_file: SourceCst) -> Result<Module, ConversionError>
 pub fn compile_with_diagnostics(db: &dyn salsa::Database, source_file: SourceCst) -> CompilationResult
+pub fn compile_to_native_binary(db: &dyn salsa::Database, source: SourceCst) -> Option<Vec<u8>>
 ```
 
 Returns `CompilationResult` containing:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ current language and compiler design. If code/tests/older docs conflict,
 - `new-plans/ir.md`: TrunkIR (multi-level dialect IR) and pipeline
 - `new-plans/implementation.md`: ability implementation strategy
   (evidence passing, prompts/continuations)
+- `new-plans/cranelift-backend.md`: Cranelift native backend architecture
 
 ## Project Overview (Updated)
 
@@ -64,6 +65,7 @@ Use `gh issue list` to browse.
 | `syntax` | Parser and syntax features |
 | `lsp` | Language Server Protocol (#31-37) |
 | `wasm` | WebAssembly backend (#38-41) |
+| `cranelift` | Cranelift native backend |
 | `good first issue` | Good for newcomers |
 | `enhancement` | New feature |
 | `bug` | Something isn't working |

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -1,0 +1,187 @@
+# Cranelift Backend Architecture
+
+> 이 문서는 Tribute → Native 컴파일 백엔드의 아키텍처를 정의한다.
+> WASM 백엔드 문서는 [wasm-backend.md](wasm-backend.md)를 참조.
+
+## Overview
+
+Cranelift 백엔드는 WASM 백엔드와 동일한 **2-layer 패턴**을 따른다:
+
+1. **타겟 독립적 IR 유지**: trunk-ir는 특정 타겟에 종속되지 않음
+2. **Backend-specific lowering**: `clif.*` dialect은 Cranelift IR과 1:1 대응
+3. **관심사 분리**: lowering (tribute-passes/native)과
+   emission (trunk-ir-cranelift-backend) 분리
+
+---
+
+## 크레이트 구조
+
+```mermaid
+graph TD
+    subgraph "trunk-ir (언어 독립적)"
+        dialects["dialect/\nfunc, arith, scf, cont, ...\nwasm.rs | clif.rs"]
+    end
+
+    subgraph "trunk-ir-cranelift-backend (trunk-ir만 의존)"
+        translate["translate.rs — ObjectModule → object file"]
+        function["function.rs — clif.* → Cranelift FunctionBuilder"]
+        validation["validation.rs — pre-emit 검증"]
+        passes["passes/\nfunc_to_clif, arith_to_clif, ..."]
+    end
+
+    subgraph "tribute-passes/src/native/ (tribute-ir 의존)"
+        lower["lower.rs — 오케스트레이션"]
+        type_conv["type_converter.rs — 네이티브 타입 변환"]
+        cont_libmprompt["cont_to_libmprompt.rs — effect lowering"]
+        rc["rc.rs — RC 삽입 (future)"]
+    end
+
+    subgraph "tribute (main crate)"
+        pipeline["pipeline.rs — --target native"]
+    end
+
+    dialects --> passes
+    dialects --> cont_libmprompt
+    passes --> translate
+    translate --> function
+    translate --> validation
+    lower --> passes
+    lower --> cont_libmprompt
+    pipeline --> lower
+    pipeline --> translate
+```
+
+---
+
+## Lowering 경로
+
+### Native 타겟
+
+```mermaid
+flowchart TB
+    input["TrunkIR Module\n(cont.*, func.*, arith.*, scf.*, adt.*)"]
+
+    subgraph native_passes["tribute-passes/src/native/"]
+        cont["cont_to_libmprompt\ncont.* → libmprompt FFI 호출"]
+        rc_pass["rc 삽입 (future)\nretain/release 삽입"]
+    end
+
+    subgraph clif_passes["trunk-ir-cranelift-backend/passes/"]
+        arith["arith_to_clif\narith.* → clif.iadd, clif.fadd, ..."]
+        scf["scf_to_clif\nscf.if → clif.brif + blocks"]
+        adt["adt_to_clif\nadt.* → clif.load/store + malloc"]
+        func["func_to_clif\nfunc.* → clif.func, clif.call, ..."]
+        intrinsic["intrinsic_to_posix\nstd::intrinsics::posix → clif.call"]
+        const_pass["const_to_clif\nfunc.constant → clif.iconst, ..."]
+    end
+
+    subgraph emit["trunk-ir-cranelift-backend/"]
+        validate["validation — 모든 ops가 clif.*인지 검증"]
+        codegen["function.rs — clif.* → Cranelift IR"]
+        obj["translate.rs — ObjectModule → .o"]
+    end
+
+    output[".o (object file)\n→ cc 링크 → 실행 파일"]
+
+    input --> cont --> rc_pass
+    rc_pass --> arith --> scf --> adt --> func --> intrinsic --> const_pass
+    const_pass --> validate --> codegen --> obj --> output
+```
+
+### WASM 타겟과 비교
+
+| 측면 | WASM | Native |
+| ---- | ---- | ------ |
+| Effect | trampoline (yield bubbling) | libmprompt (스택 관리) |
+| 메모리 | WasmGC (런타임 GC) | Reference Counting |
+| ADT | GC struct/array | 포인터 + load/store |
+| 제어 흐름 | Structured (block/loop/if) | CFG (brif/jump/br_table) |
+| 함수 참조 | funcref + table | 함수 포인터 |
+| 출력 | `.wasm` binary | `.o` object file |
+
+---
+
+## `clif.*` Dialect
+
+Cranelift IR과 1:1 대응하는 저수준 연산. 전체 연산 목록은 [ir.md](ir.md#clif-dialect)를 참조.
+
+핵심 차이점 (`wasm.*` 대비):
+
+- **GC 타입 없음**: struct/array 대신 포인터 + load/store
+- **CFG 기반**: structured control flow 대신 brif/jump/br_table
+- **스택 할당**: stack_slot으로 로컬 메모리 할당 가능
+- **함수 포인터**: funcref 대신 symbol_addr로 함수 주소 획득
+
+---
+
+## Effect 구현: libmprompt
+
+WASM의 trampoline 방식과 달리, libmprompt가 스택 자체를 관리하므로
+라이브 변수 캡처/state struct가 불필요하다.
+
+상세 내용은 [implementation.md](implementation.md#cranelift-libmprompt)를 참조.
+
+---
+
+## 메모리 관리: Reference Counting
+
+상세 내용은 [implementation.md](implementation.md#cranelift-reference-counting)를 참조.
+
+### ADT 메모리 레이아웃
+
+```text
+Struct: [fields in order, naturally aligned]
+Enum:   [tag: i32] [padding] [payload: max(variant sizes)]
+Array:  [length: i64] [elements...]
+```
+
+### RC Object 헤더
+
+```text
+[-8 bytes] refcount: u32 + type_id: u32
+[ 0 bytes] first field
+```
+
+---
+
+## 구현 단계
+
+### Phase 1: 기본 함수 컴파일
+
+- `clif` dialect 정의
+- `trunk-ir-cranelift-backend` 크레이트 스캐폴딩
+- `func_to_clif` + `arith_to_clif` passes
+- Cranelift codegen (function.rs + translate.rs)
+- `fn main() -> Int { 42 }` → object file
+
+### Phase 2: 제어 흐름 + ADT + 클로저
+
+- `scf_to_clif` pass (CFG 변환)
+- `adt_to_clif` pass (malloc/free 기반)
+- 간접 호출 (call_indirect)
+- if/case/loop, struct/enum 지원
+
+### Phase 3: Reference Counting
+
+- RC retain/release 삽입 pass
+- Valgrind / AddressSanitizer 검증
+
+### Phase 4: libmprompt 기반 Effect
+
+- `cont_to_libmprompt` pass
+- Evidence 런타임 (native)
+- libmprompt 정적 링킹
+
+### Phase 5: E2E 파이프라인
+
+- `tribute compile --target native file.trb` → 실행 파일
+- E2E 테스트 (ability 포함)
+
+---
+
+## References
+
+- [libmprompt](https://github.com/koka-lang/libmprompt)
+  — Koka 언어의 delimited continuation 런타임
+- [Cranelift](https://cranelift.dev/) — Rust로 작성된 코드 생성기
+- [wasm-backend.md](wasm-backend.md) — WASM 백엔드 아키텍처 (대칭 구조)

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -502,10 +502,87 @@ wasm.ref_cast : (ref: ref) -> ref
 
 ### clif Dialect
 
-Cranelift 타겟. (상세 정의 추후)
+Cranelift IR과 1:1 대응하는 저수준 연산. `wasm.*`과 대칭 구조.
 
 ```text
-clif.* : Cranelift IR에 대응하는 연산들
+// 모듈/함수 정의
+clif.func          : (sym_name, type) { body } — 함수 정의
+clif.call          : (callee: Symbol, args...) -> result — 직접 호출
+clif.call_indirect : (sig: Type, callee_ptr, args...) -> result — 간접 호출
+clif.return        : (values...) — 함수 반환
+
+// 상수
+clif.iconst        : (value: i64) -> result — 정수 상수
+clif.f32const      : (value: f32) -> result — f32 상수
+clif.f64const      : (value: f64) -> result — f64 상수
+
+// 정수 산술
+clif.iadd          : (lhs, rhs) -> result
+clif.isub          : (lhs, rhs) -> result
+clif.imul          : (lhs, rhs) -> result
+clif.sdiv          : (lhs, rhs) -> result
+clif.udiv          : (lhs, rhs) -> result
+clif.srem          : (lhs, rhs) -> result
+clif.urem          : (lhs, rhs) -> result
+clif.ineg          : (val) -> result
+
+// 부동소수점 산술
+clif.fadd          : (lhs, rhs) -> result
+clif.fsub          : (lhs, rhs) -> result
+clif.fmul          : (lhs, rhs) -> result
+clif.fdiv          : (lhs, rhs) -> result
+clif.fneg          : (val) -> result
+
+// 비교
+clif.icmp          : (cond: Cond, lhs, rhs) -> i8
+clif.fcmp          : (cond: Cond, lhs, rhs) -> i8
+
+// 비트 연산
+clif.band          : (lhs, rhs) -> result
+clif.bor           : (lhs, rhs) -> result
+clif.bxor          : (lhs, rhs) -> result
+clif.ishl          : (lhs, rhs) -> result
+clif.sshr          : (lhs, rhs) -> result
+clif.ushr          : (lhs, rhs) -> result
+
+// 제어 흐름
+clif.brif          : (cond, then_block, else_block) — 조건 분기
+clif.jump          : (target_block, args...) — 무조건 점프
+clif.br_table      : (index, targets...) — 테이블 분기
+
+// 메모리
+clif.load          : (addr, offset: i32) -> result
+clif.store         : (val, addr, offset: i32)
+clif.stack_slot    : (size: i32, align: i32) -> slot
+clif.stack_addr    : (slot) -> ptr
+clif.symbol_addr   : (sym: Symbol) -> ptr
+
+// 타입 변환
+clif.ireduce       : (val) -> result — 정수 축소
+clif.uextend       : (val) -> result — 부호 없는 확장
+clif.sextend       : (val) -> result — 부호 있는 확장
+clif.fpromote      : (val) -> result — 부동소수점 확장 (f32 → f64)
+clif.fdemote       : (val) -> result — 부동소수점 축소 (f64 → f32)
+clif.fcvt_to_sint  : (val) -> result — float → signed int
+clif.fcvt_from_sint: (val) -> result — signed int → float
+clif.fcvt_to_uint  : (val) -> result — float → unsigned int
+clif.fcvt_from_uint: (val) -> result — unsigned int → float
+```
+
+**`wasm.*`과 비교:**
+
+| 측면 | `wasm.*` | `clif.*` |
+| ---- | -------- | -------- |
+| GC 타입 (struct/array/ref) | 있음 | 없음 — 포인터 + load/store |
+| 제어 흐름 | Structured (block/loop/if) | CFG (brif/jump/br_table) |
+| 메모리 | Linear memory (i32 addr) | 포인터 기반 (i64 addr) |
+| 함수 참조 | funcref + table | 함수 포인터 |
+| 스택 할당 | 없음 | stack_slot |
+
+**타입:**
+
+```text
+clif.i8, clif.i16, clif.i32, clif.i64, clif.f32, clif.f64
 ```
 
 ---

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -38,6 +38,9 @@ tribute/                  # main crate - 파이프라인 조율
 └── pipeline.rs
 ```
 
+Native (Cranelift) 백엔드는
+[cranelift-backend.md](cranelift-backend.md)를 참조.
+
 ---
 
 ## Lowering 경로

--- a/plans/README.md
+++ b/plans/README.md
@@ -19,6 +19,7 @@ See **[../new-plans/](../new-plans/)** directory:
 | [type-inference.md](../new-plans/type-inference.md) | Type inference and effect rows |
 | [ir.md](../new-plans/ir.md) | TrunkIR multi-level dialect IR |
 | [implementation.md](../new-plans/implementation.md) | Ability implementation strategy |
+| [cranelift-backend.md](../new-plans/cranelift-backend.md) | Cranelift native backend architecture |
 
 ---
 
@@ -29,6 +30,7 @@ See **[../new-plans/](../new-plans/)** directory:
 | Plan | Description | Priority |
 | ---- | ----------- | -------- |
 | [02.04-wasm-translation.md](02.04-wasm-translation.md) | Wasm backend (see #38-41 for remaining work) | High |
+| Cranelift backend | Native backend via libmprompt + RC (see [cranelift-backend.md](../new-plans/cranelift-backend.md)) | High |
 
 ### Future
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive design documentation for the Cranelift native code generation backend, establishing the architecture and implementation strategy alongside the existing WASM backend.

Key additions:

- **New architecture document** (`new-plans/cranelift-backend.md`) - Complete Cranelift backend design covering the 2-layer lowering pattern, crate structure, pipeline stages, libmprompt integration, and RC memory management strategy
- **Expanded clif dialect reference** (`new-plans/ir.md`) - Full operation reference for the `clif` dialect with WASM comparison table and dialect organization
- **Updated implementation guide** (`new-plans/implementation.md`) - Detailed cont-to-libmprompt mapping, Done/Shift protocol, pipeline branching strategy, and RC implementation approach
- **Native lowering passes** (`new-plans/lowering.md`) - Documentation for func/arith/scf/adt_to_clif, intrinsic_to_posix, and const_to_clif passes
- **Project documentation updates** - Synchronized crates.md, pipeline.md, AGENTS.md, and plans/README.md with new backend structure

## Technical Highlights

- **2-layer lowering pattern**: High-level TrunkIR dialects (func, scf, arith, adt) → clif dialect → Cranelift IR, maintaining clean separation between Tribute semantics and Cranelift specifics
- **libmprompt integration**: Native continuation support via libmprompt library with Done/Shift protocol for effect handlers
- **RC memory management**: Reference-counted heap allocation strategy with cycle collector for native target (contrasts with WASM's GC)
- **Parallel backend design**: Architecture mirrors wasm-backend.md for consistency while addressing native platform requirements

## Files Changed

- `new-plans/cranelift-backend.md` (new, 187 lines) - Primary architecture document
- `new-plans/ir.md` (+85 lines) - clif dialect reference expansion  
- `new-plans/implementation.md` (+118/-76 lines) - Implementation details refinement
- `new-plans/lowering.md` (+110 lines) - Native lowering passes
- `new-plans/design.md` (+59/-76 lines) - Cranelift section updates
- `.claude/rules/` - Project documentation synchronization

Generated with [Claude Code](https://claude.com/claude-code)