### PR TITLE
Use variant name for CtorId in TDNR cons test

### DIFF
--- a/crates/tribute-front/src/tdnr/resolver.rs
+++ b/crates/tribute-front/src/tdnr/resolver.rs
@@ -977,11 +977,12 @@ mod tests {
             },
         );
 
-        let ctor_id = CtorId::new(db, option_name);
+        let some_name = Symbol::new("Some");
+        let ctor_id = CtorId::new(db, some_name);
         let ctor_ref = TypedRef {
             resolved: ResolvedRef::Constructor {
                 id: ctor_id,
-                variant: Symbol::new("Some"),
+                variant: some_name,
             },
             ty: ctor_func_ty,
         };


### PR DESCRIPTION
## Summary

- Fix TDNR test fixture to use variant name (`"Some"`) instead of enum name (`"Option"`) when constructing `CtorId`
- Aligns test data with how `collect_enum_def()` registers constructors

The test still passes because `get_expr_type()` doesn't inspect the `CtorId` value, but this makes the fixture semantically correct.

Closes #553

## Test plan

- [x] `cargo nextest run -p tribute-front -- test_get_expr_type_cons` — both tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored unit test for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->