### PR TITLE
feat: implement short-circuit evaluation for && and || (#619)

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -8,9 +8,10 @@ use salsa::Accumulator;
 use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{adt, arith, core, func};
+use trunk_ir::dialect::{adt, arith, core, func, scf};
 use trunk_ir::refs::{TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, Location};
+use trunk_ir::{BlockData, RegionData};
 
 use crate::ast::{BinOpKind, Expr, ExprKind, PatternKind, ResolvedRef, Stmt, TypeKind, TypedRef};
 
@@ -189,22 +190,39 @@ pub(super) fn lower_expr<'db>(
         },
 
         ExprKind::BinOp { op, lhs, rhs } => {
+            // Short-circuit evaluation:
+            //   a && b → scf.if(a, then={yield b}, else={yield false})
+            //   a || b → scf.if(a, then={yield true}, else={yield b})
             let lhs_val = lower_expr(builder, lhs)?;
-            let rhs_val = lower_expr(builder, rhs)?;
             let bool_ty = builder.ctx.bool_type(builder.ir);
-            let result = match op {
+
+            let (then_region, else_region) = match op {
                 BinOpKind::And => {
-                    let op = arith::and(builder.ir, location, lhs_val, rhs_val, bool_ty);
-                    builder.ir.push_op(builder.block, op.op_ref());
-                    op.result(builder.ir)
+                    let then_region =
+                        build_short_circuit_rhs_region(builder, location, bool_ty, rhs);
+                    let else_region =
+                        build_short_circuit_const_region(builder.ir, location, bool_ty, false);
+                    (then_region, else_region)
                 }
                 BinOpKind::Or => {
-                    let op = arith::or(builder.ir, location, lhs_val, rhs_val, bool_ty);
-                    builder.ir.push_op(builder.block, op.op_ref());
-                    op.result(builder.ir)
+                    let then_region =
+                        build_short_circuit_const_region(builder.ir, location, bool_ty, true);
+                    let else_region =
+                        build_short_circuit_rhs_region(builder, location, bool_ty, rhs);
+                    (then_region, else_region)
                 }
             };
-            Some(result)
+
+            let if_op = scf::r#if(
+                builder.ir,
+                location,
+                lhs_val,
+                bool_ty,
+                then_region,
+                else_region,
+            );
+            builder.ir.push_op(builder.block, if_op.op_ref());
+            Some(if_op.result(builder.ir))
         }
 
         ExprKind::Block { stmts, value } => lower_block(builder, stmts, value),
@@ -1562,6 +1580,71 @@ pub(super) fn pack_ability_args(
     } else {
         arg_values
     }
+}
+
+/// Build a region that evaluates an expression and yields its result.
+/// Used for short-circuit evaluation of boolean operators.
+fn build_short_circuit_rhs_region<'db>(
+    builder: &mut IrBuilder<'_, 'db>,
+    location: Location,
+    bool_ty: TypeRef,
+    rhs: Expr<TypedRef<'db>>,
+) -> trunk_ir::refs::RegionRef {
+    let block = builder.ir.create_block(BlockData {
+        location,
+        args: vec![],
+        ops: Default::default(),
+        parent_region: None,
+    });
+
+    let rhs_val = {
+        let mut inner = IrBuilder::new(builder.ctx, builder.ir, block);
+        lower_expr(&mut inner, rhs)
+    };
+
+    let yield_val = match rhs_val {
+        Some(v) => v,
+        None => {
+            let op = arith::r#const(builder.ir, location, bool_ty, Attribute::Bool(false));
+            builder.ir.push_op(block, op.op_ref());
+            op.result(builder.ir)
+        }
+    };
+    let yield_op = scf::r#yield(builder.ir, location, [yield_val]);
+    builder.ir.push_op(block, yield_op.op_ref());
+
+    builder.ir.create_region(RegionData {
+        location,
+        blocks: trunk_ir::smallvec::smallvec![block],
+        parent_op: None,
+    })
+}
+
+/// Build a region that yields a boolean constant.
+/// Used for short-circuit evaluation of boolean operators.
+fn build_short_circuit_const_region(
+    ir: &mut IrContext,
+    location: Location,
+    bool_ty: TypeRef,
+    value: bool,
+) -> trunk_ir::refs::RegionRef {
+    let block = ir.create_block(BlockData {
+        location,
+        args: vec![],
+        ops: Default::default(),
+        parent_region: None,
+    });
+
+    let const_op = arith::r#const(ir, location, bool_ty, Attribute::Bool(value));
+    ir.push_op(block, const_op.op_ref());
+    let yield_op = scf::r#yield(ir, location, [const_op.result(ir)]);
+    ir.push_op(block, yield_op.op_ref());
+
+    ir.create_region(RegionData {
+        location,
+        blocks: trunk_ir::smallvec::smallvec![block],
+        parent_op: None,
+    })
 }
 
 /// Create an `adt.struct` type for packing multiple ability operation arguments.

--- a/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
@@ -5,9 +5,19 @@ expression: ir_text
 ---
 core.module @test {
   func.func @logic(%0: core.i1, %1: core.i1) -> core.i1 {
-      %2 = arith.const {value = false} : core.i1
-      %3 = arith.and %1, %2 : core.i1
-      %4 = arith.or %0, %3 : core.i1
-      func.return %4
+      %2 = scf.if %0 : core.i1 {
+          %3 = arith.const {value = true} : core.i1
+          scf.yield %3
+      } {
+          %4 = scf.if %1 : core.i1 {
+              %5 = arith.const {value = false} : core.i1
+              scf.yield %5
+          } {
+              %6 = arith.const {value = false} : core.i1
+              scf.yield %6
+          }
+          scf.yield %4
+      }
+      func.return %2
   }
 }

--- a/new-plans/types.md
+++ b/new-plans/types.md
@@ -38,8 +38,8 @@ struct Flags { read: Bool, write: Bool, execute: Bool }
 ```rust
 // 단순 enum
 enum Bool {
-    True
     False
+    True
 }
 
 // 제네릭 enum - positional fields

--- a/tests/e2e_native.rs
+++ b/tests/e2e_native.rs
@@ -261,6 +261,97 @@ fn main() {
     );
 }
 
+/// Test short-circuit evaluation for &&.
+#[test]
+fn test_native_short_circuit_and() {
+    assert_native_output(
+        "short_circuit_and.trb",
+        r#"
+fn bool_to_nat(b: Bool) -> Nat {
+    case b {
+        True -> 1
+        False -> 0
+    }
+}
+
+fn main() {
+    __tribute_print_nat(bool_to_nat(False && True))
+    __tribute_print_nat(bool_to_nat(True && True))
+    __tribute_print_nat(bool_to_nat(True && False))
+}
+"#,
+        "0\n1\n0",
+    );
+}
+
+/// Test short-circuit evaluation for ||.
+#[test]
+fn test_native_short_circuit_or() {
+    assert_native_output(
+        "short_circuit_or.trb",
+        r#"
+fn bool_to_nat(b: Bool) -> Nat {
+    case b {
+        True -> 1
+        False -> 0
+    }
+}
+
+fn main() {
+    __tribute_print_nat(bool_to_nat(True || False))
+    __tribute_print_nat(bool_to_nat(False || True))
+    __tribute_print_nat(bool_to_nat(False || False))
+}
+"#,
+        "1\n1\n0",
+    );
+}
+
+/// Test that short-circuit && does not evaluate rhs when lhs is false.
+/// If rhs were evaluated, the side effect would appear in the output.
+#[test]
+fn test_native_short_circuit_and_skips_rhs() {
+    assert_native_output(
+        "short_circuit_and_side_effect.trb",
+        r#"
+fn side_effect() -> Bool {
+    __tribute_print_nat(99)
+    True
+}
+
+fn main() {
+    case False && side_effect() {
+        True -> __tribute_print_nat(1)
+        False -> __tribute_print_nat(0)
+    }
+}
+"#,
+        "0",
+    );
+}
+
+/// Test that short-circuit || does not evaluate rhs when lhs is true.
+#[test]
+fn test_native_short_circuit_or_skips_rhs() {
+    assert_native_output(
+        "short_circuit_or_side_effect.trb",
+        r#"
+fn side_effect() -> Bool {
+    __tribute_print_nat(99)
+    False
+}
+
+fn main() {
+    case True || side_effect() {
+        True -> __tribute_print_nat(1)
+        False -> __tribute_print_nat(0)
+    }
+}
+"#,
+        "1",
+    );
+}
+
 /// Test enum destructuring with mixed-type fields.
 /// Regression test: each pattern binding must get a fresh type variable.
 #[test]


### PR DESCRIPTION
## Summary

- Implements short-circuit evaluation for `&&` and `||` operators in `ast_to_ir` lowering
  - `&&` lowers to `scf.if(a, then={yield b}, else={yield false})`
  - `||` lowers to `scf.if(a, then={yield true}, else={yield b})`
- Fixed Bool enum declaration order in `new-plans/types.md` to clarify `False=tag 0, True=tag 1`
- Adds 4 E2E tests covering correctness and side-effect skipping for both operators

## Background

A previous attempt (#618) was reverted due to a Bool representation issue. The current codebase handles Bool representation correctly, making this implementation straightforward.

## Test plan

- [ ] `&&` short-circuits: right-hand side is not evaluated when left is `false`
- [ ] `&&` evaluates right-hand side when left is `true`
- [ ] `||` short-circuits: right-hand side is not evaluated when left is `true`
- [ ] `||` evaluates right-hand side when left is `false`
- [ ] Snapshot test updated for boolean operator lowering

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean operators (`&&` and `||`) now implement proper short-circuit evaluation, preventing unnecessary evaluation of the right operand when the result is determined by the left operand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->