### PR TITLE
docs(ir): update ir.md to reflect arena-based IR and current ability ops

### DIFF
--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -84,7 +84,8 @@ ref<T>?         // nullable
 /// lasso::Spur로 구현되어 4바이트, O(1) 비교
 ///
 /// Qualified path는 `::`로 구분된 문자열로 저장됨 (e.g., "std::List::map")
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "salsa", derive(salsa::Update))]
 pub struct Symbol(lasso::Spur);
 
 impl Symbol {
@@ -171,8 +172,11 @@ ability.evidence_lookup : (evidence: EvidencePtr, ability_ref: Type) -> Marker
 ability.evidence_extend : (evidence: EvidencePtr, ability_ref: Type, prompt_tag: PromptTag) -> EvidencePtr
     새 marker로 evidence 확장
 
-ability.marker_prompt : (marker: Marker) -> PromptTag
-    Marker에서 prompt tag 추출
+ability.handler_table : (max_ops_per_handler: u32, entries: Region) -> ()
+    핸들러 테이블 정의 (ability별 핸들러 엔트리 목록)
+
+ability.handler_entry : (tag: u32, op_count: u32, funcs: Region) -> ()
+    핸들러 테이블의 개별 엔트리 (ability op 구현 함수 목록)
 ```
 
 핸들러 lowering은 `cont.push_prompt` + runtime 호출로 직접 처리된다.
@@ -803,7 +807,7 @@ persistent data structure를 고려할 수 있다.
 
 **배경:**
 
-- TrunkIR은 Salsa tracked struct로 immutable
+- TrunkIR은 arena 기반 IR (IrContext가 모든 데이터 소유)
 - 현재 rewrite는 블록 전체를 재구축 (O(n) 복사)
 - 대부분의 rewrite pass에서 변경되는 op은 소수
 


### PR DESCRIPTION
## Summary

- Replace bare `salsa::Update` derive with `cfg_attr(feature = \"salsa\")` in the `Symbol` example, matching the actual implementation
- Replace nonexistent `ability.marker_prompt` op with the current `handler_table` / `handler_entry` ops in the ability dialect table
- Update the Future Considerations section: \"Salsa tracked struct\" → \"arena 기반 IR (IrContext가 모든 데이터 소유)\" to reflect the completed migration to the arena-based IR

Closes #451

## Test plan

- Documentation-only change; no code was modified
- Verify the updated op names and code examples match the current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added handler table and handler entry operations to ability dialect for improved handler management.

* **Bug Fixes / Changes**
  * Removed marker_prompt operation from ability dialect API.

* **Documentation**
  * Updated TrunkIR backend description to reflect current arena-based ownership model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->