### PR TITLE
build(deps): bump winnow from 0.7 to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,9 +1787,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ trunk-ir-cranelift-backend = { path = "crates/trunk-ir-cranelift-backend" }
 trunk-ir-wasm-backend = { path = "crates/trunk-ir-wasm-backend" }
 unsynn = "0.3.0"
 wasm-encoder = "0.245.1"
-winnow = "0.7"
+winnow = "1.0"
 zmij = "1"
 
 [package]

--- a/crates/trunk-ir/src/parser/raw.rs
+++ b/crates/trunk-ir/src/parser/raw.rs
@@ -324,12 +324,14 @@ pub(crate) fn raw_attr_value<'a>(input: &mut &'a str) -> ModalResult<RawAttribut
             (ws, ']'),
         )
         .map(RawAttribute::List),
-        // Float (requires dot: 3.14, -1.0)
-        float_with_dot.map(RawAttribute::Float),
-        // Integer (42, -1)
-        integer_lit.map(RawAttribute::Int),
-        // Type (dialect.name...)
-        raw_type.map(RawAttribute::Type),
+        alt((
+            // Float (requires dot: 3.14, -1.0)
+            float_with_dot.map(RawAttribute::Float),
+            // Integer (42, -1)
+            integer_lit.map(RawAttribute::Int),
+            // Type (dialect.name...)
+            raw_type.map(RawAttribute::Type),
+        )),
     ))
     .parse_next(input)
 }


### PR DESCRIPTION
## Summary

- Upgrades the `winnow` parser combinator crate from 0.7 to 1.0
- Adapts `raw_attr_value` in `crates/trunk-ir/src/parser/raw.rs` to nest the last three branches of an 11-branch `alt()` into a nested `alt()`, since winnow 1.0 reduced the maximum supported tuple arity from 21 to 10

## Test plan

- [ ] `cargo build` succeeds
- [ ] `cargo test` passes (existing parser tests cover `raw_attr_value` parsing of floats, integers, and type attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated `winnow` parsing library dependency to version 1.0

* **Refactor**
  * Reorganized internal parser code structure for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->