### PR TITLE
Add generic type (struct/enum) monomorphization (#667)

### DIFF
--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use trunk_ir::Symbol;
+
 use crate::ast::{
     Decl, Expr, ExprKind, FuncDefId, Module, ResolvedRef, Stmt, Type, TypeKind, TypeScheme,
     TypedRef,
@@ -253,6 +255,230 @@ impl<'db> InstantiationCollector<'db> {
     }
 }
 
+// ============================================================================
+// Type instantiation collection (for generic struct/enum monomorphization)
+// ============================================================================
+
+/// Collect all generic type instantiations from a typed module.
+///
+/// Walks all types in the AST (recursively through Func, Tuple, Named, etc.)
+/// and records which concrete type argument combinations each generic type
+/// is used with. Only collects types whose names match generic struct/enum
+/// declarations (those with non-empty `type_params`).
+pub fn collect_type_instantiations<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+) -> HashMap<Symbol, HashSet<Vec<Type<'db>>>> {
+    let generic_types = collect_generic_type_names(module);
+    let mut result: HashMap<Symbol, HashSet<Vec<Type<'db>>>> = HashMap::new();
+
+    let mut visitor = TypeInstantiationVisitor {
+        db,
+        generic_types: &generic_types,
+        instantiations: &mut result,
+    };
+    visitor.visit_module(module);
+    result
+}
+
+/// Collect names of all struct/enum declarations that have type parameters.
+fn collect_generic_type_names(module: &Module<TypedRef<'_>>) -> HashSet<Symbol> {
+    let mut names = HashSet::new();
+    collect_generic_type_names_inner(&module.decls, &mut names);
+    names
+}
+
+fn collect_generic_type_names_inner(decls: &[Decl<TypedRef<'_>>], names: &mut HashSet<Symbol>) {
+    for decl in decls {
+        match decl {
+            Decl::Struct(s) if !s.type_params.is_empty() => {
+                names.insert(s.name);
+            }
+            Decl::Enum(e) if !e.type_params.is_empty() => {
+                names.insert(e.name);
+            }
+            Decl::Module(m) => {
+                if let Some(body) = &m.body {
+                    collect_generic_type_names_inner(body, names);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Recursively walk a Type and collect all `Named { name, args }` where
+/// `args` is non-empty and `name` is a known generic type.
+fn collect_from_type<'db>(
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    generic_types: &HashSet<Symbol>,
+    result: &mut HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+) {
+    match ty.kind(db) {
+        TypeKind::Named { name, args } => {
+            if !args.is_empty() && generic_types.contains(name) {
+                result.entry(*name).or_default().insert(args.clone());
+            }
+            // Recurse into type arguments (e.g., List(Option(Int)) → collect Option(Int))
+            for arg in args {
+                collect_from_type(db, *arg, generic_types, result);
+            }
+        }
+        TypeKind::Func {
+            params,
+            result: ret,
+            ..
+        } => {
+            for p in params {
+                collect_from_type(db, *p, generic_types, result);
+            }
+            collect_from_type(db, *ret, generic_types, result);
+        }
+        TypeKind::Tuple(elems) => {
+            for e in elems {
+                collect_from_type(db, *e, generic_types, result);
+            }
+        }
+        TypeKind::App { ctor, args } => {
+            collect_from_type(db, *ctor, generic_types, result);
+            for a in args {
+                collect_from_type(db, *a, generic_types, result);
+            }
+        }
+        TypeKind::Continuation {
+            arg, result: ret, ..
+        } => {
+            collect_from_type(db, *arg, generic_types, result);
+            collect_from_type(db, *ret, generic_types, result);
+        }
+        // Primitives and variables: no nested Named types
+        _ => {}
+    }
+}
+
+struct TypeInstantiationVisitor<'a, 'db> {
+    db: &'db dyn salsa::Database,
+    generic_types: &'a HashSet<Symbol>,
+    instantiations: &'a mut HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+}
+
+impl<'a, 'db> TypeInstantiationVisitor<'a, 'db> {
+    fn collect_type(&mut self, ty: Type<'db>) {
+        collect_from_type(self.db, ty, self.generic_types, self.instantiations);
+    }
+
+    fn visit_typed_ref(&mut self, tr: &TypedRef<'db>) {
+        self.collect_type(tr.ty);
+    }
+
+    fn visit_module(&mut self, module: &Module<TypedRef<'db>>) {
+        for decl in &module.decls {
+            self.visit_decl(decl);
+        }
+    }
+
+    fn visit_decl(&mut self, decl: &Decl<TypedRef<'db>>) {
+        match decl {
+            Decl::Function(func) => self.visit_expr(&func.body),
+            Decl::Module(m) => {
+                if let Some(body) = &m.body {
+                    for d in body {
+                        self.visit_decl(d);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expr<TypedRef<'db>>) {
+        match expr.kind.as_ref() {
+            ExprKind::Var(tr) => self.visit_typed_ref(tr),
+            ExprKind::Call { callee, args } => {
+                self.visit_expr(callee);
+                for arg in args {
+                    self.visit_expr(arg);
+                }
+            }
+            ExprKind::Block { stmts, value } => {
+                for s in stmts {
+                    self.visit_stmt(s);
+                }
+                self.visit_expr(value);
+            }
+            ExprKind::Case { scrutinee, arms } => {
+                self.visit_expr(scrutinee);
+                for arm in arms {
+                    if let Some(guard) = &arm.guard {
+                        self.visit_expr(guard);
+                    }
+                    self.visit_expr(&arm.body);
+                }
+            }
+            ExprKind::Lambda { body, .. } => self.visit_expr(body),
+            ExprKind::Handle { body, handlers } => {
+                self.visit_expr(body);
+                for h in handlers {
+                    self.visit_expr(&h.body);
+                }
+            }
+            ExprKind::Resume { arg, .. } => self.visit_expr(arg),
+            ExprKind::Cons { ctor, args } => {
+                self.visit_typed_ref(ctor);
+                for a in args {
+                    self.visit_expr(a);
+                }
+            }
+            ExprKind::Record {
+                type_name,
+                fields,
+                spread,
+                ..
+            } => {
+                self.visit_typed_ref(type_name);
+                for (_, e) in fields {
+                    self.visit_expr(e);
+                }
+                if let Some(s) = spread {
+                    self.visit_expr(s);
+                }
+            }
+            ExprKind::BinOp { lhs, rhs, .. } => {
+                self.visit_expr(lhs);
+                self.visit_expr(rhs);
+            }
+            ExprKind::Tuple(es) | ExprKind::List(es) => {
+                for e in es {
+                    self.visit_expr(e);
+                }
+            }
+            ExprKind::MethodCall { receiver, args, .. } => {
+                self.visit_expr(receiver);
+                for a in args {
+                    self.visit_expr(a);
+                }
+            }
+            ExprKind::NatLit(_)
+            | ExprKind::IntLit(_)
+            | ExprKind::FloatLit(_)
+            | ExprKind::StringLit(_)
+            | ExprKind::BytesLit(_)
+            | ExprKind::BoolLit(_)
+            | ExprKind::RuneLit(_)
+            | ExprKind::Nil
+            | ExprKind::Error => {}
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt<TypedRef<'db>>) {
+        match stmt {
+            Stmt::Let { value, .. } => self.visit_expr(value),
+            Stmt::Expr { expr, .. } => self.visit_expr(expr),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ast::{EffectRow, TypeParam, TypeScheme};
@@ -467,6 +693,118 @@ mod tests {
         let scheme = make_scheme(&db, 0, body);
         assert_eq!(extract_type_args(&db, scheme, body), None);
     }
+
+    // ========================================================================
+    // collect_type_instantiations tests
+    // ========================================================================
+
+    #[test]
+    fn test_collect_type_from_named() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                name: trunk_ir::Symbol::new("Option"),
+                args: vec![int],
+            },
+        );
+
+        let mut generic_types = HashSet::new();
+        generic_types.insert(trunk_ir::Symbol::new("Option"));
+
+        let mut result = HashMap::new();
+        collect_from_type(&db, option_int, &generic_types, &mut result);
+
+        assert_eq!(result.len(), 1);
+        let option_insts = result.get(&trunk_ir::Symbol::new("Option")).unwrap();
+        assert!(option_insts.contains(&vec![int]));
+    }
+
+    #[test]
+    fn test_collect_type_nested() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                name: trunk_ir::Symbol::new("Option"),
+                args: vec![int],
+            },
+        );
+        let list_option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                name: trunk_ir::Symbol::new("List"),
+                args: vec![option_int],
+            },
+        );
+
+        let mut generic_types = HashSet::new();
+        generic_types.insert(trunk_ir::Symbol::new("Option"));
+        generic_types.insert(trunk_ir::Symbol::new("List"));
+
+        let mut result = HashMap::new();
+        collect_from_type(&db, list_option_int, &generic_types, &mut result);
+
+        assert_eq!(result.len(), 2);
+        assert!(result[&trunk_ir::Symbol::new("Option")].contains(&vec![int]));
+        assert!(result[&trunk_ir::Symbol::new("List")].contains(&vec![option_int]));
+    }
+
+    #[test]
+    fn test_collect_type_in_func_params() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let pair_int_int = Type::new(
+            &db,
+            TypeKind::Named {
+                name: trunk_ir::Symbol::new("Pair"),
+                args: vec![int, int],
+            },
+        );
+        let func_ty = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![pair_int_int],
+                result: int,
+                effect: pure_effect(&db),
+            },
+        );
+
+        let mut generic_types = HashSet::new();
+        generic_types.insert(trunk_ir::Symbol::new("Pair"));
+
+        let mut result = HashMap::new();
+        collect_from_type(&db, func_ty, &generic_types, &mut result);
+
+        assert_eq!(result.len(), 1);
+        assert!(result[&trunk_ir::Symbol::new("Pair")].contains(&vec![int, int]));
+    }
+
+    #[test]
+    fn test_collect_type_ignores_non_generic() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        // Named type with args but NOT in generic_types set
+        let unknown = Type::new(
+            &db,
+            TypeKind::Named {
+                name: trunk_ir::Symbol::new("Unknown"),
+                args: vec![int],
+            },
+        );
+
+        let generic_types = HashSet::new(); // empty — nothing is generic
+        let mut result = HashMap::new();
+        collect_from_type(&db, unknown, &generic_types, &mut result);
+
+        assert!(result.is_empty());
+    }
+
+    // ========================================================================
+    // extract_type_args tests (continued)
+    // ========================================================================
 
     #[test]
     fn test_extract_func_type_arg() {

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -123,7 +123,7 @@ fn build_rewrite_map<'db>(
                 (type_args.clone(), mangled)
             })
             .collect();
-        entries.sort_by(|a, b| a.1.cmp(&b.1));
+        entries.sort_by_key(|e| e.1);
         rewrite_map.insert(*func_id, entries);
     }
 

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -18,10 +18,10 @@ pub struct MonomorphizeResult<'db> {
 /// Run monomorphization on a typed module.
 ///
 /// This is the main entry point that:
-/// 1. Collects all generic function instantiations
+/// 1. Collects all generic function/type instantiations
 /// 2. Generates specialized copies with concrete types
-/// 3. Rewrites call sites to use the specialized versions
-/// 4. Appends specialized functions to the module
+/// 3. Rewrites call sites and type references to use specialized versions
+/// 4. Appends specialized functions/types to the module
 pub fn monomorphize_functions<'db>(
     db: &'db dyn salsa::Database,
     module: Module<TypedRef<'db>>,
@@ -30,46 +30,73 @@ pub fn monomorphize_functions<'db>(
     let fn_types_vec: Vec<(Symbol, TypeScheme<'db>)> =
         function_types.iter().map(|(k, v)| (*k, *v)).collect();
 
-    // Step 1: Collect instantiations
-    let instantiations = collect::collect_instantiations(db, &module, &fn_types_vec);
+    // === Function monomorphization ===
 
-    if instantiations.is_empty() {
-        return MonomorphizeResult {
-            module,
-            function_types: fn_types_vec,
-        };
-    }
+    // Step 1: Collect function instantiations
+    let func_instantiations = collect::collect_instantiations(db, &module, &fn_types_vec);
 
-    // Step 2: Generate specialized functions
-    let (specialized_decls, specialized_fn_types) =
-        specialize::generate_specializations(db, &module, &instantiations, &fn_types_vec);
+    let module = if !func_instantiations.is_empty() {
+        // Step 2: Generate specialized functions
+        let (specialized_decls, specialized_fn_types) =
+            specialize::generate_specializations(db, &module, &func_instantiations, &fn_types_vec);
 
-    // Build rewrite map: (original FuncDefId, type_args) → specialized FuncDefId
-    let rewrite_map = build_rewrite_map(db, &instantiations, &fn_types_vec);
+        // Build rewrite map
+        let rewrite_map = build_rewrite_map(db, &func_instantiations, &fn_types_vec);
 
-    // Step 3: Rewrite call sites in the module
-    let rewritten_module = rewrite::rewrite_module(db, module, &fn_types_vec, &rewrite_map);
+        // Step 3: Rewrite call sites in the module
+        let rewritten_module = rewrite::rewrite_module(db, module, &fn_types_vec, &rewrite_map);
 
-    // Step 4: Rewrite call sites inside specialized function bodies
-    // (e.g., a specialized function calling another generic function)
-    let specialized_decls: Vec<Decl<TypedRef<'db>>> =
-        specialized_decls.into_iter().map(Decl::Function).collect();
-    let rewritten_specialized =
-        rewrite::rewrite_decls(db, specialized_decls, &fn_types_vec, &rewrite_map);
+        // Step 4: Rewrite call sites inside specialized function bodies
+        let specialized_decls: Vec<Decl<TypedRef<'db>>> =
+            specialized_decls.into_iter().map(Decl::Function).collect();
+        let rewritten_specialized =
+            rewrite::rewrite_decls(db, specialized_decls, &fn_types_vec, &rewrite_map);
 
-    // Step 5: Append specialized functions to module
-    let mut decls = rewritten_module.decls;
-    decls.extend(rewritten_specialized);
+        // Step 5: Append specialized functions to module
+        let mut decls = rewritten_module.decls;
+        decls.extend(rewritten_specialized);
 
-    let final_module = Module::new(rewritten_module.id, rewritten_module.name, decls);
+        // Update function types for downstream
+        let mut all_fn_types = fn_types_vec;
+        all_fn_types.extend(specialized_fn_types);
 
-    // Merge function types
-    let mut all_fn_types = fn_types_vec;
-    all_fn_types.extend(specialized_fn_types);
+        // Return intermediate result with updated fn_types
+        let module = Module::new(rewritten_module.id, rewritten_module.name, decls);
+        (module, all_fn_types)
+    } else {
+        (module, fn_types_vec)
+    };
+
+    let (module, fn_types_vec) = module;
+
+    // === Type monomorphization (struct/enum) ===
+
+    let type_instantiations = collect::collect_type_instantiations(db, &module);
+
+    let module = if !type_instantiations.is_empty() {
+        // Generate specialized struct/enum declarations
+        let specialized_structs =
+            specialize::generate_struct_specializations(db, &module, &type_instantiations);
+        let specialized_enums =
+            specialize::generate_enum_specializations(db, &module, &type_instantiations);
+
+        // Build type rewrite map and rewrite Named types throughout the module
+        let type_rewrite_map = rewrite::build_type_rewrite_map(db, &type_instantiations);
+        let rewritten_module = rewrite::rewrite_types_in_module(db, module, &type_rewrite_map);
+
+        // Append specialized types to module
+        let mut decls = rewritten_module.decls;
+        decls.extend(specialized_structs.into_iter().map(Decl::Struct));
+        decls.extend(specialized_enums.into_iter().map(Decl::Enum));
+
+        Module::new(rewritten_module.id, rewritten_module.name, decls)
+    } else {
+        module
+    };
 
     MonomorphizeResult {
-        module: final_module,
-        function_types: all_fn_types,
+        module,
+        function_types: fn_types_vec,
     }
 }
 

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -320,16 +320,16 @@ pub fn rewrite_type<'db>(
                 args.iter().map(|a| rewrite_type(db, *a, map)).collect();
 
             // Check if this Named type should be mangled
-            if let Some(entries) = map.get(name) {
-                if let Some((_, mangled)) = entries.iter().find(|(ta, _)| *ta == rewritten_args) {
-                    return Type::new(
-                        db,
-                        TypeKind::Named {
-                            name: *mangled,
-                            args: vec![],
-                        },
-                    );
-                }
+            if let Some(entries) = map.get(name)
+                && let Some((_, mangled)) = entries.iter().find(|(ta, _)| *ta == rewritten_args)
+            {
+                return Type::new(
+                    db,
+                    TypeKind::Named {
+                        name: *mangled,
+                        args: vec![],
+                    },
+                );
             }
             // Not in rewrite map — return with rewritten args
             Type::new(

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -696,3 +696,136 @@ fn rewrite_types_in_pattern<'db>(
     };
     Pattern::new(pattern.id, kind)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::EffectRow;
+
+    #[salsa::db]
+    #[derive(Default)]
+    struct TestDb {
+        storage: salsa::Storage<Self>,
+    }
+
+    #[salsa::db]
+    impl salsa::Database for TestDb {}
+
+    fn pure_effect(db: &dyn salsa::Database) -> EffectRow<'_> {
+        EffectRow::new(db, vec![], None)
+    }
+
+    fn make_type_rewrite_map<'db>(
+        _db: &'db dyn salsa::Database,
+        entries: Vec<(Symbol, Vec<Type<'db>>, Symbol)>,
+    ) -> TypeRewriteMap<'db> {
+        let mut map = TypeRewriteMap::new();
+        for (name, args, mangled) in entries {
+            map.entry(name).or_default().push((args, mangled));
+        }
+        map
+    }
+
+    #[test]
+    fn test_rewrite_type_named_with_args() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Option"),
+                args: vec![int],
+            },
+        );
+        let map = make_type_rewrite_map(
+            &db,
+            vec![(Symbol::new("Option"), vec![int], Symbol::new("Option$Int"))],
+        );
+
+        let result = rewrite_type(&db, option_int, &map);
+        match result.kind(&db) {
+            TypeKind::Named { name, args } => {
+                assert_eq!(name.to_string(), "Option$Int");
+                assert!(args.is_empty());
+            }
+            other => panic!("expected Named, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_type_leaves_primitives() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let map = TypeRewriteMap::new();
+        assert_eq!(rewrite_type(&db, int, &map), int);
+    }
+
+    #[test]
+    fn test_rewrite_type_named_no_args_unchanged() {
+        let db = TestDb::default();
+        let text = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Text"),
+                args: vec![],
+            },
+        );
+        let map = TypeRewriteMap::new();
+        assert_eq!(rewrite_type(&db, text, &map), text);
+    }
+
+    #[test]
+    fn test_rewrite_type_nested_in_func() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Option"),
+                args: vec![int],
+            },
+        );
+        let func_ty = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![option_int],
+                result: int,
+                effect: pure_effect(&db),
+            },
+        );
+        let map = make_type_rewrite_map(
+            &db,
+            vec![(Symbol::new("Option"), vec![int], Symbol::new("Option$Int"))],
+        );
+
+        let result = rewrite_type(&db, func_ty, &map);
+        match result.kind(&db) {
+            TypeKind::Func { params, .. } => match params[0].kind(&db) {
+                TypeKind::Named { name, args } => {
+                    assert_eq!(name.to_string(), "Option$Int");
+                    assert!(args.is_empty());
+                }
+                other => panic!("expected Named, got {:?}", other),
+            },
+            other => panic!("expected Func, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_type_not_in_map_preserves_args() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let unknown = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Unknown"),
+                args: vec![int],
+            },
+        );
+        let map = TypeRewriteMap::new(); // empty
+
+        let result = rewrite_type(&db, unknown, &map);
+        // Should be unchanged
+        assert_eq!(result, unknown);
+    }
+}

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -259,7 +259,7 @@ pub fn build_type_rewrite_map<'db>(
                 (type_args.clone(), mangled)
             })
             .collect();
-        entries.sort_by(|a, b| a.1.cmp(&b.1));
+        entries.sort_by_key(|e| e.1);
         map.insert(*name, entries);
     }
     map

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -9,8 +9,9 @@ use std::collections::{HashMap, HashSet};
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    Arm, CtorId, Decl, Expr, ExprKind, FieldPattern, FuncDefId, HandlerArm, Module, ModuleDecl,
-    Pattern, PatternKind, ResolvedRef, Stmt, Type, TypeDefId, TypeKind, TypeScheme, TypedRef,
+    Arm, CtorId, Decl, Expr, ExprKind, FieldPattern, FuncDefId, HandlerArm, HandlerKind, Module,
+    ModuleDecl, Pattern, PatternKind, ResolvedRef, Stmt, Type, TypeDefId, TypeKind, TypeScheme,
+    TypedRef,
 };
 
 use super::collect::extract_type_args;
@@ -522,10 +523,43 @@ fn rewrite_types_in_expr<'db>(
             body: rewrite_types_in_expr(db, body, map),
             handlers: handlers
                 .into_iter()
-                .map(|h| HandlerArm {
-                    id: h.id,
-                    kind: h.kind,
-                    body: rewrite_types_in_expr(db, h.body, map),
+                .map(|h| {
+                    let kind = match h.kind {
+                        HandlerKind::Do { binding } => HandlerKind::Do {
+                            binding: rewrite_types_in_pattern(db, binding, map),
+                        },
+                        HandlerKind::Fn {
+                            ability,
+                            op,
+                            params,
+                        } => HandlerKind::Fn {
+                            ability: rewrite_typed_ref_type(db, ability, map),
+                            op,
+                            params: params
+                                .into_iter()
+                                .map(|p| rewrite_types_in_pattern(db, p, map))
+                                .collect(),
+                        },
+                        HandlerKind::Op {
+                            ability,
+                            op,
+                            params,
+                            resume_local_id,
+                        } => HandlerKind::Op {
+                            ability: rewrite_typed_ref_type(db, ability, map),
+                            op,
+                            params: params
+                                .into_iter()
+                                .map(|p| rewrite_types_in_pattern(db, p, map))
+                                .collect(),
+                            resume_local_id,
+                        },
+                    };
+                    HandlerArm {
+                        id: h.id,
+                        kind,
+                        body: rewrite_types_in_expr(db, h.body, map),
+                    }
                 })
                 .collect(),
         },

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -1,21 +1,26 @@
-//! Call site rewriting for monomorphization.
+//! Call site and type rewriting for monomorphization.
 //!
 //! Rewrites references to generic functions with their specialized versions
 //! by matching the callee's concrete type against collected instantiations.
+//! Also rewrites Named types with type arguments to their mangled monomorphic versions.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    Arm, Decl, Expr, ExprKind, FuncDefId, HandlerArm, Module, ModuleDecl, ResolvedRef, Stmt, Type,
-    TypeScheme, TypedRef,
+    Arm, CtorId, Decl, Expr, ExprKind, FuncDefId, HandlerArm, Module, ModuleDecl, ResolvedRef,
+    Stmt, Type, TypeDefId, TypeKind, TypeScheme, TypedRef,
 };
 
 use super::collect::extract_type_args;
+use super::mangle::mangle_name;
 
 /// Rewrite map: original FuncDefId → list of (type_args, mangled_name) pairs.
 pub type RewriteMap<'db> = HashMap<FuncDefId<'db>, Vec<(Vec<Type<'db>>, Symbol)>>;
+
+/// Type rewrite map: type name → set of (type_args, mangled_name) pairs.
+pub type TypeRewriteMap<'db> = HashMap<Symbol, Vec<(Vec<Type<'db>>, Symbol)>>;
 
 /// Rewrite all generic function call sites in a module to use specialized versions.
 pub fn rewrite_module<'db>(
@@ -232,5 +237,363 @@ impl<'a, 'db> CallSiteRewriter<'a, 'db> {
             kind: arm.kind,
             body: self.rewrite_expr(arm.body),
         }
+    }
+}
+
+// ============================================================================
+// Type rewriting: Named { name, args } → Named { mangled, args: [] }
+// ============================================================================
+
+/// Build a type rewrite map from collected type instantiations.
+pub fn build_type_rewrite_map<'db>(
+    db: &'db dyn salsa::Database,
+    instantiations: &HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+) -> TypeRewriteMap<'db> {
+    let mut map = TypeRewriteMap::new();
+    for (name, type_arg_sets) in instantiations {
+        let mut entries: Vec<(Vec<Type<'db>>, Symbol)> = type_arg_sets
+            .iter()
+            .map(|type_args| {
+                let mangled = mangle_name(db, *name, type_args);
+                (type_args.clone(), mangled)
+            })
+            .collect();
+        entries.sort_by(|a, b| a.1.cmp(&b.1));
+        map.insert(*name, entries);
+    }
+    map
+}
+
+/// Rewrite all Named types with type arguments to their mangled monomorphic versions
+/// throughout a module's expressions.
+pub fn rewrite_types_in_module<'db>(
+    db: &'db dyn salsa::Database,
+    module: Module<TypedRef<'db>>,
+    type_rewrite_map: &TypeRewriteMap<'db>,
+) -> Module<TypedRef<'db>> {
+    let decls = module
+        .decls
+        .into_iter()
+        .map(|d| rewrite_types_in_decl(db, d, type_rewrite_map))
+        .collect();
+    Module::new(module.id, module.name, decls)
+}
+
+fn rewrite_types_in_decl<'db>(
+    db: &'db dyn salsa::Database,
+    decl: Decl<TypedRef<'db>>,
+    map: &TypeRewriteMap<'db>,
+) -> Decl<TypedRef<'db>> {
+    match decl {
+        Decl::Function(mut func) => {
+            func.body = rewrite_types_in_expr(db, func.body, map);
+            Decl::Function(func)
+        }
+        Decl::Module(m) => {
+            let body = m.body.map(|decls| {
+                decls
+                    .into_iter()
+                    .map(|d| rewrite_types_in_decl(db, d, map))
+                    .collect()
+            });
+            Decl::Module(ModuleDecl {
+                id: m.id,
+                name: m.name,
+                is_pub: m.is_pub,
+                body,
+            })
+        }
+        other => other,
+    }
+}
+
+/// Rewrite a Type, replacing Named types with non-empty args with their mangled versions.
+pub fn rewrite_type<'db>(
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    map: &TypeRewriteMap<'db>,
+) -> Type<'db> {
+    match ty.kind(db) {
+        TypeKind::Named { name, args } if !args.is_empty() => {
+            // First recurse into args (for nested generics like List(Option(Int)))
+            let rewritten_args: Vec<Type<'db>> =
+                args.iter().map(|a| rewrite_type(db, *a, map)).collect();
+
+            // Check if this Named type should be mangled
+            if let Some(entries) = map.get(name) {
+                if let Some((_, mangled)) = entries.iter().find(|(ta, _)| *ta == rewritten_args) {
+                    return Type::new(
+                        db,
+                        TypeKind::Named {
+                            name: *mangled,
+                            args: vec![],
+                        },
+                    );
+                }
+            }
+            // Not in rewrite map — return with rewritten args
+            Type::new(
+                db,
+                TypeKind::Named {
+                    name: *name,
+                    args: rewritten_args,
+                },
+            )
+        }
+        TypeKind::Func {
+            params,
+            result,
+            effect,
+        } => {
+            let new_params: Vec<_> = params.iter().map(|p| rewrite_type(db, *p, map)).collect();
+            let new_result = rewrite_type(db, *result, map);
+            if new_params == *params && new_result == *result {
+                return ty;
+            }
+            Type::new(
+                db,
+                TypeKind::Func {
+                    params: new_params,
+                    result: new_result,
+                    effect: *effect,
+                },
+            )
+        }
+        TypeKind::Tuple(elems) => {
+            let new_elems: Vec<_> = elems.iter().map(|e| rewrite_type(db, *e, map)).collect();
+            if new_elems == *elems {
+                return ty;
+            }
+            Type::new(db, TypeKind::Tuple(new_elems))
+        }
+        TypeKind::Named { .. }
+        | TypeKind::Int
+        | TypeKind::Nat
+        | TypeKind::Float
+        | TypeKind::Bool
+        | TypeKind::Bytes
+        | TypeKind::Rune
+        | TypeKind::Nil
+        | TypeKind::Never
+        | TypeKind::BoundVar { .. }
+        | TypeKind::UniVar { .. }
+        | TypeKind::App { .. }
+        | TypeKind::Continuation { .. }
+        | TypeKind::Error => ty,
+    }
+}
+
+fn rewrite_typed_ref_type<'db>(
+    db: &'db dyn salsa::Database,
+    tr: TypedRef<'db>,
+    map: &TypeRewriteMap<'db>,
+) -> TypedRef<'db> {
+    let new_ty = rewrite_type(db, tr.ty, map);
+    // Also rewrite CtorId/TypeDefId if the type was rewritten
+    let resolved = match &tr.resolved {
+        ResolvedRef::Constructor { id, variant } => {
+            if let Some(mangled) = find_mangled_for_ctor(db, *id, tr.ty, map) {
+                ResolvedRef::Constructor {
+                    id: CtorId::new(db, mangled),
+                    variant: *variant,
+                }
+            } else {
+                tr.resolved.clone()
+            }
+        }
+        ResolvedRef::TypeDef { id } => {
+            if let Some(mangled) = find_mangled_for_typedef(db, *id, tr.ty, map) {
+                ResolvedRef::TypeDef {
+                    id: TypeDefId::new(db, mangled),
+                }
+            } else {
+                tr.resolved.clone()
+            }
+        }
+        _ => tr.resolved.clone(),
+    };
+    TypedRef::new(resolved, new_ty)
+}
+
+fn find_mangled_for_ctor<'db>(
+    db: &'db dyn salsa::Database,
+    _ctor_id: CtorId<'db>,
+    ty: Type<'db>,
+    map: &TypeRewriteMap<'db>,
+) -> Option<Symbol> {
+    // Extract the result type from the constructor's function type
+    let result_ty = match ty.kind(db) {
+        TypeKind::Func { result, .. } => *result,
+        _ => ty,
+    };
+    // Check if the result type is a Named type with args
+    match result_ty.kind(db) {
+        TypeKind::Named { name, args } if !args.is_empty() => {
+            let entries = map.get(name)?;
+            let rewritten_args: Vec<_> = args.iter().map(|a| rewrite_type(db, *a, map)).collect();
+            let (_, mangled) = entries.iter().find(|(ta, _)| *ta == rewritten_args)?;
+            Some(*mangled)
+        }
+        _ => None,
+    }
+}
+
+fn find_mangled_for_typedef<'db>(
+    db: &'db dyn salsa::Database,
+    _type_def_id: TypeDefId<'db>,
+    ty: Type<'db>,
+    map: &TypeRewriteMap<'db>,
+) -> Option<Symbol> {
+    match ty.kind(db) {
+        TypeKind::Named { name, args } if !args.is_empty() => {
+            let entries = map.get(name)?;
+            let rewritten_args: Vec<_> = args.iter().map(|a| rewrite_type(db, *a, map)).collect();
+            let (_, mangled) = entries.iter().find(|(ta, _)| *ta == rewritten_args)?;
+            Some(*mangled)
+        }
+        _ => None,
+    }
+}
+
+fn rewrite_types_in_expr<'db>(
+    db: &'db dyn salsa::Database,
+    expr: Expr<TypedRef<'db>>,
+    map: &TypeRewriteMap<'db>,
+) -> Expr<TypedRef<'db>> {
+    let kind = match *expr.kind {
+        ExprKind::Var(tr) => ExprKind::Var(rewrite_typed_ref_type(db, tr, map)),
+        ExprKind::Call { callee, args } => ExprKind::Call {
+            callee: rewrite_types_in_expr(db, callee, map),
+            args: args
+                .into_iter()
+                .map(|a| rewrite_types_in_expr(db, a, map))
+                .collect(),
+        },
+        ExprKind::Block { stmts, value } => ExprKind::Block {
+            stmts: stmts
+                .into_iter()
+                .map(|s| rewrite_types_in_stmt(db, s, map))
+                .collect(),
+            value: rewrite_types_in_expr(db, value, map),
+        },
+        ExprKind::Case { scrutinee, arms } => ExprKind::Case {
+            scrutinee: rewrite_types_in_expr(db, scrutinee, map),
+            arms: arms
+                .into_iter()
+                .map(|a| rewrite_types_in_arm(db, a, map))
+                .collect(),
+        },
+        ExprKind::Lambda { params, body } => ExprKind::Lambda {
+            params,
+            body: rewrite_types_in_expr(db, body, map),
+        },
+        ExprKind::Handle { body, handlers } => ExprKind::Handle {
+            body: rewrite_types_in_expr(db, body, map),
+            handlers: handlers
+                .into_iter()
+                .map(|h| HandlerArm {
+                    id: h.id,
+                    kind: h.kind,
+                    body: rewrite_types_in_expr(db, h.body, map),
+                })
+                .collect(),
+        },
+        ExprKind::Resume { arg, local_id } => ExprKind::Resume {
+            arg: rewrite_types_in_expr(db, arg, map),
+            local_id,
+        },
+        ExprKind::Cons { ctor, args } => ExprKind::Cons {
+            ctor: rewrite_typed_ref_type(db, ctor, map),
+            args: args
+                .into_iter()
+                .map(|a| rewrite_types_in_expr(db, a, map))
+                .collect(),
+        },
+        ExprKind::Record {
+            type_name,
+            fields,
+            spread,
+        } => ExprKind::Record {
+            type_name: rewrite_typed_ref_type(db, type_name, map),
+            fields: fields
+                .into_iter()
+                .map(|(name, e)| (name, rewrite_types_in_expr(db, e, map)))
+                .collect(),
+            spread: spread.map(|s| rewrite_types_in_expr(db, s, map)),
+        },
+        ExprKind::MethodCall {
+            receiver,
+            method,
+            args,
+        } => ExprKind::MethodCall {
+            receiver: rewrite_types_in_expr(db, receiver, map),
+            method,
+            args: args
+                .into_iter()
+                .map(|a| rewrite_types_in_expr(db, a, map))
+                .collect(),
+        },
+        ExprKind::BinOp { op, lhs, rhs } => ExprKind::BinOp {
+            op,
+            lhs: rewrite_types_in_expr(db, lhs, map),
+            rhs: rewrite_types_in_expr(db, rhs, map),
+        },
+        ExprKind::Tuple(es) => ExprKind::Tuple(
+            es.into_iter()
+                .map(|e| rewrite_types_in_expr(db, e, map))
+                .collect(),
+        ),
+        ExprKind::List(es) => ExprKind::List(
+            es.into_iter()
+                .map(|e| rewrite_types_in_expr(db, e, map))
+                .collect(),
+        ),
+        ExprKind::NatLit(v) => ExprKind::NatLit(v),
+        ExprKind::IntLit(v) => ExprKind::IntLit(v),
+        ExprKind::FloatLit(v) => ExprKind::FloatLit(v),
+        ExprKind::StringLit(v) => ExprKind::StringLit(v),
+        ExprKind::BytesLit(v) => ExprKind::BytesLit(v),
+        ExprKind::BoolLit(v) => ExprKind::BoolLit(v),
+        ExprKind::RuneLit(v) => ExprKind::RuneLit(v),
+        ExprKind::Nil => ExprKind::Nil,
+        ExprKind::Error => ExprKind::Error,
+    };
+    Expr::new(expr.id, kind)
+}
+
+fn rewrite_types_in_stmt<'db>(
+    db: &'db dyn salsa::Database,
+    stmt: Stmt<TypedRef<'db>>,
+    map: &TypeRewriteMap<'db>,
+) -> Stmt<TypedRef<'db>> {
+    match stmt {
+        Stmt::Let {
+            id,
+            pattern,
+            ty,
+            value,
+        } => Stmt::Let {
+            id,
+            pattern,
+            ty,
+            value: rewrite_types_in_expr(db, value, map),
+        },
+        Stmt::Expr { id, expr } => Stmt::Expr {
+            id,
+            expr: rewrite_types_in_expr(db, expr, map),
+        },
+    }
+}
+
+fn rewrite_types_in_arm<'db>(
+    db: &'db dyn salsa::Database,
+    arm: Arm<TypedRef<'db>>,
+    map: &TypeRewriteMap<'db>,
+) -> Arm<TypedRef<'db>> {
+    Arm {
+        id: arm.id,
+        pattern: arm.pattern,
+        guard: arm.guard.map(|g| rewrite_types_in_expr(db, g, map)),
+        body: rewrite_types_in_expr(db, arm.body, map),
     }
 }

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -9,8 +9,8 @@ use std::collections::{HashMap, HashSet};
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    Arm, CtorId, Decl, Expr, ExprKind, FuncDefId, HandlerArm, Module, ModuleDecl, ResolvedRef,
-    Stmt, Type, TypeDefId, TypeKind, TypeScheme, TypedRef,
+    Arm, CtorId, Decl, Expr, ExprKind, FieldPattern, FuncDefId, HandlerArm, Module, ModuleDecl,
+    Pattern, PatternKind, ResolvedRef, Stmt, Type, TypeDefId, TypeKind, TypeScheme, TypedRef,
 };
 
 use super::collect::extract_type_args;
@@ -366,6 +366,39 @@ pub fn rewrite_type<'db>(
             }
             Type::new(db, TypeKind::Tuple(new_elems))
         }
+        TypeKind::App { ctor, args } => {
+            let new_ctor = rewrite_type(db, *ctor, map);
+            let new_args: Vec<_> = args.iter().map(|a| rewrite_type(db, *a, map)).collect();
+            if new_ctor == *ctor && new_args == *args {
+                return ty;
+            }
+            Type::new(
+                db,
+                TypeKind::App {
+                    ctor: new_ctor,
+                    args: new_args,
+                },
+            )
+        }
+        TypeKind::Continuation {
+            arg,
+            result,
+            effect,
+        } => {
+            let new_arg = rewrite_type(db, *arg, map);
+            let new_result = rewrite_type(db, *result, map);
+            if new_arg == *arg && new_result == *result {
+                return ty;
+            }
+            Type::new(
+                db,
+                TypeKind::Continuation {
+                    arg: new_arg,
+                    result: new_result,
+                    effect: *effect,
+                },
+            )
+        }
         TypeKind::Named { .. }
         | TypeKind::Int
         | TypeKind::Nat
@@ -377,8 +410,6 @@ pub fn rewrite_type<'db>(
         | TypeKind::Never
         | TypeKind::BoundVar { .. }
         | TypeKind::UniVar { .. }
-        | TypeKind::App { .. }
-        | TypeKind::Continuation { .. }
         | TypeKind::Error => ty,
     }
 }
@@ -574,7 +605,7 @@ fn rewrite_types_in_stmt<'db>(
             value,
         } => Stmt::Let {
             id,
-            pattern,
+            pattern: rewrite_types_in_pattern(db, pattern, map),
             ty,
             value: rewrite_types_in_expr(db, value, map),
         },
@@ -592,8 +623,76 @@ fn rewrite_types_in_arm<'db>(
 ) -> Arm<TypedRef<'db>> {
     Arm {
         id: arm.id,
-        pattern: arm.pattern,
+        pattern: rewrite_types_in_pattern(db, arm.pattern, map),
         guard: arm.guard.map(|g| rewrite_types_in_expr(db, g, map)),
         body: rewrite_types_in_expr(db, arm.body, map),
     }
+}
+
+fn rewrite_types_in_pattern<'db>(
+    db: &'db dyn salsa::Database,
+    pattern: Pattern<TypedRef<'db>>,
+    map: &TypeRewriteMap<'db>,
+) -> Pattern<TypedRef<'db>> {
+    let kind = match *pattern.kind {
+        PatternKind::Variant { ctor, fields } => PatternKind::Variant {
+            ctor: rewrite_typed_ref_type(db, ctor, map),
+            fields: fields
+                .into_iter()
+                .map(|f| rewrite_types_in_pattern(db, f, map))
+                .collect(),
+        },
+        PatternKind::Record {
+            type_name,
+            fields,
+            rest,
+        } => PatternKind::Record {
+            type_name: type_name.map(|tn| rewrite_typed_ref_type(db, tn, map)),
+            fields: fields
+                .into_iter()
+                .map(|f| FieldPattern {
+                    id: f.id,
+                    name: f.name,
+                    pattern: f.pattern.map(|p| rewrite_types_in_pattern(db, p, map)),
+                })
+                .collect(),
+            rest,
+        },
+        PatternKind::Tuple(ps) => PatternKind::Tuple(
+            ps.into_iter()
+                .map(|p| rewrite_types_in_pattern(db, p, map))
+                .collect(),
+        ),
+        PatternKind::List(ps) => PatternKind::List(
+            ps.into_iter()
+                .map(|p| rewrite_types_in_pattern(db, p, map))
+                .collect(),
+        ),
+        PatternKind::ListRest {
+            head,
+            rest,
+            rest_local_id,
+        } => PatternKind::ListRest {
+            head: head
+                .into_iter()
+                .map(|p| rewrite_types_in_pattern(db, p, map))
+                .collect(),
+            rest,
+            rest_local_id,
+        },
+        PatternKind::As {
+            pattern: inner,
+            name,
+            local_id,
+        } => PatternKind::As {
+            pattern: rewrite_types_in_pattern(db, inner, map),
+            name,
+            local_id,
+        },
+        PatternKind::Wildcard => PatternKind::Wildcard,
+        PatternKind::Bind { name, local_id } => PatternKind::Bind { name, local_id },
+        PatternKind::Literal(lit) => PatternKind::Literal(lit),
+        PatternKind::Error => PatternKind::Error,
+    };
+    Pattern::new(pattern.id, kind)
 }

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -316,13 +316,11 @@ pub fn rewrite_type<'db>(
 ) -> Type<'db> {
     match ty.kind(db) {
         TypeKind::Named { name, args } if !args.is_empty() => {
-            // First recurse into args (for nested generics like List(Option(Int)))
-            let rewritten_args: Vec<Type<'db>> =
-                args.iter().map(|a| rewrite_type(db, *a, map)).collect();
-
-            // Check if this Named type should be mangled
+            // The rewrite map is keyed on the original (un-rewritten) args as
+            // collected from the module, so look up using `args` directly —
+            // not the recursively rewritten ones.
             if let Some(entries) = map.get(name)
-                && let Some((_, mangled)) = entries.iter().find(|(ta, _)| *ta == rewritten_args)
+                && let Some((_, mangled)) = entries.iter().find(|(ta, _)| ta == args)
             {
                 return Type::new(
                     db,
@@ -332,7 +330,11 @@ pub fn rewrite_type<'db>(
                     },
                 );
             }
-            // Not in rewrite map — return with rewritten args
+            // Not in rewrite map — recurse into args (for nested generics like
+            // List(Option(Int)) where the outer ctor is non-generic but inner
+            // args still need rewriting).
+            let rewritten_args: Vec<Type<'db>> =
+                args.iter().map(|a| rewrite_type(db, *a, map)).collect();
             Type::new(
                 db,
                 TypeKind::Named {
@@ -462,8 +464,8 @@ fn find_mangled_for_ctor<'db>(
     match result_ty.kind(db) {
         TypeKind::Named { name, args } if !args.is_empty() => {
             let entries = map.get(name)?;
-            let rewritten_args: Vec<_> = args.iter().map(|a| rewrite_type(db, *a, map)).collect();
-            let (_, mangled) = entries.iter().find(|(ta, _)| *ta == rewritten_args)?;
+            // Match against the original args stored in the map.
+            let (_, mangled) = entries.iter().find(|(ta, _)| ta == args)?;
             Some(*mangled)
         }
         _ => None,
@@ -479,8 +481,8 @@ fn find_mangled_for_typedef<'db>(
     match ty.kind(db) {
         TypeKind::Named { name, args } if !args.is_empty() => {
             let entries = map.get(name)?;
-            let rewritten_args: Vec<_> = args.iter().map(|a| rewrite_type(db, *a, map)).collect();
-            let (_, mangled) = entries.iter().find(|(ta, _)| *ta == rewritten_args)?;
+            // Match against the original args stored in the map.
+            let (_, mangled) = entries.iter().find(|(ta, _)| ta == args)?;
             Some(*mangled)
         }
         _ => None,
@@ -861,5 +863,49 @@ mod tests {
         let result = rewrite_type(&db, unknown, &map);
         // Should be unchanged
         assert_eq!(result, unknown);
+    }
+
+    /// Regression: outer generic with nested generic args must still be
+    /// mangled. The map is keyed on original args, so recursing before lookup
+    /// would cause a miss.
+    #[test]
+    fn test_rewrite_type_outer_generic_with_nested_generic_args() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let bool_ty = Type::new(&db, TypeKind::Bool);
+        let option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Option"),
+                args: vec![int],
+            },
+        );
+        let pair_option_int_bool = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Pair"),
+                args: vec![option_int, bool_ty],
+            },
+        );
+        let map = make_type_rewrite_map(
+            &db,
+            vec![
+                (Symbol::new("Option"), vec![int], Symbol::new("Option$Int")),
+                (
+                    Symbol::new("Pair"),
+                    vec![option_int, bool_ty],
+                    Symbol::new("Pair$Option$0$Int$1$Bool"),
+                ),
+            ],
+        );
+
+        let result = rewrite_type(&db, pair_option_int_bool, &map);
+        match result.kind(&db) {
+            TypeKind::Named { name, args } => {
+                assert_eq!(name.to_string(), "Pair$Option$0$Int$1$Bool");
+                assert!(args.is_empty());
+            }
+            other => panic!("expected mangled Named, got {:?}", other),
+        }
     }
 }

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -57,7 +57,7 @@ pub fn generate_specializations<'db>(
     }
 
     // Sort by mangled name for deterministic output (HashMap/HashSet iteration is unordered)
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.sort_by_key(|e| e.0);
 
     let mut new_decls = Vec::with_capacity(entries.len());
     let mut new_function_types = Vec::with_capacity(entries.len());
@@ -97,7 +97,7 @@ pub fn generate_struct_specializations<'db>(
         }
     }
 
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.sort_by_key(|e| e.0);
     entries.into_iter().map(|(_, decl)| decl).collect()
 }
 
@@ -125,7 +125,7 @@ pub fn generate_enum_specializations<'db>(
         }
     }
 
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.sort_by_key(|e| e.0);
     entries.into_iter().map(|(_, decl)| decl).collect()
 }
 

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -287,22 +287,52 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
 
 fn collect_struct_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a StructDecl> {
     let mut map = HashMap::new();
-    for decl in &module.decls {
-        if let Decl::Struct(s) = decl {
-            map.insert(s.name, s);
+    collect_struct_decls_inner(&module.decls, &mut map);
+    map
+}
+
+fn collect_struct_decls_inner<'a>(
+    decls: &'a [Decl<TypedRef<'_>>],
+    map: &mut HashMap<Symbol, &'a StructDecl>,
+) {
+    for decl in decls {
+        match decl {
+            Decl::Struct(s) => {
+                map.insert(s.name, s);
+            }
+            Decl::Module(m) => {
+                if let Some(body) = &m.body {
+                    collect_struct_decls_inner(body, map);
+                }
+            }
+            _ => {}
         }
     }
-    map
 }
 
 fn collect_enum_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a EnumDecl> {
     let mut map = HashMap::new();
-    for decl in &module.decls {
-        if let Decl::Enum(e) = decl {
-            map.insert(e.name, e);
+    collect_enum_decls_inner(&module.decls, &mut map);
+    map
+}
+
+fn collect_enum_decls_inner<'a>(
+    decls: &'a [Decl<TypedRef<'_>>],
+    map: &mut HashMap<Symbol, &'a EnumDecl>,
+) {
+    for decl in decls {
+        match decl {
+            Decl::Enum(e) => {
+                map.insert(e.name, e);
+            }
+            Decl::Module(m) => {
+                if let Some(body) = &m.body {
+                    collect_enum_decls_inner(body, map);
+                }
+            }
+            _ => {}
         }
     }
-    map
 }
 
 // ============================================================================

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -5,8 +5,9 @@ use std::num::NonZero;
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    Arm, Decl, Expr, ExprKind, FieldPattern, FuncDecl, FuncDefId, HandlerArm, HandlerKind, Module,
-    Pattern, PatternKind, Stmt, Type, TypeScheme, TypedRef,
+    Arm, Decl, EnumDecl, Expr, ExprKind, FieldDecl, FieldPattern, FuncDecl, FuncDefId, HandlerArm,
+    HandlerKind, Module, NodeId, Pattern, PatternKind, Stmt, StructDecl, Type, TypeAnnotation,
+    TypeAnnotationKind, TypeKind, TypeScheme, TypedRef, VariantDecl,
 };
 use crate::typeck::subst::substitute_bound_vars;
 
@@ -67,6 +68,246 @@ pub fn generate_specializations<'db>(
 
     (new_decls, new_function_types)
 }
+
+// ============================================================================
+// Generic struct/enum specialization
+// ============================================================================
+
+/// Generate specialized struct declarations for each type instantiation.
+pub fn generate_struct_specializations<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+    instantiations: &HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+) -> Vec<StructDecl> {
+    let struct_decls = collect_struct_decls(module);
+    let mut entries: Vec<(Symbol, StructDecl)> = Vec::new();
+
+    for (name, type_arg_sets) in instantiations {
+        let Some(decl) = struct_decls.get(name) else {
+            continue;
+        };
+        if decl.type_params.is_empty() {
+            continue;
+        }
+
+        for type_args in type_arg_sets {
+            let mangled = mangle_name(db, *name, type_args);
+            let specialized = specialize_struct_decl(db, decl, type_args, mangled);
+            entries.push((mangled, specialized));
+        }
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.into_iter().map(|(_, decl)| decl).collect()
+}
+
+/// Generate specialized enum declarations for each type instantiation.
+pub fn generate_enum_specializations<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+    instantiations: &HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+) -> Vec<EnumDecl> {
+    let enum_decls = collect_enum_decls(module);
+    let mut entries: Vec<(Symbol, EnumDecl)> = Vec::new();
+
+    for (name, type_arg_sets) in instantiations {
+        let Some(decl) = enum_decls.get(name) else {
+            continue;
+        };
+        if decl.type_params.is_empty() {
+            continue;
+        }
+
+        for type_args in type_arg_sets {
+            let mangled = mangle_name(db, *name, type_args);
+            let specialized = specialize_enum_decl(db, decl, type_args, mangled);
+            entries.push((mangled, specialized));
+        }
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.into_iter().map(|(_, decl)| decl).collect()
+}
+
+fn specialize_struct_decl<'db>(
+    db: &'db dyn salsa::Database,
+    decl: &StructDecl,
+    type_args: &[Type<'db>],
+    mangled_name: Symbol,
+) -> StructDecl {
+    let variant = type_args_variant(type_args);
+    let param_names: Vec<Symbol> = decl.type_params.iter().map(|p| p.name).collect();
+
+    StructDecl {
+        id: decl.id.with_variant(variant),
+        is_pub: false,
+        name: mangled_name,
+        type_params: vec![],
+        fields: decl
+            .fields
+            .iter()
+            .map(|f| FieldDecl {
+                id: f.id.with_variant(variant),
+                is_pub: f.is_pub,
+                name: f.name,
+                ty: substitute_annotation(db, &f.ty, &param_names, type_args),
+            })
+            .collect(),
+    }
+}
+
+fn specialize_enum_decl<'db>(
+    db: &'db dyn salsa::Database,
+    decl: &EnumDecl,
+    type_args: &[Type<'db>],
+    mangled_name: Symbol,
+) -> EnumDecl {
+    let variant = type_args_variant(type_args);
+    let param_names: Vec<Symbol> = decl.type_params.iter().map(|p| p.name).collect();
+
+    EnumDecl {
+        id: decl.id.with_variant(variant),
+        is_pub: false,
+        name: mangled_name,
+        type_params: vec![],
+        variants: decl
+            .variants
+            .iter()
+            .map(|v| VariantDecl {
+                id: v.id.with_variant(variant),
+                name: v.name,
+                fields: v
+                    .fields
+                    .iter()
+                    .map(|f| FieldDecl {
+                        id: f.id.with_variant(variant),
+                        is_pub: f.is_pub,
+                        name: f.name,
+                        ty: substitute_annotation(db, &f.ty, &param_names, type_args),
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+/// Substitute type parameter names in a TypeAnnotation with concrete types.
+///
+/// If a `TypeAnnotationKind::Named(name)` matches a type parameter name,
+/// it's replaced with a TypeAnnotation for the concrete type.
+fn substitute_annotation<'db>(
+    db: &'db dyn salsa::Database,
+    ann: &TypeAnnotation,
+    param_names: &[Symbol],
+    type_args: &[Type<'db>],
+) -> TypeAnnotation {
+    let kind = match &ann.kind {
+        TypeAnnotationKind::Named(name) => {
+            // Check if this name matches a type parameter
+            if let Some(idx) = param_names.iter().position(|p| p == name) {
+                if let Some(ty) = type_args.get(idx) {
+                    return type_to_annotation(db, *ty, ann.id);
+                }
+            }
+            ann.kind.clone()
+        }
+        TypeAnnotationKind::App { ctor, args } => TypeAnnotationKind::App {
+            ctor: Box::new(substitute_annotation(db, ctor, param_names, type_args)),
+            args: args
+                .iter()
+                .map(|a| substitute_annotation(db, a, param_names, type_args))
+                .collect(),
+        },
+        TypeAnnotationKind::Func {
+            params,
+            result,
+            abilities,
+        } => TypeAnnotationKind::Func {
+            params: params
+                .iter()
+                .map(|p| substitute_annotation(db, p, param_names, type_args))
+                .collect(),
+            result: Box::new(substitute_annotation(db, result, param_names, type_args)),
+            abilities: abilities.clone(),
+        },
+        TypeAnnotationKind::Tuple(elems) => TypeAnnotationKind::Tuple(
+            elems
+                .iter()
+                .map(|e| substitute_annotation(db, e, param_names, type_args))
+                .collect(),
+        ),
+        TypeAnnotationKind::Path(_) | TypeAnnotationKind::Infer | TypeAnnotationKind::Error => {
+            ann.kind.clone()
+        }
+    };
+    TypeAnnotation { id: ann.id, kind }
+}
+
+/// Convert a semantic Type to a TypeAnnotation.
+///
+/// Used when generating specialized field types — the concrete Type
+/// from type checking is mapped back to a source-level annotation.
+fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> TypeAnnotation {
+    let kind = match ty.kind(db) {
+        TypeKind::Int => TypeAnnotationKind::Named(Symbol::new("Int")),
+        TypeKind::Nat => TypeAnnotationKind::Named(Symbol::new("Nat")),
+        TypeKind::Float => TypeAnnotationKind::Named(Symbol::new("Float")),
+        TypeKind::Bool => TypeAnnotationKind::Named(Symbol::new("Bool")),
+        TypeKind::Bytes => TypeAnnotationKind::Named(Symbol::new("Bytes")),
+        TypeKind::Rune => TypeAnnotationKind::Named(Symbol::new("Rune")),
+        TypeKind::Nil => TypeAnnotationKind::Named(Symbol::new("Nil")),
+        TypeKind::Never => TypeAnnotationKind::Named(Symbol::new("Never")),
+        TypeKind::Named { name, args } => {
+            if args.is_empty() {
+                TypeAnnotationKind::Named(*name)
+            } else {
+                // Use mangled name for generic types with args
+                let mangled = mangle_name(db, *name, args);
+                TypeAnnotationKind::Named(mangled)
+            }
+        }
+        TypeKind::Func { params, result, .. } => TypeAnnotationKind::Func {
+            params: params
+                .iter()
+                .map(|p| type_to_annotation(db, *p, id))
+                .collect(),
+            result: Box::new(type_to_annotation(db, *result, id)),
+            abilities: vec![],
+        },
+        TypeKind::Tuple(elems) => TypeAnnotationKind::Tuple(
+            elems
+                .iter()
+                .map(|e| type_to_annotation(db, *e, id))
+                .collect(),
+        ),
+        _ => TypeAnnotationKind::Infer,
+    };
+    TypeAnnotation { id, kind }
+}
+
+fn collect_struct_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a StructDecl> {
+    let mut map = HashMap::new();
+    for decl in &module.decls {
+        if let Decl::Struct(s) = decl {
+            map.insert(s.name, s);
+        }
+    }
+    map
+}
+
+fn collect_enum_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a EnumDecl> {
+    let mut map = HashMap::new();
+    for decl in &module.decls {
+        if let Decl::Enum(e) = decl {
+            map.insert(e.name, e);
+        }
+    }
+    map
+}
+
+// ============================================================================
+// Generic function specialization helpers
+// ============================================================================
 
 fn collect_func_decls<'a, 'db>(
     module: &'a Module<TypedRef<'db>>,

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -871,4 +871,231 @@ mod tests {
             );
         }
     }
+
+    // ========================================================================
+    // type_to_annotation tests
+    // ========================================================================
+
+    #[test]
+    fn test_type_to_annotation_primitives() {
+        let db = TestDb::default();
+        let id = node_id(1);
+        let cases = [
+            (TypeKind::Int, "Int"),
+            (TypeKind::Nat, "Nat"),
+            (TypeKind::Float, "Float"),
+            (TypeKind::Bool, "Bool"),
+            (TypeKind::Nil, "Nil"),
+        ];
+        for (kind, expected_name) in cases {
+            let ty = Type::new(&db, kind);
+            let ann = type_to_annotation(&db, ty, id);
+            match &ann.kind {
+                TypeAnnotationKind::Named(name) => {
+                    assert_eq!(name.to_string(), expected_name);
+                }
+                _ => panic!("expected Named annotation for {:?}", expected_name),
+            }
+        }
+    }
+
+    #[test]
+    fn test_type_to_annotation_named_no_args() {
+        let db = TestDb::default();
+        let ty = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Text"),
+                args: vec![],
+            },
+        );
+        let ann = type_to_annotation(&db, ty, node_id(1));
+        match &ann.kind {
+            TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Text"),
+            _ => panic!("expected Named"),
+        }
+    }
+
+    #[test]
+    fn test_type_to_annotation_named_with_args_uses_mangled() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let ty = Type::new(
+            &db,
+            TypeKind::Named {
+                name: Symbol::new("Option"),
+                args: vec![int],
+            },
+        );
+        let ann = type_to_annotation(&db, ty, node_id(1));
+        match &ann.kind {
+            TypeAnnotationKind::Named(name) => {
+                assert_eq!(name.to_string(), "Option$Int");
+            }
+            _ => panic!("expected Named with mangled name"),
+        }
+    }
+
+    // ========================================================================
+    // specialize_struct_decl tests
+    // ========================================================================
+
+    #[test]
+    fn test_specialize_struct_decl_basic() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let bool_ty = Type::new(&db, TypeKind::Bool);
+
+        // struct Pair(a, b) { first: a, second: b }
+        let decl = StructDecl {
+            id: node_id(1),
+            is_pub: true,
+            name: Symbol::new("Pair"),
+            type_params: vec![
+                crate::ast::TypeParamDecl {
+                    id: node_id(2),
+                    name: Symbol::new("a"),
+                    bounds: vec![],
+                },
+                crate::ast::TypeParamDecl {
+                    id: node_id(3),
+                    name: Symbol::new("b"),
+                    bounds: vec![],
+                },
+            ],
+            fields: vec![
+                FieldDecl {
+                    id: node_id(4),
+                    is_pub: false,
+                    name: Some(Symbol::new("first")),
+                    ty: TypeAnnotation {
+                        id: node_id(5),
+                        kind: TypeAnnotationKind::Named(Symbol::new("a")),
+                    },
+                },
+                FieldDecl {
+                    id: node_id(6),
+                    is_pub: false,
+                    name: Some(Symbol::new("second")),
+                    ty: TypeAnnotation {
+                        id: node_id(7),
+                        kind: TypeAnnotationKind::Named(Symbol::new("b")),
+                    },
+                },
+            ],
+        };
+
+        let mangled = mangle_name(&db, Symbol::new("Pair"), &[int, bool_ty]);
+        let specialized = specialize_struct_decl(&db, &decl, &[int, bool_ty], mangled);
+
+        assert_eq!(specialized.name.to_string(), "Pair$Int$Bool");
+        assert!(specialized.type_params.is_empty());
+        assert_eq!(specialized.fields.len(), 2);
+
+        // first field should be Int
+        match &specialized.fields[0].ty.kind {
+            TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Int"),
+            other => panic!("expected Named(Int), got {:?}", other),
+        }
+        // second field should be Bool
+        match &specialized.fields[1].ty.kind {
+            TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Bool"),
+            other => panic!("expected Named(Bool), got {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // specialize_enum_decl tests
+    // ========================================================================
+
+    #[test]
+    fn test_specialize_enum_decl_basic() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+
+        // enum Option(a) { Some(a), None }
+        let decl = EnumDecl {
+            id: node_id(1),
+            is_pub: true,
+            name: Symbol::new("Option"),
+            type_params: vec![crate::ast::TypeParamDecl {
+                id: node_id(2),
+                name: Symbol::new("a"),
+                bounds: vec![],
+            }],
+            variants: vec![
+                VariantDecl {
+                    id: node_id(3),
+                    name: Symbol::new("Some"),
+                    fields: vec![FieldDecl {
+                        id: node_id(4),
+                        is_pub: false,
+                        name: None,
+                        ty: TypeAnnotation {
+                            id: node_id(5),
+                            kind: TypeAnnotationKind::Named(Symbol::new("a")),
+                        },
+                    }],
+                },
+                VariantDecl {
+                    id: node_id(6),
+                    name: Symbol::new("None"),
+                    fields: vec![],
+                },
+            ],
+        };
+
+        let mangled = mangle_name(&db, Symbol::new("Option"), &[int]);
+        let specialized = specialize_enum_decl(&db, &decl, &[int], mangled);
+
+        assert_eq!(specialized.name.to_string(), "Option$Int");
+        assert!(specialized.type_params.is_empty());
+        assert_eq!(specialized.variants.len(), 2);
+
+        // Some variant should have Int field
+        assert_eq!(specialized.variants[0].name.to_string(), "Some");
+        assert_eq!(specialized.variants[0].fields.len(), 1);
+        match &specialized.variants[0].fields[0].ty.kind {
+            TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Int"),
+            other => panic!("expected Named(Int), got {:?}", other),
+        }
+
+        // None variant should have no fields
+        assert_eq!(specialized.variants[1].name.to_string(), "None");
+        assert!(specialized.variants[1].fields.is_empty());
+    }
+
+    // ========================================================================
+    // substitute_annotation tests
+    // ========================================================================
+
+    #[test]
+    fn test_substitute_annotation_replaces_param() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let ann = TypeAnnotation {
+            id: node_id(1),
+            kind: TypeAnnotationKind::Named(Symbol::new("a")),
+        };
+        let result = substitute_annotation(&db, &ann, &[Symbol::new("a")], &[int]);
+        match &result.kind {
+            TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Int"),
+            other => panic!("expected Named(Int), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_substitute_annotation_leaves_non_param() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let ann = TypeAnnotation {
+            id: node_id(1),
+            kind: TypeAnnotationKind::Named(Symbol::new("Text")),
+        };
+        let result = substitute_annotation(&db, &ann, &[Symbol::new("a")], &[int]);
+        match &result.kind {
+            TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Text"),
+            other => panic!("expected Named(Text), got {:?}", other),
+        }
+    }
 }

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -287,22 +287,27 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
 
 fn collect_struct_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a StructDecl> {
     let mut map = HashMap::new();
-    collect_struct_decls_inner(&module.decls, &mut map);
+    let mut prefix = String::new();
+    collect_struct_decls_inner(&module.decls, &mut prefix, &mut map);
     map
 }
 
 fn collect_struct_decls_inner<'a>(
     decls: &'a [Decl<TypedRef<'_>>],
+    prefix: &mut String,
     map: &mut HashMap<Symbol, &'a StructDecl>,
 ) {
     for decl in decls {
         match decl {
             Decl::Struct(s) => {
-                map.insert(s.name, s);
+                let qualified = crate::qualified_symbol(prefix, s.name);
+                map.insert(qualified, s);
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
-                    collect_struct_decls_inner(body, map);
+                    let len = crate::push_prefix(prefix, m.name);
+                    collect_struct_decls_inner(body, prefix, map);
+                    prefix.truncate(len);
                 }
             }
             _ => {}
@@ -312,22 +317,27 @@ fn collect_struct_decls_inner<'a>(
 
 fn collect_enum_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a EnumDecl> {
     let mut map = HashMap::new();
-    collect_enum_decls_inner(&module.decls, &mut map);
+    let mut prefix = String::new();
+    collect_enum_decls_inner(&module.decls, &mut prefix, &mut map);
     map
 }
 
 fn collect_enum_decls_inner<'a>(
     decls: &'a [Decl<TypedRef<'_>>],
+    prefix: &mut String,
     map: &mut HashMap<Symbol, &'a EnumDecl>,
 ) {
     for decl in decls {
         match decl {
             Decl::Enum(e) => {
-                map.insert(e.name, e);
+                let qualified = crate::qualified_symbol(prefix, e.name);
+                map.insert(qualified, e);
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
-                    collect_enum_decls_inner(body, map);
+                    let len = crate::push_prefix(prefix, m.name);
+                    collect_enum_decls_inner(body, prefix, map);
+                    prefix.truncate(len);
                 }
             }
             _ => {}

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -266,14 +266,58 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
                 TypeAnnotationKind::Named(mangled)
             }
         }
-        TypeKind::Func { params, result, .. } => TypeAnnotationKind::Func {
-            params: params
+        TypeKind::Func {
+            params,
+            result,
+            effect,
+        } => {
+            // Preserve the effect row as ability annotations. Each Effect
+            // becomes a Named (or App) annotation; a row variable (`rest`) is
+            // represented as `Infer`, matching the "effect polymorphic" encoding
+            // documented on TypeAnnotationKind::Func.
+            let mut abilities: Vec<TypeAnnotation> = effect
+                .effects(db)
                 .iter()
-                .map(|p| type_to_annotation(db, *p, id))
-                .collect(),
-            result: Box::new(type_to_annotation(db, *result, id)),
-            abilities: vec![],
-        },
+                .map(|eff| {
+                    let name = eff.ability_id.name(db);
+                    if eff.args.is_empty() {
+                        TypeAnnotation {
+                            id,
+                            kind: TypeAnnotationKind::Named(name),
+                        }
+                    } else {
+                        TypeAnnotation {
+                            id,
+                            kind: TypeAnnotationKind::App {
+                                ctor: Box::new(TypeAnnotation {
+                                    id,
+                                    kind: TypeAnnotationKind::Named(name),
+                                }),
+                                args: eff
+                                    .args
+                                    .iter()
+                                    .map(|a| type_to_annotation(db, *a, id))
+                                    .collect(),
+                            },
+                        }
+                    }
+                })
+                .collect();
+            if effect.rest(db).is_some() {
+                abilities.push(TypeAnnotation {
+                    id,
+                    kind: TypeAnnotationKind::Infer,
+                });
+            }
+            TypeAnnotationKind::Func {
+                params: params
+                    .iter()
+                    .map(|p| type_to_annotation(db, *p, id))
+                    .collect(),
+                result: Box::new(type_to_annotation(db, *result, id)),
+                abilities,
+            }
+        }
         TypeKind::Tuple(elems) => TypeAnnotationKind::Tuple(
             elems
                 .iter()
@@ -943,6 +987,95 @@ mod tests {
                 assert_eq!(name.to_string(), "Option$Int");
             }
             _ => panic!("expected Named with mangled name"),
+        }
+    }
+
+    /// Regression: effect row must be preserved when converting Func types
+    /// back to annotations (previously the `abilities` field was hardcoded
+    /// to `vec![]`, silently turning effectful functions into pure ones).
+    #[test]
+    fn test_type_to_annotation_func_preserves_abilities() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let console_id = crate::ast::AbilityId::new(&db, Symbol::new("std::console::Console"));
+        let state_id = crate::ast::AbilityId::new(&db, Symbol::new("std::state::State"));
+        let effect = EffectRow::new(
+            &db,
+            vec![
+                crate::ast::Effect {
+                    ability_id: console_id,
+                    args: vec![],
+                },
+                crate::ast::Effect {
+                    ability_id: state_id,
+                    args: vec![int],
+                },
+            ],
+            None,
+        );
+        let func_ty = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![int],
+                result: int,
+                effect,
+            },
+        );
+        let ann = type_to_annotation(&db, func_ty, node_id(1));
+        match &ann.kind {
+            TypeAnnotationKind::Func { abilities, .. } => {
+                assert_eq!(abilities.len(), 2);
+                match &abilities[0].kind {
+                    TypeAnnotationKind::Named(name) => {
+                        assert_eq!(name.to_string(), "Console");
+                    }
+                    other => panic!("expected Named(Console), got {:?}", other),
+                }
+                match &abilities[1].kind {
+                    TypeAnnotationKind::App { ctor, args } => {
+                        match &ctor.kind {
+                            TypeAnnotationKind::Named(name) => {
+                                assert_eq!(name.to_string(), "State");
+                            }
+                            other => panic!("expected Named(State) ctor, got {:?}", other),
+                        }
+                        assert_eq!(args.len(), 1);
+                        match &args[0].kind {
+                            TypeAnnotationKind::Named(name) => {
+                                assert_eq!(name.to_string(), "Int");
+                            }
+                            other => panic!("expected Named(Int) arg, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected App(State, [Int]), got {:?}", other),
+                }
+            }
+            other => panic!("expected Func annotation, got {:?}", other),
+        }
+    }
+
+    /// Regression: a row variable on the effect row should map to `Infer`
+    /// (effect-polymorphic), not be silently dropped.
+    #[test]
+    fn test_type_to_annotation_func_preserves_rest_var() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let effect = EffectRow::new(&db, vec![], Some(crate::ast::EffectVar { id: 0 }));
+        let func_ty = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![int],
+                result: int,
+                effect,
+            },
+        );
+        let ann = type_to_annotation(&db, func_ty, node_id(1));
+        match &ann.kind {
+            TypeAnnotationKind::Func { abilities, .. } => {
+                assert_eq!(abilities.len(), 1);
+                assert!(matches!(abilities[0].kind, TypeAnnotationKind::Infer));
+            }
+            other => panic!("expected Func annotation, got {:?}", other),
         }
     }
 

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -204,10 +204,10 @@ fn substitute_annotation<'db>(
     let kind = match &ann.kind {
         TypeAnnotationKind::Named(name) => {
             // Check if this name matches a type parameter
-            if let Some(idx) = param_names.iter().position(|p| p == name) {
-                if let Some(ty) = type_args.get(idx) {
-                    return type_to_annotation(db, *ty, ann.id);
-                }
+            if let Some(idx) = param_names.iter().position(|p| p == name)
+                && let Some(ty) = type_args.get(idx)
+            {
+                return type_to_annotation(db, *ty, ann.id);
             }
             ann.kind.clone()
         }


### PR DESCRIPTION
## Summary

Extend monomorphization to handle generic struct and enum types (Phase 5 of #53):

**Step 1 - Type instantiation collection** (`collect.rs`):
- `collect_type_instantiations()` walks all `TypedRef.ty` in the AST
- Recursively finds `Named` types with concrete type args (e.g., `Option(Int)`, `Pair(Int, Bool)`)
- Filters by generic struct/enum declarations (those with non-empty `type_params`)

**Step 2 - Struct/enum specialization** (`specialize.rs`):
- `generate_struct_specializations()` / `generate_enum_specializations()`
- Substitutes type param names in `TypeAnnotation` with concrete types
- `type_to_annotation()` converts semantic `Type` back to source-level annotation

**Step 3 - Named type rewriting** (`rewrite.rs`):
- `rewrite_types_in_module()` rewrites `Named{name, args}` → `Named{mangled, []}`
- Also rewrites `CtorId` and `TypeDefId` to mangled versions
- Recursive: handles nested generics like `List(Option(Int))`

**Step 4 - Pipeline integration** (`mod.rs`):
- `monomorphize_functions()` now runs type monomorphization after function monomorphization

Closes #667

## Test plan

- [x] 4 new unit tests for type instantiation collection
- [x] All 10 generic/record E2E tests pass
- [x] Full test suite passes (1226 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collects observed generic type instantiations, rewrites generic type references and typed usages across modules, and generates mangled, monomorphic struct/enum declarations with deterministic ordering.

* **Refactor**
  * Splits monomorphization into separate function and type phases with distinct rewriting passes and clearer per-phase control flow.

* **Tests**
  * Adds unit tests covering recursive type-walking, instantiation collection, specialization, and type-rewrite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->