### PR TITLE
Add call site rewriting and pipeline integration (#666)

### DIFF
--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -1,3 +1,97 @@
 pub mod collect;
 pub mod mangle;
+mod rewrite;
 pub mod specialize;
+
+use std::collections::HashMap;
+
+use trunk_ir::Symbol;
+
+use crate::ast::{Decl, FuncDefId, Module, Type, TypeScheme, TypedRef};
+
+/// Result of monomorphization: updated module + function types.
+pub struct MonomorphizeResult<'db> {
+    pub module: Module<TypedRef<'db>>,
+    pub function_types: Vec<(Symbol, TypeScheme<'db>)>,
+}
+
+/// Run monomorphization on a typed module.
+///
+/// This is the main entry point that:
+/// 1. Collects all generic function instantiations
+/// 2. Generates specialized copies with concrete types
+/// 3. Rewrites call sites to use the specialized versions
+/// 4. Appends specialized functions to the module
+pub fn monomorphize_functions<'db>(
+    db: &'db dyn salsa::Database,
+    module: Module<TypedRef<'db>>,
+    function_types: HashMap<Symbol, TypeScheme<'db>>,
+) -> MonomorphizeResult<'db> {
+    let fn_types_vec: Vec<(Symbol, TypeScheme<'db>)> =
+        function_types.iter().map(|(k, v)| (*k, *v)).collect();
+
+    // Step 1: Collect instantiations
+    let instantiations = collect::collect_instantiations(db, &module, &fn_types_vec);
+
+    if instantiations.is_empty() {
+        return MonomorphizeResult {
+            module,
+            function_types: fn_types_vec,
+        };
+    }
+
+    // Step 2: Generate specialized functions
+    let (specialized_decls, specialized_fn_types) =
+        specialize::generate_specializations(db, &module, &instantiations, &fn_types_vec);
+
+    // Build rewrite map: (original FuncDefId, type_args) → specialized FuncDefId
+    let rewrite_map = build_rewrite_map(db, &instantiations, &fn_types_vec);
+
+    // Step 3: Rewrite call sites in the module
+    let rewritten_module = rewrite::rewrite_module(db, module, &fn_types_vec, &rewrite_map);
+
+    // Step 4: Append specialized functions to module
+    let mut decls = rewritten_module.decls;
+    decls.extend(specialized_decls.into_iter().map(Decl::Function));
+
+    let final_module = Module::new(rewritten_module.id, rewritten_module.name, decls);
+
+    // Merge function types
+    let mut all_fn_types = fn_types_vec;
+    all_fn_types.extend(specialized_fn_types);
+
+    MonomorphizeResult {
+        module: final_module,
+        function_types: all_fn_types,
+    }
+}
+
+/// Build a map from (original FuncDefId, concrete callee type) → mangled Symbol
+/// for use during call site rewriting.
+fn build_rewrite_map<'db>(
+    db: &'db dyn salsa::Database,
+    instantiations: &HashMap<FuncDefId<'db>, std::collections::HashSet<Vec<Type<'db>>>>,
+    function_types: &[(Symbol, TypeScheme<'db>)],
+) -> HashMap<FuncDefId<'db>, Vec<(Vec<Type<'db>>, Symbol)>> {
+    let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
+    let mut rewrite_map: HashMap<FuncDefId<'db>, Vec<(Vec<Type<'db>>, Symbol)>> = HashMap::new();
+
+    for (func_id, type_arg_sets) in instantiations {
+        let qualified = func_id.qualified(db);
+        let Some(_scheme) = scheme_map.get(&qualified) else {
+            continue;
+        };
+
+        let mut entries: Vec<(Vec<Type<'db>>, Symbol)> = type_arg_sets
+            .iter()
+            .map(|type_args| {
+                let mangled = mangle::mangle_name(db, qualified, type_args);
+                (type_args.clone(), mangled)
+            })
+            .collect();
+        entries.sort_by(|a, b| a.1.cmp(&b.1));
+        rewrite_map.insert(*func_id, entries);
+    }
+
+    rewrite_map
+}

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -50,9 +50,16 @@ pub fn monomorphize_functions<'db>(
     // Step 3: Rewrite call sites in the module
     let rewritten_module = rewrite::rewrite_module(db, module, &fn_types_vec, &rewrite_map);
 
-    // Step 4: Append specialized functions to module
+    // Step 4: Rewrite call sites inside specialized function bodies
+    // (e.g., a specialized function calling another generic function)
+    let specialized_decls: Vec<Decl<TypedRef<'db>>> =
+        specialized_decls.into_iter().map(Decl::Function).collect();
+    let rewritten_specialized =
+        rewrite::rewrite_decls(db, specialized_decls, &fn_types_vec, &rewrite_map);
+
+    // Step 5: Append specialized functions to module
     let mut decls = rewritten_module.decls;
-    decls.extend(specialized_decls.into_iter().map(Decl::Function));
+    decls.extend(rewritten_specialized);
 
     let final_module = Module::new(rewritten_module.id, rewritten_module.name, decls);
 

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -1,0 +1,214 @@
+//! Call site rewriting for monomorphization.
+//!
+//! Rewrites references to generic functions with their specialized versions
+//! by matching the callee's concrete type against collected instantiations.
+
+use std::collections::HashMap;
+
+use trunk_ir::Symbol;
+
+use crate::ast::{
+    Arm, Decl, Expr, ExprKind, FuncDefId, HandlerArm, Module, ModuleDecl, ResolvedRef, Stmt, Type,
+    TypeScheme, TypedRef,
+};
+
+use super::collect::extract_type_args;
+
+/// Rewrite map: original FuncDefId → list of (type_args, mangled_name) pairs.
+pub type RewriteMap<'db> = HashMap<FuncDefId<'db>, Vec<(Vec<Type<'db>>, Symbol)>>;
+
+/// Rewrite all generic function call sites in a module to use specialized versions.
+pub fn rewrite_module<'db>(
+    db: &'db dyn salsa::Database,
+    module: Module<TypedRef<'db>>,
+    function_types: &[(Symbol, TypeScheme<'db>)],
+    rewrite_map: &RewriteMap<'db>,
+) -> Module<TypedRef<'db>> {
+    let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
+    let mut rewriter = CallSiteRewriter {
+        db,
+        scheme_map,
+        rewrite_map,
+    };
+    let decls = module
+        .decls
+        .into_iter()
+        .map(|d| rewriter.rewrite_decl(d))
+        .collect();
+    Module::new(module.id, module.name, decls)
+}
+
+struct CallSiteRewriter<'a, 'db> {
+    db: &'db dyn salsa::Database,
+    scheme_map: HashMap<Symbol, TypeScheme<'db>>,
+    rewrite_map: &'a RewriteMap<'db>,
+}
+
+impl<'a, 'db> CallSiteRewriter<'a, 'db> {
+    fn try_rewrite_ref(&self, typed_ref: &TypedRef<'db>) -> Option<TypedRef<'db>> {
+        let ResolvedRef::Function { id } = &typed_ref.resolved else {
+            return None;
+        };
+        let entries = self.rewrite_map.get(id)?;
+        let qualified = id.qualified(self.db);
+        let scheme = self.scheme_map.get(&qualified)?;
+        let type_args = extract_type_args(self.db, *scheme, typed_ref.ty)?;
+
+        // Find the matching mangled name
+        let mangled = entries.iter().find_map(|(args, name)| {
+            if args == &type_args {
+                Some(*name)
+            } else {
+                None
+            }
+        })?;
+
+        let specialized_id = FuncDefId::new(self.db, mangled);
+        Some(TypedRef::new(
+            ResolvedRef::Function { id: specialized_id },
+            typed_ref.ty,
+        ))
+    }
+
+    fn rewrite_typed_ref(&self, tr: TypedRef<'db>) -> TypedRef<'db> {
+        self.try_rewrite_ref(&tr).unwrap_or(tr)
+    }
+
+    fn rewrite_decl(&mut self, decl: Decl<TypedRef<'db>>) -> Decl<TypedRef<'db>> {
+        match decl {
+            Decl::Function(mut func) => {
+                func.body = self.rewrite_expr(func.body);
+                Decl::Function(func)
+            }
+            Decl::Module(m) => {
+                let body = m
+                    .body
+                    .map(|decls| decls.into_iter().map(|d| self.rewrite_decl(d)).collect());
+                Decl::Module(ModuleDecl {
+                    id: m.id,
+                    name: m.name,
+                    is_pub: m.is_pub,
+                    body,
+                })
+            }
+            other => other,
+        }
+    }
+
+    fn rewrite_expr(&mut self, expr: Expr<TypedRef<'db>>) -> Expr<TypedRef<'db>> {
+        let kind = match *expr.kind {
+            ExprKind::Var(tr) => ExprKind::Var(self.rewrite_typed_ref(tr)),
+            ExprKind::Call { callee, args } => ExprKind::Call {
+                callee: self.rewrite_expr(callee),
+                args: args.into_iter().map(|a| self.rewrite_expr(a)).collect(),
+            },
+            ExprKind::Block { stmts, value } => ExprKind::Block {
+                stmts: stmts.into_iter().map(|s| self.rewrite_stmt(s)).collect(),
+                value: self.rewrite_expr(value),
+            },
+            ExprKind::Case { scrutinee, arms } => ExprKind::Case {
+                scrutinee: self.rewrite_expr(scrutinee),
+                arms: arms.into_iter().map(|a| self.rewrite_arm(a)).collect(),
+            },
+            ExprKind::Lambda { params, body } => ExprKind::Lambda {
+                params,
+                body: self.rewrite_expr(body),
+            },
+            ExprKind::Handle { body, handlers } => ExprKind::Handle {
+                body: self.rewrite_expr(body),
+                handlers: handlers
+                    .into_iter()
+                    .map(|h| self.rewrite_handler_arm(h))
+                    .collect(),
+            },
+            ExprKind::Resume { arg, local_id } => ExprKind::Resume {
+                arg: self.rewrite_expr(arg),
+                local_id,
+            },
+            ExprKind::Cons { ctor, args } => ExprKind::Cons {
+                ctor,
+                args: args.into_iter().map(|a| self.rewrite_expr(a)).collect(),
+            },
+            ExprKind::Record {
+                type_name,
+                fields,
+                spread,
+            } => ExprKind::Record {
+                type_name,
+                fields: fields
+                    .into_iter()
+                    .map(|(name, e)| (name, self.rewrite_expr(e)))
+                    .collect(),
+                spread: spread.map(|s| self.rewrite_expr(s)),
+            },
+            ExprKind::MethodCall {
+                receiver,
+                method,
+                args,
+            } => ExprKind::MethodCall {
+                receiver: self.rewrite_expr(receiver),
+                method,
+                args: args.into_iter().map(|a| self.rewrite_expr(a)).collect(),
+            },
+            ExprKind::BinOp { op, lhs, rhs } => ExprKind::BinOp {
+                op,
+                lhs: self.rewrite_expr(lhs),
+                rhs: self.rewrite_expr(rhs),
+            },
+            ExprKind::Tuple(es) => {
+                ExprKind::Tuple(es.into_iter().map(|e| self.rewrite_expr(e)).collect())
+            }
+            ExprKind::List(es) => {
+                ExprKind::List(es.into_iter().map(|e| self.rewrite_expr(e)).collect())
+            }
+            // Leaf nodes
+            ExprKind::NatLit(v) => ExprKind::NatLit(v),
+            ExprKind::IntLit(v) => ExprKind::IntLit(v),
+            ExprKind::FloatLit(v) => ExprKind::FloatLit(v),
+            ExprKind::StringLit(v) => ExprKind::StringLit(v),
+            ExprKind::BytesLit(v) => ExprKind::BytesLit(v),
+            ExprKind::BoolLit(v) => ExprKind::BoolLit(v),
+            ExprKind::RuneLit(v) => ExprKind::RuneLit(v),
+            ExprKind::Nil => ExprKind::Nil,
+            ExprKind::Error => ExprKind::Error,
+        };
+        Expr::new(expr.id, kind)
+    }
+
+    fn rewrite_stmt(&mut self, stmt: Stmt<TypedRef<'db>>) -> Stmt<TypedRef<'db>> {
+        match stmt {
+            Stmt::Let {
+                id,
+                pattern,
+                ty,
+                value,
+            } => Stmt::Let {
+                id,
+                pattern,
+                ty,
+                value: self.rewrite_expr(value),
+            },
+            Stmt::Expr { id, expr } => Stmt::Expr {
+                id,
+                expr: self.rewrite_expr(expr),
+            },
+        }
+    }
+
+    fn rewrite_arm(&mut self, arm: Arm<TypedRef<'db>>) -> Arm<TypedRef<'db>> {
+        Arm {
+            id: arm.id,
+            pattern: arm.pattern,
+            guard: arm.guard.map(|g| self.rewrite_expr(g)),
+            body: self.rewrite_expr(arm.body),
+        }
+    }
+
+    fn rewrite_handler_arm(&mut self, arm: HandlerArm<TypedRef<'db>>) -> HandlerArm<TypedRef<'db>> {
+        HandlerArm {
+            id: arm.id,
+            kind: arm.kind,
+            body: self.rewrite_expr(arm.body),
+        }
+    }
+}

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -24,18 +24,40 @@ pub fn rewrite_module<'db>(
     function_types: &[(Symbol, TypeScheme<'db>)],
     rewrite_map: &RewriteMap<'db>,
 ) -> Module<TypedRef<'db>> {
-    let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
-    let mut rewriter = CallSiteRewriter {
-        db,
-        scheme_map,
-        rewrite_map,
-    };
+    let mut rewriter = make_rewriter(db, function_types, rewrite_map);
     let decls = module
         .decls
         .into_iter()
         .map(|d| rewriter.rewrite_decl(d))
         .collect();
     Module::new(module.id, module.name, decls)
+}
+
+/// Rewrite call sites in a list of declarations (e.g., specialized function bodies).
+pub fn rewrite_decls<'db>(
+    db: &'db dyn salsa::Database,
+    decls: Vec<Decl<TypedRef<'db>>>,
+    function_types: &[(Symbol, TypeScheme<'db>)],
+    rewrite_map: &RewriteMap<'db>,
+) -> Vec<Decl<TypedRef<'db>>> {
+    let mut rewriter = make_rewriter(db, function_types, rewrite_map);
+    decls
+        .into_iter()
+        .map(|d| rewriter.rewrite_decl(d))
+        .collect()
+}
+
+fn make_rewriter<'a, 'db>(
+    db: &'db dyn salsa::Database,
+    function_types: &[(Symbol, TypeScheme<'db>)],
+    rewrite_map: &'a RewriteMap<'db>,
+) -> CallSiteRewriter<'a, 'db> {
+    let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
+    CallSiteRewriter {
+        db,
+        scheme_map,
+        rewrite_map,
+    }
 }
 
 struct CallSiteRewriter<'a, 'db> {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -303,6 +303,13 @@ fn merge_and_lower_to_ir<'db>(
             )
         };
 
+    // Monomorphize generic functions
+    let mono_result =
+        tribute_front::monomorphize::monomorphize_functions(db, merged_module, merged_fn_types);
+    let merged_module = mono_result.module;
+    let merged_fn_types: std::collections::HashMap<_, _> =
+        mono_result.function_types.into_iter().collect();
+
     // AST → TrunkIR (arena)
     let source_uri = source.uri(db).as_str();
     let mut ir = IrContext::new();


### PR DESCRIPTION
## Summary

Complete the monomorphization pipeline (Phase 4 of #53):

- `rewrite.rs`: AST pass that rewrites `ResolvedRef::Function` references from generic functions to their specialized versions by matching callee types against collected instantiations
- `mod.rs`: `monomorphize_functions()` orchestrates the full pipeline: collect → specialize → rewrite → merge
- `pipeline.rs`: Insert monomorphization after prelude merge, before `ast_to_ir`

This is the phase where monomorphization becomes end-to-end functional.

Closes #666

## Test plan

- [x] All 8 generic E2E tests pass: `test_generic_int_identity`, `test_generic_float_identity`, `test_generic_multiple_types`, `test_generic_two_params`, `test_generic_nested_calls`, `test_generic_indirect_call`, `test_generic_function_type`, `test_generic_struct_argument`
- [x] Full test suite passes (1222 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compilation now performs function specialization (monomorphization) on typed modules, generating specialized function variants and updating call sites before IR lowering.
* **Chores**
  * Introduced a rewrite-based pass to map and replace generic function references with their specialized counterparts and merged resulting function type information into the compilation artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->