### PR TITLE
Implement Cranelift native code generation

### DIFF
--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -1,0 +1,339 @@
+//! Function-level code generation for Cranelift backend.
+//!
+//! Translates `clif.*` dialect operations within a single function body
+//! to Cranelift IR instructions using `FunctionBuilder`.
+
+use std::collections::HashMap;
+
+use cranelift_codegen::ir::types as cl_types;
+use cranelift_codegen::ir::{self as cl_ir, InstBuilder};
+use cranelift_codegen::isa::CallConv;
+use cranelift_frontend::FunctionBuilder;
+use trunk_ir::dialect::{clif, core};
+use trunk_ir::{DialectOp, DialectType, Operation, Symbol, Type, Value};
+
+use crate::{CompilationError, CompilationResult};
+
+/// Translate a TrunkIR core type to a Cranelift IR type.
+pub(crate) fn translate_type(
+    db: &dyn salsa::Database,
+    ty: Type<'_>,
+) -> CompilationResult<cl_types::Type> {
+    if core::I8::from_type(db, ty).is_some() {
+        return Ok(cl_types::I8);
+    }
+    if core::I16::from_type(db, ty).is_some() {
+        return Ok(cl_types::I16);
+    }
+    if core::I32::from_type(db, ty).is_some() {
+        return Ok(cl_types::I32);
+    }
+    if core::I64::from_type(db, ty).is_some() {
+        return Ok(cl_types::I64);
+    }
+    if core::F32::from_type(db, ty).is_some() {
+        return Ok(cl_types::F32);
+    }
+    if core::F64::from_type(db, ty).is_some() {
+        return Ok(cl_types::F64);
+    }
+    Err(CompilationError::type_error(format!(
+        "unsupported type for Cranelift: {}.{}",
+        ty.dialect(db),
+        ty.name(db),
+    )))
+}
+
+/// Translate a TrunkIR `core.func` type to a Cranelift `Signature`.
+pub(crate) fn translate_signature(
+    db: &dyn salsa::Database,
+    func_ty: core::Func<'_>,
+    call_conv: CallConv,
+) -> CompilationResult<cl_ir::Signature> {
+    let mut sig = cl_ir::Signature::new(call_conv);
+
+    for &param_ty in func_ty.params(db).iter() {
+        let cl_ty = translate_type(db, param_ty)?;
+        sig.params.push(cl_ir::AbiParam::new(cl_ty));
+    }
+
+    let ret_ty = func_ty.result(db);
+    // Nil return type means void — no return values.
+    if core::Nil::from_type(db, ret_ty).is_none() {
+        let cl_ty = translate_type(db, ret_ty)?;
+        sig.returns.push(cl_ir::AbiParam::new(cl_ty));
+    }
+
+    Ok(sig)
+}
+
+/// Translates `clif.*` operations within a single function body
+/// to Cranelift IR instructions.
+pub(crate) struct FunctionTranslator<'a, 'db> {
+    db: &'db dyn salsa::Database,
+    pub(crate) builder: FunctionBuilder<'a>,
+    /// Maps TrunkIR values to Cranelift IR values.
+    pub(crate) values: HashMap<Value<'db>, cl_ir::Value>,
+    /// Maps function symbols to Cranelift FuncRefs for call instructions.
+    func_refs: &'a HashMap<Symbol, cl_ir::FuncRef>,
+}
+
+impl<'a, 'db> FunctionTranslator<'a, 'db> {
+    pub(crate) fn new(
+        db: &'db dyn salsa::Database,
+        builder: FunctionBuilder<'a>,
+        func_refs: &'a HashMap<Symbol, cl_ir::FuncRef>,
+    ) -> Self {
+        Self {
+            db,
+            builder,
+            values: HashMap::new(),
+            func_refs,
+        }
+    }
+
+    /// Look up a TrunkIR value in the value mapping.
+    fn lookup(&self, ir_val: Value<'db>) -> CompilationResult<cl_ir::Value> {
+        self.values.get(&ir_val).copied().ok_or_else(|| {
+            CompilationError::codegen("TrunkIR value not found in Cranelift mapping")
+        })
+    }
+
+    /// Translate a single `clif.*` operation to Cranelift IR.
+    pub(crate) fn translate_op(&mut self, op: &Operation<'db>) -> CompilationResult<()> {
+        let db = self.db;
+
+        // === Constants ===
+        if let Ok(c) = clif::Iconst::from_operation(db, *op) {
+            let ty = translate_type(db, c.result_ty(db))?;
+            let val = self.builder.ins().iconst(ty, c.value(db));
+            self.values.insert(c.result(db), val);
+            return Ok(());
+        }
+        if let Ok(c) = clif::F32const::from_operation(db, *op) {
+            let val = self.builder.ins().f32const(c.value(db));
+            self.values.insert(c.result(db), val);
+            return Ok(());
+        }
+        if let Ok(c) = clif::F64const::from_operation(db, *op) {
+            let val = self.builder.ins().f64const(c.value(db));
+            self.values.insert(c.result(db), val);
+            return Ok(());
+        }
+
+        // === Integer Arithmetic ===
+        if let Ok(o) = clif::Iadd::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().iadd(a, c)
+            });
+        }
+        if let Ok(o) = clif::Isub::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().isub(a, c)
+            });
+        }
+        if let Ok(o) = clif::Imul::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().imul(a, c)
+            });
+        }
+        if let Ok(o) = clif::Sdiv::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().sdiv(a, c)
+            });
+        }
+        if let Ok(o) = clif::Udiv::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().udiv(a, c)
+            });
+        }
+        if let Ok(o) = clif::Srem::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().srem(a, c)
+            });
+        }
+        if let Ok(o) = clif::Urem::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().urem(a, c)
+            });
+        }
+        if let Ok(o) = clif::Ineg::from_operation(db, *op) {
+            return self.emit_unary(o.operand(db), o.result(db), |b, v| b.ins().ineg(v));
+        }
+
+        // === Floating Point Arithmetic ===
+        if let Ok(o) = clif::Fadd::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().fadd(a, c)
+            });
+        }
+        if let Ok(o) = clif::Fsub::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().fsub(a, c)
+            });
+        }
+        if let Ok(o) = clif::Fmul::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().fmul(a, c)
+            });
+        }
+        if let Ok(o) = clif::Fdiv::from_operation(db, *op) {
+            return self.emit_binary(o.lhs(db), o.rhs(db), o.result(db), |b, a, c| {
+                b.ins().fdiv(a, c)
+            });
+        }
+        if let Ok(o) = clif::Fneg::from_operation(db, *op) {
+            return self.emit_unary(o.operand(db), o.result(db), |b, v| b.ins().fneg(v));
+        }
+
+        // === Call ===
+        if let Ok(call) = clif::Call::from_operation(db, *op) {
+            let callee_sym = call.callee(db);
+            let func_ref = self
+                .func_refs
+                .get(&callee_sym)
+                .copied()
+                .ok_or_else(|| CompilationError::function_not_found(&callee_sym.to_string()))?;
+
+            let args: Vec<cl_ir::Value> = call
+                .args(db)
+                .iter()
+                .map(|v| self.lookup(*v))
+                .collect::<CompilationResult<_>>()?;
+
+            let inst = self.builder.ins().call(func_ref, &args);
+            let results = self.builder.inst_results(inst);
+            if !results.is_empty() {
+                self.values.insert(call.result(db), results[0]);
+            }
+            return Ok(());
+        }
+
+        // === Return ===
+        if let Ok(ret) = clif::Return::from_operation(db, *op) {
+            let vals: Vec<cl_ir::Value> = ret
+                .values(db)
+                .iter()
+                .map(|v| self.lookup(*v))
+                .collect::<CompilationResult<_>>()?;
+            self.builder.ins().return_(&vals);
+            return Ok(());
+        }
+
+        Err(CompilationError::codegen(format!(
+            "unsupported operation: {}.{}",
+            op.dialect(db),
+            op.name(db),
+        )))
+    }
+
+    /// Helper: emit a binary operation (two inputs, one output).
+    fn emit_binary(
+        &mut self,
+        lhs_ir: Value<'db>,
+        rhs_ir: Value<'db>,
+        result_ir: Value<'db>,
+        f: impl FnOnce(&mut FunctionBuilder<'a>, cl_ir::Value, cl_ir::Value) -> cl_ir::Value,
+    ) -> CompilationResult<()> {
+        let lhs = self.lookup(lhs_ir)?;
+        let rhs = self.lookup(rhs_ir)?;
+        let cl_val = f(&mut self.builder, lhs, rhs);
+        self.values.insert(result_ir, cl_val);
+        Ok(())
+    }
+
+    /// Helper: emit a unary operation (one input, one output).
+    fn emit_unary(
+        &mut self,
+        operand_ir: Value<'db>,
+        result_ir: Value<'db>,
+        f: impl FnOnce(&mut FunctionBuilder<'a>, cl_ir::Value) -> cl_ir::Value,
+    ) -> CompilationResult<()> {
+        let operand = self.lookup(operand_ir)?;
+        let cl_val = f(&mut self.builder, operand);
+        self.values.insert(result_ir, cl_val);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use salsa_test_macros::salsa_test;
+    use trunk_ir::IdVec;
+
+    #[salsa_test]
+    fn test_translate_type_integers(db: &salsa::DatabaseImpl) {
+        assert_eq!(
+            translate_type(db, core::I8::new(db).as_type()).unwrap(),
+            cl_types::I8
+        );
+        assert_eq!(
+            translate_type(db, core::I16::new(db).as_type()).unwrap(),
+            cl_types::I16
+        );
+        assert_eq!(
+            translate_type(db, core::I32::new(db).as_type()).unwrap(),
+            cl_types::I32
+        );
+        assert_eq!(
+            translate_type(db, core::I64::new(db).as_type()).unwrap(),
+            cl_types::I64
+        );
+    }
+
+    #[salsa_test]
+    fn test_translate_type_floats(db: &salsa::DatabaseImpl) {
+        assert_eq!(
+            translate_type(db, core::F32::new(db).as_type()).unwrap(),
+            cl_types::F32
+        );
+        assert_eq!(
+            translate_type(db, core::F64::new(db).as_type()).unwrap(),
+            cl_types::F64
+        );
+    }
+
+    #[salsa_test]
+    fn test_translate_type_unsupported(db: &salsa::DatabaseImpl) {
+        let nil_ty = core::Nil::new(db).as_type();
+        assert!(translate_type(db, nil_ty).is_err());
+    }
+
+    #[salsa_test]
+    fn test_translate_signature_params_and_return(db: &salsa::DatabaseImpl) {
+        let i64_ty = core::I64::new(db).as_type();
+        let i32_ty = core::I32::new(db).as_type();
+        let func_ty = core::Func::new(db, IdVec::from(vec![i32_ty, i32_ty]), i64_ty);
+
+        let sig = translate_signature(db, func_ty, CallConv::SystemV).unwrap();
+        assert_eq!(sig.params.len(), 2);
+        assert_eq!(sig.params[0].value_type, cl_types::I32);
+        assert_eq!(sig.params[1].value_type, cl_types::I32);
+        assert_eq!(sig.returns.len(), 1);
+        assert_eq!(sig.returns[0].value_type, cl_types::I64);
+    }
+
+    #[salsa_test]
+    fn test_translate_signature_void_return(db: &salsa::DatabaseImpl) {
+        let i64_ty = core::I64::new(db).as_type();
+        let nil_ty = core::Nil::new(db).as_type();
+        let func_ty = core::Func::new(db, IdVec::from(vec![i64_ty]), nil_ty);
+
+        let sig = translate_signature(db, func_ty, CallConv::SystemV).unwrap();
+        assert_eq!(sig.params.len(), 1);
+        assert_eq!(sig.params[0].value_type, cl_types::I64);
+        assert_eq!(sig.returns.len(), 0);
+    }
+
+    #[salsa_test]
+    fn test_translate_signature_no_params(db: &salsa::DatabaseImpl) {
+        let i64_ty = core::I64::new(db).as_type();
+        let func_ty = core::Func::new(db, IdVec::new(), i64_ty);
+
+        let sig = translate_signature(db, func_ty, CallConv::SystemV).unwrap();
+        assert_eq!(sig.params.len(), 0);
+        assert_eq!(sig.returns.len(), 1);
+        assert_eq!(sig.returns[0].value_type, cl_types::I64);
+    }
+}

--- a/crates/trunk-ir-cranelift-backend/src/lib.rs
+++ b/crates/trunk-ir-cranelift-backend/src/lib.rs
@@ -15,6 +15,7 @@
 //! - `validation`: Pre-emit validation (all ops must be clif.*)
 
 mod errors;
+mod function;
 pub mod passes;
 mod translate;
 mod validation;

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -3,39 +3,173 @@
 //! This module provides functions for validating and emitting native object files
 //! from TrunkIR modules that have already been lowered to the clif dialect.
 
-use trunk_ir::dialect::core::Module;
+use std::collections::HashMap;
 
-use crate::{CompilationResult, validate_clif_ir};
+use cranelift_codegen::ir::{self as cl_ir, UserFuncName};
+use cranelift_codegen::settings::{self, Configurable};
+use cranelift_codegen::{Context, isa};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_module::{Linkage, Module as CraneliftModule, default_libcall_names};
+use cranelift_object::{ObjectBuilder, ObjectModule};
+use target_lexicon::Triple;
+use trunk_ir::dialect::{clif, core};
+use trunk_ir::{DialectOp, DialectType, Symbol};
+
+use crate::function::{FunctionTranslator, translate_signature};
+use crate::{CompilationError, CompilationResult, validate_clif_ir};
 
 /// Emit a native object file from a lowered TrunkIR module.
 ///
 /// This function assumes the module has already been lowered to clif dialect
 /// and all type conversions have been resolved. It:
 /// 1. Validates the IR (checks for non-clif ops)
-/// 2. Emits native code via Cranelift (stub: returns empty bytes)
+/// 2. Emits native code via Cranelift
 ///
 /// For Tribute-specific compilation (including lowering from high-level IR),
 /// use the orchestration in the main crate's pipeline.
 #[salsa::tracked]
 pub fn emit_module_to_native<'db>(
     db: &'db dyn salsa::Database,
-    module: Module<'db>,
+    module: core::Module<'db>,
 ) -> CompilationResult<Vec<u8>> {
-    // Validate IR (check for non-clif ops)
     validate_clif_ir(db, module)?;
+    emit_module_impl(db, module)
+}
 
-    // TODO(#344): Emit native code via Cranelift
-    // For now, return empty bytes as a stub
-    Ok(Vec::new())
+/// Internal implementation of module emission.
+fn emit_module_impl<'db>(
+    db: &'db dyn salsa::Database,
+    module: core::Module<'db>,
+) -> CompilationResult<Vec<u8>> {
+    // 1. ISA setup — use host triple
+    let triple = Triple::host();
+    let mut flag_builder = settings::builder();
+    flag_builder
+        .set("is_pic", "true")
+        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    let isa_builder = isa::lookup(triple).map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    let isa = isa_builder
+        .finish(settings::Flags::new(flag_builder))
+        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    let call_conv = isa.default_call_conv();
+
+    // 2. ObjectModule creation
+    let module_name = module.name(db).to_string();
+    let obj_builder = ObjectBuilder::new(isa, module_name, default_libcall_names())
+        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    let mut obj_module = ObjectModule::new(obj_builder);
+
+    // 3. First pass — declare all functions
+    let mut func_ids: HashMap<Symbol, cranelift_module::FuncId> = HashMap::new();
+    let body = module.body(db);
+    for block in body.blocks(db).iter() {
+        for op in block.operations(db).iter() {
+            if let Ok(func_op) = clif::Func::from_operation(db, *op) {
+                let name_sym = func_op.sym_name(db);
+                let func_type_attr = func_op.r#type(db);
+                let func_ty = core::Func::from_type(db, func_type_attr).ok_or_else(|| {
+                    CompilationError::type_error("expected core.func type on clif.func")
+                })?;
+
+                let sig = translate_signature(db, func_ty, call_conv)?;
+
+                let name_str = name_sym.to_string();
+                let linkage = if name_str == "main" {
+                    Linkage::Export
+                } else {
+                    Linkage::Local
+                };
+
+                let func_id = obj_module
+                    .declare_function(&name_str, linkage, &sig)
+                    .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+                func_ids.insert(name_sym, func_id);
+            }
+        }
+    }
+
+    // 4. Second pass — define functions
+    let mut fb_ctx = FunctionBuilderContext::new();
+
+    for block in body.blocks(db).iter() {
+        for op in block.operations(db).iter() {
+            if let Ok(func_op) = clif::Func::from_operation(db, *op) {
+                let name_sym = func_op.sym_name(db);
+                let func_type_attr = func_op.r#type(db);
+                let func_ty = core::Func::from_type(db, func_type_attr).ok_or_else(|| {
+                    CompilationError::type_error("expected core.func type on clif.func")
+                })?;
+
+                let sig = translate_signature(db, func_ty, call_conv)?;
+                let func_id = func_ids[&name_sym];
+
+                let mut cl_func = cl_ir::Function::with_name_signature(
+                    UserFuncName::user(0, func_id.as_u32()),
+                    sig,
+                );
+
+                // Declare all known functions as FuncRefs within this function
+                let mut func_refs: HashMap<Symbol, cl_ir::FuncRef> = HashMap::new();
+                for (&sym, &fid) in &func_ids {
+                    let fref = obj_module.declare_func_in_func(fid, &mut cl_func);
+                    func_refs.insert(sym, fref);
+                }
+
+                // Build the function body
+                {
+                    let builder = FunctionBuilder::new(&mut cl_func, &mut fb_ctx);
+                    let mut translator = FunctionTranslator::new(db, builder, &func_refs);
+
+                    let entry_block = translator.builder.create_block();
+                    translator
+                        .builder
+                        .append_block_params_for_function_params(entry_block);
+                    translator.builder.switch_to_block(entry_block);
+
+                    // Map TrunkIR block arguments (function params) to Cranelift block params
+                    let func_body = func_op.body(db);
+                    if let Some(ir_entry_block) = func_body.blocks(db).first() {
+                        let cl_params: Vec<_> =
+                            translator.builder.block_params(entry_block).to_vec();
+                        for (i, &cl_param) in cl_params.iter().enumerate() {
+                            let ir_arg = ir_entry_block.arg(db, i);
+                            translator.values.insert(ir_arg, cl_param);
+                        }
+
+                        // Translate each operation in the entry block
+                        for ir_op in ir_entry_block.operations(db).iter() {
+                            translator.translate_op(ir_op)?;
+                        }
+                    }
+
+                    translator.builder.seal_all_blocks();
+                    translator.builder.finalize();
+                }
+
+                // Compile the function via Cranelift
+                let mut ctx = Context::for_function(cl_func);
+                obj_module
+                    .define_function(func_id, &mut ctx)
+                    .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+            }
+        }
+    }
+
+    // 5. Emit object file
+    let product = obj_module.finish();
+    let bytes = product
+        .emit()
+        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+
+    Ok(bytes)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use salsa_test_macros::salsa_test;
-    use trunk_ir::dialect::{clif, core};
     use trunk_ir::{
-        Block, BlockId, DialectOp, DialectType, Location, PathId, Region, Span, Symbol, idvec,
+        Block, BlockArg, BlockId, DialectType, IdVec, Location, PathId, Region, Span, idvec,
     };
 
     fn test_location(db: &dyn salsa::Database) -> Location<'_> {
@@ -43,29 +177,176 @@ mod tests {
         Location::new(path, Span::new(0, 0))
     }
 
+    /// Helper: build a `core.module` containing the given `clif.func` operations.
+    fn build_module<'db>(
+        db: &'db dyn salsa::Database,
+        location: Location<'db>,
+        func_ops: Vec<trunk_ir::Operation<'db>>,
+    ) -> core::Module<'db> {
+        let ops: IdVec<trunk_ir::Operation<'db>> = func_ops.into_iter().collect();
+        let module_block = Block::new(db, BlockId::fresh(), location, idvec![], ops);
+        let module_body = Region::new(db, location, idvec![module_block]);
+        core::Module::create(db, location, "test".into(), module_body)
+    }
+
+    // --- iconst + return ---
+
     #[salsa::tracked]
-    fn make_clif_module(db: &dyn salsa::Database) -> Module<'_> {
+    fn make_iconst_return_module(db: &dyn salsa::Database) -> core::Module<'_> {
         let location = test_location(db);
         let i64_ty = core::I64::new(db).as_type();
 
-        let iconst_op = clif::iconst(db, location, i64_ty, 42).as_operation();
+        // fn main() -> I64 { iconst 42; return }
+        let func_ty = core::Func::new(db, IdVec::new(), i64_ty).as_type();
+        let iconst_op = clif::iconst(db, location, i64_ty, 42);
+        let ret_op = clif::r#return(db, location, [iconst_op.result(db)]);
 
-        let block = Block::new(db, BlockId::fresh(), location, idvec![], idvec![iconst_op]);
-        let region = Region::new(db, location, idvec![block]);
-        Module::create(db, location, "test".into(), region)
+        let block = Block::new(
+            db,
+            BlockId::fresh(),
+            location,
+            idvec![],
+            idvec![iconst_op.as_operation(), ret_op.as_operation()],
+        );
+        let body = Region::new(db, location, idvec![block]);
+        let func_op = clif::func(db, location, Symbol::new("main"), func_ty, body);
+
+        build_module(db, location, vec![func_op.as_operation()])
     }
 
     #[salsa_test]
-    fn test_emit_module_stub(db: &salsa::DatabaseImpl) {
-        let module = make_clif_module(db);
+    fn test_emit_iconst_return(db: &salsa::DatabaseImpl) {
+        let module = make_iconst_return_module(db);
         let result = emit_module_to_native(db, module);
-        assert!(result.is_ok());
-        // Stub returns empty bytes
-        assert!(result.unwrap().is_empty());
+        assert!(result.is_ok(), "emit failed: {:?}", result.err());
+        let bytes = result.unwrap();
+        assert!(!bytes.is_empty(), "object file should not be empty");
     }
 
+    // --- arithmetic: iconst + iadd + return ---
+
     #[salsa::tracked]
-    fn make_invalid_module(db: &dyn salsa::Database) -> Module<'_> {
+    fn make_arithmetic_module(db: &dyn salsa::Database) -> core::Module<'_> {
+        let location = test_location(db);
+        let i64_ty = core::I64::new(db).as_type();
+
+        // fn main() -> I64 { let a = 10; let b = 20; return a + b; }
+        let func_ty = core::Func::new(db, IdVec::new(), i64_ty).as_type();
+
+        let a = clif::iconst(db, location, i64_ty, 10);
+        let b = clif::iconst(db, location, i64_ty, 20);
+        // Constructor order: operands, result_ty (no attributes)
+        let sum = clif::iadd(db, location, a.result(db), b.result(db), i64_ty);
+        let ret = clif::r#return(db, location, [sum.result(db)]);
+
+        let block = Block::new(
+            db,
+            BlockId::fresh(),
+            location,
+            idvec![],
+            idvec![
+                a.as_operation(),
+                b.as_operation(),
+                sum.as_operation(),
+                ret.as_operation()
+            ],
+        );
+        let body = Region::new(db, location, idvec![block]);
+        let func_op = clif::func(db, location, Symbol::new("main"), func_ty, body);
+
+        build_module(db, location, vec![func_op.as_operation()])
+    }
+
+    #[salsa_test]
+    fn test_emit_arithmetic(db: &salsa::DatabaseImpl) {
+        let module = make_arithmetic_module(db);
+        let result = emit_module_to_native(db, module);
+        assert!(result.is_ok(), "emit failed: {:?}", result.err());
+        assert!(!result.unwrap().is_empty());
+    }
+
+    // --- function call ---
+
+    #[salsa::tracked]
+    fn make_function_call_module(db: &dyn salsa::Database) -> core::Module<'_> {
+        let location = test_location(db);
+        let i64_ty = core::I64::new(db).as_type();
+
+        // fn add(a: I64, b: I64) -> I64 { return a + b; }
+        let add_func_ty = core::Func::new(db, IdVec::from(vec![i64_ty, i64_ty]), i64_ty).as_type();
+
+        let add_block_id = BlockId::fresh();
+        let arg_a_ty = BlockArg::of_type(db, i64_ty);
+        let arg_b_ty = BlockArg::of_type(db, i64_ty);
+        // Create block with args first to get Value references
+        let add_block = Block::new(
+            db,
+            add_block_id,
+            location,
+            idvec![arg_a_ty, arg_b_ty],
+            idvec![],
+        );
+        let arg_a = add_block.arg(db, 0);
+        let arg_b = add_block.arg(db, 1);
+        // Constructor order: operands (lhs, rhs), result_ty
+        let sum = clif::iadd(db, location, arg_a, arg_b, i64_ty);
+        let ret = clif::r#return(db, location, [sum.result(db)]);
+        // Rebuild block with operations (same block id preserves arg Values)
+        let add_block = Block::new(
+            db,
+            add_block_id,
+            location,
+            idvec![arg_a_ty, arg_b_ty],
+            idvec![sum.as_operation(), ret.as_operation()],
+        );
+        let add_body = Region::new(db, location, idvec![add_block]);
+        let add_func =
+            clif::func(db, location, Symbol::new("add"), add_func_ty, add_body).as_operation();
+
+        // fn main() -> I64 { return add(10, 20); }
+        let main_func_ty = core::Func::new(db, IdVec::new(), i64_ty).as_type();
+        let c10 = clif::iconst(db, location, i64_ty, 10);
+        let c20 = clif::iconst(db, location, i64_ty, 20);
+        // Constructor order: variadic operands, result_ty, callee attribute
+        let call = clif::call(
+            db,
+            location,
+            [c10.result(db), c20.result(db)],
+            i64_ty,
+            Symbol::new("add"),
+        );
+        let main_ret = clif::r#return(db, location, [call.result(db)]);
+        let main_block = Block::new(
+            db,
+            BlockId::fresh(),
+            location,
+            idvec![],
+            idvec![
+                c10.as_operation(),
+                c20.as_operation(),
+                call.as_operation(),
+                main_ret.as_operation()
+            ],
+        );
+        let main_body = Region::new(db, location, idvec![main_block]);
+        let main_func =
+            clif::func(db, location, Symbol::new("main"), main_func_ty, main_body).as_operation();
+
+        build_module(db, location, vec![add_func, main_func])
+    }
+
+    #[salsa_test]
+    fn test_emit_function_call(db: &salsa::DatabaseImpl) {
+        let module = make_function_call_module(db);
+        let result = emit_module_to_native(db, module);
+        assert!(result.is_ok(), "emit failed: {:?}", result.err());
+        assert!(!result.unwrap().is_empty());
+    }
+
+    // --- validation: reject non-clif ops ---
+
+    #[salsa::tracked]
+    fn make_invalid_module(db: &dyn salsa::Database) -> core::Module<'_> {
         let location = test_location(db);
         let i64_ty = core::I64::new(db).as_type();
 
@@ -75,7 +356,7 @@ mod tests {
 
         let block = Block::new(db, BlockId::fresh(), location, idvec![], idvec![const_op]);
         let region = Region::new(db, location, idvec![block]);
-        Module::create(db, location, "test".into(), region)
+        core::Module::create(db, location, "test".into(), region)
     }
 
     #[salsa_test]


### PR DESCRIPTION
## Summary

- Implement ObjectModule-based native code emission for trunk-ir-cranelift-backend
- Add function.rs with type/signature translation and FunctionTranslator
  - Translate TrunkIR core types (i8/i16/i32/i64/f32/f64) to Cranelift types
  - Build Cranelift IR from clif dialect operations
  - Support Phase 1 ops: constants, arithmetic (int/float), function calls, returns
- Update translate.rs from stub to real implementation
  - Two-pass compilation: declare all functions, then define bodies
  - Use ObjectModule for host-triple native code generation
  - Validate IR contains only clif dialect operations

## Test plan

- All 12 tests passing (9 unit tests + 3 integration tests)
- Validates type translation for core types
- Tests function signature translation
- Verifies ObjectModule compilation produces native object code
- Confirms clif dialect operation lowering

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Cranelift backend to support translating function bodies
  * Added support for converting types and generating function signatures
  * Enabled arithmetic operations, function calls, and return statements
  * Improved error handling for unsupported operations

* **Tests**
  * Added validation tests for type and signature translation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->