### PR TITLE
refactor(tribute-front): remove intermediate diagnostic collection from AstLoweringCtx

### DIFF
--- a/crates/tribute-front/src/astgen/context.rs
+++ b/crates/tribute-front/src/astgen/context.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use ropey::Rope;
+use salsa::Accumulator;
 use tree_sitter::Node;
 use trunk_ir::{Span, Symbol};
 
@@ -10,27 +11,41 @@ use crate::ast::{NodeId, SpanMapBuilder};
 use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 
 /// Context for lowering CST to AST.
-pub struct AstLoweringCtx {
+pub struct AstLoweringCtx<'db> {
     pub source: Rope,
     /// Source hash for distinguishing parse sessions (derived from source URI).
     source_hash: u64,
     /// Builder for span map.
     span_builder: SpanMapBuilder,
-    /// Diagnostics collected during lowering.
-    diagnostics: Vec<Diagnostic>,
+    /// Salsa database for accumulating diagnostics directly.
+    /// `None` in test-only paths where diagnostics are discarded.
+    db: Option<&'db dyn salsa::Database>,
 }
 
-impl AstLoweringCtx {
-    /// Create a new lowering context.
+impl<'db> AstLoweringCtx<'db> {
+    /// Create a new lowering context without a database.
     ///
-    /// `source_hash` distinguishes parse sessions (derived from source URI via
-    /// [`crate::ast::node_id::source_hash`]).
+    /// Diagnostics emitted through this context will be silently discarded.
+    /// **Intended for tests and debugging only.** Production code should use
+    /// [`AstLoweringCtx::with_db`].
     pub fn new(source: Rope, source_hash: u64) -> Self {
         Self {
             source,
             source_hash,
             span_builder: SpanMapBuilder::new(),
-            diagnostics: Vec::new(),
+            db: None,
+        }
+    }
+
+    /// Create a new lowering context with a Salsa database.
+    ///
+    /// Diagnostics are accumulated directly into Salsa via the database.
+    pub fn with_db(db: &'db dyn salsa::Database, source: Rope, source_hash: u64) -> Self {
+        Self {
+            source,
+            source_hash,
+            span_builder: SpanMapBuilder::new(),
+            db: Some(db),
         }
     }
 
@@ -48,27 +63,33 @@ impl AstLoweringCtx {
 
     /// Emit a diagnostic error.
     pub fn error(&mut self, span: Span, message: impl Into<String>) {
-        self.diagnostics.push(Diagnostic::new(
-            message,
-            span,
-            DiagnosticSeverity::Error,
-            CompilationPhase::AstGeneration,
-        ));
+        if let Some(db) = self.db {
+            Diagnostic::new(
+                message,
+                span,
+                DiagnosticSeverity::Error,
+                CompilationPhase::AstGeneration,
+            )
+            .accumulate(db);
+        }
     }
 
     /// Emit a parse error diagnostic for syntax errors.
     pub fn parse_error(&mut self, span: Span, message: impl Into<String>) {
-        self.diagnostics.push(Diagnostic::new(
-            message,
-            span,
-            DiagnosticSeverity::Error,
-            CompilationPhase::Parsing,
-        ));
+        if let Some(db) = self.db {
+            Diagnostic::new(
+                message,
+                span,
+                DiagnosticSeverity::Error,
+                CompilationPhase::Parsing,
+            )
+            .accumulate(db);
+        }
     }
 
-    /// Consume the context and return the span builder and diagnostics.
-    pub fn finish(self) -> (SpanMapBuilder, Vec<Diagnostic>) {
-        (self.span_builder, self.diagnostics)
+    /// Consume the context and return the span builder.
+    pub fn finish(self) -> SpanMapBuilder {
+        self.span_builder
     }
 
     /// Get the text content of a node.

--- a/crates/tribute-front/src/astgen/declarations.rs
+++ b/crates/tribute-front/src/astgen/declarations.rs
@@ -18,7 +18,7 @@ use super::helpers::is_comment;
 /// The `module_name` parameter is the name derived from the source file path.
 /// If `None`, a later phase (or the IR lowering) can assign a default.
 pub fn lower_module(
-    ctx: &mut AstLoweringCtx,
+    ctx: &mut AstLoweringCtx<'_>,
     root: Node,
     module_name: Option<Symbol>,
 ) -> Module<UnresolvedName> {
@@ -47,7 +47,7 @@ pub fn lower_module(
 
 /// Lower a CST declaration node to an AST Decl.
 /// Returns a Vec because use declarations can expand to multiple items.
-fn lower_decl(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Decl<UnresolvedName>> {
+fn lower_decl(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<Decl<UnresolvedName>> {
     match node.kind() {
         "function_definition" => lower_function(ctx, node).into_iter().collect(),
         "struct_declaration" => lower_struct(ctx, node)
@@ -69,7 +69,7 @@ fn lower_decl(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Decl<UnresolvedName>>
 ///
 /// Returns either `Decl::Function` or `Decl::ExternFunction` depending on whether
 /// the function is `regular_function` or `extern_function`.
-fn lower_function(ctx: &mut AstLoweringCtx, node: Node) -> Option<Decl<UnresolvedName>> {
+fn lower_function(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<Decl<UnresolvedName>> {
     // function_definition always contains regular_function or extern_function
     let func_node = node
         .named_child(0)
@@ -157,7 +157,7 @@ fn lower_function(ctx: &mut AstLoweringCtx, node: Node) -> Option<Decl<Unresolve
 }
 
 /// Extract function name, handling operator names like `(<>)`.
-fn extract_function_name(ctx: &AstLoweringCtx, name_node: Node) -> Symbol {
+fn extract_function_name(ctx: &AstLoweringCtx<'_>, name_node: Node) -> Symbol {
     if name_node.kind() == "operator_name" {
         let text = ctx.node_text(&name_node);
         // Strip surrounding parentheses: "(<>)" -> "<>"
@@ -175,7 +175,7 @@ fn extract_function_name(ctx: &AstLoweringCtx, name_node: Node) -> Symbol {
 ///
 /// Handles both `parameter_list` (with `parameter` children) and
 /// `typed_parameter_list` (with `typed_parameter` children).
-fn lower_param_list(ctx: &mut AstLoweringCtx, node: Node) -> Vec<ParamDecl> {
+fn lower_param_list(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<ParamDecl> {
     let mut params = Vec::new();
     let mut cursor = node.walk();
 
@@ -202,7 +202,7 @@ fn lower_param_list(ctx: &mut AstLoweringCtx, node: Node) -> Vec<ParamDecl> {
 }
 
 /// Lower a type annotation.
-fn lower_type_annotation(ctx: &mut AstLoweringCtx, node: Node) -> Option<TypeAnnotation> {
+fn lower_type_annotation(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAnnotation> {
     // Check if the node itself is already a type node
     if matches!(
         node.kind(),
@@ -227,7 +227,7 @@ fn lower_type_annotation(ctx: &mut AstLoweringCtx, node: Node) -> Option<TypeAnn
 }
 
 /// Lower a type node directly (for variant tuple fields).
-fn lower_type_node(ctx: &mut AstLoweringCtx, node: Node) -> Option<TypeAnnotation> {
+fn lower_type_node(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAnnotation> {
     // Handle various type node kinds
     match node.kind() {
         // type_variable in grammar is just identifier, so we need to handle both
@@ -334,7 +334,7 @@ fn lower_type_node(ctx: &mut AstLoweringCtx, node: Node) -> Option<TypeAnnotatio
 /// Grammar: `ability_row = "{" ability_list? "}"`
 /// where `ability_list` contains `ability_item` (e.g. `State(Int)`) and
 /// `ability_tail` (row variable, e.g. `e`).
-fn lower_ability_row(ctx: &mut AstLoweringCtx, node: Node) -> Vec<TypeAnnotation> {
+fn lower_ability_row(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<TypeAnnotation> {
     let mut effects = Vec::new();
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
@@ -368,7 +368,7 @@ fn lower_ability_row(ctx: &mut AstLoweringCtx, node: Node) -> Vec<TypeAnnotation
 ///
 /// Grammar: `ability_item = type_identifier optional(type_arguments)`
 /// e.g. `Console` or `State(Int)`
-fn lower_ability_item(ctx: &mut AstLoweringCtx, node: Node) -> Option<TypeAnnotation> {
+fn lower_ability_item(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAnnotation> {
     let mut cursor = node.walk();
     let children: Vec<_> = node.named_children(&mut cursor).collect();
 
@@ -403,7 +403,7 @@ fn lower_ability_item(ctx: &mut AstLoweringCtx, node: Node) -> Option<TypeAnnota
 /// Lower type parameters from a type_parameters node.
 ///
 /// Parses `(a, b, c)` into a list of TypeParamDecl.
-fn lower_type_parameters(ctx: &mut AstLoweringCtx, node: Node) -> Vec<TypeParamDecl> {
+fn lower_type_parameters(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<TypeParamDecl> {
     let mut params = Vec::new();
     let mut cursor = node.walk();
 
@@ -423,7 +423,7 @@ fn lower_type_parameters(ctx: &mut AstLoweringCtx, node: Node) -> Vec<TypeParamD
 }
 
 /// Lower a struct declaration.
-fn lower_struct(ctx: &mut AstLoweringCtx, node: Node) -> Option<StructDecl> {
+fn lower_struct(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<StructDecl> {
     let name_node = node.child_by_field_name("name")?;
     let body_node = node.child_by_field_name("body")?;
 
@@ -447,7 +447,7 @@ fn lower_struct(ctx: &mut AstLoweringCtx, node: Node) -> Option<StructDecl> {
 }
 
 /// Lower struct fields from struct body.
-fn lower_struct_fields(ctx: &mut AstLoweringCtx, node: Node) -> Vec<FieldDecl> {
+fn lower_struct_fields(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<FieldDecl> {
     let mut fields = Vec::new();
     let mut cursor = node.walk();
 
@@ -480,7 +480,7 @@ fn lower_struct_fields(ctx: &mut AstLoweringCtx, node: Node) -> Vec<FieldDecl> {
 }
 
 /// Lower a single struct field.
-fn lower_struct_field(ctx: &mut AstLoweringCtx, node: Node) -> Option<FieldDecl> {
+fn lower_struct_field(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<FieldDecl> {
     let name_node = node.child_by_field_name("name")?;
     let type_node = node.child_by_field_name("type")?;
 
@@ -497,7 +497,7 @@ fn lower_struct_field(ctx: &mut AstLoweringCtx, node: Node) -> Option<FieldDecl>
 }
 
 /// Lower an enum declaration.
-fn lower_enum(ctx: &mut AstLoweringCtx, node: Node) -> Option<EnumDecl> {
+fn lower_enum(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<EnumDecl> {
     let name_node = node.child_by_field_name("name")?;
     let body_node = node.child_by_field_name("body")?;
 
@@ -521,7 +521,7 @@ fn lower_enum(ctx: &mut AstLoweringCtx, node: Node) -> Option<EnumDecl> {
 }
 
 /// Lower enum variants from enum body.
-fn lower_enum_variants(ctx: &mut AstLoweringCtx, node: Node) -> Vec<VariantDecl> {
+fn lower_enum_variants(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<VariantDecl> {
     let mut variants = Vec::new();
     let mut cursor = node.walk();
 
@@ -546,7 +546,7 @@ fn lower_enum_variants(ctx: &mut AstLoweringCtx, node: Node) -> Vec<VariantDecl>
 }
 
 /// Lower a single enum variant.
-fn lower_enum_variant(ctx: &mut AstLoweringCtx, node: Node) -> Option<VariantDecl> {
+fn lower_enum_variant(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<VariantDecl> {
     let name_node = node.child_by_field_name("name")?;
     let id = ctx.fresh_id_with_span(&node);
     let name = ctx.node_symbol(&name_node);
@@ -562,7 +562,7 @@ fn lower_enum_variant(ctx: &mut AstLoweringCtx, node: Node) -> Option<VariantDec
 }
 
 /// Lower variant fields (tuple or struct style).
-fn lower_variant_fields(ctx: &mut AstLoweringCtx, node: Node) -> Vec<FieldDecl> {
+fn lower_variant_fields(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<FieldDecl> {
     let mut fields = Vec::new();
 
     // Handle the variant_fields wrapper which contains tuple_fields or struct_fields_block
@@ -609,7 +609,7 @@ fn lower_variant_fields(ctx: &mut AstLoweringCtx, node: Node) -> Vec<FieldDecl> 
 }
 
 /// Lower an ability declaration.
-fn lower_ability(ctx: &mut AstLoweringCtx, node: Node) -> Option<AbilityDecl> {
+fn lower_ability(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<AbilityDecl> {
     let name_node = node.child_by_field_name("name")?;
     let body_node = node.child_by_field_name("body")?;
 
@@ -633,7 +633,7 @@ fn lower_ability(ctx: &mut AstLoweringCtx, node: Node) -> Option<AbilityDecl> {
 }
 
 /// Lower ability operations from ability body.
-fn lower_ability_operations(ctx: &mut AstLoweringCtx, node: Node) -> Vec<OpDecl> {
+fn lower_ability_operations(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<OpDecl> {
     let mut operations = Vec::new();
     let mut cursor = node.walk();
 
@@ -667,7 +667,7 @@ fn lower_ability_operations(ctx: &mut AstLoweringCtx, node: Node) -> Vec<OpDecl>
 }
 
 /// Lower a single ability operation.
-fn lower_ability_operation(ctx: &mut AstLoweringCtx, node: Node) -> Option<OpDecl> {
+fn lower_ability_operation(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<OpDecl> {
     let name_node = node.child_by_field_name("name")?;
     let id = ctx.fresh_id_with_span(&node);
     let name = ctx.node_symbol(&name_node);
@@ -707,7 +707,7 @@ fn lower_ability_operation(ctx: &mut AstLoweringCtx, node: Node) -> Option<OpDec
 
 /// Lower a use declaration.
 /// Returns a Vec because `use std::{io, fmt}` expands to multiple UseDecls.
-fn lower_use(ctx: &mut AstLoweringCtx, node: Node) -> Vec<UseDecl> {
+fn lower_use(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<UseDecl> {
     let Some(tree_node) = node.child_by_field_name("tree") else {
         return Vec::new();
     };
@@ -733,7 +733,7 @@ fn lower_use(ctx: &mut AstLoweringCtx, node: Node) -> Vec<UseDecl> {
 /// Expand a use tree into a list of (path, alias) pairs.
 /// Handles nested groups like `use std::{io, fmt, collections::{List, Map}}`.
 fn expand_use_tree(
-    ctx: &AstLoweringCtx,
+    ctx: &AstLoweringCtx<'_>,
     node: Node,
     prefix: &[Symbol],
 ) -> Vec<(Vec<Symbol>, Option<Symbol>)> {
@@ -794,7 +794,7 @@ fn expand_use_tree(
 }
 
 /// Lower a module declaration.
-fn lower_mod(ctx: &mut AstLoweringCtx, node: Node) -> Option<ModuleDecl<UnresolvedName>> {
+fn lower_mod(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<ModuleDecl<UnresolvedName>> {
     let name_node = node.child_by_field_name("name")?;
 
     let id = ctx.fresh_id_with_span(&node);

--- a/crates/tribute-front/src/astgen/expressions.rs
+++ b/crates/tribute-front/src/astgen/expressions.rs
@@ -14,7 +14,7 @@ use super::helpers::is_comment;
 use super::patterns::lower_pattern;
 
 /// Lower a CST expression node to an AST Expr.
-pub fn lower_expr(ctx: &mut AstLoweringCtx, node: Node) -> Expr<UnresolvedName> {
+pub fn lower_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Expr<UnresolvedName> {
     let id = ctx.fresh_id_with_span(&node);
 
     let kind = match node.kind() {
@@ -167,7 +167,7 @@ pub fn lower_expr(ctx: &mut AstLoweringCtx, node: Node) -> Expr<UnresolvedName> 
     Expr::new(id, kind)
 }
 
-fn lower_binary_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_binary_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let lhs_node = node.child_by_field_name("left");
     let rhs_node = node.child_by_field_name("right");
     let op_node = node.child_by_field_name("operator");
@@ -201,7 +201,7 @@ fn lower_binary_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unresolve
     ExprKind::BinOp { op, lhs, rhs }
 }
 
-fn lower_call_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_call_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let callee_node = node.child_by_field_name("function");
     // Note: tree-sitter grammar doesn't define "arguments" field for call_expression,
     // so we find argument_list by kind instead
@@ -221,7 +221,7 @@ fn lower_call_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedN
     ExprKind::Call { callee, args }
 }
 
-fn lower_method_call(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_method_call(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let receiver_node = node.child_by_field_name("receiver");
     let method_node = node.child_by_field_name("method");
     // Note: tree-sitter grammar doesn't define an "arguments" field for
@@ -248,7 +248,7 @@ fn lower_method_call(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unresolve
     }
 }
 
-fn lower_constructor_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_constructor_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let name_node = node.child_by_field_name("constructor");
 
     // argument_list doesn't have a field name in the grammar, so we find it by kind
@@ -271,7 +271,7 @@ fn lower_constructor_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unre
     ExprKind::Cons { ctor, args }
 }
 
-fn lower_record_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_record_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let type_node = node.child_by_field_name("type");
     let fields_node = node.child_by_field_name("fields");
 
@@ -316,7 +316,7 @@ fn lower_record_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unresolve
 }
 
 fn lower_field_initializer(
-    ctx: &mut AstLoweringCtx,
+    ctx: &mut AstLoweringCtx<'_>,
     node: Node,
 ) -> Option<(Symbol, Expr<UnresolvedName>)> {
     let name_node = node.child_by_field_name("name")?;
@@ -328,7 +328,7 @@ fn lower_field_initializer(
     Some((name, value))
 }
 
-fn lower_field_access(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_field_access(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let expr_node = node.child_by_field_name("value");
     let field_node = node.child_by_field_name("field");
 
@@ -355,7 +355,7 @@ fn is_statement_node(node: &Node) -> bool {
     node.kind() == "let_statement"
 }
 
-fn lower_block(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_block(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let mut stmts = Vec::new();
     let mut cursor = node.walk();
 
@@ -404,7 +404,7 @@ fn lower_block(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName>
 }
 
 fn lower_block_item_as_stmt(
-    ctx: &mut AstLoweringCtx,
+    ctx: &mut AstLoweringCtx<'_>,
     child: &Node,
 ) -> Option<Stmt<UnresolvedName>> {
     match child.kind() {
@@ -431,7 +431,7 @@ fn lower_block_item_as_stmt(
     }
 }
 
-fn lower_block_item_as_expr(ctx: &mut AstLoweringCtx, child: &Node) -> Expr<UnresolvedName> {
+fn lower_block_item_as_expr(ctx: &mut AstLoweringCtx<'_>, child: &Node) -> Expr<UnresolvedName> {
     match child.kind() {
         "let_statement" => {
             // A let as the last item - block value is Nil, but we need to add the let as a stmt
@@ -460,7 +460,7 @@ fn lower_block_item_as_expr(ctx: &mut AstLoweringCtx, child: &Node) -> Expr<Unre
     }
 }
 
-fn lower_let_statement(ctx: &mut AstLoweringCtx, node: Node) -> Option<Stmt<UnresolvedName>> {
+fn lower_let_statement(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<Stmt<UnresolvedName>> {
     let pattern_node = node.child_by_field_name("pattern")?;
     let value_node = node.child_by_field_name("value")?;
 
@@ -479,7 +479,7 @@ fn lower_let_statement(ctx: &mut AstLoweringCtx, node: Node) -> Option<Stmt<Unre
     })
 }
 
-fn lower_case_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_case_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let scrutinee_node = node.child_by_field_name("value");
 
     let Some(scrutinee_node) = scrutinee_node else {
@@ -502,7 +502,7 @@ fn lower_case_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedN
     ExprKind::Case { scrutinee, arms }
 }
 
-fn lower_case_arm(ctx: &mut AstLoweringCtx, node: Node) -> Option<Arm<UnresolvedName>> {
+fn lower_case_arm(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<Arm<UnresolvedName>> {
     // case_arm has pattern and body as positional named children, not fields
     // Pattern is the first named child, body is the second
     let mut cursor = node.walk();
@@ -538,7 +538,7 @@ fn lower_case_arm(ctx: &mut AstLoweringCtx, node: Node) -> Option<Arm<Unresolved
     })
 }
 
-fn lower_lambda_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_lambda_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let params_node = node.child_by_field_name("params");
     let body_node = node.child_by_field_name("body");
 
@@ -554,7 +554,7 @@ fn lower_lambda_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unresolve
     ExprKind::Lambda { params, body }
 }
 
-fn lower_param_list(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Param> {
+fn lower_param_list(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<Param> {
     let mut params = Vec::new();
     let mut cursor = node.walk();
 
@@ -588,7 +588,7 @@ fn lower_param_list(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Param> {
     params
 }
 
-fn lower_tuple_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_tuple_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let mut elements = Vec::new();
     let mut cursor = node.walk();
 
@@ -601,7 +601,7 @@ fn lower_tuple_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unresolved
     ExprKind::Tuple(elements)
 }
 
-fn lower_list_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_list_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let mut elements = Vec::new();
     let mut cursor = node.walk();
 
@@ -614,7 +614,7 @@ fn lower_list_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedN
     ExprKind::List(elements)
 }
 
-fn lower_handle_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_handle_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     // grammar.js: field("expr", $._expression) for the body
     let expr_node = node.child_by_field_name("expr");
 
@@ -638,7 +638,10 @@ fn lower_handle_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unresolve
     ExprKind::Handle { body, handlers }
 }
 
-fn lower_handler_arm(ctx: &mut AstLoweringCtx, node: Node) -> Option<HandlerArm<UnresolvedName>> {
+fn lower_handler_arm(
+    ctx: &mut AstLoweringCtx<'_>,
+    node: Node,
+) -> Option<HandlerArm<UnresolvedName>> {
     // New grammar: handler_arm is a choice of completion_handler, fn_handler, op_handler
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
@@ -654,7 +657,7 @@ fn lower_handler_arm(ctx: &mut AstLoweringCtx, node: Node) -> Option<HandlerArm<
 
 /// Lower `do result { body }` handler arm.
 fn lower_completion_handler(
-    ctx: &mut AstLoweringCtx,
+    ctx: &mut AstLoweringCtx<'_>,
     node: Node,
 ) -> Option<HandlerArm<UnresolvedName>> {
     let binding_node = node.child_by_field_name("binding")?;
@@ -672,7 +675,10 @@ fn lower_completion_handler(
 }
 
 /// Lower `fn Op(args) { body }` handler arm.
-fn lower_fn_handler(ctx: &mut AstLoweringCtx, node: Node) -> Option<HandlerArm<UnresolvedName>> {
+fn lower_fn_handler(
+    ctx: &mut AstLoweringCtx<'_>,
+    node: Node,
+) -> Option<HandlerArm<UnresolvedName>> {
     let (ability, op) = lower_handler_operation_path(ctx, node)?;
     let params = lower_handler_params(ctx, node);
     let body_node = node.child_by_field_name("body")?;
@@ -692,7 +698,10 @@ fn lower_fn_handler(ctx: &mut AstLoweringCtx, node: Node) -> Option<HandlerArm<U
 }
 
 /// Lower `op Op(args) { body }` handler arm.
-fn lower_op_handler(ctx: &mut AstLoweringCtx, node: Node) -> Option<HandlerArm<UnresolvedName>> {
+fn lower_op_handler(
+    ctx: &mut AstLoweringCtx<'_>,
+    node: Node,
+) -> Option<HandlerArm<UnresolvedName>> {
     let (ability, op) = lower_handler_operation_path(ctx, node)?;
     let params = lower_handler_params(ctx, node);
     let body_node = node.child_by_field_name("body")?;
@@ -715,7 +724,7 @@ fn lower_op_handler(ctx: &mut AstLoweringCtx, node: Node) -> Option<HandlerArm<U
 /// Parse the operation path from a fn_handler or op_handler node.
 /// Returns (ability, op_name).
 fn lower_handler_operation_path(
-    ctx: &mut AstLoweringCtx,
+    ctx: &mut AstLoweringCtx<'_>,
     node: Node,
 ) -> Option<(UnresolvedName, Symbol)> {
     let op_node = node.child_by_field_name("operation")?;
@@ -730,7 +739,7 @@ fn lower_handler_operation_path(
 }
 
 /// Parse handler parameters (identifiers) from a fn_handler or op_handler node.
-fn lower_handler_params(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Pattern<UnresolvedName>> {
+fn lower_handler_params(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<Pattern<UnresolvedName>> {
     let Some(params_node) = node.child_by_field_name("params") else {
         return Vec::new();
     };
@@ -745,7 +754,7 @@ fn lower_handler_params(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Pattern<Unr
 }
 
 /// Lower `resume expr` expression.
-fn lower_resume_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<UnresolvedName> {
+fn lower_resume_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedName> {
     let arg = match node.child_by_field_name("value") {
         Some(value_node) => lower_expr(ctx, value_node),
         None => {
@@ -763,7 +772,7 @@ fn lower_resume_expr(ctx: &mut AstLoweringCtx, node: Node) -> ExprKind<Unresolve
     }
 }
 
-fn lower_argument_list(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Expr<UnresolvedName>> {
+fn lower_argument_list(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<Expr<UnresolvedName>> {
     let mut args = Vec::new();
     let mut cursor = node.walk();
 

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -16,7 +16,7 @@ mod expressions;
 mod helpers;
 mod patterns;
 
-use crate::ast::{Module, SpanMap, SpanMapBuilder, UnresolvedName};
+use crate::ast::{Module, SpanMap, UnresolvedName};
 use crate::query::ParsedCst;
 use crate::source_file::SourceCst;
 use ropey::Rope;
@@ -31,40 +31,26 @@ pub use patterns::lower_pattern;
 // Entry Points
 // =============================================================================
 
-/// Internal result from CST → AST lowering (non-Salsa).
-struct LoweringResult {
-    module: Module<UnresolvedName>,
-    span_builder: SpanMapBuilder,
-    diagnostics: Vec<tribute_core::diagnostic::Diagnostic>,
-}
-
 /// Lower a parsed CST to an AST Module (internal, non-Salsa).
 ///
-/// Returns both the module and the span builder for creating a SpanMap.
-/// The `module_name` is derived from the source file path and passed through.
+/// Collects ERROR nodes and lowers the CST into an AST `Module`.
+/// Diagnostics are accumulated directly via the context's Salsa database
+/// (if present).
 fn lower_cst_to_ast_internal(
-    source: &Rope,
+    ctx: &mut AstLoweringCtx<'_>,
     cst: &ParsedCst,
     module_name: Option<trunk_ir::Symbol>,
-    source_hash: u64,
-) -> LoweringResult {
-    let mut ctx = AstLoweringCtx::new(source.clone(), source_hash);
+) -> Module<UnresolvedName> {
     let root = cst.root_node();
 
     // Check for ERROR nodes anywhere in the CST
-    collect_error_nodes(&mut ctx, root);
+    collect_error_nodes(ctx, root);
 
-    let module = lower_module(&mut ctx, root, module_name);
-    let (span_builder, diagnostics) = ctx.finish();
-    LoweringResult {
-        module,
-        span_builder,
-        diagnostics,
-    }
+    lower_module(ctx, root, module_name)
 }
 
 /// Recursively collect ERROR nodes from the CST and emit parse error diagnostics.
-fn collect_error_nodes(ctx: &mut AstLoweringCtx, node: tree_sitter::Node) {
+fn collect_error_nodes(ctx: &mut AstLoweringCtx<'_>, node: tree_sitter::Node) {
     if node.kind() == "ERROR" {
         let span = trunk_ir::Span::new(node.start_byte(), node.end_byte());
         ctx.parse_error(span, "syntax error: unexpected token");
@@ -90,7 +76,8 @@ fn collect_error_nodes(ctx: &mut AstLoweringCtx, node: tree_sitter::Node) {
 /// [`lower_source_to_parsed_ast`], which computes a proper source hash from
 /// the [`SourceCst`] URI and preserves span information.
 pub fn lower_cst_to_ast(source: &Rope, cst: &ParsedCst) -> Module<UnresolvedName> {
-    lower_cst_to_ast_internal(source, cst, None, 0).module
+    let mut ctx = AstLoweringCtx::new(source.clone(), 0);
+    lower_cst_to_ast_internal(&mut ctx, cst, None)
 }
 
 /// Salsa-tracked parsing result containing both Module and SpanMap.
@@ -131,17 +118,13 @@ pub fn lower_source_to_parsed_ast_with_module_path<'db>(
     use crate::ast::node_id::source_hash;
     use crate::query::parse_cst;
 
-    use salsa::Accumulator;
-
     let cst = parse_cst(db, source)?;
     let text = source.text(db);
     let sh = source_hash(source.uri(db).as_str());
-    let result = lower_cst_to_ast_internal(text, &cst, module_path, sh);
-    for diag in result.diagnostics {
-        diag.accumulate(db);
-    }
-    let span_map = result.span_builder.finish();
-    Some(ParsedAst::new(db, result.module, span_map))
+    let mut ctx = AstLoweringCtx::with_db(db, text.clone(), sh);
+    let module = lower_cst_to_ast_internal(&mut ctx, &cst, module_path);
+    let span_map = ctx.finish().finish();
+    Some(ParsedAst::new(db, module, span_map))
 }
 
 /// Derive a module name from a source file URI.

--- a/crates/tribute-front/src/astgen/patterns.rs
+++ b/crates/tribute-front/src/astgen/patterns.rs
@@ -9,7 +9,7 @@ use super::context::AstLoweringCtx;
 use super::helpers::is_comment;
 
 /// Lower a CST pattern node to an AST Pattern.
-pub fn lower_pattern(ctx: &mut AstLoweringCtx, node: Node) -> Pattern<UnresolvedName> {
+pub fn lower_pattern(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Pattern<UnresolvedName> {
     let id = ctx.fresh_id_with_span(&node);
 
     let kind = match node.kind() {
@@ -100,7 +100,10 @@ pub fn lower_pattern(ctx: &mut AstLoweringCtx, node: Node) -> Pattern<Unresolved
     Pattern::new(id, kind)
 }
 
-fn lower_constructor_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<UnresolvedName> {
+fn lower_constructor_pattern(
+    ctx: &mut AstLoweringCtx<'_>,
+    node: Node,
+) -> PatternKind<UnresolvedName> {
     // grammar.js: field("name", $.type_identifier)
     //   + optional choice of:
     //     - Tuple-style: field("args", $.pattern_list)
@@ -140,7 +143,10 @@ fn lower_constructor_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKin
 }
 
 /// Lower struct-style pattern fields (pattern_fields) to a list of patterns.
-fn lower_constructor_fields(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Pattern<UnresolvedName>> {
+fn lower_constructor_fields(
+    ctx: &mut AstLoweringCtx<'_>,
+    node: Node,
+) -> Vec<Pattern<UnresolvedName>> {
     let mut patterns = Vec::new();
     let mut cursor = node.walk();
 
@@ -173,7 +179,7 @@ fn lower_constructor_fields(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Pattern
     patterns
 }
 
-fn lower_record_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<UnresolvedName> {
+fn lower_record_pattern(ctx: &mut AstLoweringCtx<'_>, node: Node) -> PatternKind<UnresolvedName> {
     let type_node = node.child_by_field_name("type");
     let fields_node = node.child_by_field_name("fields");
 
@@ -223,7 +229,7 @@ fn lower_record_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<Unr
 }
 
 fn lower_field_pattern(
-    ctx: &mut AstLoweringCtx,
+    ctx: &mut AstLoweringCtx<'_>,
     node: Node,
 ) -> Option<FieldPattern<UnresolvedName>> {
     let name_node = node.child_by_field_name("name")?;
@@ -236,7 +242,7 @@ fn lower_field_pattern(
     Some(FieldPattern { id, name, pattern })
 }
 
-fn lower_tuple_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<UnresolvedName> {
+fn lower_tuple_pattern(ctx: &mut AstLoweringCtx<'_>, node: Node) -> PatternKind<UnresolvedName> {
     // tuple_pattern has field "elements" which is a pattern_list
     let elements_node = node.child_by_field_name("elements");
     let elements = elements_node
@@ -245,7 +251,7 @@ fn lower_tuple_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<Unre
     PatternKind::Tuple(elements)
 }
 
-fn lower_list_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<UnresolvedName> {
+fn lower_list_pattern(ctx: &mut AstLoweringCtx<'_>, node: Node) -> PatternKind<UnresolvedName> {
     let mut head = Vec::new();
     let mut has_rest = false;
     let mut rest: Option<Symbol> = None;
@@ -283,7 +289,7 @@ fn lower_list_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<Unres
     }
 }
 
-fn lower_as_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<UnresolvedName> {
+fn lower_as_pattern(ctx: &mut AstLoweringCtx<'_>, node: Node) -> PatternKind<UnresolvedName> {
     let pattern_node = node.child_by_field_name("pattern");
     // grammar.js uses "binding" field for the as-pattern name
     let name_node = node.child_by_field_name("binding");
@@ -302,7 +308,7 @@ fn lower_as_pattern(ctx: &mut AstLoweringCtx, node: Node) -> PatternKind<Unresol
     }
 }
 
-fn lower_pattern_list(ctx: &mut AstLoweringCtx, node: Node) -> Vec<Pattern<UnresolvedName>> {
+fn lower_pattern_list(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<Pattern<UnresolvedName>> {
     let mut patterns = Vec::new();
     let mut cursor = node.walk();
 


### PR DESCRIPTION
## Summary

- Eliminates the intermediate `Vec<Diagnostic>` in `AstLoweringCtx` and the `LoweringResult` wrapper struct that was used to ferry diagnostics from the lowering context back to the Salsa caller
- Adds `AstLoweringCtx::with_db` constructor that takes `Option<&'db dyn salsa::Database>`; diagnostics are now accumulated directly via `Diagnostic::new(...).accumulate(db)` at emit time
- Test-only paths continue to use `AstLoweringCtx::new()` (db=None), which silently discards diagnostics as before
- `finish()` now returns only `SpanMapBuilder` instead of `(SpanMapBuilder, Vec<Diagnostic>)`

Closes #597

## Test plan

- [ ] `cargo nextest run` passes with no regressions
- [ ] Verify diagnostic accumulation in Salsa still works end-to-end for parse/AST errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal AST lowering system architecture to enhance diagnostic handling integration within the compilation pipeline, strengthening code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->