### PR TITLE
Scaffold trunk-ir-cranelift-backend crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "ariadne"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +148,15 @@ name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "cc"
@@ -218,6 +239,160 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0377b13bf002a0774fcccac4f1102a10f04893d24060cf4b7350c87e4cbb647c"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa027979140d023b25bf7509fb7ede3a54c3d3871fb5ead4673c4b633f671a2"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618e4da87d9179a70b3c2f664451ca8898987aa6eb9f487d16988588b5d8cc40"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db53764b5dad233b37b8f5dc54d3caa9900c54579195e00f17ea21f03f71aaa7"
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae927f1d8c0abddaa863acd201471d56e7fc6c3925104f4861ed4dc3e28b421"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.15.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fcf1e3e6757834bd2584f4cbff023fcc198e9279dcb5d684b4bb27a9b19f54"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "205dcb9e6ccf9d368b7466be675ff6ee54a63e36da6fe20e72d45169cf6fd254"
+
+[[package]]
+name = "cranelift-control"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108eca9fcfe86026054f931eceaf57b722c1b97464bf8265323a9b5877238817"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d96496910065d3165f84ff8e1e393916f4c086f88ac8e1b407678bc78735aa"
+dependencies = [
+ "cranelift-bitset",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e303983ad7e23c850f24d9c41fc3cb346e1b930f066d3966545e4c98dac5c9fb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b0cf8d867d891245836cac7abafb0a5b0ea040a019d720702b3b8bcba40bfa"
+
+[[package]]
+name = "cranelift-module"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "792ba2a54100e34f8a36e3e329a5207cafd1f0918a031d34695db73c163fdcc7"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-object"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecba1f219a201cf946150538e631defd620c5051b62c52ecb89a0004bab263d4"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-module",
+ "log",
+ "object",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.128.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e378a54e7168a689486d67ee1f818b7e5356e54ae51a1d7a53f4f13f7f8b7a"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -329,6 +504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +552,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -509,6 +701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +799,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -794,6 +1004,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1039,6 +1263,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "str_indices"
@@ -1303,6 +1533,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "trunk-ir-cranelift-backend"
+version = "0.1.0"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-module",
+ "cranelift-object",
+ "derive_more",
+ "insta",
+ "salsa",
+ "salsa-test-macros",
+ "target-lexicon",
+ "tracing",
+ "trunk-ir",
+]
+
+[[package]]
 name = "trunk-ir-wasm-backend"
 version = "0.1.0"
 dependencies = [
@@ -1417,6 +1664,15 @@ dependencies = [
  "bitflags 2.10.0",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "41.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6f615d528eda9adc6eefb062135f831b5215c348f4c3ec3e143690c730605b"
+dependencies = [
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT"
 [workspace.dependencies]
 ariadne = "0.6"
 clap = { version = "4.5", features = ["derive"] }
+cranelift-codegen = "0.128.3"
+cranelift-frontend = "0.128.3"
+cranelift-module = "0.128.3"
+cranelift-object = "0.128.3"
 dashmap = "6.1"
 derive_more = { version = "2.0", features = ["display", "error", "from"] }
 fluent-uri = "0.1.4"
@@ -41,6 +45,7 @@ tribute-front = { path = "crates/tribute-front" }
 tribute-ir = { path = "crates/tribute-ir" }
 tribute-passes = { path = "crates/tribute-passes" }
 trunk-ir = { path = "crates/trunk-ir" }
+trunk-ir-cranelift-backend = { path = "crates/trunk-ir-cranelift-backend" }
 trunk-ir-wasm-backend = { path = "crates/trunk-ir-wasm-backend" }
 unsynn = "0.3.0"
 wasm-encoder = "0.244.0"

--- a/crates/trunk-ir-cranelift-backend/Cargo.toml
+++ b/crates/trunk-ir-cranelift-backend/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "trunk-ir-cranelift-backend"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Cranelift native backend for TrunkIR (language-agnostic)"
+
+[dependencies]
+cranelift-codegen.workspace = true
+cranelift-frontend.workspace = true
+cranelift-module.workspace = true
+cranelift-object.workspace = true
+derive_more.workspace = true
+salsa.workspace = true
+target-lexicon.workspace = true
+tracing.workspace = true
+trunk-ir.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+salsa-test-macros = { path = "../salsa-test-macros" }

--- a/crates/trunk-ir-cranelift-backend/src/errors.rs
+++ b/crates/trunk-ir-cranelift-backend/src/errors.rs
@@ -1,0 +1,98 @@
+//! Error types for Cranelift backend emission.
+
+use derive_more::{Display, From};
+
+pub type CompilationResult<T> = Result<T, CompilationError>;
+
+#[derive(Clone, Display, Debug, From, PartialEq, salsa::Update)]
+#[display("{kind}")]
+pub struct CompilationError {
+    #[from]
+    kind: Box<CompilationErrorKind>,
+}
+
+impl<E> From<E> for CompilationError
+where
+    CompilationErrorKind: From<E>,
+{
+    fn from(error: E) -> Self {
+        CompilationError {
+            kind: Box::new(CompilationErrorKind::from(error)),
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl CompilationError {
+    pub fn unsupported_feature(feature: &'static str) -> Self {
+        CompilationErrorKind::UnsupportedFeature(feature.to_string()).into()
+    }
+
+    pub fn unsupported_feature_msg(msg: impl std::fmt::Display) -> Self {
+        CompilationErrorKind::UnsupportedFeature(msg.to_string()).into()
+    }
+
+    pub fn type_error(msg: impl std::fmt::Display) -> Self {
+        CompilationErrorKind::TypeError(msg.to_string()).into()
+    }
+
+    pub fn invalid_module(msg: impl std::fmt::Display) -> Self {
+        CompilationErrorKind::InvalidModule(msg.to_string()).into()
+    }
+
+    pub fn function_not_found(name: &str) -> Self {
+        CompilationErrorKind::FunctionNotFound(name.to_string()).into()
+    }
+
+    pub fn missing_attribute(attr: &'static str) -> Self {
+        CompilationErrorKind::MissingAttribute(attr).into()
+    }
+
+    pub fn invalid_operation(op: &'static str) -> Self {
+        CompilationErrorKind::InvalidOperation(op).into()
+    }
+
+    pub fn invalid_attribute(msg: impl std::fmt::Display) -> Self {
+        CompilationErrorKind::InvalidAttribute(msg.to_string()).into()
+    }
+
+    pub fn ir_validation(msg: impl std::fmt::Display) -> Self {
+        CompilationErrorKind::IrValidation(msg.to_string()).into()
+    }
+
+    pub fn codegen(msg: impl std::fmt::Display) -> Self {
+        CompilationErrorKind::Codegen(msg.to_string()).into()
+    }
+}
+
+#[derive(Clone, Display, Debug, PartialEq)]
+pub enum CompilationErrorKind {
+    #[display("Unsupported feature: {_0}")]
+    UnsupportedFeature(String),
+
+    #[display("Type error: {_0}")]
+    TypeError(String),
+
+    #[display("Invalid module: {_0}")]
+    InvalidModule(String),
+
+    #[display("Missing attribute: {_0}")]
+    MissingAttribute(&'static str),
+
+    #[display("Invalid attribute: {_0}")]
+    InvalidAttribute(String),
+
+    #[display("Function not found: {_0}")]
+    FunctionNotFound(String),
+
+    #[display("Invalid operation: {_0}")]
+    InvalidOperation(&'static str),
+
+    #[display("IR validation failed: {_0}")]
+    IrValidation(String),
+
+    #[display("Codegen error: {_0}")]
+    Codegen(String),
+}
+
+impl std::error::Error for CompilationError {}

--- a/crates/trunk-ir-cranelift-backend/src/lib.rs
+++ b/crates/trunk-ir-cranelift-backend/src/lib.rs
@@ -1,0 +1,24 @@
+//! Cranelift native backend for TrunkIR.
+//!
+//! This crate provides language-agnostic lowering passes and emission for converting
+//! TrunkIR dialects to native object files via Cranelift.
+//!
+//! ## Passes (planned)
+//!
+//! - `func_to_clif`: Lowers `func.*` operations to `clif.*`
+//! - `arith_to_clif`: Lowers `arith.*` operations to `clif.*`
+//!
+//! ## Emission
+//!
+//! - `translate`: Module-level orchestration (validate + emit -> object file)
+//! - `function`: clif.* -> Cranelift FunctionBuilder emit
+//! - `validation`: Pre-emit validation (all ops must be clif.*)
+
+mod errors;
+pub mod passes;
+mod translate;
+mod validation;
+
+pub use errors::{CompilationError, CompilationErrorKind, CompilationResult};
+pub use translate::emit_module_to_native;
+pub use validation::{ValidationError, validate_clif_ir};

--- a/crates/trunk-ir-cranelift-backend/src/passes/mod.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/mod.rs
@@ -1,0 +1,3 @@
+//! TrunkIR to Cranelift lowering passes.
+//!
+//! These passes lower language-agnostic TrunkIR dialects to clif operations.

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -1,0 +1,87 @@
+//! Cranelift native object file translation.
+//!
+//! This module provides functions for validating and emitting native object files
+//! from TrunkIR modules that have already been lowered to the clif dialect.
+
+use trunk_ir::dialect::core::Module;
+
+use crate::{CompilationResult, validate_clif_ir};
+
+/// Emit a native object file from a lowered TrunkIR module.
+///
+/// This function assumes the module has already been lowered to clif dialect
+/// and all type conversions have been resolved. It:
+/// 1. Validates the IR (checks for non-clif ops)
+/// 2. Emits native code via Cranelift (stub: returns empty bytes)
+///
+/// For Tribute-specific compilation (including lowering from high-level IR),
+/// use the orchestration in the main crate's pipeline.
+#[salsa::tracked]
+pub fn emit_module_to_native<'db>(
+    db: &'db dyn salsa::Database,
+    module: Module<'db>,
+) -> CompilationResult<Vec<u8>> {
+    // Validate IR (check for non-clif ops)
+    validate_clif_ir(db, module)?;
+
+    // TODO(#344): Emit native code via Cranelift
+    // For now, return empty bytes as a stub
+    Ok(Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use salsa_test_macros::salsa_test;
+    use trunk_ir::dialect::{clif, core};
+    use trunk_ir::{
+        Block, BlockId, DialectOp, DialectType, Location, PathId, Region, Span, Symbol, idvec,
+    };
+
+    fn test_location(db: &dyn salsa::Database) -> Location<'_> {
+        let path = PathId::new(db, "file:///test.trb".to_owned());
+        Location::new(path, Span::new(0, 0))
+    }
+
+    #[salsa::tracked]
+    fn make_clif_module(db: &dyn salsa::Database) -> Module<'_> {
+        let location = test_location(db);
+        let i64_ty = core::I64::new(db).as_type();
+
+        let iconst_op = clif::iconst(db, location, i64_ty, 42).as_operation();
+
+        let block = Block::new(db, BlockId::fresh(), location, idvec![], idvec![iconst_op]);
+        let region = Region::new(db, location, idvec![block]);
+        Module::create(db, location, "test".into(), region)
+    }
+
+    #[salsa_test]
+    fn test_emit_module_stub(db: &salsa::DatabaseImpl) {
+        let module = make_clif_module(db);
+        let result = emit_module_to_native(db, module);
+        assert!(result.is_ok());
+        // Stub returns empty bytes
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[salsa::tracked]
+    fn make_invalid_module(db: &dyn salsa::Database) -> Module<'_> {
+        let location = test_location(db);
+        let i64_ty = core::I64::new(db).as_type();
+
+        let const_op =
+            trunk_ir::dialect::func::constant(db, location, i64_ty, Symbol::new("some_func"))
+                .as_operation();
+
+        let block = Block::new(db, BlockId::fresh(), location, idvec![], idvec![const_op]);
+        let region = Region::new(db, location, idvec![block]);
+        Module::create(db, location, "test".into(), region)
+    }
+
+    #[salsa_test]
+    fn test_emit_rejects_non_clif_module(db: &salsa::DatabaseImpl) {
+        let module = make_invalid_module(db);
+        let result = emit_module_to_native(db, module);
+        assert!(result.is_err());
+    }
+}

--- a/crates/trunk-ir-cranelift-backend/src/validation.rs
+++ b/crates/trunk-ir-cranelift-backend/src/validation.rs
@@ -1,0 +1,155 @@
+//! IR validation for Cranelift backend.
+//!
+//! This module validates that IR is ready for emission:
+//! - All operations must be in the `clif` dialect (error)
+//!
+//! Dialect validation errors prevent emission from proceeding.
+
+use trunk_ir::dialect::core::Module;
+use trunk_ir::{DialectOp, Operation, Region, Symbol};
+
+use crate::{CompilationError, CompilationResult};
+
+/// Validation error details.
+#[derive(Debug)]
+pub struct ValidationError {
+    pub message: String,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// Validate that a module's IR is ready for Cranelift emission.
+///
+/// This function checks that all operations are in the `clif` dialect
+/// (except allowed exceptions like `core.module`).
+///
+/// Returns an error if validation fails, preventing emission.
+pub fn validate_clif_ir<'db>(
+    db: &'db dyn salsa::Database,
+    module: Module<'db>,
+) -> CompilationResult<()> {
+    let mut errors: Vec<String> = Vec::new();
+
+    let body = module.body(db);
+    validate_region(db, body, &mut errors);
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        let message = format!(
+            "IR validation failed with {} error(s):\n  - {}",
+            errors.len(),
+            errors.join("\n  - ")
+        );
+        Err(CompilationError::ir_validation(message))
+    }
+}
+
+/// Validate a region recursively.
+fn validate_region<'db>(
+    db: &'db dyn salsa::Database,
+    region: Region<'db>,
+    errors: &mut Vec<String>,
+) {
+    for block in region.blocks(db).iter() {
+        for op in block.operations(db).iter() {
+            validate_operation(db, op, errors);
+        }
+    }
+}
+
+/// Validate a single operation.
+fn validate_operation<'db>(
+    db: &'db dyn salsa::Database,
+    op: &Operation<'db>,
+    errors: &mut Vec<String>,
+) {
+    let dialect = op.dialect(db);
+    let name = op.name(db);
+
+    // Check dialect - must be clif (with specific exceptions)
+    if !is_allowed_dialect(db, op) {
+        errors.push(format!("Non-clif operation found: {}.{}", dialect, name));
+    }
+
+    // Recursively validate nested regions
+    for region in op.regions(db).iter() {
+        validate_region(db, *region, errors);
+    }
+}
+
+/// Check if an operation's dialect is allowed in the emit phase.
+fn is_allowed_dialect<'db>(db: &'db dyn salsa::Database, op: &Operation<'db>) -> bool {
+    let clif_dialect = Symbol::new("clif");
+    let dialect = op.dialect(db);
+
+    if dialect == clif_dialect {
+        return true;
+    }
+
+    // Allow core.module at the top level
+    if trunk_ir::dialect::core::Module::matches(db, *op) {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use salsa_test_macros::salsa_test;
+    use trunk_ir::dialect::{clif, core};
+    use trunk_ir::{Block, BlockId, DialectOp, DialectType, Location, PathId, Span, Symbol, idvec};
+
+    fn test_location(db: &dyn salsa::Database) -> Location<'_> {
+        let path = PathId::new(db, "file:///test.trb".to_owned());
+        Location::new(path, Span::new(0, 0))
+    }
+
+    #[salsa::tracked]
+    fn make_valid_module(db: &dyn salsa::Database) -> Module<'_> {
+        let location = test_location(db);
+        let i64_ty = core::I64::new(db).as_type();
+
+        let iconst_op = clif::iconst(db, location, i64_ty, 42).as_operation();
+
+        let block = Block::new(db, BlockId::fresh(), location, idvec![], idvec![iconst_op]);
+        let region = trunk_ir::Region::new(db, location, idvec![block]);
+        Module::create(db, location, "test".into(), region)
+    }
+
+    #[salsa_test]
+    fn test_validate_valid_module(db: &salsa::DatabaseImpl) {
+        let module = make_valid_module(db);
+        assert!(validate_clif_ir(db, module).is_ok());
+    }
+
+    #[salsa::tracked]
+    fn make_invalid_module(db: &dyn salsa::Database) -> Module<'_> {
+        let location = test_location(db);
+        let i64_ty = core::I64::new(db).as_type();
+
+        // Use a func.constant (non-clif) operation
+        let const_op =
+            trunk_ir::dialect::func::constant(db, location, i64_ty, Symbol::new("some_func"))
+                .as_operation();
+
+        let block = Block::new(db, BlockId::fresh(), location, idvec![], idvec![const_op]);
+        let region = trunk_ir::Region::new(db, location, idvec![block]);
+        Module::create(db, location, "test".into(), region)
+    }
+
+    #[salsa_test]
+    fn test_validate_rejects_non_clif_ops(db: &salsa::DatabaseImpl) {
+        let module = make_invalid_module(db);
+        let result = validate_clif_ir(db, module);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Non-clif operation found"));
+    }
+}


### PR DESCRIPTION
Closes #342

## Summary

- Scaffold the `trunk-ir-cranelift-backend` crate as a language-agnostic Cranelift native backend
- Follow the 2-layer pattern established by `trunk-ir-wasm-backend`
- Add `validate_clif_ir()` to ensure all operations are `clif.*` dialect before emission
- Provide `emit_module_to_native()` stub entry point (validates, returns empty bytes for now)
- Include error handling infrastructure with `Codegen` variant
- Add workspace Cranelift dependencies (cranelift-codegen/frontend/module/object v0.128.3)

## Test plan

- [x] `cargo nextest run -p trunk-ir-cranelift-backend` — 4 tests pass
- [x] `cargo build --workspace` succeeds with new crate included
- [x] Pre-commit hooks pass (fmt, clippy, markdownlint, 924 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cranelift-based backend for native code compilation
  * Implemented IR validation with detailed error reporting for invalid operations
  * Added structured error handling for compilation failures, including type errors, unsupported features, and module validation issues
  * Introduced module translation pipeline with native code emission

<!-- end of auto-generated comment: release notes by coderabbit.ai -->