### PR TITLE
chore(canonicalize): surface fixed-point miss to caller

### DIFF
--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -266,6 +266,12 @@ macro_rules! register_canonicalize_pattern {
 // =========================================================================
 
 /// Outcome of one `canonicalize` invocation.
+///
+/// `#[must_use]` because silently dropping the result hides the case
+/// where the pass exhausted its iteration budget without reaching a
+/// fixed point — a real bug we want callers to acknowledge (log, fail,
+/// or explicitly `let _ = ...` to opt out).
+#[must_use]
 #[derive(Debug, Clone, Copy)]
 pub struct CanonicalizeResult {
     pub iterations: usize,

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -432,4 +432,53 @@ mod tests {
         // `scf.if`; it should not appear in the walked module.
         assert_eq!(count_ops(&ctx, module, "arith", "muli"), 0);
     }
+
+    #[test]
+    fn canonicalize_reports_no_changes_on_already_canonical_module() {
+        // A module with nothing to fold must converge in a single
+        // sweep that records zero changes — the result fields the
+        // pipeline now relies on (iterations / total_changes /
+        // reached_fixpoint) must reflect that exactly.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    func.return %x
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = canonicalize(&mut ctx, module);
+        assert!(result.reached_fixpoint);
+        assert_eq!(result.iterations, 1);
+        assert_eq!(result.total_changes, 0);
+    }
+
+    #[test]
+    fn applicator_reports_non_fixpoint_when_iteration_budget_exhausted() {
+        // `((x + 0) + 0)` collapses fully in one greedy sweep, but
+        // confirming the fixed point still requires a follow-up
+        // iteration with zero changes. Capping the budget at 1
+        // forces the run to terminate as non-fixpoint with at
+        // least one fold applied — the exact case
+        // `run_cleanup_passes` now logs about.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %z = arith.const {value = 0} : core.i32
+    %t = arith.addi %x, %z : core.i32
+    %r = arith.addi %t, %z : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let applicator = PatternApplicator::new(TypeConverter::new())
+            .with_max_iterations(1)
+            .add_pattern_box(Box::new(FoldDispatchPattern::from_inventory()));
+        let result = applicator.apply_partial(&mut ctx, module);
+
+        assert!(!result.reached_fixpoint);
+        assert_eq!(result.iterations, 1);
+        assert!(result.total_changes >= 1);
+    }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -499,7 +499,14 @@ fn run_lowering_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Conversio
 ///
 fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
     trunk_ir::transforms::global_dce::eliminate_dead_functions(ctx, m);
-    trunk_ir::transforms::canonicalize::canonicalize(ctx, m);
+    let result = trunk_ir::transforms::canonicalize::canonicalize(ctx, m);
+    if !result.reached_fixpoint {
+        tracing::warn!(
+            "canonicalize did not reach a fixed point: {} iterations, {} changes",
+            result.iterations,
+            result.total_changes,
+        );
+    }
     let tc = generic_type_converter(ctx);
     resolve_unrealized_casts(ctx, m, &tc);
 }


### PR DESCRIPTION
## Summary

- Mark `CanonicalizeResult` `#[must_use]` so callers can't silently drop the outcome of the pass — in particular, the case where the iteration budget (default 10) was exhausted without reaching a fixed point.
- At the pipeline cleanup-passes call site, log a `tracing::warn!` when `reached_fixpoint == false` so non-converging runs are visible.

## Why

`PatternApplicator::apply_partial` caps at `max_iterations = 10` and returns `reached_fixpoint: false` when the cap is hit, but the only production caller (`run_cleanup_passes` in `src/pipeline.rs`) was throwing the result away. There was no way to know whether canonicalize was actually converging on real inputs.

Behavior is unchanged on success — this is purely observability. Once we have data from real runs, raising `max_iterations` (or removing the cap) becomes a justified follow-up rather than guesswork.

## Test plan

- [x] `cargo nextest run --workspace` — 1313/1313 passed
- [x] `.ci/lint.sh` — rustfmt + clippy + markdownlint clean
- [x] `cargo build` — `#[must_use]` introduced no warnings (all current callers already capture the result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emit warnings when internal processing hits iteration limits, showing iteration and change counts for better visibility.
* **Documentation**
  * Clarified behavior of canonicalization results in docs to highlight when results must be inspected.
* **Tests**
  * Added pass-level tests to ensure canonicalization convergence and correct reporting when iteration budgets are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->