### PR TITLE
feat(trunk-ir): add canonicalize pass with integer identity folds

### DIFF
--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -1,0 +1,344 @@
+//! Canonicalization pass for TrunkIR.
+//!
+//! Greedy fixed-point pass that folds operations into a canonical form via
+//! local rewrite patterns. The first iteration ships a small set of integer
+//! identity rewrites that the inliner produces in bulk:
+//!
+//! - `arith.addi %x, 0` / `arith.addi 0, %x` → `%x`
+//! - `arith.muli %x, 1` / `arith.muli 1, %x` → `%x`
+//! - `arith.muli %x, 0` / `arith.muli 0, %x` → `arith.const 0`
+//!
+//! Float / div-rem / scf / `unrealized_conversion_cast` patterns live in
+//! follow-up PRs once each one's semantics are pinned down.
+//!
+//! Patterns are language-agnostic: this module sits in `trunk-ir`, not
+//! `tribute-passes`. Each pattern self-filters by dialect/op-name inside
+//! `match_and_rewrite` (the applicator does no central op-kind dispatch).
+
+use crate::context::IrContext;
+use crate::dialect::arith;
+use crate::refs::{OpRef, ValueDef, ValueRef};
+use crate::rewrite::{Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter};
+use crate::symbol::Symbol;
+use crate::types::Attribute;
+
+/// Outcome of one `canonicalize` invocation.
+#[derive(Debug, Clone, Copy)]
+pub struct CanonicalizeResult {
+    pub iterations: usize,
+    pub total_changes: usize,
+    pub reached_fixpoint: bool,
+}
+
+/// Run canonicalization to a fixed point on `module`.
+pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
+    let applicator = PatternApplicator::new(TypeConverter::new())
+        .add_pattern(AddZeroFold)
+        .add_pattern(MulOneFold)
+        .add_pattern(MulZeroFold);
+    let result = applicator.apply_partial(ctx, module);
+    CanonicalizeResult {
+        iterations: result.iterations,
+        total_changes: result.total_changes,
+        reached_fixpoint: result.reached_fixpoint,
+    }
+}
+
+// =========================================================================
+// Patterns
+// =========================================================================
+
+/// `arith.addi %x, 0` / `arith.addi 0, %x` → `%x`.
+pub struct AddZeroFold;
+
+impl RewritePattern for AddZeroFold {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if !op_is(ctx, op, ARITH, ADDI) {
+            return false;
+        }
+        let Some((other, _)) = find_const_int_operand(ctx, op, 0) else {
+            return false;
+        };
+        rewriter.erase_op(vec![other]);
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "AddZeroFold"
+    }
+}
+
+/// `arith.muli %x, 1` / `arith.muli 1, %x` → `%x`.
+pub struct MulOneFold;
+
+impl RewritePattern for MulOneFold {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if !op_is(ctx, op, ARITH, MULI) {
+            return false;
+        }
+        let Some((other, _)) = find_const_int_operand(ctx, op, 1) else {
+            return false;
+        };
+        rewriter.erase_op(vec![other]);
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "MulOneFold"
+    }
+}
+
+/// `arith.muli %x, 0` / `arith.muli 0, %x` → `arith.const {value = 0}`.
+pub struct MulZeroFold;
+
+impl RewritePattern for MulZeroFold {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if !op_is(ctx, op, ARITH, MULI) {
+            return false;
+        }
+        if find_const_int_operand(ctx, op, 0).is_none() {
+            return false;
+        }
+        let loc = ctx.op(op).location;
+        let result_types = ctx.op_result_types(op).to_vec();
+        let result_ty = match result_types.as_slice() {
+            [t] => *t,
+            _ => return false,
+        };
+        let zero = arith::r#const(ctx, loc, result_ty, Attribute::Int(0));
+        rewriter.replace_op(zero.op_ref());
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "MulZeroFold"
+    }
+}
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+const ARITH: &str = "arith";
+const ADDI: &str = "addi";
+const MULI: &str = "muli";
+const CONST: &str = "const";
+const VALUE: &str = "value";
+
+fn op_is(ctx: &IrContext, op: OpRef, dialect: &'static str, name: &'static str) -> bool {
+    let data = ctx.op(op);
+    data.dialect == Symbol::new(dialect) && data.name == Symbol::new(name)
+}
+
+/// If `op` has exactly two operands and one of them is produced by an
+/// `arith.const {value = Int(target)}`, return `(other_operand, const_op)`.
+/// `other_operand` is the operand *not* matched against the constant.
+fn find_const_int_operand(ctx: &IrContext, op: OpRef, target: i128) -> Option<(ValueRef, OpRef)> {
+    let operands = ctx.op_operands(op);
+    if operands.len() != 2 {
+        return None;
+    }
+    let lhs = operands[0];
+    let rhs = operands[1];
+
+    if let Some(c) = const_int_producer(ctx, rhs, target) {
+        return Some((lhs, c));
+    }
+    if let Some(c) = const_int_producer(ctx, lhs, target) {
+        return Some((rhs, c));
+    }
+    None
+}
+
+fn const_int_producer(ctx: &IrContext, value: ValueRef, target: i128) -> Option<OpRef> {
+    let producer = match ctx.value_def(value) {
+        ValueDef::OpResult(op, _) => op,
+        ValueDef::BlockArg(_, _) => return None,
+    };
+    if !op_is(ctx, producer, ARITH, CONST) {
+        return None;
+    }
+    let value_sym: Symbol = Symbol::new(VALUE);
+    match ctx.op(producer).attributes.get(&value_sym) {
+        Some(Attribute::Int(v)) if *v == target => Some(producer),
+        _ => None,
+    }
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::IrContext;
+    use crate::parser::parse_test_module;
+    use crate::printer::print_module;
+    use crate::walk::{WalkAction, walk_op};
+    use std::ops::ControlFlow;
+
+    fn count_ops(ctx: &IrContext, module: Module, dialect: &str, name: &str) -> usize {
+        let dialect_sym = Symbol::from_dynamic(dialect);
+        let name_sym = Symbol::from_dynamic(name);
+        let mut count = 0usize;
+        let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+            let data = ctx.op(op);
+            if data.dialect == dialect_sym && data.name == name_sym {
+                count += 1;
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        count
+    }
+
+    #[test]
+    fn add_zero_fold_rhs_zero() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %z = arith.const {value = 0} : core.i32
+    %r = arith.addi %x, %z : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 0);
+        insta::assert_snapshot!(print_module(&ctx, module.op()));
+    }
+
+    #[test]
+    fn add_zero_fold_lhs_zero() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %z = arith.const {value = 0} : core.i32
+    %r = arith.addi %z, %x : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 0);
+    }
+
+    #[test]
+    fn add_zero_fold_does_not_match_when_neither_operand_is_const_zero() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32, %y: core.i32) -> core.i32 {
+    %r = arith.addi %x, %y : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert_eq!(result.total_changes, 0);
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 1);
+    }
+
+    #[test]
+    fn mul_one_fold_rhs_one() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %one = arith.const {value = 1} : core.i32
+    %r = arith.muli %x, %one : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        assert_eq!(count_ops(&ctx, module, "arith", "muli"), 0);
+    }
+
+    #[test]
+    fn mul_zero_fold_replaces_with_const_zero() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %z = arith.const {value = 0} : core.i32
+    %r = arith.muli %x, %z : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        // muli is gone, two const ops remain: the original `%z` plus the
+        // freshly-built zero replacing the multiplication result.
+        assert_eq!(count_ops(&ctx, module, "arith", "muli"), 0);
+        assert_eq!(count_ops(&ctx, module, "arith", "const"), 2);
+        insta::assert_snapshot!(print_module(&ctx, module.op()));
+    }
+
+    #[test]
+    fn canonicalize_walks_into_nested_regions() {
+        // The fold target lives inside an `scf.if` then-region. The
+        // applicator must descend into nested regions for the rewrite
+        // to fire.
+        let input = r#"core.module @test {
+  func.func @f(%cond: core.i1, %x: core.i32) -> core.i32 {
+    %r = scf.if %cond : core.i32 {
+      %z = arith.const {value = 0} : core.i32
+      %s = arith.addi %x, %z : core.i32
+      scf.yield %s
+    } {
+      scf.yield %x
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 0);
+    }
+
+    #[test]
+    fn canonicalize_reaches_fixpoint_on_chained_identity() {
+        // `((x + 0) + 0)` must collapse to `x` in a single canonicalize
+        // call. The applicator iterates until no pattern fires.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %z = arith.const {value = 0} : core.i32
+    %t = arith.addi %x, %z : core.i32
+    %r = arith.addi %t, %z : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.reached_fixpoint);
+        assert!(result.total_changes >= 2);
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 0);
+    }
+}

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -1302,19 +1302,20 @@ mod pass {
     fn composes_with_another_rewrite_pattern_in_same_applicator() {
         use crate::analysis::AnalysisCache;
         use crate::rewrite::{PatternApplicator, TypeConverter};
-        use std::cell::Cell;
+        use crate::transforms::canonicalize::AddZeroFold;
 
         // helper(%arg) -> %arg + 0
         // main()       -> helper(5)
         //
-        // Running the inliner pattern alongside a "x + 0 → x" fold pattern
-        // in the same applicator drives both to fixed point: inlining
-        // exposes `arith.add %5, %0` inside `main`, the fold pattern erases
-        // it, and the final result contains a single constant + return.
+        // Running the inliner pattern alongside the canonicalize
+        // `AddZeroFold` pattern in the same applicator drives both to a
+        // fixed point: inlining exposes `arith.addi %5, %0` inside `main`,
+        // the fold pattern erases it, and the final result contains a
+        // single constant + return.
         let input = r#"core.module @test {
   func.func @helper(%arg: core.i32) -> core.i32 {
     %0 = arith.const {value = 0} : core.i32
-    %1 = arith.add %arg, %0 : core.i32
+    %1 = arith.addi %arg, %0 : core.i32
     func.return %1
   }
   func.func @main() -> core.i32 {
@@ -1333,27 +1334,24 @@ mod pass {
         let inline_pattern =
             InlineCallSite::new(Arc::clone(&graph), recursive, InlineConfig::default());
 
-        let fold_counter = std::rc::Rc::new(Cell::new(0usize));
-        let fold_pattern = AddZeroFold {
-            counter: std::rc::Rc::clone(&fold_counter),
-        };
-
-        {
+        let total_changes = {
             let applicator = PatternApplicator::new(TypeConverter::new())
                 .add_pattern(inline_pattern)
-                .add_pattern(fold_pattern);
-            applicator.apply_partial(&mut ctx, module);
-        }
+                .add_pattern(AddZeroFold);
+            applicator.apply_partial(&mut ctx, module).total_changes
+        };
 
-        // Fold must have fired at least once on the inlined `arith.add`.
+        // The applicator must have fired both patterns: the inliner once
+        // (call → spliced body) and the fold at least once on the exposed
+        // `arith.addi`. With one call + one add this floor is two changes.
         assert!(
-            fold_counter.get() > 0,
-            "expected add-zero fold to fire at least once"
+            total_changes >= 2,
+            "expected at least one inline + one fold mutation, got {total_changes}"
         );
 
-        // End state: `main` has no calls and no `arith.add` — just the
+        // End state: `main` has no calls and no `arith.addi` — just the
         // const + return left. This is the composition property: the
-        // inliner exposed the `arith.add %5, %0` inside `main`, and the
+        // inliner exposed the `arith.addi %5, %0` inside `main`, and the
         // fold pattern erased it in the same applicator sweep.
         let main_op = graph
             .func_ops
@@ -1365,7 +1363,7 @@ mod pass {
         assert!(!has_call, "main should not contain any calls after run");
         assert!(
             !has_add,
-            "main should not contain any arith.add after composition"
+            "main should not contain any arith.addi after composition"
         );
     }
 
@@ -1378,60 +1376,12 @@ mod pass {
             if func::Call::matches(ctx, op) || func::TailCall::matches(ctx, op) {
                 has_call = true;
             }
-            if ctx.op(op).dialect == Symbol::new("arith") && ctx.op(op).name == Symbol::new("add") {
+            if ctx.op(op).dialect == Symbol::new("arith") && ctx.op(op).name == Symbol::new("addi")
+            {
                 has_add = true;
             }
             ControlFlow::Continue(WalkAction::Advance)
         });
         (has_call, has_add)
-    }
-
-    /// Tiny "x + 0 → x" folding pattern for the composition test.
-    ///
-    /// Matches `arith.add %x, %y` where `%y` is the result of
-    /// `arith.const {value = 0}`, and erases the add while mapping its
-    /// result back to `%x`.
-    struct AddZeroFold {
-        counter: std::rc::Rc<std::cell::Cell<usize>>,
-    }
-
-    impl RewritePattern for AddZeroFold {
-        fn match_and_rewrite(
-            &self,
-            ctx: &mut IrContext,
-            op: OpRef,
-            rewriter: &mut PatternRewriter<'_>,
-        ) -> bool {
-            if ctx.op(op).dialect != Symbol::new("arith") || ctx.op(op).name != Symbol::new("add") {
-                return false;
-            }
-            let operands = ctx.op_operands(op).to_vec();
-            if operands.len() != 2 {
-                return false;
-            }
-            let rhs_def = match ctx.value_def(operands[1]) {
-                crate::refs::ValueDef::OpResult(def_op, _) => def_op,
-                _ => return false,
-            };
-            if ctx.op(rhs_def).dialect != Symbol::new("arith")
-                || ctx.op(rhs_def).name != Symbol::new("const")
-            {
-                return false;
-            }
-            let is_zero = matches!(
-                ctx.op(rhs_def).attributes.get(&Symbol::new("value")),
-                Some(Attribute::Int(0))
-            );
-            if !is_zero {
-                return false;
-            }
-            rewriter.erase_op(vec![operands[0]]);
-            self.counter.set(self.counter.get() + 1);
-            true
-        }
-
-        fn name(&self) -> &'static str {
-            "AddZeroFold"
-        }
     }
 }

--- a/crates/trunk-ir/src/transforms/mod.rs
+++ b/crates/trunk-ir/src/transforms/mod.rs
@@ -5,12 +5,14 @@
 //! value remapping.
 
 pub mod call_graph;
+pub mod canonicalize;
 pub mod dce;
 pub mod global_dce;
 pub mod inline;
 pub mod scf_to_cf;
 
 pub use call_graph::{CallGraph, build_call_graph, recursive_functions, tarjan_scc};
+pub use canonicalize::{CanonicalizeResult, canonicalize};
 pub use dce::{DceConfig, DceResult, eliminate_dead_code, eliminate_dead_code_with_config};
 pub use global_dce::{
     GlobalDceConfig, GlobalDceResult, eliminate_dead_functions,

--- a/crates/trunk-ir/src/transforms/snapshots/trunk_ir__transforms__canonicalize__tests__add_zero_fold_rhs_zero.snap
+++ b/crates/trunk-ir/src/transforms/snapshots/trunk_ir__transforms__canonicalize__tests__add_zero_fold_rhs_zero.snap
@@ -1,0 +1,10 @@
+---
+source: crates/trunk-ir/src/transforms/canonicalize.rs
+expression: "print_module(&ctx, module.op())"
+---
+core.module @test {
+  func.func @f(%0: core.i32) -> core.i32 {
+      %1 = arith.const {value = 0} : core.i32
+      func.return %0
+  }
+}

--- a/crates/trunk-ir/src/transforms/snapshots/trunk_ir__transforms__canonicalize__tests__mul_zero_fold_replaces_with_const_zero.snap
+++ b/crates/trunk-ir/src/transforms/snapshots/trunk_ir__transforms__canonicalize__tests__mul_zero_fold_replaces_with_const_zero.snap
@@ -1,0 +1,11 @@
+---
+source: crates/trunk-ir/src/transforms/canonicalize.rs
+expression: "print_module(&ctx, module.op())"
+---
+core.module @test {
+  func.func @f(%0: core.i32) -> core.i32 {
+      %1 = arith.const {value = 0} : core.i32
+      %2 = arith.const {value = 0} : core.i32
+      func.return %2
+  }
+}

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -499,6 +499,7 @@ fn run_lowering_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Conversio
 ///
 fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
     trunk_ir::transforms::global_dce::eliminate_dead_functions(ctx, m);
+    trunk_ir::transforms::canonicalize::canonicalize(ctx, m);
     let tc = generic_type_converter(ctx);
     resolve_unrealized_casts(ctx, m, &tc);
 }


### PR DESCRIPTION
## Summary

Introduce a language-agnostic canonicalize pass driven by `PatternApplicator`,
running to a fixed point inside `run_cleanup_passes` between
`eliminate_dead_functions` and `resolve_unrealized_casts`. Ships three integer
identity rewrites that the inliner produces in bulk after #683:

- `arith.addi %x, 0` / `arith.addi 0, %x` → `%x` (`AddZeroFold`)
- `arith.muli %x, 1` / `arith.muli 1, %x` → `%x` (`MulOneFold`)
- `arith.muli %x, 0` / `arith.muli 0, %x` → `arith.const 0` (`MulZeroFold`)

This is the first PR for #676. The scope is intentionally narrow — pattern
shell + 3 patterns — so that the cost-heavy decisions (entry signature,
applicator usage, pipeline call site, test conventions) are pinned down once
and follow-up PRs only have to add patterns.

Patterns self-filter by dialect/op-name; producer lookup goes through
`ctx.value_def` and matches `Attribute::Int(target)` on the const op. Float,
div/rem, scf, and `unrealized_conversion_cast` patterns are deferred — each
carries its own semantic question (NaN/-0.0, division-by-zero, region splice,
materialization vs identity).

The inliner's `composes_with_another_rewrite_pattern_in_same_applicator` test
was removed of its local prototype `AddZeroFold` and instead imports the
canonicalize pattern, exercising both inline + canonicalize patterns inside
the same applicator. The input IR's `arith.add` (which was never registered
in the dialect; the parser accepted it as an unknown op) is corrected to
`arith.addi`.

## Follow-up roadmap (per #676 plan)

- **PR-B**: `addi/subi/muli` const fold + remaining identities; div/rem
  guards.
- **PR-C**: `unrealized_conversion_cast` identity / round-trip; tighten
  contract with `resolve_unrealized_casts`.
- **PR-D**: `scf.if(arith.const Bool(_))` region splice + inline+canonicalize
  integration test (interleaved patterns in one applicator).

## Test plan

- [x] `cargo nextest run -p trunk-ir` (237/237)
- [x] `cargo nextest run --workspace` (1280/1280, no e2e regressions)
- [x] `.ci/lint.sh` (rustfmt + clippy + markdownlint)
- [x] 7 in-file tests via `parse_test_module` + `insta::assert_snapshot`
  (positive ×4, negative ×1, nested-region walk ×1, fixed-point chain ×1)

Closes #676 partially (PR-A scope). Follow-up PRs B/C/D will extend the
pattern set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IR canonicalization transformation that automatically optimizes arithmetic operations by folding constant patterns and simplifying expressions into their reduced forms.

* **Improvements**
  * Integrated canonicalization into the compiler optimization pipeline to normalize intermediate representation before downstream transformations, enhancing overall compilation quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->