### PR TITLE
fix(ast-to-ir): insert return type cast for mismatched function body results

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -241,6 +241,7 @@ fn lower_function<'db>(
         // Lower function body
         let mut builder = IrBuilder::new(&mut scope, ir, entry_block);
         if let Some(result) = expr::lower_expr(&mut builder, func_decl.body) {
+            let result = builder.cast_if_needed(location, result, return_ty);
             let ret_op = func::r#return(builder.ir, location, [result]);
             builder.ir.push_op(builder.block, ret_op.op_ref());
         } else {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/tribute-front/tests/lambda_effect_type.rs
+assertion_line: 244
 expression: ir_text
 ---
 core.module @test {
@@ -53,6 +54,7 @@ core.module @test {
       %5 = arith.const {value = 0} : core.i32
       %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
       %7 = func.call %0, %6 {callee = @run_state} : tribute_rt.anyref
-      func.return %7
+      %8 = core.unrealized_conversion_cast %7 : core.i32
+      func.return %8
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/tribute-front/tests/lambda_effect_type.rs
+assertion_line: 319
 expression: ir_text
 ---
 core.module @test {
@@ -41,6 +42,7 @@ core.module @test {
       %2 = arith.const {value = 42} : core.i32
       %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
       %4 = func.call %0, %3 {callee = @with_state} : tribute_rt.anyref
-      func.return %4
+      %5 = core.unrealized_conversion_cast %4 : core.i32
+      func.return %5
   }
 }

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 136
+assertion_line: 144
 expression: ir_text
 ---
 core.module @test {
@@ -22,6 +22,7 @@ core.module @test {
       %0 = arith.const {value = 10} : core.i32
       %1 = arith.const {value = 20} : core.i32
       %2 = adt.struct_new %0, %1 {type = !Point} : adt.typeref() {name = @Point}
-      func.return %2
+      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      func.return %3
   }
 }

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 172
+assertion_line: 182
 expression: ir_text
 ---
 core.module @test {
@@ -22,6 +22,7 @@ core.module @test {
       %0 = arith.const {value = 42} : core.i32
       %1 = arith.const {value = true} : core.i1
       %2 = adt.struct_new %0, %1 {type = !Pair} : adt.typeref() {name = @Pair}
-      func.return %2
+      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      func.return %3
   }
 }

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 154
+assertion_line: 163
 expression: ir_text
 ---
 core.module @test {
@@ -22,6 +22,7 @@ core.module @test {
       %1 = arith.const {value = 100} : core.i32
       %2 = adt.struct_get %0 {field = 1, type = !Point} : tribute_rt.anyref
       %3 = adt.struct_new %1, %2 {type = !Point} : adt.typeref() {name = @Point}
-      func.return %3
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      func.return %4
   }
 }

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 210
+assertion_line: 222
 expression: ir_text
 ---
 core.module @test {
@@ -22,6 +22,7 @@ core.module @test {
       %1 = arith.const {value = 1} : core.i32
       %2 = arith.const {value = 2} : core.i32
       %3 = adt.struct_new %1, %2 {type = !Point} : adt.typeref() {name = @Point}
-      func.return %3
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      func.return %4
   }
 }

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 191
+assertion_line: 202
 expression: ir_text
 ---
 core.module @test {
@@ -22,6 +22,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 0, type = !Config} : tribute_rt.anyref
       %2 = adt.struct_get %0 {field = 1, type = !Config} : tribute_rt.anyref
       %3 = adt.struct_new %1, %2 {type = !Config} : adt.typeref() {name = @Config}
-      func.return %3
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      func.return %4
   }
 }

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/tribute-front/tests/ufcs_method_call.rs
+assertion_line: 169
 expression: ir_text
 ---
 core.module @test {
@@ -38,7 +39,8 @@ core.module @test {
       %2 = func.call %0 {callee = @"Pair::x"} : core.i32
       %3 = func.call %0 {callee = @"Pair::y"} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple} : adt.typeref() {name = @Triple}
-      func.return %4
+      %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      func.return %5
   }
   func.func @"Triple::sum"(%0: tribute_rt.anyref) -> core.i32 {
       %1 = func.call %0 {callee = @"Triple::x"} : core.i32

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
@@ -39,7 +39,8 @@ core.module @test {
       %2 = func.call %0 {callee = @"Pair::x"} : core.i32
       %3 = func.call %0 {callee = @"Pair::y"} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple} : adt.typeref() {name = @Triple}
-      func.return %4
+      %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      func.return %5
   }
   func.func @test(%0: tribute_rt.anyref) -> tribute_rt.anyref {
       %1 = arith.const {value = 3} : core.i32

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -330,7 +330,6 @@ fn main() {
 /// When `case` branches have different types (Never vs Nat), Cranelift
 /// codegen currently has a type mismatch. This test is ignored until fixed.
 #[test]
-#[ignore = "Cranelift codegen type mismatch with Never in case branches"]
 fn test_abort_conditional() {
     let code = r#"ability Abort {
     op abort() -> Never


### PR DESCRIPTION
## Summary

- Fixes #621: Cranelift codegen type mismatch when `case` expressions have branches returning `Never` (from ability abort/perform ops) alongside concrete return types like `Nat`
- Root cause: The function body result (e.g., `anyref` from an ability `perform`) differed from the declared return type (e.g., `i32`), with no conversion inserted before `func.return`
- Fix: One line added in `decl.rs` — calls `cast_if_needed` before emitting `func.return` to insert an `unrealized_conversion_cast` when types mismatch
- Side effect: Several IR snapshot tests updated to reflect the newly inserted cast operation
- `test_abort_conditional` (previously marked `#[ignore]`) now passes and has been re-enabled

## Test plan

- [ ] `cargo nextest run` passes without failures
- [ ] `test_abort_conditional` in `tests/e2e_ability_handler.rs` passes (previously `#[ignore]`)
- [ ] IR snapshot tests reflect the new `unrealized_conversion_cast` in affected snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function return type handling to ensure values match declared return types.

* **Tests**
  * Enabled previously skipped test case for conditional abort functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->