### PR TITLE
feat(trunk-ir): add MLIR-style deep clone to IrContext

### DIFF
--- a/crates/tribute-passes/src/cont_to_libmprompt/handler_dispatch.rs
+++ b/crates/tribute-passes/src/cont_to_libmprompt/handler_dispatch.rs
@@ -28,8 +28,7 @@
 //! }
 //! ```
 
-use std::collections::HashMap;
-
+use trunk_ir::IrMapping;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{
@@ -186,10 +185,10 @@ fn build_done_branch(
     let done_value = cast_if_needed(ctx, new_block, loc, current, ptr_ty, done_arg_ty);
 
     // Build value remap: done block args -> done_value
-    let mut value_remap: HashMap<ValueRef, ValueRef> = HashMap::new();
+    let mut mapping = IrMapping::new();
     let done_block_args = ctx.block_args(done_block).to_vec();
     if !done_block_args.is_empty() {
-        value_remap.insert(done_block_args[0], done_value);
+        mapping.map_value(done_block_args[0], done_value);
     }
 
     // Copy done block operations, replacing scf.yield with scf.break
@@ -198,24 +197,13 @@ fn build_done_branch(
         if arena_scf::Yield::matches(ctx, done_op) {
             let yielded_operands: Vec<ValueRef> = ctx.op_operands(done_op).to_vec();
             if let Some(&result) = yielded_operands.first() {
-                let remapped = value_remap.get(&result).copied().unwrap_or(result);
+                let remapped = mapping.lookup_value_or_default(result);
                 let brk = arena_scf::r#break(ctx, loc, remapped);
                 ctx.push_op(new_block, brk.op_ref());
             }
             continue;
         }
-        // Clone op into the new block with remapping
-        clone_op_into_block_with_remap(ctx, new_block, done_op, &value_remap);
-
-        // Map old results -> new results
-        let new_ops = ctx.block(new_block).ops.clone();
-        if let Some(&new_op) = new_ops.last() {
-            let old_results: Vec<ValueRef> = ctx.op_results(done_op).to_vec();
-            let new_results: Vec<ValueRef> = ctx.op_results(new_op).to_vec();
-            for (old_r, new_r) in old_results.into_iter().zip(new_results) {
-                value_remap.insert(old_r, new_r);
-            }
-        }
+        ctx.clone_op_into_block(new_block, done_op, &mut mapping);
     }
 
     ctx.create_region(RegionData {
@@ -422,13 +410,13 @@ fn build_arm_region(
     };
 
     // Build value remap: block args -> FFI getter values
-    let mut value_remap: HashMap<ValueRef, ValueRef> = HashMap::new();
+    let mut mapping = IrMapping::new();
     let block_args = ctx.block_args(arm_block).to_vec();
     if !block_args.is_empty() {
-        value_remap.insert(block_args[0], k);
+        mapping.map_value(block_args[0], k);
     }
     if block_args.len() >= 2 {
-        value_remap.insert(block_args[1], v);
+        mapping.map_value(block_args[1], v);
     }
 
     // Clone arm block ops into new block, replacing scf.yield
@@ -446,24 +434,14 @@ fn build_arm_region(
         if arena_scf::Yield::matches(ctx, op) {
             let yielded_operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
             if let Some(&result) = yielded_operands.first() {
-                let remapped = value_remap.get(&result).copied().unwrap_or(result);
+                let remapped = mapping.lookup_value_or_default(result);
                 let y = arena_scf::r#yield(ctx, loc, [remapped]);
                 ctx.push_op(new_block, y.op_ref());
                 has_yield = true;
             }
             continue;
         }
-        clone_op_into_block_with_remap(ctx, new_block, op, &value_remap);
-
-        // Map old results -> new results
-        let new_ops = ctx.block(new_block).ops.clone();
-        if let Some(&new_op) = new_ops.last() {
-            let old_results: Vec<ValueRef> = ctx.op_results(op).to_vec();
-            let new_results: Vec<ValueRef> = ctx.op_results(new_op).to_vec();
-            for (old_r, new_r) in old_results.into_iter().zip(new_results) {
-                value_remap.insert(old_r, new_r);
-            }
-        }
+        ctx.clone_op_into_block(new_block, op, &mut mapping);
     }
 
     if !has_yield {
@@ -506,118 +484,4 @@ fn cast_if_needed(
         ctx.push_op(block, cast.op_ref());
         cast.result(ctx)
     }
-}
-
-/// Clone an operation into a new block, applying a value remap to operands.
-///
-/// Results of the cloned operation are added to the remap so that subsequent
-/// cloned ops pick them up automatically.
-///
-/// Nested regions are deep-cloned so that captured values inside them
-/// are remapped correctly.
-pub(crate) fn clone_op_into_block_with_remap(
-    ctx: &mut IrContext,
-    dest_block: trunk_ir::refs::BlockRef,
-    src_op: OpRef,
-    value_remap: &HashMap<ValueRef, ValueRef>,
-) {
-    use trunk_ir::context::OperationDataBuilder;
-
-    let data = ctx.op(src_op);
-    let loc = data.location;
-    let dialect = data.dialect;
-    let name = data.name;
-    let attrs = data.attributes.clone();
-    let regions: Vec<_> = data.regions.to_vec();
-    let successors: Vec<_> = data.successors.to_vec();
-    let operands: Vec<_> = ctx.op_operands(src_op).to_vec();
-    let result_types: Vec<_> = ctx.op_result_types(src_op).to_vec();
-
-    let mut builder = OperationDataBuilder::new(loc, dialect, name);
-    for &v in &operands {
-        let remapped = value_remap.get(&v).copied().unwrap_or(v);
-        builder = builder.operand(remapped);
-    }
-    for &ty in &result_types {
-        builder = builder.result(ty);
-    }
-    for (k, v) in attrs {
-        builder = builder.attr(k, v);
-    }
-    for r in regions {
-        let cloned_region = deep_clone_region(ctx, r, value_remap);
-        builder = builder.region(cloned_region);
-    }
-    for s in successors {
-        builder = builder.successor(s);
-    }
-
-    let data = builder.build(ctx);
-    let new_op = ctx.create_op(data);
-    ctx.push_op(dest_block, new_op);
-}
-
-/// Deep-clone a region, recursively remapping values in all nested ops.
-fn deep_clone_region(
-    ctx: &mut IrContext,
-    region: RegionRef,
-    parent_remap: &HashMap<ValueRef, ValueRef>,
-) -> RegionRef {
-    let region_data = ctx.region(region);
-    let loc = region_data.location;
-    let src_blocks: Vec<_> = region_data.blocks.to_vec();
-
-    let mut remap = parent_remap.clone();
-    let mut new_blocks = Vec::with_capacity(src_blocks.len());
-
-    for &src_block in &src_blocks {
-        let src_args = ctx.block_args(src_block).to_vec();
-        let arg_data: Vec<BlockArgData> = src_args
-            .iter()
-            .map(|&v| BlockArgData {
-                ty: ctx.value_ty(v),
-                attrs: Default::default(),
-            })
-            .collect();
-
-        let new_block = ctx.create_block(BlockData {
-            location: ctx.block(src_block).location,
-            args: arg_data,
-            ops: smallvec![],
-            parent_region: None,
-        });
-
-        // Map old block args -> new block args
-        let new_args = ctx.block_args(new_block).to_vec();
-        for (old_arg, new_arg) in src_args.into_iter().zip(new_args) {
-            remap.insert(old_arg, new_arg);
-        }
-
-        new_blocks.push((src_block, new_block));
-    }
-
-    // Clone ops in each block
-    for &(src_block, new_block) in &new_blocks {
-        let src_ops: Vec<OpRef> = ctx.block(src_block).ops.clone().to_vec();
-        for &op in &src_ops {
-            clone_op_into_block_with_remap(ctx, new_block, op, &remap);
-
-            // Map old results -> new results
-            let new_ops_list = ctx.block(new_block).ops.clone();
-            if let Some(&new_op) = new_ops_list.last() {
-                let old_results: Vec<ValueRef> = ctx.op_results(op).to_vec();
-                let new_results: Vec<ValueRef> = ctx.op_results(new_op).to_vec();
-                for (old_r, new_r) in old_results.into_iter().zip(new_results) {
-                    remap.insert(old_r, new_r);
-                }
-            }
-        }
-    }
-
-    let block_refs: Vec<_> = new_blocks.into_iter().map(|(_, b)| b).collect();
-    ctx.create_region(RegionData {
-        location: loc,
-        blocks: block_refs.into(),
-        parent_op: None,
-    })
 }

--- a/crates/tribute-passes/src/cont_to_libmprompt/push_prompt.rs
+++ b/crates/tribute-passes/src/cont_to_libmprompt/push_prompt.rs
@@ -243,9 +243,6 @@ fn generate_outlined_body(
     body_region: RegionRef,
     loc: trunk_ir::types::Location,
 ) -> OpRef {
-    use super::handler_dispatch::clone_op_into_block_with_remap;
-    use std::collections::HashMap;
-
     let ptr_ty = arena_core::ptr(ctx).as_type_ref();
 
     // Create entry block with ptr parameter (the env struct)
@@ -261,7 +258,7 @@ fn generate_outlined_body(
     let env_value = ctx.block_args(entry_block)[0];
 
     // Build value remap: live-in values -> extracted values from env struct
-    let mut value_remap: HashMap<ValueRef, ValueRef> = HashMap::new();
+    let mut mapping = trunk_ir::IrMapping::new();
 
     if !live_ins.is_empty() {
         let env_struct_ty = build_env_struct_type(ctx, live_ins.len(), ptr_ty);
@@ -284,7 +281,7 @@ fn generate_outlined_body(
                 field.result(ctx)
             };
 
-            value_remap.insert(orig_value, extracted);
+            mapping.map_value(orig_value, extracted);
         }
     }
 
@@ -299,32 +296,22 @@ fn generate_outlined_body(
                 let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
                 last_result = operands
                     .first()
-                    .map(|&v| value_remap.get(&v).copied().unwrap_or(v));
+                    .map(|&v| mapping.lookup_value_or_default(v));
                 continue;
             }
             if arena_func::Return::matches(ctx, op) {
                 let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
                 last_result = operands
                     .first()
-                    .map(|&v| value_remap.get(&v).copied().unwrap_or(v));
+                    .map(|&v| mapping.lookup_value_or_default(v));
                 continue;
             }
 
             // Clone op into entry block with value remapping
-            clone_op_into_block_with_remap(ctx, entry_block, op, &value_remap);
+            let new_op = ctx.clone_op_into_block(entry_block, op, &mut mapping);
 
-            // Map old results -> new results for subsequent ops
-            let new_ops = ctx.block(entry_block).ops.clone();
-            if let Some(&new_op) = new_ops.last() {
-                let old_results: Vec<ValueRef> = ctx.op_results(op).to_vec();
-                let new_results: Vec<ValueRef> = ctx.op_results(new_op).to_vec();
-                for (old_r, new_r) in old_results.into_iter().zip(new_results) {
-                    value_remap.insert(old_r, new_r);
-                }
-
-                if !ctx.op_results(new_op).is_empty() {
-                    last_result = Some(ctx.op_results(new_op)[0]);
-                }
+            if !ctx.op_results(new_op).is_empty() {
+                last_result = Some(ctx.op_results(new_op)[0]);
             }
         }
     }

--- a/crates/tribute-passes/src/tr_dispatch.rs
+++ b/crates/tribute-passes/src/tr_dispatch.rs
@@ -45,10 +45,7 @@
 //! }
 //! ```
 
-use std::collections::HashMap;
-
 use tribute_ir::dialect::ability as arena_ability;
-use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::adt as arena_adt;
 use trunk_ir::dialect::arith;
@@ -60,6 +57,7 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::Module;
 use trunk_ir::types::{Attribute, Location};
+use trunk_ir::{IrMapping, Symbol};
 
 use crate::cont_util::{SuspendArm, collect_suspend_arms, compute_op_idx};
 use crate::tail_resumptive;
@@ -516,22 +514,25 @@ fn emit_arm_value_computation(
     };
 
     // Build value remapping: original shift_value -> dispatch function's shift_value
-    let mut remap: HashMap<ValueRef, ValueRef> = HashMap::new();
-    remap.insert(extraction.shift_value_arg, shift_value_arg);
+    let mut mapping = IrMapping::from_values([(extraction.shift_value_arg, shift_value_arg)]);
 
     // Clone each op, remapping operands
     for &src_op in &extraction.ops_to_clone {
-        let new_op = clone_op_with_remap(ctx, src_op, &mut remap);
-        ctx.push_op(target_block, new_op);
+        // TR dispatch only handles flat ops (no nested regions)
+        assert!(
+            ctx.op(src_op).regions.is_empty(),
+            "clone in TR dispatch: cannot clone region-bearing op {}.{}; \
+             TR dispatch extraction does not support nested regions",
+            ctx.op(src_op).dialect,
+            ctx.op(src_op).name,
+        );
+        ctx.clone_op_into_block(target_block, src_op, &mut mapping);
     }
 
     // Get the remapped resume_value
-    let result_val = if let Some(&remapped) = remap.get(&extraction.resume_value) {
-        remapped
-    } else {
-        // resume_value is the shift_value itself (not produced by any cloned op)
-        shift_value_arg
-    };
+    let result_val = mapping
+        .lookup_value(extraction.resume_value)
+        .unwrap_or(shift_value_arg);
 
     // Cast result to ptr if needed (dispatch function returns ptr)
     let result_ty = ctx.value_ty(result_val);
@@ -551,66 +552,6 @@ fn emit_arm_value_computation(
     } else {
         result_val
     }
-}
-
-/// Clone an operation with operand remapping.
-/// Updates remap with the new result values.
-///
-/// # Panics
-///
-/// Panics if the source operation has nested regions (e.g., `scf.if`, loops).
-/// Region-bearing ops are not supported in TR dispatch extraction; they should
-/// be filtered out by `is_arm_self_contained`.
-fn clone_op_with_remap(
-    ctx: &mut IrContext,
-    src_op: OpRef,
-    remap: &mut HashMap<ValueRef, ValueRef>,
-) -> OpRef {
-    let op_data = ctx.op(src_op);
-    let loc = op_data.location;
-    let dialect = op_data.dialect;
-    let name = op_data.name;
-
-    // Reject region-bearing ops — they cannot be shallow-cloned safely
-    assert!(
-        op_data.regions.is_empty(),
-        "clone_op_with_remap: cannot clone region-bearing op {dialect}.{name}; \
-         TR dispatch extraction does not support nested regions"
-    );
-
-    // Remap operands
-    let operands: Vec<ValueRef> = ctx
-        .op_operands(src_op)
-        .iter()
-        .map(|&v| remap.get(&v).copied().unwrap_or(v))
-        .collect();
-
-    // Get result types
-    let result_types: Vec<TypeRef> = ctx.op_result_types(src_op).to_vec();
-
-    // Clone attributes
-    let attributes = op_data.attributes.clone();
-
-    // Build new op
-    let mut builder = trunk_ir::context::OperationDataBuilder::new(loc, dialect, name);
-    for operand in &operands {
-        builder = builder.operand(*operand);
-    }
-    for result_ty in &result_types {
-        builder = builder.result(*result_ty);
-    }
-    let mut op_data = builder.build(ctx);
-    op_data.attributes = attributes;
-    let new_op = ctx.create_op(op_data);
-
-    // Update remap for results
-    let old_results = ctx.op_results(src_op);
-    let new_results = ctx.op_results(new_op);
-    for (old_r, new_r) in old_results.iter().zip(new_results.iter()) {
-        remap.insert(*old_r, *new_r);
-    }
-
-    new_op
 }
 
 // ============================================================================

--- a/crates/trunk-ir/src/context.rs
+++ b/crates/trunk-ir/src/context.rs
@@ -11,6 +11,7 @@ use smallvec::SmallVec;
 
 use super::refs::*;
 use super::types::*;
+use crate::ir_mapping::IrMapping;
 use crate::symbol::Symbol;
 
 // ============================================================================
@@ -528,6 +529,145 @@ impl IrContext {
     // ========================================================================
     // RAUW (Replace All Uses With)
     // ========================================================================
+
+    // ========================================================================
+    // Deep Clone
+    // ========================================================================
+
+    /// Clone an operation, remapping operands, successors, and nested regions.
+    ///
+    /// - Operands are remapped via `mapping.lookup_value_or_default()`.
+    /// - Successors are remapped via `mapping.lookup_block_or_default()`.
+    /// - Nested regions are recursively deep-cloned via [`clone_region`].
+    /// - Result values are automatically registered in the mapping
+    ///   (old results → new results).
+    ///
+    /// The cloned operation is **not** attached to any block. Use
+    /// [`push_op`] or [`clone_op_into_block`] to insert it.
+    pub fn clone_op(&mut self, src_op: OpRef, mapping: &mut IrMapping) -> OpRef {
+        // Copy all data from src_op into locals to avoid borrow conflicts.
+        let data = &self.ops[src_op];
+        let loc = data.location;
+        let dialect = data.dialect;
+        let name = data.name;
+        let attrs = data.attributes.clone();
+        let regions: SmallVec<[RegionRef; 4]> = data.regions.clone();
+        let successors: SmallVec<[BlockRef; 4]> = data.successors.clone();
+        let operands: SmallVec<[ValueRef; 8]> = data.operands.as_slice(&self.value_pool).into();
+        let result_types: SmallVec<[TypeRef; 4]> = data.results.as_slice(&self.type_pool).into();
+
+        // Build new operation with remapped operands and successors.
+        let mut builder = OperationDataBuilder::new(loc, dialect, name);
+        for &v in &operands {
+            builder = builder.operand(mapping.lookup_value_or_default(v));
+        }
+        for ty in &result_types {
+            builder = builder.result(*ty);
+        }
+        for (k, v) in attrs {
+            builder = builder.attr(k, v);
+        }
+        for &r in &regions {
+            let cloned_region = self.clone_region(r, mapping);
+            builder = builder.region(cloned_region);
+        }
+        for &s in &successors {
+            builder = builder.successor(mapping.lookup_block_or_default(s));
+        }
+
+        let op_data = builder.build(self);
+        let new_op = self.create_op(op_data);
+
+        // Register result value mappings: old results → new results.
+        let old_results: SmallVec<[ValueRef; 4]> =
+            self.result_values[src_op].as_slice(&self.value_pool).into();
+        let new_results: SmallVec<[ValueRef; 4]> =
+            self.result_values[new_op].as_slice(&self.value_pool).into();
+        for (old_r, new_r) in old_results.into_iter().zip(new_results) {
+            mapping.map_value(old_r, new_r);
+        }
+
+        new_op
+    }
+
+    /// Deep-clone a region, recursively remapping all values and blocks.
+    ///
+    /// Uses a 2-pass approach to handle forward block references:
+    /// 1. Create all block headers (with arguments), register block/arg
+    ///    mappings.
+    /// 2. Clone operations in each block using [`clone_op`].
+    ///
+    /// Values not in the mapping (external references) pass through
+    /// unchanged.
+    pub fn clone_region(&mut self, src_region: RegionRef, mapping: &mut IrMapping) -> RegionRef {
+        let loc = self.regions[src_region].location;
+        let src_blocks: SmallVec<[BlockRef; 4]> = self.regions[src_region].blocks.clone();
+
+        let mut new_blocks = Vec::with_capacity(src_blocks.len());
+
+        // Pass 1: create block headers and register block/arg mappings.
+        for &src_block in &src_blocks {
+            let src_args: SmallVec<[ValueRef; 4]> = self.block_arg_values[src_block]
+                .as_slice(&self.value_pool)
+                .into();
+            let arg_data: Vec<BlockArgData> = self.blocks[src_block]
+                .args
+                .iter()
+                .map(|a| BlockArgData {
+                    ty: a.ty,
+                    attrs: a.attrs.clone(),
+                })
+                .collect();
+            let block_loc = self.blocks[src_block].location;
+
+            let new_block = self.create_block(BlockData {
+                location: block_loc,
+                args: arg_data,
+                ops: SmallVec::new(),
+                parent_region: None,
+            });
+
+            mapping.map_block(src_block, new_block);
+
+            let new_args: SmallVec<[ValueRef; 4]> = self.block_arg_values[new_block]
+                .as_slice(&self.value_pool)
+                .into();
+            for (old_arg, new_arg) in src_args.into_iter().zip(new_args) {
+                mapping.map_value(old_arg, new_arg);
+            }
+
+            new_blocks.push(new_block);
+        }
+
+        // Pass 2: clone operations in each block.
+        for (&src_block, &new_block) in src_blocks.iter().zip(new_blocks.iter()) {
+            let src_ops: SmallVec<[OpRef; 4]> = self.blocks[src_block].ops.clone();
+            for &op in &src_ops {
+                let new_op = self.clone_op(op, mapping);
+                self.push_op(new_block, new_op);
+            }
+        }
+
+        self.create_region(RegionData {
+            location: loc,
+            blocks: new_blocks.into(),
+            parent_op: None,
+        })
+    }
+
+    /// Clone an operation and append it to a destination block.
+    ///
+    /// Convenience wrapper around [`clone_op`] + [`push_op`].
+    pub fn clone_op_into_block(
+        &mut self,
+        dest: BlockRef,
+        src_op: OpRef,
+        mapping: &mut IrMapping,
+    ) -> OpRef {
+        let new_op = self.clone_op(src_op, mapping);
+        self.push_op(dest, new_op);
+        new_op
+    }
 
     /// Replace all uses of `old` with `new` in all operations.
     ///
@@ -1323,5 +1463,173 @@ mod tests {
             blocks: smallvec![block],
             parent_op: None,
         });
+    }
+
+    // ====================================================================
+    // Deep clone tests
+    // ====================================================================
+
+    /// Helper: parse IR, clone the first func's body region, add the
+    /// clone as a new func, and print the whole module.
+    fn clone_first_func_region(input: &str, new_name: &'static str) -> String {
+        use crate::parser::parse_test_module;
+        use crate::printer::print_module;
+
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        // Find the first func.func in the module's top-level block
+        let module_region = ctx.op(module.op()).regions[0];
+        let module_block = ctx.region(module_region).blocks[0];
+        let func_op = ctx
+            .block(module_block)
+            .ops
+            .iter()
+            .copied()
+            .find(|&op| {
+                ctx.op(op).dialect == Symbol::new("func") && ctx.op(op).name == Symbol::new("func")
+            })
+            .expect("no func.func found");
+
+        // Clone the body region
+        let body_region = ctx.op(func_op).regions[0];
+        let mut mapping = IrMapping::new();
+        let cloned_region = ctx.clone_region(body_region, &mut mapping);
+
+        // Build a new func.func with the cloned region
+        let func_ty = ctx
+            .op(func_op)
+            .attributes
+            .get(&Symbol::new("type"))
+            .cloned()
+            .unwrap();
+        let new_func = OperationDataBuilder::new(
+            ctx.op(func_op).location,
+            Symbol::new("func"),
+            Symbol::new("func"),
+        )
+        .attr("sym_name", Attribute::Symbol(Symbol::new(new_name)))
+        .attr("type", func_ty)
+        .region(cloned_region)
+        .build(&mut ctx);
+        let new_func_op = ctx.create_op(new_func);
+
+        // Add to module
+        let module_region = ctx.op(module.op()).regions[0];
+        let module_block = ctx.region(module_region).blocks[0];
+        ctx.push_op(module_block, new_func_op);
+
+        print_module(&ctx, module.op())
+    }
+
+    #[test]
+    fn clone_flat_ops() {
+        let output = clone_first_func_region(
+            r#"core.module @test {
+  func.func @original() -> core.i32 {
+    %0 = arith.const {value = 7} : core.i32
+    %1 = arith.neg %0 : core.i32
+    func.return %1
+  }
+}"#,
+            "cloned",
+        );
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn clone_op_with_nested_region() {
+        let output = clone_first_func_region(
+            r#"core.module @test {
+  func.func @original(%0: core.i1) -> core.i32 {
+    %1 = scf.if %0 : core.i32 {
+      %2 = arith.const {value = 1} : core.i32
+      scf.yield %2
+    } {
+      %3 = arith.const {value = 2} : core.i32
+      scf.yield %3
+    }
+    func.return %1
+  }
+}"#,
+            "cloned",
+        );
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn clone_region_with_forward_block_ref() {
+        let output = clone_first_func_region(
+            r#"core.module @test {
+  func.func @original() -> core.i32 {
+  ^bb0:
+    %0 = arith.const {value = 1} : core.i32
+    cf.br %0 [^bb1]
+  ^bb1(%1: core.i32):
+    func.return %1
+  }
+}"#,
+            "cloned",
+        );
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn clone_external_values_passthrough() {
+        // External values (defined outside the cloned region) pass through
+        // unchanged. We test this by cloning a flat op directly.
+        use crate::printer::print_op;
+
+        let mut ctx = IrContext::new();
+        let loc = test_location(&mut ctx);
+        let i32_ty = i32_type(&mut ctx);
+
+        let ext_data = OperationDataBuilder::new(loc, Symbol::new("arith"), Symbol::new("const"))
+            .result(i32_ty)
+            .build(&mut ctx);
+        let ext_op = ctx.create_op(ext_data);
+        let ext_val = ctx.op_result(ext_op, 0);
+
+        let op_data = OperationDataBuilder::new(loc, Symbol::new("arith"), Symbol::new("neg"))
+            .operand(ext_val)
+            .result(i32_ty)
+            .build(&mut ctx);
+        let op = ctx.create_op(op_data);
+
+        let mut mapping = IrMapping::new();
+        let cloned = ctx.clone_op(op, &mut mapping);
+
+        // Cloned op should reference the same external value
+        assert_eq!(ctx.op_operands(cloned), &[ext_val]);
+
+        // Both original and clone should print the same textual form
+        assert_eq!(print_op(&ctx, op), print_op(&ctx, cloned));
+    }
+
+    #[test]
+    fn clone_op_result_mapping() {
+        let mut ctx = IrContext::new();
+        let loc = test_location(&mut ctx);
+        let i32_ty = i32_type(&mut ctx);
+
+        let data = OperationDataBuilder::new(loc, Symbol::new("test"), Symbol::new("multi"))
+            .result(i32_ty)
+            .result(i32_ty)
+            .build(&mut ctx);
+        let op = ctx.create_op(data);
+        let r0 = ctx.op_result(op, 0);
+        let r1 = ctx.op_result(op, 1);
+
+        let mut mapping = IrMapping::new();
+        let cloned = ctx.clone_op(op, &mut mapping);
+
+        let cr0 = ctx.op_result(cloned, 0);
+        let cr1 = ctx.op_result(cloned, 1);
+
+        // Old results should map to new results
+        assert_eq!(mapping.lookup_value(r0), Some(cr0));
+        assert_eq!(mapping.lookup_value(r1), Some(cr1));
+        assert_ne!(r0, cr0);
+        assert_ne!(r1, cr1);
     }
 }

--- a/crates/trunk-ir/src/ir_mapping.rs
+++ b/crates/trunk-ir/src/ir_mapping.rs
@@ -24,6 +24,17 @@ impl IrMapping {
         Self::default()
     }
 
+    /// Create a mapping pre-populated with value correspondences.
+    ///
+    /// Useful for converting existing `HashMap<ValueRef, ValueRef>` into
+    /// an `IrMapping`.
+    pub fn from_values(iter: impl IntoIterator<Item = (ValueRef, ValueRef)>) -> Self {
+        Self {
+            values: iter.into_iter().collect(),
+            blocks: HashMap::new(),
+        }
+    }
+
     /// Map an old value to a new value.
     pub fn map_value(&mut self, from: ValueRef, to: ValueRef) {
         self.values.insert(from, to);

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -28,6 +28,9 @@ pub mod types;
 // === Dialect definitions ===
 pub mod dialect;
 
+// === IR mapping for clone/transform ===
+pub mod ir_mapping;
+
 // === IR infrastructure ===
 pub mod printer;
 pub mod rewrite;
@@ -65,6 +68,7 @@ pub use context::{
     BlockArgData, BlockData, IrContext, OperationData, OperationDataBuilder, RegionData, Use,
     ValueData,
 };
+pub use ir_mapping::IrMapping;
 pub use refs::{BlockRef, OpRef, PathRef, RegionRef, TypeRef, ValueDef, ValueRef};
 pub use rewrite::Module;
 pub use types::{Attribute, Location, PathInterner, TypeData, TypeDataBuilder, TypeInterner};

--- a/crates/trunk-ir/src/snapshots/trunk_ir__context__tests__clone_flat_ops.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__context__tests__clone_flat_ops.snap
@@ -1,0 +1,16 @@
+---
+source: crates/trunk-ir/src/context.rs
+expression: output
+---
+core.module @test {
+  func.func @original() -> core.i32 {
+      %0 = arith.const {value = 7} : core.i32
+      %1 = arith.neg %0 : core.i32
+      func.return %1
+  }
+  func.func @cloned() -> core.i32 {
+      %0 = arith.const {value = 7} : core.i32
+      %1 = arith.neg %0 : core.i32
+      func.return %1
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__context__tests__clone_op_with_nested_region.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__context__tests__clone_op_with_nested_region.snap
@@ -1,0 +1,28 @@
+---
+source: crates/trunk-ir/src/context.rs
+expression: output
+---
+core.module @test {
+  func.func @original(%0: core.i1) -> core.i32 {
+    ^bb0:
+      %1 = scf.if %0 : core.i32 {
+          %2 = arith.const {value = 1} : core.i32
+          scf.yield %2
+      } {
+          %3 = arith.const {value = 2} : core.i32
+          scf.yield %3
+      }
+      func.return %1
+  }
+  func.func @cloned(%0: core.i1) -> core.i32 {
+    ^bb0:
+      %1 = scf.if %0 : core.i32 {
+          %2 = arith.const {value = 1} : core.i32
+          scf.yield %2
+      } {
+          %3 = arith.const {value = 2} : core.i32
+          scf.yield %3
+      }
+      func.return %1
+  }
+}

--- a/crates/trunk-ir/src/snapshots/trunk_ir__context__tests__clone_region_with_forward_block_ref.snap
+++ b/crates/trunk-ir/src/snapshots/trunk_ir__context__tests__clone_region_with_forward_block_ref.snap
@@ -1,0 +1,20 @@
+---
+source: crates/trunk-ir/src/context.rs
+expression: output
+---
+core.module @test {
+  func.func @original() -> core.i32 {
+    ^bb0:
+      %0 = arith.const {value = 1} : core.i32
+      cf.br %0 [^bb1]
+    ^bb1(%1: core.i32):
+      func.return %1
+  }
+  func.func @cloned() -> core.i32 {
+    ^bb0:
+      %0 = arith.const {value = 1} : core.i32
+      cf.br %0 [^bb1]
+    ^bb1(%1: core.i32):
+      func.return %1
+  }
+}


### PR DESCRIPTION
## Summary

- Add `IrContext::clone_op()`, `clone_region()`, and `clone_op_into_block()` — an MLIR-style deep clone API for TrunkIR
- Add `IrMapping::from_values()` constructor and re-export `IrMapping` from the `trunk-ir` crate root
- Use a two-pass approach when cloning regions so forward block references are resolved correctly
- Refactor `cont_to_libmprompt/handler_dispatch.rs`, `cont_to_libmprompt/push_prompt.rs`, and `tr_dispatch.rs` to use the new centralized API, removing ~150 lines of duplicated manual clone logic
- Add snapshot-based unit tests covering flat op cloning, nested regions, and forward block references

## Motivation

Three separate passes in `tribute-passes` each contained hand-rolled op/region duplication logic. The logic was non-trivial (value remapping, block argument fixup, successor patching) and diverged subtly across the three sites. Centralizing it in `IrContext` makes future passes easier to write correctly and keeps the duplication surface to a single well-tested implementation.

## Test plan

- [ ] `cargo nextest run -p trunk-ir` — new snapshot tests for `clone_op`, `clone_region`, `clone_op_with_nested_region`, `clone_region_with_forward_block_ref`
- [ ] `cargo nextest run --workspace` — full suite passes with refactored passes
- [ ] `cargo insta review` if snapshot files need updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deep-cloning capabilities for IR operations and regions with value and block remapping support.
  * Introduced `IrMapping` abstraction for managing value and block correspondence during transformations.

* **Refactor**
  * Consolidated remapping logic across multiple components using unified `IrMapping` approach instead of manual HashMap handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->