### PR TITLE
Remove BuiltinRef::Print and BuiltinRef::ReadLine

### DIFF
--- a/crates/tribute-front/src/ast/phases.rs
+++ b/crates/tribute-front/src/ast/phases.rs
@@ -212,10 +212,6 @@ pub enum BuiltinRef {
     // List operations
     Cons,
     ListConcat,
-
-    // IO operations
-    Print,
-    ReadLine,
 }
 
 /// Module path reference for qualified imports.

--- a/crates/tribute-front/src/resolve/resolver.rs
+++ b/crates/tribute-front/src/resolve/resolver.rs
@@ -11,19 +11,12 @@ use tribute_ir::ModulePathExt as _;
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    AbilityDecl, Arm, BuiltinRef, Decl, EnumDecl, Expr, ExprKind, FieldPattern, FuncDecl,
-    HandlerArm, HandlerKind, LocalId, LocalIdGen, Module, ModulePath, Param, Pattern, PatternKind,
-    ResolvedRef, SpanMap, Stmt, StructDecl, UnresolvedName, UseDecl,
+    AbilityDecl, Arm, Decl, EnumDecl, Expr, ExprKind, FieldPattern, FuncDecl, HandlerArm,
+    HandlerKind, LocalId, LocalIdGen, Module, ModulePath, Param, Pattern, PatternKind, ResolvedRef,
+    SpanMap, Stmt, StructDecl, UnresolvedName, UseDecl,
 };
 
 use super::env::{Binding, ModuleEnv};
-
-/// Builtin name → BuiltinRef mapping. Source of truth for both resolution and suggestions.
-const BUILTINS: &[(&str, BuiltinRef)] = &[
-    ("print", BuiltinRef::Print),
-    ("readLine", BuiltinRef::ReadLine),
-    ("read_line", BuiltinRef::ReadLine),
-];
 
 /// Find the best matches from `candidates` by a caller-provided score function.
 ///
@@ -154,11 +147,6 @@ impl<'db> Resolver<'db> {
                 return ResolvedRef::local(local_id, sym);
             }
 
-            // Check for builtin operators
-            if let Some(builtin) = self.resolve_builtin(sym) {
-                return ResolvedRef::builtin(builtin);
-            }
-
             // Check module environment (unqualified lookup)
             if let Some(binding) = self.env.lookup(sym) {
                 return self.binding_to_ref(binding, sym);
@@ -211,7 +199,6 @@ impl<'db> Resolver<'db> {
             .iter()
             .flat_map(|scope| scope.keys().copied())
             .chain(self.env.iter_all_names())
-            .chain(BUILTINS.iter().map(|(n, _)| Symbol::new(n)))
             .collect();
 
         let target = name.to_string();
@@ -240,11 +227,6 @@ impl<'db> Resolver<'db> {
             }
             Binding::Ability { id } => ResolvedRef::ability(*id),
         }
-    }
-
-    /// Check if a name refers to a builtin operation.
-    fn resolve_builtin(&self, name: Symbol) -> Option<BuiltinRef> {
-        BUILTINS.iter().find(|(n, _)| name == *n).map(|(_, r)| *r)
     }
 
     /// Resolve a module, transforming all declarations.
@@ -727,48 +709,6 @@ mod tests {
                 assert_eq!(name, param_name);
             }
             _ => panic!("Expected local variable, got {:?}", resolved),
-        }
-    }
-
-    #[salsa_test]
-    fn test_resolve_builtin_print(db: &salsa::DatabaseImpl) {
-        let env = ModuleEnv::new();
-        let resolver = Resolver::new(db, env, SpanMap::default());
-
-        // Create unresolved reference to print
-        let unresolved = UnresolvedName::new(Symbol::new("print"), NodeId::from_raw(1));
-
-        // Resolve the builtin
-        let resolved = resolver.resolve_name(&unresolved);
-
-        // Should resolve to a builtin
-        match resolved {
-            ResolvedRef::Builtin(BuiltinRef::Print) => {}
-            _ => panic!("Expected print builtin, got {:?}", resolved),
-        }
-    }
-
-    #[salsa_test]
-    fn test_local_shadows_builtin(db: &salsa::DatabaseImpl) {
-        let env = ModuleEnv::new();
-        let mut resolver = Resolver::new(db, env, SpanMap::default());
-
-        // Bind a local variable named 'print' (same as builtin)
-        let name = Symbol::new("print");
-        resolver.push_scope();
-        resolver.bind_local(name);
-
-        // Create unresolved reference
-        let unresolved = UnresolvedName::new(name, NodeId::from_raw(1));
-
-        // Resolve - should get local, not builtin
-        let resolved = resolver.resolve_name(&unresolved);
-
-        match resolved {
-            ResolvedRef::Local { name: n, .. } => {
-                assert_eq!(n, name);
-            }
-            _ => panic!("Expected local to shadow builtin, got {:?}", resolved),
         }
     }
 

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -714,16 +714,6 @@ impl<'db> TypeChecker<'db> {
                 let list_a = ctx.named_type(Symbol::new("List"), vec![a]);
                 ctx.func_type(vec![list_a, list_a], list_a, effect)
             }
-            // IO operations
-            BuiltinRef::Print => {
-                let a = ctx.fresh_type_var();
-                let io_effect = ctx.fresh_effect_row();
-                ctx.func_type(vec![a], ctx.nil_type(), io_effect)
-            }
-            BuiltinRef::ReadLine => {
-                let io_effect = ctx.fresh_effect_row();
-                ctx.func_type(vec![], ctx.string_type(), io_effect)
-            }
         }
     }
 
@@ -2359,55 +2349,6 @@ mod tests {
             assert!(effect.is_pure(db));
         } else {
             panic!("ListConcat should return Func type");
-        }
-    }
-
-    #[salsa_test]
-    fn test_builtin_io_ops(db: &dyn salsa::Database) {
-        let checker = make_test_checker(db);
-        let env = ModuleTypeEnv::new(db);
-        let mut ctx = make_test_ctx(db, &env);
-        let nil_ty = Type::new(db, TypeKind::Nil);
-        let string_ty = Type::new(db, TypeKind::string());
-
-        // Print: (a) ->{?e} Nil
-        let print_ty = checker.infer_builtin_with_ctx(&mut ctx, &BuiltinRef::Print);
-        if let TypeKind::Func {
-            params,
-            result,
-            effect,
-        } = print_ty.kind(db)
-        {
-            assert_eq!(params.len(), 1);
-            // Param should be a fresh type var
-            assert!(matches!(params[0].kind(db), TypeKind::UniVar { .. }));
-            assert_eq!(*result, nil_ty);
-            // Effect should be open (fresh row var)
-            assert!(
-                effect.rest(db).is_some(),
-                "Print should have open effect row"
-            );
-        } else {
-            panic!("Print should return Func type");
-        }
-
-        // ReadLine: () ->{?e} String
-        let readline_ty = checker.infer_builtin_with_ctx(&mut ctx, &BuiltinRef::ReadLine);
-        if let TypeKind::Func {
-            params,
-            result,
-            effect,
-        } = readline_ty.kind(db)
-        {
-            assert!(params.is_empty());
-            assert_eq!(*result, string_ty);
-            // Effect should be open (fresh row var)
-            assert!(
-                effect.rest(db).is_some(),
-                "ReadLine should have open effect row"
-            );
-        } else {
-            panic!("ReadLine should return Func type");
         }
     }
 

--- a/lib/std/prelude.trb
+++ b/lib/std/prelude.trb
@@ -238,6 +238,11 @@ pub mod Bytes {
 // I/O functions
 // =============================================================================
 
+/// Print a string to standard output (no trailing newline).
+fn print(message: String) -> Nil {
+    __tribute_bytes_print(message.to_bytes())
+}
+
 /// Print a line to standard output.
 fn print_line(message: String) -> Nil {
     __tribute_bytes_print(message.to_bytes())


### PR DESCRIPTION
## Summary

Closes #573

- Remove `Print` and `ReadLine` variants from `BuiltinRef` (the only name-based builtins; all others are mapped from operator syntax)
- Remove `BUILTINS` const, `resolve_builtin()` method, and name-based builtin resolution from the resolver
- Remove type-checking arms and tests for `Print`/`ReadLine`
- Add `print(message: String) -> Nil` function to the prelude (prints without trailing newline)

These builtins were dead code — IR lowering produced "unsupported" errors for them. All working IO already goes through `print_line` in the prelude.

`read_line` is not added in this PR because there is no corresponding runtime function (`__tribute_read_line`). It can be tracked as a follow-up issue.

## Test plan

- [x] `cargo nextest run` — 315 tests passed, 0 failed
- [x] e2e native `print_line` tests still pass through prelude resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relocated print and readline operations from compiler built-in definitions to library-level implementations. The compiler no longer resolves these as built-in references; they are now handled through standard library functions. This internal restructuring maintains existing functionality while simplifying the compiler's built-in operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->