### PR TITLE
feat: add Abort/Throw(e) to prelude with module-qualified ability path support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,8 +1428,8 @@ checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
 name = "tree-sitter-tribute"
-version = "0.6.3"
-source = "git+https://github.com/Kroisse/tree-sitter-tribute?tag=v0.6.3#39607da837cdd87ef21db035355e3d9ecfcaf766"
+version = "0.7.0"
+source = "git+https://github.com/Kroisse/tree-sitter-tribute?tag=v0.7.0#8d9b29b9868f2dac07effe820d6254a67ada79d6"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tempfile = "3.27"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tree-sitter = "0.26.7"
-tree-sitter-tribute = { git = "https://github.com/Kroisse/tree-sitter-tribute", tag = "v0.6.3" }
+tree-sitter-tribute = { git = "https://github.com/Kroisse/tree-sitter-tribute", tag = "v0.7.0" }
 tribute-core = { path = "crates/tribute-core" }
 tribute-front = { path = "crates/tribute-front" }
 tribute-ir = { path = "crates/tribute-ir" }

--- a/crates/tribute-front/src/astgen/declarations.rs
+++ b/crates/tribute-front/src/astgen/declarations.rs
@@ -369,23 +369,21 @@ fn lower_ability_row(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Vec<TypeAnnota
 
 /// Lower an ability_item into a TypeAnnotation.
 ///
-/// Grammar: `ability_item = type_identifier optional(type_arguments)`
-/// e.g. `Console` or `State(Int)`
+/// Grammar: `ability_item = ability_path optional(type_arguments)`
+/// e.g. `Console`, `State(Int)`, or `abilities::Throw(Nat)`
 fn lower_ability_item(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAnnotation> {
     let mut cursor = node.walk();
     let children: Vec<_> = node.named_children(&mut cursor).collect();
 
-    let name_node = children.first().filter(|n| n.kind() == "type_identifier")?;
+    let path_node = children
+        .first()
+        .filter(|n| n.kind() == "ability_path" || n.kind() == "type_identifier")?;
     let id = ctx.fresh_id_with_span(&node);
-    let name = ctx.node_symbol(name_node);
+    let name_ann = lower_ability_path(ctx, *path_node);
 
     // Check for type_arguments (e.g. State(Int))
     let type_args_node = children.iter().find(|n| n.kind() == "type_arguments");
     if let Some(args_node) = type_args_node {
-        let ctor = Box::new(TypeAnnotation {
-            id: ctx.fresh_id_with_span(name_node),
-            kind: TypeAnnotationKind::Named(name),
-        });
         let mut args_cursor = args_node.walk();
         let args: Vec<TypeAnnotation> = args_node
             .named_children(&mut args_cursor)
@@ -393,13 +391,53 @@ fn lower_ability_item(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAn
             .collect();
         Some(TypeAnnotation {
             id,
-            kind: TypeAnnotationKind::App { ctor, args },
+            kind: TypeAnnotationKind::App {
+                ctor: Box::new(name_ann),
+                args,
+            },
         })
     } else {
-        Some(TypeAnnotation {
+        Some(name_ann)
+    }
+}
+
+/// Lower an ability_path into a TypeAnnotation.
+///
+/// Single segment (`Abort`) → `Named`, multi-segment (`abilities::Throw`) → `Path`.
+fn lower_ability_path(ctx: &mut AstLoweringCtx<'_>, node: Node) -> TypeAnnotation {
+    let id = ctx.fresh_id_with_span(&node);
+
+    // Single segment: ability_path is just a type_identifier
+    if node.kind() == "type_identifier" {
+        let name = ctx.node_symbol(&node);
+        return TypeAnnotation {
             id,
             kind: TypeAnnotationKind::Named(name),
-        })
+        };
+    }
+
+    // Multi-segment or single-segment ability_path
+    let mut segments = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "path_segment" | "path_keyword" | "type_identifier" => {
+                segments.push(ctx.node_symbol(&child));
+            }
+            _ => {}
+        }
+    }
+
+    if segments.len() == 1 {
+        TypeAnnotation {
+            id,
+            kind: TypeAnnotationKind::Named(segments[0]),
+        }
+    } else {
+        TypeAnnotation {
+            id,
+            kind: TypeAnnotationKind::Path(segments),
+        }
     }
 }
 

--- a/crates/tribute-front/src/resolve/resolver.rs
+++ b/crates/tribute-front/src/resolve/resolver.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 
 use salsa::Accumulator as _;
 use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
-use tribute_ir::ModulePathExt as _;
 use trunk_ir::Symbol;
 
 use crate::ast::{
@@ -152,14 +151,12 @@ impl<'db> Resolver<'db> {
                 return self.binding_to_ref(binding, sym);
             }
         } else {
-            // Qualified path: e.g., State::get, Option::Some
+            // Qualified path: e.g., State::get, Option::Some, abilities::Throw::throw
             if let Some(namespace) = name.namespace()
-                && namespace.is_simple()
                 && let Some(binding) = self.env.lookup_qualified(namespace, sym)
             {
                 return self.binding_to_ref(binding, sym);
             }
-            // TODO: Support multi-level paths (e.g., std::io::Reader)
         }
 
         // Not found - emit diagnostic and return unresolved sentinel

--- a/lib/std/prelude.trb
+++ b/lib/std/prelude.trb
@@ -288,6 +288,24 @@ pub mod Bytes {
 }
 
 // =============================================================================
+// Standard Abilities
+// =============================================================================
+
+pub mod abilities {
+    /// A non-resumptive ability that aborts the current computation.
+    /// The handler provides an alternative result.
+    pub ability Abort {
+        op abort() -> Never
+    }
+
+    /// A parameterized non-resumptive ability for typed error handling.
+    /// The handler receives the thrown error value of type `e`.
+    pub ability Throw(e) {
+        op throw(error: e) -> Never
+    }
+}
+
+// =============================================================================
 // I/O functions
 // =============================================================================
 

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -742,26 +742,24 @@ fn main() {
 
 // =============================================================================
 // Throw(e) Ability Tests (#193)
+//
+// These tests use the prelude-defined abilities (abilities::Abort, abilities::Throw).
 // =============================================================================
 
-/// Test basic Throw(e) ability: parameterized non-resumptive effect.
+/// Test basic Throw(e) ability from prelude.
 ///
 /// Throw(e) combines parameterized ability (like State(s)) with Never return
 /// type (like Abort). The handler catches the thrown error value.
 #[test]
 fn test_throw_basic() {
-    let code = r#"ability Throw(e) {
-    op throw(error: e) -> Never
-}
-
-fn do_throw() ->{Throw(Nat)} Nat {
-    Throw::throw(42)
+    let code = r#"fn do_throw() ->{abilities::Throw(Nat)} Nat {
+    abilities::Throw::throw(42)
 }
 
 fn main() {
     let result = handle do_throw() {
         do result { result }
-        op Throw::throw(error) { error }
+        op abilities::Throw::throw(error) { error }
     }
     __tribute_print_nat(result)
 }
@@ -775,18 +773,14 @@ fn main() {
 /// an alternative result.
 #[test]
 fn test_throw_with_payload() {
-    let code = r#"ability Throw(e) {
-    op throw(error: e) -> Never
-}
-
-fn throw_with_offset(x: Nat) ->{Throw(Nat)} Nat {
-    Throw::throw(x + 100)
+    let code = r#"fn throw_with_offset(x: Nat) ->{abilities::Throw(Nat)} Nat {
+    abilities::Throw::throw(x + 100)
 }
 
 fn main() {
     let result = handle throw_with_offset(5) {
         do result { result }
-        op Throw::throw(error) { error }
+        op abilities::Throw::throw(error) { error }
     }
     __tribute_print_nat(result)
 }
@@ -805,19 +799,15 @@ fn main() {
 #[test]
 #[ignore = "CPS continuation applied to non-resumptive op result in sequential let bindings (#624)"]
 fn test_throw_multiple_operations() {
-    let code = r#"ability Throw(e) {
-    op throw(error: e) -> Never
-}
-
-fn no_throw() ->{Throw(Nat)} Nat {
+    let code = r#"fn no_throw() ->{abilities::Throw(Nat)} Nat {
     10
 }
 
-fn must_throw() ->{Throw(Nat)} Nat {
-    Throw::throw(77)
+fn must_throw() ->{abilities::Throw(Nat)} Nat {
+    abilities::Throw::throw(77)
 }
 
-fn do_work() ->{Throw(Nat)} Nat {
+fn do_work() ->{abilities::Throw(Nat)} Nat {
     let a = no_throw()
     let b = must_throw()
     a + b
@@ -826,10 +816,28 @@ fn do_work() ->{Throw(Nat)} Nat {
 fn main() {
     let result = handle do_work() {
         do result { result }
-        op Throw::throw(error) { error }
+        op abilities::Throw::throw(error) { error }
     }
     __tribute_print_nat(result)
 }
 "#;
     assert_native_output("throw_multiple_ops.trb", code, "77");
+}
+
+/// Test Abort ability from prelude.
+#[test]
+fn test_prelude_abort() {
+    let code = r#"fn do_abort() ->{abilities::Abort} Nat {
+    abilities::Abort::abort()
+}
+
+fn main() {
+    let result = handle do_abort() {
+        do result { result }
+        op abilities::Abort::abort() { 99 }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("prelude_abort.trb", code, "99");
 }


### PR DESCRIPTION
## Summary

- Add `Abort` and `Throw(e)` abilities to `pub mod abilities` in prelude
- Bump tree-sitter-tribute to v0.7.0 — new `ability_path` grammar rule for module-qualified paths in effect annotations (e.g., `{abilities::Throw(Nat)}`)
- Update CST→AST lowering to handle `ability_path` nodes
- Support multi-segment qualified paths in name resolution by removing `is_simple()` guard in `resolve_name()`
- Update E2E tests to use prelude-defined abilities

## Test plan

- [x] `test_throw_basic`, `test_throw_with_payload` — prelude Throw(e) E2E
- [x] `test_prelude_abort` — prelude Abort E2E
- [x] All 339 existing tests pass
- [x] tree-sitter-tribute corpus tests pass (163/163)

Partially addresses #629 (module-qualified paths work; unqualified TDNR not yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)