### PR TITLE
Implement general function inlining (#675)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1488,7 @@ dependencies = [
 name = "tribute-core"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "salsa",
  "serde",
  "target-lexicon",
@@ -1553,6 +1563,7 @@ dependencies = [
  "cranelift-entity",
  "insta",
  "inventory",
+ "itertools",
  "lasso",
  "parking_lot",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ derive_more = { version = "2.0", features = ["display", "error", "from"] }
 fluent-uri = "0.1.4"
 im = "15"
 insta = { version = "1.47.2", features = ["yaml"] }
+itertools = "0.14"
 itoa = "1"
 inventory = "0.3"
 lasso = "0.7"

--- a/crates/tribute-core/Cargo.toml
+++ b/crates/tribute-core/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+itertools.workspace = true
 salsa.workspace = true
 serde.workspace = true
 target-lexicon.workspace = true

--- a/crates/tribute-core/src/fmt.rs
+++ b/crates/tribute-core/src/fmt.rs
@@ -21,7 +21,11 @@ impl PluralExt for usize {
     }
 }
 
-/// Joins items from an iterator with a separator, returning a [`Display`](fmt::Display) value.
+/// Joins items from an iterator with a separator, returning a
+/// [`Display`](fmt::Display) value (lazy).
+///
+/// Thin wrapper over [`itertools::Itertools::format`]. Display the result at
+/// most once — the underlying iterator is consumed on first use.
 ///
 /// # Examples
 ///
@@ -38,36 +42,10 @@ impl PluralExt for usize {
 pub fn joined<'a, I>(sep: &'a str, iter: I) -> impl fmt::Display + 'a
 where
     I: IntoIterator + 'a,
-    I::IntoIter: Clone,
     I::Item: fmt::Display,
 {
-    struct Joined<'a, I> {
-        sep: &'a str,
-        iter: I,
-    }
-
-    impl<I> fmt::Display for Joined<'_, I>
-    where
-        I: Iterator + Clone,
-        I::Item: fmt::Display,
-    {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let mut first = true;
-            for item in self.iter.clone() {
-                if !first {
-                    f.write_str(self.sep)?;
-                }
-                first = false;
-                write!(f, "{item}")?;
-            }
-            Ok(())
-        }
-    }
-
-    Joined {
-        sep,
-        iter: iter.into_iter(),
-    }
+    use itertools::Itertools;
+    iter.into_iter().format(sep)
 }
 
 /// Like [`joined`], but uses a custom formatting closure for each item.

--- a/crates/trunk-ir/Cargo.toml
+++ b/crates/trunk-ir/Cargo.toml
@@ -13,6 +13,7 @@ salsa = ["dep:salsa"]
 [dependencies]
 cranelift-entity.workspace = true
 inventory.workspace = true
+itertools.workspace = true
 lasso.workspace = true
 parking_lot.workspace = true
 paste.workspace = true

--- a/crates/trunk-ir/src/transforms/call_graph.rs
+++ b/crates/trunk-ir/src/transforms/call_graph.rs
@@ -1,0 +1,543 @@
+//! Call graph analysis for TrunkIR.
+//!
+//! Builds a directed graph of function call relationships from `func.call`,
+//! `func.tail_call`, and `func.constant` operations. Provides Tarjan's SCC
+//! for detecting recursive functions (direct self-recursion and mutual
+//! recursion), which is a prerequisite for inlining (`inline.rs`) and other
+//! interprocedural transforms.
+//!
+//! Recurses into nested `core.module` operations, qualifying function names
+//! with their module path (e.g. `nested::helper`).
+
+use std::collections::{HashMap, HashSet};
+use std::ops::ControlFlow;
+
+use crate::context::IrContext;
+use crate::refs::{OpRef, RegionRef};
+use crate::rewrite::Module;
+use crate::symbol::Symbol;
+use crate::types::Attribute;
+use crate::walk::{WalkAction, walk_region};
+
+/// A function call graph over a module.
+///
+/// Edges include direct calls (`func.call`), tail calls (`func.tail_call`),
+/// and reference-as-value (`func.constant`). Reference edges are conservative:
+/// they represent "function X escapes as a value, so could be called from
+/// anywhere later" and should be treated as a call edge for recursion
+/// detection.
+#[derive(Debug, Default)]
+pub struct CallGraph {
+    /// Caller → set of callees (includes direct calls and `func.constant` refs).
+    pub edges: HashMap<Symbol, HashSet<Symbol>>,
+    /// Function name (possibly qualified) → its defining `func.func` op.
+    pub func_ops: HashMap<Symbol, OpRef>,
+    /// Functions referenced by at least one `func.constant` anywhere in the module.
+    pub has_constant_ref: HashSet<Symbol>,
+    /// Callee → number of static direct-call sites across the whole module.
+    /// `func.constant` references are *not* counted here (they are tracked in
+    /// `has_constant_ref`).
+    pub call_site_count: HashMap<Symbol, usize>,
+}
+
+/// Build a call graph for `module`, recursing into nested `core.module` ops.
+pub fn build_call_graph(ctx: &IrContext, module: Module) -> CallGraph {
+    let mut builder = Builder::new();
+    if let Some(body) = module.body(ctx) {
+        builder.analyze_region(ctx, body, &[]);
+    }
+    builder.into_call_graph()
+}
+
+/// Compute the SCC id for every function in the call graph using Tarjan's algorithm.
+///
+/// Only functions defined in `graph.func_ops` are assigned an id. External
+/// callees (callees that appear in edges but have no corresponding `func.func`)
+/// are skipped.
+pub fn tarjan_scc(graph: &CallGraph) -> HashMap<Symbol, u32> {
+    let mut state = TarjanState::default();
+    for &v in graph.func_ops.keys() {
+        if !state.index.contains_key(&v) {
+            strongconnect(v, &mut state, graph);
+        }
+    }
+    state.scc_id
+}
+
+/// Functions that participate in a recursive cycle (direct or mutual).
+///
+/// A function is "recursive" if it belongs to an SCC of size > 1 **or** its
+/// singleton SCC contains a self-edge (direct self-recursion).
+pub fn recursive_functions(graph: &CallGraph) -> HashSet<Symbol> {
+    let scc_ids = tarjan_scc(graph);
+    let mut by_scc: HashMap<u32, Vec<Symbol>> = HashMap::new();
+    for (&v, &id) in &scc_ids {
+        by_scc.entry(id).or_default().push(v);
+    }
+    let mut result = HashSet::new();
+    for members in by_scc.into_values() {
+        if members.len() > 1 {
+            result.extend(members);
+        } else {
+            let v = members[0];
+            if graph.edges.get(&v).is_some_and(|s| s.contains(&v)) {
+                result.insert(v);
+            }
+        }
+    }
+    result
+}
+
+// =========================================================================
+// Builder
+// =========================================================================
+
+struct Builder {
+    syms: Syms,
+    graph: CallGraph,
+}
+
+impl Builder {
+    fn new() -> Self {
+        Self {
+            syms: Syms::new(),
+            graph: CallGraph::default(),
+        }
+    }
+
+    fn into_call_graph(self) -> CallGraph {
+        self.graph
+    }
+
+    fn analyze_region(&mut self, ctx: &IrContext, region: RegionRef, module_path: &[Symbol]) {
+        let blocks = ctx.region(region).blocks.to_vec();
+        for block in blocks {
+            let ops = ctx.block(block).ops.to_vec();
+            for op in ops {
+                let dialect = ctx.op(op).dialect;
+                let name = ctx.op(op).name;
+
+                // Recurse into nested core.module
+                if dialect == self.syms.dialect_core && name == self.syms.module {
+                    let new_path = self.extend_module_path(ctx, op, module_path);
+                    for &region in &ctx.op(op).regions {
+                        self.analyze_region(ctx, region, &new_path);
+                    }
+                    continue;
+                }
+
+                // Record func.func definitions and walk their bodies
+                if dialect == self.syms.dialect_func
+                    && name == self.syms.func
+                    && let Some(func_name) = self.extract_func_name(ctx, op, module_path)
+                {
+                    self.graph.func_ops.insert(func_name, op);
+                    // Iterate over a snapshot: collect_calls_from_region may mutate
+                    // self.graph, but ctx remains immutably borrowed.
+                    let regions: Vec<RegionRef> = ctx.op(op).regions.iter().copied().collect();
+                    for region in regions {
+                        self.collect_calls_from_region(ctx, region, func_name);
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_calls_from_region(&mut self, ctx: &IrContext, region: RegionRef, caller: Symbol) {
+        let _ = walk_region::<()>(ctx, region, &mut |op| {
+            let dialect = ctx.op(op).dialect;
+            let name = ctx.op(op).name;
+
+            if dialect == self.syms.dialect_func {
+                if (name == self.syms.call || name == self.syms.tail_call)
+                    && let Some(callee) = self.extract_symbol_attr(ctx, op, &self.syms.callee)
+                {
+                    self.graph.edges.entry(caller).or_default().insert(callee);
+                    *self.graph.call_site_count.entry(callee).or_insert(0) += 1;
+                } else if name == self.syms.constant
+                    && let Some(func_ref) = self.extract_symbol_attr(ctx, op, &self.syms.func_ref)
+                {
+                    self.graph.edges.entry(caller).or_default().insert(func_ref);
+                    self.graph.has_constant_ref.insert(func_ref);
+                }
+            }
+
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+    }
+
+    fn extract_symbol_attr(&self, ctx: &IrContext, op: OpRef, key: &Symbol) -> Option<Symbol> {
+        match ctx.op(op).attributes.get(key)? {
+            Attribute::Symbol(s) => Some(*s),
+            _ => None,
+        }
+    }
+
+    fn extract_func_name(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        module_path: &[Symbol],
+    ) -> Option<Symbol> {
+        let sym_name = self.extract_symbol_attr(ctx, op, &self.syms.sym_name)?;
+        if module_path.is_empty() {
+            Some(sym_name)
+        } else {
+            let mut path = String::new();
+            for (i, seg) in module_path.iter().enumerate() {
+                if i > 0 {
+                    path.push_str("::");
+                }
+                seg.with_str(|s| path.push_str(s));
+            }
+            path.push_str("::");
+            sym_name.with_str(|s| path.push_str(s));
+            Some(Symbol::from_dynamic(&path))
+        }
+    }
+
+    fn extend_module_path(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        current_path: &[Symbol],
+    ) -> Vec<Symbol> {
+        let nested_name = self.extract_symbol_attr(ctx, op, &self.syms.name_attr);
+        if let Some(n) = nested_name {
+            let mut p = current_path.to_vec();
+            p.push(n);
+            p
+        } else {
+            current_path.to_vec()
+        }
+    }
+}
+
+// =========================================================================
+// Tarjan's SCC
+// =========================================================================
+
+#[derive(Default)]
+struct TarjanState {
+    next_index: u32,
+    stack: Vec<Symbol>,
+    on_stack: HashSet<Symbol>,
+    index: HashMap<Symbol, u32>,
+    lowlink: HashMap<Symbol, u32>,
+    scc_id: HashMap<Symbol, u32>,
+    next_scc: u32,
+}
+
+fn strongconnect(v: Symbol, state: &mut TarjanState, graph: &CallGraph) {
+    let v_index = state.next_index;
+    state.next_index += 1;
+    state.index.insert(v, v_index);
+    state.lowlink.insert(v, v_index);
+    state.stack.push(v);
+    state.on_stack.insert(v);
+
+    if let Some(successors) = graph.edges.get(&v) {
+        let successors: Vec<Symbol> = successors.iter().copied().collect();
+        for w in successors {
+            // Skip external callees (not defined in this module).
+            if !graph.func_ops.contains_key(&w) {
+                continue;
+            }
+            if !state.index.contains_key(&w) {
+                strongconnect(w, state, graph);
+                let w_low = state.lowlink[&w];
+                let v_low = state.lowlink[&v];
+                state.lowlink.insert(v, v_low.min(w_low));
+            } else if state.on_stack.contains(&w) {
+                let w_idx = state.index[&w];
+                let v_low = state.lowlink[&v];
+                state.lowlink.insert(v, v_low.min(w_idx));
+            }
+        }
+    }
+
+    if state.lowlink[&v] == state.index[&v] {
+        let scc_id = state.next_scc;
+        state.next_scc += 1;
+        loop {
+            let w = state
+                .stack
+                .pop()
+                .expect("stack non-empty while popping SCC");
+            state.on_stack.remove(&w);
+            state.scc_id.insert(w, scc_id);
+            if w == v {
+                break;
+            }
+        }
+    }
+}
+
+// =========================================================================
+// Cached symbols
+// =========================================================================
+
+struct Syms {
+    func: Symbol,
+    call: Symbol,
+    tail_call: Symbol,
+    constant: Symbol,
+    module: Symbol,
+    sym_name: Symbol,
+    callee: Symbol,
+    func_ref: Symbol,
+    name_attr: Symbol,
+    dialect_func: Symbol,
+    dialect_core: Symbol,
+}
+
+impl Syms {
+    fn new() -> Self {
+        Self {
+            func: Symbol::new("func"),
+            call: Symbol::new("call"),
+            tail_call: Symbol::new("tail_call"),
+            constant: Symbol::new("constant"),
+            module: Symbol::new("module"),
+            sym_name: Symbol::new("sym_name"),
+            callee: Symbol::new("callee"),
+            func_ref: Symbol::new("func_ref"),
+            name_attr: Symbol::new("name"),
+            dialect_func: Symbol::new("func"),
+            dialect_core: Symbol::new("core"),
+        }
+    }
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dialect::func;
+    use crate::location::Span;
+    use crate::*;
+    use smallvec::smallvec;
+
+    fn test_ctx() -> (IrContext, Location) {
+        let mut ctx = IrContext::new();
+        let path = ctx.paths.intern("test.trb".to_owned());
+        let loc = Location::new(path, Span::new(0, 0));
+        (ctx, loc)
+    }
+
+    fn fn_type(ctx: &mut IrContext) -> TypeRef {
+        let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
+        crate::dialect::core::func(ctx, nil_ty, []).as_type_ref()
+    }
+
+    fn i32_type(ctx: &mut IrContext) -> TypeRef {
+        ctx.types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
+    }
+
+    fn simple_func(ctx: &mut IrContext, loc: Location, name: &str) -> OpRef {
+        let fn_ty = fn_type(ctx);
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let ret = func::r#return(ctx, loc, std::iter::empty());
+        ctx.push_op(entry, ret.op_ref());
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        func::func(ctx, loc, Symbol::from_dynamic(name), fn_ty, body).op_ref()
+    }
+
+    fn func_that_calls(ctx: &mut IrContext, loc: Location, name: &str, callees: &[&str]) -> OpRef {
+        let fn_ty = fn_type(ctx);
+        let i32_ty = i32_type(ctx);
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for callee in callees {
+            let call = func::call(
+                ctx,
+                loc,
+                std::iter::empty(),
+                i32_ty,
+                Symbol::from_dynamic(callee),
+            );
+            ctx.push_op(entry, call.op_ref());
+        }
+        let ret = func::r#return(ctx, loc, std::iter::empty());
+        ctx.push_op(entry, ret.op_ref());
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        func::func(ctx, loc, Symbol::from_dynamic(name), fn_ty, body).op_ref()
+    }
+
+    fn func_that_takes_constant_of(
+        ctx: &mut IrContext,
+        loc: Location,
+        name: &str,
+        target: &str,
+    ) -> OpRef {
+        let fn_ty = fn_type(ctx);
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let c = func::constant(ctx, loc, fn_ty, Symbol::from_dynamic(target));
+        ctx.push_op(entry, c.op_ref());
+        let ret = func::r#return(ctx, loc, std::iter::empty());
+        ctx.push_op(entry, ret.op_ref());
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        func::func(ctx, loc, Symbol::from_dynamic(name), fn_ty, body).op_ref()
+    }
+
+    fn build_module(ctx: &mut IrContext, loc: Location, ops: Vec<OpRef>) -> Module {
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for op in ops {
+            ctx.push_op(block, op);
+        }
+        let region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+        let module_data =
+            OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
+                .attr("sym_name", Attribute::Symbol(Symbol::new("test")))
+                .region(region)
+                .build(ctx);
+        let module_op = ctx.create_op(module_data);
+        Module::new(ctx, module_op).unwrap()
+    }
+
+    #[test]
+    fn call_graph_records_direct_calls() {
+        let (mut ctx, loc) = test_ctx();
+        let leaf = simple_func(&mut ctx, loc, "leaf");
+        let mid = func_that_calls(&mut ctx, loc, "mid", &["leaf"]);
+        let main = func_that_calls(&mut ctx, loc, "main", &["mid"]);
+        let module = build_module(&mut ctx, loc, vec![leaf, mid, main]);
+
+        let g = build_call_graph(&ctx, module);
+        assert!(
+            g.edges
+                .get(&Symbol::new("main"))
+                .unwrap()
+                .contains(&Symbol::new("mid"))
+        );
+        assert!(
+            g.edges
+                .get(&Symbol::new("mid"))
+                .unwrap()
+                .contains(&Symbol::new("leaf"))
+        );
+        assert!(g.func_ops.contains_key(&Symbol::new("leaf")));
+        assert!(g.func_ops.contains_key(&Symbol::new("mid")));
+        assert!(g.func_ops.contains_key(&Symbol::new("main")));
+    }
+
+    #[test]
+    fn call_graph_records_func_constant_as_edge() {
+        let (mut ctx, loc) = test_ctx();
+        let target = simple_func(&mut ctx, loc, "target");
+        let holder = func_that_takes_constant_of(&mut ctx, loc, "holder", "target");
+        let module = build_module(&mut ctx, loc, vec![target, holder]);
+
+        let g = build_call_graph(&ctx, module);
+        assert!(
+            g.edges
+                .get(&Symbol::new("holder"))
+                .unwrap()
+                .contains(&Symbol::new("target"))
+        );
+        assert!(g.has_constant_ref.contains(&Symbol::new("target")));
+        // func.constant should NOT count toward call_site_count
+        assert_eq!(g.call_site_count.get(&Symbol::new("target")).copied(), None);
+    }
+
+    #[test]
+    fn call_graph_counts_static_call_sites() {
+        let (mut ctx, loc) = test_ctx();
+        let leaf = simple_func(&mut ctx, loc, "leaf");
+        // main calls leaf twice in its body
+        let main = func_that_calls(&mut ctx, loc, "main", &["leaf", "leaf"]);
+        let module = build_module(&mut ctx, loc, vec![leaf, main]);
+
+        let g = build_call_graph(&ctx, module);
+        assert_eq!(g.call_site_count[&Symbol::new("leaf")], 2);
+    }
+
+    #[test]
+    fn tarjan_detects_self_recursion() {
+        let (mut ctx, loc) = test_ctx();
+        let f = func_that_calls(&mut ctx, loc, "f", &["f"]);
+        let module = build_module(&mut ctx, loc, vec![f]);
+
+        let g = build_call_graph(&ctx, module);
+        let rec = recursive_functions(&g);
+        assert!(rec.contains(&Symbol::new("f")));
+    }
+
+    #[test]
+    fn tarjan_detects_mutual_recursion() {
+        let (mut ctx, loc) = test_ctx();
+        let a = func_that_calls(&mut ctx, loc, "a", &["b"]);
+        let b = func_that_calls(&mut ctx, loc, "b", &["a"]);
+        let module = build_module(&mut ctx, loc, vec![a, b]);
+
+        let g = build_call_graph(&ctx, module);
+        let rec = recursive_functions(&g);
+        assert!(rec.contains(&Symbol::new("a")));
+        assert!(rec.contains(&Symbol::new("b")));
+    }
+
+    #[test]
+    fn tarjan_trivial_scc_not_flagged() {
+        let (mut ctx, loc) = test_ctx();
+        let leaf = simple_func(&mut ctx, loc, "leaf");
+        let main = func_that_calls(&mut ctx, loc, "main", &["leaf"]);
+        let module = build_module(&mut ctx, loc, vec![leaf, main]);
+
+        let g = build_call_graph(&ctx, module);
+        let rec = recursive_functions(&g);
+        assert!(rec.is_empty());
+    }
+
+    #[test]
+    fn tarjan_assigns_scc_ids_to_all_functions() {
+        let (mut ctx, loc) = test_ctx();
+        let a = simple_func(&mut ctx, loc, "a");
+        let b = simple_func(&mut ctx, loc, "b");
+        let module = build_module(&mut ctx, loc, vec![a, b]);
+
+        let g = build_call_graph(&ctx, module);
+        let ids = tarjan_scc(&g);
+        assert_eq!(ids.len(), 2);
+        // Two non-recursive functions → two distinct SCCs
+        assert_ne!(ids[&Symbol::new("a")], ids[&Symbol::new("b")]);
+    }
+}

--- a/crates/trunk-ir/src/transforms/call_graph.rs
+++ b/crates/trunk-ir/src/transforms/call_graph.rs
@@ -181,19 +181,14 @@ impl Builder {
     ) -> Option<Symbol> {
         let sym_name = self.extract_symbol_attr(ctx, op, &self.syms.sym_name)?;
         if module_path.is_empty() {
-            Some(sym_name)
-        } else {
-            let mut path = String::new();
-            for (i, seg) in module_path.iter().enumerate() {
-                if i > 0 {
-                    path.push_str("::");
-                }
-                seg.with_str(|s| path.push_str(s));
-            }
-            path.push_str("::");
-            sym_name.with_str(|s| path.push_str(s));
-            Some(Symbol::from_dynamic(&path))
+            return Some(sym_name);
         }
+        use itertools::Itertools;
+        let qualified = module_path
+            .iter()
+            .chain(std::iter::once(&sym_name))
+            .join("::");
+        Some(Symbol::from_dynamic(&qualified))
     }
 
     fn extend_module_path(

--- a/crates/trunk-ir/src/transforms/call_graph.rs
+++ b/crates/trunk-ir/src/transforms/call_graph.rs
@@ -197,7 +197,7 @@ impl Builder {
         op: OpRef,
         current_path: &[Symbol],
     ) -> Vec<Symbol> {
-        let nested_name = self.extract_symbol_attr(ctx, op, &self.syms.name_attr);
+        let nested_name = self.extract_symbol_attr(ctx, op, &self.syms.sym_name);
         if let Some(n) = nested_name {
             let mut p = current_path.to_vec();
             p.push(n);
@@ -281,7 +281,6 @@ struct Syms {
     sym_name: Symbol,
     callee: Symbol,
     func_ref: Symbol,
-    name_attr: Symbol,
     dialect_func: Symbol,
     dialect_core: Symbol,
 }
@@ -297,7 +296,6 @@ impl Syms {
             sym_name: Symbol::new("sym_name"),
             callee: Symbol::new("callee"),
             func_ref: Symbol::new("func_ref"),
-            name_attr: Symbol::new("name"),
             dialect_func: Symbol::new("func"),
             dialect_core: Symbol::new("core"),
         }
@@ -406,6 +404,11 @@ mod tests {
     }
 
     fn build_module(ctx: &mut IrContext, loc: Location, ops: Vec<OpRef>) -> Module {
+        let module_op = build_module_op(ctx, loc, "test", ops);
+        Module::new(ctx, module_op).unwrap()
+    }
+
+    fn build_module_op(ctx: &mut IrContext, loc: Location, name: &str, ops: Vec<OpRef>) -> OpRef {
         let block = ctx.create_block(BlockData {
             location: loc,
             args: vec![],
@@ -422,11 +425,10 @@ mod tests {
         });
         let module_data =
             OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
-                .attr("sym_name", Attribute::Symbol(Symbol::new("test")))
+                .attr("sym_name", Attribute::Symbol(Symbol::from_dynamic(name)))
                 .region(region)
                 .build(ctx);
-        let module_op = ctx.create_op(module_data);
-        Module::new(ctx, module_op).unwrap()
+        ctx.create_op(module_data)
     }
 
     #[test]
@@ -520,6 +522,29 @@ mod tests {
         let g = build_call_graph(&ctx, module);
         let rec = recursive_functions(&g);
         assert!(rec.is_empty());
+    }
+
+    #[test]
+    fn nested_module_qualifies_func_names() {
+        let (mut ctx, loc) = test_ctx();
+        // Outer module contains a nested `core.module` named "inner"
+        // with a single `func.func` named "foo". The call graph should
+        // record the function as `inner::foo`, not just `foo`.
+        let foo = simple_func(&mut ctx, loc, "foo");
+        let inner = build_module_op(&mut ctx, loc, "inner", vec![foo]);
+        let top = simple_func(&mut ctx, loc, "top");
+        let module = build_module(&mut ctx, loc, vec![inner, top]);
+
+        let g = build_call_graph(&ctx, module);
+        assert!(
+            g.func_ops.contains_key(&Symbol::from_dynamic("inner::foo")),
+            "expected qualified symbol `inner::foo`, got: {:?}",
+            g.func_ops.keys().collect::<Vec<_>>()
+        );
+        // Unqualified symbol should not leak through.
+        assert!(!g.func_ops.contains_key(&Symbol::new("foo")));
+        // Top-level function stays unqualified.
+        assert!(g.func_ops.contains_key(&Symbol::new("top")));
     }
 
     #[test]

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -18,11 +18,12 @@
 use std::collections::BTreeMap;
 
 use crate::context::{BlockArgData, IrContext};
-use crate::dialect::{cf, func};
+use crate::dialect::{cf, core, func};
 use crate::ir_mapping::IrMapping;
 use crate::ops::DialectOp;
+use crate::ops::DialectType;
 use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
-use crate::rewrite::helpers::{erase_op, inline_region_blocks, split_block};
+use crate::rewrite::helpers::{inline_region_blocks, split_block};
 use crate::types::Location;
 
 // =========================================================================
@@ -175,17 +176,25 @@ fn inline_regular_call(
     call_operands: &[ValueRef],
     loc: Location,
 ) -> Result<(), InlineError> {
-    // Snapshot result values & types before mutations.
-    let call_results: Vec<_> = ctx.op_results(call_op).to_vec();
-    let call_result_types: Vec<_> = ctx.op_result_types(call_op).to_vec();
+    // Snapshot result values & types before mutations. Skip nil-typed
+    // results: they are "void" in the backend type system and pass-through
+    // block args for them confuse cranelift lowering (same convention as
+    // `scf_to_cf`).
+    let call_results_and_types: Vec<_> = ctx
+        .op_results(call_op)
+        .iter()
+        .copied()
+        .zip(ctx.op_result_types(call_op).iter().copied())
+        .filter(|(_, ty)| !core::Nil::matches(ctx, *ty))
+        .collect();
 
     // 1. Split the caller block so call_op + everything after moves to
     //    `continuation_block`.
     let continuation_block = split_block(ctx, caller_block, call_op);
 
-    // 2. Add block args on the continuation block matching the call's
-    //    result types, then RAUW call results → continuation args.
-    for (result, ty) in call_results.iter().zip(call_result_types.iter()) {
+    // 2. Add block args on the continuation block for non-nil call results,
+    //    then RAUW call results → continuation args.
+    for (result, ty) in &call_results_and_types {
         let new_arg = ctx.add_block_arg(
             continuation_block,
             BlockArgData {
@@ -207,8 +216,11 @@ fn inline_regular_call(
     // 5. Rewrite each cloned `func.return %v` → `cf.br %v → continuation`.
     replace_returns_with_branches(ctx, cloned_entry, continuation_block, loc);
 
-    // 6. Erase the original call op. After RAUW its results have no uses.
-    erase_op(ctx, call_op);
+    // 6. Detach the original call op. Nil-typed results we filtered earlier
+    //    may still be referenced by downstream ops; `detach_op` (vs.
+    //    `erase_op`) matches the `scf_to_cf` lowering convention and keeps
+    //    those dangling SSA values live in the arena without breaking them.
+    ctx.detach_op(call_op);
 
     Ok(())
 }
@@ -233,7 +245,9 @@ fn inline_tail_call(
     inline_region_blocks(ctx, cloned_region, parent_region, None);
 
     // 2. Replace the tail-call terminator with `cf.br cloned_entry(...ops)`.
-    erase_op(ctx, call_op);
+    //    `detach_op` rather than `erase_op` keeps arena invariants stable
+    //    even if a nil-typed tail-call variant is ever introduced.
+    ctx.detach_op(call_op);
     let br_op = cf::br(ctx, loc, call_operands.iter().copied(), cloned_entry);
     ctx.push_op(caller_block, br_op.op_ref());
 
@@ -255,13 +269,9 @@ fn replace_returns_with_branches(
     target: BlockRef,
     loc: Location,
 ) {
-    // Walk all blocks in the region that became the cloned body. Since
-    // `inline_region_blocks` moved those blocks into `parent_region`, we'd
-    // like to limit rewrites to the just-inlined blocks.
-    //
-    // Trick: collect all blocks reachable from `entry_block` via successor
-    // edges. Since the cloned body is self-contained, this hits exactly the
-    // inlined blocks without touching pre-existing ones.
+    // Walk all blocks reachable from `entry_block`; these are exactly the
+    // just-inlined blocks (the cloned body is self-contained).
+    let target_arg_count = ctx.block_args(target).len();
     let mut visited: std::collections::HashSet<BlockRef> = std::collections::HashSet::new();
     let mut stack = vec![entry_block];
     while let Some(b) = stack.pop() {
@@ -271,7 +281,14 @@ fn replace_returns_with_branches(
         let ops: Vec<OpRef> = ctx.block(b).ops.to_vec();
         for op in ops {
             if func::Return::matches(ctx, op) {
-                let values: Vec<_> = ctx.op_operands(op).to_vec();
+                // If the target has fewer args than the return supplies
+                // (e.g., nil return filtered out), take only the first N.
+                let values: Vec<_> = ctx
+                    .op_operands(op)
+                    .iter()
+                    .copied()
+                    .take(target_arg_count)
+                    .collect();
                 let br = cf::br(ctx, loc, values, target);
                 ctx.remove_op_from_block(b, op);
                 ctx.push_op(b, br.op_ref());
@@ -284,6 +301,189 @@ fn replace_returns_with_branches(
             }
         }
     }
+}
+
+// =========================================================================
+// Policy
+// =========================================================================
+
+use super::call_graph::{CallGraph, build_call_graph, recursive_functions};
+use crate::rewrite::Module;
+use crate::symbol::Symbol;
+use std::collections::HashSet;
+
+/// Knobs for the inlining pass.
+#[derive(Debug, Clone)]
+pub struct InlineConfig {
+    /// Inline callees whose body has at most this many ops (summed across
+    /// all blocks and nested regions).
+    pub size_threshold: usize,
+    /// If true, always inline callees with exactly one static call site
+    /// (provided they do not escape via `func.constant`).
+    pub always_inline_single_call_site: bool,
+    /// If true, inline even when the callee is referenced by `func.constant`
+    /// somewhere. Defaults to false (conservative).
+    pub inline_across_func_constant: bool,
+}
+
+impl Default for InlineConfig {
+    fn default() -> Self {
+        Self {
+            size_threshold: 16,
+            always_inline_single_call_site: true,
+            inline_across_func_constant: false,
+        }
+    }
+}
+
+/// Count all ops in a `func.func`'s body (recursively through nested regions).
+fn op_count(ctx: &IrContext, func_op: OpRef) -> usize {
+    let regions: Vec<RegionRef> = ctx.op(func_op).regions.iter().copied().collect();
+    regions.iter().map(|&r| region_op_count(ctx, r)).sum()
+}
+
+fn region_op_count(ctx: &IrContext, region: RegionRef) -> usize {
+    let blocks: Vec<_> = ctx.region(region).blocks.iter().copied().collect();
+    let mut total = 0usize;
+    for block in blocks {
+        let ops: Vec<_> = ctx.block(block).ops.iter().copied().collect();
+        for op in ops {
+            total += 1;
+            let nested: Vec<_> = ctx.op(op).regions.iter().copied().collect();
+            for r in nested {
+                total += region_op_count(ctx, r);
+            }
+        }
+    }
+    total
+}
+
+/// Decide whether `callee` should be inlined based on the graph and config.
+fn should_inline(
+    graph: &CallGraph,
+    config: &InlineConfig,
+    recursive: &HashSet<Symbol>,
+    ctx: &IrContext,
+    callee: Symbol,
+) -> bool {
+    // Must have a body in this module.
+    let Some(&callee_op) = graph.func_ops.get(&callee) else {
+        return false;
+    };
+    if ctx.op(callee_op).regions.is_empty() {
+        return false;
+    }
+    // Skip extern/ABI functions: they are externally callable and the body
+    // may be empty or have calling-convention constraints.
+    if ctx
+        .op(callee_op)
+        .attributes
+        .contains_key(&Symbol::new("abi"))
+    {
+        return false;
+    }
+    // Skip recursive functions to avoid unbounded instantiation.
+    if recursive.contains(&callee) {
+        return false;
+    }
+    let escapes = graph.has_constant_ref.contains(&callee);
+
+    // Single-call-site rule (only when the callee doesn't escape).
+    if config.always_inline_single_call_site
+        && !escapes
+        && graph.call_site_count.get(&callee).copied().unwrap_or(0) == 1
+    {
+        return true;
+    }
+
+    // Size threshold.
+    if !escapes || config.inline_across_func_constant {
+        return op_count(ctx, callee_op) <= config.size_threshold;
+    }
+
+    false
+}
+
+// =========================================================================
+// Pass entry + worklist
+// =========================================================================
+
+/// Summary of an inlining run.
+#[derive(Debug, Default)]
+pub struct InlineResult {
+    pub inlined_count: usize,
+    /// Per-site: (caller, callee) qualified names.
+    pub inlined_sites: Vec<(Symbol, Symbol)>,
+}
+
+/// Run one pass of function inlining over `module` using default config.
+pub fn inline_functions(ctx: &mut IrContext, module: Module) -> InlineResult {
+    inline_functions_with_config(ctx, module, InlineConfig::default())
+}
+
+/// Run one pass of function inlining with custom config.
+pub fn inline_functions_with_config(
+    ctx: &mut IrContext,
+    module: Module,
+    config: InlineConfig,
+) -> InlineResult {
+    let graph = build_call_graph(ctx, module);
+    let recursive = recursive_functions(&graph);
+
+    // Snapshot all call sites first to avoid invalidation during mutation.
+    let candidates = collect_candidates(ctx, &graph);
+
+    let mut result = InlineResult::default();
+    for (caller, call_op, callee) in candidates {
+        if !should_inline(&graph, &config, &recursive, ctx, callee) {
+            continue;
+        }
+        let Some(&callee_op) = graph.func_ops.get(&callee) else {
+            continue;
+        };
+        match inline_single_call(ctx, call_op, callee_op) {
+            Ok(()) => {
+                result.inlined_count += 1;
+                result.inlined_sites.push((caller, callee));
+            }
+            Err(_) => {
+                // Silently skip; policy said yes but primitive rejected
+                // (e.g. callee has no body). Keep pass resilient.
+            }
+        }
+    }
+    result
+}
+
+/// Walk every `func.func` in the module and collect `(caller, call_op, callee)`
+/// for each `func.call` and `func.tail_call` site.
+fn collect_candidates(ctx: &IrContext, graph: &CallGraph) -> Vec<(Symbol, OpRef, Symbol)> {
+    use crate::walk::{WalkAction, walk_region};
+    use std::ops::ControlFlow;
+    let mut out = Vec::new();
+    let func_sym = Symbol::new("func");
+    let call_sym = Symbol::new("call");
+    let tail_call_sym = Symbol::new("tail_call");
+    let callee_attr = Symbol::new("callee");
+
+    for (&caller, &func_op) in &graph.func_ops {
+        let regions: Vec<RegionRef> = ctx.op(func_op).regions.iter().copied().collect();
+        for region in regions {
+            let _ = walk_region::<()>(ctx, region, &mut |op| {
+                let d = ctx.op(op).dialect;
+                let n = ctx.op(op).name;
+                if d == func_sym
+                    && (n == call_sym || n == tail_call_sym)
+                    && let Some(crate::types::Attribute::Symbol(s)) =
+                        ctx.op(op).attributes.get(&callee_attr)
+                {
+                    out.push((caller, op, *s));
+                }
+                ControlFlow::Continue(WalkAction::Advance)
+            });
+        }
+    }
+    out
 }
 
 // =========================================================================
@@ -661,5 +861,289 @@ mod mechanics {
             ControlFlow::Continue(WalkAction::Advance)
         });
         found
+    }
+}
+
+#[cfg(test)]
+mod pass {
+    use super::*;
+    use crate::location::Span;
+    use crate::*;
+    use smallvec::smallvec;
+
+    fn test_ctx() -> (IrContext, Location) {
+        let mut ctx = IrContext::new();
+        let path = ctx.paths.intern("test.trb".to_owned());
+        let loc = Location::new(path, Span::new(0, 0));
+        (ctx, loc)
+    }
+
+    fn i32_type(ctx: &mut IrContext) -> TypeRef {
+        ctx.types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
+    }
+
+    fn build_func<F>(
+        ctx: &mut IrContext,
+        loc: Location,
+        name: &str,
+        param_tys: &[TypeRef],
+        ret_ty: TypeRef,
+        body_builder: F,
+    ) -> OpRef
+    where
+        F: FnOnce(&mut IrContext, BlockRef, &[ValueRef]),
+    {
+        let fn_ty = {
+            let mut params = vec![ret_ty];
+            params.extend_from_slice(param_tys);
+            ctx.types.intern(
+                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                    .params(params)
+                    .build(),
+            )
+        };
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: param_tys
+                .iter()
+                .map(|&ty| BlockArgData {
+                    ty,
+                    attrs: BTreeMap::new(),
+                })
+                .collect(),
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let args: Vec<_> = ctx.block_args(entry).to_vec();
+        body_builder(ctx, entry, &args);
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        func::func(ctx, loc, Symbol::from_dynamic(name), fn_ty, body).op_ref()
+    }
+
+    fn build_module(ctx: &mut IrContext, loc: Location, ops: Vec<OpRef>) -> Module {
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for op in ops {
+            ctx.push_op(block, op);
+        }
+        let region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+        let module_data =
+            OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
+                .attr("sym_name", Attribute::Symbol(Symbol::new("test")))
+                .region(region)
+                .build(ctx);
+        let module_op = ctx.create_op(module_data);
+        Module::new(ctx, module_op).unwrap()
+    }
+
+    fn count_calls_to(ctx: &IrContext, func_op: OpRef, callee: &str) -> usize {
+        use crate::walk::{WalkAction, walk_region};
+        use std::ops::ControlFlow;
+        let target = Symbol::from_dynamic(callee);
+        let mut count = 0;
+        let body = ctx.op(func_op).regions[0];
+        let _ = walk_region::<()>(ctx, body, &mut |op| {
+            if func::Call::matches(ctx, op)
+                && let Some(crate::types::Attribute::Symbol(s)) =
+                    ctx.op(op).attributes.get(&Symbol::new("callee"))
+                && *s == target
+            {
+                count += 1;
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        count
+    }
+
+    #[test]
+    fn inlines_small_single_call_site_helper() {
+        // helper() -> i32 { return 42 }   — 2 ops (const, return) → small
+        // main() -> i32 { return helper() }
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let helper = build_func(&mut ctx, loc, "helper", &[], i32_ty, |ctx, entry, _args| {
+            let c = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(42));
+            ctx.push_op(entry, c.op_ref());
+            let ret = func::r#return(ctx, loc, [c.result(ctx)]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let main = build_func(&mut ctx, loc, "main", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(ctx, loc, std::iter::empty(), i32_ty, Symbol::new("helper"));
+            let r = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [r]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let module = build_module(&mut ctx, loc, vec![helper, main]);
+
+        let result = inline_functions(&mut ctx, module);
+        assert_eq!(result.inlined_count, 1);
+        assert_eq!(count_calls_to(&ctx, main, "helper"), 0);
+    }
+
+    #[test]
+    fn skips_recursive_function() {
+        // f() { return f() }  — self-recursion → must not inline
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let f = build_func(&mut ctx, loc, "f", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(ctx, loc, std::iter::empty(), i32_ty, Symbol::new("f"));
+            let r = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [r]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let module = build_module(&mut ctx, loc, vec![f]);
+
+        let result = inline_functions(&mut ctx, module);
+        assert_eq!(result.inlined_count, 0);
+        assert_eq!(count_calls_to(&ctx, f, "f"), 1);
+    }
+
+    #[test]
+    fn skips_when_escapes_via_func_constant() {
+        // helper() { ... }
+        // other() { %c = func.constant @helper; ... }  — helper escapes
+        // main() { helper() }  — would be single call site, but escapes
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let helper = build_func(&mut ctx, loc, "helper", &[], i32_ty, |ctx, entry, _args| {
+            let c = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(42));
+            ctx.push_op(entry, c.op_ref());
+            let ret = func::r#return(ctx, loc, [c.result(ctx)]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let fn_ty_helper = ctx.op(helper).attributes.get(&Symbol::new("type")).cloned();
+        let helper_fn_ty = match fn_ty_helper {
+            Some(Attribute::Type(t)) => t,
+            _ => panic!("expected type attr"),
+        };
+
+        let other = build_func(&mut ctx, loc, "other", &[], i32_ty, |ctx, entry, _args| {
+            let c = func::constant(ctx, loc, helper_fn_ty, Symbol::new("helper"));
+            ctx.push_op(entry, c.op_ref());
+            let z = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(0));
+            ctx.push_op(entry, z.op_ref());
+            let ret = func::r#return(ctx, loc, [z.result(ctx)]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+
+        let main = build_func(&mut ctx, loc, "main", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(ctx, loc, std::iter::empty(), i32_ty, Symbol::new("helper"));
+            let r = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [r]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let module = build_module(&mut ctx, loc, vec![helper, other, main]);
+
+        // Helper size is 2 ops (≤16) so size-threshold path would still accept
+        // under default config. But inline_across_func_constant=false → skip.
+        let result = inline_functions(&mut ctx, module);
+        assert_eq!(result.inlined_count, 0);
+        assert_eq!(count_calls_to(&ctx, main, "helper"), 1);
+    }
+
+    #[test]
+    fn respects_size_threshold() {
+        // helper is built with 20 ops; threshold=16 should skip it.
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let helper = build_func(&mut ctx, loc, "helper", &[], i32_ty, |ctx, entry, _args| {
+            // Chain 18 arith.const ops + 1 dummy + 1 return = 20 ops
+            let mut last = None;
+            for i in 0..19 {
+                let c = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(i as i128));
+                ctx.push_op(entry, c.op_ref());
+                last = Some(c.result(ctx));
+            }
+            let ret = func::r#return(ctx, loc, [last.unwrap()]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        // Two call sites so single-call-site rule doesn't trigger.
+        let a = build_func(&mut ctx, loc, "a", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(ctx, loc, std::iter::empty(), i32_ty, Symbol::new("helper"));
+            let r = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [r]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let b = build_func(&mut ctx, loc, "b", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(ctx, loc, std::iter::empty(), i32_ty, Symbol::new("helper"));
+            let r = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [r]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let module = build_module(&mut ctx, loc, vec![helper, a, b]);
+
+        let result = inline_functions(&mut ctx, module);
+        assert_eq!(result.inlined_count, 0);
+    }
+
+    #[test]
+    fn skips_abi_function() {
+        // helper has abi attr — externally callable, skip even if small.
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let c = crate::dialect::arith::r#const(&mut ctx, loc, i32_ty, Attribute::Int(1));
+        let c_result = c.result(&ctx);
+        ctx.push_op(entry, c.op_ref());
+        let ret = func::r#return(&mut ctx, loc, [c_result]);
+        ctx.push_op(entry, ret.op_ref());
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+
+        let fn_ty = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                .params(vec![i32_ty])
+                .build(),
+        );
+        let helper_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
+            .attr("sym_name", Attribute::Symbol(Symbol::new("helper")))
+            .attr("type", Attribute::Type(fn_ty))
+            .attr("abi", Attribute::String("C".to_owned()))
+            .region(body)
+            .build(&mut ctx);
+        let helper = ctx.create_op(helper_data);
+
+        let main = build_func(&mut ctx, loc, "main", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(ctx, loc, std::iter::empty(), i32_ty, Symbol::new("helper"));
+            let r = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [r]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let module = build_module(&mut ctx, loc, vec![helper, main]);
+
+        let result = inline_functions(&mut ctx, module);
+        assert_eq!(result.inlined_count, 0);
     }
 }

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -675,7 +675,10 @@ mod mechanics {
 
         let call_op = find_call_in(&ctx, caller);
         let err = inline_single_call(&mut ctx, call_op, helper).unwrap_err();
-        matches!(err, InlineError::ArityMismatch { .. });
+        assert!(
+            matches!(err, InlineError::ArityMismatch { .. }),
+            "expected ArityMismatch, got {err:?}"
+        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -1,30 +1,26 @@
 //! Function inlining pass for TrunkIR.
 //!
-//! Replaces `func.call` and `func.tail_call` ops with a cloned copy of the
-//! callee's body, splicing it into the caller's CFG.
+//! Replaces `func.call` and `func.tail_call` ops whose callee has a single
+//! top-level block by splicing the callee body directly into the caller:
 //!
-//! # Strategy
+//! - Regular call: clone pre-return ops into the caller block before the
+//!   call site, RAUW call results with the mapped return values, detach
+//!   the call op.
+//! - Tail call: same clone, then emit a `func.return` with the mapped
+//!   return values in place of the tail call.
 //!
-//! For regular `func.call` sites, split-and-splice is used uniformly even
-//! for single-block callees — the continuation block's degeneracy can be
-//! collapsed later by canonicalization. See
-//! `transforms::scf_to_cf::replace_yield_with_br` for the same pattern
-//! applied to SCF lowering.
-//!
-//! For `func.tail_call`, no split is required: the tail call is itself
-//! a terminator and "callee return = caller return", so cloned `func.return`
-//! ops remain valid in the caller's function body.
+//! This pass does **not** depend on the `cf` dialect. Structured control
+//! flow inside a callee (via `scf.if`, `scf.match`, etc.) lives inside op
+//! regions, so the callee's *top-level* block remains singular even for
+//! complex bodies. Multi-block callees — which typically only exist after
+//! `scf_to_cf` has already lowered them — fall out of scope for v1 and
+//! return `InlineError::MultiBlockCallee`.
 
-use std::collections::BTreeMap;
-
-use crate::context::{BlockArgData, IrContext};
-use crate::dialect::{cf, core, func};
+use crate::context::IrContext;
+use crate::dialect::func;
 use crate::ir_mapping::IrMapping;
 use crate::ops::DialectOp;
-use crate::ops::DialectType;
-use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
-use crate::rewrite::helpers::{inline_region_blocks, split_block};
-use crate::types::Location;
+use crate::refs::{OpRef, RegionRef, ValueRef};
 
 // =========================================================================
 // Errors
@@ -37,6 +33,12 @@ pub enum InlineError {
     CalleeHasNoBody,
     /// The callee body region is empty (no entry block).
     CalleeHasEmptyBody,
+    /// The callee body has more than one top-level block. The v1 inliner
+    /// only handles single-block callees to stay independent of the `cf`
+    /// dialect; multi-block inlining is a follow-up.
+    MultiBlockCallee,
+    /// The callee body's terminator is not `func.return`.
+    CalleeHasNoReturn,
     /// The call-site operand count does not match the callee's parameter count.
     ArityMismatch {
         callee_params: usize,
@@ -56,33 +58,15 @@ pub enum InlineError {
 
 /// Inline a single call site. Handles both `func.call` and `func.tail_call`.
 ///
-/// Steps common to both:
-/// 1. Look up callee body, entry block, and parameters.
-/// 2. Validate operand/return arity.
-/// 3. Clone the callee body into a detached region, mapping callee params
-///    to call-site operand values.
-///
-/// Regular call steps:
-/// 4. Split caller block at the call op → continuation block. Add block
-///    args for call results; RAUW results to those args.
-/// 5. Splice cloned body before the continuation block.
-/// 6. Append `cf.br cloned_entry` to the caller block as its new terminator.
-/// 7. Rewrite each cloned `func.return %v` to `cf.br %v → continuation`.
-/// 8. Erase the original call op (detached from continuation block).
-///
-/// Tail call steps:
-/// 4'. Splice cloned body at the end of the caller's parent region
-///     (no continuation block is needed).
-/// 5'. Append `cf.br cloned_entry` to the caller block, replacing the
-///     tail-call terminator.
-/// 6'. Erase the original tail-call op. Cloned `func.return` ops remain
-///     as-is — they now return from the *caller*.
+/// Requires the callee's body region to contain exactly one top-level block
+/// terminated by a `func.return`. Structured control flow inside the callee
+/// (`scf.if`, `scf.match`, etc.) is preserved as-is because it lives inside
+/// nested op regions, not top-level blocks.
 pub fn inline_single_call(
     ctx: &mut IrContext,
     call_op: OpRef,
     callee_func_op: OpRef,
 ) -> Result<(), InlineError> {
-    // --- Shared validation and cloning ---
     let is_tail = func::TailCall::matches(ctx, call_op);
     let is_regular = func::Call::matches(ctx, call_op);
     if !is_tail && !is_regular {
@@ -96,28 +80,24 @@ pub fn inline_single_call(
         .op(call_op)
         .parent_block
         .ok_or(InlineError::CallOpDetached)?;
-    let parent_region = ctx
-        .block(caller_block)
-        .parent_region
-        .expect("caller block must belong to a region");
 
     let call_loc = ctx.op(call_op).location;
 
-    // Callee body region & entry block
+    // Callee body & entry block (must be single-block).
     let callee_body = ctx
         .op(callee_func_op)
         .regions
         .first()
         .copied()
         .ok_or(InlineError::CalleeHasNoBody)?;
-    let callee_entry = ctx
-        .region(callee_body)
-        .blocks
+    let callee_blocks: Vec<_> = ctx.region(callee_body).blocks.iter().copied().collect();
+    if callee_blocks.len() > 1 {
+        return Err(InlineError::MultiBlockCallee);
+    }
+    let callee_entry = *callee_blocks
         .first()
-        .copied()
         .ok_or(InlineError::CalleeHasEmptyBody)?;
 
-    // Callee params (entry block args) & call operands
     let callee_params: Vec<_> = ctx.block_args(callee_entry).to_vec();
     let call_operands: Vec<_> = ctx.op_operands(call_op).to_vec();
     if callee_params.len() != call_operands.len() {
@@ -127,180 +107,55 @@ pub fn inline_single_call(
         });
     }
 
-    // Deep-clone the callee body region. `clone_region` creates fresh entry
-    // block args and maps old callee params → new cloned args. We pass the
-    // call operands as `cf.br` block args, matching the new entry args.
-    let mut mapping = IrMapping::new();
-    let cloned_region = ctx.clone_region(callee_body, &mut mapping);
-    let cloned_entry = mapping
-        .lookup_block(callee_entry)
-        .expect("clone_region must register entry block mapping");
-
-    if is_tail {
-        inline_tail_call(
-            ctx,
-            call_op,
-            caller_block,
-            parent_region,
-            cloned_region,
-            cloned_entry,
-            &call_operands,
-            call_loc,
-        )
-    } else {
-        inline_regular_call(
-            ctx,
-            call_op,
-            caller_block,
-            parent_region,
-            cloned_region,
-            cloned_entry,
-            &call_operands,
-            call_loc,
-        )
+    // Split the callee block's ops into body (all ops except the terminator)
+    // and the `func.return` terminator itself.
+    let callee_ops: Vec<OpRef> = ctx.block(callee_entry).ops.iter().copied().collect();
+    let (ret_op, body_ops) = callee_ops
+        .split_last()
+        .ok_or(InlineError::CalleeHasEmptyBody)?;
+    if !func::Return::matches(ctx, *ret_op) {
+        return Err(InlineError::CalleeHasNoReturn);
     }
-}
 
-// =========================================================================
-// Regular call path
-// =========================================================================
+    // Mapping: callee params → call-site operands. External references in the
+    // cloned body pass through via `lookup_value_or_default`.
+    let mut mapping = IrMapping::new();
+    for (param, arg) in callee_params.iter().zip(call_operands.iter()) {
+        mapping.map_value(*param, *arg);
+    }
 
-#[allow(clippy::too_many_arguments)]
-fn inline_regular_call(
-    ctx: &mut IrContext,
-    call_op: OpRef,
-    caller_block: BlockRef,
-    parent_region: RegionRef,
-    cloned_region: RegionRef,
-    cloned_entry: BlockRef,
-    call_operands: &[ValueRef],
-    loc: Location,
-) -> Result<(), InlineError> {
-    // Snapshot result values & types before mutations. Skip nil-typed
-    // results: they are "void" in the backend type system and pass-through
-    // block args for them confuse cranelift lowering (same convention as
-    // `scf_to_cf`).
-    let call_results_and_types: Vec<_> = ctx
-        .op_results(call_op)
+    // Clone each body op (in order) into the caller block before `call_op`.
+    // `clone_op` registers old-result → new-result in `mapping`, so later
+    // ops see the remapped SSA values.
+    for &op in body_ops {
+        let new_op = ctx.clone_op(op, &mut mapping);
+        ctx.insert_op_before(caller_block, call_op, new_op);
+    }
+
+    // Map the callee's return operands through the value mapping. These are
+    // what the call site's result values should effectively become.
+    let ret_values: Vec<ValueRef> = ctx
+        .op_operands(*ret_op)
         .iter()
-        .copied()
-        .zip(ctx.op_result_types(call_op).iter().copied())
-        .filter(|(_, ty)| !core::Nil::matches(ctx, *ty))
+        .map(|v| mapping.lookup_value_or_default(*v))
         .collect();
 
-    // 1. Split the caller block so call_op + everything after moves to
-    //    `continuation_block`.
-    let continuation_block = split_block(ctx, caller_block, call_op);
-
-    // 2. Add block args on the continuation block for non-nil call results,
-    //    then RAUW call results → continuation args.
-    for (result, ty) in &call_results_and_types {
-        let new_arg = ctx.add_block_arg(
-            continuation_block,
-            BlockArgData {
-                ty: *ty,
-                attrs: BTreeMap::new(),
-            },
-        );
-        ctx.replace_all_uses(*result, new_arg);
+    if is_tail {
+        // Replace the tail-call terminator with an equivalent `func.return`.
+        let new_ret = func::r#return(ctx, call_loc, ret_values);
+        ctx.insert_op_before(caller_block, call_op, new_ret.op_ref());
+        ctx.detach_op(call_op);
+    } else {
+        // Regular call: RAUW each call result with its mapped return value,
+        // then detach the original call op.
+        let call_results: Vec<_> = ctx.op_results(call_op).to_vec();
+        for (call_result, ret_val) in call_results.iter().zip(ret_values.iter()) {
+            ctx.replace_all_uses(*call_result, *ret_val);
+        }
+        ctx.detach_op(call_op);
     }
 
-    // 3. Splice cloned body before the continuation block.
-    inline_region_blocks(ctx, cloned_region, parent_region, Some(continuation_block));
-
-    // 4. Append `cf.br cloned_entry(...call_operands)` to the caller block.
-    //    The call operands become the cloned entry block's args.
-    let br_op = cf::br(ctx, loc, call_operands.iter().copied(), cloned_entry);
-    ctx.push_op(caller_block, br_op.op_ref());
-
-    // 5. Rewrite each cloned `func.return %v` → `cf.br %v → continuation`.
-    replace_returns_with_branches(ctx, cloned_entry, continuation_block, loc);
-
-    // 6. Detach the original call op. Nil-typed results we filtered earlier
-    //    may still be referenced by downstream ops; `detach_op` (vs.
-    //    `erase_op`) matches the `scf_to_cf` lowering convention and keeps
-    //    those dangling SSA values live in the arena without breaking them.
-    ctx.detach_op(call_op);
-
     Ok(())
-}
-
-// =========================================================================
-// Tail call path
-// =========================================================================
-
-#[allow(clippy::too_many_arguments)]
-fn inline_tail_call(
-    ctx: &mut IrContext,
-    call_op: OpRef,
-    caller_block: BlockRef,
-    parent_region: RegionRef,
-    cloned_region: RegionRef,
-    cloned_entry: BlockRef,
-    call_operands: &[ValueRef],
-    loc: Location,
-) -> Result<(), InlineError> {
-    // 1. Splice cloned body at end of the caller's parent region. CFG
-    //    correctness depends on `cf.br`, not on block order in the region.
-    inline_region_blocks(ctx, cloned_region, parent_region, None);
-
-    // 2. Replace the tail-call terminator with `cf.br cloned_entry(...ops)`.
-    //    `detach_op` rather than `erase_op` keeps arena invariants stable
-    //    even if a nil-typed tail-call variant is ever introduced.
-    ctx.detach_op(call_op);
-    let br_op = cf::br(ctx, loc, call_operands.iter().copied(), cloned_entry);
-    ctx.push_op(caller_block, br_op.op_ref());
-
-    // 3. Cloned `func.return` ops stay as-is: they now return from the caller.
-
-    Ok(())
-}
-
-// =========================================================================
-// Helpers
-// =========================================================================
-
-/// Walk the block graph starting from `entry_block` (all blocks reachable
-/// within the same parent region) and replace each `func.return %v...` with
-/// `cf.br %v... → target`.
-fn replace_returns_with_branches(
-    ctx: &mut IrContext,
-    entry_block: BlockRef,
-    target: BlockRef,
-    loc: Location,
-) {
-    // Walk all blocks reachable from `entry_block`; these are exactly the
-    // just-inlined blocks (the cloned body is self-contained).
-    let target_arg_count = ctx.block_args(target).len();
-    let mut visited: std::collections::HashSet<BlockRef> = std::collections::HashSet::new();
-    let mut stack = vec![entry_block];
-    while let Some(b) = stack.pop() {
-        if !visited.insert(b) {
-            continue;
-        }
-        let ops: Vec<OpRef> = ctx.block(b).ops.to_vec();
-        for op in ops {
-            if func::Return::matches(ctx, op) {
-                // If the target has fewer args than the return supplies
-                // (e.g., nil return filtered out), take only the first N.
-                let values: Vec<_> = ctx
-                    .op_operands(op)
-                    .iter()
-                    .copied()
-                    .take(target_arg_count)
-                    .collect();
-                let br = cf::br(ctx, loc, values, target);
-                ctx.remove_op_from_block(b, op);
-                ctx.push_op(b, br.op_ref());
-                // Don't chase successors of a return op — there are none.
-            } else {
-                let successors = ctx.op(op).successors.clone();
-                for succ in &successors {
-                    stack.push(*succ);
-                }
-            }
-        }
-    }
 }
 
 // =========================================================================
@@ -493,9 +348,11 @@ fn collect_candidates(ctx: &IrContext, graph: &CallGraph) -> Vec<(Symbol, OpRef,
 #[cfg(test)]
 mod mechanics {
     use super::*;
+    use crate::dialect::cf;
     use crate::location::Span;
     use crate::*;
     use smallvec::smallvec;
+    use std::collections::BTreeMap;
 
     fn test_ctx() -> (IrContext, Location) {
         let mut ctx = IrContext::new();
@@ -747,16 +604,9 @@ mod mechanics {
         let _module = build_simple_module(&mut ctx, loc, vec![helper, caller]);
 
         let call_op = find_call_in(&ctx, caller);
-        inline_single_call(&mut ctx, call_op, helper).expect("inline should succeed");
-
-        let body = ctx.op(caller).regions[0];
-        // After inlining, there should be multiple blocks in caller's body.
-        assert!(
-            ctx.region(body).blocks.len() > 1,
-            "multi-block callee should leave caller with multiple blocks"
-        );
-        let (has_call, _) = scan_body(&ctx, body);
-        assert!(!has_call);
+        // v1 rejects multi-block callees to stay independent of the cf dialect.
+        let err = inline_single_call(&mut ctx, call_op, helper).unwrap_err();
+        assert_eq!(err, InlineError::MultiBlockCallee);
     }
 
     #[test]
@@ -870,6 +720,7 @@ mod pass {
     use crate::location::Span;
     use crate::*;
     use smallvec::smallvec;
+    use std::collections::BTreeMap;
 
     fn test_ctx() -> (IrContext, Location) {
         let mut ctx = IrContext::new();

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -1,0 +1,665 @@
+//! Function inlining pass for TrunkIR.
+//!
+//! Replaces `func.call` and `func.tail_call` ops with a cloned copy of the
+//! callee's body, splicing it into the caller's CFG.
+//!
+//! # Strategy
+//!
+//! For regular `func.call` sites, split-and-splice is used uniformly even
+//! for single-block callees — the continuation block's degeneracy can be
+//! collapsed later by canonicalization. See
+//! `transforms::scf_to_cf::replace_yield_with_br` for the same pattern
+//! applied to SCF lowering.
+//!
+//! For `func.tail_call`, no split is required: the tail call is itself
+//! a terminator and "callee return = caller return", so cloned `func.return`
+//! ops remain valid in the caller's function body.
+
+use std::collections::BTreeMap;
+
+use crate::context::{BlockArgData, IrContext};
+use crate::dialect::{cf, func};
+use crate::ir_mapping::IrMapping;
+use crate::ops::DialectOp;
+use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
+use crate::rewrite::helpers::{erase_op, inline_region_blocks, split_block};
+use crate::types::Location;
+
+// =========================================================================
+// Errors
+// =========================================================================
+
+/// Reasons an inline attempt can fail at the primitive level.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InlineError {
+    /// The callee `func.func` has no body region (extern declaration).
+    CalleeHasNoBody,
+    /// The callee body region is empty (no entry block).
+    CalleeHasEmptyBody,
+    /// The call-site operand count does not match the callee's parameter count.
+    ArityMismatch {
+        callee_params: usize,
+        call_operands: usize,
+    },
+    /// The call op is not attached to a block (malformed state).
+    CallOpDetached,
+    /// The callee op is not a `func.func`.
+    NotAFunc,
+    /// The call op is neither `func.call` nor `func.tail_call`.
+    NotACall,
+}
+
+// =========================================================================
+// Public entry: inline_single_call
+// =========================================================================
+
+/// Inline a single call site. Handles both `func.call` and `func.tail_call`.
+///
+/// Steps common to both:
+/// 1. Look up callee body, entry block, and parameters.
+/// 2. Validate operand/return arity.
+/// 3. Clone the callee body into a detached region, mapping callee params
+///    to call-site operand values.
+///
+/// Regular call steps:
+/// 4. Split caller block at the call op → continuation block. Add block
+///    args for call results; RAUW results to those args.
+/// 5. Splice cloned body before the continuation block.
+/// 6. Append `cf.br cloned_entry` to the caller block as its new terminator.
+/// 7. Rewrite each cloned `func.return %v` to `cf.br %v → continuation`.
+/// 8. Erase the original call op (detached from continuation block).
+///
+/// Tail call steps:
+/// 4'. Splice cloned body at the end of the caller's parent region
+///     (no continuation block is needed).
+/// 5'. Append `cf.br cloned_entry` to the caller block, replacing the
+///     tail-call terminator.
+/// 6'. Erase the original tail-call op. Cloned `func.return` ops remain
+///     as-is — they now return from the *caller*.
+pub fn inline_single_call(
+    ctx: &mut IrContext,
+    call_op: OpRef,
+    callee_func_op: OpRef,
+) -> Result<(), InlineError> {
+    // --- Shared validation and cloning ---
+    let is_tail = func::TailCall::matches(ctx, call_op);
+    let is_regular = func::Call::matches(ctx, call_op);
+    if !is_tail && !is_regular {
+        return Err(InlineError::NotACall);
+    }
+    if !func::Func::matches(ctx, callee_func_op) {
+        return Err(InlineError::NotAFunc);
+    }
+
+    let caller_block = ctx
+        .op(call_op)
+        .parent_block
+        .ok_or(InlineError::CallOpDetached)?;
+    let parent_region = ctx
+        .block(caller_block)
+        .parent_region
+        .expect("caller block must belong to a region");
+
+    let call_loc = ctx.op(call_op).location;
+
+    // Callee body region & entry block
+    let callee_body = ctx
+        .op(callee_func_op)
+        .regions
+        .first()
+        .copied()
+        .ok_or(InlineError::CalleeHasNoBody)?;
+    let callee_entry = ctx
+        .region(callee_body)
+        .blocks
+        .first()
+        .copied()
+        .ok_or(InlineError::CalleeHasEmptyBody)?;
+
+    // Callee params (entry block args) & call operands
+    let callee_params: Vec<_> = ctx.block_args(callee_entry).to_vec();
+    let call_operands: Vec<_> = ctx.op_operands(call_op).to_vec();
+    if callee_params.len() != call_operands.len() {
+        return Err(InlineError::ArityMismatch {
+            callee_params: callee_params.len(),
+            call_operands: call_operands.len(),
+        });
+    }
+
+    // Deep-clone the callee body region. `clone_region` creates fresh entry
+    // block args and maps old callee params → new cloned args. We pass the
+    // call operands as `cf.br` block args, matching the new entry args.
+    let mut mapping = IrMapping::new();
+    let cloned_region = ctx.clone_region(callee_body, &mut mapping);
+    let cloned_entry = mapping
+        .lookup_block(callee_entry)
+        .expect("clone_region must register entry block mapping");
+
+    if is_tail {
+        inline_tail_call(
+            ctx,
+            call_op,
+            caller_block,
+            parent_region,
+            cloned_region,
+            cloned_entry,
+            &call_operands,
+            call_loc,
+        )
+    } else {
+        inline_regular_call(
+            ctx,
+            call_op,
+            caller_block,
+            parent_region,
+            cloned_region,
+            cloned_entry,
+            &call_operands,
+            call_loc,
+        )
+    }
+}
+
+// =========================================================================
+// Regular call path
+// =========================================================================
+
+#[allow(clippy::too_many_arguments)]
+fn inline_regular_call(
+    ctx: &mut IrContext,
+    call_op: OpRef,
+    caller_block: BlockRef,
+    parent_region: RegionRef,
+    cloned_region: RegionRef,
+    cloned_entry: BlockRef,
+    call_operands: &[ValueRef],
+    loc: Location,
+) -> Result<(), InlineError> {
+    // Snapshot result values & types before mutations.
+    let call_results: Vec<_> = ctx.op_results(call_op).to_vec();
+    let call_result_types: Vec<_> = ctx.op_result_types(call_op).to_vec();
+
+    // 1. Split the caller block so call_op + everything after moves to
+    //    `continuation_block`.
+    let continuation_block = split_block(ctx, caller_block, call_op);
+
+    // 2. Add block args on the continuation block matching the call's
+    //    result types, then RAUW call results → continuation args.
+    for (result, ty) in call_results.iter().zip(call_result_types.iter()) {
+        let new_arg = ctx.add_block_arg(
+            continuation_block,
+            BlockArgData {
+                ty: *ty,
+                attrs: BTreeMap::new(),
+            },
+        );
+        ctx.replace_all_uses(*result, new_arg);
+    }
+
+    // 3. Splice cloned body before the continuation block.
+    inline_region_blocks(ctx, cloned_region, parent_region, Some(continuation_block));
+
+    // 4. Append `cf.br cloned_entry(...call_operands)` to the caller block.
+    //    The call operands become the cloned entry block's args.
+    let br_op = cf::br(ctx, loc, call_operands.iter().copied(), cloned_entry);
+    ctx.push_op(caller_block, br_op.op_ref());
+
+    // 5. Rewrite each cloned `func.return %v` → `cf.br %v → continuation`.
+    replace_returns_with_branches(ctx, cloned_entry, continuation_block, loc);
+
+    // 6. Erase the original call op. After RAUW its results have no uses.
+    erase_op(ctx, call_op);
+
+    Ok(())
+}
+
+// =========================================================================
+// Tail call path
+// =========================================================================
+
+#[allow(clippy::too_many_arguments)]
+fn inline_tail_call(
+    ctx: &mut IrContext,
+    call_op: OpRef,
+    caller_block: BlockRef,
+    parent_region: RegionRef,
+    cloned_region: RegionRef,
+    cloned_entry: BlockRef,
+    call_operands: &[ValueRef],
+    loc: Location,
+) -> Result<(), InlineError> {
+    // 1. Splice cloned body at end of the caller's parent region. CFG
+    //    correctness depends on `cf.br`, not on block order in the region.
+    inline_region_blocks(ctx, cloned_region, parent_region, None);
+
+    // 2. Replace the tail-call terminator with `cf.br cloned_entry(...ops)`.
+    erase_op(ctx, call_op);
+    let br_op = cf::br(ctx, loc, call_operands.iter().copied(), cloned_entry);
+    ctx.push_op(caller_block, br_op.op_ref());
+
+    // 3. Cloned `func.return` ops stay as-is: they now return from the caller.
+
+    Ok(())
+}
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+/// Walk the block graph starting from `entry_block` (all blocks reachable
+/// within the same parent region) and replace each `func.return %v...` with
+/// `cf.br %v... → target`.
+fn replace_returns_with_branches(
+    ctx: &mut IrContext,
+    entry_block: BlockRef,
+    target: BlockRef,
+    loc: Location,
+) {
+    // Walk all blocks in the region that became the cloned body. Since
+    // `inline_region_blocks` moved those blocks into `parent_region`, we'd
+    // like to limit rewrites to the just-inlined blocks.
+    //
+    // Trick: collect all blocks reachable from `entry_block` via successor
+    // edges. Since the cloned body is self-contained, this hits exactly the
+    // inlined blocks without touching pre-existing ones.
+    let mut visited: std::collections::HashSet<BlockRef> = std::collections::HashSet::new();
+    let mut stack = vec![entry_block];
+    while let Some(b) = stack.pop() {
+        if !visited.insert(b) {
+            continue;
+        }
+        let ops: Vec<OpRef> = ctx.block(b).ops.to_vec();
+        for op in ops {
+            if func::Return::matches(ctx, op) {
+                let values: Vec<_> = ctx.op_operands(op).to_vec();
+                let br = cf::br(ctx, loc, values, target);
+                ctx.remove_op_from_block(b, op);
+                ctx.push_op(b, br.op_ref());
+                // Don't chase successors of a return op — there are none.
+            } else {
+                let successors = ctx.op(op).successors.clone();
+                for succ in &successors {
+                    stack.push(*succ);
+                }
+            }
+        }
+    }
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod mechanics {
+    use super::*;
+    use crate::location::Span;
+    use crate::*;
+    use smallvec::smallvec;
+
+    fn test_ctx() -> (IrContext, Location) {
+        let mut ctx = IrContext::new();
+        let path = ctx.paths.intern("test.trb".to_owned());
+        let loc = Location::new(path, Span::new(0, 0));
+        (ctx, loc)
+    }
+
+    fn i32_type(ctx: &mut IrContext) -> TypeRef {
+        ctx.types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
+    }
+
+    /// Build `func.func @name(params) -> ret_ty { body_builder }`.
+    fn build_func<F>(
+        ctx: &mut IrContext,
+        loc: Location,
+        name: &str,
+        param_tys: &[TypeRef],
+        ret_ty: TypeRef,
+        body_builder: F,
+    ) -> OpRef
+    where
+        F: FnOnce(&mut IrContext, BlockRef, &[ValueRef]),
+    {
+        let fn_ty = {
+            let mut params = vec![ret_ty];
+            params.extend_from_slice(param_tys);
+            ctx.types.intern(
+                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                    .params(params)
+                    .build(),
+            )
+        };
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: param_tys
+                .iter()
+                .map(|&ty| BlockArgData {
+                    ty,
+                    attrs: BTreeMap::new(),
+                })
+                .collect(),
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let args: Vec<_> = ctx.block_args(entry).to_vec();
+        body_builder(ctx, entry, &args);
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        func::func(ctx, loc, Symbol::from_dynamic(name), fn_ty, body).op_ref()
+    }
+
+    fn build_simple_module(ctx: &mut IrContext, loc: Location, ops: Vec<OpRef>) -> OpRef {
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for op in ops {
+            ctx.push_op(block, op);
+        }
+        let region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+        let module_data =
+            OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
+                .attr("sym_name", Attribute::Symbol(Symbol::new("test")))
+                .region(region)
+                .build(ctx);
+        ctx.create_op(module_data)
+    }
+
+    /// Find the single func.call inside `func_op`'s body. Panics if there
+    /// is none or more than one.
+    fn find_call_in(ctx: &IrContext, func_op: OpRef) -> OpRef {
+        use crate::walk::{WalkAction, walk_region};
+        use std::ops::ControlFlow;
+        let mut calls = Vec::new();
+        let body = ctx.op(func_op).regions[0];
+        let _ = walk_region::<()>(ctx, body, &mut |op| {
+            if func::Call::matches(ctx, op) || func::TailCall::matches(ctx, op) {
+                calls.push(op);
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        assert_eq!(
+            calls.len(),
+            1,
+            "expected exactly one call, found {}",
+            calls.len()
+        );
+        calls[0]
+    }
+
+    #[test]
+    fn inline_single_block_callee_no_args() {
+        // helper() -> i32 { return 42 }
+        // caller() -> i32 { return helper() }
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let helper = build_func(&mut ctx, loc, "helper", &[], i32_ty, |ctx, entry, _args| {
+            let c = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(42));
+            ctx.push_op(entry, c.op_ref());
+            let ret = func::r#return(ctx, loc, [c.result(ctx)]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let caller = build_func(&mut ctx, loc, "caller", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(ctx, loc, std::iter::empty(), i32_ty, Symbol::new("helper"));
+            let result = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [result]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+
+        let _module = build_simple_module(&mut ctx, loc, vec![helper, caller]);
+
+        let call_op = find_call_in(&ctx, caller);
+        inline_single_call(&mut ctx, call_op, helper).expect("inline should succeed");
+
+        // Walk caller body, confirm no func.call remains, arith.const present.
+        let body = ctx.op(caller).regions[0];
+        let (has_call, has_const) = scan_body(&ctx, body);
+        assert!(!has_call, "call should be gone after inlining");
+        assert!(has_const, "inlined constant should be present");
+    }
+
+    #[test]
+    fn inline_single_block_callee_with_args() {
+        // helper(x) -> i32 { return x + 1 }
+        // caller() -> i32 { let c = 10; return helper(c) }
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let helper = build_func(
+            &mut ctx,
+            loc,
+            "helper",
+            &[i32_ty],
+            i32_ty,
+            |ctx, entry, args| {
+                let one = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(1));
+                ctx.push_op(entry, one.op_ref());
+                let add_data =
+                    OperationDataBuilder::new(loc, Symbol::new("arith"), Symbol::new("add"))
+                        .operand(args[0])
+                        .operand(one.result(ctx))
+                        .result(i32_ty)
+                        .build(ctx);
+                let add = ctx.create_op(add_data);
+                ctx.push_op(entry, add);
+                let add_result = ctx.op_results(add)[0];
+                let ret = func::r#return(ctx, loc, [add_result]);
+                ctx.push_op(entry, ret.op_ref());
+            },
+        );
+
+        let caller = build_func(&mut ctx, loc, "caller", &[], i32_ty, |ctx, entry, _args| {
+            let c = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(10));
+            ctx.push_op(entry, c.op_ref());
+            let call = func::call(ctx, loc, [c.result(ctx)], i32_ty, Symbol::new("helper"));
+            let result = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [result]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+
+        let _module = build_simple_module(&mut ctx, loc, vec![helper, caller]);
+
+        let call_op = find_call_in(&ctx, caller);
+        inline_single_call(&mut ctx, call_op, helper).expect("inline should succeed");
+
+        let body = ctx.op(caller).regions[0];
+        let (has_call, _) = scan_body(&ctx, body);
+        assert!(!has_call);
+    }
+
+    #[test]
+    fn inline_multi_block_callee() {
+        // helper(x) { if (x) { return x } else { return 0 } }
+        // caller() { let c = 5; return helper(c) }
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        // Build helper with two blocks via cf.cond_br
+        let helper = build_func(
+            &mut ctx,
+            loc,
+            "helper",
+            &[i32_ty],
+            i32_ty,
+            |ctx, entry, args| {
+                // then/else blocks
+                let then_b = ctx.create_block(BlockData {
+                    location: loc,
+                    args: vec![],
+                    ops: smallvec![],
+                    parent_region: None,
+                });
+                let else_b = ctx.create_block(BlockData {
+                    location: loc,
+                    args: vec![],
+                    ops: smallvec![],
+                    parent_region: None,
+                });
+                let cond_br = cf::cond_br(ctx, loc, args[0], then_b, else_b);
+                ctx.push_op(entry, cond_br.op_ref());
+
+                // then: return x
+                let ret_then = func::r#return(ctx, loc, [args[0]]);
+                ctx.push_op(then_b, ret_then.op_ref());
+
+                // else: return 0
+                let zero = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(0));
+                ctx.push_op(else_b, zero.op_ref());
+                let ret_else = func::r#return(ctx, loc, [zero.result(ctx)]);
+                ctx.push_op(else_b, ret_else.op_ref());
+            },
+        );
+
+        // After building the func we need to add the then/else blocks into the body region.
+        // They were created but not attached. Let's add them now.
+        let body = ctx.op(helper).regions[0];
+        let entry_block = ctx.region(body).blocks[0];
+        let then_b = ctx.op(ctx.block(entry_block).ops[0]).successors[0];
+        let else_b = ctx.op(ctx.block(entry_block).ops[0]).successors[1];
+        ctx.region_mut(body).blocks.push(then_b);
+        ctx.region_mut(body).blocks.push(else_b);
+        ctx.block_mut(then_b).parent_region = Some(body);
+        ctx.block_mut(else_b).parent_region = Some(body);
+
+        let caller = build_func(&mut ctx, loc, "caller", &[], i32_ty, |ctx, entry, _args| {
+            let c = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(5));
+            ctx.push_op(entry, c.op_ref());
+            let call = func::call(ctx, loc, [c.result(ctx)], i32_ty, Symbol::new("helper"));
+            let result = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [result]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+
+        let _module = build_simple_module(&mut ctx, loc, vec![helper, caller]);
+
+        let call_op = find_call_in(&ctx, caller);
+        inline_single_call(&mut ctx, call_op, helper).expect("inline should succeed");
+
+        let body = ctx.op(caller).regions[0];
+        // After inlining, there should be multiple blocks in caller's body.
+        assert!(
+            ctx.region(body).blocks.len() > 1,
+            "multi-block callee should leave caller with multiple blocks"
+        );
+        let (has_call, _) = scan_body(&ctx, body);
+        assert!(!has_call);
+    }
+
+    #[test]
+    fn inline_tail_call_single_block() {
+        // helper() -> i32 { return 42 }
+        // caller() -> i32 { tail_call helper() }
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let helper = build_func(&mut ctx, loc, "helper", &[], i32_ty, |ctx, entry, _args| {
+            let c = crate::dialect::arith::r#const(ctx, loc, i32_ty, Attribute::Int(42));
+            ctx.push_op(entry, c.op_ref());
+            let ret = func::r#return(ctx, loc, [c.result(ctx)]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+        let caller = build_func(&mut ctx, loc, "caller", &[], i32_ty, |ctx, entry, _args| {
+            let tc = func::tail_call(ctx, loc, std::iter::empty(), Symbol::new("helper"));
+            ctx.push_op(entry, tc.op_ref());
+        });
+
+        let _module = build_simple_module(&mut ctx, loc, vec![helper, caller]);
+
+        let call_op = find_call_in(&ctx, caller);
+        inline_single_call(&mut ctx, call_op, helper).expect("inline should succeed");
+
+        let body = ctx.op(caller).regions[0];
+        let (has_call, has_const) = scan_body(&ctx, body);
+        assert!(!has_call);
+        assert!(has_const, "inlined constant should be present");
+        // func.return survives in cloned body (as caller's return).
+        assert!(has_return(&ctx, body));
+    }
+
+    #[test]
+    fn inline_arity_mismatch_returns_err() {
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        // helper expects 1 arg, caller passes 0
+        let helper = build_func(
+            &mut ctx,
+            loc,
+            "helper",
+            &[i32_ty],
+            i32_ty,
+            |ctx, entry, args| {
+                let ret = func::r#return(ctx, loc, [args[0]]);
+                ctx.push_op(entry, ret.op_ref());
+            },
+        );
+        let caller = build_func(&mut ctx, loc, "caller", &[], i32_ty, |ctx, entry, _args| {
+            let call = func::call(
+                ctx,
+                loc,
+                std::iter::empty(), // no operands
+                i32_ty,
+                Symbol::new("helper"),
+            );
+            let result = call.result(ctx);
+            ctx.push_op(entry, call.op_ref());
+            let ret = func::r#return(ctx, loc, [result]);
+            ctx.push_op(entry, ret.op_ref());
+        });
+
+        let _module = build_simple_module(&mut ctx, loc, vec![helper, caller]);
+
+        let call_op = find_call_in(&ctx, caller);
+        let err = inline_single_call(&mut ctx, call_op, helper).unwrap_err();
+        matches!(err, InlineError::ArityMismatch { .. });
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers for assertions
+    // -----------------------------------------------------------------
+
+    fn scan_body(ctx: &IrContext, region: RegionRef) -> (bool, bool) {
+        use crate::walk::{WalkAction, walk_region};
+        use std::ops::ControlFlow;
+        let mut has_call = false;
+        let mut has_const = false;
+        let _ = walk_region::<()>(ctx, region, &mut |op| {
+            if func::Call::matches(ctx, op) || func::TailCall::matches(ctx, op) {
+                has_call = true;
+            }
+            if ctx.op(op).dialect == Symbol::new("arith") && ctx.op(op).name == Symbol::new("const")
+            {
+                has_const = true;
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        (has_call, has_const)
+    }
+
+    fn has_return(ctx: &IrContext, region: RegionRef) -> bool {
+        use crate::walk::{WalkAction, walk_region};
+        use std::ops::ControlFlow;
+        let mut found = false;
+        let _ = walk_region::<()>(ctx, region, &mut |op| {
+            if func::Return::matches(ctx, op) {
+                found = true;
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        found
+    }
+}

--- a/crates/trunk-ir/src/transforms/mod.rs
+++ b/crates/trunk-ir/src/transforms/mod.rs
@@ -4,13 +4,17 @@
 //! leveraging use-chains for efficient dead code detection and RAUW for
 //! value remapping.
 
+pub mod call_graph;
 pub mod dce;
 pub mod global_dce;
+pub mod inline;
 pub mod scf_to_cf;
 
+pub use call_graph::{CallGraph, build_call_graph, recursive_functions, tarjan_scc};
 pub use dce::{DceConfig, DceResult, eliminate_dead_code, eliminate_dead_code_with_config};
 pub use global_dce::{
     GlobalDceConfig, GlobalDceResult, eliminate_dead_functions,
     eliminate_dead_functions_with_config,
 };
+pub use inline::{InlineError, inline_single_call};
 pub use scf_to_cf::lower_scf_to_cf;

--- a/crates/trunk-ir/src/transforms/mod.rs
+++ b/crates/trunk-ir/src/transforms/mod.rs
@@ -16,5 +16,8 @@ pub use global_dce::{
     GlobalDceConfig, GlobalDceResult, eliminate_dead_functions,
     eliminate_dead_functions_with_config,
 };
-pub use inline::{InlineError, inline_single_call};
+pub use inline::{
+    InlineConfig, InlineError, InlineResult, inline_functions, inline_functions_with_config,
+    inline_single_call,
+};
 pub use scf_to_cf::lower_scf_to_cf;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -495,7 +495,8 @@ fn run_lowering_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Conversio
     Ok(())
 }
 
-/// Run DCE + resolve_casts (shared cleanup after all lowering).
+/// Run inlining + DCE + resolve_casts (shared cleanup after all lowering).
+///
 fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
     trunk_ir::transforms::global_dce::eliminate_dead_functions(ctx, m);
     let tc = generic_type_converter(ctx);
@@ -513,6 +514,11 @@ fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Conver
 fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), ConversionError> {
     run_lowering_pipeline(ctx, m)?;
 
+    // NOTE: General function inlining (trunk_ir::transforms::inline) is
+    // intentionally not wired into the pipeline yet. The pass mechanics
+    // are fully tested (see inline.rs), but integration uncovered
+    // interactions with `evidence_to_native` on ability-handling IR that
+    // need root-cause analysis. Tracked as follow-up to #675.
     tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
     if cfg!(debug_assertions) {
         let result = trunk_ir::validation::validate_value_integrity(ctx, m);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -514,12 +514,16 @@ fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Conver
 fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), ConversionError> {
     run_lowering_pipeline(ctx, m)?;
 
-    // NOTE: General function inlining (trunk_ir::transforms::inline) is
-    // intentionally not wired into the pipeline yet. The pass mechanics
-    // are fully tested (see inline.rs), but integration uncovered
-    // interactions with `evidence_to_native` on ability-handling IR that
-    // need root-cause analysis. Tracked as follow-up to #675.
     tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
+
+    // General function inlining runs AFTER evidence_to_native. That pass
+    // correlates Marker struct_new / evidence_lookup producer ops with
+    // their consumer calls via a per-block HashMap; inline's split-and-
+    // splice can move producer and consumer into different blocks, which
+    // would break the correlation and leave dead producers with live uses.
+    // Running inline afterwards avoids that because the rewrites have
+    // already collapsed those producer ops into opaque extern calls.
+    trunk_ir::transforms::inline::inline_functions(ctx, m);
     if cfg!(debug_assertions) {
         let result = trunk_ir::validation::validate_value_integrity(ctx, m);
         if !result.is_ok() {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -506,6 +506,11 @@ fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
 /// Run the WASM target pipeline: lowering + cleanup.
 fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), ConversionError> {
     run_lowering_pipeline(ctx, m)?;
+
+    // General function inlining. The pass is single-block-only and cf-free,
+    // so its output stays within dialects WASM lowering already handles.
+    trunk_ir::transforms::inline::inline_functions(ctx, m);
+
     run_cleanup_passes(ctx, m);
     Ok(())
 }
@@ -514,16 +519,13 @@ fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Conver
 fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), ConversionError> {
     run_lowering_pipeline(ctx, m)?;
 
-    tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
-
-    // General function inlining runs AFTER evidence_to_native. That pass
-    // correlates Marker struct_new / evidence_lookup producer ops with
-    // their consumer calls via a per-block HashMap; inline's split-and-
-    // splice can move producer and consumer into different blocks, which
-    // would break the correlation and leave dead producers with live uses.
-    // Running inline afterwards avoids that because the rewrites have
-    // already collapsed those producer ops into opaque extern calls.
+    // General function inlining. Single-block-only (no `cf` dialect
+    // dependency), so it preserves the caller's block structure. That
+    // keeps `evidence_to_native`'s per-block producer/consumer correlation
+    // assumptions intact, and lets the same pass work on both backend paths.
     trunk_ir::transforms::inline::inline_functions(ctx, m);
+
+    tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
     if cfg!(debug_assertions) {
         let result = trunk_ir::validation::validate_value_integrity(ctx, m);
         if !result.is_ok() {


### PR DESCRIPTION
## Summary

- Adds `crates/trunk-ir/src/transforms/call_graph.rs`: directed call graph analysis with Tarjan's SCC for recursion detection, collecting `func.call`/`func.tail_call`/`func.constant` edges across nested `core.module`s
- Adds `crates/trunk-ir/src/transforms/inline.rs`: `inline_single_call` primitive, `InlineConfig`/`InlineResult` types, and `inline_functions` pass entry; single-block callees only (no `cf` dialect dependency)
- Wires inlining into `src/pipeline.rs` for both native and WASM target pipelines

## Design decisions

- **Single-block callee only**: splices callee ops in-place before the call site; no block split, no `cf.br`. This keeps the pass `cf`-dialect-free so it can run on the WASM path as well.
- **Inlining policy**: inline if callee has ≤ 16 ops OR has exactly one call site, unless it escapes via `func.constant`, is recursive (via SCC), or is an ABI function.
- **Pipeline placement (native)**: runs before `evidence_to_native`. An earlier split-and-splice approach caused a "result value still has uses" panic because `evidence_to_native` assumes an `adt.struct_new` Marker and its consumer are in the same block; single-block inlining avoids the split entirely.
- **Pipeline placement (WASM)**: runs before `run_cleanup_passes`.

## Tests

15 unit tests covering:
- Mechanics: single-block inline, argument substitution, tail call, multi-block callee rejection, arity mismatch
- Policy: size threshold, single-call-site, recursion exclusion, escape via `func.constant`, ABI exclusion

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added call-graph construction with recursion detection.
  * Added a configurable function inlining pass with policy controls and single-call-site handling.
* **Behavior Changes**
  * Inlining now runs in native and WebAssembly compilation pipelines (before cleanup), enabling earlier optimization.
* **Tests**
  * Added comprehensive unit tests covering call-graph, inlining correctness, recursion detection, and policy enforcement.
* **Chores**
  * Updated workspace dependencies and simplified iterator formatting to use itertools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->