### PR TITLE
refactor(trunk-ir): MLIR-style fold API for canonicalize patterns

### DIFF
--- a/crates/trunk-ir/src/dialect/arith.rs
+++ b/crates/trunk-ir/src/dialect/arith.rs
@@ -89,262 +89,123 @@ mod arith {
 }
 
 // =========================================================================
-// Canonicalization patterns
+// Canonicalization folds
 //
 // Owned by this dialect and aggregated by `transforms::canonicalize` via
-// [`canonicalization_patterns`]. Each pattern self-filters by op name in
-// `match_and_rewrite` (the applicator does no central op-kind dispatch),
-// so adding a new arith pattern only requires touching this file.
+// [`folds`]. Each fold returns a `FoldResult` describing how the
+// pass should rewrite the op (or `None` to leave it alone). The driver
+// dispatches by (dialect, op_name) so folds don't self-filter.
 // =========================================================================
 
 use crate::context::IrContext;
 use crate::refs::{OpRef, TypeRef, ValueDef, ValueRef};
-use crate::rewrite::{PatternRewriter, RewritePattern};
 use crate::symbol::Symbol;
+use crate::transforms::canonicalize::{FoldFn, FoldResult};
 use crate::types::Attribute;
 
-/// Patterns this dialect contributes to `transforms::canonicalize`.
-pub fn canonicalization_patterns() -> Vec<Box<dyn RewritePattern>> {
+/// Folds this dialect contributes to `transforms::canonicalize`. Returns
+/// `(dialect_symbol, op_name_symbol, fold_fn)` triples — the canonicalize
+/// pass merges these with other dialects' folds into a single dispatcher.
+pub(crate) fn folds() -> Vec<(Symbol, Symbol, FoldFn)> {
+    let arith = Symbol::new("arith");
     vec![
-        Box::new(AddZeroFold),
-        Box::new(SubZeroFold),
-        Box::new(MulOneFold),
-        Box::new(MulZeroFold),
-        Box::new(IntConstFold),
+        (arith, Symbol::new("addi"), fold_addi as FoldFn),
+        (arith, Symbol::new("subi"), fold_subi as FoldFn),
+        (arith, Symbol::new("muli"), fold_muli as FoldFn),
     ]
 }
 
-/// `arith.addi %x, 0` / `arith.addi 0, %x` → `%x`.
-pub struct AddZeroFold;
-
-impl RewritePattern for AddZeroFold {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !op_is(ctx, op, "arith", "addi") {
-            return false;
-        }
-        let Some((other, _)) = find_const_int_operand(ctx, op, 0) else {
-            return false;
-        };
-        rewriter.erase_op(vec![other]);
-        true
+/// `arith.addi` folds:
+/// - `x + 0` / `0 + x` → `x`
+/// - `const(a) + const(b)` → `const(wrap(a+b))` at the result width
+pub(crate) fn fold_addi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
+    let (lhs, rhs) = two_operands(ctx, op)?;
+    if const_int_value(ctx, rhs) == Some(0) {
+        return Some(FoldResult::Forward(lhs));
     }
-
-    fn name(&self) -> &'static str {
-        "AddZeroFold"
+    if const_int_value(ctx, lhs) == Some(0) {
+        return Some(FoldResult::Forward(rhs));
     }
+    let (a, b) = (const_int_value(ctx, lhs)?, const_int_value(ctx, rhs)?);
+    let width = core_int_width(ctx, single_result_type(ctx, op)?)?;
+    Some(FoldResult::ArithConst(Attribute::Int(
+        wrap_signed_to_width(a.wrapping_add(b), width),
+    )))
 }
 
-/// `arith.muli %x, 1` / `arith.muli 1, %x` → `%x`.
-pub struct MulOneFold;
-
-impl RewritePattern for MulOneFold {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !op_is(ctx, op, "arith", "muli") {
-            return false;
-        }
-        let Some((other, _)) = find_const_int_operand(ctx, op, 1) else {
-            return false;
-        };
-        rewriter.erase_op(vec![other]);
-        true
+/// `arith.subi` folds:
+/// - `x - 0` → `x`. (`0 - x` is the `negi` semantic and is left for a
+///   separate fold so the rewrite direction stays unambiguous.)
+/// - `const(a) - const(b)` → `const(wrap(a-b))` at the result width.
+pub(crate) fn fold_subi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
+    let (lhs, rhs) = two_operands(ctx, op)?;
+    if const_int_value(ctx, rhs) == Some(0) {
+        return Some(FoldResult::Forward(lhs));
     }
-
-    fn name(&self) -> &'static str {
-        "MulOneFold"
-    }
+    let (a, b) = (const_int_value(ctx, lhs)?, const_int_value(ctx, rhs)?);
+    let width = core_int_width(ctx, single_result_type(ctx, op)?)?;
+    Some(FoldResult::ArithConst(Attribute::Int(
+        wrap_signed_to_width(a.wrapping_sub(b), width),
+    )))
 }
 
-/// `arith.muli %x, 0` / `arith.muli 0, %x` → `arith.const {value = 0}`.
-pub struct MulZeroFold;
-
-impl RewritePattern for MulZeroFold {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !op_is(ctx, op, "arith", "muli") {
-            return false;
-        }
-        if find_const_int_operand(ctx, op, 0).is_none() {
-            return false;
-        }
-        let loc = ctx.op(op).location;
-        let result_types = ctx.op_result_types(op).to_vec();
-        let result_ty = match result_types.as_slice() {
-            [t] => *t,
-            _ => return false,
-        };
-        let zero = r#const(ctx, loc, result_ty, Attribute::Int(0));
-        rewriter.replace_op(zero.op_ref());
-        true
+/// `arith.muli` folds:
+/// - `x * 0` / `0 * x` → `const 0` (checked before x*1 to short-circuit).
+/// - `x * 1` / `1 * x` → `x`.
+/// - `const(a) * const(b)` → `const(wrap(a*b))` at the result width.
+pub(crate) fn fold_muli(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
+    let (lhs, rhs) = two_operands(ctx, op)?;
+    if const_int_value(ctx, rhs) == Some(0) || const_int_value(ctx, lhs) == Some(0) {
+        return Some(FoldResult::ArithConst(Attribute::Int(0)));
     }
-
-    fn name(&self) -> &'static str {
-        "MulZeroFold"
+    if const_int_value(ctx, rhs) == Some(1) {
+        return Some(FoldResult::Forward(lhs));
     }
-}
-
-/// `arith.subi %x, 0` → `%x`.
-///
-/// `arith.subi 0, %x` is the `negi` semantic and is left for a separate
-/// pattern to keep the rewrite direction unambiguous.
-pub struct SubZeroFold;
-
-impl RewritePattern for SubZeroFold {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !op_is(ctx, op, "arith", "subi") {
-            return false;
-        }
-        let operands = ctx.op_operands(op);
-        if operands.len() != 2 {
-            return false;
-        }
-        let lhs = operands[0];
-        let rhs = operands[1];
-        if const_int_producer(ctx, rhs, 0).is_none() {
-            return false;
-        }
-        rewriter.erase_op(vec![lhs]);
-        true
+    if const_int_value(ctx, lhs) == Some(1) {
+        return Some(FoldResult::Forward(rhs));
     }
-
-    fn name(&self) -> &'static str {
-        "SubZeroFold"
-    }
-}
-
-/// Constant-fold integer binary ops with two `arith.const` operands.
-///
-/// Folds `addi`/`subi`/`muli` at the result type's bit-width. The raw
-/// operation is performed in i128 (wide enough for any width up to i64
-/// without intermediate overflow), then sign-truncated to fit the result
-/// type — so e.g. `arith.addi const(i32::MAX), const(1) : core.i32`
-/// folds to `arith.const i32::MIN`, matching codegen semantics.
-///
-/// Result types must be `core.i{N}` with `1 <= N <= 128`. Other
-/// dialects and exotic integer types fall through unchanged.
-///
-/// `divsi` / `divui` / `remsi` / `remui` are intentionally excluded — they
-/// require a division-by-zero guard that is its own design decision.
-pub struct IntConstFold;
-
-impl RewritePattern for IntConstFold {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        let fold = if op_is(ctx, op, "arith", "addi") {
-            i128::wrapping_add
-        } else if op_is(ctx, op, "arith", "subi") {
-            i128::wrapping_sub
-        } else if op_is(ctx, op, "arith", "muli") {
-            i128::wrapping_mul
-        } else {
-            return false;
-        };
-
-        let operands = ctx.op_operands(op);
-        if operands.len() != 2 {
-            return false;
-        }
-        let lhs = operands[0];
-        let rhs = operands[1];
-        let lhs_val = const_int_value(ctx, lhs);
-        let rhs_val = const_int_value(ctx, rhs);
-        let (Some(a), Some(b)) = (lhs_val, rhs_val) else {
-            return false;
-        };
-
-        let result_types = ctx.op_result_types(op).to_vec();
-        let result_ty = match result_types.as_slice() {
-            [t] => *t,
-            _ => return false,
-        };
-        let Some(width) = core_int_width(ctx, result_ty) else {
-            return false;
-        };
-        let folded = wrap_signed_to_width(fold(a, b), width);
-        let loc = ctx.op(op).location;
-        let new_const = r#const(ctx, loc, result_ty, Attribute::Int(folded));
-        rewriter.replace_op(new_const.op_ref());
-        true
-    }
-
-    fn name(&self) -> &'static str {
-        "IntConstFold"
-    }
+    let (a, b) = (const_int_value(ctx, lhs)?, const_int_value(ctx, rhs)?);
+    let width = core_int_width(ctx, single_result_type(ctx, op)?)?;
+    Some(FoldResult::ArithConst(Attribute::Int(
+        wrap_signed_to_width(a.wrapping_mul(b), width),
+    )))
 }
 
 // =========================================================================
-// Pattern helpers (private to this module)
+// Fold helpers (private to this module)
 // =========================================================================
 
-fn op_is(ctx: &IrContext, op: OpRef, dialect: &'static str, name: &'static str) -> bool {
-    let data = ctx.op(op);
-    data.dialect == Symbol::new(dialect) && data.name == Symbol::new(name)
+/// Extract `(lhs, rhs)` from a binary op. `None` if the op doesn't have
+/// exactly two operands.
+fn two_operands(ctx: &IrContext, op: OpRef) -> Option<(ValueRef, ValueRef)> {
+    match ctx.op_operands(op) {
+        [lhs, rhs] => Some((*lhs, *rhs)),
+        _ => None,
+    }
 }
 
-/// If `op` has exactly two operands and one of them is produced by an
-/// `arith.const {value = Int(target)}`, return `(other_operand, const_op)`.
-/// `other_operand` is the operand *not* matched against the constant.
-fn find_const_int_operand(ctx: &IrContext, op: OpRef, target: i128) -> Option<(ValueRef, OpRef)> {
-    let operands = ctx.op_operands(op);
-    if operands.len() != 2 {
-        return None;
+/// Extract the op's single result type. `None` if the op has zero or
+/// multiple results.
+fn single_result_type(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
+    match ctx.op_result_types(op) {
+        [t] => Some(*t),
+        _ => None,
     }
-    let lhs = operands[0];
-    let rhs = operands[1];
-
-    if let Some(c) = const_int_producer(ctx, rhs, target) {
-        return Some((lhs, c));
-    }
-    if let Some(c) = const_int_producer(ctx, lhs, target) {
-        return Some((rhs, c));
-    }
-    None
-}
-
-fn const_int_producer(ctx: &IrContext, value: ValueRef, target: i128) -> Option<OpRef> {
-    let (producer, v) = const_int_def(ctx, value)?;
-    if v == target { Some(producer) } else { None }
 }
 
 /// If `value` is the result of an `arith.const {value = Int(_)}`, return
 /// its raw integer attribute.
-fn const_int_value(ctx: &IrContext, value: ValueRef) -> Option<i128> {
-    const_int_def(ctx, value).map(|(_, v)| v)
-}
-
-fn const_int_def(ctx: &IrContext, value: ValueRef) -> Option<(OpRef, i128)> {
+pub(crate) fn const_int_value(ctx: &IrContext, value: ValueRef) -> Option<i128> {
     let producer = match ctx.value_def(value) {
         ValueDef::OpResult(op, _) => op,
         ValueDef::BlockArg(_, _) => return None,
     };
-    if !op_is(ctx, producer, "arith", "const") {
+    let producer_data = ctx.op(producer);
+    if producer_data.dialect != Symbol::new("arith") || producer_data.name != Symbol::new("const") {
         return None;
     }
-    let value_sym: Symbol = Symbol::new("value");
-    match ctx.op(producer).attributes.get(&value_sym) {
-        Some(Attribute::Int(v)) => Some((producer, *v)),
+    match producer_data.attributes.get(&Symbol::new("value")) {
+        Some(Attribute::Int(v)) => Some(*v),
         _ => None,
     }
 }
@@ -393,18 +254,20 @@ mod canonicalize_tests {
     use super::*;
     use crate::parser::parse_test_module;
     use crate::printer::print_module;
-    use crate::rewrite::{Module, PatternApplicator, TypeConverter};
+    use crate::rewrite::{ApplyResult, Module, PatternApplicator, TypeConverter};
+    use crate::transforms::canonicalize::FoldDispatchPattern;
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
-    /// Run only this dialect's patterns on `module`. Returns the
-    /// applicator's partial-application result for assertions.
-    fn run_arith_patterns(ctx: &mut IrContext, module: Module) -> crate::rewrite::ApplyResult {
-        let applicator = canonicalization_patterns().into_iter().fold(
-            PatternApplicator::new(TypeConverter::new()),
-            PatternApplicator::add_pattern_box,
-        );
-        applicator.apply_partial(ctx, module)
+    /// Run only this dialect's folds on `module` via a single
+    /// [`FoldDispatchPattern`]. Lets the per-fold tests stay isolated
+    /// from other dialects' folds even though the production
+    /// `canonicalize` pass aggregates everyone.
+    fn run_arith_patterns(ctx: &mut IrContext, module: Module) -> ApplyResult {
+        let dispatcher = FoldDispatchPattern::from_folds(folds());
+        PatternApplicator::new(TypeConverter::new())
+            .add_pattern_box(Box::new(dispatcher))
+            .apply_partial(ctx, module)
     }
 
     fn count_ops(ctx: &IrContext, module: Module, dialect: &str, name: &str) -> usize {

--- a/crates/trunk-ir/src/dialect/core.rs
+++ b/crates/trunk-ir/src/dialect/core.rs
@@ -25,121 +25,66 @@ mod core {
 }
 
 // =========================================================================
-// Canonicalization patterns
+// Canonicalization folds
 //
 // Owned by this dialect and aggregated by `transforms::canonicalize` via
-// [`canonicalization_patterns`]. Each pattern self-filters on
-// `core.unrealized_conversion_cast` via the typed wrapper.
+// [`folds`]. Folds are looked up by (dialect, op_name) so they don't
+// self-filter — they assume the dispatcher already decided this op is
+// `core.unrealized_conversion_cast`.
 // =========================================================================
 
 use crate::context::IrContext;
 use crate::ops::DialectOp;
 use crate::refs::{OpRef, ValueDef};
-use crate::rewrite::{PatternRewriter, RewritePattern};
+use crate::symbol::Symbol;
+use crate::transforms::canonicalize::{FoldFn, FoldResult};
 
-/// Patterns this dialect contributes to `transforms::canonicalize`.
-pub fn canonicalization_patterns() -> Vec<Box<dyn RewritePattern>> {
-    vec![
-        Box::new(UnrealizedCastIdentity),
-        Box::new(UnrealizedCastRoundTrip),
-    ]
+/// Folds this dialect contributes to `transforms::canonicalize`.
+pub(crate) fn folds() -> Vec<(Symbol, Symbol, FoldFn)> {
+    vec![(
+        Symbol::new("core"),
+        Symbol::new("unrealized_conversion_cast"),
+        fold_unrealized_conversion_cast as FoldFn,
+    )]
 }
 
-/// `core.unrealized_conversion_cast %x : T → T` → `%x`.
+/// `core.unrealized_conversion_cast` folds:
 ///
-/// A no-op cast left over from a type conversion that ended up matching the
-/// input type (e.g. after surrounding ops were rewritten). The op carries no
-/// useful work — drop it and forward the operand.
-pub struct UnrealizedCastIdentity;
-
-impl RewritePattern for UnrealizedCastIdentity {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !UnrealizedConversionCast::matches(ctx, op) {
-            return false;
-        }
-        let operands = ctx.op_operands(op);
-        let result_types = ctx.op_result_types(op);
-        if operands.len() != 1 || result_types.len() != 1 {
-            return false;
-        }
-        let input = operands[0];
-        let result_ty = result_types[0];
-        if ctx.value_ty(input) != result_ty {
-            return false;
-        }
-        rewriter.erase_op(vec![input]);
-        true
-    }
-
-    fn name(&self) -> &'static str {
-        "UnrealizedCastIdentity"
-    }
-}
-
-/// `cast<A → B>(cast<B → A>(%x))` → `%x`.
+/// - **Identity** (`%x : T → T`): drop the cast and forward `%x`.
+/// - **Round-trip** (`cast<A → B>(cast<B → A>(%x))`): forward the inner
+///   cast's input; the now-dead inner cast falls to DCE.
 ///
-/// A pair of casts that collapse back to the input type — common when one
-/// rewrite materializes `B` and a later rewrite expects `A` again. We forward
-/// the inner cast's input. The inner cast is left in place; if it had no
-/// other users it becomes dead and is collected by DCE.
-///
-/// Safe *specifically* because both ops are `core.unrealized_conversion_cast`
-/// — dialect-conversion placeholders that carry no value-level conversion
-/// semantics. Resolved casts like `arith.trunc` followed by `arith.extend`
-/// would *not* be safe to collapse this way: a narrower intermediate type
-/// loses information that the outer cast cannot recover (e.g.
-/// `i64 → i32 → i64` discards the upper 32 bits). The pattern's self-filter
-/// on `UnrealizedConversionCast` is what restricts the rewrite to the
-/// information-preserving placeholder case; once `resolve_unrealized_casts`
-/// has run the materializer, no `unrealized_conversion_cast` ops remain and
-/// this pattern is a no-op.
-pub struct UnrealizedCastRoundTrip;
+/// Safe *specifically* because both ops are
+/// `core.unrealized_conversion_cast` — dialect-conversion placeholders
+/// that carry no value-level conversion semantics. A resolved cast pair
+/// like `arith.trunc` followed by `arith.extend` is *not* safe to collapse
+/// the same way (narrower intermediate types lose information). Once
+/// `resolve_unrealized_casts` has run, no `unrealized_conversion_cast`
+/// ops remain and this fold is a no-op.
+pub(crate) fn fold_unrealized_conversion_cast(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
+    let operands = ctx.op_operands(op);
+    let result_types = ctx.op_result_types(op);
+    if operands.len() != 1 || result_types.len() != 1 {
+        return None;
+    }
+    let input = operands[0];
+    let result_ty = result_types[0];
 
-impl RewritePattern for UnrealizedCastRoundTrip {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !UnrealizedConversionCast::matches(ctx, op) {
-            return false;
-        }
-        let operands = ctx.op_operands(op);
-        let result_types = ctx.op_result_types(op);
-        if operands.len() != 1 || result_types.len() != 1 {
-            return false;
-        }
-        let outer_input = operands[0];
-        let outer_result_ty = result_types[0];
-        let producer = match ctx.value_def(outer_input) {
-            ValueDef::OpResult(p, _) => p,
-            ValueDef::BlockArg(_, _) => return false,
-        };
-        if !UnrealizedConversionCast::matches(ctx, producer) {
-            return false;
-        }
-        let inner_operands = ctx.op_operands(producer);
-        let Some(&inner_input) = inner_operands.first() else {
-            return false;
-        };
-        // Round-trip iff the outer's result type matches the inner cast's
-        // input type, i.e. types form `A → B → A`.
-        if ctx.value_ty(inner_input) != outer_result_ty {
-            return false;
-        }
-        rewriter.erase_op(vec![inner_input]);
-        true
+    // Identity: T → T
+    if ctx.value_ty(input) == result_ty {
+        return Some(FoldResult::Forward(input));
     }
 
-    fn name(&self) -> &'static str {
-        "UnrealizedCastRoundTrip"
+    // Round-trip: A → B → A
+    if let ValueDef::OpResult(producer, _) = ctx.value_def(input)
+        && UnrealizedConversionCast::matches(ctx, producer)
+        && let Some(&inner_input) = ctx.op_operands(producer).first()
+        && ctx.value_ty(inner_input) == result_ty
+    {
+        return Some(FoldResult::Forward(inner_input));
     }
+
+    None
 }
 
 // =========================================================================
@@ -156,12 +101,13 @@ mod canonicalize_tests {
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
+    use crate::transforms::canonicalize::FoldDispatchPattern;
+
     fn run_core_patterns(ctx: &mut IrContext, module: Module) -> ApplyResult {
-        let applicator = canonicalization_patterns().into_iter().fold(
-            PatternApplicator::new(TypeConverter::new()),
-            PatternApplicator::add_pattern_box,
-        );
-        applicator.apply_partial(ctx, module)
+        let dispatcher = FoldDispatchPattern::from_folds(folds());
+        PatternApplicator::new(TypeConverter::new())
+            .add_pattern_box(Box::new(dispatcher))
+            .apply_partial(ctx, module)
     }
 
     fn count_ops(ctx: &IrContext, module: Module, dialect: &str, name: &str) -> usize {

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -1,27 +1,142 @@
 //! Canonicalization pass for TrunkIR.
 //!
-//! Greedy fixed-point pass that folds operations into a canonical form via
-//! local rewrite patterns. Patterns are owned by the dialect that defines
-//! the ops they operate on, and aggregated here at pass-construction time.
+//! Greedy fixed-point pass that folds operations into a canonical form.
+//! Each dialect contributes per-op `fold` functions (one fold per op kind)
+//! that return either a value to forward or an attribute that the driver
+//! materializes as `arith.const`. The pass aggregates all dialect folds
+//! into a single dispatch pattern that O(1)-looks up the fold for each
+//! visited op.
 //!
-//! - `arith::canonicalization_patterns()` — integer identities (`x+0`,
-//!   `x*1`, `x*0`, `x-0`) and constant folding for `addi`/`subi`/`muli` at
-//!   the result type's bit-width.
-//! - `core::canonicalization_patterns()` — `unrealized_conversion_cast`
-//!   identity (same source/target type) and round-trip elimination
-//!   (`A → B → A`).
+//! - `arith::folds()` — `addi`/`subi`/`muli` integer identities and
+//!   constant folding at the result type's bit-width.
+//! - `core::folds()` — `unrealized_conversion_cast` identity (same
+//!   source/target type) and round-trip elimination (`A → B → A`).
 //!
-//! Adding a new pattern to an existing dialect requires editing only that
-//! dialect's module. Adding a brand-new dialect's patterns is a one-line
-//! `chain` here. Tracked in #690.
+//! Adding a fold for an existing op = edit one function in that dialect.
+//! Adding a brand-new dialect's folds = a one-line `chain` here. Truly
+//! local rewrites that don't fit the fold shape (e.g. region splice for
+//! `scf.if(const)`) still go through `RewritePattern`; tracked in #690.
 //!
-//! Float, div/rem, and `scf` patterns live in follow-up PRs once each
-//! one's semantics are pinned down (NaN/-0.0, division-by-zero, region
-//! splice).
+//! Float and div/rem folds are deferred until each one's edge cases
+//! (NaN/-0.0, division-by-zero) are pinned down.
+
+use std::collections::HashMap;
 
 use crate::context::IrContext;
 use crate::dialect::{arith, core as core_dialect};
-use crate::rewrite::{Module, PatternApplicator, TypeConverter};
+use crate::refs::{OpRef, ValueRef};
+use crate::rewrite::{Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter};
+use crate::symbol::Symbol;
+use crate::types::Attribute;
+
+// =========================================================================
+// Fold API
+// =========================================================================
+
+/// Result of trying to fold an operation.
+///
+/// Folds are *strict-progress* rewrites — applying one must remove the op
+/// from the IR. A fold function that produces another op of the same
+/// (dialect, op_name) would loop the canonicalize pass; this is a bug in
+/// the fold, not a property the driver tries to detect.
+#[derive(Debug, Clone)]
+pub enum FoldResult {
+    /// RAUW the op's single result with this existing value.
+    Forward(ValueRef),
+    /// Replace with a freshly-built `arith.const` of the op's result type,
+    /// carrying this attribute. The driver materializes the const op.
+    ///
+    /// Specifically named `ArithConst` (not `Const`) so that future
+    /// const-producing dialects require an explicit new variant — the
+    /// driver currently knows only how to build `arith.const`.
+    ArithConst(Attribute),
+}
+
+/// Per-op fold function. `&IrContext` is read-only; mutation happens in
+/// the driver after the fold returns.
+pub type FoldFn = fn(&IrContext, OpRef) -> Option<FoldResult>;
+
+/// One `RewritePattern` that dispatches to per-op fold functions via
+/// hashmap lookup.
+///
+/// Replaces N individual self-filtering patterns (one per op kind) with
+/// a single O(1) dispatcher: instead of every pattern testing
+/// `op.dialect == "arith" && op.name == "addi"`, the dispatcher does one
+/// `HashMap::get((dialect, name))` and calls the fold directly.
+///
+/// The hashmap is built once at pass-construction time. Duplicate
+/// registrations for the same (dialect, op_name) are caught by
+/// `debug_assert!`.
+pub struct FoldDispatchPattern {
+    table: HashMap<(Symbol, Symbol), FoldFn>,
+}
+
+impl FoldDispatchPattern {
+    /// Build a dispatcher from an iterator of `(dialect, op_name, fold)`
+    /// triples. Panics in debug builds on duplicate keys.
+    pub fn from_folds(folds: impl IntoIterator<Item = (Symbol, Symbol, FoldFn)>) -> Self {
+        let mut table = HashMap::new();
+        for (dialect, op_name, fold) in folds {
+            debug_assert!(
+                table.insert((dialect, op_name), fold).is_none(),
+                "duplicate canonicalize fold for {dialect}.{op_name}",
+            );
+        }
+        Self { table }
+    }
+
+    /// Convenience for tests: build a single-entry dispatcher. Lets a
+    /// test compose one specific fold with other patterns in the same
+    /// applicator without pulling in every registered fold.
+    #[cfg(test)]
+    pub(crate) fn single(dialect: &'static str, op_name: &'static str, fold: FoldFn) -> Self {
+        Self::from_folds([(Symbol::new(dialect), Symbol::new(op_name), fold)])
+    }
+}
+
+impl RewritePattern for FoldDispatchPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let key = {
+            let data = ctx.op(op);
+            (data.dialect, data.name)
+        };
+        let Some(fold) = self.table.get(&key).copied() else {
+            return false;
+        };
+        let Some(result) = fold(ctx, op) else {
+            return false;
+        };
+        match result {
+            FoldResult::Forward(v) => {
+                rewriter.erase_op(vec![v]);
+                true
+            }
+            FoldResult::ArithConst(attr) => {
+                let loc = ctx.op(op).location;
+                let result_ty = match ctx.op_result_types(op) {
+                    [t] => *t,
+                    _ => return false,
+                };
+                let new_const = arith::r#const(ctx, loc, result_ty, attr);
+                rewriter.replace_op(new_const.op_ref());
+                true
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "FoldDispatch"
+    }
+}
+
+// =========================================================================
+// Pass entry
+// =========================================================================
 
 /// Outcome of one `canonicalize` invocation.
 #[derive(Debug, Clone, Copy)]
@@ -33,13 +148,10 @@ pub struct CanonicalizeResult {
 
 /// Run canonicalization to a fixed point on `module`.
 pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
-    let applicator = arith::canonicalization_patterns()
-        .into_iter()
-        .chain(core_dialect::canonicalization_patterns())
-        .fold(
-            PatternApplicator::new(TypeConverter::new()),
-            PatternApplicator::add_pattern_box,
-        );
+    let folds = arith::folds().into_iter().chain(core_dialect::folds());
+    let dispatcher = FoldDispatchPattern::from_folds(folds);
+    let applicator =
+        PatternApplicator::new(TypeConverter::new()).add_pattern_box(Box::new(dispatcher));
     let result = applicator.apply_partial(ctx, module);
     CanonicalizeResult {
         iterations: result.iterations,
@@ -52,16 +164,15 @@ pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
 // Pass-level tests
 //
 // Tests that exercise the pass *shell* — region walk, fixed-point
-// iteration, and the collaboration between patterns from one or more
-// dialects. Per-pattern positive/negative tests live alongside the
-// patterns themselves in their respective dialect modules.
+// iteration, and the collaboration between folds from one or more
+// dialects. Per-fold positive/negative tests live alongside the fold
+// itself in its dialect module.
 // =========================================================================
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::parser::parse_test_module;
-    use crate::symbol::Symbol;
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
@@ -128,8 +239,8 @@ mod tests {
     #[test]
     fn fold_and_identity_collaborate_to_fixpoint() {
         // `((2 + 3) * x) + 0` should collapse to `5 * x` after one
-        // canonicalize call: const fold turns `2 + 3` into `5`, then
-        // AddZeroFold erases `_ + 0`.
+        // canonicalize call: `fold_addi` const-folds `2 + 3` to `5`, then
+        // the same fold (on the outer addi) erases `_ + 0`.
         let input = r#"core.module @test {
   func.func @f(%x: core.i32) -> core.i32 {
     %a = arith.const {value = 2} : core.i32

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -1301,17 +1301,19 @@ mod pass {
     #[test]
     fn composes_with_another_rewrite_pattern_in_same_applicator() {
         use crate::analysis::AnalysisCache;
-        use crate::dialect::arith::AddZeroFold;
+        use crate::dialect::arith::fold_addi;
         use crate::rewrite::{PatternApplicator, TypeConverter};
+        use crate::transforms::canonicalize::FoldDispatchPattern;
 
         // helper(%arg) -> %arg + 0
         // main()       -> helper(5)
         //
-        // Running the inliner pattern alongside the canonicalize
-        // `AddZeroFold` pattern in the same applicator drives both to a
-        // fixed point: inlining exposes `arith.addi %5, %0` inside `main`,
-        // the fold pattern erases it, and the final result contains a
-        // single constant + return.
+        // Running the inliner pattern alongside a single-entry
+        // canonicalize fold dispatcher in the same applicator drives
+        // both to a fixed point: inlining exposes `arith.addi %5, %0`
+        // inside `main`, the fold dispatcher rewrites it via
+        // `fold_addi`, and the final result contains a single constant
+        // + return.
         let input = r#"core.module @test {
   func.func @helper(%arg: core.i32) -> core.i32 {
     %0 = arith.const {value = 0} : core.i32
@@ -1335,9 +1337,10 @@ mod pass {
             InlineCallSite::new(Arc::clone(&graph), recursive, InlineConfig::default());
 
         let total_changes = {
+            let dispatcher = FoldDispatchPattern::single("arith", "addi", fold_addi);
             let applicator = PatternApplicator::new(TypeConverter::new())
                 .add_pattern(inline_pattern)
-                .add_pattern(AddZeroFold);
+                .add_pattern_box(Box::new(dispatcher));
             applicator.apply_partial(&mut ctx, module).total_changes
         };
 


### PR DESCRIPTION
PR-X1 of two — fold API today, inventory registration as follow-up. Stacked on top of #693 (per-dialect registry); base is set to that branch and will retarget to \`main\` once #693 merges.

## Summary

The seven \`RewritePattern\` structs that handled integer identities, const folding, and \`unrealized_conversion_cast\` cleanup were mostly "single op in, single value or constant out" — a shape that doesn't need the full \`match_and_rewrite\` ceremony. This PR collapses them to four per-op fold functions returning \`Option<FoldResult>\`, mirroring MLIR's \`fold\` method:

- \`fold_addi\`, \`fold_subi\`, \`fold_muli\` (in \`dialect::arith\`)
- \`fold_unrealized_conversion_cast\` (in \`dialect::core\`)

The cast fold consolidates what was previously \`UnrealizedCastIdentity\` + \`UnrealizedCastRoundTrip\` into one function with two branches; same for arith addi where \`AddZeroFold\` + \`IntConstFold\`'s addi case merge.

\`FoldResult\` is two variants:
- \`Forward(ValueRef)\` — RAUW the op's result with this existing value.
- \`ArithConst(Attribute)\` — replace the op with a fresh \`arith.const\` carrying this attribute. Specifically named (not just \`Const\`) so future const-producing dialects require an explicit new variant.

A single \`FoldDispatchPattern\` hashmap-dispatches visited ops to their fold by \`(dialect, op_name)\`, replacing seven self-filtering patterns with one O(1) lookup. Duplicate-registration is caught by \`debug_assert\` on \`HashMap::insert\`.

Per-dialect ownership is preserved via \`pub(crate) fn folds() -> Vec<(Symbol, Symbol, FoldFn)>\`. The pass aggregates them with \`.chain\`, just as it did with \`canonicalization_patterns()\` before. PR-X2 will move that aggregation to \`inventory::iter\` so the pass no longer imports any specific dialect.

The \`composes_with_another_rewrite_pattern_in_same_applicator\` test in \`inline.rs\` reshapes to compose the inliner with \`FoldDispatchPattern::single(\"arith\", \"addi\", fold_addi)\` instead of the removed \`AddZeroFold\` struct — same composition property tested, new wrapping.

## Why split into PR-X1 and PR-X2?

Different risk profiles:
- **PR-X1** (this): pure shape refactor. Behavior preservation provable by snapshot diff = 0.
- **PR-X2** (follow-up): introduces inventory registration. Different surface area (link-time submission, test isolation, registration determinism). Bisectable independently.

## No behavior change

- 1296 workspace tests pass.
- 0 snapshot diffs (\`find . -name '*.snap.new'\` returns empty).
- Same pass position in \`run_cleanup_passes\`.

## Test plan

- [x] \`cargo nextest run -p trunk-ir\` (253/253 passing)
- [x] \`cargo nextest run --workspace\` (1296/1296 passing)
- [x] \`.ci/lint.sh\` (rustfmt + clippy + markdownlint clean)
- [x] No pending insta snapshots

## Follow-up

PR-X2 will replace \`pub(crate) fn folds()\` with \`inventory::submit!\` calls and add \`register_canonicalize_fold!\` / \`register_canonicalize_pattern!\` macros, completing the dependency inversion (\`canonicalize.rs\` will no longer mention any specific dialect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored canonicalization system from pattern-based to dispatcher-driven fold model for improved performance in constant folding and operation optimization.
  * Streamlined arithmetic and core dialect optimizations with enhanced dispatch efficiency and simplified fold function registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->