### PR TITLE
test(ability): add E2E tests for Throw(e) parameterized ability

### DIFF
--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -740,3 +740,97 @@ fn main() {
 "#;
     assert_native_output("handler_multi_param_op.trb", code, "60");
 }
+
+// =============================================================================
+// Throw(e) Ability Tests (#193)
+// =============================================================================
+
+/// Test basic Throw(e) ability: parameterized non-resumptive effect.
+///
+/// Throw(e) combines parameterized ability (like State(s)) with Never return
+/// type (like Abort). The handler catches the thrown error value.
+#[test]
+fn test_throw_basic() {
+    let code = r#"ability Throw(e) {
+    op throw(error: e) -> Never
+}
+
+fn do_throw() ->{Throw(Nat)} Nat {
+    Throw::throw(42)
+}
+
+fn main() {
+    let result = handle do_throw() {
+        do result { result }
+        op Throw::throw(error) { error }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("throw_basic.trb", code, "42");
+}
+
+/// Test Throw(e) with error payload used in handler computation.
+///
+/// The handler receives the thrown error value and uses it to compute
+/// an alternative result.
+#[test]
+fn test_throw_with_payload() {
+    let code = r#"ability Throw(e) {
+    op throw(error: e) -> Never
+}
+
+fn check_positive(x: Nat) ->{Throw(Nat)} Nat {
+    Throw::throw(x + 100)
+}
+
+fn main() {
+    let result = handle check_positive(5) {
+        do result { result }
+        op Throw::throw(error) { error }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("throw_with_payload.trb", code, "105");
+}
+
+/// Test Throw(e) with multiple throwing operations composed sequentially.
+///
+/// Two functions share the same Throw(Nat) effect. The first succeeds,
+/// the second throws, and the handler catches the error.
+///
+/// Currently fails because CPS transformation applies the continuation
+/// to the error value for non-resumptive operations in sequential let
+/// bindings (produces 87 = 10 + 77 instead of 77).
+#[test]
+#[ignore = "CPS continuation applied to non-resumptive op result in sequential let bindings (#624)"]
+fn test_throw_multiple_operations() {
+    let code = r#"ability Throw(e) {
+    op throw(error: e) -> Never
+}
+
+fn no_throw() ->{Throw(Nat)} Nat {
+    10
+}
+
+fn must_throw() ->{Throw(Nat)} Nat {
+    Throw::throw(77)
+}
+
+fn do_work() ->{Throw(Nat)} Nat {
+    let a = no_throw()
+    let b = must_throw()
+    a + b
+}
+
+fn main() {
+    let result = handle do_work() {
+        do result { result }
+        op Throw::throw(error) { error }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("throw_multiple_ops.trb", code, "77");
+}


### PR DESCRIPTION
## Summary

- Adds E2E tests for `Throw(e)`, a parameterized non-resumptive ability (closes #193)
- `Throw(e)` combines parameterized ability (like `State(s)`) with a `Never` return type (like `Abort`) and works with existing infrastructure
- Adds a third test (`test_throw_multiple_operations`) marked `#[ignore]` to document a discovered CPS bug (#624): the CPS pass incorrectly applies the continuation to the error value when a non-resumptive operation appears in a sequential `let` binding

## Test plan

- [ ] `cargo nextest run -p tribute test_throw_basic` passes
- [ ] `cargo nextest run -p tribute test_throw_with_payload` passes
- [ ] `cargo nextest run -p tribute test_throw_multiple_operations` is ignored (tracked by #624)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for error handling functionality, covering basic error scenarios, payload handling, and sequential operation composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->