### PR TITLE
refactor(tests): replace source_from_str helpers with SourceCst::from_source_str

### DIFF
--- a/crates/tribute-front/tests/block_scope.rs
+++ b/crates/tribute-front/tests/block_scope.rs
@@ -5,9 +5,10 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline_with_ir, source_from_str};
+use self::common::run_ast_pipeline_with_ir;
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
 
 // ========================================================================
 // Block Scope Tests - Success Cases
@@ -16,7 +17,7 @@ use salsa_test_macros::salsa_test;
 /// Test that let bindings inside a block are accessible within the block.
 #[salsa_test]
 fn test_block_let_binding_accessible_inside(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -36,7 +37,7 @@ fn example() -> Nat {
 /// Test nested blocks with let bindings at different levels.
 #[salsa_test]
 fn test_nested_blocks_separate_scopes(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -57,7 +58,7 @@ fn example() -> Nat {
 /// Test that outer scope variables are accessible in inner blocks.
 #[salsa_test]
 fn test_outer_scope_accessible_in_inner_block(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -78,7 +79,7 @@ fn example() -> Nat {
 /// Test multiple sequential blocks with independent scopes.
 #[salsa_test]
 fn test_sequential_blocks_independent_scopes(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -103,7 +104,7 @@ fn example() -> Nat {
 /// Test block with case expression containing let bindings in patterns.
 #[salsa_test]
 fn test_block_with_case_pattern_binding(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"

--- a/crates/tribute-front/tests/case_type.rs
+++ b/crates/tribute-front/tests/case_type.rs
@@ -5,9 +5,10 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline_with_ir, source_from_str};
+use self::common::run_ast_pipeline_with_ir;
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
 
 // ========================================================================
 // Basic Case Expression Tests
@@ -17,7 +18,7 @@ use salsa_test_macros::salsa_test;
 /// Pattern type (Nat) should unify with scrutinee type (Nat).
 #[salsa_test]
 fn test_case_nat_literal(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -39,7 +40,7 @@ fn classify(x: Nat) -> Nat {
 /// Pattern type (Int) should unify with scrutinee type (Int).
 #[salsa_test]
 fn test_case_int_literal(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -60,7 +61,7 @@ fn sign(x: Int) -> Int {
 /// Test case expression with Bool patterns.
 #[salsa_test]
 fn test_case_bool_literal(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -80,7 +81,7 @@ fn invert(x: Bool) -> Bool {
 /// Test case expression with enum variant patterns.
 #[salsa_test]
 fn test_case_enum_variant(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -106,7 +107,7 @@ fn unwrap_or(opt: Option(Nat), default: Nat) -> Nat {
 /// All arm body types should unify with the case expression's result type.
 #[salsa_test]
 fn test_case_result_type_unification(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -126,7 +127,7 @@ fn to_nat(b: Bool) -> Nat {
 /// Test nested case expressions.
 #[salsa_test]
 fn test_case_nested(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -1,19 +1,8 @@
 //! Shared test helpers for tribute-front integration tests.
 
-use ropey::Rope;
-use tree_sitter::Parser;
 use tribute_front::SourceCst;
 use trunk_ir::context::IrContext;
 use trunk_ir::printer::print_module;
-
-pub fn source_from_str(db: &dyn salsa::Database, path: &str, text: &str) -> SourceCst {
-    let mut parser = Parser::new();
-    parser
-        .set_language(&tree_sitter_tribute::LANGUAGE.into())
-        .expect("Failed to set language");
-    let tree = parser.parse(text, None).expect("Failed to parse");
-    SourceCst::from_path(db, path, Rope::from_str(text), Some(tree))
-}
 
 /// Run the full AST pipeline (parse → resolve → typecheck → TDNR → IR)
 /// and return the IR text.

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -8,9 +8,10 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline_with_ir, source_from_str};
+use self::common::run_ast_pipeline_with_ir;
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
 
 // ========================================================================
 // Resume Expression Tests
@@ -20,7 +21,7 @@ use salsa_test_macros::salsa_test;
 /// on the continuation closure.
 #[salsa_test]
 fn test_resume_in_op_handler(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -53,7 +54,7 @@ fn main() { }
 /// with a trivial identity continuation.
 #[salsa_test]
 fn test_single_ability_op_in_block(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -78,7 +79,7 @@ fn main() { }
 /// `ability.perform` with a continuation that evaluates the remaining code.
 #[salsa_test]
 fn test_ability_op_then_pure_expr(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -104,7 +105,7 @@ fn main() { }
 /// the first continuation contains the second `ability.perform`.
 #[salsa_test]
 fn test_sequential_ability_ops(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -136,7 +137,7 @@ fn main() { }
 /// - A dispatch body region with `ability.done` and `ability.suspend` ops
 #[salsa_test]
 fn test_handle_with_do_and_op_arms(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -169,7 +170,7 @@ fn main() { }
 /// should work without explicit `resume`.
 #[salsa_test]
 fn test_handle_with_fn_handler(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -206,7 +207,7 @@ fn main() { }
 /// before passing to `ability.perform`.
 #[salsa_test]
 fn test_multi_arg_ability_op(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"

--- a/crates/tribute-front/tests/lambda_effect_type.rs
+++ b/crates/tribute-front/tests/lambda_effect_type.rs
@@ -8,9 +8,10 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline_with_ir, source_from_str};
+use self::common::run_ast_pipeline_with_ir;
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
 
 // ========================================================================
 // Pure Lambda Tests - No Effect Expected
@@ -19,7 +20,7 @@ use salsa_test_macros::salsa_test;
 /// Test that a pure lambda (no effects) is lifted without effect type.
 #[salsa_test]
 fn test_pure_lambda_no_effect(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -38,7 +39,7 @@ fn main() -> Int {
 /// Test that a pure lambda capturing a variable has no effect type.
 #[salsa_test]
 fn test_pure_lambda_with_capture_no_effect(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -65,7 +66,7 @@ fn main() -> Int {
 /// in its lifted function type.
 #[salsa_test]
 fn test_effectful_lambda_direct_ability_call(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -98,7 +99,7 @@ fn main() -> Int {
 /// because `counter` has that effect.
 #[salsa_test]
 fn test_effectful_lambda_indirect_effect_call(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -134,7 +135,7 @@ fn main() -> Int {
 /// Test that multiple ability operations in lambda accumulate effects.
 #[salsa_test]
 fn test_effectful_lambda_multiple_operations(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -178,7 +179,7 @@ fn main() -> Int {
 /// from the outer handler context.
 #[salsa_test]
 fn test_handler_arm_continuation_lambda(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -206,7 +207,7 @@ fn main() -> Int { 0 }
 /// Test the full ability_core pattern with multiple counter calls.
 #[salsa_test]
 fn test_ability_core_full_pattern(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -250,7 +251,7 @@ fn main() -> Int {
 /// Test nested lambdas where inner lambda has effect.
 #[salsa_test]
 fn test_nested_lambda_inner_effectful(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -289,7 +290,7 @@ fn main() -> Int {
 /// the lambda's effect should include State(s) with the row variable e.
 #[salsa_test]
 fn test_lambda_effect_row_unification(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"

--- a/crates/tribute-front/tests/record_field_type.rs
+++ b/crates/tribute-front/tests/record_field_type.rs
@@ -5,15 +5,16 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline, run_ast_pipeline_with_ir, source_from_str};
+use self::common::{run_ast_pipeline, run_ast_pipeline_with_ir};
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
 
 /// Test basic record construction with correct field types.
 /// This should compile successfully.
 #[salsa_test]
 fn test_record_field_type_correct(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -31,7 +32,7 @@ fn make_point() -> Point {
 /// Test record construction with multiple field types.
 #[salsa_test]
 fn test_record_mixed_field_types(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -50,7 +51,7 @@ fn make_person() -> Person {
 /// The spread expression should be constrained to the struct type.
 #[salsa_test]
 fn test_record_spread_same_type(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -68,7 +69,7 @@ fn update_x(p: Point) -> Point {
 /// Test record construction with only spread (no explicit fields).
 #[salsa_test]
 fn test_record_spread_only(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -86,7 +87,7 @@ fn copy_config(c: Config) -> Config {
 /// Test record with generic type parameter.
 #[salsa_test]
 fn test_record_generic_type(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -104,7 +105,7 @@ fn make_pair() -> Pair(Int, Bool) {
 /// Test record field type inference in let binding.
 #[salsa_test]
 fn test_record_field_type_inference(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -127,7 +128,7 @@ fn test() -> Int {
 /// Snapshot test for basic record construction IR.
 #[salsa_test]
 fn test_snapshot_record_construction(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -146,7 +147,7 @@ fn make_point() -> Point {
 /// Snapshot test for record with spread operator.
 #[salsa_test]
 fn test_snapshot_record_spread(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -165,7 +166,7 @@ fn update_x(p: Point) -> Point {
 /// Snapshot test for generic record construction.
 #[salsa_test]
 fn test_snapshot_record_generic(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -185,7 +186,7 @@ fn make_pair() -> Pair(Int, Bool) {
 /// All fields should be extracted via `adt.struct_get` from the base.
 #[salsa_test]
 fn test_snapshot_record_spread_only(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -205,7 +206,7 @@ fn copy_config(c: Config) -> Config {
 /// Explicit fields should take priority over spread values.
 #[salsa_test]
 fn test_snapshot_record_spread_all_fields_explicit(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -224,7 +225,7 @@ fn replace_all(p: Point) -> Point {
 /// Test record spread with a function call as the spread expression.
 #[salsa_test]
 fn test_record_spread_complex_expr(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -254,7 +255,7 @@ fn shift_x() -> Point {
 /// before lowering, regardless of declaration order in the source.
 #[salsa_test]
 fn test_record_forward_reference(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"

--- a/crates/tribute-front/tests/tuple_pattern.rs
+++ b/crates/tribute-front/tests/tuple_pattern.rs
@@ -5,15 +5,16 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline, run_ast_pipeline_with_ir, source_from_str};
+use self::common::{run_ast_pipeline, run_ast_pipeline_with_ir};
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
 
 /// Test basic tuple pattern matching in case expression.
 /// This should infer types correctly without UniVar leakage.
 #[salsa_test]
 fn test_tuple_pattern_basic(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -33,7 +34,7 @@ fn test(x: Bool, y: Bool) -> Int {
 /// Test tuple pattern with nested structure.
 #[salsa_test]
 fn test_tuple_pattern_nested(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -53,7 +54,7 @@ fn test(a: Bool, b: Bool, c: Bool) -> Int {
 /// Test tuple pattern in generic function context.
 #[salsa_test]
 fn test_tuple_pattern_generic(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -79,7 +80,7 @@ fn test() -> Int {
 /// Test basic tuple let destructuring lowers to adt.struct_get with correct types.
 #[salsa_test]
 fn test_tuple_let_destructure_basic(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -98,7 +99,7 @@ fn test() -> Nat {
 /// Test tuple let destructuring with nested tuples.
 #[salsa_test]
 fn test_tuple_let_destructure_nested(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -117,7 +118,7 @@ fn test() -> Nat {
 /// Test tuple let destructuring with wildcard elements.
 #[salsa_test]
 fn test_tuple_let_destructure_wildcard(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -136,7 +137,7 @@ fn test() -> Nat {
 /// Test tuple let destructuring used in function arguments.
 #[salsa_test]
 fn test_tuple_let_destructure_from_function(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"

--- a/src/lsp/completion_index.rs
+++ b/src/lsp/completion_index.rs
@@ -376,21 +376,9 @@ pub fn find_signature(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ropey::Rope;
-    use tree_sitter::Parser;
-    use tribute_front::path_to_uri;
 
     fn make_source(db: &dyn salsa::Database, text: &str) -> SourceCst {
-        let uri = path_to_uri(std::path::Path::new("test.trb"));
-        let rope = Rope::from_str(text);
-
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_tribute::LANGUAGE.into())
-            .expect("Failed to set language");
-        let tree = parser.parse(text, None);
-
-        SourceCst::new(db, uri, rope, tree)
+        SourceCst::from_source_str(db, "test.trb", text)
     }
 
     // Completion tests

--- a/src/lsp/definition_index.rs
+++ b/src/lsp/definition_index.rs
@@ -913,21 +913,9 @@ pub fn validate_identifier(name: &str, kind: DefinitionKind) -> Result<(), Renam
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ropey::Rope;
-    use tree_sitter::Parser;
-    use tribute_front::path_to_uri;
 
     fn make_source(db: &dyn salsa::Database, text: &str) -> SourceCst {
-        let uri = path_to_uri(std::path::Path::new("test.trb"));
-        let rope = Rope::from_str(text);
-
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_tribute::LANGUAGE.into())
-            .expect("Failed to set language");
-        let tree = parser.parse(text, None);
-
-        SourceCst::new(db, uri, rope, tree)
+        SourceCst::from_source_str(db, "test.trb", text)
     }
 
     #[test]

--- a/src/lsp/type_index.rs
+++ b/src/lsp/type_index.rs
@@ -483,22 +483,10 @@ pub fn type_index<'db>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ropey::Rope;
-    use tree_sitter::Parser;
     use tribute_front::ast::UniVarId;
-    use tribute_front::path_to_uri;
 
     fn make_source(db: &dyn salsa::Database, text: &str) -> SourceCst {
-        let uri = path_to_uri(std::path::Path::new("test.trb"));
-        let rope = Rope::from_str(text);
-
-        let mut parser = Parser::new();
-        parser
-            .set_language(&tree_sitter_tribute::LANGUAGE.into())
-            .expect("Failed to set language");
-        let tree = parser.parse(text, None);
-
-        SourceCst::new(db, uri, rope, tree)
+        SourceCst::from_source_str(db, "test.trb", text)
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -916,18 +916,10 @@ pub fn link_native_binary(object_bytes: &[u8], output: &Path) -> Result<(), Link
 mod tests {
     use super::*;
     use salsa_test_macros::salsa_test;
-    use tree_sitter::Parser;
 
     fn source_from_str(path: &str, text: &str) -> SourceCst {
-        salsa::with_attached_database(|db| {
-            let mut parser = Parser::new();
-            parser
-                .set_language(&tree_sitter_tribute::LANGUAGE.into())
-                .expect("Failed to set language");
-            let tree = parser.parse(text, None).expect("tree");
-            SourceCst::from_path(db, path, text.into(), Some(tree))
-        })
-        .expect("attached db")
+        salsa::with_attached_database(|db| SourceCst::from_source_str(db, path, text))
+            .expect("attached db")
     }
 
     #[salsa_test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,22 +4,10 @@ use std::process::{Command, Output};
 
 use ropey::Rope;
 use salsa::Database;
-use tree_sitter::Parser;
 use tribute::TributeDatabaseImpl;
 use tribute::pipeline::{CompilationConfig, compile_to_native_binary, link_native_binary};
 use tribute_front::SourceCst;
 use tribute_passes::Diagnostic;
-
-/// Create a [`SourceCst`] from a source string, for use in tests with a Salsa database.
-#[allow(dead_code)]
-pub fn source_from_str(db: &dyn salsa::Database, path: &str, text: &str) -> SourceCst {
-    let mut parser = Parser::new();
-    parser
-        .set_language(&tree_sitter_tribute::LANGUAGE.into())
-        .expect("Failed to set language");
-    let tree = parser.parse(text, None).expect("Failed to parse");
-    SourceCst::from_path(db, path, Rope::from_str(text), Some(tree))
-}
 
 /// Compile source to a native object file, panicking with diagnostics on failure.
 #[allow(dead_code)]

--- a/tests/diagnostic_snapshots.rs
+++ b/tests/diagnostic_snapshots.rs
@@ -7,9 +7,9 @@
 
 mod common;
 
-use self::common::source_from_str;
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::compile_with_diagnostics;
+use tribute_front::SourceCst;
 
 // =============================================================================
 // Name resolution errors
@@ -17,7 +17,7 @@ use tribute::pipeline::compile_with_diagnostics;
 
 #[salsa_test]
 fn diag_unresolved_name(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(db, "test.trb", "fn main() -> Int { undefined_var }");
+    let source = SourceCst::from_source_str(db, "test.trb", "fn main() -> Int { undefined_var }");
     let result = compile_with_diagnostics(db, source);
     assert!(!result.diagnostics.is_empty());
     insta::assert_yaml_snapshot!(result.diagnostics);
@@ -25,7 +25,7 @@ fn diag_unresolved_name(db: &salsa::DatabaseImpl) {
 
 #[salsa_test]
 fn diag_unresolved_name_with_suggestion(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -41,7 +41,7 @@ fn main() -> Int { compue(42) }
 
 #[salsa_test]
 fn diag_unresolved_type(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(db, "test.trb", "fn main() -> Foo { 42 }");
+    let source = SourceCst::from_source_str(db, "test.trb", "fn main() -> Foo { 42 }");
     let result = compile_with_diagnostics(db, source);
     assert!(!result.diagnostics.is_empty());
     insta::assert_yaml_snapshot!(result.diagnostics);
@@ -53,7 +53,7 @@ fn diag_unresolved_type(db: &salsa::DatabaseImpl) {
 
 #[salsa_test]
 fn diag_syntax_error(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(db, "test.trb", "fn main( { }");
+    let source = SourceCst::from_source_str(db, "test.trb", "fn main( { }");
     let result = compile_with_diagnostics(db, source);
     assert!(!result.diagnostics.is_empty());
     insta::assert_yaml_snapshot!(result.diagnostics);
@@ -65,7 +65,7 @@ fn diag_syntax_error(db: &salsa::DatabaseImpl) {
 
 #[salsa_test]
 fn diag_non_exhaustive_case(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -83,7 +83,7 @@ fn test(x: Nat) -> Nat {
 
 #[salsa_test]
 fn diag_type_mismatch_in_function(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -101,7 +101,7 @@ fn test() -> Int {
 
 #[salsa_test]
 fn diag_main_must_return_nil(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(db, "test.trb", "fn main() -> Int { 42 }");
+    let source = SourceCst::from_source_str(db, "test.trb", "fn main() -> Int { 42 }");
     let result = compile_with_diagnostics(db, source);
     assert!(!result.diagnostics.is_empty());
     insta::assert_yaml_snapshot!(result.diagnostics);
@@ -115,7 +115,7 @@ fn diag_main_must_return_nil(db: &salsa::DatabaseImpl) {
 #[ignore = "lowering diagnostic accumulate panics outside tracked function"]
 #[salsa_test]
 fn diag_unknown_struct_field(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -135,7 +135,7 @@ fn test() -> Point {
 #[ignore = "lowering diagnostic accumulate panics outside tracked function"]
 #[salsa_test]
 fn diag_missing_struct_field(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -157,7 +157,7 @@ fn test() -> Point {
 
 #[salsa_test]
 fn diag_unhandled_effect_in_main(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -177,7 +177,7 @@ fn main() -> Int {
 
 #[salsa_test]
 fn diag_misspelled_ability_name(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"
@@ -199,7 +199,7 @@ fn test() ->{MyEffec} Int {
 #[ignore = "arity mismatch panics in effect row merging"]
 #[salsa_test]
 fn diag_effect_arg_arity_mismatch(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(
+    let source = SourceCst::from_source_str(
         db,
         "test.trb",
         r#"

--- a/tests/effect_var_collision.rs
+++ b/tests/effect_var_collision.rs
@@ -13,9 +13,9 @@
 
 mod common;
 
-use self::common::source_from_str;
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::compile_with_diagnostics;
+use tribute_front::SourceCst;
 
 /// Test that pure lambdas inside effectful functions have distinct effect variables.
 ///
@@ -40,7 +40,7 @@ fn effectful_with_lambda() ->{State(Int)} Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "effect_collision.trb", code);
+    let source = SourceCst::from_source_str(db, "effect_collision.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {
@@ -73,7 +73,7 @@ fn effectful_with_multiple_lambdas() ->{State(Int)} Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "multiple_lambdas.trb", code);
+    let source = SourceCst::from_source_str(db, "multiple_lambdas.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {
@@ -123,7 +123,7 @@ fn effectful_using_pure(init: Int) ->{State(Int)} Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "pure_in_effectful.trb", code);
+    let source = SourceCst::from_source_str(db, "pure_in_effectful.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {
@@ -172,7 +172,7 @@ fn should_fail() ->{State(Int)} Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "effectful_rejected.trb", code);
+    let source = SourceCst::from_source_str(db, "effectful_rejected.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     // This SHOULD fail with a type error
@@ -205,7 +205,7 @@ fn nested_lambdas() ->{State(Int)} Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "nested_lambdas.trb", code);
+    let source = SourceCst::from_source_str(db, "nested_lambdas.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {
@@ -241,7 +241,7 @@ fn test_lambda() -> Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "pure_lambda_basic.trb", code);
+    let source = SourceCst::from_source_str(db, "pure_lambda_basic.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {
@@ -273,7 +273,7 @@ fn test_compose() -> Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "multiple_pure_lambdas.trb", code);
+    let source = SourceCst::from_source_str(db, "multiple_pure_lambdas.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {
@@ -303,7 +303,7 @@ fn test_nested() -> Int {
 fn main() { }
 "#;
 
-    let source = source_from_str(db, "nested_pure_lambdas.trb", code);
+    let source = SourceCst::from_source_str(db, "nested_pure_lambdas.trb", code);
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -18,9 +18,9 @@
 
 mod common;
 
-use self::common::source_from_str;
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::compile_to_wasm_binary;
+use tribute_front::SourceCst;
 use tribute_passes::diagnostic::Diagnostic;
 
 // =============================================================================
@@ -29,7 +29,7 @@ use tribute_passes::diagnostic::Diagnostic;
 
 #[salsa_test]
 fn test_compile_simple_literal(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(db, "literal.trb", "fn main() { 42 }");
+    let source = SourceCst::from_source_str(db, "literal.trb", "fn main() { 42 }");
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile literal return");
 
@@ -39,7 +39,7 @@ fn test_compile_simple_literal(db: &salsa::DatabaseImpl) {
 
 #[salsa_test]
 fn test_compile_arithmetic_expr(db: &salsa::DatabaseImpl) {
-    let source = source_from_str(db, "arith.trb", "fn main() { 1 + 2 * 3 }");
+    let source = SourceCst::from_source_str(db, "arith.trb", "fn main() { 1 + 2 * 3 }");
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile arithmetic expression");
 }
@@ -50,7 +50,7 @@ fn test_compile_function_with_params(db: &salsa::DatabaseImpl) {
 fn add(a, b) { a + b }
 fn main() { add(1, 2) }
 "#;
-    let source = source_from_str(db, "params.trb", code);
+    let source = SourceCst::from_source_str(db, "params.trb", code);
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile function with params");
 }
@@ -66,7 +66,7 @@ extern "intrinsic" fn __print_line(message: String) -> Nil
 fn my_print(message: String) -> Nil { __print_line(message) }
 fn main() { my_print("Hello, World!") }
 "#;
-    let source = source_from_str(db, "hello.trb", code);
+    let source = SourceCst::from_source_str(db, "hello.trb", code);
     let binary = compile_to_wasm_binary(db, source);
 
     if binary.is_none() {
@@ -90,7 +90,7 @@ fn test_ops() {
 }
 fn main() { test_ops() }
 "#;
-    let source = source_from_str(db, "locals.trb", code);
+    let source = SourceCst::from_source_str(db, "locals.trb", code);
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile local variables");
 }
@@ -114,7 +114,7 @@ fn classify(n) {
 }
 fn main() { classify(1) }
 "#;
-    let source = source_from_str(db, "case_expr.trb", code);
+    let source = SourceCst::from_source_str(db, "case_expr.trb", code);
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile case expression");
 }


### PR DESCRIPTION
Closes #585

## Summary

- Replaces all ad-hoc `source_from_str` / `make_source` helper functions in test code with `SourceCst::from_source_str` (added in #584)
- Removes duplicate tree-sitter parsing boilerplate from `crates/tribute-front/tests/common/mod.rs`, `tests/common/mod.rs`, `src/pipeline.rs` tests, and LSP index test modules

## Test plan

- [ ] `cargo test` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined test infrastructure by standardizing source input construction patterns across all test modules.
  * Simplified internal test helpers by consolidating source creation logic.
  * Reduced testing setup complexity while maintaining full test coverage and behavioral equivalence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->