### PR TITLE
feat(prelude): add String::empty() and Bytes::empty() constructors

### DIFF
--- a/lib/std/prelude.trb
+++ b/lib/std/prelude.trb
@@ -124,6 +124,9 @@ enum String {
 }
 
 pub mod String {
+    /// Create an empty string.
+    pub fn empty() -> String { Leaf(b"") }
+
     /// Create a string from a byte sequence (assumed UTF-8).
     pub fn from_bytes(bytes: Bytes) -> String { Leaf(bytes) }
 
@@ -179,6 +182,9 @@ extern "C" fn __tribute_print_newline() -> Nil
 
 /// Bytes module with operations for byte sequences.
 pub mod Bytes {
+    /// Create an empty byte sequence.
+    pub fn empty() -> Bytes { b"" }
+
     /// Get the length of a byte sequence.
     pub fn len(bytes: Bytes) -> Nat {
         __tribute_bytes_len(bytes)

--- a/tests/e2e_native.rs
+++ b/tests/e2e_native.rs
@@ -773,3 +773,35 @@ fn main() {
     );
     assert_eq!(stdout.trim(), "Hello, World!");
 }
+
+// =========================================================================
+// String::empty() and Bytes::empty() tests
+// =========================================================================
+
+#[test]
+fn test_native_string_empty() {
+    assert_native_output(
+        "string_empty.trb",
+        r#"
+fn main() {
+    let s = String::empty()
+    __tribute_print_nat(s.len())
+}
+"#,
+        "0",
+    );
+}
+
+#[test]
+fn test_native_bytes_empty() {
+    assert_native_output(
+        "bytes_empty.trb",
+        r#"
+fn main() {
+    let bs = Bytes::empty()
+    __tribute_print_nat(bs.len())
+}
+"#,
+        "0",
+    );
+}


### PR DESCRIPTION
## Summary

- Add `String::empty()` constructor to `lib/std/prelude.trb`, returning `Leaf(b"")`
- Add `Bytes::empty()` constructor to `lib/std/prelude.trb`, returning `b""`
- These constructors were specified in `new-plans/text.md` but were missing from the prelude
- Depends on bytes literal lowering implemented in #607

Closes #601

## Test plan

- [x] `test_native_string_empty` — compiles and runs a program calling `String::empty()`, asserts length is 0
- [x] `test_native_bytes_empty` — compiles and runs a program calling `Bytes::empty()`, asserts length is 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `String::empty()` constructor to create empty UTF-8 strings
  * Added `Bytes::empty()` constructor to create empty byte sequences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->