### PR TITLE
Add specialized function generator for monomorphization (#665)

### DIFF
--- a/crates/tribute-front/src/ast/node_id.rs
+++ b/crates/tribute-front/src/ast/node_id.rs
@@ -5,6 +5,7 @@
 //! This follows the rust-analyzer pattern of separating structure from metadata.
 
 use std::hash::{Hash, Hasher};
+use std::num::NonZero;
 
 use tree_sitter::Node;
 
@@ -16,12 +17,19 @@ use tree_sitter::Node;
 /// tag assignment. This prevents key-space collisions when merging SpanMaps or
 /// node_types HashMaps.
 ///
+/// For monomorphized copies of generic functions, the `variant` field
+/// distinguishes nodes from different specializations. Original AST nodes
+/// have `variant: None`, while specialized copies carry a hash of the
+/// concrete type arguments. Use [`origin()`](NodeId::origin) to recover
+/// the original NodeId for SpanMap lookups.
+///
 /// NodeIds are local to a compilation unit and should not be used
 /// for cross-module references.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, salsa::Update)]
 pub struct NodeId {
     source: u64,
     raw: usize,
+    variant: Option<NonZero<u64>>,
 }
 
 impl NodeId {
@@ -34,6 +42,33 @@ impl NodeId {
         Self {
             source,
             raw: node.id(),
+            variant: None,
+        }
+    }
+
+    /// Create a specialized copy of this NodeId for monomorphization.
+    ///
+    /// The `variant` hash distinguishes different specializations of the
+    /// same generic function (e.g., `identity$Int` vs `identity$Float`).
+    #[inline]
+    pub const fn with_variant(self, variant: NonZero<u64>) -> Self {
+        Self {
+            source: self.source,
+            raw: self.raw,
+            variant: Some(variant),
+        }
+    }
+
+    /// Get the original NodeId, stripping any specialization variant.
+    ///
+    /// Use this to look up spans in SpanMap, which only contains entries
+    /// for original (non-specialized) nodes.
+    #[inline]
+    pub const fn origin(self) -> Self {
+        Self {
+            source: self.source,
+            raw: self.raw,
+            variant: None,
         }
     }
 
@@ -47,6 +82,12 @@ impl NodeId {
     #[inline]
     pub const fn source(self) -> u64 {
         self.source
+    }
+
+    /// Get the specialization variant, if any.
+    #[inline]
+    pub const fn variant(self) -> Option<NonZero<u64>> {
+        self.variant
     }
 }
 
@@ -75,7 +116,11 @@ impl NodeId {
     /// Create a NodeId from a raw value (for testing only).
     /// Uses source hash 0 by default.
     pub const fn from_raw(id: usize) -> Self {
-        Self { source: 0, raw: id }
+        Self {
+            source: 0,
+            raw: id,
+            variant: None,
+        }
     }
 }
 
@@ -105,10 +150,12 @@ mod tests {
         let id1 = NodeId {
             source: source_hash("file:///a.trb"),
             raw: 42,
+            variant: None,
         };
         let id2 = NodeId {
             source: source_hash("prelude:///std/prelude"),
             raw: 42,
+            variant: None,
         };
         assert_ne!(id1, id2);
     }
@@ -124,6 +171,7 @@ mod tests {
         let id = NodeId {
             source: 0xff,
             raw: 123,
+            variant: None,
         };
         assert_eq!(format!("{}", id), "#ff:123");
     }

--- a/crates/tribute-front/src/ast/span_map.rs
+++ b/crates/tribute-front/src/ast/span_map.rs
@@ -86,13 +86,22 @@ impl SpanMap {
     }
 
     /// Look up a span by NodeId.
+    ///
+    /// For specialized (monomorphized) nodes, falls back to the origin NodeId
+    /// so that spans are inherited from the original generic function.
     pub fn get(&self, id: NodeId) -> Option<Span> {
-        self.0.get(&id).copied()
+        self.0.get(&id).copied().or_else(|| {
+            if id.variant().is_some() {
+                self.0.get(&id.origin()).copied()
+            } else {
+                None
+            }
+        })
     }
 
     /// Look up a span by NodeId, returning a default span if not found.
     pub fn get_or_default(&self, id: NodeId) -> Span {
-        self.0.get(&id).copied().unwrap_or(Span::new(0, 0))
+        self.get(id).unwrap_or(Span::new(0, 0))
     }
 
     /// Check if this NodeId has a recorded span.

--- a/crates/tribute-front/src/ast/span_map.rs
+++ b/crates/tribute-front/src/ast/span_map.rs
@@ -180,4 +180,22 @@ mod tests {
         assert!(span_map.contains(id));
         assert!(!span_map.contains(NodeId::from_raw(999)));
     }
+
+    #[test]
+    fn test_span_map_variant_fallback() {
+        let mut builder = SpanMapBuilder::new();
+        let origin = NodeId::from_raw(42);
+        let span = Span::new(10, 20);
+        builder.insert(origin, span);
+
+        let span_map = builder.finish();
+
+        // Specialized NodeId should fall back to origin's span
+        let variant = std::num::NonZero::new(12345u64).unwrap();
+        let specialized = origin.with_variant(variant);
+
+        assert_ne!(origin, specialized);
+        assert_eq!(span_map.get(specialized), Some(span));
+        assert_eq!(span_map.get_or_default(specialized), span);
+    }
 }

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -1,2 +1,3 @@
 pub mod collect;
 pub mod mangle;
+pub mod specialize;

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -23,8 +23,7 @@ pub fn generate_specializations<'db>(
     let func_decls = collect_func_decls(module);
     let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
 
-    let mut new_decls = Vec::new();
-    let mut new_function_types = Vec::new();
+    let mut entries: Vec<(Symbol, FuncDecl<TypedRef<'db>>, TypeScheme<'db>)> = Vec::new();
 
     for (func_id, type_arg_sets) in instantiations {
         let qualified = func_id.qualified(db);
@@ -38,15 +37,23 @@ pub fn generate_specializations<'db>(
         for type_args in type_arg_sets {
             let mangled = mangle_name(db, qualified, type_args);
             let specialized = specialize_func_decl(db, func, type_args, mangled);
-
             let specialized_scheme = TypeScheme::new(
                 db,
                 vec![],
                 substitute_bound_vars(db, scheme.body(db), type_args).unwrap_or(scheme.body(db)),
             );
-            new_decls.push(specialized);
-            new_function_types.push((mangled, specialized_scheme));
+            entries.push((mangled, specialized, specialized_scheme));
         }
+    }
+
+    // Sort by mangled name for deterministic output (HashMap/HashSet iteration is unordered)
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut new_decls = Vec::with_capacity(entries.len());
+    let mut new_function_types = Vec::with_capacity(entries.len());
+    for (name, decl, scheme) in entries {
+        new_decls.push(decl);
+        new_function_types.push((name, scheme));
     }
 
     (new_decls, new_function_types)
@@ -539,5 +546,13 @@ mod tests {
         let names: HashSet<String> = new_decls.iter().map(|d| d.name.to_string()).collect();
         assert!(names.contains("identity$Int"));
         assert!(names.contains("identity$Float"));
+
+        // All specialized TypeSchemes must be monomorphic
+        for (_, scheme) in &new_fn_types {
+            assert!(
+                scheme.is_mono(&db),
+                "specialized scheme should have no type params"
+            );
+        }
     }
 }

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -42,7 +42,14 @@ pub fn generate_specializations<'db>(
             let specialized_scheme = TypeScheme::new(
                 db,
                 vec![],
-                substitute_bound_vars(db, scheme.body(db), type_args).unwrap_or(scheme.body(db)),
+                substitute_bound_vars(db, scheme.body(db), type_args).unwrap_or_else(
+                    |index, max| {
+                        panic!(
+                            "BoundVar index out of range in specialization of {}: index={}, subst.len()={}",
+                            qualified, index, max
+                        )
+                    },
+                ),
             );
             entries.push((mangled, specialized, specialized_scheme));
         }
@@ -128,7 +135,11 @@ fn subst_type<'db>(
     ty: Type<'db>,
     type_args: &[Type<'db>],
 ) -> Type<'db> {
-    substitute_bound_vars(db, ty, type_args).unwrap_or(ty)
+    substitute_bound_vars(db, ty, type_args).unwrap_or_else(|index, max| {
+        panic!(
+            "BoundVar index out of range during monomorphization: index={index}, subst.len()={max}"
+        )
+    })
 }
 
 fn subst_typed_ref<'db>(

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::num::NonZero;
 
 use trunk_ir::Symbol;
 
@@ -86,21 +88,34 @@ fn collect_func_decls_inner<'a, 'db>(
     }
 }
 
+/// Compute a NonZero<u64> variant hash from concrete type arguments.
+///
+/// This is used to give specialized AST nodes unique NodeIds that
+/// don't collide with the original or other specializations.
+fn type_args_variant(type_args: &[Type<'_>]) -> NonZero<u64> {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    type_args.hash(&mut hasher);
+    let hash = hasher.finish();
+    // Ensure non-zero: if hash happens to be 0, use 1
+    NonZero::new(hash).unwrap_or(NonZero::new(1).unwrap())
+}
+
 fn specialize_func_decl<'db>(
     db: &'db dyn salsa::Database,
     func: &FuncDecl<TypedRef<'db>>,
     type_args: &[Type<'db>],
     mangled_name: Symbol,
 ) -> FuncDecl<TypedRef<'db>> {
+    let variant = type_args_variant(type_args);
     FuncDecl {
-        id: func.id,
+        id: func.id.with_variant(variant),
         is_pub: false,
         name: mangled_name,
         type_params: vec![],
         params: func.params.clone(),
         return_ty: func.return_ty.clone(),
         effects: func.effects.clone(),
-        body: substitute_expr(db, func.body.clone(), type_args),
+        body: substitute_expr(db, func.body.clone(), type_args, variant),
     }
 }
 
@@ -131,50 +146,51 @@ fn substitute_expr<'db>(
     db: &'db dyn salsa::Database,
     expr: Expr<TypedRef<'db>>,
     type_args: &[Type<'db>],
+    variant: NonZero<u64>,
 ) -> Expr<TypedRef<'db>> {
     let kind = match *expr.kind {
         ExprKind::Var(tr) => ExprKind::Var(subst_typed_ref(db, tr, type_args)),
         ExprKind::Call { callee, args } => ExprKind::Call {
-            callee: substitute_expr(db, callee, type_args),
+            callee: substitute_expr(db, callee, type_args, variant),
             args: args
                 .into_iter()
-                .map(|a| substitute_expr(db, a, type_args))
+                .map(|a| substitute_expr(db, a, type_args, variant))
                 .collect(),
         },
         ExprKind::Block { stmts, value } => ExprKind::Block {
             stmts: stmts
                 .into_iter()
-                .map(|s| substitute_stmt(db, s, type_args))
+                .map(|s| substitute_stmt(db, s, type_args, variant))
                 .collect(),
-            value: substitute_expr(db, value, type_args),
+            value: substitute_expr(db, value, type_args, variant),
         },
         ExprKind::Case { scrutinee, arms } => ExprKind::Case {
-            scrutinee: substitute_expr(db, scrutinee, type_args),
+            scrutinee: substitute_expr(db, scrutinee, type_args, variant),
             arms: arms
                 .into_iter()
-                .map(|a| substitute_arm(db, a, type_args))
+                .map(|a| substitute_arm(db, a, type_args, variant))
                 .collect(),
         },
         ExprKind::Lambda { params, body } => ExprKind::Lambda {
             params,
-            body: substitute_expr(db, body, type_args),
+            body: substitute_expr(db, body, type_args, variant),
         },
         ExprKind::Handle { body, handlers } => ExprKind::Handle {
-            body: substitute_expr(db, body, type_args),
+            body: substitute_expr(db, body, type_args, variant),
             handlers: handlers
                 .into_iter()
-                .map(|h| substitute_handler_arm(db, h, type_args))
+                .map(|h| substitute_handler_arm(db, h, type_args, variant))
                 .collect(),
         },
         ExprKind::Resume { arg, local_id } => ExprKind::Resume {
-            arg: substitute_expr(db, arg, type_args),
+            arg: substitute_expr(db, arg, type_args, variant),
             local_id,
         },
         ExprKind::Cons { ctor, args } => ExprKind::Cons {
             ctor: subst_typed_ref(db, ctor, type_args),
             args: args
                 .into_iter()
-                .map(|a| substitute_expr(db, a, type_args))
+                .map(|a| substitute_expr(db, a, type_args, variant))
                 .collect(),
         },
         ExprKind::Record {
@@ -185,35 +201,35 @@ fn substitute_expr<'db>(
             type_name: subst_typed_ref(db, type_name, type_args),
             fields: fields
                 .into_iter()
-                .map(|(name, e)| (name, substitute_expr(db, e, type_args)))
+                .map(|(name, e)| (name, substitute_expr(db, e, type_args, variant)))
                 .collect(),
-            spread: spread.map(|s| substitute_expr(db, s, type_args)),
+            spread: spread.map(|s| substitute_expr(db, s, type_args, variant)),
         },
         ExprKind::MethodCall {
             receiver,
             method,
             args,
         } => ExprKind::MethodCall {
-            receiver: substitute_expr(db, receiver, type_args),
+            receiver: substitute_expr(db, receiver, type_args, variant),
             method,
             args: args
                 .into_iter()
-                .map(|a| substitute_expr(db, a, type_args))
+                .map(|a| substitute_expr(db, a, type_args, variant))
                 .collect(),
         },
         ExprKind::BinOp { op, lhs, rhs } => ExprKind::BinOp {
             op,
-            lhs: substitute_expr(db, lhs, type_args),
-            rhs: substitute_expr(db, rhs, type_args),
+            lhs: substitute_expr(db, lhs, type_args, variant),
+            rhs: substitute_expr(db, rhs, type_args, variant),
         },
         ExprKind::Tuple(es) => ExprKind::Tuple(
             es.into_iter()
-                .map(|e| substitute_expr(db, e, type_args))
+                .map(|e| substitute_expr(db, e, type_args, variant))
                 .collect(),
         ),
         ExprKind::List(es) => ExprKind::List(
             es.into_iter()
-                .map(|e| substitute_expr(db, e, type_args))
+                .map(|e| substitute_expr(db, e, type_args, variant))
                 .collect(),
         ),
         // Leaf nodes — no types to substitute
@@ -227,13 +243,14 @@ fn substitute_expr<'db>(
         ExprKind::Nil => ExprKind::Nil,
         ExprKind::Error => ExprKind::Error,
     };
-    Expr::new(expr.id, kind)
+    Expr::new(expr.id.with_variant(variant), kind)
 }
 
 fn substitute_stmt<'db>(
     db: &'db dyn salsa::Database,
     stmt: Stmt<TypedRef<'db>>,
     type_args: &[Type<'db>],
+    variant: NonZero<u64>,
 ) -> Stmt<TypedRef<'db>> {
     match stmt {
         Stmt::Let {
@@ -242,14 +259,14 @@ fn substitute_stmt<'db>(
             ty,
             value,
         } => Stmt::Let {
-            id,
-            pattern: substitute_pattern(db, pattern, type_args),
+            id: id.with_variant(variant),
+            pattern: substitute_pattern(db, pattern, type_args, variant),
             ty,
-            value: substitute_expr(db, value, type_args),
+            value: substitute_expr(db, value, type_args, variant),
         },
         Stmt::Expr { id, expr } => Stmt::Expr {
-            id,
-            expr: substitute_expr(db, expr, type_args),
+            id: id.with_variant(variant),
+            expr: substitute_expr(db, expr, type_args, variant),
         },
     }
 }
@@ -258,12 +275,15 @@ fn substitute_arm<'db>(
     db: &'db dyn salsa::Database,
     arm: Arm<TypedRef<'db>>,
     type_args: &[Type<'db>],
+    variant: NonZero<u64>,
 ) -> Arm<TypedRef<'db>> {
     Arm {
-        id: arm.id,
-        pattern: substitute_pattern(db, arm.pattern, type_args),
-        guard: arm.guard.map(|g| substitute_expr(db, g, type_args)),
-        body: substitute_expr(db, arm.body, type_args),
+        id: arm.id.with_variant(variant),
+        pattern: substitute_pattern(db, arm.pattern, type_args, variant),
+        guard: arm
+            .guard
+            .map(|g| substitute_expr(db, g, type_args, variant)),
+        body: substitute_expr(db, arm.body, type_args, variant),
     }
 }
 
@@ -271,10 +291,11 @@ fn substitute_handler_arm<'db>(
     db: &'db dyn salsa::Database,
     arm: HandlerArm<TypedRef<'db>>,
     type_args: &[Type<'db>],
+    variant: NonZero<u64>,
 ) -> HandlerArm<TypedRef<'db>> {
     let kind = match arm.kind {
         HandlerKind::Do { binding } => HandlerKind::Do {
-            binding: substitute_pattern(db, binding, type_args),
+            binding: substitute_pattern(db, binding, type_args, variant),
         },
         HandlerKind::Fn {
             ability,
@@ -285,7 +306,7 @@ fn substitute_handler_arm<'db>(
             op,
             params: params
                 .into_iter()
-                .map(|p| substitute_pattern(db, p, type_args))
+                .map(|p| substitute_pattern(db, p, type_args, variant))
                 .collect(),
         },
         HandlerKind::Op {
@@ -298,15 +319,15 @@ fn substitute_handler_arm<'db>(
             op,
             params: params
                 .into_iter()
-                .map(|p| substitute_pattern(db, p, type_args))
+                .map(|p| substitute_pattern(db, p, type_args, variant))
                 .collect(),
             resume_local_id,
         },
     };
     HandlerArm {
-        id: arm.id,
+        id: arm.id.with_variant(variant),
         kind,
-        body: substitute_expr(db, arm.body, type_args),
+        body: substitute_expr(db, arm.body, type_args, variant),
     }
 }
 
@@ -314,13 +335,14 @@ fn substitute_pattern<'db>(
     db: &'db dyn salsa::Database,
     pattern: Pattern<TypedRef<'db>>,
     type_args: &[Type<'db>],
+    variant: NonZero<u64>,
 ) -> Pattern<TypedRef<'db>> {
     let kind = match *pattern.kind {
         PatternKind::Variant { ctor, fields } => PatternKind::Variant {
             ctor: subst_typed_ref(db, ctor, type_args),
             fields: fields
                 .into_iter()
-                .map(|f| substitute_pattern(db, f, type_args))
+                .map(|f| substitute_pattern(db, f, type_args, variant))
                 .collect(),
         },
         PatternKind::Record {
@@ -332,21 +354,23 @@ fn substitute_pattern<'db>(
             fields: fields
                 .into_iter()
                 .map(|f| FieldPattern {
-                    id: f.id,
+                    id: f.id.with_variant(variant),
                     name: f.name,
-                    pattern: f.pattern.map(|p| substitute_pattern(db, p, type_args)),
+                    pattern: f
+                        .pattern
+                        .map(|p| substitute_pattern(db, p, type_args, variant)),
                 })
                 .collect(),
             rest,
         },
         PatternKind::Tuple(ps) => PatternKind::Tuple(
             ps.into_iter()
-                .map(|p| substitute_pattern(db, p, type_args))
+                .map(|p| substitute_pattern(db, p, type_args, variant))
                 .collect(),
         ),
         PatternKind::List(ps) => PatternKind::List(
             ps.into_iter()
-                .map(|p| substitute_pattern(db, p, type_args))
+                .map(|p| substitute_pattern(db, p, type_args, variant))
                 .collect(),
         ),
         PatternKind::ListRest {
@@ -356,7 +380,7 @@ fn substitute_pattern<'db>(
         } => PatternKind::ListRest {
             head: head
                 .into_iter()
-                .map(|p| substitute_pattern(db, p, type_args))
+                .map(|p| substitute_pattern(db, p, type_args, variant))
                 .collect(),
             rest,
             rest_local_id,
@@ -366,7 +390,7 @@ fn substitute_pattern<'db>(
             name,
             local_id,
         } => PatternKind::As {
-            pattern: substitute_pattern(db, inner, type_args),
+            pattern: substitute_pattern(db, inner, type_args, variant),
             name,
             local_id,
         },
@@ -376,7 +400,7 @@ fn substitute_pattern<'db>(
         PatternKind::Literal(lit) => PatternKind::Literal(lit),
         PatternKind::Error => PatternKind::Error,
     };
-    Pattern::new(pattern.id, kind)
+    Pattern::new(pattern.id.with_variant(variant), kind)
 }
 
 #[cfg(test)]
@@ -430,7 +454,12 @@ mod tests {
             bv0,
         );
         let expr = Expr::new(node_id(1), ExprKind::Var(tr));
-        let result = substitute_expr(&db, expr, &[int]);
+        let variant = type_args_variant(&[int]);
+        let result = substitute_expr(&db, expr, &[int], variant);
+
+        // NodeId should have the variant applied
+        assert!(result.id.variant().is_some());
+        assert_eq!(result.id.origin(), node_id(1));
 
         match result.kind.as_ref() {
             ExprKind::Var(tr) => assert_eq!(tr.ty, int),

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -72,22 +72,27 @@ fn collect_func_decls<'a, 'db>(
     module: &'a Module<TypedRef<'db>>,
 ) -> HashMap<Symbol, &'a FuncDecl<TypedRef<'db>>> {
     let mut map = HashMap::new();
-    collect_func_decls_inner(&module.decls, &mut map);
+    let mut prefix = String::new();
+    collect_func_decls_inner(&module.decls, &mut prefix, &mut map);
     map
 }
 
 fn collect_func_decls_inner<'a, 'db>(
     decls: &'a [Decl<TypedRef<'db>>],
+    prefix: &mut String,
     map: &mut HashMap<Symbol, &'a FuncDecl<TypedRef<'db>>>,
 ) {
     for decl in decls {
         match decl {
             Decl::Function(func) => {
-                map.insert(func.name, func);
+                let qualified = crate::qualified_symbol(prefix, func.name);
+                map.insert(qualified, func);
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
-                    collect_func_decls_inner(body, map);
+                    let len = crate::push_prefix(prefix, m.name);
+                    collect_func_decls_inner(body, prefix, map);
+                    prefix.truncate(len);
                 }
             }
             _ => {}

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -1,0 +1,543 @@
+use std::collections::{HashMap, HashSet};
+
+use trunk_ir::Symbol;
+
+use crate::ast::{
+    Arm, Decl, Expr, ExprKind, FieldPattern, FuncDecl, FuncDefId, HandlerArm, HandlerKind, Module,
+    Pattern, PatternKind, Stmt, Type, TypeScheme, TypedRef,
+};
+use crate::typeck::subst::substitute_bound_vars;
+
+use super::mangle::mangle_name;
+
+/// Generate specialized copies of generic functions for each instantiation.
+///
+/// Returns a list of new specialized `FuncDecl`s and their corresponding
+/// `(Symbol, TypeScheme)` entries for `function_types`.
+pub fn generate_specializations<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+    instantiations: &HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    function_types: &[(Symbol, TypeScheme<'db>)],
+) -> (Vec<FuncDecl<TypedRef<'db>>>, Vec<(Symbol, TypeScheme<'db>)>) {
+    let func_decls = collect_func_decls(module);
+    let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
+
+    let mut new_decls = Vec::new();
+    let mut new_function_types = Vec::new();
+
+    for (func_id, type_arg_sets) in instantiations {
+        let qualified = func_id.qualified(db);
+        let Some(func) = func_decls.get(&qualified) else {
+            continue;
+        };
+        let Some(scheme) = scheme_map.get(&qualified) else {
+            continue;
+        };
+
+        for type_args in type_arg_sets {
+            let mangled = mangle_name(db, qualified, type_args);
+            let specialized = specialize_func_decl(db, func, type_args, mangled);
+
+            let specialized_scheme = TypeScheme::new(
+                db,
+                vec![],
+                substitute_bound_vars(db, scheme.body(db), type_args).unwrap_or(scheme.body(db)),
+            );
+            new_decls.push(specialized);
+            new_function_types.push((mangled, specialized_scheme));
+        }
+    }
+
+    (new_decls, new_function_types)
+}
+
+fn collect_func_decls<'a, 'db>(
+    module: &'a Module<TypedRef<'db>>,
+) -> HashMap<Symbol, &'a FuncDecl<TypedRef<'db>>> {
+    let mut map = HashMap::new();
+    collect_func_decls_inner(&module.decls, &mut map);
+    map
+}
+
+fn collect_func_decls_inner<'a, 'db>(
+    decls: &'a [Decl<TypedRef<'db>>],
+    map: &mut HashMap<Symbol, &'a FuncDecl<TypedRef<'db>>>,
+) {
+    for decl in decls {
+        match decl {
+            Decl::Function(func) => {
+                map.insert(func.name, func);
+            }
+            Decl::Module(m) => {
+                if let Some(body) = &m.body {
+                    collect_func_decls_inner(body, map);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn specialize_func_decl<'db>(
+    db: &'db dyn salsa::Database,
+    func: &FuncDecl<TypedRef<'db>>,
+    type_args: &[Type<'db>],
+    mangled_name: Symbol,
+) -> FuncDecl<TypedRef<'db>> {
+    FuncDecl {
+        id: func.id,
+        is_pub: false,
+        name: mangled_name,
+        type_params: vec![],
+        params: func.params.clone(),
+        return_ty: func.return_ty.clone(),
+        effects: func.effects.clone(),
+        body: substitute_expr(db, func.body.clone(), type_args),
+    }
+}
+
+// ============================================================================
+// Expr-level type substitution
+// ============================================================================
+
+fn subst_type<'db>(
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    type_args: &[Type<'db>],
+) -> Type<'db> {
+    substitute_bound_vars(db, ty, type_args).unwrap_or(ty)
+}
+
+fn subst_typed_ref<'db>(
+    db: &'db dyn salsa::Database,
+    tr: TypedRef<'db>,
+    type_args: &[Type<'db>],
+) -> TypedRef<'db> {
+    TypedRef {
+        resolved: tr.resolved,
+        ty: subst_type(db, tr.ty, type_args),
+    }
+}
+
+fn substitute_expr<'db>(
+    db: &'db dyn salsa::Database,
+    expr: Expr<TypedRef<'db>>,
+    type_args: &[Type<'db>],
+) -> Expr<TypedRef<'db>> {
+    let kind = match *expr.kind {
+        ExprKind::Var(tr) => ExprKind::Var(subst_typed_ref(db, tr, type_args)),
+        ExprKind::Call { callee, args } => ExprKind::Call {
+            callee: substitute_expr(db, callee, type_args),
+            args: args
+                .into_iter()
+                .map(|a| substitute_expr(db, a, type_args))
+                .collect(),
+        },
+        ExprKind::Block { stmts, value } => ExprKind::Block {
+            stmts: stmts
+                .into_iter()
+                .map(|s| substitute_stmt(db, s, type_args))
+                .collect(),
+            value: substitute_expr(db, value, type_args),
+        },
+        ExprKind::Case { scrutinee, arms } => ExprKind::Case {
+            scrutinee: substitute_expr(db, scrutinee, type_args),
+            arms: arms
+                .into_iter()
+                .map(|a| substitute_arm(db, a, type_args))
+                .collect(),
+        },
+        ExprKind::Lambda { params, body } => ExprKind::Lambda {
+            params,
+            body: substitute_expr(db, body, type_args),
+        },
+        ExprKind::Handle { body, handlers } => ExprKind::Handle {
+            body: substitute_expr(db, body, type_args),
+            handlers: handlers
+                .into_iter()
+                .map(|h| substitute_handler_arm(db, h, type_args))
+                .collect(),
+        },
+        ExprKind::Resume { arg, local_id } => ExprKind::Resume {
+            arg: substitute_expr(db, arg, type_args),
+            local_id,
+        },
+        ExprKind::Cons { ctor, args } => ExprKind::Cons {
+            ctor: subst_typed_ref(db, ctor, type_args),
+            args: args
+                .into_iter()
+                .map(|a| substitute_expr(db, a, type_args))
+                .collect(),
+        },
+        ExprKind::Record {
+            type_name,
+            fields,
+            spread,
+        } => ExprKind::Record {
+            type_name: subst_typed_ref(db, type_name, type_args),
+            fields: fields
+                .into_iter()
+                .map(|(name, e)| (name, substitute_expr(db, e, type_args)))
+                .collect(),
+            spread: spread.map(|s| substitute_expr(db, s, type_args)),
+        },
+        ExprKind::MethodCall {
+            receiver,
+            method,
+            args,
+        } => ExprKind::MethodCall {
+            receiver: substitute_expr(db, receiver, type_args),
+            method,
+            args: args
+                .into_iter()
+                .map(|a| substitute_expr(db, a, type_args))
+                .collect(),
+        },
+        ExprKind::BinOp { op, lhs, rhs } => ExprKind::BinOp {
+            op,
+            lhs: substitute_expr(db, lhs, type_args),
+            rhs: substitute_expr(db, rhs, type_args),
+        },
+        ExprKind::Tuple(es) => ExprKind::Tuple(
+            es.into_iter()
+                .map(|e| substitute_expr(db, e, type_args))
+                .collect(),
+        ),
+        ExprKind::List(es) => ExprKind::List(
+            es.into_iter()
+                .map(|e| substitute_expr(db, e, type_args))
+                .collect(),
+        ),
+        // Leaf nodes — no types to substitute
+        ExprKind::NatLit(v) => ExprKind::NatLit(v),
+        ExprKind::IntLit(v) => ExprKind::IntLit(v),
+        ExprKind::FloatLit(v) => ExprKind::FloatLit(v),
+        ExprKind::StringLit(v) => ExprKind::StringLit(v),
+        ExprKind::BytesLit(v) => ExprKind::BytesLit(v),
+        ExprKind::BoolLit(v) => ExprKind::BoolLit(v),
+        ExprKind::RuneLit(v) => ExprKind::RuneLit(v),
+        ExprKind::Nil => ExprKind::Nil,
+        ExprKind::Error => ExprKind::Error,
+    };
+    Expr::new(expr.id, kind)
+}
+
+fn substitute_stmt<'db>(
+    db: &'db dyn salsa::Database,
+    stmt: Stmt<TypedRef<'db>>,
+    type_args: &[Type<'db>],
+) -> Stmt<TypedRef<'db>> {
+    match stmt {
+        Stmt::Let {
+            id,
+            pattern,
+            ty,
+            value,
+        } => Stmt::Let {
+            id,
+            pattern: substitute_pattern(db, pattern, type_args),
+            ty,
+            value: substitute_expr(db, value, type_args),
+        },
+        Stmt::Expr { id, expr } => Stmt::Expr {
+            id,
+            expr: substitute_expr(db, expr, type_args),
+        },
+    }
+}
+
+fn substitute_arm<'db>(
+    db: &'db dyn salsa::Database,
+    arm: Arm<TypedRef<'db>>,
+    type_args: &[Type<'db>],
+) -> Arm<TypedRef<'db>> {
+    Arm {
+        id: arm.id,
+        pattern: substitute_pattern(db, arm.pattern, type_args),
+        guard: arm.guard.map(|g| substitute_expr(db, g, type_args)),
+        body: substitute_expr(db, arm.body, type_args),
+    }
+}
+
+fn substitute_handler_arm<'db>(
+    db: &'db dyn salsa::Database,
+    arm: HandlerArm<TypedRef<'db>>,
+    type_args: &[Type<'db>],
+) -> HandlerArm<TypedRef<'db>> {
+    let kind = match arm.kind {
+        HandlerKind::Do { binding } => HandlerKind::Do {
+            binding: substitute_pattern(db, binding, type_args),
+        },
+        HandlerKind::Fn {
+            ability,
+            op,
+            params,
+        } => HandlerKind::Fn {
+            ability: subst_typed_ref(db, ability, type_args),
+            op,
+            params: params
+                .into_iter()
+                .map(|p| substitute_pattern(db, p, type_args))
+                .collect(),
+        },
+        HandlerKind::Op {
+            ability,
+            op,
+            params,
+            resume_local_id,
+        } => HandlerKind::Op {
+            ability: subst_typed_ref(db, ability, type_args),
+            op,
+            params: params
+                .into_iter()
+                .map(|p| substitute_pattern(db, p, type_args))
+                .collect(),
+            resume_local_id,
+        },
+    };
+    HandlerArm {
+        id: arm.id,
+        kind,
+        body: substitute_expr(db, arm.body, type_args),
+    }
+}
+
+fn substitute_pattern<'db>(
+    db: &'db dyn salsa::Database,
+    pattern: Pattern<TypedRef<'db>>,
+    type_args: &[Type<'db>],
+) -> Pattern<TypedRef<'db>> {
+    let kind = match *pattern.kind {
+        PatternKind::Variant { ctor, fields } => PatternKind::Variant {
+            ctor: subst_typed_ref(db, ctor, type_args),
+            fields: fields
+                .into_iter()
+                .map(|f| substitute_pattern(db, f, type_args))
+                .collect(),
+        },
+        PatternKind::Record {
+            type_name,
+            fields,
+            rest,
+        } => PatternKind::Record {
+            type_name: type_name.map(|tn| subst_typed_ref(db, tn, type_args)),
+            fields: fields
+                .into_iter()
+                .map(|f| FieldPattern {
+                    id: f.id,
+                    name: f.name,
+                    pattern: f.pattern.map(|p| substitute_pattern(db, p, type_args)),
+                })
+                .collect(),
+            rest,
+        },
+        PatternKind::Tuple(ps) => PatternKind::Tuple(
+            ps.into_iter()
+                .map(|p| substitute_pattern(db, p, type_args))
+                .collect(),
+        ),
+        PatternKind::List(ps) => PatternKind::List(
+            ps.into_iter()
+                .map(|p| substitute_pattern(db, p, type_args))
+                .collect(),
+        ),
+        PatternKind::ListRest {
+            head,
+            rest,
+            rest_local_id,
+        } => PatternKind::ListRest {
+            head: head
+                .into_iter()
+                .map(|p| substitute_pattern(db, p, type_args))
+                .collect(),
+            rest,
+            rest_local_id,
+        },
+        PatternKind::As {
+            pattern: inner,
+            name,
+            local_id,
+        } => PatternKind::As {
+            pattern: substitute_pattern(db, inner, type_args),
+            name,
+            local_id,
+        },
+        // Leaf patterns — no types to substitute
+        PatternKind::Wildcard => PatternKind::Wildcard,
+        PatternKind::Bind { name, local_id } => PatternKind::Bind { name, local_id },
+        PatternKind::Literal(lit) => PatternKind::Literal(lit),
+        PatternKind::Error => PatternKind::Error,
+    };
+    Pattern::new(pattern.id, kind)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast::{EffectRow, NodeId, ResolvedRef, TypeKind, TypeParam};
+
+    use super::*;
+
+    #[salsa::db]
+    #[derive(Default)]
+    struct TestDb {
+        storage: salsa::Storage<Self>,
+    }
+
+    #[salsa::db]
+    impl salsa::Database for TestDb {}
+
+    fn pure_effect(db: &dyn salsa::Database) -> EffectRow<'_> {
+        EffectRow::new(db, vec![], None)
+    }
+
+    fn node_id(n: usize) -> NodeId {
+        NodeId::from_raw(n)
+    }
+
+    #[test]
+    fn test_subst_type_replaces_bound_var() {
+        let db = TestDb::default();
+        let bv0 = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let int = Type::new(&db, TypeKind::Int);
+        assert_eq!(subst_type(&db, bv0, &[int]), int);
+    }
+
+    #[test]
+    fn test_subst_type_leaves_concrete_unchanged() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        assert_eq!(subst_type(&db, int, &[]), int);
+    }
+
+    #[test]
+    fn test_substitute_expr_var() {
+        let db = TestDb::default();
+        let bv0 = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let int = Type::new(&db, TypeKind::Int);
+
+        let tr = TypedRef::new(
+            ResolvedRef::Function {
+                id: FuncDefId::new(&db, Symbol::new("f")),
+            },
+            bv0,
+        );
+        let expr = Expr::new(node_id(1), ExprKind::Var(tr));
+        let result = substitute_expr(&db, expr, &[int]);
+
+        match result.kind.as_ref() {
+            ExprKind::Var(tr) => assert_eq!(tr.ty, int),
+            _ => panic!("expected Var"),
+        }
+    }
+
+    #[test]
+    fn test_specialize_func_decl_basic() {
+        let db = TestDb::default();
+        let bv0 = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let int = Type::new(&db, TypeKind::Int);
+
+        // Build a simple generic function: fn identity(a)(x: a) -> a { x }
+        let body_ref = TypedRef::new(
+            ResolvedRef::Local {
+                id: crate::ast::LocalId::new(0),
+                name: Symbol::new("x"),
+            },
+            bv0,
+        );
+        let body = Expr::new(node_id(10), ExprKind::Var(body_ref));
+
+        let func = FuncDecl {
+            id: node_id(1),
+            is_pub: true,
+            name: Symbol::new("identity"),
+            type_params: vec![crate::ast::TypeParamDecl {
+                id: node_id(2),
+                name: Symbol::new("a"),
+                bounds: vec![],
+            }],
+            params: vec![],
+            return_ty: None,
+            effects: None,
+            body,
+        };
+
+        let mangled = mangle_name(&db, Symbol::new("identity"), &[int]);
+        let specialized = specialize_func_decl(&db, &func, &[int], mangled);
+
+        assert_eq!(specialized.name.to_string(), "identity$Int");
+        assert!(specialized.type_params.is_empty());
+        assert!(!specialized.is_pub);
+
+        // Body should have Int instead of BoundVar(0)
+        match specialized.body.kind.as_ref() {
+            ExprKind::Var(tr) => assert_eq!(tr.ty, int),
+            _ => panic!("expected Var"),
+        }
+    }
+
+    #[test]
+    fn test_generate_specializations_produces_correct_count() {
+        let db = TestDb::default();
+        let bv0 = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let int = Type::new(&db, TypeKind::Int);
+        let float = Type::new(&db, TypeKind::Float);
+
+        let func_name = Symbol::new("identity");
+        let func_id = FuncDefId::new(&db, func_name);
+
+        // Build function
+        let body_ref = TypedRef::new(
+            ResolvedRef::Local {
+                id: crate::ast::LocalId::new(0),
+                name: Symbol::new("x"),
+            },
+            bv0,
+        );
+        let body = Expr::new(node_id(10), ExprKind::Var(body_ref));
+        let func = FuncDecl {
+            id: node_id(1),
+            is_pub: true,
+            name: func_name,
+            type_params: vec![crate::ast::TypeParamDecl {
+                id: node_id(2),
+                name: Symbol::new("a"),
+                bounds: vec![],
+            }],
+            params: vec![],
+            return_ty: None,
+            effects: None,
+            body,
+        };
+
+        let module = Module::new(node_id(0), None, vec![Decl::Function(func)]);
+
+        let scheme_body = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![bv0],
+                result: bv0,
+                effect: pure_effect(&db),
+            },
+        );
+        let scheme = TypeScheme::new(&db, vec![TypeParam::anonymous()], scheme_body);
+        let function_types = vec![(func_name, scheme)];
+
+        let mut type_arg_sets = HashSet::new();
+        type_arg_sets.insert(vec![int]);
+        type_arg_sets.insert(vec![float]);
+        let mut instantiations = HashMap::new();
+        instantiations.insert(func_id, type_arg_sets);
+
+        let (new_decls, new_fn_types) =
+            generate_specializations(&db, &module, &instantiations, &function_types);
+
+        assert_eq!(new_decls.len(), 2);
+        assert_eq!(new_fn_types.len(), 2);
+
+        // Verify names are mangled
+        let names: HashSet<String> = new_decls.iter().map(|d| d.name.to_string()).collect();
+        assert!(names.contains("identity$Int"));
+        assert!(names.contains("identity$Float"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `specialize.rs` to `monomorphize/` module (Phase 3 of #53)
- `substitute_expr()`: recursively substitutes BoundVars in all TypedRef.ty fields throughout an Expr tree
- `specialize_func_decl()`: clones FuncDecl, clears type_params, applies mangled name, substitutes body types
- `generate_specializations()`: public API producing specialized FuncDecls + TypeSchemes for all instantiations
- Handles all AST node types: Expr, Stmt, Arm, HandlerArm, Pattern with exhaustive matching

Closes #665

## Test plan

- [x] 5 unit tests for type substitution, FuncDecl specialization, and multi-instantiation generation
- [x] Full test suite passes (1221 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generates monomorphic specializations of generic functions as mangled, non-public variants and exposes them for downstream use.

* **Behavior**
  * Node identifiers can carry a specialization variant; source-span lookup falls back to the original declaration for specialized instances so generated code retains source mapping.

* **Tests**
  * Added tests for bound-variable substitution, AST node-id variant propagation, expression/statement rewriting, and specialization generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->