### PR TITLE
fix(ci): include all workspace crates in coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,7 @@ jobs:
           tool: cargo-llvm-cov,nextest,wasmtime
 
       - name: Generate coverage report
-        run: |
-          source <(cargo llvm-cov show-env --sh)
-          cargo build --workspace
-          cargo nextest run --workspace
-          cargo llvm-cov report --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

- `cargo llvm-cov report` defaults to the root package only, so the coverage CI job was silently omitting all workspace crates other than `src/`.
- Replaces the manual `show-env` + `cargo build` + `cargo nextest run` + `cargo llvm-cov report` sequence with a single `cargo llvm-cov nextest --workspace` invocation, which both runs the tests and collects coverage across all workspace crates.

## Test plan

- [x] CI coverage job passes and Codecov receives a report covering all workspace crates (not just the root `tribute` crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)