### PR TITLE
feat(trunk-ir): add parse_test_module helper and round-trip tests

### DIFF
--- a/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_adt_struct.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_adt_struct.snap
@@ -1,0 +1,13 @@
+---
+source: crates/trunk-ir/src/parser.rs
+expression: printed
+---
+core.module @test {
+  func.func @f() -> core.i32 {
+    %0 = arith.const {value = 10} : core.i32
+    %1 = arith.const {value = 20} : core.i32
+    %2 = adt.struct_new %0, %1 {type = adt.struct() {name = @Point, fields = [@x, @y]}} : adt.struct() {name = @Point, fields = [@x, @y]}
+    %3 = adt.struct_get %2 {type = adt.struct() {name = @Point, fields = [@x, @y]}, field = 0} : core.i32
+    func.return %3
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_arith_ops.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_arith_ops.snap
@@ -1,0 +1,16 @@
+---
+source: crates/trunk-ir/src/parser.rs
+expression: printed
+---
+core.module @test {
+  func.func @f(%a: core.i32, %b: core.i32) -> core.i1 {
+    %0 = arith.add %a, %b : core.i32
+    %1 = arith.sub %a, %b : core.i32
+    %2 = arith.mul %a, %b : core.i32
+    %3 = arith.div %a, %b : core.i32
+    %4 = arith.neg %a : core.i32
+    %5 = arith.cmp_eq %a, %b : core.i1
+    %6 = arith.cmp_lt %a, %b : core.i1
+    func.return %5
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_func_call.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_func_call.snap
@@ -1,0 +1,16 @@
+---
+source: crates/trunk-ir/src/parser.rs
+expression: printed
+---
+core.module @test {
+  func.func @add(%x: core.i32, %y: core.i32) -> core.i32 {
+    %0 = arith.add %x, %y : core.i32
+    func.return %0
+  }
+  func.func @main() -> core.i32 {
+    %0 = arith.const {value = 3} : core.i32
+    %1 = arith.const {value = 4} : core.i32
+    %2 = func.call %0, %1 {callee = @add} : core.i32
+    func.return %2
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_func_effects.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_func_effects.snap
@@ -1,0 +1,10 @@
+---
+source: crates/trunk-ir/src/parser.rs
+expression: printed
+---
+core.module @test {
+  func.func @f() -> core.i32 effects core.nil {
+    %0 = arith.const {value = 42} : core.i32
+    func.return %0
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_scf_if.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_scf_if.snap
@@ -1,0 +1,16 @@
+---
+source: crates/trunk-ir/src/parser.rs
+expression: printed
+---
+core.module @test {
+  func.func @f(%cond: core.i1) -> core.i32 {
+    %0 = scf.if %cond : core.i32 {
+      %1 = arith.const {value = 1} : core.i32
+      scf.yield %1
+    } {
+      %2 = arith.const {value = 0} : core.i32
+      scf.yield %2
+    }
+    func.return %0
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_scf_loop.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_scf_loop.snap
@@ -1,0 +1,23 @@
+---
+source: crates/trunk-ir/src/parser.rs
+expression: printed
+---
+core.module @test {
+  func.func @f() -> core.i32 {
+    %0 = arith.const {value = 0} : core.i32
+    %1 = scf.loop %0 : core.i32 {
+    ^bb1(%acc: core.i32):
+      %2 = arith.const {value = 10} : core.i32
+      %3 = arith.cmp_ge %acc, %2 : core.i1
+      %4 = scf.if %3 : core.i32 {
+        scf.break %acc
+      } {
+        %5 = arith.const {value = 1} : core.i32
+        %6 = arith.add %acc, %5 : core.i32
+        scf.continue %6
+      }
+      scf.yield %4
+    }
+    func.return %1
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_scf_switch.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__parser__tests__roundtrip_scf_switch.snap
@@ -1,0 +1,23 @@
+---
+source: crates/trunk-ir/src/parser.rs
+expression: printed
+---
+core.module @test {
+  func.func @f(%disc: core.i32) -> core.i32 {
+    scf.switch %disc {
+      scf.case {value = 0} {
+        %0 = arith.const {value = 100} : core.i32
+        scf.yield %0
+      }
+      scf.case {value = 1} {
+        %1 = arith.const {value = 200} : core.i32
+        scf.yield %1
+      }
+      scf.default {
+        %2 = arith.const {value = 0} : core.i32
+        scf.yield %2
+      }
+    }
+    func.return %disc
+  }
+}


### PR DESCRIPTION
## Summary

Add a `parse_test_module` convenience helper and comprehensive round-trip verification tests to establish a foundation for migrating test infrastructure to textual IR format.

## Changes

### New Helper Function
- Added `parse_test_module()` - wraps `parse_module` + `core::Module::from_operation`
  - Panics with descriptive messages on parse errors or non-module operations
  - Simplifies test code that constructs IR from textual format
  - Must be called from `#[salsa::tracked]` context (like all IR construction)

### Round-trip Verification Tests (7 new tests)
All tests verify parse → print → parse → print stability using `insta` snapshots:

1. **scf.if** - then/else regions with condition and yields
2. **scf.loop** - init operands, body region with block arguments, nested if
3. **scf.switch** - multiple case regions plus default case
4. **func.call** - multiple function definitions with calls
5. **adt.struct** - struct_new/struct_get with type-level attributes
6. **arith ops** - add, sub, mul, div, neg, cmp_eq, cmp_lt
7. **func effects** - function with explicit effect type annotation

All tests use raw string literals (`r#"..."#`) for readability and avoid escape sequences.

## Testing

- All 7 new tests pass with accepted insta snapshots
- Total test counts:
  - trunk-ir: 129 tests passing
  - Workspace-wide: 1085 tests passing
- Each test verifies that printed IR can be re-parsed to produce identical output

## Future Work

This establishes infrastructure for migrating 70+ `make_*_module` test helpers to use textual IR format, improving test readability and maintainability (planned for future PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded public API exports for enhanced module accessibility.
  * Added new public parsing function for test module handling.

* **Tests**
  * Extended test coverage with round-trip and helper tests for various IR constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->