### PR TITLE
fix(native): use correct struct type for __prompt_env in cont_to_libmprompt

### DIFF
--- a/crates/tribute-passes/src/cont_to_libmprompt/push_prompt.rs
+++ b/crates/tribute-passes/src/cont_to_libmprompt/push_prompt.rs
@@ -120,7 +120,8 @@ impl<'db> RewritePattern<'db> for LowerPushPromptPattern<'db> {
             let env_struct_ty = build_env_struct_type(db, live_ins.len());
 
             // adt.struct_new to create the env
-            let struct_new = adt::struct_new(db, location, field_ptrs, env_struct_ty, ptr_ty);
+            let struct_new =
+                adt::struct_new(db, location, field_ptrs, env_struct_ty, env_struct_ty);
             ops.push(struct_new.as_operation());
 
             // Cast struct to ptr for FFI

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -626,7 +626,7 @@ fn insert_rc_in_block<'db>(
                 ValueDef::BlockArg(_) => (0usize, v.index(db)),
                 ValueDef::OpResult(def_op) => {
                     let pos = ops.iter().position(|o| *o == def_op).unwrap_or(usize::MAX);
-                    (1 + pos, v.index(db))
+                    (pos.saturating_add(1), v.index(db))
                 }
             });
             live
@@ -753,7 +753,7 @@ fn insert_rc_in_block<'db>(
                 .iter()
                 .position(|op| *op == def_op)
                 .unwrap_or(usize::MAX);
-            (1 + pos, v.index(db))
+            (pos.saturating_add(1), v.index(db))
         }
     });
 

--- a/lang-examples/ability_core.trb
+++ b/lang-examples/ability_core.trb
@@ -3,7 +3,7 @@ ability State(s) {
     fn set(value: s) -> Nil
 }
 
-fn counter() ->{State(Int)} Int {
+fn counter() ->{State(Nat)} Nat {
     let n = State::get()
     State::set(n + 1)
     n
@@ -17,10 +17,11 @@ fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
     }
 }
 
-fn main() -> Int {
+fn main() -> Nil {
     run_state(fn() {
         counter()
         counter()
         counter()
     }, 0)
+    Nil
 }


### PR DESCRIPTION
## Summary

- Fix `adt::struct_new` in `push_prompt.rs` to use `env_struct_ty` as the result type instead of `ptr_ty`, so the `__prompt_env` value carries the correct struct type through the IR before it is cast to a raw pointer for FFI
- Replace two `1 + pos` expressions in `rc_insertion.rs` with `pos.saturating_add(1)` to avoid integer overflow when `pos` is `usize::MAX` (the sentinel for not found)
- Fix `lang-examples/ability_core.trb` to use the correct types (`Nat` instead of `Int`) and add the missing `Nil` return in `main`

## Test plan

- [ ] `cargo nextest run --workspace` passes
- [ ] `cargo run -- compile lang-examples/ability_core.trb --target native` compiles without ICE or miscompilation related to prompt env struct type
- [ ] Verify no integer overflow panics in RC insertion on pathological inputs

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential overflow in sorting operations during value handling.

* **Documentation**
  * Updated example code with corrected function return types to align with language specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->