### PR TITLE
feat(ast-to-ir): integrate evidence params into IR lowering (#642)

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -73,6 +73,11 @@ pub struct IrLoweringCtx<'db> {
     /// When set, pure results at the end of continuation chains should call
     /// this closure instead of `func.return`.
     pub(crate) done_k: Option<ValueRef>,
+
+    /// Evidence value for the enclosing effectful function.
+    /// Passed as the first parameter to effectful functions and threaded
+    /// through to effectful callees.
+    pub(crate) evidence: Option<ValueRef>,
 }
 
 impl<'db> IrLoweringCtx<'db> {
@@ -103,6 +108,7 @@ impl<'db> IrLoweringCtx<'db> {
             node_types,
             cps_handler_mode: false,
             done_k: None,
+            evidence: None,
         }
     }
 

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use tribute_ir::dialect::ability;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, core, func};
@@ -224,9 +225,19 @@ fn lower_function<'db>(
         })
         .collect();
 
-    // Effectful functions receive a done_k (continuation closure) as the first parameter.
+    // Effectful functions receive evidence and done_k as the first two parameters.
+    // Evidence is threaded through to effectful callees.
     // The function calls done_k(result) instead of func.return on normal completion.
     let block_args = if is_effectful {
+        let evidence_ty = ability::evidence_adt_type_ref(ir);
+        let mut ev_arg = BlockArgData {
+            ty: evidence_ty,
+            attrs: Default::default(),
+        };
+        ev_arg.attrs.insert(
+            Symbol::new("bind_name"),
+            Attribute::Symbol(Symbol::new("__evidence")),
+        );
         let mut done_k_arg = BlockArgData {
             ty: anyref_ty,
             attrs: Default::default(),
@@ -235,7 +246,7 @@ fn lower_function<'db>(
             Symbol::new("bind_name"),
             Attribute::Symbol(Symbol::new("__done_k")),
         );
-        let mut args = vec![done_k_arg];
+        let mut args = vec![ev_arg, done_k_arg];
         args.append(&mut block_args);
         args
     } else {
@@ -252,8 +263,8 @@ fn lower_function<'db>(
     // Bind parameters to their block argument values
     {
         let mut scope = ctx.scope();
-        // When effectful, done_k is at index 0, params start at 1
-        let param_offset: u32 = if is_effectful { 1 } else { 0 };
+        // When effectful, evidence=0, done_k=1, params start at 2
+        let param_offset: u32 = if is_effectful { 2 } else { 0 };
         for (i, param) in func_decl.params.iter().enumerate() {
             if let Some(local_id) = param.local_id {
                 let arg_val = ir.block_arg(entry_block, i as u32 + param_offset);
@@ -266,7 +277,10 @@ fn lower_function<'db>(
         // instead of func.return, handled by build_cps_continuation.
         if is_effectful {
             let prev_done_k = scope.done_k;
-            let done_k_val = ir.block_arg(entry_block, 0);
+            let prev_evidence = scope.evidence;
+            let evidence_val = ir.block_arg(entry_block, 0);
+            let done_k_val = ir.block_arg(entry_block, 1);
+            scope.evidence = Some(evidence_val);
             scope.done_k = Some(done_k_val);
 
             let mut builder = IrBuilder::new(&mut scope, ir, entry_block);
@@ -287,6 +301,7 @@ fn lower_function<'db>(
             // ability.perform → lower_ability_perform will add func.return
 
             scope.done_k = prev_done_k;
+            scope.evidence = prev_evidence;
         } else {
             // Pure function: lower body normally
             let mut builder = IrBuilder::new(&mut scope, ir, entry_block);
@@ -303,9 +318,10 @@ fn lower_function<'db>(
     }
 
     // Build function type
-    // Effectful functions: done_k is the first param, return type is anyref
+    // Effectful functions: evidence + done_k are the first two params, return type is anyref
     let (final_param_types, final_return_ty) = if is_effectful {
-        let mut params = vec![anyref_ty]; // done_k first
+        let evidence_ty = ability::evidence_adt_type_ref(ir);
+        let mut params = vec![evidence_ty, anyref_ty]; // evidence, done_k
         params.extend_from_slice(&param_ir_types);
         (params, anyref_ty)
     } else {

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -247,11 +247,12 @@ pub(super) fn lower_expr<'db>(
                         // If callee is effectful, pass done_k as first arg.
                         // Use existing done_k if available, otherwise create identity.
                         if callee_is_effectful {
+                            let evidence = super::get_or_create_evidence(builder, location);
                             let done_k = builder.ctx.done_k.unwrap_or_else(|| {
                                 super::create_identity_done_k(builder, location)
                             });
                             let anyref_ty = builder.ctx.anyref_type(builder.ir);
-                            let mut cps_args = vec![done_k];
+                            let mut cps_args = vec![evidence, done_k];
                             cps_args.append(&mut arg_values);
                             let op =
                                 func::call(builder.ir, location, cps_args, anyref_ty, callee_name);
@@ -1011,9 +1012,10 @@ fn try_lower_value_effectful_call<'db>(
 
     let anyref_ty = builder.ctx.anyref_type(builder.ir);
 
-    // Get done_k — the caller's continuation (first arg)
+    // Get evidence and done_k — the caller's evidence and continuation
+    let evidence = super::get_or_create_evidence(builder, location);
     let done_k = builder.ctx.done_k?;
-    let mut cps_args = vec![done_k];
+    let mut cps_args = vec![evidence, done_k];
     cps_args.append(&mut arg_values);
 
     let call_op = func::call(builder.ir, location, cps_args, anyref_ty, callee_name);
@@ -1389,8 +1391,9 @@ fn lower_cps_call<'db>(
                 }
             }
 
-            // Call effectful function with continuation as first arg (done_k)
-            let mut cps_args = vec![continuation];
+            // Call effectful function with evidence + continuation as first args
+            let evidence = super::get_or_create_evidence(builder, location);
+            let mut cps_args = vec![evidence, continuation];
             cps_args.append(&mut arg_values);
 
             let call_op = func::call(builder.ir, location, cps_args, anyref_ty, callee_name);

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -1445,6 +1445,26 @@ fn lower_cps_call<'db>(
 /// statements and value expression. Pure results are wrapped in
 /// `YieldResult::Done`; CPS results (from nested ability.perform) are
 /// returned directly.
+/// Add an internal context value (evidence or done_k) to the capture list
+/// if present and not already captured.
+fn capture_ctx_value(
+    captures: &mut Vec<super::super::context::CaptureInfo>,
+    builder: &IrBuilder<'_, '_>,
+    name: Symbol,
+    value: Option<ValueRef>,
+) {
+    if let Some(val) = value
+        && !captures.iter().any(|c| c.value == val)
+    {
+        captures.push(super::super::context::CaptureInfo {
+            name,
+            local_id: crate::ast::LocalId::UNRESOLVED,
+            ty: builder.ir.value_ty(val),
+            value: val,
+        });
+    }
+}
+
 fn build_cps_continuation<'db>(
     builder: &mut IrBuilder<'_, 'db>,
     location: Location,
@@ -1466,20 +1486,16 @@ fn build_cps_continuation<'db>(
         &excluded_ids,
     );
 
-    // If we're inside an effectful function (done_k is set), capture done_k
-    // so it's available at the end of the continuation chain.
-    if let Some(done_k_val) = builder.ctx.done_k {
-        // Add done_k to captures if not already present
-        let already_captured = captures.iter().any(|c| c.value == done_k_val);
-        if !already_captured {
-            captures.push(super::super::context::CaptureInfo {
-                name: Symbol::new("__done_k"),
-                local_id: crate::ast::LocalId::UNRESOLVED,
-                ty: builder.ir.value_ty(done_k_val),
-                value: done_k_val,
-            });
-        }
-    }
+    // Inside effectful functions, capture done_k so it's available
+    // at the end of the continuation chain after lambda lifting.
+    // Evidence is NOT captured here — it's provided by the lifted function's
+    // own evidence parameter (added by lower_closure_lambda).
+    capture_ctx_value(
+        &mut captures,
+        builder,
+        Symbol::new("__done_k"),
+        builder.ctx.done_k,
+    );
 
     // Build body region with one parameter: the ability op result (anyref).
     // Continuation closures are internal mechanism closures, not user lambdas,

--- a/crates/tribute-front/src/ast_to_ir/lower/lambda.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/lambda.rs
@@ -441,7 +441,9 @@ pub(super) fn wrap_func_as_closure(
     }
 
     if callee_is_effectful {
-        // Effectful original: forward done_k as first arg
+        // Effectful original: forward done_k as first arg.
+        // Evidence is handled by closure_lower which extracts it from
+        // the wrapper's own evidence parameter.
         let mut cps_args = vec![done_k_val];
         cps_args.append(&mut call_args);
         let call_op = func::call(builder.ir, location, cps_args, any_ty, func_name);

--- a/crates/tribute-front/src/ast_to_ir/lower/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/mod.rs
@@ -387,6 +387,24 @@ pub(super) fn create_identity_done_k(
 /// Emit a call to the `done_k` continuation closure with a result value,
 /// followed by `func.return` with the call's result.
 ///
+/// Get the evidence value from the current scope, or create an empty evidence
+/// placeholder (`adt.ref_null`) if not in an effectful context.
+///
+/// The placeholder is later resolved by `resolve_evidence` pass into a
+/// `func.call @__tribute_evidence_empty()`.
+pub(super) fn get_or_create_evidence(
+    builder: &mut IrBuilder<'_, '_>,
+    location: Location,
+) -> ValueRef {
+    if let Some(ev) = builder.ctx.evidence {
+        return ev;
+    }
+    let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(builder.ir);
+    let null_op = trunk_ir::dialect::adt::ref_null(builder.ir, location, evidence_ty, evidence_ty);
+    builder.ir.push_op(builder.block, null_op.op_ref());
+    null_op.result(builder.ir)
+}
+
 /// Used by effectful functions in CPS mode: instead of `func.return result`,
 /// they call `done_k(result)` and return the call's result.
 ///

--- a/crates/tribute-front/tests/evidence_lowering.rs
+++ b/crates/tribute-front/tests/evidence_lowering.rs
@@ -1,0 +1,96 @@
+//! Tests for evidence parameter insertion during AST-to-IR lowering.
+//!
+//! Verifies that:
+//! - Effectful functions receive `(evidence, done_k, params...)` in their signature
+//! - Effectful call sites pass evidence as the first argument
+//! - Pure functions do not have evidence parameters
+//! - Pure contexts create null evidence when calling effectful functions
+
+mod common;
+
+use self::common::run_ast_pipeline_with_ir;
+use insta::assert_snapshot;
+use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
+
+/// Effectful function should have evidence as first block arg, before done_k.
+#[salsa_test]
+fn test_effectful_func_has_evidence_param(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Foo {
+    op bar() -> Nat
+}
+
+fn effectful() ->{Foo} Nat {
+    Foo::bar()
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
+/// Direct call to an effectful function from another effectful function
+/// should pass the caller's evidence as the first argument.
+#[salsa_test]
+fn test_effectful_call_passes_evidence(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Counter {
+    op inc() -> Nat
+}
+
+fn get_count() ->{Counter} Nat {
+    Counter::inc()
+}
+
+fn use_counter() ->{Counter} Nat {
+    let a = get_count()
+    let b = get_count()
+    a + b
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
+/// Pure function calling an effectful function through a handler should
+/// create null evidence for the outer call context.
+#[salsa_test]
+fn test_pure_context_creates_null_evidence(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Ask {
+    op ask() -> Nat
+}
+
+fn use_ask() ->{Ask} Nat {
+    Ask::ask()
+}
+
+fn main() {
+    let r = handle use_ask() {
+        do result { result }
+        op Ask::ask() { resume 42 }
+    }
+}
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}

--- a/crates/tribute-front/tests/snapshots/cps_lowering__ability_op_then_pure_expr.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__ability_op_then_pure_expr.snap
@@ -3,13 +3,13 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @get_value(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %2 = core.unrealized_conversion_cast %1 : core.i32
-      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %5 = func.call_indirect %4, %3 : tribute_rt.anyref
-      func.return %5
+  func.func @get_value(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
+      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.i32
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %5 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
+      func.return %6
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
@@ -6,13 +6,13 @@ core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @get_state(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %2 = core.unrealized_conversion_cast %1 : core.i32
-      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %0 : !t0
-      %5 = func.call_indirect %4, %3 : tribute_rt.anyref
-      func.return %5
+  func.func @get_state(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
+      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.i32
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %5 = core.unrealized_conversion_cast %1 : !t0
+      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
+      func.return %6
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -31,70 +31,71 @@ core.module @test {
   }
   func.func @run() -> core.i32 {
       %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
-          %2 = func.call %1 {callee = @get_state} : tribute_rt.anyref
-          func.return %2
+          %2 = adt.ref_null {type = !t1} : !t1
+          %3 = func.call %2, %1 {callee = @get_state} : tribute_rt.anyref
+          func.return %3
       }
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = closure.new %3 {func_ref = @"test::__lambda_0"} : !t0
-      %5 = func.call_indirect %0, %4 : tribute_rt.anyref
-      %6 = closure.lambda(%7: tribute_rt.anyref, %8: core.i32, %9: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
-          %10 = arith.const {value = 1972422014} : core.i32
-          %11 = arith.cmpi %8, %10 {predicate = @eq} : core.i1
-          %12 = scf.if %11 : tribute_rt.anyref {
-              %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %14 = closure.new %13 {func_ref = @"test::__lambda_3"} : !t0
-              %15 = arith.const {value = 42} : core.i32
-              %16 = core.unrealized_conversion_cast %15 : tribute_rt.anyref
-              %17 = core.unrealized_conversion_cast %7 : !t0
-              %18 = func.call_indirect %17, %16 : tribute_rt.anyref
-              scf.yield %18
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t0
+      %6 = func.call_indirect %0, %5 : tribute_rt.anyref
+      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
+          %11 = arith.const {value = 1972422014} : core.i32
+          %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
+          %13 = scf.if %12 : tribute_rt.anyref {
+              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %15 = closure.new %14 {func_ref = @"test::__lambda_3"} : !t0
+              %16 = arith.const {value = 42} : core.i32
+              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+              %18 = core.unrealized_conversion_cast %8 : !t0
+              %19 = func.call_indirect %18, %17 : tribute_rt.anyref
+              scf.yield %19
           } {
-              %19 = arith.const {value = 1} : core.i1
-              %20 = scf.if %19 : tribute_rt.anyref {
-                  %21 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %22 = closure.new %21 {func_ref = @"test::__lambda_4"} : !t0
-                  %23 = arith.const {value = unit} : core.nil
-                  %24 = core.unrealized_conversion_cast %23 : tribute_rt.anyref
-                  %25 = core.unrealized_conversion_cast %7 : !t0
-                  %26 = func.call_indirect %25, %24 : tribute_rt.anyref
-                  scf.yield %26
+              %20 = arith.const {value = 1} : core.i1
+              %21 = scf.if %20 : tribute_rt.anyref {
+                  %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %23 = closure.new %22 {func_ref = @"test::__lambda_4"} : !t0
+                  %24 = arith.const {value = unit} : core.nil
+                  %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
+                  %26 = core.unrealized_conversion_cast %8 : !t0
+                  %27 = func.call_indirect %26, %25 : tribute_rt.anyref
+                  scf.yield %27
               } {
                   func.unreachable
               }
-              scf.yield %20
+              scf.yield %21
           }
-          func.return %12
+          func.return %13
       }
-      %27 = arith.const {value = 0} : tribute_rt.anyref
-      %28 = ability.handle_dispatch %5, %6, %27 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %28 = arith.const {value = 0} : tribute_rt.anyref
+      %29 = ability.handle_dispatch %6, %7, %28 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb8(%29: tribute_rt.anyref):
-              %30 = core.unrealized_conversion_cast %29 : core.i32
-              scf.yield %30
+            ^bb8(%30: tribute_rt.anyref):
+              %31 = core.unrealized_conversion_cast %30 : core.i32
+              scf.yield %31
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb9(%31: tribute_rt.anyref, %32: tribute_rt.anyref):
-              %33 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %34 = closure.new %33 {func_ref = @"test::__lambda_1"} : !t0
-              %35 = arith.const {value = 42} : core.i32
-              %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
-              %37 = core.unrealized_conversion_cast %31 : !t0
-              %38 = func.call_indirect %37, %36 : tribute_rt.anyref
-              scf.yield %38
+            ^bb9(%32: tribute_rt.anyref, %33: tribute_rt.anyref):
+              %34 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %35 = closure.new %34 {func_ref = @"test::__lambda_1"} : !t0
+              %36 = arith.const {value = 42} : core.i32
+              %37 = core.unrealized_conversion_cast %36 : tribute_rt.anyref
+              %38 = core.unrealized_conversion_cast %32 : !t0
+              %39 = func.call_indirect %38, %37 : tribute_rt.anyref
+              scf.yield %39
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb10(%39: tribute_rt.anyref, %40: tribute_rt.anyref):
-              %41 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %42 = closure.new %41 {func_ref = @"test::__lambda_2"} : !t0
-              %43 = arith.const {value = unit} : core.nil
-              %44 = core.unrealized_conversion_cast %43 : tribute_rt.anyref
-              %45 = core.unrealized_conversion_cast %39 : !t0
-              %46 = func.call_indirect %45, %44 : tribute_rt.anyref
-              scf.yield %46
+            ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
+              %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %43 = closure.new %42 {func_ref = @"test::__lambda_2"} : !t0
+              %44 = arith.const {value = unit} : core.nil
+              %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
+              %46 = core.unrealized_conversion_cast %40 : !t0
+              %47 = func.call_indirect %46, %45 : tribute_rt.anyref
+              scf.yield %47
           }
       }
-      %47 = core.unrealized_conversion_cast %28 : core.i32
-      func.return %47
+      %48 = core.unrealized_conversion_cast %29 : core.i32
+      func.return %48
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
@@ -3,109 +3,110 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @get_state(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %2 = core.unrealized_conversion_cast %1 : core.i32
-      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %0 : !t0
-      %5 = func.call_indirect %4, %3 : tribute_rt.anyref
-      func.return %5
+  func.func @get_state(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
+      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.i32
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %5 = core.unrealized_conversion_cast %1 : !t1
+      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
+      func.return %6
   }
-  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_3"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_4"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
   func.func @run() -> core.i32 {
       %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
-          %2 = func.call %1 {callee = @get_state} : tribute_rt.anyref
-          func.return %2
+          %2 = adt.ref_null {type = !t0} : !t0
+          %3 = func.call %2, %1 {callee = @get_state} : tribute_rt.anyref
+          func.return %3
       }
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = closure.new %3 {func_ref = @"test::__lambda_0"} : !t0
-      %5 = func.call_indirect %0, %4 : tribute_rt.anyref
-      %6 = closure.lambda(%7: tribute_rt.anyref, %8: core.i32, %9: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
-          %10 = arith.const {value = 1972422014} : core.i32
-          %11 = arith.cmpi %8, %10 {predicate = @eq} : core.i1
-          %12 = scf.if %11 : tribute_rt.anyref {
-              %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %14 = closure.new %13 {func_ref = @"test::__lambda_3"} : !t0
-              %15 = arith.const {value = 42} : core.i32
-              %16 = core.unrealized_conversion_cast %15 : tribute_rt.anyref
-              scf.yield %16
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t1
+      %6 = func.call_indirect %0, %5 : tribute_rt.anyref
+      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
+          %11 = arith.const {value = 1972422014} : core.i32
+          %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
+          %13 = scf.if %12 : tribute_rt.anyref {
+              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %15 = closure.new %14 {func_ref = @"test::__lambda_3"} : !t1
+              %16 = arith.const {value = 42} : core.i32
+              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+              scf.yield %17
           } {
-              %17 = arith.const {value = 1} : core.i1
-              %18 = scf.if %17 : tribute_rt.anyref {
-                  %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %20 = closure.new %19 {func_ref = @"test::__lambda_4"} : !t0
-                  %21 = arith.const {value = unit} : core.nil
-                  %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
-                  scf.yield %22
+              %18 = arith.const {value = 1} : core.i1
+              %19 = scf.if %18 : tribute_rt.anyref {
+                  %20 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %21 = closure.new %20 {func_ref = @"test::__lambda_4"} : !t1
+                  %22 = arith.const {value = unit} : core.nil
+                  %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
+                  scf.yield %23
               } {
                   func.unreachable
               }
-              scf.yield %18
+              scf.yield %19
           }
-          func.return %12
+          func.return %13
       }
-      %23 = closure.lambda(%24: core.i32, %25: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
-          %26 = arith.const {value = 1972422014} : core.i32
-          %27 = arith.cmpi %24, %26 {predicate = @eq} : core.i1
-          %28 = scf.if %27 : tribute_rt.anyref {
-              %29 = arith.const {value = 42} : core.i32
-              %30 = core.unrealized_conversion_cast %29 : tribute_rt.anyref
-              scf.yield %30
+      %24 = closure.lambda(%25: core.i32, %26: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} {
+          %27 = arith.const {value = 1972422014} : core.i32
+          %28 = arith.cmpi %25, %27 {predicate = @eq} : core.i1
+          %29 = scf.if %28 : tribute_rt.anyref {
+              %30 = arith.const {value = 42} : core.i32
+              %31 = core.unrealized_conversion_cast %30 : tribute_rt.anyref
+              scf.yield %31
           } {
-              %31 = arith.const {value = 1} : core.i1
-              %32 = scf.if %31 : tribute_rt.anyref {
-                  %33 = arith.const {value = unit} : core.nil
-                  %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
-                  scf.yield %34
+              %32 = arith.const {value = 1} : core.i1
+              %33 = scf.if %32 : tribute_rt.anyref {
+                  %34 = arith.const {value = unit} : core.nil
+                  %35 = core.unrealized_conversion_cast %34 : tribute_rt.anyref
+                  scf.yield %35
               } {
                   func.unreachable
               }
-              scf.yield %32
+              scf.yield %33
           }
-          func.return %28
+          func.return %29
       }
-      %35 = ability.handle_dispatch %5, %6, %23 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %36 = ability.handle_dispatch %6, %7, %24 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb13(%36: tribute_rt.anyref):
-              %37 = core.unrealized_conversion_cast %36 : core.i32
-              scf.yield %37
+            ^bb13(%37: tribute_rt.anyref):
+              %38 = core.unrealized_conversion_cast %37 : core.i32
+              scf.yield %38
           }
           ability.yield {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb14(%38: tribute_rt.anyref, %39: tribute_rt.anyref):
-              %40 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %41 = closure.new %40 {func_ref = @"test::__lambda_1"} : !t0
-              %42 = arith.const {value = 42} : core.i32
-              %43 = core.unrealized_conversion_cast %42 : tribute_rt.anyref
-              scf.yield %43
+            ^bb14(%39: tribute_rt.anyref, %40: tribute_rt.anyref):
+              %41 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %42 = closure.new %41 {func_ref = @"test::__lambda_1"} : !t1
+              %43 = arith.const {value = 42} : core.i32
+              %44 = core.unrealized_conversion_cast %43 : tribute_rt.anyref
+              scf.yield %44
           }
           ability.yield {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb15(%44: tribute_rt.anyref, %45: tribute_rt.anyref):
-              %46 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %47 = closure.new %46 {func_ref = @"test::__lambda_2"} : !t0
-              %48 = arith.const {value = unit} : core.nil
-              %49 = core.unrealized_conversion_cast %48 : tribute_rt.anyref
-              scf.yield %49
+            ^bb15(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
+              %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %48 = closure.new %47 {func_ref = @"test::__lambda_2"} : !t1
+              %49 = arith.const {value = unit} : core.nil
+              %50 = core.unrealized_conversion_cast %49 : tribute_rt.anyref
+              scf.yield %50
           }
       }
-      %50 = core.unrealized_conversion_cast %35 : core.i32
-      func.return %50
+      %51 = core.unrealized_conversion_cast %36 : core.i32
+      func.return %51
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
@@ -5,18 +5,18 @@ expression: ir_text
 core.module @test {
   !__ability_args_tuple = adt.struct() {fields = [[@_0, tribute_rt.anyref], [@_1, tribute_rt.anyref]], name = @__ability_args_tuple}
 
-  func.func @store(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32, core.i32) {name = @KV}) {tail_var_id = 0} {
-      %1 = arith.const {value = 1} : core.i32
-      %2 = arith.const {value = 2} : core.i32
-      %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
+  func.func @store(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32, core.i32) {name = @KV}) {tail_var_id = 0} {
+      %2 = arith.const {value = 1} : core.i32
+      %3 = arith.const {value = 2} : core.i32
       %4 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %5 = adt.struct_new %3, %4 {type = !__ability_args_tuple} : tribute_rt.anyref
-      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %6 : core.nil
-      %8 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-      %9 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
-      func.return %10
+      %5 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %6 = adt.struct_new %4, %5 {type = !__ability_args_tuple} : tribute_rt.anyref
+      %7 = ability.call %6 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
+      %8 = core.unrealized_conversion_cast %7 : core.nil
+      %9 = core.unrealized_conversion_cast %8 : tribute_rt.anyref
+      %10 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+      %11 = func.call_indirect %10, %9 : tribute_rt.anyref
+      func.return %11
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/cps_lowering__sequential_ability_ops.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__sequential_ability_ops.snap
@@ -3,16 +3,16 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @set_and_get(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-      %1 = arith.const {value = 42} : core.i32
-      %2 = ability.call %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.nil
-      %4 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %4 : core.i32
-      %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %8 = func.call_indirect %7, %6 : tribute_rt.anyref
-      func.return %8
+  func.func @set_and_get(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
+      %2 = arith.const {value = 42} : core.i32
+      %3 = ability.call %2 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %4 = core.unrealized_conversion_cast %3 : core.nil
+      %5 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %5 : core.i32
+      %7 = core.unrealized_conversion_cast %6 : tribute_rt.anyref
+      %8 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+      %9 = func.call_indirect %8, %7 : tribute_rt.anyref
+      func.return %9
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/cps_lowering__single_ability_op_in_block.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__single_ability_op_in_block.snap
@@ -3,13 +3,13 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @get_state(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %2 = core.unrealized_conversion_cast %1 : core.i32
-      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %5 = func.call_indirect %4, %3 : tribute_rt.anyref
-      func.return %5
+  func.func @get_state(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
+      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.i32
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %5 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
+      func.return %6
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
@@ -1,0 +1,34 @@
+---
+source: crates/tribute-front/tests/evidence_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+
+  func.func @get_count(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @Counter}) {tail_var_id = 0} {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Counter}, op_name = @inc} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @use_counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @Counter}) {tail_var_id = 0} {
+      %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
+          %4 = core.unrealized_conversion_cast %3 : core.i32
+          %5 = closure.lambda(%6: tribute_rt.anyref) -> tribute_rt.anyref [%4, %1] {
+              %7 = core.unrealized_conversion_cast %6 : core.i32
+              %8 = func.call %4, %7 {callee = @"Nat::+"} : core.i32
+              %9 = core.unrealized_conversion_cast %8 : tribute_rt.anyref
+              %10 = core.unrealized_conversion_cast %1 : !t0
+              %11 = func.call_indirect %10, %9 : tribute_rt.anyref
+              func.return %11
+          }
+          %12 = func.call %0, %5 {callee = @get_count} : tribute_rt.anyref
+          func.return %12
+      }
+      %13 = func.call %0, %2 {callee = @get_count} : tribute_rt.anyref
+      func.return %13
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tribute-front/tests/evidence_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  func.func @effectful(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @Foo}) {tail_var_id = 0} {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Foo}, op_name = @bar} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
@@ -1,0 +1,68 @@
+---
+source: crates/tribute-front/tests/evidence_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+
+  func.func @use_ask(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @Ask}) {tail_var_id = 0} {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @main() -> core.nil {
+      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @Ask}) {tail_var_id = 0} {
+          %2 = adt.ref_null {type = !t0} : !t0
+          %3 = func.call %2, %1 {callee = @use_ask} : tribute_rt.anyref
+          func.return %3
+      }
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t1
+      %6 = func.call_indirect %0, %5 : tribute_rt.anyref
+      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @Ask}) {tail_var_id = 0} {
+          %11 = arith.const {value = 1} : core.i1
+          %12 = scf.if %11 : tribute_rt.anyref {
+              %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %14 = closure.new %13 {func_ref = @"test::__lambda_2"} : !t1
+              %15 = arith.const {value = 42} : core.i32
+              %16 = core.unrealized_conversion_cast %15 : tribute_rt.anyref
+              %17 = core.unrealized_conversion_cast %8 : !t1
+              %18 = func.call_indirect %17, %16 : tribute_rt.anyref
+              scf.yield %18
+          } {
+              func.unreachable
+          }
+          func.return %12
+      }
+      %19 = arith.const {value = 0} : tribute_rt.anyref
+      %20 = ability.handle_dispatch %6, %7, %19 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+          ability.done {
+            ^bb6(%21: tribute_rt.anyref):
+              %22 = core.unrealized_conversion_cast %21 : core.i32
+              scf.yield %22
+          }
+          ability.suspend {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask} {
+            ^bb7(%23: tribute_rt.anyref, %24: tribute_rt.anyref):
+              %25 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %26 = closure.new %25 {func_ref = @"test::__lambda_1"} : !t1
+              %27 = arith.const {value = 42} : core.i32
+              %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
+              %29 = core.unrealized_conversion_cast %23 : !t1
+              %30 = func.call_indirect %29, %28 : tribute_rt.anyref
+              scf.yield %30
+          }
+      }
+      %31 = core.unrealized_conversion_cast %20 : core.i32
+      %32 = arith.const {value = unit} : core.nil
+      func.return %32
+  }
+}

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/lambda_effect_type.rs
-assertion_line: 244
 expression: ir_text
 ---
 core.module @test {
@@ -9,17 +8,17 @@ core.module @test {
   !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref) {effect = core.effect_row() {tail_var_id = 11}})
   !t3 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref) {effect = core.effect_row() {tail_var_id = 17}})
 
-  func.func @counter(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %2 = core.unrealized_conversion_cast %1 : core.i32
-      %3 = arith.const {value = 1} : core.i32
-      %4 = func.call %2, %3 {callee = @"Int::+"} : core.i32
-      %5 = ability.call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.nil
-      %7 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %8 = core.unrealized_conversion_cast %0 : !t0
-      %9 = func.call_indirect %8, %7 : tribute_rt.anyref
-      func.return %9
+  func.func @counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
+      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.i32
+      %4 = arith.const {value = 1} : core.i32
+      %5 = func.call %3, %4 {callee = @"Int::+"} : core.i32
+      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.nil
+      %8 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %9 = core.unrealized_conversion_cast %1 : !t0
+      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
+      func.return %10
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -36,93 +35,93 @@ core.module @test {
   func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run_state(%0: tribute_rt.anyref, %1: core.func(tribute_rt.anyref) {effect = core.effect_row(core.ability_ref(tribute_rt.anyref) {name = @State}) {tail_var_id = 1010}}, %2: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 1010} {
-      %3 = closure.lambda(%4: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%1] {
-          %5 = core.unrealized_conversion_cast %1 : !t0
-          %6 = func.call_indirect %5, %4 : tribute_rt.anyref
-          func.return %6
+  func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref) {effect = core.effect_row(core.ability_ref(tribute_rt.anyref) {name = @State}) {tail_var_id = 1010}}, %3: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 1010} {
+      %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%2] {
+          %6 = core.unrealized_conversion_cast %2 : !t0
+          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
+          func.return %7
       }
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_0"} : !t0
-      %9 = func.call_indirect %3, %8 : tribute_rt.anyref
-      %10 = closure.lambda(%11: tribute_rt.anyref, %12: core.i32, %13: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%2] {
-          %14 = arith.const {value = 1972422014} : core.i32
-          %15 = arith.cmpi %12, %14 {predicate = @eq} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = closure.new %17 {func_ref = @"test::__lambda_3"} : !t0
-              %19 = closure.lambda(%20: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%11, %2] {
-                  %21 = core.unrealized_conversion_cast %11 : !t0
-                  %22 = func.call_indirect %21, %2 : tribute_rt.anyref
-                  %23 = core.unrealized_conversion_cast %20 : !t0
-                  %24 = func.call_indirect %23, %22 : tribute_rt.anyref
-                  func.return %24
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = closure.new %8 {func_ref = @"test::__lambda_0"} : !t0
+      %10 = func.call_indirect %4, %9 : tribute_rt.anyref
+      %11 = closure.lambda(%12: tribute_rt.anyref, %13: core.i32, %14: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%3] {
+          %15 = arith.const {value = 1972422014} : core.i32
+          %16 = arith.cmpi %13, %15 {predicate = @eq} : core.i1
+          %17 = scf.if %16 : tribute_rt.anyref {
+              %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
+              %20 = closure.lambda(%21: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%12, %3] {
+                  %22 = core.unrealized_conversion_cast %12 : !t0
+                  %23 = func.call_indirect %22, %3 : tribute_rt.anyref
+                  %24 = core.unrealized_conversion_cast %21 : !t0
+                  %25 = func.call_indirect %24, %23 : tribute_rt.anyref
+                  func.return %25
               }
-              %25 = func.call %18, %19, %2 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %25
+              %26 = func.call %0, %19, %20, %3 {callee = @run_state} : tribute_rt.anyref
+              scf.yield %26
           } {
-              %26 = arith.const {value = 1} : core.i1
-              %27 = scf.if %26 : tribute_rt.anyref {
-                  %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %29 = closure.new %28 {func_ref = @"test::__lambda_4"} : !t0
-                  %30 = closure.lambda(%31: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%11] {
-                      %32 = arith.const {value = unit} : core.nil
-                      %33 = core.unrealized_conversion_cast %32 : tribute_rt.anyref
-                      %34 = core.unrealized_conversion_cast %11 : !t0
-                      %35 = func.call_indirect %34, %33 : tribute_rt.anyref
-                      %36 = core.unrealized_conversion_cast %31 : !t0
-                      %37 = func.call_indirect %36, %35 : tribute_rt.anyref
-                      func.return %37
+              %27 = arith.const {value = 1} : core.i1
+              %28 = scf.if %27 : tribute_rt.anyref {
+                  %29 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %30 = closure.new %29 {func_ref = @"test::__lambda_4"} : !t0
+                  %31 = closure.lambda(%32: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%12] {
+                      %33 = arith.const {value = unit} : core.nil
+                      %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
+                      %35 = core.unrealized_conversion_cast %12 : !t0
+                      %36 = func.call_indirect %35, %34 : tribute_rt.anyref
+                      %37 = core.unrealized_conversion_cast %32 : !t0
+                      %38 = func.call_indirect %37, %36 : tribute_rt.anyref
+                      func.return %38
                   }
-                  %38 = func.call %29, %30, %13 {callee = @run_state} : tribute_rt.anyref
-                  scf.yield %38
+                  %39 = func.call %0, %30, %31, %14 {callee = @run_state} : tribute_rt.anyref
+                  scf.yield %39
               } {
                   func.unreachable
               }
-              scf.yield %27
+              scf.yield %28
           }
-          func.return %16
+          func.return %17
       }
-      %39 = arith.const {value = 0} : tribute_rt.anyref
-      %40 = ability.handle_dispatch %9, %10, %39 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %40 = arith.const {value = 0} : tribute_rt.anyref
+      %41 = ability.handle_dispatch %10, %11, %40 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb10(%41: tribute_rt.anyref):
-              scf.yield %41
+            ^bb10(%42: tribute_rt.anyref):
+              scf.yield %42
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb11(%42: tribute_rt.anyref, %43: tribute_rt.anyref):
-              %44 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %45 = closure.new %44 {func_ref = @"test::__lambda_1"} : !t0
-              %46 = closure.lambda(%47: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%42, %2] {
-                  %48 = core.unrealized_conversion_cast %42 : !t0
-                  %49 = func.call_indirect %48, %2 : tribute_rt.anyref
-                  %50 = core.unrealized_conversion_cast %47 : !t0
-                  %51 = func.call_indirect %50, %49 : tribute_rt.anyref
-                  func.return %51
+            ^bb11(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
+              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t0
+              %47 = closure.lambda(%48: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%43, %3] {
+                  %49 = core.unrealized_conversion_cast %43 : !t0
+                  %50 = func.call_indirect %49, %3 : tribute_rt.anyref
+                  %51 = core.unrealized_conversion_cast %48 : !t0
+                  %52 = func.call_indirect %51, %50 : tribute_rt.anyref
+                  func.return %52
               }
-              %52 = func.call %45, %46, %2 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %52
+              %53 = func.call %0, %46, %47, %3 {callee = @run_state} : tribute_rt.anyref
+              scf.yield %53
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb13(%53: tribute_rt.anyref, %54: tribute_rt.anyref):
-              %55 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %56 = closure.new %55 {func_ref = @"test::__lambda_2"} : !t0
-              %57 = closure.lambda(%58: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%53] {
-                  %59 = arith.const {value = unit} : core.nil
-                  %60 = core.unrealized_conversion_cast %59 : tribute_rt.anyref
-                  %61 = core.unrealized_conversion_cast %53 : !t0
-                  %62 = func.call_indirect %61, %60 : tribute_rt.anyref
-                  %63 = core.unrealized_conversion_cast %58 : !t0
-                  %64 = func.call_indirect %63, %62 : tribute_rt.anyref
-                  func.return %64
+            ^bb13(%54: tribute_rt.anyref, %55: tribute_rt.anyref):
+              %56 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %57 = closure.new %56 {func_ref = @"test::__lambda_2"} : !t0
+              %58 = closure.lambda(%59: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%54] {
+                  %60 = arith.const {value = unit} : core.nil
+                  %61 = core.unrealized_conversion_cast %60 : tribute_rt.anyref
+                  %62 = core.unrealized_conversion_cast %54 : !t0
+                  %63 = func.call_indirect %62, %61 : tribute_rt.anyref
+                  %64 = core.unrealized_conversion_cast %59 : !t0
+                  %65 = func.call_indirect %64, %63 : tribute_rt.anyref
+                  func.return %65
               }
-              %65 = func.call %56, %57, %54 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %65
+              %66 = func.call %0, %57, %58, %55 {callee = @run_state} : tribute_rt.anyref
+              scf.yield %66
           }
       }
-      %66 = core.unrealized_conversion_cast %0 : !t0
-      %67 = func.call_indirect %66, %40 : tribute_rt.anyref
-      func.return %67
+      %67 = core.unrealized_conversion_cast %1 : !t0
+      %68 = func.call_indirect %67, %41 : tribute_rt.anyref
+      func.return %68
   }
   func.func @"test::__lambda_5"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -133,21 +132,25 @@ core.module @test {
               %4 = core.unrealized_conversion_cast %3 : core.i32
               %5 = closure.lambda(%6: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
                   %7 = core.unrealized_conversion_cast %6 : core.i32
-                  %8 = func.call %1 {callee = @counter} : tribute_rt.anyref
-                  func.return %8
+                  %8 = adt.ref_null {type = !t1} : !t1
+                  %9 = func.call %8, %1 {callee = @counter} : tribute_rt.anyref
+                  func.return %9
               }
-              %9 = func.call %5 {callee = @counter} : tribute_rt.anyref
-              func.return %9
+              %10 = adt.ref_null {type = !t1} : !t1
+              %11 = func.call %10, %5 {callee = @counter} : tribute_rt.anyref
+              func.return %11
           }
-          %10 = func.call %2 {callee = @counter} : tribute_rt.anyref
-          func.return %10
+          %12 = adt.ref_null {type = !t1} : !t1
+          %13 = func.call %12, %2 {callee = @counter} : tribute_rt.anyref
+          func.return %13
       }
-      %11 = arith.const {value = 0} : core.i32
-      %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
-      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = closure.new %13 {func_ref = @"test::__lambda_5"} : !t0
-      %15 = func.call %14, %0, %12 {callee = @run_state} : tribute_rt.anyref
-      %16 = core.unrealized_conversion_cast %15 : core.i32
-      func.return %16
+      %14 = arith.const {value = 0} : core.i32
+      %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
+      %16 = adt.ref_null {type = !t1} : !t1
+      %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %18 = closure.new %17 {func_ref = @"test::__lambda_5"} : !t0
+      %19 = func.call %16, %18, %0, %15 {callee = @run_state} : tribute_rt.anyref
+      %20 = core.unrealized_conversion_cast %19 : core.i32
+      func.return %20
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -1,23 +1,22 @@
 ---
 source: crates/tribute-front/tests/lambda_effect_type.rs
-assertion_line: 132
 expression: ir_text
 ---
 core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @counter(%0: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %2 = core.unrealized_conversion_cast %1 : core.i32
-      %3 = arith.const {value = 1} : core.i32
-      %4 = func.call %2, %3 {callee = @"Int::+"} : core.i32
-      %5 = ability.call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.nil
-      %7 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %8 = core.unrealized_conversion_cast %0 : !t0
-      %9 = func.call_indirect %8, %7 : tribute_rt.anyref
-      func.return %9
+  func.func @counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
+      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.i32
+      %4 = arith.const {value = 1} : core.i32
+      %5 = func.call %3, %4 {callee = @"Int::+"} : core.i32
+      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.nil
+      %8 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %9 = core.unrealized_conversion_cast %1 : !t0
+      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
+      func.return %10
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -106,10 +105,11 @@ core.module @test {
   }
   func.func @main() -> core.i32 {
       %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref(core.i32) {name = @State}) {tail_var_id = 0} {
-          %2 = func.call %1 {callee = @counter} : tribute_rt.anyref
-          func.return %2
+          %2 = adt.ref_null {type = !t1} : !t1
+          %3 = func.call %2, %1 {callee = @counter} : tribute_rt.anyref
+          func.return %3
       }
-      %3 = func.call %0 {callee = @run_with_state} : core.i32
-      func.return %3
+      %4 = func.call %0 {callee = @run_with_state} : core.i32
+      func.return %4
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/lambda_effect_type.rs
-assertion_line: 204
 expression: ir_text
 ---
 core.module @test {
@@ -24,93 +23,93 @@ core.module @test {
   func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run_state(%0: tribute_rt.anyref, %1: core.func(tribute_rt.anyref) {effect = core.effect_row(core.ability_ref(tribute_rt.anyref) {name = @State}) {tail_var_id = 1010}}, %2: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 1010} {
-      %3 = closure.lambda(%4: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%1] {
-          %5 = core.unrealized_conversion_cast %1 : !t0
-          %6 = func.call_indirect %5, %4 : tribute_rt.anyref
-          func.return %6
+  func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref) {effect = core.effect_row(core.ability_ref(tribute_rt.anyref) {name = @State}) {tail_var_id = 1010}}, %3: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 1010} {
+      %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%2] {
+          %6 = core.unrealized_conversion_cast %2 : !t0
+          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
+          func.return %7
       }
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_0"} : !t0
-      %9 = func.call_indirect %3, %8 : tribute_rt.anyref
-      %10 = closure.lambda(%11: tribute_rt.anyref, %12: core.i32, %13: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%2] {
-          %14 = arith.const {value = 1972422014} : core.i32
-          %15 = arith.cmpi %12, %14 {predicate = @eq} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = closure.new %17 {func_ref = @"test::__lambda_3"} : !t0
-              %19 = closure.lambda(%20: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%11, %2] {
-                  %21 = core.unrealized_conversion_cast %11 : !t0
-                  %22 = func.call_indirect %21, %2 : tribute_rt.anyref
-                  %23 = core.unrealized_conversion_cast %20 : !t0
-                  %24 = func.call_indirect %23, %22 : tribute_rt.anyref
-                  func.return %24
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = closure.new %8 {func_ref = @"test::__lambda_0"} : !t0
+      %10 = func.call_indirect %4, %9 : tribute_rt.anyref
+      %11 = closure.lambda(%12: tribute_rt.anyref, %13: core.i32, %14: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%3] {
+          %15 = arith.const {value = 1972422014} : core.i32
+          %16 = arith.cmpi %13, %15 {predicate = @eq} : core.i1
+          %17 = scf.if %16 : tribute_rt.anyref {
+              %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
+              %20 = closure.lambda(%21: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%12, %3] {
+                  %22 = core.unrealized_conversion_cast %12 : !t0
+                  %23 = func.call_indirect %22, %3 : tribute_rt.anyref
+                  %24 = core.unrealized_conversion_cast %21 : !t0
+                  %25 = func.call_indirect %24, %23 : tribute_rt.anyref
+                  func.return %25
               }
-              %25 = func.call %18, %19, %2 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %25
+              %26 = func.call %0, %19, %20, %3 {callee = @run_state} : tribute_rt.anyref
+              scf.yield %26
           } {
-              %26 = arith.const {value = 1} : core.i1
-              %27 = scf.if %26 : tribute_rt.anyref {
-                  %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %29 = closure.new %28 {func_ref = @"test::__lambda_4"} : !t0
-                  %30 = closure.lambda(%31: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%11] {
-                      %32 = arith.const {value = unit} : core.nil
-                      %33 = core.unrealized_conversion_cast %32 : tribute_rt.anyref
-                      %34 = core.unrealized_conversion_cast %11 : !t0
-                      %35 = func.call_indirect %34, %33 : tribute_rt.anyref
-                      %36 = core.unrealized_conversion_cast %31 : !t0
-                      %37 = func.call_indirect %36, %35 : tribute_rt.anyref
-                      func.return %37
+              %27 = arith.const {value = 1} : core.i1
+              %28 = scf.if %27 : tribute_rt.anyref {
+                  %29 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %30 = closure.new %29 {func_ref = @"test::__lambda_4"} : !t0
+                  %31 = closure.lambda(%32: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%12] {
+                      %33 = arith.const {value = unit} : core.nil
+                      %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
+                      %35 = core.unrealized_conversion_cast %12 : !t0
+                      %36 = func.call_indirect %35, %34 : tribute_rt.anyref
+                      %37 = core.unrealized_conversion_cast %32 : !t0
+                      %38 = func.call_indirect %37, %36 : tribute_rt.anyref
+                      func.return %38
                   }
-                  %38 = func.call %29, %30, %13 {callee = @run_state} : tribute_rt.anyref
-                  scf.yield %38
+                  %39 = func.call %0, %30, %31, %14 {callee = @run_state} : tribute_rt.anyref
+                  scf.yield %39
               } {
                   func.unreachable
               }
-              scf.yield %27
+              scf.yield %28
           }
-          func.return %16
+          func.return %17
       }
-      %39 = arith.const {value = 0} : tribute_rt.anyref
-      %40 = ability.handle_dispatch %9, %10, %39 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %40 = arith.const {value = 0} : tribute_rt.anyref
+      %41 = ability.handle_dispatch %10, %11, %40 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb10(%41: tribute_rt.anyref):
-              scf.yield %41
+            ^bb10(%42: tribute_rt.anyref):
+              scf.yield %42
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb11(%42: tribute_rt.anyref, %43: tribute_rt.anyref):
-              %44 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %45 = closure.new %44 {func_ref = @"test::__lambda_1"} : !t0
-              %46 = closure.lambda(%47: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%42, %2] {
-                  %48 = core.unrealized_conversion_cast %42 : !t0
-                  %49 = func.call_indirect %48, %2 : tribute_rt.anyref
-                  %50 = core.unrealized_conversion_cast %47 : !t0
-                  %51 = func.call_indirect %50, %49 : tribute_rt.anyref
-                  func.return %51
+            ^bb11(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
+              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t0
+              %47 = closure.lambda(%48: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%43, %3] {
+                  %49 = core.unrealized_conversion_cast %43 : !t0
+                  %50 = func.call_indirect %49, %3 : tribute_rt.anyref
+                  %51 = core.unrealized_conversion_cast %48 : !t0
+                  %52 = func.call_indirect %51, %50 : tribute_rt.anyref
+                  func.return %52
               }
-              %52 = func.call %45, %46, %2 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %52
+              %53 = func.call %0, %46, %47, %3 {callee = @run_state} : tribute_rt.anyref
+              scf.yield %53
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb13(%53: tribute_rt.anyref, %54: tribute_rt.anyref):
-              %55 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %56 = closure.new %55 {func_ref = @"test::__lambda_2"} : !t0
-              %57 = closure.lambda(%58: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%53] {
-                  %59 = arith.const {value = unit} : core.nil
-                  %60 = core.unrealized_conversion_cast %59 : tribute_rt.anyref
-                  %61 = core.unrealized_conversion_cast %53 : !t0
-                  %62 = func.call_indirect %61, %60 : tribute_rt.anyref
-                  %63 = core.unrealized_conversion_cast %58 : !t0
-                  %64 = func.call_indirect %63, %62 : tribute_rt.anyref
-                  func.return %64
+            ^bb13(%54: tribute_rt.anyref, %55: tribute_rt.anyref):
+              %56 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %57 = closure.new %56 {func_ref = @"test::__lambda_2"} : !t0
+              %58 = closure.lambda(%59: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%54] {
+                  %60 = arith.const {value = unit} : core.nil
+                  %61 = core.unrealized_conversion_cast %60 : tribute_rt.anyref
+                  %62 = core.unrealized_conversion_cast %54 : !t0
+                  %63 = func.call_indirect %62, %61 : tribute_rt.anyref
+                  %64 = core.unrealized_conversion_cast %59 : !t0
+                  %65 = func.call_indirect %64, %63 : tribute_rt.anyref
+                  func.return %65
               }
-              %65 = func.call %56, %57, %54 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %65
+              %66 = func.call %0, %57, %58, %55 {callee = @run_state} : tribute_rt.anyref
+              scf.yield %66
           }
       }
-      %66 = core.unrealized_conversion_cast %0 : !t0
-      %67 = func.call_indirect %66, %40 : tribute_rt.anyref
-      func.return %67
+      %67 = core.unrealized_conversion_cast %1 : !t0
+      %68 = func.call_indirect %67, %41 : tribute_rt.anyref
+      func.return %68
   }
   func.func @main() -> core.i32 {
       %0 = arith.const {value = 0} : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -23,93 +23,93 @@ core.module @test {
   func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @with_state(%0: tribute_rt.anyref, %1: core.func(tribute_rt.anyref) {effect = core.effect_row(core.ability_ref(tribute_rt.anyref) {name = @State}) {tail_var_id = 1010}}, %2: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 1010} {
-      %3 = closure.lambda(%4: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%1] {
-          %5 = core.unrealized_conversion_cast %1 : !t0
-          %6 = func.call_indirect %5, %4 : tribute_rt.anyref
-          func.return %6
+  func.func @with_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref) {effect = core.effect_row(core.ability_ref(tribute_rt.anyref) {name = @State}) {tail_var_id = 1010}}, %3: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 1010} {
+      %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%2] {
+          %6 = core.unrealized_conversion_cast %2 : !t0
+          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
+          func.return %7
       }
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_0"} : !t0
-      %9 = func.call_indirect %3, %8 : tribute_rt.anyref
-      %10 = closure.lambda(%11: tribute_rt.anyref, %12: core.i32, %13: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%2] {
-          %14 = arith.const {value = 1972422014} : core.i32
-          %15 = arith.cmpi %12, %14 {predicate = @eq} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = closure.new %17 {func_ref = @"test::__lambda_3"} : !t0
-              %19 = closure.lambda(%20: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%11, %2] {
-                  %21 = core.unrealized_conversion_cast %11 : !t0
-                  %22 = func.call_indirect %21, %2 : tribute_rt.anyref
-                  %23 = core.unrealized_conversion_cast %20 : !t0
-                  %24 = func.call_indirect %23, %22 : tribute_rt.anyref
-                  func.return %24
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = closure.new %8 {func_ref = @"test::__lambda_0"} : !t0
+      %10 = func.call_indirect %4, %9 : tribute_rt.anyref
+      %11 = closure.lambda(%12: tribute_rt.anyref, %13: core.i32, %14: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row(core.ability_ref() {name = @State}, core.ability_ref() {name = @State}) {tail_var_id = 0} [%3] {
+          %15 = arith.const {value = 1972422014} : core.i32
+          %16 = arith.cmpi %13, %15 {predicate = @eq} : core.i1
+          %17 = scf.if %16 : tribute_rt.anyref {
+              %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
+              %20 = closure.lambda(%21: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%12, %3] {
+                  %22 = core.unrealized_conversion_cast %12 : !t0
+                  %23 = func.call_indirect %22, %3 : tribute_rt.anyref
+                  %24 = core.unrealized_conversion_cast %21 : !t0
+                  %25 = func.call_indirect %24, %23 : tribute_rt.anyref
+                  func.return %25
               }
-              %25 = func.call %18, %19, %2 {callee = @with_state} : tribute_rt.anyref
-              scf.yield %25
+              %26 = func.call %0, %19, %20, %3 {callee = @with_state} : tribute_rt.anyref
+              scf.yield %26
           } {
-              %26 = arith.const {value = 1} : core.i1
-              %27 = scf.if %26 : tribute_rt.anyref {
-                  %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %29 = closure.new %28 {func_ref = @"test::__lambda_4"} : !t0
-                  %30 = closure.lambda(%31: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%11] {
-                      %32 = arith.const {value = unit} : core.nil
-                      %33 = core.unrealized_conversion_cast %32 : tribute_rt.anyref
-                      %34 = core.unrealized_conversion_cast %11 : !t0
-                      %35 = func.call_indirect %34, %33 : tribute_rt.anyref
-                      %36 = core.unrealized_conversion_cast %31 : !t0
-                      %37 = func.call_indirect %36, %35 : tribute_rt.anyref
-                      func.return %37
+              %27 = arith.const {value = 1} : core.i1
+              %28 = scf.if %27 : tribute_rt.anyref {
+                  %29 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %30 = closure.new %29 {func_ref = @"test::__lambda_4"} : !t0
+                  %31 = closure.lambda(%32: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%12] {
+                      %33 = arith.const {value = unit} : core.nil
+                      %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
+                      %35 = core.unrealized_conversion_cast %12 : !t0
+                      %36 = func.call_indirect %35, %34 : tribute_rt.anyref
+                      %37 = core.unrealized_conversion_cast %32 : !t0
+                      %38 = func.call_indirect %37, %36 : tribute_rt.anyref
+                      func.return %38
                   }
-                  %38 = func.call %29, %30, %13 {callee = @with_state} : tribute_rt.anyref
-                  scf.yield %38
+                  %39 = func.call %0, %30, %31, %14 {callee = @with_state} : tribute_rt.anyref
+                  scf.yield %39
               } {
                   func.unreachable
               }
-              scf.yield %27
+              scf.yield %28
           }
-          func.return %16
+          func.return %17
       }
-      %39 = arith.const {value = 0} : tribute_rt.anyref
-      %40 = ability.handle_dispatch %9, %10, %39 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %40 = arith.const {value = 0} : tribute_rt.anyref
+      %41 = ability.handle_dispatch %10, %11, %40 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb10(%41: tribute_rt.anyref):
-              scf.yield %41
+            ^bb10(%42: tribute_rt.anyref):
+              scf.yield %42
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb11(%42: tribute_rt.anyref, %43: tribute_rt.anyref):
-              %44 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %45 = closure.new %44 {func_ref = @"test::__lambda_1"} : !t0
-              %46 = closure.lambda(%47: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%42, %2] {
-                  %48 = core.unrealized_conversion_cast %42 : !t0
-                  %49 = func.call_indirect %48, %2 : tribute_rt.anyref
-                  %50 = core.unrealized_conversion_cast %47 : !t0
-                  %51 = func.call_indirect %50, %49 : tribute_rt.anyref
-                  func.return %51
+            ^bb11(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
+              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t0
+              %47 = closure.lambda(%48: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 11} [%43, %3] {
+                  %49 = core.unrealized_conversion_cast %43 : !t0
+                  %50 = func.call_indirect %49, %3 : tribute_rt.anyref
+                  %51 = core.unrealized_conversion_cast %48 : !t0
+                  %52 = func.call_indirect %51, %50 : tribute_rt.anyref
+                  func.return %52
               }
-              %52 = func.call %45, %46, %2 {callee = @with_state} : tribute_rt.anyref
-              scf.yield %52
+              %53 = func.call %0, %46, %47, %3 {callee = @with_state} : tribute_rt.anyref
+              scf.yield %53
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb13(%53: tribute_rt.anyref, %54: tribute_rt.anyref):
-              %55 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %56 = closure.new %55 {func_ref = @"test::__lambda_2"} : !t0
-              %57 = closure.lambda(%58: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%53] {
-                  %59 = arith.const {value = unit} : core.nil
-                  %60 = core.unrealized_conversion_cast %59 : tribute_rt.anyref
-                  %61 = core.unrealized_conversion_cast %53 : !t0
-                  %62 = func.call_indirect %61, %60 : tribute_rt.anyref
-                  %63 = core.unrealized_conversion_cast %58 : !t0
-                  %64 = func.call_indirect %63, %62 : tribute_rt.anyref
-                  func.return %64
+            ^bb13(%54: tribute_rt.anyref, %55: tribute_rt.anyref):
+              %56 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %57 = closure.new %56 {func_ref = @"test::__lambda_2"} : !t0
+              %58 = closure.lambda(%59: tribute_rt.anyref) -> tribute_rt.anyref effects core.effect_row() {tail_var_id = 17} [%54] {
+                  %60 = arith.const {value = unit} : core.nil
+                  %61 = core.unrealized_conversion_cast %60 : tribute_rt.anyref
+                  %62 = core.unrealized_conversion_cast %54 : !t0
+                  %63 = func.call_indirect %62, %61 : tribute_rt.anyref
+                  %64 = core.unrealized_conversion_cast %59 : !t0
+                  %65 = func.call_indirect %64, %63 : tribute_rt.anyref
+                  func.return %65
               }
-              %65 = func.call %56, %57, %54 {callee = @with_state} : tribute_rt.anyref
-              scf.yield %65
+              %66 = func.call %0, %57, %58, %55 {callee = @with_state} : tribute_rt.anyref
+              scf.yield %66
           }
       }
-      %66 = core.unrealized_conversion_cast %0 : !t0
-      %67 = func.call_indirect %66, %40 : tribute_rt.anyref
-      func.return %67
+      %67 = core.unrealized_conversion_cast %1 : !t0
+      %68 = func.call_indirect %67, %41 : tribute_rt.anyref
+      func.return %68
   }
   func.func @"test::__lambda_5"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -123,10 +123,11 @@ core.module @test {
       }
       %5 = arith.const {value = 42} : core.i32
       %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_5"} : !t0
-      %9 = func.call %8, %0, %6 {callee = @with_state} : tribute_rt.anyref
-      %10 = core.unrealized_conversion_cast %9 : core.i32
-      func.return %10
+      %7 = adt.ref_null {type = !t1} : !t1
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = closure.new %8 {func_ref = @"test::__lambda_5"} : !t0
+      %10 = func.call %7, %9, %0, %6 {callee = @with_state} : tribute_rt.anyref
+      %11 = core.unrealized_conversion_cast %10 : core.i32
+      func.return %11
   }
 }

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -555,6 +555,19 @@ fn transform_closure_calls_in_block(
             continue;
         }
 
+        // Skip if evidence is already present as the first non-table-idx argument
+        {
+            let operands = ctx.op_operands(op);
+            if operands.len() > 1
+                && tribute_ir::dialect::ability::is_evidence_type_ref(
+                    ctx,
+                    ctx.value_ty(operands[1]),
+                )
+            {
+                continue;
+            }
+        }
+
         let evidence = if let Some(ev) = evidence_from_param {
             ev
         } else {

--- a/crates/tribute-passes/src/evidence.rs
+++ b/crates/tribute-passes/src/evidence.rs
@@ -286,9 +286,12 @@ impl RewritePattern for TransformEvidenceCallPattern {
             return false;
         };
 
-        // Check if evidence is already the first argument
+        // Check if evidence is already the first argument (by value or by type)
         let operands = ctx.op_operands(op);
-        if !operands.is_empty() && operands[0] == ev_value {
+        if !operands.is_empty()
+            && (operands[0] == ev_value
+                || arena_ability::is_evidence_type_ref(ctx, ctx.value_ty(operands[0])))
+        {
             return false;
         }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -73,7 +73,6 @@ use std::path::Path;
 use tree_sitter::Parser;
 use tribute_front::source_file::parse_with_rope;
 use tribute_passes::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
-use tribute_passes::evidence;
 use tribute_passes::generic_type_converter;
 use trunk_ir::Span;
 use trunk_ir::conversion::resolve_unrealized_casts;
@@ -403,7 +402,7 @@ fn compile_to_wasm(ctx: &mut IrContext, module: Module) -> WasmCompilationResult
 
 /// Run pipeline through evidence params (for testing).
 ///
-/// Runs frontend + `add_evidence_params` in a single arena session.
+/// Evidence params are now inserted during ast_to_ir lowering.
 pub fn run_through_evidence_params(
     db: &dyn salsa::Database,
     source: SourceCst,
@@ -411,13 +410,12 @@ pub fn run_through_evidence_params(
     let (mut ctx, m) = compile_frontend(db, source)?;
     tribute_passes::lower_closure_lambda::lower_closure_lambda(&mut ctx, m);
     tribute_passes::intrinsic_to_arith::lower_intrinsic_to_arith(&mut ctx, m);
-    evidence::add_evidence_params(&mut ctx, m);
     Some((ctx, m))
 }
 
 /// Run pipeline through closure lower (for testing).
 ///
-/// Runs frontend + `lower_closure_lambda` + `add_evidence_params` + `lower_closures`
+/// Runs frontend + `lower_closure_lambda` + `lower_closures`
 /// in a single arena session.
 pub fn run_through_closure_lower(
     db: &dyn salsa::Database,
@@ -426,7 +424,6 @@ pub fn run_through_closure_lower(
     let (mut ctx, m) = compile_frontend(db, source)?;
     tribute_passes::lower_closure_lambda::lower_closure_lambda(&mut ctx, m);
     tribute_passes::intrinsic_to_arith::lower_intrinsic_to_arith(&mut ctx, m);
-    evidence::add_evidence_params(&mut ctx, m);
     tribute_passes::closure_lower::lower_closures(&mut ctx, m);
     Some((ctx, m))
 }
@@ -448,9 +445,8 @@ fn run_shared_pipeline(db: &dyn salsa::Database, source: SourceCst) -> Option<(I
     // Middle-end passes
     tribute_passes::lower_closure_lambda::lower_closure_lambda(&mut ctx, m);
     tribute_passes::intrinsic_to_arith::lower_intrinsic_to_arith(&mut ctx, m);
-    evidence::add_evidence_params(&mut ctx, m);
+    // Evidence params are now inserted directly during ast_to_ir lowering.
     tribute_passes::closure_lower::lower_closures(&mut ctx, m);
-    evidence::transform_evidence_calls(&mut ctx, m);
     // CPS effect handling: lower_ability_perform produces ability.evidence_lookup ops
     // that resolve_evidence needs to process. lower_handle_dispatch consumes
     // handle_dispatch ops, so it must run AFTER resolve_evidence expands evidence.


### PR DESCRIPTION
## Summary

- Move evidence parameter insertion from the separate `add_evidence_params` / `transform_evidence_calls` passes into ast_to_ir lowering, alongside existing done_k insertion
- Effectful functions now emit `(evidence, done_k, params...)` directly during IR lowering
- Effectful call sites pass evidence as the first argument via `get_or_create_evidence` helper
- Remove both evidence pass calls from all pipeline functions (now fully integrated)
- Make Phase 2 evidence pass idempotent via type-based duplicate check (defense-in-depth)

This is Step 1+2 of #642. Step 3 (removing the `effect` attribute from `core.func`/`func.func`) can follow as a separate PR.

## Test plan

- [x] All 1192 tests pass with evidence passes removed from pipeline
- [x] Previously failing ability tests pass (counter, core execution, effect row poly)
- [x] 10 IR snapshots updated for new evidence parameter in function signatures

Relates to #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Evidence parameter insertion moved earlier into AST→IR lowering; helper logic added to supply or synthesize evidence values.

* **Behavior**
  * Effectful function signatures now include an evidence parameter; effectful calls pass caller evidence and pure contexts use null evidence.
  * Duplicate evidence insertion is avoided when evidence is already present.

* **Tests**
  * Added snapshot tests validating evidence parameter insertion and resulting lowered IR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->