### PR TITLE
fix(ast-to-ir): box/unbox multi-param ability op handler args (#562)

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -1566,7 +1566,7 @@ fn build_cps_continuation<'db>(
 }
 
 /// Pack multiple ability op arguments into a single anyref tuple if needed.
-fn pack_ability_args(
+pub(super) fn pack_ability_args(
     builder: &mut IrBuilder<'_, '_>,
     location: Location,
     arg_values: Vec<ValueRef>,

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -1573,8 +1573,13 @@ fn pack_ability_args(
 ) -> Vec<ValueRef> {
     if arg_values.len() > 1 {
         let any_ty = builder.ctx.anyref_type(builder.ir);
-        let tuple_ty = ability_args_tuple_type(builder.ir, arg_values.len());
-        let tuple_op = adt::struct_new(builder.ir, location, arg_values, any_ty, tuple_ty);
+        // Cast each arg to anyref (inserts box_int etc. via unrealized_conversion_cast)
+        let boxed_args: Vec<ValueRef> = arg_values
+            .into_iter()
+            .map(|v| builder.cast_if_needed(location, v, any_ty))
+            .collect();
+        let tuple_ty = ability_args_tuple_type(builder.ir, boxed_args.len());
+        let tuple_op = adt::struct_new(builder.ir, location, boxed_args, any_ty, tuple_ty);
         builder.ir.push_op(builder.block, tuple_op.op_ref());
         vec![tuple_op.result(builder.ir)]
     } else {

--- a/crates/tribute-front/src/ast_to_ir/lower/handle.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/handle.rs
@@ -42,15 +42,8 @@ pub(super) fn lower_ability_fn_call<'db>(
     let anyref_ty = builder.ctx.anyref_type(builder.ir);
     let ability_ref = builder.ctx.ability_ref_type(builder.ir, ability, &[]);
 
-    // Pack multiple arguments into a tuple if needed
-    let packed_args = if args.len() > 1 {
-        let tuple_ty = super::expr::ability_args_tuple_type(builder.ir, args.len());
-        let tuple_op = adt::struct_new(builder.ir, location, args, anyref_ty, tuple_ty);
-        builder.ir.push_op(builder.block, tuple_op.op_ref());
-        vec![tuple_op.result(builder.ir)]
-    } else {
-        args
-    };
+    // Pack multiple arguments into a tuple if needed (with boxing)
+    let packed_args = super::expr::pack_ability_args(builder, location, args);
 
     // Emit ability.call (direct call, no continuation)
     let call_op = ability::call(
@@ -96,15 +89,8 @@ pub(super) fn lower_ability_op_call<'db>(
     let anyref_ty = builder.ctx.anyref_type(builder.ir);
     let ability_ref = builder.ctx.ability_ref_type(builder.ir, ability, &[]);
 
-    // Pack multiple arguments into a tuple if needed
-    let packed_args = if args.len() > 1 {
-        let tuple_ty = super::expr::ability_args_tuple_type(builder.ir, args.len());
-        let tuple_op = adt::struct_new(builder.ir, location, args, anyref_ty, tuple_ty);
-        builder.ir.push_op(builder.block, tuple_op.op_ref());
-        vec![tuple_op.result(builder.ir)]
-    } else {
-        args
-    };
+    // Pack multiple arguments into a tuple if needed (with boxing)
+    let packed_args = super::expr::pack_ability_args(builder, location, args);
 
     // Build identity continuation: fn(result) { result }
     // Continuation closures are internal mechanism, not user lambdas.

--- a/crates/tribute-front/src/ast_to_ir/lower/handle.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/handle.rs
@@ -20,7 +20,7 @@ use trunk_ir::types::{Attribute, Location};
 
 use tribute_ir::dialect::{ability, closure};
 
-use crate::ast::{Expr, HandlerArm, HandlerKind, ResolvedRef, TypedRef};
+use crate::ast::{Expr, HandlerArm, HandlerKind, Pattern, ResolvedRef, TypedRef};
 
 use super::super::context::IrLoweringCtx;
 use super::IrBuilder;
@@ -611,19 +611,7 @@ fn build_cps_suspend_handler_region<'db>(
         }
 
         // Bind params patterns
-        if params.len() == 1 {
-            bind_pattern_fields(&mut scope, ir, block, location, shift_value, &params[0]);
-        } else if params.len() > 1 {
-            // Multiple params - destructure as tuple
-            let tuple_ty = super::expr::ability_args_tuple_type(ir, params.len());
-            for (i, param) in params.iter().enumerate() {
-                let field_op =
-                    adt::struct_get(ir, location, shift_value, any_ty, tuple_ty, i as u32);
-                ir.push_op(block, field_op.op_ref());
-                let field_val = field_op.result(ir);
-                bind_pattern_fields(&mut scope, ir, block, location, field_val, param);
-            }
-        }
+        bind_handler_params(&mut scope, ir, block, location, shift_value, params, any_ty);
 
         // Create identity done_k for the handler arm body.
         // Handler arms may call effectful functions (e.g., run_state) that
@@ -1044,18 +1032,9 @@ fn build_fn_handler_arm_for_dispatch<'db>(
         // No resume binding for fn handlers
 
         // Bind params patterns
-        if params.len() == 1 {
-            bind_pattern_fields(&mut scope, ir, block, location, value_val, &params[0]);
-        } else if params.len() > 1 {
-            let tuple_ty = super::expr::ability_args_tuple_type(ir, params.len());
-            for (i, param) in params.iter().enumerate() {
-                let field_op =
-                    adt::struct_get(ir, location, value_val, anyref_ty, tuple_ty, i as u32);
-                ir.push_op(block, field_op.op_ref());
-                let field_val = field_op.result(ir);
-                bind_pattern_fields(&mut scope, ir, block, location, field_val, param);
-            }
-        }
+        bind_handler_params(
+            &mut scope, ir, block, location, value_val, params, anyref_ty,
+        );
 
         // Evaluate the handler body
         {
@@ -1251,18 +1230,9 @@ fn build_handler_arm_for_dispatch<'db>(
         }
 
         // Bind params patterns
-        if params.len() == 1 {
-            bind_pattern_fields(&mut scope, ir, block, location, value_val, &params[0]);
-        } else if params.len() > 1 {
-            let tuple_ty = super::expr::ability_args_tuple_type(ir, params.len());
-            for (i, param) in params.iter().enumerate() {
-                let field_op =
-                    adt::struct_get(ir, location, value_val, anyref_ty, tuple_ty, i as u32);
-                ir.push_op(block, field_op.op_ref());
-                let field_val = field_op.result(ir);
-                bind_pattern_fields(&mut scope, ir, block, location, field_val, param);
-            }
-        }
+        bind_handler_params(
+            &mut scope, ir, block, location, value_val, params, anyref_ty,
+        );
 
         // Create identity done_k for effectful calls in handler arm body.
         let prev_done_k = scope.done_k;
@@ -1310,4 +1280,44 @@ fn build_handler_arm_for_dispatch<'db>(
         blocks: trunk_ir::smallvec::smallvec![block],
         parent_op: None,
     })
+}
+
+/// Bind handler arm parameters from an ability operation's packed arguments.
+///
+/// Single-param ops pass the value directly; multi-param ops pack arguments
+/// into an `anyref` tuple struct. This function destructures the tuple and
+/// inserts `unrealized_conversion_cast` to convert each `anyref` field to
+/// the pattern's actual IR type (e.g., `core.i32` for `Nat`).
+fn bind_handler_params<'db>(
+    ctx: &mut IrLoweringCtx<'db>,
+    ir: &mut IrContext,
+    block: trunk_ir::refs::BlockRef,
+    location: Location,
+    value: ValueRef,
+    params: &[Pattern<TypedRef<'db>>],
+    anyref_ty: TypeRef,
+) {
+    if params.len() == 1 {
+        bind_pattern_fields(ctx, ir, block, location, value, &params[0]);
+    } else if params.len() > 1 {
+        let tuple_ty = super::expr::ability_args_tuple_type(ir, params.len());
+        for (i, param) in params.iter().enumerate() {
+            let field_op = adt::struct_get(ir, location, value, anyref_ty, tuple_ty, i as u32);
+            ir.push_op(block, field_op.op_ref());
+            let mut field_val = field_op.result(ir);
+
+            // Cast anyref → actual param type (inserts unbox via unrealized_conversion_cast)
+            let param_ty = ctx
+                .get_node_type(param.id)
+                .map(|ty| ctx.convert_type(ir, *ty))
+                .unwrap_or(anyref_ty);
+            if param_ty != anyref_ty {
+                let cast_op = core::unrealized_conversion_cast(ir, location, field_val, param_ty);
+                ir.push_op(block, cast_op.op_ref());
+                field_val = cast_op.result(ir);
+            }
+
+            bind_pattern_fields(ctx, ir, block, location, field_val, param);
+        }
+    }
 }

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1795,6 +1795,25 @@ impl<'db> TypeChecker<'db> {
             })
             .collect();
 
+        // Check arity before constraining
+        if params.len() != op_param_types.len() {
+            if let Some(first) = params.first() {
+                Diagnostic::new(
+                    format!(
+                        "handler arm has {} parameter(s), but operation '{}' expects {}",
+                        params.len(),
+                        op,
+                        op_param_types.len()
+                    ),
+                    self.get_span(first.id),
+                    DiagnosticSeverity::Error,
+                    CompilationPhase::TypeChecking,
+                )
+                .accumulate(self.db());
+            }
+            return;
+        }
+
         // Infer, constrain, and bind each pattern to the corresponding op param type
         for (pattern, op_ty) in params.iter().zip(op_param_types.iter()) {
             let pattern_ty = self.infer_pattern_type_with_ctx(ctx, pattern);

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1679,7 +1679,7 @@ impl<'db> TypeChecker<'db> {
                 op,
                 params,
             } => {
-                self.constrain_handler_params(ctx, &ability, op, &params);
+                self.constrain_handler_params(ctx, &ability, op, &params, arm.id);
                 HandlerKind::Fn {
                     ability: self.convert_ref_with_ctx(ctx, ability),
                     op,
@@ -1728,7 +1728,7 @@ impl<'db> TypeChecker<'db> {
                     }
                 }
 
-                self.constrain_handler_params(ctx, &ability, op, &params);
+                self.constrain_handler_params(ctx, &ability, op, &params, arm.id);
                 HandlerKind::Op {
                     ability: self.convert_ref_with_ctx(ctx, ability),
                     op,
@@ -1759,6 +1759,7 @@ impl<'db> TypeChecker<'db> {
         ability: &ResolvedRef<'db>,
         op: Symbol,
         params: &[Pattern<ResolvedRef<'db>>],
+        arm_id: crate::ast::NodeId,
     ) {
         let Some(ability_id) = self.extract_ability_id_from_ref(ability) else {
             return;
@@ -1797,20 +1798,22 @@ impl<'db> TypeChecker<'db> {
 
         // Check arity before constraining
         if params.len() != op_param_types.len() {
-            if let Some(first) = params.first() {
-                Diagnostic::new(
-                    format!(
-                        "handler arm has {} parameter(s), but operation '{}' expects {}",
-                        params.len(),
-                        op,
-                        op_param_types.len()
-                    ),
-                    self.get_span(first.id),
-                    DiagnosticSeverity::Error,
-                    CompilationPhase::TypeChecking,
-                )
-                .accumulate(self.db());
-            }
+            let span = params
+                .first()
+                .map(|p| self.get_span(p.id))
+                .unwrap_or_else(|| self.get_span(arm_id));
+            Diagnostic::new(
+                format!(
+                    "handler arm has {} parameter(s), but operation '{}' expects {}",
+                    params.len(),
+                    op,
+                    op_param_types.len()
+                ),
+                span,
+                DiagnosticSeverity::Error,
+                CompilationPhase::TypeChecking,
+            )
+            .accumulate(self.db());
             return;
         }
 

--- a/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
@@ -8,13 +8,15 @@ core.module @test {
   func.func @store(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32, core.i32) {name = @KV}) {tail_var_id = 0} {
       %1 = arith.const {value = 1} : core.i32
       %2 = arith.const {value = 2} : core.i32
-      %3 = adt.struct_new %1, %2 {type = !__ability_args_tuple} : tribute_rt.anyref
-      %4 = ability.call %3 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %4 : core.nil
-      %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %8 = func.call_indirect %7, %6 : tribute_rt.anyref
-      func.return %8
+      %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
+      %4 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      %5 = adt.struct_new %3, %4 {type = !__ability_args_tuple} : tribute_rt.anyref
+      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.nil
+      %8 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+      %9 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
+      func.return %10
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/tests/diagnostic_snapshots.rs
+++ b/tests/diagnostic_snapshots.rs
@@ -300,9 +300,7 @@ fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
 "#,
     );
     let result = compile_with_diagnostics(db, source);
-    // Baseline: the compiler does not yet validate handler arm parameter
-    // counts against ability operation definitions.
-    assert!(result.diagnostics.is_empty());
+    assert!(!result.diagnostics.is_empty());
     insta::assert_yaml_snapshot!(result.diagnostics);
 }
 

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -719,7 +719,6 @@ fn main() {
 /// Currently segfaults at runtime: handler unpack produces anyref values that
 /// are used directly in arith.add without unbox_int, causing type mismatch.
 #[test]
-#[ignore = "multi-param handler unpack missing unbox for struct_get results"]
 fn test_handler_multi_param_op() {
     let code = r#"ability Multi {
     op combine(x: Nat, y: Nat, z: Nat) -> Nat

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -739,6 +739,96 @@ fn main() {
     assert_native_output("handler_multi_param_op.trb", code, "60");
 }
 
+/// Test two-parameter ability op handler (simplest multi-param case).
+#[test]
+fn test_handler_two_param_op() {
+    let code = r#"ability Pair {
+    op make(a: Nat, b: Nat) -> Nat
+}
+
+fn use_pair() ->{Pair} Nat {
+    Pair::make(3, 7)
+}
+
+fn main() {
+    let result = handle use_pair() {
+        do result { result }
+        op Pair::make(a, b) { resume a + b }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("handler_two_param_op.trb", code, "10");
+}
+
+/// Test multi-param op where handler only uses one parameter.
+#[test]
+fn test_handler_multi_param_partial_use() {
+    let code = r#"ability Pick {
+    op choose(a: Nat, b: Nat, c: Nat) -> Nat
+}
+
+fn use_pick() ->{Pick} Nat {
+    Pick::choose(100, 200, 300)
+}
+
+fn main() {
+    let result = handle use_pick() {
+        do result { result }
+        op Pick::choose(a, _, c) { resume a + c }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("handler_multi_param_partial.trb", code, "400");
+}
+
+/// Test multi-param ability op with `fn` (tail-resumptive) handler.
+#[test]
+fn test_handler_multi_param_fn_arm() {
+    let code = r#"ability Arith {
+    fn add(a: Nat, b: Nat) -> Nat
+}
+
+fn use_arith() ->{Arith} Nat {
+    Arith::add(15, 27)
+}
+
+fn main() {
+    let result = handle use_arith() {
+        do result { result }
+        fn Arith::add(a, b) { a + b }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("handler_multi_param_fn.trb", code, "42");
+}
+
+/// Test multi-param op called multiple times within a handler.
+#[test]
+fn test_handler_multi_param_repeated_calls() {
+    let code = r#"ability Math {
+    op mul(a: Nat, b: Nat) -> Nat
+}
+
+fn computation() ->{Math} Nat {
+    let x = Math::mul(3, 4)
+    let y = Math::mul(x, 5)
+    y
+}
+
+fn main() {
+    let result = handle computation() {
+        do result { result }
+        op Math::mul(a, b) { resume a * b }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("handler_multi_param_repeated.trb", code, "60");
+}
+
 // =============================================================================
 // Throw(e) Ability Tests (#193)
 //

--- a/tests/snapshots/diagnostic_snapshots__diag_handler_arm_wrong_signature.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_handler_arm_wrong_signature.snap
@@ -2,4 +2,9 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-[]
+- message: "handler arm has 2 parameter(s), but operation 'set' expects 1"
+  span:
+    start: 337
+    end: 338
+  severity: Error
+  phase: TypeChecking


### PR DESCRIPTION
## Summary

- Multi-param ability ops pack args into an `anyref` tuple, but packing omitted boxing (`i32`→`anyref`) and unpacking omitted unboxing (`anyref`→`i32`), causing segfaults at runtime
- **Pack side**: cast each arg to `anyref` via `unrealized_conversion_cast` before `struct_new`
- **Unpack side**: extract `bind_handler_params` helper that inserts `unrealized_conversion_cast` after `struct_get` for each param
- Unify 3 separate inline pack sites in `handle.rs` to reuse `pack_ability_args`
- Fix `fn` handler call path (`lower_ability_fn_call`) which had the same missing boxing

## Test plan

- [x] `test_handler_multi_param_op` — existing ignored test, now passes
- [x] `test_handler_two_param_op` — two-param op (simplest multi-param)
- [x] `test_handler_multi_param_partial_use` — wildcard param
- [x] `test_handler_multi_param_fn_arm` — `fn` handler arm
- [x] `test_handler_multi_param_repeated_calls` — repeated op calls
- [x] Full test suite: 1192 passed, 11 skipped

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for multi-parameter ability handlers is now functional.

* **Bug Fixes**
  * Fixed parameter handling in ability operations with multiple arguments.
  * Enhanced validation with clearer error messages when handler signatures don't match operation requirements.

* **Tests**
  * Added comprehensive test coverage for multi-parameter ability handler scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->