### PR TITLE
feat(astgen): improve parser error messages with context (#568)

### DIFF
--- a/crates/tribute-front/src/astgen/declarations.rs
+++ b/crates/tribute-front/src/astgen/declarations.rs
@@ -35,7 +35,14 @@ pub fn lower_module(
         // Emit parse error diagnostic for ERROR nodes
         if child.kind() == "ERROR" {
             let span = trunk_ir::Span::new(child.start_byte(), child.end_byte());
-            ctx.parse_error(span, "syntax error: unexpected token");
+            let text = ctx.node_text(&child);
+            let token_preview = super::truncate_token_preview(&text);
+            ctx.parse_error(
+                span,
+                format!(
+                    "syntax error: unexpected `{token_preview}`; expected a declaration (fn, struct, enum, ability, mod, or use)"
+                ),
+            );
             continue;
         }
 

--- a/crates/tribute-front/src/astgen/declarations.rs
+++ b/crates/tribute-front/src/astgen/declarations.rs
@@ -32,17 +32,8 @@ pub fn lower_module(
             continue;
         }
 
-        // Emit parse error diagnostic for ERROR nodes
+        // Skip ERROR nodes — diagnostics are emitted by collect_error_nodes
         if child.kind() == "ERROR" {
-            let span = trunk_ir::Span::new(child.start_byte(), child.end_byte());
-            let text = ctx.node_text(&child);
-            let token_preview = super::truncate_token_preview(&text);
-            ctx.parse_error(
-                span,
-                format!(
-                    "syntax error: unexpected `{token_preview}`; expected a declaration (fn, struct, enum, ability, mod, or use)"
-                ),
-            );
             continue;
         }
 

--- a/crates/tribute-front/src/astgen/expressions.rs
+++ b/crates/tribute-front/src/astgen/expressions.rs
@@ -379,7 +379,14 @@ fn lower_block(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedN
         .filter(|c| {
             if c.kind() == "ERROR" {
                 let span = trunk_ir::Span::new(c.start_byte(), c.end_byte());
-                ctx.parse_error(span, "syntax error: unexpected token");
+                let text = ctx.node_text(&c);
+                let token_preview = super::truncate_token_preview(&text);
+                ctx.parse_error(
+                    span,
+                    format!(
+                        "syntax error: unexpected `{token_preview}`; expected a statement or expression"
+                    ),
+                );
                 false
             } else {
                 !is_comment(c.kind())

--- a/crates/tribute-front/src/astgen/expressions.rs
+++ b/crates/tribute-front/src/astgen/expressions.rs
@@ -378,15 +378,7 @@ fn lower_block(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedN
         .named_children(&mut cursor)
         .filter(|c| {
             if c.kind() == "ERROR" {
-                let span = trunk_ir::Span::new(c.start_byte(), c.end_byte());
-                let text = ctx.node_text(c);
-                let token_preview = super::truncate_token_preview(&text);
-                ctx.parse_error(
-                    span,
-                    format!(
-                        "syntax error: unexpected `{token_preview}`; expected a statement or expression"
-                    ),
-                );
+                // Skip — diagnostics are emitted by collect_error_nodes
                 false
             } else {
                 !is_comment(c.kind())

--- a/crates/tribute-front/src/astgen/expressions.rs
+++ b/crates/tribute-front/src/astgen/expressions.rs
@@ -379,7 +379,7 @@ fn lower_block(ctx: &mut AstLoweringCtx<'_>, node: Node) -> ExprKind<UnresolvedN
         .filter(|c| {
             if c.kind() == "ERROR" {
                 let span = trunk_ir::Span::new(c.start_byte(), c.end_byte());
-                let text = ctx.node_text(&c);
+                let text = ctx.node_text(c);
                 let token_preview = super::truncate_token_preview(&text);
                 ctx.parse_error(
                     span,

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -16,8 +16,6 @@ mod expressions;
 mod helpers;
 mod patterns;
 
-use std::borrow::Cow;
-
 use crate::ast::{Module, SpanMap, UnresolvedName};
 use crate::query::ParsedCst;
 use crate::source_file::SourceCst;
@@ -67,15 +65,15 @@ fn collect_error_nodes(ctx: &mut AstLoweringCtx<'_>, node: tree_sitter::Node) {
         if let Some(msg) = detect_unmatched_delimiter(&text) {
             ctx.parse_error(span, msg);
         } else {
-            let token_preview = truncate_token_preview(&text);
             let parent_ctx = node
                 .parent()
                 .map(|p| describe_parent_context(p.kind()))
                 .unwrap_or_default();
-            ctx.parse_error(
-                span,
-                format!("syntax error: unexpected `{token_preview}`{parent_ctx}"),
+            let msg = format!(
+                "syntax error: unexpected `{}`{parent_ctx}",
+                truncate_token_preview(&text)
             );
+            ctx.parse_error(span, msg);
         }
         return; // Don't recurse into ERROR nodes
     }
@@ -90,14 +88,26 @@ fn collect_error_nodes(ctx: &mut AstLoweringCtx<'_>, node: tree_sitter::Node) {
 }
 
 /// Truncate token text for display in error messages.
-pub(super) fn truncate_token_preview<'a>(text: &'a str) -> Cow<'a, str> {
+///
+/// Returns a `Display` wrapper that lazily truncates to the first line,
+/// at most 20 characters, with `...` appended if truncated.
+/// No intermediate allocation — writes directly into the formatter.
+pub(super) fn truncate_token_preview(text: &str) -> impl std::fmt::Display + '_ {
+    struct TruncatedToken<'a>(&'a str);
+
+    impl std::fmt::Display for TruncatedToken<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            if let Some((byte_idx, _)) = self.0.char_indices().nth(20) {
+                write!(f, "{}...", &self.0[..byte_idx])
+            } else {
+                f.write_str(self.0)
+            }
+        }
+    }
+
     let trimmed = text.trim();
     let first_line = trimmed.lines().next().unwrap_or(trimmed);
-    if first_line.len() > 20 {
-        Cow::Owned(format!("{}...", &first_line[..20]))
-    } else {
-        Cow::Borrowed(first_line)
-    }
+    TruncatedToken(first_line)
 }
 
 /// Describe the parent context for error messages.
@@ -2581,5 +2591,52 @@ mod tests {
             matches!(pattern.kind.as_ref(), PatternKind::Variant { .. }),
             "Expected variant pattern inside as"
         );
+    }
+
+    #[test]
+    fn test_truncate_token_preview_short() {
+        assert_eq!(truncate_token_preview("hello").to_string(), "hello");
+    }
+
+    #[test]
+    fn test_truncate_token_preview_exact_20() {
+        let s = "12345678901234567890"; // exactly 20 chars
+        assert_eq!(truncate_token_preview(s).to_string(), s);
+    }
+
+    #[test]
+    fn test_truncate_token_preview_over_20() {
+        let s = "123456789012345678901"; // 21 chars
+        assert_eq!(
+            truncate_token_preview(s).to_string(),
+            "12345678901234567890..."
+        );
+    }
+
+    #[test]
+    fn test_truncate_token_preview_multiline() {
+        assert_eq!(
+            truncate_token_preview("first line\nsecond line").to_string(),
+            "first line"
+        );
+    }
+
+    #[test]
+    fn test_truncate_token_preview_trims_whitespace() {
+        assert_eq!(truncate_token_preview("  hello  ").to_string(), "hello");
+    }
+
+    #[test]
+    fn test_truncate_token_preview_multibyte_chars() {
+        // 21 Korean characters — must not panic on multibyte boundary
+        let s = "가나다라마바사아자차카타파하거너더러머버서";
+        let result = truncate_token_preview(s).to_string();
+        assert!(result.ends_with("..."));
+        assert_eq!(result, "가나다라마바사아자차카타파하거너더러머버...");
+    }
+
+    #[test]
+    fn test_truncate_token_preview_empty() {
+        assert_eq!(truncate_token_preview("").to_string(), "");
     }
 }

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -134,9 +134,28 @@ fn describe_parent_context(parent_kind: &str) -> &'static str {
 /// delimiter whose matching pair is missing.
 fn detect_unmatched_delimiter(text: &str) -> Option<String> {
     let mut stack: Vec<char> = Vec::new();
+    let mut chars = text.chars().peekable();
 
-    for ch in text.chars() {
+    while let Some(ch) = chars.next() {
         match ch {
+            // Skip string literals
+            '"' => {
+                while let Some(c) = chars.next() {
+                    if c == '\\' {
+                        chars.next(); // skip escaped char
+                    } else if c == '"' {
+                        break;
+                    }
+                }
+            }
+            // Skip line comments
+            '/' if chars.peek() == Some(&'/') => {
+                for c in chars.by_ref() {
+                    if c == '\n' {
+                        break;
+                    }
+                }
+            }
             '(' | '[' | '{' => stack.push(ch),
             ')' => {
                 if stack.last() == Some(&'(') {

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -62,15 +62,21 @@ fn collect_error_nodes(ctx: &mut AstLoweringCtx<'_>, node: tree_sitter::Node) {
     if node.kind() == "ERROR" {
         let span = trunk_ir::Span::new(node.start_byte(), node.end_byte());
         let text = ctx.node_text(&node);
-        let token_preview = truncate_token_preview(&text);
-        let parent_ctx = node
-            .parent()
-            .map(|p| describe_parent_context(p.kind()))
-            .unwrap_or_default();
-        ctx.parse_error(
-            span,
-            format!("syntax error: unexpected `{token_preview}`{parent_ctx}"),
-        );
+
+        // Check for unmatched delimiters first
+        if let Some(msg) = detect_unmatched_delimiter(&text) {
+            ctx.parse_error(span, msg);
+        } else {
+            let token_preview = truncate_token_preview(&text);
+            let parent_ctx = node
+                .parent()
+                .map(|p| describe_parent_context(p.kind()))
+                .unwrap_or_default();
+            ctx.parse_error(
+                span,
+                format!("syntax error: unexpected `{token_preview}`{parent_ctx}"),
+            );
+        }
         return; // Don't recurse into ERROR nodes
     }
 
@@ -110,6 +116,57 @@ fn describe_parent_context(parent_kind: &str) -> &'static str {
         "handle_expression" => " in handle expression",
         _ => "",
     }
+}
+
+/// Detect unmatched delimiters in ERROR node text.
+///
+/// Scans for `(`, `)`, `[`, `]`, `{`, `}` and reports the first
+/// delimiter whose matching pair is missing.
+fn detect_unmatched_delimiter(text: &str) -> Option<String> {
+    let mut stack: Vec<char> = Vec::new();
+
+    for ch in text.chars() {
+        match ch {
+            '(' | '[' | '{' => stack.push(ch),
+            ')' => {
+                if stack.last() == Some(&'(') {
+                    stack.pop();
+                } else {
+                    return Some("syntax error: unmatched `)`".to_string());
+                }
+            }
+            ']' => {
+                if stack.last() == Some(&'[') {
+                    stack.pop();
+                } else {
+                    return Some("syntax error: unmatched `]`".to_string());
+                }
+            }
+            '}' => {
+                if stack.last() == Some(&'{') {
+                    stack.pop();
+                } else {
+                    return Some("syntax error: unmatched `}`".to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Report the first unclosed opener
+    if let Some(&open) = stack.first() {
+        let close = match open {
+            '(' => ')',
+            '[' => ']',
+            '{' => '}',
+            _ => unreachable!(),
+        };
+        return Some(format!(
+            "syntax error: unmatched `{open}`, expected `{close}`"
+        ));
+    }
+
+    None
 }
 
 /// Lower a parsed CST to an AST Module.

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -16,6 +16,8 @@ mod expressions;
 mod helpers;
 mod patterns;
 
+use std::borrow::Cow;
+
 use crate::ast::{Module, SpanMap, UnresolvedName};
 use crate::query::ParsedCst;
 use crate::source_file::SourceCst;
@@ -49,11 +51,26 @@ fn lower_cst_to_ast_internal(
     lower_module(ctx, root, module_name)
 }
 
-/// Recursively collect ERROR nodes from the CST and emit parse error diagnostics.
+/// Recursively collect ERROR and MISSING nodes from the CST and emit parse error diagnostics.
 fn collect_error_nodes(ctx: &mut AstLoweringCtx<'_>, node: tree_sitter::Node) {
+    if node.is_missing() {
+        let span = trunk_ir::Span::new(node.start_byte(), node.end_byte());
+        ctx.parse_error(span, format!("syntax error: expected '{}'", node.kind()));
+        return;
+    }
+
     if node.kind() == "ERROR" {
         let span = trunk_ir::Span::new(node.start_byte(), node.end_byte());
-        ctx.parse_error(span, "syntax error: unexpected token");
+        let text = ctx.node_text(&node);
+        let token_preview = truncate_token_preview(&text);
+        let parent_ctx = node
+            .parent()
+            .map(|p| describe_parent_context(p.kind()))
+            .unwrap_or_default();
+        ctx.parse_error(
+            span,
+            format!("syntax error: unexpected `{token_preview}`{parent_ctx}"),
+        );
         return; // Don't recurse into ERROR nodes
     }
 
@@ -63,6 +80,35 @@ fn collect_error_nodes(ctx: &mut AstLoweringCtx<'_>, node: tree_sitter::Node) {
         for child in node.children(&mut cursor) {
             collect_error_nodes(ctx, child);
         }
+    }
+}
+
+/// Truncate token text for display in error messages.
+pub(super) fn truncate_token_preview<'a>(text: &'a str) -> Cow<'a, str> {
+    let trimmed = text.trim();
+    let first_line = trimmed.lines().next().unwrap_or(trimmed);
+    if first_line.len() > 20 {
+        Cow::Owned(format!("{}...", &first_line[..20]))
+    } else {
+        Cow::Borrowed(first_line)
+    }
+}
+
+/// Describe the parent context for error messages.
+fn describe_parent_context(parent_kind: &str) -> &'static str {
+    match parent_kind {
+        "source_file" => "; expected a declaration (fn, struct, enum, ability, mod, or use)",
+        "block" => "; expected a statement or expression",
+        "function_definition" => " in function definition",
+        "struct_declaration" => " in struct declaration",
+        "enum_declaration" => " in enum declaration",
+        "ability_declaration" => " in ability declaration",
+        "parameters" | "param_list" => " in parameter list",
+        "arguments" | "arg_list" => " in argument list",
+        "type_annotation" => " in type annotation",
+        "case_expression" => " in case expression",
+        "handle_expression" => " in handle expression",
+        _ => "",
     }
 }
 

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -163,8 +163,8 @@ fn detect_unmatched_delimiter(text: &str) -> Option<String> {
         }
     }
 
-    // Report the first unclosed opener
-    if let Some(&open) = stack.first() {
+    // Report the innermost (most recent) unclosed opener
+    if let Some(&open) = stack.last() {
         let close = match open {
             '(' => ')',
             '[' => ']',

--- a/tests/snapshots/diagnostic_snapshots__diag_syntax_error.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_syntax_error.snap
@@ -2,13 +2,13 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "syntax error: unexpected token"
+- message: "syntax error: unexpected `fn main( { }`; expected a declaration (fn, struct, enum, ability, mod, or use)"
   span:
     start: 0
     end: 12
   severity: Error
   phase: Parsing
-- message: "syntax error: unexpected token"
+- message: "syntax error: unexpected `fn main( { }`; expected a declaration (fn, struct, enum, ability, mod, or use)"
   span:
     start: 0
     end: 12

--- a/tests/snapshots/diagnostic_snapshots__diag_syntax_error.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_syntax_error.snap
@@ -2,13 +2,7 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "syntax error: unexpected `fn main( { }`; expected a declaration (fn, struct, enum, ability, mod, or use)"
-  span:
-    start: 0
-    end: 12
-  severity: Error
-  phase: Parsing
-- message: "syntax error: unexpected `fn main( { }`; expected a declaration (fn, struct, enum, ability, mod, or use)"
+- message: "syntax error: unmatched `(`, expected `)`"
   span:
     start: 0
     end: 12


### PR DESCRIPTION
## Summary

- Replaced generic "syntax error: unexpected token" messages with context-aware diagnostics
- ERROR nodes now show the actual token text and the expected context (e.g., "unexpected token `foo` in block")
- MISSING nodes now produce "expected 'X'" messages instead of a silent or generic error
- Added `truncate_token_preview()` helper (returns `Cow<str>`) to safely trim long token text in diagnostics
- Added `describe_parent_context()` helper to produce human-readable context descriptions from the parse tree

Closes #568

## Test plan

- [ ] Verify existing snapshot tests still pass (`cargo nextest run`)
- [ ] Manually test with a `.trb` file containing a syntax error to confirm improved message output
- [ ] Check that MISSING node messages render correctly for common missing tokens (`;`, `}`, etc.)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More helpful syntax error messages: token previews, contextual hints, and unmatched-delimiter detection.
  * Reduced redundant parse errors by skipping certain error nodes during processing so diagnostics are clearer.
  * Missing-token cases now report "expected '<kind>'" style diagnostics.

* **Tests**
  * Added unit tests covering token-preview formatting and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->