### PR TITLE
refactor(trunk-ir): drop crate = crate knob via extern crate self

### DIFF
--- a/crates/trunk-ir-macros/src/lib.rs
+++ b/crates/trunk-ir-macros/src/lib.rs
@@ -25,10 +25,10 @@ mod parse;
 /// }
 /// ```
 ///
-/// ## Crate path
-///
-/// - `#[dialect] mod ...` — defaults to `trunk_ir` (for external crates)
-/// - `#[dialect(crate = crate)] mod ...` — for use within `trunk-ir` itself
+/// The macro emits absolute `::trunk_ir::...` paths. In-crate uses rely
+/// on `extern crate self as trunk_ir;` (declared at the trunk-ir crate
+/// root); external crates resolve `trunk_ir` through the normal
+/// dependency.
 ///
 /// ## Generated code
 ///
@@ -56,6 +56,7 @@ fn dialect_impl(
     attr: proc_macro2::TokenStream,
     item: proc_macro2::TokenStream,
 ) -> Result<proc_macro2::TokenStream, String> {
-    let (crate_path, module) = parse::parse_input(attr, item)?;
+    let module = parse::parse_input(attr, item)?;
+    let crate_path = quote::quote!(::trunk_ir);
     Ok(codegen::generate(&crate_path, &module))
 }

--- a/crates/trunk-ir-macros/src/parse.rs
+++ b/crates/trunk-ir-macros/src/parse.rs
@@ -98,46 +98,16 @@ pub enum RegionOrSuccessor {
 // Top-level input parsing
 // ============================================================================
 
-/// Parse attribute macro input: `attr` contains optional `crate = path`,
-/// `item` contains `mod name { ... }`.
+/// Parse attribute macro input: `attr` must be empty, `item` contains
+/// `mod name { ... }`.
 pub fn parse_input(
     attr: proc_macro2::TokenStream,
     item: proc_macro2::TokenStream,
-) -> Result<(proc_macro2::TokenStream, DialectModule), String> {
-    let crate_path = parse_crate_attr(attr)?;
-    let module = parse_module(item)?;
-    Ok((crate_path, module))
-}
-
-/// Parse optional `crate = path` from the attribute arguments.
-fn parse_crate_attr(stream: proc_macro2::TokenStream) -> Result<proc_macro2::TokenStream, String> {
-    let mut iter = stream.to_token_iter();
-
-    if !has_remaining(&iter) {
-        return Ok(quote::quote!(trunk_ir));
+) -> Result<DialectModule, String> {
+    if !attr.is_empty() {
+        return Err("`#[dialect]` does not accept arguments".to_string());
     }
-
-    let kw: Ident =
-        Ident::parser(&mut iter).map_err(|e| format!("expected `crate` keyword: {e}"))?;
-    if kw != "crate" {
-        return Err(format!("expected `crate`, got `{kw}`"));
-    }
-
-    expect_punct(&mut iter, '=')?;
-
-    // Collect the remaining tokens as the crate path
-    let mut path_tokens = proc_macro2::TokenStream::new();
-    while has_remaining(&iter) {
-        let tt: TokenTree =
-            TokenTree::parser(&mut iter).map_err(|e| format!("error parsing crate path: {e}"))?;
-        path_tokens.extend(std::iter::once(tt));
-    }
-
-    if path_tokens.is_empty() {
-        return Err("expected crate path after `=`".into());
-    }
-
-    Ok(path_tokens)
+    parse_module(item)
 }
 
 /// Parse `mod name { ... }` from the item token stream.
@@ -714,13 +684,12 @@ mod tests {
     use quote::quote;
 
     fn parse_test_module(item: proc_macro2::TokenStream) -> Result<DialectModule, String> {
-        let (_, module) = parse_input(quote! {}, item)?;
-        Ok(module)
+        parse_input(quote! {}, item)
     }
 
     #[test]
-    fn test_parse_default_crate_path() {
-        let (path, module) = parse_input(
+    fn test_parse_empty_attr() {
+        let module = parse_input(
             quote! {},
             quote! {
                 mod arith {
@@ -730,38 +699,27 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path.to_string(), "trunk_ir");
         assert_eq!(module.name, "arith");
     }
 
     #[test]
-    fn test_parse_crate_path_crate() {
-        let (path, _) = parse_input(
+    fn test_parse_rejects_non_empty_attr() {
+        // The macro emits absolute `::trunk_ir::...` paths, so the
+        // legacy `crate = crate` knob has no purpose. Reject any
+        // attribute argument outright.
+        let result = parse_input(
             quote! { crate = crate },
             quote! {
                 mod arith {
                     fn add(lhs: (), rhs: ()) -> result {}
                 }
             },
-        )
-        .unwrap();
+        );
 
-        assert_eq!(path.to_string(), "crate");
-    }
-
-    #[test]
-    fn test_parse_crate_path_custom() {
-        let (path, _) = parse_input(
-            quote! { crate = my_crate::ir },
-            quote! {
-                mod arith {
-                    fn add(lhs: (), rhs: ()) -> result {}
-                }
-            },
-        )
-        .unwrap();
-
-        assert_eq!(path.to_string(), "my_crate :: ir");
+        let Err(err) = result else {
+            panic!("expected error for non-empty attr");
+        };
+        assert!(err.contains("does not accept arguments"), "got: {err}");
     }
 
     #[test]

--- a/crates/trunk-ir/src/dialect/adt.rs
+++ b/crates/trunk-ir/src/dialect/adt.rs
@@ -32,7 +32,7 @@ crate::register_pure_op!(adt.ref_cast);
 crate::register_pure_op!(adt.string_const);
 crate::register_pure_op!(adt.bytes_const);
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod adt {
     #[attr(r#type: Type)]
     fn struct_new(#[rest] fields: ()) -> result {}

--- a/crates/trunk-ir/src/dialect/arith.rs
+++ b/crates/trunk-ir/src/dialect/arith.rs
@@ -44,7 +44,7 @@ crate::register_pure_op!(arith.trunc);
 crate::register_pure_op!(arith.extend);
 crate::register_pure_op!(arith.convert);
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod arith {
     #[attr(value: any)]
     fn r#const() -> result {}

--- a/crates/trunk-ir/src/dialect/cf.rs
+++ b/crates/trunk-ir/src/dialect/cf.rs
@@ -1,6 +1,6 @@
 //! Arena-based cf dialect.
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod cf {
     fn br(#[rest] args: ()) {
         #[successor(dest)]

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -1,6 +1,6 @@
 //! Arena-based clif dialect.
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod clif {
     // Module
     #[attr(sym_name: Symbol, r#type: Type)]

--- a/crates/trunk-ir/src/dialect/core.rs
+++ b/crates/trunk-ir/src/dialect/core.rs
@@ -3,7 +3,7 @@
 // === Operation registrations ===
 crate::register_isolated_op!(core.module);
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod core {
     #[attr(sym_name: Symbol)]
     fn module() {

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -4,7 +4,7 @@
 crate::register_pure_op!(func.constant);
 crate::register_isolated_op!(func.func);
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod func {
     #[attr(sym_name: Symbol, r#type: Type)]
     fn func() {

--- a/crates/trunk-ir/src/dialect/mem.rs
+++ b/crates/trunk-ir/src/dialect/mem.rs
@@ -4,7 +4,7 @@
 crate::register_pure_op!(mem.data);
 // mem.load is intentionally NOT pure: loads depend on mutable memory and may trap.
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod mem {
     #[attr(bytes: any)]
     fn data() -> result {}

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -1,6 +1,6 @@
 //! Arena-based scf dialect.
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod scf {
     fn r#if(cond: ()) -> result {
         #[region(then_region)]

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -1,6 +1,6 @@
 //! Arena-based wasm dialect.
 
-#[crate::dialect(crate = crate)]
+#[trunk_ir::dialect]
 mod wasm {
     // Types (abstract heap types)
     struct Anyref;

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -5,6 +5,10 @@
 
 #![recursion_limit = "512"]
 
+// Self-alias so proc-macro–generated `::trunk_ir::...` paths resolve
+// inside this crate the same way they do for downstream consumers.
+extern crate self as trunk_ir;
+
 // === Salsa-independent primitives ===
 pub mod symbol;
 


### PR DESCRIPTION
## Summary

Pure-refactor preparation step for upcoming `#[canonicalize_fold]` / `#[canonicalize_pattern]` proc-macro work — removes the `crate = crate` asymmetry between in-crate and external-crate uses of `#[dialect]` so the new attributes don't have to inherit it.

- `crates/trunk-ir/src/lib.rs`: declare `extern crate self as trunk_ir;` so absolute `::trunk_ir::...` paths resolve from inside the crate.
- `crates/trunk-ir-macros/src/{lib,parse}.rs`: remove the `parse_crate_attr` parser and the threading; the macro now always emits `::trunk_ir::...`. Reject any non-empty attribute argument (no back-compat shim).
- 9 in-crate dialect call sites: `#[crate::dialect(crate = crate)]` → `#[trunk_ir::dialect]`.
- Replace the 3 \`crate = path\` parser tests with two new ones (empty-attr-accepted, non-empty-attr-rejected).

External `#[trunk_ir::dialect]` uses in `tribute-ir` (closure / ability / tribute_rt) are untouched.

## Why

The next planned PR introduces `#[canonicalize_fold(arith.addi)]` / `#[canonicalize_pattern]` proc macros to replace today's `register_canonicalize_fold!` / `register_canonicalize_pattern!` macro_rules!. Doing it on top of this PR means the new attributes can use the same form everywhere instead of needing their own `crate = crate` knob.

## Test plan

- [x] \`cargo build -p trunk-ir-macros\`, \`cargo build -p trunk-ir\`, \`cargo build -p tribute-ir\` — all pass.
- [x] \`cargo nextest run --workspace\` — 1324/1324 passed (was 1325; net −1 because 3 \`crate = path\` parser tests collapsed into 2 new ones).
- [x] \`.ci/lint.sh\` — rustfmt + clippy + markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified `#[dialect]` macro syntax: dialect attributes across all modules now use `#[trunk_ir::dialect]` instead of requiring custom crate path parameters.
  * Updated macro implementation to use absolute path resolution for consistent code generation.
  * Removed custom crate path configuration option from macro parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->