### PR TITLE
feat(front): add Lambda/Call/Tuple generators and multi-function modules (Phase 3, #358)

### DIFF
--- a/crates/tribute-front/src/ast/prop.rs
+++ b/crates/tribute-front/src/ast/prop.rs
@@ -574,11 +574,15 @@ fn two_fn_module() -> BoxedStrategy<Module<UnresolvedName>> {
     let main_arg = expr_with_env(0, 3);
     (
         (node_id(), node_id(), node_id()),
-        (node_id(), node_id(), node_id()),
+        (node_id(), node_id(), node_id(), node_id()),
         (helper_body, main_arg),
     )
         .prop_map(
-            |((mod_id, helper_fid, helper_pid), (main_fid, call_id, callee_nid), (h_body, arg))| {
+            |(
+                (mod_id, helper_fid, helper_pid),
+                (main_fid, call_id, callee_expr_id, callee_nid),
+                (h_body, arg),
+            )| {
                 let helper = FuncDecl {
                     id: helper_fid,
                     is_pub: false,
@@ -595,7 +599,7 @@ fn two_fn_module() -> BoxedStrategy<Module<UnresolvedName>> {
                     body: h_body,
                 };
                 let callee_name = UnresolvedName::simple(Symbol::new(FUNC_NAMES[0]), callee_nid);
-                let callee_expr = Expr::new(call_id, ExprKind::Var(callee_name));
+                let callee_expr = Expr::new(callee_expr_id, ExprKind::Var(callee_name));
                 let main_body = Expr::new(
                     call_id,
                     ExprKind::Call {
@@ -637,13 +641,20 @@ fn three_fn_module() -> BoxedStrategy<Module<UnresolvedName>> {
     (
         (node_id(), node_id(), node_id(), node_id()),
         (node_id(), node_id(), node_id(), node_id()),
-        (node_id(), alpha_body, beta_body, inner_arg),
+        (node_id(), node_id(), node_id(), node_id()),
+        (alpha_body, beta_body, inner_arg),
     )
         .prop_map(
             |(
                 (mod_id, alpha_fid, alpha_pid, beta_fid),
                 (beta_pid, main_fid, call_outer_id, call_inner_id),
-                (callee_nid, a_body, b_body, arg),
+                (
+                    alpha_callee_expr_id,
+                    alpha_callee_name_id,
+                    beta_callee_expr_id,
+                    beta_callee_name_id,
+                ),
+                (a_body, b_body, arg),
             )| {
                 let alpha_fn = FuncDecl {
                     id: alpha_fid,
@@ -677,10 +688,10 @@ fn three_fn_module() -> BoxedStrategy<Module<UnresolvedName>> {
                 };
                 // main body: alpha(beta(arg))
                 let beta_callee = Expr::new(
-                    callee_nid,
+                    beta_callee_expr_id,
                     ExprKind::Var(UnresolvedName::simple(
                         Symbol::new(FUNC_NAMES[1]),
-                        callee_nid,
+                        beta_callee_name_id,
                     )),
                 );
                 let inner_call = Expr::new(
@@ -691,10 +702,10 @@ fn three_fn_module() -> BoxedStrategy<Module<UnresolvedName>> {
                     },
                 );
                 let alpha_callee = Expr::new(
-                    callee_nid,
+                    alpha_callee_expr_id,
                     ExprKind::Var(UnresolvedName::simple(
                         Symbol::new(FUNC_NAMES[0]),
-                        callee_nid,
+                        alpha_callee_name_id,
                     )),
                 );
                 let outer_call = Expr::new(


### PR DESCRIPTION
## Summary

Continues the proptest-based random AST generator (#358), adding the remaining
expression forms and multi-function module support.

- Add `lambda_variant`: generates `Lambda` expressions with 1–3 parameters,
  drawn from `VAR_NAMES[env_size..]` so that parameter names never shadow
  existing scope entries. The body is generated in the extended scope.
- Add `call_variant`: generates `Call` expressions with 0–2 arguments; both
  callee and arguments are produced from the current scope.
- Add `tuple_variant`: generates `Tuple` expressions with 0–3 elements from
  the current scope.
- Expose all three variants in `expr_with_env`; `lambda_variant` is gated
  behind a `remaining > 0` check (same as `block_variant`).
- Expand `parsed_module` from a fixed `fn main()` wrapper into a
  `prop_oneof!` of three variants:
  - `single_fn_module`: `fn main() { expr }` (unchanged shape)
  - `two_fn_module`: `fn alpha(foo) { … }` + `fn main() { alpha(expr) }`
  - `three_fn_module`: `fn alpha(foo) { … }` + `fn beta(foo) { … }` + `fn main() { alpha(beta(expr)) }`
- Reduce `expr_default` depth budget from 5 to 3 to keep strategy-tree
  construction O(1) as the branching factor grows from 3 to 6 variants.
- Extend `expr_depth`, `all_vars_bound`, and the proptest test suite to
  cover `Lambda`, `Call`, and `Tuple` (three new targeted property tests).

## Changed files

- `crates/tribute-front/src/ast/prop.rs`

## Test plan

- `cargo nextest run -p tribute-front` — all existing and new proptest cases pass
- `depth_is_bounded`: generated depth ≤ configured maximum
- `all_vars_in_scope`: every `Var` reference resolves to a bound name
- `lambda_has_params`: `lambda_variant` always produces ≥1 parameter
- `call_callee_exists`: `call_variant` args count ≤ 2
- `tuple_elements_bounded`: `tuple_variant` element count ≤ 3
- `module_construction_does_not_panic`: all three module shapes construct without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced AST expression generation: tuples (0–3 elements), lambdas with parameters, and function calls (0–2 args)
  * Module generation now yields three distinct module shapes instead of a single fixed layout

* **Tests**
  * Expanded tests covering lambda parameters, call callees, tuple sizes, depth/scope behavior, and new module variants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->