### PR TITLE
feat(trunk-ir): canonicalize scf.if with constant condition

### DIFF
--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -36,3 +36,257 @@ mod scf {
 
     fn r#break(value: ()) {}
 }
+
+// =========================================================================
+// Canonicalization patterns
+//
+// `scf.if(arith.const Int(_) : core.i1)` is the first user of the
+// non-fold escape hatch in `transforms::canonicalize`: the rewrite
+// splices the chosen region's body into the parent block — a multi-op
+// mutation that doesn't fit the single-op `FoldResult` shape.
+// =========================================================================
+
+use crate::context::IrContext;
+use crate::dialect::arith::const_int_value;
+use crate::ops::DialectOp;
+use crate::refs::{OpRef, ValueRef};
+use crate::rewrite::{PatternRewriter, RewritePattern};
+
+crate::register_canonicalize_pattern!(make_if_const_fold);
+
+fn make_if_const_fold() -> Box<dyn RewritePattern> {
+    Box::new(IfConstFold)
+}
+
+/// `scf.if(arith.const Int(c) : core.i1)` → splice the chosen region's
+/// body into the parent block.
+///
+/// When the condition is a compile-time constant, exactly one branch
+/// runs; the other is dead. The chosen region's `scf.yield <values>`
+/// supplies the if op's results, so:
+///
+/// 1. Move every non-terminator op out of the active region's single
+///    block, into the parent block, in original order, immediately
+///    before the `scf.if` op. Captured operands stay valid because the
+///    cloned ops keep referencing the same `ValueRef`s.
+/// 2. RAUW the if op's results with the yield's operands.
+/// 3. Erase the `scf.if`. Its other (dead) region is dropped along
+///    with the orphaned yield from the active region.
+///
+/// Multi-block regions are left alone — they only appear post-`scf_to_cf`,
+/// where this pattern doesn't run anyway. The pattern self-filters on
+/// `scf.if` and bails out on any structural mismatch (yield arity,
+/// non-`i1` const, malformed regions).
+pub struct IfConstFold;
+
+impl RewritePattern for IfConstFold {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if !If::matches(ctx, op) {
+            return false;
+        }
+        let if_op = match If::from_op(ctx, op) {
+            Ok(o) => o,
+            Err(_) => return false,
+        };
+        let cond = if_op.cond(ctx);
+
+        let Some(cond_value) = const_int_value(ctx, cond) else {
+            return false;
+        };
+        let active_region = if cond_value != 0 {
+            if_op.then_region(ctx)
+        } else {
+            if_op.else_region(ctx)
+        };
+
+        // Active region must be a single block whose terminator is `scf.yield`.
+        let blocks = ctx.region(active_region).blocks.to_vec();
+        let [active_block] = blocks.as_slice() else {
+            return false;
+        };
+        let active_block = *active_block;
+        let region_ops: Vec<OpRef> = ctx.block(active_block).ops.to_vec();
+        let Some((yield_op, body_ops)) = region_ops.split_last() else {
+            return false;
+        };
+        if !Yield::matches(ctx, *yield_op) {
+            return false;
+        }
+
+        // Yield arity must match the if op's result count.
+        let yield_operands: Vec<ValueRef> = ctx.op_operands(*yield_op).to_vec();
+        let if_result_count = ctx.op_results(op).len();
+        if yield_operands.len() != if_result_count {
+            return false;
+        }
+
+        // Splice body ops out into the parent block, before `op`.
+        let parent_block = match ctx.op(op).parent_block {
+            Some(b) => b,
+            None => return false,
+        };
+        for body_op in body_ops {
+            ctx.detach_op(*body_op);
+            ctx.insert_op_before(parent_block, op, *body_op);
+        }
+
+        // Detach + destroy the yield — its only user was the implicit
+        // edge to the if op's results, which we are about to erase.
+        ctx.detach_op(*yield_op);
+        ctx.remove_op(*yield_op);
+
+        // Erase the if op, mapping its results to the yield's operands.
+        rewriter.erase_op(yield_operands);
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "IfConstFold"
+    }
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod canonicalize_tests {
+    use super::*;
+    use crate::parser::parse_test_module;
+    use crate::printer::print_module;
+    use crate::rewrite::{ApplyResult, Module, PatternApplicator, TypeConverter};
+    use crate::symbol::Symbol;
+    use crate::walk::{WalkAction, walk_op};
+    use std::ops::ControlFlow;
+
+    /// Run only `IfConstFold` on `module`. Tests stay focused on this
+    /// pattern even though the production `canonicalize` pass aggregates
+    /// every registered fold and pattern.
+    fn run_if_const_fold(ctx: &mut IrContext, module: Module) -> ApplyResult {
+        PatternApplicator::new(TypeConverter::new())
+            .add_pattern(IfConstFold)
+            .apply_partial(ctx, module)
+    }
+
+    fn count_ops(ctx: &IrContext, module: Module, dialect: &str, name: &str) -> usize {
+        let dialect_sym = Symbol::from_dynamic(dialect);
+        let name_sym = Symbol::from_dynamic(name);
+        let mut count = 0usize;
+        let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+            let data = ctx.op(op);
+            if data.dialect == dialect_sym && data.name == name_sym {
+                count += 1;
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        count
+    }
+
+    #[test]
+    fn if_const_true_splices_then_region() {
+        // `scf.if(const true) { %a = arith.addi %x, %x; yield %a } { yield %x }`
+        // → splice the addi into the parent block, replace the if's
+        // result with %a (the yield's operand).
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %t = arith.const {value = 1} : core.i1
+    %r = scf.if %t : core.i32 {
+      %a = arith.addi %x, %x : core.i32
+      scf.yield %a
+    } {
+      scf.yield %x
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_if_const_fold(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
+        // The then-region's `arith.addi` is now at the parent block.
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 1);
+        insta::assert_snapshot!(print_module(&ctx, module.op()));
+    }
+
+    #[test]
+    fn if_const_false_splices_else_region() {
+        // Mirror of the previous test but with const false: the else
+        // region is the active one.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %f = arith.const {value = 0} : core.i1
+    %r = scf.if %f : core.i32 {
+      scf.yield %x
+    } {
+      %a = arith.addi %x, %x : core.i32
+      scf.yield %a
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_if_const_fold(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 1);
+    }
+
+    #[test]
+    fn if_const_does_not_match_non_const_cond() {
+        // The condition is a block argument — the pattern can't decide
+        // which branch runs at compile time, so the if must stay.
+        let input = r#"core.module @test {
+  func.func @f(%cond: core.i1, %x: core.i32) -> core.i32 {
+    %r = scf.if %cond : core.i32 {
+      scf.yield %x
+    } {
+      scf.yield %x
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_if_const_fold(&mut ctx, module);
+        assert_eq!(result.total_changes, 0);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 1);
+    }
+
+    #[test]
+    fn if_const_with_empty_active_region_just_forwards_yield() {
+        // No body ops in the active region — the rewrite still fires:
+        // the if is erased and its result becomes the yield's operand.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %t = arith.const {value = 1} : core.i1
+    %r = scf.if %t : core.i32 {
+      scf.yield %x
+    } {
+      %a = arith.addi %x, %x : core.i32
+      scf.yield %a
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_if_const_fold(&mut ctx, module);
+        assert!(result.total_changes >= 1);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
+        // The else region's addi was dropped along with the if op (it
+        // was unreachable). Only the parent's `func.return` remains for
+        // `arith` ops, plus the const cond.
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 0);
+    }
+}

--- a/crates/trunk-ir/src/dialect/snapshots/trunk_ir__dialect__scf__canonicalize_tests__if_const_true_splices_then_region.snap
+++ b/crates/trunk-ir/src/dialect/snapshots/trunk_ir__dialect__scf__canonicalize_tests__if_const_true_splices_then_region.snap
@@ -1,0 +1,11 @@
+---
+source: crates/trunk-ir/src/dialect/scf.rs
+expression: "print_module(&ctx, module.op())"
+---
+core.module @test {
+  func.func @f(%0: core.i32) -> core.i32 {
+      %1 = arith.const {value = 1} : core.i1
+      %2 = arith.addi %0, %0 : core.i32
+      func.return %2
+  }
+}

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -389,4 +389,41 @@ mod tests {
         // muli %s, %x stays — only one operand is const.
         assert_eq!(count_ops(&ctx, module, "arith", "muli"), 1);
     }
+
+    #[test]
+    fn if_const_collaborates_with_arith_folds() {
+        // `scf.if(true) { yield (x + 0) } { yield x }` should collapse to
+        // `func.return %x` in one canonicalize call, exercising both the
+        // pattern-based escape hatch (`IfConstFold` splices the then
+        // region) and the per-op folds (`fold_addi` erases the `_ + 0`).
+        // The dead else region's `arith.muli` is dropped along with the
+        // erased `scf.if` op.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %t = arith.const {value = 1} : core.i1
+    %r = scf.if %t : core.i32 {
+      %z = arith.const {value = 0} : core.i32
+      %a = arith.addi %x, %z : core.i32
+      scf.yield %a
+    } {
+      %two = arith.const {value = 2} : core.i32
+      %m = arith.muli %x, %two : core.i32
+      scf.yield %m
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.reached_fixpoint);
+        // scf.if is gone; the then-region's body was spliced out.
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
+        // arith.addi was folded away (`x + 0` → `x`).
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 0);
+        // The else region's `arith.muli` was orphaned with the erased
+        // `scf.if`; it should not appear in the walked module.
+        assert_eq!(count_ops(&ctx, module, "arith", "muli"), 0);
+    }
 }


### PR DESCRIPTION
PR-D in the #676 canonicalize roadmap. First user of the non-fold escape hatch (\`register_canonicalize_pattern!\`) introduced in the inventory refactor.

## Summary

Adds \`IfConstFold\` to \`dialect::scf\`: when an \`scf.if\`'s condition is \`arith.const Int(c) : core.i1\`, one branch is unreachable. The pattern splices the active region's body into the parent block, RAUWs the if's results with the chosen \`scf.yield\`'s operands, and erases the if op (dropping the dead region with it).

The rewrite is multi-op (move N body ops + erase yield + erase if), which is exactly why folds aren't enough — \`FoldResult\` is single-op replacement only. \`IfConstFold\` validates the escape hatch design.

Implementation notes:
- Registered via \`crate::register_canonicalize_pattern!(make_if_const_fold);\` next to the op definition in \`dialect/scf.rs\`. \`canonicalize.rs\` doesn't import scf at all — discovery is purely through inventory.
- Reuses \`dialect::arith::const_int_value\` (now \`pub(crate)\` after the typed-wrapper refactor in 679d73cd) so the arith.const walk doesn't have to be duplicated.
- Bails on multi-block regions, missing yield, or yield arity mismatch — those only appear post-\`scf_to_cf\` where canonicalize doesn't run.
- Uses the typed wrappers \`scf::If::matches\` / \`from_op\` and \`scf::Yield::matches\` per \`.claude/rules/conventions.md\`.

## Tests

Per-pattern (in \`dialect::scf::canonicalize_tests\`):
- \`if_const_true_splices_then_region\` — positive, with snapshot.
- \`if_const_false_splices_else_region\` — positive (mirror).
- \`if_const_does_not_match_non_const_cond\` — negative.
- \`if_const_with_empty_active_region_just_forwards_yield\` — degenerate active region.

Pass-level integration (in \`transforms::canonicalize::tests\`):
- \`if_const_collaborates_with_arith_folds\` — \`scf.if(true) { yield (x + 0) }\` collapses to \`func.return %x\` in one canonicalize call. Demonstrates the pattern escape hatch and per-op folds working together via the same applicator pass.

## Test plan

- [x] \`cargo nextest run -p trunk-ir\` (258/258)
- [x] \`cargo nextest run --workspace\` (1301/1301)
- [x] \`.ci/lint.sh\` (rustfmt + clippy + markdownlint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added constant-folding optimization for conditional branches with compile-time-constant conditions.

* **Tests**
  * Added tests to verify optimization behavior and interaction with other simplifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->