### PR TITLE
refactor(trunk-ir): inventory-based registration for canonicalize folds

### DIFF
--- a/crates/trunk-ir/src/dialect/arith.rs
+++ b/crates/trunk-ir/src/dialect/arith.rs
@@ -100,20 +100,15 @@ mod arith {
 use crate::context::IrContext;
 use crate::refs::{OpRef, TypeRef, ValueDef, ValueRef};
 use crate::symbol::Symbol;
-use crate::transforms::canonicalize::{FoldFn, FoldResult};
+use crate::transforms::canonicalize::FoldResult;
 use crate::types::Attribute;
 
-/// Folds this dialect contributes to `transforms::canonicalize`. Returns
-/// `(dialect_symbol, op_name_symbol, fold_fn)` triples — the canonicalize
-/// pass merges these with other dialects' folds into a single dispatcher.
-pub(crate) fn folds() -> Vec<(Symbol, Symbol, FoldFn)> {
-    let arith = Symbol::new("arith");
-    vec![
-        (arith, Symbol::new("addi"), fold_addi as FoldFn),
-        (arith, Symbol::new("subi"), fold_subi as FoldFn),
-        (arith, Symbol::new("muli"), fold_muli as FoldFn),
-    ]
-}
+// Folds this dialect contributes to `transforms::canonicalize`, registered
+// via `inventory`. The pass discovers them at startup; no manual aggregation
+// in `canonicalize.rs` is needed.
+crate::register_canonicalize_fold!(arith.addi => fold_addi);
+crate::register_canonicalize_fold!(arith.subi => fold_subi);
+crate::register_canonicalize_fold!(arith.muli => fold_muli);
 
 /// `arith.addi` folds:
 /// - `x + 0` / `0 + x` → `x`
@@ -255,16 +250,16 @@ mod canonicalize_tests {
     use crate::parser::parse_test_module;
     use crate::printer::print_module;
     use crate::rewrite::{ApplyResult, Module, PatternApplicator, TypeConverter};
-    use crate::transforms::canonicalize::FoldDispatchPattern;
+    use crate::transforms::canonicalize::{FoldDispatchPattern, folds_for_dialect};
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
     /// Run only this dialect's folds on `module` via a single
-    /// [`FoldDispatchPattern`]. Lets the per-fold tests stay isolated
-    /// from other dialects' folds even though the production
-    /// `canonicalize` pass aggregates everyone.
+    /// [`FoldDispatchPattern`]. Filters the inventory by dialect so
+    /// per-fold tests stay isolated from other dialects' folds even
+    /// though the production `canonicalize` pass aggregates everyone.
     fn run_arith_patterns(ctx: &mut IrContext, module: Module) -> ApplyResult {
-        let dispatcher = FoldDispatchPattern::from_folds(folds());
+        let dispatcher = FoldDispatchPattern::from_folds(folds_for_dialect("arith"));
         PatternApplicator::new(TypeConverter::new())
             .add_pattern_box(Box::new(dispatcher))
             .apply_partial(ctx, module)

--- a/crates/trunk-ir/src/dialect/core.rs
+++ b/crates/trunk-ir/src/dialect/core.rs
@@ -36,17 +36,11 @@ mod core {
 use crate::context::IrContext;
 use crate::ops::DialectOp;
 use crate::refs::{OpRef, ValueDef};
-use crate::symbol::Symbol;
-use crate::transforms::canonicalize::{FoldFn, FoldResult};
+use crate::transforms::canonicalize::FoldResult;
 
-/// Folds this dialect contributes to `transforms::canonicalize`.
-pub(crate) fn folds() -> Vec<(Symbol, Symbol, FoldFn)> {
-    vec![(
-        Symbol::new("core"),
-        Symbol::new("unrealized_conversion_cast"),
-        fold_unrealized_conversion_cast as FoldFn,
-    )]
-}
+// Folds this dialect contributes to `transforms::canonicalize`, registered
+// via `inventory`.
+crate::register_canonicalize_fold!(core.unrealized_conversion_cast => fold_unrealized_conversion_cast);
 
 /// `core.unrealized_conversion_cast` folds:
 ///
@@ -101,10 +95,10 @@ mod canonicalize_tests {
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
-    use crate::transforms::canonicalize::FoldDispatchPattern;
+    use crate::transforms::canonicalize::{FoldDispatchPattern, folds_for_dialect};
 
     fn run_core_patterns(ctx: &mut IrContext, module: Module) -> ApplyResult {
-        let dispatcher = FoldDispatchPattern::from_folds(folds());
+        let dispatcher = FoldDispatchPattern::from_folds(folds_for_dialect("core"));
         PatternApplicator::new(TypeConverter::new())
             .add_pattern_box(Box::new(dispatcher))
             .apply_partial(ctx, module)

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -71,19 +71,21 @@ pub type FoldFn = fn(&IrContext, OpRef) -> Option<FoldResult>;
 /// `HashMap::get((dialect, name))` and calls the fold directly.
 ///
 /// The hashmap is built once at pass-construction time. Duplicate
-/// registrations for the same (dialect, op_name) are caught by
-/// `debug_assert!`.
+/// registrations for the same (dialect, op_name) panic via `assert!`
+/// in all build profiles — silently overwriting one fold with another
+/// is always a bug.
 pub struct FoldDispatchPattern {
     table: HashMap<(Symbol, Symbol), FoldFn>,
 }
 
 impl FoldDispatchPattern {
     /// Build a dispatcher from an iterator of `(dialect, op_name, fold)`
-    /// triples. Panics in debug builds on duplicate keys.
+    /// triples. Panics on duplicate keys (in release builds too — see
+    /// type-level docs).
     pub fn from_folds(folds: impl IntoIterator<Item = (Symbol, Symbol, FoldFn)>) -> Self {
         let mut table = HashMap::new();
         for (dialect, op_name, fold) in folds {
-            debug_assert!(
+            assert!(
                 table.insert((dialect, op_name), fold).is_none(),
                 "duplicate canonicalize fold for {dialect}.{op_name}",
             );
@@ -169,6 +171,15 @@ inventory::collect!(CanonicalizeFold);
 /// `'static + Sync` bound. The function builds a fresh boxed pattern
 /// every time the pass runs; any state should be in the pattern itself,
 /// not captured.
+///
+/// **Determinism warning**: `inventory::iter` order is unspecified
+/// (linker-dependent). With a single registered pattern this is
+/// harmless; the moment a *second* `CanonicalizePattern` is registered,
+/// add explicit ordering (e.g. `priority: i32` + `name: &'static str`
+/// fields and sort by `(priority, name)` in `canonicalize()`) so the
+/// first-match-wins behavior of `PatternApplicator` doesn't drift
+/// across builds. Folds are dispatched by op key in
+/// `FoldDispatchPattern`, so the ordering issue applies only here.
 pub struct CanonicalizePattern {
     pub make: fn() -> Box<dyn RewritePattern>,
 }

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -1,21 +1,27 @@
 //! Canonicalization pass for TrunkIR.
 //!
 //! Greedy fixed-point pass that folds operations into a canonical form.
-//! Each dialect contributes per-op `fold` functions (one fold per op kind)
-//! that return either a value to forward or an attribute that the driver
-//! materializes as `arith.const`. The pass aggregates all dialect folds
-//! into a single dispatch pattern that O(1)-looks up the fold for each
-//! visited op.
+//! Each dialect contributes per-op `fold` functions registered via
+//! [`crate::register_canonicalize_fold!`]; the pass discovers them at
+//! startup time through `inventory` rather than referencing each dialect
+//! by name. As a result this module knows nothing about which dialects
+//! exist — adding a new dialect's folds requires no edit here.
 //!
-//! - `arith::folds()` — `addi`/`subi`/`muli` integer identities and
-//!   constant folding at the result type's bit-width.
-//! - `core::folds()` — `unrealized_conversion_cast` identity (same
-//!   source/target type) and round-trip elimination (`A → B → A`).
+//! The driver dispatches each visited op to its fold (if any) by
+//! `(dialect, op_name)` HashMap lookup. A fold returns either a value
+//! to forward (RAUW the op's result) or an `Attribute` that the driver
+//! materializes as `arith.const` of the op's result type.
 //!
-//! Adding a fold for an existing op = edit one function in that dialect.
-//! Adding a brand-new dialect's folds = a one-line `chain` here. Truly
-//! local rewrites that don't fit the fold shape (e.g. region splice for
-//! `scf.if(const)`) still go through `RewritePattern`; tracked in #690.
+//! Multi-op rewrites that don't fit the fold shape (e.g. region splice
+//! for `scf.if(const)`) register as full [`RewritePattern`]s via
+//! [`crate::register_canonicalize_pattern!`] instead.
+//!
+//! Currently registered (across `arith`, `core`):
+//!
+//! - `arith.addi`/`subi`/`muli` — integer identity (`x+0`, `x-0`,
+//!   `x*0`, `x*1`) and constant folding at the result type's bit-width.
+//! - `core.unrealized_conversion_cast` — identity (same source/target
+//!   type) and round-trip elimination (`A → B → A`).
 //!
 //! Float and div/rem folds are deferred until each one's edge cases
 //! (NaN/-0.0, division-by-zero) are pinned down.
@@ -23,7 +29,7 @@
 use std::collections::HashMap;
 
 use crate::context::IrContext;
-use crate::dialect::{arith, core as core_dialect};
+use crate::dialect::arith;
 use crate::refs::{OpRef, ValueRef};
 use crate::rewrite::{Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter};
 use crate::symbol::Symbol;
@@ -85,6 +91,12 @@ impl FoldDispatchPattern {
         Self { table }
     }
 
+    /// Build a dispatcher from every fold registered via
+    /// [`crate::register_canonicalize_fold!`] across the workspace.
+    pub fn from_inventory() -> Self {
+        Self::from_folds(folds_from_inventory())
+    }
+
     /// Convenience for tests: build a single-entry dispatcher. Lets a
     /// test compose one specific fold with other patterns in the same
     /// applicator without pulling in every registered fold.
@@ -135,6 +147,110 @@ impl RewritePattern for FoldDispatchPattern {
 }
 
 // =========================================================================
+// Inventory registration
+// =========================================================================
+
+/// One inventory entry registering a per-op fold function. Submitted via
+/// [`crate::register_canonicalize_fold!`] — never constructed directly
+/// from user code.
+pub struct CanonicalizeFold {
+    pub dialect: &'static str,
+    pub op_name: &'static str,
+    pub fold: FoldFn,
+}
+inventory::collect!(CanonicalizeFold);
+
+/// One inventory entry registering a full `RewritePattern` for the
+/// canonicalize pass — used as an escape hatch for rewrites that don't
+/// fit the fold shape (e.g. multi-op region splicing). Submitted via
+/// [`crate::register_canonicalize_pattern!`].
+///
+/// `make` is a `fn` (not a closure) so the entry meets `inventory`'s
+/// `'static + Sync` bound. The function builds a fresh boxed pattern
+/// every time the pass runs; any state should be in the pattern itself,
+/// not captured.
+pub struct CanonicalizePattern {
+    pub make: fn() -> Box<dyn RewritePattern>,
+}
+inventory::collect!(CanonicalizePattern);
+
+/// Iterate every fold registered via inventory, keyed by interned
+/// `(dialect, op_name)` symbols ready for [`FoldDispatchPattern::from_folds`].
+fn folds_from_inventory() -> impl Iterator<Item = (Symbol, Symbol, FoldFn)> {
+    inventory::iter::<CanonicalizeFold>.into_iter().map(|reg| {
+        (
+            Symbol::from_dynamic(reg.dialect),
+            Symbol::from_dynamic(reg.op_name),
+            reg.fold,
+        )
+    })
+}
+
+/// Iterate inventory folds whose dialect matches `dialect`. Used by
+/// per-dialect test helpers to keep their assertions isolated from
+/// other dialects' folds (folds dispatch by op key, so cross-dialect
+/// interference is unlikely, but filtering keeps tests honest as more
+/// dialects add folds).
+#[cfg(test)]
+pub(crate) fn folds_for_dialect(
+    dialect: &'static str,
+) -> impl Iterator<Item = (Symbol, Symbol, FoldFn)> {
+    inventory::iter::<CanonicalizeFold>
+        .into_iter()
+        .filter(move |reg| reg.dialect == dialect)
+        .map(|reg| {
+            (
+                Symbol::from_dynamic(reg.dialect),
+                Symbol::from_dynamic(reg.op_name),
+                reg.fold,
+            )
+        })
+}
+
+/// Register a per-op fold for the canonicalize pass.
+///
+/// # Example
+/// ```text
+/// register_canonicalize_fold!(arith.addi => fold_addi);
+/// register_canonicalize_fold!(core.unrealized_conversion_cast => fold_uncc);
+/// ```
+///
+/// The dialect and op-name idents are stringified (handling raw
+/// identifiers like `r#const` correctly via `raw_ident_str!`). `$fold`
+/// is a path to a function with signature `fn(&IrContext, OpRef) ->
+/// Option<FoldResult>`.
+#[macro_export]
+macro_rules! register_canonicalize_fold {
+    ($dialect:ident . $op_name:ident => $fold:path) => {
+        ::inventory::submit! {
+            $crate::transforms::canonicalize::CanonicalizeFold {
+                dialect: $crate::raw_ident_str!($dialect),
+                op_name: $crate::raw_ident_str!($op_name),
+                fold: $fold,
+            }
+        }
+    };
+}
+
+/// Register a non-fold `RewritePattern` for the canonicalize pass.
+/// Use when the rewrite needs more than the fold shape allows
+/// (e.g. modifying multiple ops or splicing regions).
+///
+/// # Example
+/// ```text
+/// fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
+/// register_canonicalize_pattern!(make_if_const_fold);
+/// ```
+#[macro_export]
+macro_rules! register_canonicalize_pattern {
+    ($make:path) => {
+        ::inventory::submit! {
+            $crate::transforms::canonicalize::CanonicalizePattern { make: $make }
+        }
+    };
+}
+
+// =========================================================================
 // Pass entry
 // =========================================================================
 
@@ -148,10 +264,11 @@ pub struct CanonicalizeResult {
 
 /// Run canonicalization to a fixed point on `module`.
 pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
-    let folds = arith::folds().into_iter().chain(core_dialect::folds());
-    let dispatcher = FoldDispatchPattern::from_folds(folds);
-    let applicator =
-        PatternApplicator::new(TypeConverter::new()).add_pattern_box(Box::new(dispatcher));
+    let mut applicator = PatternApplicator::new(TypeConverter::new())
+        .add_pattern_box(Box::new(FoldDispatchPattern::from_inventory()));
+    for entry in inventory::iter::<CanonicalizePattern> {
+        applicator = applicator.add_pattern_box((entry.make)());
+    }
     let result = applicator.apply_partial(ctx, module);
     CanonicalizeResult {
         iterations: result.iterations,


### PR DESCRIPTION
PR-X2 of two. Stacked on top of PR #693 (which now also carries the fold API after #694 was merged into its branch); base is set to that branch and will retarget to \`main\` once #693 merges.

## Summary

Drops the manual aggregation in \`canonicalize()\` in favor of \`inventory\`. Previously the pass called \`arith::folds()\` and \`core::folds()\` by name — a coupling between the pass and every dialect that contributes folds. This PR replaces those calls with \`inventory::iter::<CanonicalizeFold>\` so the pass never references any specific dialect, achieving true dependency inversion: adding a brand-new dialect's folds requires zero edits to \`transforms/canonicalize.rs\`.

Models the existing \`register_pure_op!\` infrastructure in \`op_interface.rs\` — same \`inventory\` crate (already a workspace dependency), same macro shape, same \`Symbol::from_dynamic\` interning.

## API surface added

- \`CanonicalizeFold { dialect, op_name, fold }\` + \`inventory::collect!(CanonicalizeFold);\`
- \`register_canonicalize_fold!(dialect.op_name => fold_fn)\` macro using \`raw_ident_str!\` for raw identifier handling (so \`r#const\` stringifies to \`\"const\"\`).
- \`CanonicalizePattern { make: fn() -> Box<dyn RewritePattern> }\` + collect — escape hatch for non-fold rewrites that PR-D will use for \`scf.if(const)\` region splice.
- \`register_canonicalize_pattern!\` macro.
- \`FoldDispatchPattern::from_inventory()\` — builds the dispatcher from all registered folds.
- \`folds_for_dialect(dialect: &'static str)\` (test-only helper) — keeps per-dialect test helpers isolated from other dialects' folds despite the global registry.

## API surface removed

- \`pub(crate) fn folds()\` from \`dialect/arith.rs\` and \`dialect/core.rs\` — replaced with three / one \`register_canonicalize_fold!\` calls respectively.
- \`use crate::dialect::{arith, core as core_dialect};\` import in \`canonicalize.rs\` (only \`arith\` remains, kept solely so \`FoldDispatchPattern::match_and_rewrite\` can call \`arith::r#const\` to materialize \`FoldResult::ArithConst\`).

## Test isolation

\`run_arith_patterns\` and \`run_core_patterns\` switch to \`FoldDispatchPattern::from_folds(folds_for_dialect(\"arith\"))\` / \`(\"core\")\`. Same isolation property as before, preserved against future fold additions.

## Risks (per the design plan)

- **Link-time deadcode**: dialect crate splits could strip \`inventory::submit!\` items. Same risk \`register_pure_op!\` already runs; mitigated by all dialects living in \`trunk-ir\` today. Documented in the canonicalize module doc.
- **Determinism**: \`inventory::iter\` order is unspecified, but \`HashMap\` dispatch makes that irrelevant; duplicate registrations are caught by \`debug_assert!\` on insert.

## No behavior change

- 1296 workspace tests pass.
- 0 snapshot diffs (\`find . -name '*.snap.new'\` returns empty).
- Same pass position in \`run_cleanup_passes\`.

## Test plan

- [x] \`cargo nextest run -p trunk-ir\` (253/253)
- [x] \`cargo nextest run --workspace\` (1296/1296)
- [x] \`.ci/lint.sh\` (rustfmt + clippy + markdownlint clean)
- [x] No pending insta snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved canonicalization optimization registration system for more robust duplicate detection and streamlined pattern discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->