### PR TITLE
Unignore flaky ability tests and update docs

### DIFF
--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -32,7 +32,7 @@ graph TD
     subgraph "tribute-passes/src/native/ (tribute-ir 의존)"
         lower["lower.rs — 오케스트레이션"]
         type_conv["type_converter.rs — 네이티브 타입 변환"]
-        cont_libmprompt["cont_to_libmprompt.rs — effect lowering"]
+        cont_yb["cont_to_yield_bubbling — effect lowering"]
         rc["rc.rs — RC 삽입 (future)"]
     end
 
@@ -41,12 +41,12 @@ graph TD
     end
 
     dialects --> passes
-    dialects --> cont_libmprompt
+    dialects --> cont_yb
     passes --> translate
     translate --> function
     translate --> validation
     lower --> passes
-    lower --> cont_libmprompt
+    lower --> cont_yb
     pipeline --> lower
     pipeline --> translate
 ```
@@ -62,7 +62,7 @@ flowchart TB
     input["TrunkIR Module\n(cont.*, func.*, arith.*, scf.*, adt.*)"]
 
     subgraph native_passes["tribute-passes/src/native/"]
-        cont["cont_to_libmprompt\ncont.* → libmprompt FFI 호출"]
+        cont["cont_to_yield_bubbling\ncont.* → ADT-based yield bubbling"]
         rc_pass["rc 삽입 (future)\nretain/release 삽입"]
     end
 
@@ -92,7 +92,7 @@ flowchart TB
 
 | 측면 | WASM | Native |
 | ---- | ---- | ------ |
-| Effect | trampoline (yield bubbling) | libmprompt (스택 관리) |
+| Effect | yield bubbling (ADT-based) | yield bubbling (ADT-based) |
 | 메모리 | WasmGC (런타임 GC) | Reference Counting |
 | ADT | GC struct/array | 포인터 + load/store |
 | 제어 흐름 | Structured (block/loop/if) | CFG (brif/jump/br_table) |
@@ -114,12 +114,12 @@ Cranelift IR과 1:1 대응하는 저수준 연산. 전체 연산 목록은 [ir.m
 
 ---
 
-## Effect 구현: libmprompt
+## Effect 구현: Yield Bubbling
 
-WASM의 trampoline 방식과 달리, libmprompt가 스택 자체를 관리하므로
-라이브 변수 캡처/state struct가 불필요하다.
+WASM과 Native 모두 ADT 기반 yield bubbling을 사용한다.
+`cont_to_yield_bubbling` pass가 cont.* 연산을 ADT enum/struct로 변환.
 
-상세 내용은 [implementation.md](implementation.md#cranelift-libmprompt)를 참조.
+상세 내용은 [implementation.md](implementation.md#cranelift-yield-bubbling)를 참조.
 
 ---
 
@@ -166,11 +166,10 @@ Array:  [length: i64] [elements...]
 - RC retain/release 삽입 pass
 - Valgrind / AddressSanitizer 검증
 
-### Phase 4: libmprompt 기반 Effect
+### Phase 4: ADT-based Yield Bubbling Effect
 
-- `cont_to_libmprompt` pass
+- `cont_to_yield_bubbling` pass (WASM/Native 공유)
 - Evidence 런타임 (native)
-- libmprompt 정적 링킹
 
 ### Phase 5: E2E 파이프라인
 
@@ -181,7 +180,5 @@ Array:  [length: i64] [elements...]
 
 ## References
 
-- [libmprompt](https://github.com/koka-lang/libmprompt)
-  — Koka 언어의 delimited continuation 런타임
 - [Cranelift](https://cranelift.dev/) — Rust로 작성된 코드 생성기
 - [wasm-backend.md](wasm-backend.md) — WASM 백엔드 아키텍처 (대칭 구조)

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -399,58 +399,20 @@ fn effectful_call(ev: *const Evidence) -> Result<T, Yield> {
 (resume $cont (local.get $value))
 ```
 
-### Cranelift (libmprompt)
+### Cranelift (Yield Bubbling)
 
-**libmprompt C FFI:**
+Native 백엔드는 ADT 기반 yield bubbling으로 ability를 구현한다.
+`cont_to_yield_bubbling` pass가 cont.* 연산을 ADT enum/struct로 변환한다.
+(WASM 백엔드는 별도의 `cont_to_trampoline` pass를 사용.)
 
-```c
-void* mp_prompt(mp_prompt_t* p, mp_start_fun_t* fun, void* arg);
-void* mp_yield(mp_prompt_t* p, mp_yield_fun_t* fun, void* arg);
-void* mp_resume(mp_resume_t* r, void* result);
-void  mp_resume_drop(mp_resume_t* r);
-```
+**cont.* → yield bubbling 매핑:**
 
-libmprompt는 setjmp/longjmp + 스택 복사로 delimited continuation을 구현한다.
-
-**cont.* → libmprompt 매핑:**
-
-| cont.* op | libmprompt 호출 | 설명 |
-| --------- | --------------- | ---- |
-| `cont.push_prompt` | `mp_prompt(&p, body_fn, env)` | body region을 별도 함수로 outline 후 호출 |
-| `cont.shift` | `mp_yield(%tag, yield_fn, %yr)` | YieldResult { op_idx, shift_value } 할당 |
-| `cont.resume(k, val)` | `mp_resume(yr.resume, box(val))` | 캡처된 continuation 재개 |
-| `cont.drop(k)` | `mp_resume_drop(yr.resume)` | continuation 폐기 |
-
-**Done/Shift 프로토콜:**
-
-`mp_prompt` 반환 후 body가 정상 완료(Done)인지 yield(Shift)인지 구분이 필요하다.
-Thread-local `__tribute_yield_active` 플래그를 사용:
-
-```text
-mp_prompt 반환 →
-  if __tribute_yield_active == false → Done: 결과값 직접 반환
-  if __tribute_yield_active == true  → Shift: handler_dispatch 각 arm으로 분기
-```
-
-**메모리 레이아웃:**
-
-```text
-┌─────────────────┐
-│ Main Stack      │
-├─────────────────┤
-│ Prompt P1       │ ← marker
-├─────────────────┤
-│ Stack Segment   │
-├─────────────────┤
-│ Prompt P2       │ ← marker
-├─────────────────┤
-│ Current Frame   │
-└─────────────────┘
-```
-
-Continuation 캡처 시 해당 prompt까지의 스택 세그먼트를 힙에 복사.
-WASM의 trampoline과 달리 라이브 변수 캡처/state struct가 불필요 —
-libmprompt가 스택 자체를 관리.
+| cont.* op | 변환 결과 | 설명 |
+| --------- | --------- | ---- |
+| `cont.push_prompt` | body 호출 + handler dispatch loop | YieldResult enum으로 Done/Shift 구분 |
+| `cont.shift` | state 캡처 + Continuation struct + YieldResult::Shift 반환 | 라이브 변수를 ADT struct에 저장 |
+| `cont.resume(k, val)` | Continuation에서 resume_fn 추출 + call_indirect | 캡처된 상태 복원 후 재개 |
+| `cont.drop(k)` | (no-op) | RC가 자동 관리 |
 
 **파이프라인 분기:**
 
@@ -459,7 +421,7 @@ libmprompt가 스택 자체를 관리.
       → evidence_params → closure_lower → evidence_calls → resolve_evidence
 
 WASM:   → cont_to_trampoline → dce → resolve_casts → lower_to_wasm → emit_wasm
-Native: → cont_to_libmprompt → dce → resolve_casts → lower_to_clif → emit_native
+Native: → cont_to_yield_bubbling → dce → resolve_casts → lower_to_clif → emit_native
 ```
 
 ---
@@ -496,11 +458,9 @@ Cranelift 타겟에서는 **Reference Counting**을 채택한다.
 
 **Continuation과 RC:**
 
-- libmprompt가 캡처한 스택에는 RC 객체 포인터가 포함됨
-- 스택 캡처 시 포함된 모든 RC 객체를 retain
-- `mp_resume_drop` 시 캡처된 스택의 RC 객체를 release
-- 이를 위해 런타임에 "스택 스캔" 또는
-  컴파일 타임 live variable 분석이 필요
+- Yield bubbling에서 continuation은 ADT struct로 캡처됨
+- 캡처된 라이브 변수들은 struct 필드로 저장되어 RC가 자동 관리
+- Resume 시 struct에서 필드를 꺼내 복원
 
 **단계적 구현:**
 
@@ -595,7 +555,7 @@ flowchart TB
     lower_case -->|"scf.if"| dce
     dce --> wasm & cranelift & future
     wasm -->|"yield bubbling"| wasm_bin
-    cranelift -->|"libmprompt"| native
+    cranelift -->|"yield bubbling"| native
 ```
 
 ### 패스 분류
@@ -777,9 +737,7 @@ let idx = evidence_lookup(ev, STATE_ID)  // binary search
 
 - [Generalized Evidence Passing for Effect Handlers][koka-evidence] (Koka)
 - [Effect Handlers, Evidently][effect-evidently] (Scoped Resumption)
-- [libmprompt][libmprompt] (Delimited Continuation Runtime)
 - [Do Be Do Be Do](https://arxiv.org/abs/1611.09259) (Frank, Unison의 기반)
 
 [koka-evidence]: https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers-or-efficient-compilation-of-effect-handlers-to-c/
 [effect-evidently]: https://dl.acm.org/doi/10.1145/3408981
-[libmprompt]: https://github.com/koka-lang/libmprompt

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -916,7 +916,7 @@ impl std::error::Error for LinkError {
 /// Link native object bytes into an executable.
 ///
 /// Writes object bytes to a temp file and invokes the system linker (`cc`),
-/// linking against the tribute runtime library (which includes libmprompt).
+/// linking against the tribute runtime library.
 pub fn link_native_binary(object_bytes: &[u8], output: &Path) -> Result<(), LinkError> {
     let obj_file = tempfile::Builder::new()
         .suffix(".o")
@@ -927,7 +927,7 @@ pub fn link_native_binary(object_bytes: &[u8], output: &Path) -> Result<(), Link
     let mut cmd = std::process::Command::new("cc");
     cmd.arg(obj_file.path());
 
-    // Link tribute-runtime staticlib (bundles both Rust runtime and libmprompt).
+    // Link tribute-runtime staticlib.
     // The library directory is set at build time by build.rs.
     if let Some(static_lib_dir) = option_env!("TRIBUTE_RUNTIME_STATIC_LIB_DIR") {
         cmd.arg("-L").arg(static_lib_dir);

--- a/tests/e2e_ability_core.rs
+++ b/tests/e2e_ability_core.rs
@@ -477,7 +477,6 @@ fn main() { }
 ///
 /// The final return value is 2 (the last counter() call's return).
 #[test]
-#[cfg_attr(target_os = "linux", ignore = "flaky munmap_chunk crash in libmprompt")]
 fn test_ability_core_execution() {
     let code = include_str!("../lang-examples/ability_core.trb");
     let output = compile_and_run_native("ability_core.trb", code);
@@ -492,10 +491,6 @@ fn test_ability_core_execution() {
 
 /// Test simple State::get handler that returns a constant.
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "flaky munmap_chunk crash in libmprompt (#509)"
-)]
 fn test_state_get_simple() {
     let code = r#"ability State(s) {
     fn get() -> s
@@ -525,10 +520,6 @@ fn main() {
 
 /// Test State::set followed by State::get.
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "flaky munmap_chunk crash in libmprompt (#509)"
-)]
 fn test_state_set_then_get() {
     let code = r#"ability State(s) {
     fn get() -> s
@@ -564,10 +555,6 @@ fn main() {
 
 /// Test nested handler calls.
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "flaky munmap_chunk crash in libmprompt (#509)"
-)]
 fn test_nested_state_calls() {
     let code = r#"ability State(s) {
     fn get() -> s
@@ -612,10 +599,6 @@ fn main() {
 /// Stresses the runtime tag uniqueness mechanism more than
 /// `test_nested_state_calls` (5 yields × 3 increments = 15+ prompt frames).
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "flaky munmap_chunk crash in libmprompt (#509)"
-)]
 fn test_nested_state_triple_increment() {
     let code = r#"ability State(s) {
     fn get() -> s
@@ -657,10 +640,6 @@ fn main() {
 
 /// Test direct result path (no effect operations).
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "flaky munmap_chunk crash in libmprompt (#509)"
-)]
 fn test_handler_direct_result() {
     let code = r#"ability State(s) {
     fn get() -> s
@@ -1055,10 +1034,6 @@ fn main() {
 /// `use_both()` calls Reader::ask() → 10, State::set(10) (discarded by stateless handler),
 /// State::get() → 0 (stateless handler returns +0), returns 0+1=1.
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "flaky munmap_chunk crash in libmprompt (#509)"
-)]
 fn test_multiple_abilities_single_handler() {
     let code = r#"ability State(s) {
     fn get() -> s


### PR DESCRIPTION
## Summary

- Remove `#[cfg_attr(target_os = "linux", ignore)]` from 7 ability tests that were flaky due to libmprompt's `munmap_chunk` crash (#509)
- Update `new-plans/implementation.md`: replace libmprompt section with yield bubbling, update pipeline diagram and RC description
- Update `new-plans/cranelift-backend.md`: update effect implementation section, Mermaid diagrams, comparison table, references
- Update `src/pipeline.rs`: remove libmprompt references in linker comments

Depends on #525.
Part 3 of 3: libmprompt removal series. Closes #509.

## Test plan

- [x] `cargo test --test e2e_ability_core` — 39 passed, 0 failed (previously flaky tests now stable)
- [x] Full test suite passes (1065 tests via pre-commit hook)
- [ ] CI Linux: verify previously flaky tests pass without `munmap_chunk` crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated implementation guides and architectural documentation to reflect backend mechanism refinements.

* **Tests**
  * Enabled previously skipped tests on Linux to improve test coverage and stability monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->