### PR TITLE
Refactor effect row type argument handling into shared helper

### DIFF
--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -127,10 +127,9 @@ impl<'db> TypeSubst<'db> {
                     .collect();
                 let result = self.apply_with_rows(db, *result, row_subst);
                 let row_applied = row_subst.apply(db, *effect);
-                let effect =
-                    map_effect_row_type_args(db, row_applied, |a| {
-                        self.apply_with_rows(db, a, row_subst)
-                    });
+                let effect = map_effect_row_type_args(db, row_applied, |a| {
+                    self.apply_with_rows(db, a, row_subst)
+                });
                 Type::new(
                     db,
                     TypeKind::Func {
@@ -163,10 +162,9 @@ impl<'db> TypeSubst<'db> {
                 let arg = self.apply_with_rows(db, *arg, row_subst);
                 let result = self.apply_with_rows(db, *result, row_subst);
                 let row_applied = row_subst.apply(db, *effect);
-                let effect =
-                    map_effect_row_type_args(db, row_applied, |a| {
-                        self.apply_with_rows(db, a, row_subst)
-                    });
+                let effect = map_effect_row_type_args(db, row_applied, |a| {
+                    self.apply_with_rows(db, a, row_subst)
+                });
                 Type::new(
                     db,
                     TypeKind::Continuation {


### PR DESCRIPTION
## Summary
This PR refactors duplicated logic for transforming type arguments in effect rows into a shared helper function, improving code maintainability and reducing duplication across the type checker.

Closes #335.

## Key Changes
- **New helper function `map_effect_row_type_args`**: Extracted common pattern of mapping a type-transforming function over all effect type arguments in an effect row, with automatic row reconstruction only when changes occur
- **Refactored `apply_with_rows` method**: Replaced inline effect row transformation logic in both `Func` and `Continuation` type cases with calls to the new helper
- **Refactored `replace_univars_with_bound` method**: Simplified effect row handling in both `Func` and `Continuation` cases using the shared helper
- **Refactored `apply_type_subst_to_row` method**: Replaced inline transformation logic with a call to the helper function
- **New helper method `collect_univars_from_effect_row`**: Extracted duplicated logic for collecting unresolved UniVarIds from effect row type arguments, used in two locations within `collect_unresolved_univars`
- **Updated imports**: Added `Effect` to the imports from `crate::ast`

## Implementation Details
The refactoring maintains the existing optimization of only reconstructing effect rows when the type arguments actually change, avoiding unnecessary allocations. The shared helper functions encapsulate this logic in a single place, making it easier to maintain and reducing the risk of inconsistencies across different transformation passes.

https://claude.ai/code/session_01BXEuLwSx5GreDiiGKGNdAk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal type handling logic to reduce code duplication and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->