### PR TITLE
feat(trunk-ir): attribute-style canonicalize fold/pattern registration

### DIFF
--- a/crates/trunk-ir-macros/src/canonicalize.rs
+++ b/crates/trunk-ir-macros/src/canonicalize.rs
@@ -9,11 +9,12 @@ use quote::quote;
 /// Generate the expanded form for `#[canonicalize_fold(<dialect>.<op>)]`.
 pub fn gen_fold(attr: TokenStream, item: TokenStream) -> Result<TokenStream, String> {
     let (dialect, op_name) = parse_dialect_op(attr)?;
-    let fn_ident = extract_fn_ident(&item)?;
+    let (fn_attrs, fn_ident) = extract_fn_attrs_and_ident(&item)?;
     Ok(quote! {
         #item
 
-        ::inventory::submit! {
+        #fn_attrs
+        ::trunk_ir::inventory::submit! {
             ::trunk_ir::transforms::canonicalize::CanonicalizeFold {
                 dialect: #dialect,
                 op_name: #op_name,
@@ -28,11 +29,12 @@ pub fn gen_pattern(attr: TokenStream, item: TokenStream) -> Result<TokenStream, 
     if !attr.is_empty() {
         return Err("`#[canonicalize_pattern]` does not accept arguments".to_string());
     }
-    let fn_ident = extract_fn_ident(&item)?;
+    let (fn_attrs, fn_ident) = extract_fn_attrs_and_ident(&item)?;
     Ok(quote! {
         #item
 
-        ::inventory::submit! {
+        #fn_attrs
+        ::trunk_ir::inventory::submit! {
             ::trunk_ir::transforms::canonicalize::CanonicalizePattern {
                 make: #fn_ident,
             }
@@ -79,23 +81,68 @@ fn strip_raw_prefix(s: &str) -> String {
     s.strip_prefix("r#").unwrap_or(s).to_string()
 }
 
-/// Pull the function name out of the attributed item by skipping
-/// visibility tokens / modifiers and grabbing the ident right after
-/// the `fn` keyword.
-fn extract_fn_ident(item: &TokenStream) -> Result<Ident, String> {
-    let mut iter = item.clone().into_iter();
-    let mut saw_fn = false;
-    for tt in iter.by_ref() {
-        if let TokenTree::Ident(ident) = tt {
-            if saw_fn {
-                return Ok(ident);
+/// Pull the cfg-gating outer attributes and function name out of the
+/// attributed item. Only `#[cfg(...)]` and `#[cfg_attr(...)]` are
+/// forwarded onto the generated `inventory::submit!` block — they
+/// gate compilation, so the registration must observe the same gates
+/// as the function it references (otherwise a `#[cfg(test)] fn
+/// fold_...` would emit an inventory entry pointing at a non-existent
+/// function outside `cfg(test)`). Other outer attributes (doc
+/// comments, `#[allow(...)]`, etc.) stay on the function only —
+/// duplicating them onto the submit macro produces spurious
+/// warnings.
+fn extract_fn_attrs_and_ident(item: &TokenStream) -> Result<(TokenStream, Ident), String> {
+    let mut iter = item.clone().into_iter().peekable();
+    let mut cfg_attrs = TokenStream::new();
+    loop {
+        match iter.peek() {
+            Some(TokenTree::Punct(p)) if p.as_char() == '#' => {
+                let pound = iter.next().expect("peeked");
+                let group = match iter.next() {
+                    Some(tt @ TokenTree::Group(_)) => tt,
+                    Some(other) => {
+                        return Err(format!("expected `[...]` after `#`, got `{other}`"));
+                    }
+                    None => return Err("expected `[...]` after `#`".to_string()),
+                };
+                if is_cfg_gate(&group) {
+                    cfg_attrs.extend([pound, group]);
+                }
+                // Otherwise (doc comments, lint allows, etc.) just
+                // drop them — they stay on the original `#item` and
+                // shouldn't be replicated on the submit block.
             }
-            if ident == "fn" {
-                saw_fn = true;
+            Some(TokenTree::Ident(id)) if id == "fn" => {
+                iter.next();
+                return match iter.next() {
+                    Some(TokenTree::Ident(name)) => Ok((cfg_attrs, name)),
+                    Some(other) => Err(format!("expected fn name, got `{other}`")),
+                    None => Err("expected fn name".to_string()),
+                };
             }
+            Some(_) => {
+                // Visibility (`pub`, `pub(crate)`), modifiers (`unsafe`,
+                // `async`, `extern "C"`), or other tokens before `fn`.
+                // Skip without capturing.
+                iter.next();
+            }
+            None => return Err("expected `fn <name>` in attributed item".to_string()),
         }
     }
-    Err("expected `fn <name>` in attributed item".to_string())
+}
+
+/// `true` iff the given `[...]` group is `[cfg(...)]` or
+/// `[cfg_attr(...)]` — the only outer attributes that gate compilation
+/// of the function they're attached to.
+fn is_cfg_gate(group: &TokenTree) -> bool {
+    let TokenTree::Group(g) = group else {
+        return false;
+    };
+    let mut inner = g.stream().into_iter();
+    matches!(
+        inner.next(),
+        Some(TokenTree::Ident(id)) if id == "cfg" || id == "cfg_attr",
+    )
 }
 
 #[cfg(test)]
@@ -157,5 +204,78 @@ mod tests {
             Ok(_) => panic!("expected error"),
         };
         assert!(err.contains("does not accept arguments"), "got: {err}");
+    }
+
+    #[test]
+    fn fold_forwards_cfg_to_submit_block() {
+        // A `#[cfg(test)] fn fold_x` would only exist under cfg(test).
+        // The inventory::submit! must observe the same gate so the
+        // registration doesn't reference a non-existent function.
+        let attr: TokenStream = quote! { arith.foo };
+        let item: TokenStream = quote! {
+            #[cfg(test)]
+            fn fold_foo(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { None }
+        };
+        let out = gen_fold(attr, item).unwrap().to_string();
+        // Both the original fn and the submit block should carry the
+        // cfg, so the literal `# [cfg (test)]` appears twice in the
+        // expansion.
+        let cfg_count = out.matches("cfg (test)").count();
+        assert_eq!(cfg_count, 2, "expected 2 cfg(test) occurrences, got: {out}");
+    }
+
+    #[test]
+    fn fold_forwards_cfg_attr_to_submit_block() {
+        let attr: TokenStream = quote! { arith.foo };
+        let item: TokenStream = quote! {
+            #[cfg_attr(feature = "x", allow(dead_code))]
+            fn fold_foo(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { None }
+        };
+        let out = gen_fold(attr, item).unwrap().to_string();
+        let cfg_count = out.matches("cfg_attr").count();
+        assert_eq!(cfg_count, 2, "expected 2 cfg_attr occurrences, got: {out}");
+    }
+
+    #[test]
+    fn fold_does_not_forward_doc_or_lint_attrs() {
+        // Doc comments and `#[allow(...)]` etc. don't gate
+        // compilation. Forwarding them onto the submit macro
+        // produces spurious `unused_doc_comments` warnings.
+        let attr: TokenStream = quote! { arith.foo };
+        let item: TokenStream = quote! {
+            /// fold doc comment
+            #[allow(dead_code)]
+            fn fold_foo(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { None }
+        };
+        let out = gen_fold(attr, item).unwrap().to_string();
+        // The original function (`#item`) keeps the doc comment and
+        // allow, so they appear once. They must not be duplicated
+        // onto the submit block.
+        assert_eq!(
+            out.matches("fold doc comment").count(),
+            1,
+            "doc comment must not be duplicated onto submit block: {out}"
+        );
+        assert_eq!(
+            out.matches("allow (dead_code)").count(),
+            1,
+            "allow(dead_code) must not be duplicated onto submit block: {out}"
+        );
+    }
+
+    #[test]
+    fn fold_emits_trunk_ir_inventory_path() {
+        // External consumers shouldn't need a direct `inventory`
+        // dependency — the submit path goes through trunk-ir's
+        // re-export.
+        let attr: TokenStream = quote! { arith.foo };
+        let item: TokenStream = quote! {
+            fn fold_foo(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { None }
+        };
+        let out = gen_fold(attr, item).unwrap().to_string();
+        assert!(
+            out.contains(":: trunk_ir :: inventory :: submit"),
+            "expected ::trunk_ir::inventory::submit, got: {out}"
+        );
     }
 }

--- a/crates/trunk-ir-macros/src/canonicalize.rs
+++ b/crates/trunk-ir-macros/src/canonicalize.rs
@@ -1,7 +1,7 @@
-//! Proc-macro attributes for the canonicalize pass: `#[canonicalize_fold]`
-//! and `#[canonicalize_pattern]`. They submit `inventory` entries the
-//! pass discovers at startup, so the registration sits next to the
-//! function definition rather than in a separate macro_rules! call.
+//! Proc-macro attribute for the canonicalize pass:
+//! `#[canonicalize_fold]`. It submits an `inventory` entry the pass
+//! discovers at startup, so the registration sits next to the function
+//! definition rather than in a separate macro_rules! call.
 
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::quote;
@@ -19,24 +19,6 @@ pub fn gen_fold(attr: TokenStream, item: TokenStream) -> Result<TokenStream, Str
                 dialect: #dialect,
                 op_name: #op_name,
                 fold: #fn_ident,
-            }
-        }
-    })
-}
-
-/// Generate the expanded form for `#[canonicalize_pattern]`.
-pub fn gen_pattern(attr: TokenStream, item: TokenStream) -> Result<TokenStream, String> {
-    if !attr.is_empty() {
-        return Err("`#[canonicalize_pattern]` does not accept arguments".to_string());
-    }
-    let (fn_attrs, fn_ident) = extract_fn_attrs_and_ident(&item)?;
-    Ok(quote! {
-        #item
-
-        #fn_attrs
-        ::trunk_ir::inventory::submit! {
-            ::trunk_ir::transforms::canonicalize::CanonicalizePattern {
-                make: #fn_ident,
             }
         }
     })
@@ -183,27 +165,6 @@ mod tests {
             Ok(_) => panic!("expected parse error"),
         };
         assert!(err.contains("expected `.`"), "got: {err}");
-    }
-
-    #[test]
-    fn pattern_emits_inventory_submit() {
-        let item: TokenStream = quote! {
-            fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
-        };
-        let out = gen_pattern(TokenStream::new(), item).unwrap().to_string();
-        assert!(out.contains("CanonicalizePattern"), "got: {out}");
-        assert!(out.contains("make : make_if_const_fold"), "got: {out}");
-    }
-
-    #[test]
-    fn pattern_rejects_attr_args() {
-        let attr: TokenStream = quote! { foo };
-        let item: TokenStream = quote! { fn f() {} };
-        let err = match gen_pattern(attr, item) {
-            Err(e) => e,
-            Ok(_) => panic!("expected error"),
-        };
-        assert!(err.contains("does not accept arguments"), "got: {err}");
     }
 
     #[test]

--- a/crates/trunk-ir-macros/src/canonicalize.rs
+++ b/crates/trunk-ir-macros/src/canonicalize.rs
@@ -1,0 +1,161 @@
+//! Proc-macro attributes for the canonicalize pass: `#[canonicalize_fold]`
+//! and `#[canonicalize_pattern]`. They submit `inventory` entries the
+//! pass discovers at startup, so the registration sits next to the
+//! function definition rather than in a separate macro_rules! call.
+
+use proc_macro2::{Ident, TokenStream, TokenTree};
+use quote::quote;
+
+/// Generate the expanded form for `#[canonicalize_fold(<dialect>.<op>)]`.
+pub fn gen_fold(attr: TokenStream, item: TokenStream) -> Result<TokenStream, String> {
+    let (dialect, op_name) = parse_dialect_op(attr)?;
+    let fn_ident = extract_fn_ident(&item)?;
+    Ok(quote! {
+        #item
+
+        ::inventory::submit! {
+            ::trunk_ir::transforms::canonicalize::CanonicalizeFold {
+                dialect: #dialect,
+                op_name: #op_name,
+                fold: #fn_ident,
+            }
+        }
+    })
+}
+
+/// Generate the expanded form for `#[canonicalize_pattern]`.
+pub fn gen_pattern(attr: TokenStream, item: TokenStream) -> Result<TokenStream, String> {
+    if !attr.is_empty() {
+        return Err("`#[canonicalize_pattern]` does not accept arguments".to_string());
+    }
+    let fn_ident = extract_fn_ident(&item)?;
+    Ok(quote! {
+        #item
+
+        ::inventory::submit! {
+            ::trunk_ir::transforms::canonicalize::CanonicalizePattern {
+                make: #fn_ident,
+            }
+        }
+    })
+}
+
+/// Parse `<dialect_ident> . <op_ident>` from the attribute payload.
+/// Strips `r#` from raw identifiers so op names like `r#const` register
+/// as `"const"`.
+fn parse_dialect_op(attr: TokenStream) -> Result<(String, String), String> {
+    let mut iter = attr.into_iter();
+    let dialect = next_ident_str(&mut iter, "dialect name")?;
+    expect_dot(&mut iter)?;
+    let op_name = next_ident_str(&mut iter, "op name")?;
+    if let Some(extra) = iter.next() {
+        return Err(format!(
+            "unexpected token after `{dialect}.{op_name}`: `{extra}`"
+        ));
+    }
+    Ok((dialect, op_name))
+}
+
+fn next_ident_str(
+    iter: &mut impl Iterator<Item = TokenTree>,
+    what: &str,
+) -> Result<String, String> {
+    match iter.next() {
+        Some(TokenTree::Ident(id)) => Ok(strip_raw_prefix(&id.to_string())),
+        Some(other) => Err(format!("expected {what}, got `{other}`")),
+        None => Err(format!("expected {what}")),
+    }
+}
+
+fn expect_dot(iter: &mut impl Iterator<Item = TokenTree>) -> Result<(), String> {
+    match iter.next() {
+        Some(TokenTree::Punct(p)) if p.as_char() == '.' => Ok(()),
+        Some(other) => Err(format!("expected `.`, got `{other}`")),
+        None => Err("expected `.` between dialect and op name".to_string()),
+    }
+}
+
+fn strip_raw_prefix(s: &str) -> String {
+    s.strip_prefix("r#").unwrap_or(s).to_string()
+}
+
+/// Pull the function name out of the attributed item by skipping
+/// visibility tokens / modifiers and grabbing the ident right after
+/// the `fn` keyword.
+fn extract_fn_ident(item: &TokenStream) -> Result<Ident, String> {
+    let mut iter = item.clone().into_iter();
+    let mut saw_fn = false;
+    for tt in iter.by_ref() {
+        if let TokenTree::Ident(ident) = tt {
+            if saw_fn {
+                return Ok(ident);
+            }
+            if ident == "fn" {
+                saw_fn = true;
+            }
+        }
+    }
+    Err("expected `fn <name>` in attributed item".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fold_emits_inventory_submit_for_plain_idents() {
+        let attr: TokenStream = quote! { arith.addi };
+        let item: TokenStream = quote! {
+            pub(crate) fn fold_addi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { None }
+        };
+        let out = gen_fold(attr, item).unwrap().to_string();
+        assert!(out.contains("CanonicalizeFold"), "got: {out}");
+        assert!(out.contains("\"arith\""), "got: {out}");
+        assert!(out.contains("\"addi\""), "got: {out}");
+        assert!(out.contains("fold : fold_addi"), "got: {out}");
+    }
+
+    #[test]
+    fn fold_strips_raw_prefix_from_op_name() {
+        // r#const should register as "const".
+        let attr: TokenStream = quote! { core.r#const };
+        let item: TokenStream = quote! {
+            fn fold_const(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { None }
+        };
+        let out = gen_fold(attr, item).unwrap().to_string();
+        assert!(out.contains("\"const\""), "got: {out}");
+        assert!(!out.contains("\"r#const\""), "got: {out}");
+    }
+
+    #[test]
+    fn fold_rejects_missing_dot() {
+        let attr: TokenStream = quote! { arith addi };
+        let item: TokenStream = quote! { fn f() {} };
+        let err = match gen_fold(attr, item) {
+            Err(e) => e,
+            Ok(_) => panic!("expected parse error"),
+        };
+        assert!(err.contains("expected `.`"), "got: {err}");
+    }
+
+    #[test]
+    fn pattern_emits_inventory_submit() {
+        let item: TokenStream = quote! {
+            fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
+        };
+        let out = gen_pattern(TokenStream::new(), item).unwrap().to_string();
+        assert!(out.contains("CanonicalizePattern"), "got: {out}");
+        assert!(out.contains("make : make_if_const_fold"), "got: {out}");
+    }
+
+    #[test]
+    fn pattern_rejects_attr_args() {
+        let attr: TokenStream = quote! { foo };
+        let item: TokenStream = quote! { fn f() {} };
+        let err = match gen_pattern(attr, item) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(err.contains("does not accept arguments"), "got: {err}");
+    }
+}

--- a/crates/trunk-ir-macros/src/lib.rs
+++ b/crates/trunk-ir-macros/src/lib.rs
@@ -1,9 +1,8 @@
 //! Proc macros for trunk-ir dialect definitions.
 //!
 //! Provides `#[dialect]` for defining dialect operations with type-safe
-//! wrappers/accessors/constructors, plus `#[canonicalize_fold]` and
-//! `#[canonicalize_pattern]` for registering canonicalize-pass entries
-//! next to the function definition.
+//! wrappers/accessors/constructors, plus `#[canonicalize_fold]` for
+//! registering canonicalize-pass folds next to the function definition.
 
 use proc_macro::TokenStream as ProcTokenStream;
 
@@ -79,26 +78,6 @@ fn dialect_impl(
 #[proc_macro_attribute]
 pub fn canonicalize_fold(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream {
     match canonicalize::gen_fold(attr.into(), item.into()) {
-        Ok(tokens) => tokens.into(),
-        Err(msg) => quote::quote!(compile_error!(#msg);).into(),
-    }
-}
-
-/// Register a full `RewritePattern` for the canonicalize pass — used
-/// when a rewrite needs more than the per-op fold shape allows
-/// (e.g. multi-op region splicing).
-///
-/// ```ignore
-/// #[trunk_ir::canonicalize_pattern]
-/// fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
-/// ```
-///
-/// The attribute takes no arguments. The original function item is
-/// preserved unchanged; the macro only emits an adjacent
-/// `inventory::submit!` block.
-#[proc_macro_attribute]
-pub fn canonicalize_pattern(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream {
-    match canonicalize::gen_pattern(attr.into(), item.into()) {
         Ok(tokens) => tokens.into(),
         Err(msg) => quote::quote!(compile_error!(#msg);).into(),
     }

--- a/crates/trunk-ir-macros/src/lib.rs
+++ b/crates/trunk-ir-macros/src/lib.rs
@@ -1,10 +1,13 @@
 //! Proc macros for trunk-ir dialect definitions.
 //!
-//! Provides `#[dialect]` attribute macro for defining
-//! dialect operations with type-safe wrappers, accessors, and constructors.
+//! Provides `#[dialect]` for defining dialect operations with type-safe
+//! wrappers/accessors/constructors, plus `#[canonicalize_fold]` and
+//! `#[canonicalize_pattern]` for registering canonicalize-pass entries
+//! next to the function definition.
 
 use proc_macro::TokenStream as ProcTokenStream;
 
+mod canonicalize;
 mod codegen;
 mod parse;
 
@@ -59,4 +62,44 @@ fn dialect_impl(
     let module = parse::parse_input(attr, item)?;
     let crate_path = quote::quote!(::trunk_ir);
     Ok(codegen::generate(&crate_path, &module))
+}
+
+/// Register a per-op fold for the canonicalize pass.
+///
+/// ```ignore
+/// #[trunk_ir::canonicalize_fold(arith.addi)]
+/// pub(crate) fn fold_addi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { ... }
+/// ```
+///
+/// The attribute payload is `<dialect_ident>.<op_ident>`. Raw
+/// identifiers (`r#const`, `r#return`) are stripped so the registered
+/// op name matches the printed form. The original function item is
+/// preserved unchanged; the macro only emits an adjacent
+/// `inventory::submit!` block.
+#[proc_macro_attribute]
+pub fn canonicalize_fold(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream {
+    match canonicalize::gen_fold(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(msg) => quote::quote!(compile_error!(#msg);).into(),
+    }
+}
+
+/// Register a full `RewritePattern` for the canonicalize pass — used
+/// when a rewrite needs more than the per-op fold shape allows
+/// (e.g. multi-op region splicing).
+///
+/// ```ignore
+/// #[trunk_ir::canonicalize_pattern]
+/// fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
+/// ```
+///
+/// The attribute takes no arguments. The original function item is
+/// preserved unchanged; the macro only emits an adjacent
+/// `inventory::submit!` block.
+#[proc_macro_attribute]
+pub fn canonicalize_pattern(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream {
+    match canonicalize::gen_pattern(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(msg) => quote::quote!(compile_error!(#msg);).into(),
+    }
 }

--- a/crates/trunk-ir/src/dialect/arith.rs
+++ b/crates/trunk-ir/src/dialect/arith.rs
@@ -104,23 +104,14 @@ use crate::symbol::Symbol;
 use crate::transforms::canonicalize::FoldResult;
 use crate::types::Attribute;
 
-// Folds this dialect contributes to `transforms::canonicalize`, registered
-// via `inventory`. The pass discovers them at startup; no manual aggregation
-// in `canonicalize.rs` is needed.
-crate::register_canonicalize_fold!(arith.addi => fold_addi);
-crate::register_canonicalize_fold!(arith.subi => fold_subi);
-crate::register_canonicalize_fold!(arith.muli => fold_muli);
-crate::register_canonicalize_fold!(arith.divsi => fold_divsi);
-crate::register_canonicalize_fold!(arith.divui => fold_divui);
-crate::register_canonicalize_fold!(arith.remsi => fold_remsi);
-crate::register_canonicalize_fold!(arith.remui => fold_remui);
-crate::register_canonicalize_fold!(arith.and => fold_and);
-crate::register_canonicalize_fold!(arith.or => fold_or);
-crate::register_canonicalize_fold!(arith.xor => fold_xor);
+// Folds this dialect contributes to `transforms::canonicalize`. Each
+// `#[trunk_ir::canonicalize_fold(...)]` attribute below registers the
+// function via `inventory`; the pass discovers them at startup.
 
 /// `arith.addi` folds:
 /// - `x + 0` / `0 + x` → `x`
 /// - `const(a) + const(b)` → `const(wrap(a+b))` at the result width
+#[trunk_ir::canonicalize_fold(arith.addi)]
 pub(crate) fn fold_addi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     if const_int_value(ctx, rhs) == Some(0) {
@@ -140,6 +131,7 @@ pub(crate) fn fold_addi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 /// - `x - 0` → `x`. (`0 - x` is the `negi` semantic and is left for a
 ///   separate fold so the rewrite direction stays unambiguous.)
 /// - `const(a) - const(b)` → `const(wrap(a-b))` at the result width.
+#[trunk_ir::canonicalize_fold(arith.subi)]
 pub(crate) fn fold_subi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     if const_int_value(ctx, rhs) == Some(0) {
@@ -156,6 +148,7 @@ pub(crate) fn fold_subi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 /// - `x * 0` / `0 * x` → `const 0` (checked before x*1 to short-circuit).
 /// - `x * 1` / `1 * x` → `x`.
 /// - `const(a) * const(b)` → `const(wrap(a*b))` at the result width.
+#[trunk_ir::canonicalize_fold(arith.muli)]
 pub(crate) fn fold_muli(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     if const_int_value(ctx, rhs) == Some(0) || const_int_value(ctx, lhs) == Some(0) {
@@ -184,6 +177,7 @@ pub(crate) fn fold_muli(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 ///   down (`new-plans/types.md` doesn't specify wrap vs trap), so the
 ///   conservative choice is to leave the op alone — that way IR
 ///   semantics match whatever the backend does.
+#[trunk_ir::canonicalize_fold(arith.divsi)]
 pub(crate) fn fold_divsi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     let (a, b) = (const_int_value(ctx, lhs)?, const_int_value(ctx, rhs)?);
@@ -202,6 +196,7 @@ pub(crate) fn fold_divsi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 /// `arith.divui const(a), const(b)` → `arith.const(a/b)` at the result
 /// width, interpreting both operands as unsigned `N`-bit values.
 /// Bails when the unsigned divisor is zero.
+#[trunk_ir::canonicalize_fold(arith.divui)]
 pub(crate) fn fold_divui(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     let (a, b) = (const_int_value(ctx, lhs)?, const_int_value(ctx, rhs)?);
@@ -221,6 +216,7 @@ pub(crate) fn fold_divui(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 ///
 /// Mirrors [`fold_divsi`]: bails on `b == 0` and on `INT_MIN % -1` (which
 /// also traps on Cranelift `srem` and WASM `i32.rem_s`).
+#[trunk_ir::canonicalize_fold(arith.remsi)]
 pub(crate) fn fold_remsi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     let (a, b) = (const_int_value(ctx, lhs)?, const_int_value(ctx, rhs)?);
@@ -239,6 +235,7 @@ pub(crate) fn fold_remsi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 /// `arith.remui const(a), const(b)` → `arith.const(a%b)` at the result
 /// width, interpreting both operands as unsigned `N`-bit values.
 /// Bails when the unsigned divisor is zero.
+#[trunk_ir::canonicalize_fold(arith.remui)]
 pub(crate) fn fold_remui(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     let (a, b) = (const_int_value(ctx, lhs)?, const_int_value(ctx, rhs)?);
@@ -261,6 +258,7 @@ pub(crate) fn fold_remui(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 ///   width, since `Attribute::Int` values are stored sign-extended in
 ///   `i128`.
 /// - `const(a) & const(b)` → `const(wrap(a&b))` at the result width.
+#[trunk_ir::canonicalize_fold(arith.and)]
 pub(crate) fn fold_and(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     if const_int_value(ctx, rhs) == Some(0) || const_int_value(ctx, lhs) == Some(0) {
@@ -284,6 +282,7 @@ pub(crate) fn fold_and(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 /// - `x | -1` / `-1 | x` → `const -1` (all-ones; same value in any
 ///   width when interpreted as a sign-extended `i128`).
 /// - `const(a) | const(b)` → `const(wrap(a|b))` at the result width.
+#[trunk_ir::canonicalize_fold(arith.or)]
 pub(crate) fn fold_or(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     if const_int_value(ctx, rhs) == Some(0) {
@@ -309,6 +308,7 @@ pub(crate) fn fold_or(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
 /// `x ^ x → 0` would require same-operand detection and is left for a
 /// later pass that handles same-operand peepholes uniformly across
 /// the dialect (see `subi`, which doesn't fold `x - x → 0` either).
+#[trunk_ir::canonicalize_fold(arith.xor)]
 pub(crate) fn fold_xor(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let (lhs, rhs) = two_operands(ctx, op)?;
     if const_int_value(ctx, rhs) == Some(0) {

--- a/crates/trunk-ir/src/dialect/arith.rs
+++ b/crates/trunk-ir/src/dialect/arith.rs
@@ -370,7 +370,7 @@ pub(crate) fn const_int_value(ctx: &IrContext, value: ValueRef) -> Option<i128> 
 /// carrying attributes, names that don't follow the `i{N}` shape, or
 /// widths outside `[1, 128]` (the upper bound is what
 /// `wrap_signed_to_width` can represent in i128).
-fn core_int_width(ctx: &IrContext, ty: TypeRef) -> Option<u32> {
+pub(crate) fn core_int_width(ctx: &IrContext, ty: TypeRef) -> Option<u32> {
     let data = ctx.types.get(ty);
     if data.dialect != Symbol::new("core") || !data.params.is_empty() || !data.attrs.is_empty() {
         return None;

--- a/crates/trunk-ir/src/dialect/core.rs
+++ b/crates/trunk-ir/src/dialect/core.rs
@@ -38,10 +38,6 @@ use crate::ops::DialectOp;
 use crate::refs::{OpRef, ValueDef};
 use crate::transforms::canonicalize::FoldResult;
 
-// Folds this dialect contributes to `transforms::canonicalize`, registered
-// via `inventory`.
-crate::register_canonicalize_fold!(core.unrealized_conversion_cast => fold_unrealized_conversion_cast);
-
 /// `core.unrealized_conversion_cast` folds:
 ///
 /// - **Identity** (`%x : T → T`): drop the cast and forward `%x`.
@@ -55,6 +51,7 @@ crate::register_canonicalize_fold!(core.unrealized_conversion_cast => fold_unrea
 /// the same way (narrower intermediate types lose information). Once
 /// `resolve_unrealized_casts` has run, no `unrealized_conversion_cast`
 /// ops remain and this fold is a no-op.
+#[trunk_ir::canonicalize_fold(core.unrealized_conversion_cast)]
 pub(crate) fn fold_unrealized_conversion_cast(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let operands = ctx.op_operands(op);
     let result_types = ctx.op_result_types(op);

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -52,8 +52,7 @@ use crate::ops::DialectOp;
 use crate::refs::{OpRef, ValueRef};
 use crate::rewrite::{PatternRewriter, RewritePattern};
 
-crate::register_canonicalize_pattern!(make_if_const_fold);
-
+#[trunk_ir::canonicalize_pattern]
 fn make_if_const_fold() -> Box<dyn RewritePattern> {
     Box::new(IfConstFold)
 }

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -38,115 +38,72 @@ mod scf {
 }
 
 // =========================================================================
-// Canonicalization patterns
-//
-// `scf.if(arith.const Int(_) : core.i1)` is the first user of the
-// non-fold escape hatch in `transforms::canonicalize`: the rewrite
-// splices the chosen region's body into the parent block — a multi-op
-// mutation that doesn't fit the single-op `FoldResult` shape.
+// Canonicalization folds
 // =========================================================================
 
 use crate::context::IrContext;
-use crate::dialect::arith::const_int_value;
+use crate::dialect::arith::{const_int_value, core_int_width};
 use crate::ops::DialectOp;
 use crate::refs::{OpRef, ValueRef};
-use crate::rewrite::{PatternRewriter, RewritePattern};
-
-#[trunk_ir::canonicalize_pattern]
-fn make_if_const_fold() -> Box<dyn RewritePattern> {
-    Box::new(IfConstFold)
-}
+use crate::transforms::canonicalize::FoldResult;
 
 /// `scf.if(arith.const Int(c) : core.i1)` → splice the chosen region's
 /// body into the parent block.
 ///
 /// When the condition is a compile-time constant, exactly one branch
 /// runs; the other is dead. The chosen region's `scf.yield <values>`
-/// supplies the if op's results, so:
+/// supplies the if op's results, so the fold names the body ops to
+/// keep and the values that should take over the if op's result slots
+/// — the canonicalize dispatcher does the splice + cleanup of the
+/// dead branch and the chosen region's yield via [`FoldResult::Splice`].
 ///
-/// 1. Move every non-terminator op out of the active region's single
-///    block, into the parent block, in original order, immediately
-///    before the `scf.if` op. Captured operands stay valid because the
-///    cloned ops keep referencing the same `ValueRef`s.
-/// 2. RAUW the if op's results with the yield's operands.
-/// 3. Erase the `scf.if`. Its other (dead) region is dropped along
-///    with the orphaned yield from the active region.
-///
-/// Multi-block regions are left alone — they only appear post-`scf_to_cf`,
-/// where this pattern doesn't run anyway. The pattern self-filters on
-/// `scf.if` and bails out on any structural mismatch (yield arity,
-/// non-`i1` const, malformed regions).
-pub struct IfConstFold;
+/// Multi-block regions are left alone — they only appear
+/// post-`scf_to_cf`, where this pass doesn't run anyway. Bails out on
+/// any structural mismatch (yield arity, non-`i1` const, malformed
+/// regions).
+#[trunk_ir::canonicalize_fold(scf.r#if)]
+pub(crate) fn fold_if(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
+    let if_op = If::from_op(ctx, op).ok()?;
+    let cond = if_op.cond(ctx);
+    // Guard against malformed IR: only fold when the cond's type is
+    // `core.i1`. Without this, an `arith.const value=2 : core.i32`
+    // wired into the cond slot would be treated as truthy here,
+    // burning the dead branch before the validator gets to reject it.
+    if core_int_width(ctx, ctx.value_ty(cond)) != Some(1) {
+        return None;
+    }
+    let cond_value = const_int_value(ctx, cond)?;
+    // We've gated on cond's type being `core.i1`; the only valid
+    // payloads are 0 and 1. Reject anything else (e.g.
+    // `arith.const value=2 : core.i1`) so the validator surfaces the
+    // malformed const instead of the fold silently picking a branch.
+    let active_region = match cond_value {
+        0 => if_op.else_region(ctx),
+        1 => if_op.then_region(ctx),
+        _ => return None,
+    };
 
-impl RewritePattern for IfConstFold {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !If::matches(ctx, op) {
-            return false;
-        }
-        let if_op = match If::from_op(ctx, op) {
-            Ok(o) => o,
-            Err(_) => return false,
-        };
-        let cond = if_op.cond(ctx);
-
-        let Some(cond_value) = const_int_value(ctx, cond) else {
-            return false;
-        };
-        let active_region = if cond_value != 0 {
-            if_op.then_region(ctx)
-        } else {
-            if_op.else_region(ctx)
-        };
-
-        // Active region must be a single block whose terminator is `scf.yield`.
-        let blocks = ctx.region(active_region).blocks.to_vec();
-        let [active_block] = blocks.as_slice() else {
-            return false;
-        };
-        let active_block = *active_block;
-        let region_ops: Vec<OpRef> = ctx.block(active_block).ops.to_vec();
-        let Some((yield_op, body_ops)) = region_ops.split_last() else {
-            return false;
-        };
-        if !Yield::matches(ctx, *yield_op) {
-            return false;
-        }
-
-        // Yield arity must match the if op's result count.
-        let yield_operands: Vec<ValueRef> = ctx.op_operands(*yield_op).to_vec();
-        let if_result_count = ctx.op_results(op).len();
-        if yield_operands.len() != if_result_count {
-            return false;
-        }
-
-        // Splice body ops out into the parent block, before `op`.
-        let parent_block = match ctx.op(op).parent_block {
-            Some(b) => b,
-            None => return false,
-        };
-        for body_op in body_ops {
-            ctx.detach_op(*body_op);
-            ctx.insert_op_before(parent_block, op, *body_op);
-        }
-
-        // Detach + destroy the yield — its only user was the implicit
-        // edge to the if op's results, which we are about to erase.
-        ctx.detach_op(*yield_op);
-        ctx.remove_op(*yield_op);
-
-        // Erase the if op, mapping its results to the yield's operands.
-        rewriter.erase_op(yield_operands);
-        true
+    // Active region must be a single block whose terminator is `scf.yield`.
+    let blocks = ctx.region(active_region).blocks.to_vec();
+    let [active_block] = blocks.as_slice() else {
+        return None;
+    };
+    let region_ops: Vec<OpRef> = ctx.block(*active_block).ops.to_vec();
+    let (yield_op, body_ops) = region_ops.split_last()?;
+    if !Yield::matches(ctx, *yield_op) {
+        return None;
     }
 
-    fn name(&self) -> &'static str {
-        "IfConstFold"
+    // Yield arity must match the if op's result count.
+    let yield_operands: Vec<ValueRef> = ctx.op_operands(*yield_op).to_vec();
+    if yield_operands.len() != ctx.op_results(op).len() {
+        return None;
     }
+
+    Some(FoldResult::Splice {
+        body: body_ops.to_vec(),
+        results: yield_operands,
+    })
 }
 
 // =========================================================================
@@ -160,15 +117,17 @@ mod canonicalize_tests {
     use crate::printer::print_module;
     use crate::rewrite::{ApplyResult, Module, PatternApplicator, TypeConverter};
     use crate::symbol::Symbol;
+    use crate::transforms::canonicalize::{FoldDispatchPattern, folds_for_dialect};
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
-    /// Run only `IfConstFold` on `module`. Tests stay focused on this
-    /// pattern even though the production `canonicalize` pass aggregates
-    /// every registered fold and pattern.
-    fn run_if_const_fold(ctx: &mut IrContext, module: Module) -> ApplyResult {
+    /// Run only this dialect's folds on `module` via a single
+    /// [`FoldDispatchPattern`] — mirrors `arith.rs::run_arith_patterns`
+    /// to keep per-dialect tests isolated from other dialects' folds.
+    fn run_scf_patterns(ctx: &mut IrContext, module: Module) -> ApplyResult {
+        let dispatcher = FoldDispatchPattern::from_folds(folds_for_dialect("scf"));
         PatternApplicator::new(TypeConverter::new())
-            .add_pattern(IfConstFold)
+            .add_pattern_box(Box::new(dispatcher))
             .apply_partial(ctx, module)
     }
 
@@ -206,7 +165,7 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
         assert!(result.total_changes >= 1);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
         // The then-region's `arith.addi` is now at the parent block.
@@ -233,7 +192,7 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
         assert!(result.total_changes >= 1);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
         assert_eq!(count_ops(&ctx, module, "arith", "addi"), 1);
@@ -256,7 +215,55 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
+        assert_eq!(result.total_changes, 0);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 1);
+    }
+
+    #[test]
+    fn if_non_i1_const_cond_is_not_folded() {
+        // Malformed IR: the cond slot is wired to a `core.i32` constant
+        // instead of `core.i1`. The fold must bail and leave the op for
+        // validation rather than picking a branch by truthiness.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %bad = arith.const {value = 2} : core.i32
+    %r = scf.if %bad : core.i32 {
+      scf.yield %x
+    } {
+      scf.yield %x
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_scf_patterns(&mut ctx, module);
+        assert_eq!(result.total_changes, 0);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 1);
+    }
+
+    #[test]
+    fn if_malformed_i1_payload_is_not_folded() {
+        // Cond is i1-typed but carries a payload outside {0, 1}.
+        // The fold must bail so validation flags the bad const rather
+        // than the rewrite picking the then-branch by truthiness.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %bad = arith.const {value = 2} : core.i1
+    %r = scf.if %bad : core.i32 {
+      scf.yield %x
+    } {
+      scf.yield %x
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_scf_patterns(&mut ctx, module);
         assert_eq!(result.total_changes, 0);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 1);
     }
@@ -280,7 +287,7 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
         assert!(result.total_changes >= 1);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
         // The else region's addi was dropped along with the if op (it

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -62,6 +62,12 @@ pub use trunk_ir_macros::arena_dialect;
 // emits an `inventory::submit!` block alongside the user's function.
 pub use trunk_ir_macros::{canonicalize_fold, canonicalize_pattern};
 
+// Re-export `inventory` so the proc-macro–generated submit blocks
+// resolve `::trunk_ir::inventory::submit!` without requiring consumer
+// crates to declare a direct `inventory` dependency.
+#[doc(hidden)]
+pub use inventory;
+
 // Re-export paste for use in macros
 #[doc(hidden)]
 pub use paste;

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -58,6 +58,10 @@ pub use trunk_ir_macros::dialect;
 /// Deprecated alias for [`dialect`].
 pub use trunk_ir_macros::arena_dialect;
 
+// Re-export proc macros for canonicalize-pass registration. Each
+// emits an `inventory::submit!` block alongside the user's function.
+pub use trunk_ir_macros::{canonicalize_fold, canonicalize_pattern};
+
 // Re-export paste for use in macros
 #[doc(hidden)]
 pub use paste;

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -58,9 +58,9 @@ pub use trunk_ir_macros::dialect;
 /// Deprecated alias for [`dialect`].
 pub use trunk_ir_macros::arena_dialect;
 
-// Re-export proc macros for canonicalize-pass registration. Each
-// emits an `inventory::submit!` block alongside the user's function.
-pub use trunk_ir_macros::{canonicalize_fold, canonicalize_pattern};
+// Re-export proc macro for canonicalize-pass registration. Emits an
+// `inventory::submit!` block alongside the user's function.
+pub use trunk_ir_macros::canonicalize_fold;
 
 // Re-export `inventory` so the proc-macro–generated submit blocks
 // resolve `::trunk_ir::inventory::submit!` without requiring consumer

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -9,13 +9,17 @@
 //! here.
 //!
 //! The driver dispatches each visited op to its fold (if any) by
-//! `(dialect, op_name)` HashMap lookup. A fold returns either a value
-//! to forward (RAUW the op's result) or an `Attribute` that the driver
-//! materializes as `arith.const` of the op's result type.
+//! `(dialect, op_name)` HashMap lookup. A fold returns one of:
 //!
-//! Multi-op rewrites that don't fit the fold shape (e.g. region splice
-//! for `scf.if(const)`) register as full [`RewritePattern`]s via the
-//! [`canonicalize_pattern`](crate::canonicalize_pattern) attribute.
+//! - [`FoldResult::Forward`] — RAUW the op's result with an existing
+//!   value.
+//! - [`FoldResult::ArithConst`] — replace with a fresh `arith.const`
+//!   of the op's result type.
+//! - [`FoldResult::Splice`] — splice a body of ops into the parent
+//!   block before the matched op and RAUW its results with the
+//!   supplied values; the dispatcher additionally drops anything
+//!   still attached to the matched op's regions (e.g. yields and the
+//!   dead branch in `scf.if(const)`).
 //!
 //! Currently registered (across `arith`, `core`):
 //!
@@ -31,7 +35,7 @@ use std::collections::HashMap;
 
 use crate::context::IrContext;
 use crate::dialect::arith;
-use crate::refs::{OpRef, ValueRef};
+use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use crate::rewrite::{Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter};
 use crate::symbol::Symbol;
 use crate::types::Attribute;
@@ -57,6 +61,26 @@ pub enum FoldResult {
     /// const-producing dialects require an explicit new variant — the
     /// driver currently knows only how to build `arith.const`.
     ArithConst(Attribute),
+    /// Splice a sequence of body ops into the matched op's parent block
+    /// (in order, immediately before the matched op), then erase the
+    /// matched op while RAUW'ing its results to `results`.
+    ///
+    /// Used by region-bearing ops whose canonicalization is "pick one
+    /// region's body and inline it" — `scf.if(const)` being the seed
+    /// case. The dispatcher additionally drops any ops still attached
+    /// to the matched op's regions (typically the chosen region's
+    /// yield + the dead branch's body); fold authors only have to name
+    /// the ops they want to *keep* (`body`) and the values that should
+    /// take over the matched op's result slots (`results`).
+    Splice {
+        /// Ops to detach from their current parent and insert in the
+        /// matched op's parent block, in order, immediately before the
+        /// matched op.
+        body: Vec<OpRef>,
+        /// Values to RAUW the matched op's results with. Length must
+        /// match the matched op's result count.
+        results: Vec<ValueRef>,
+    },
 }
 
 /// Per-op fold function. `&IrContext` is read-only; mutation happens in
@@ -141,12 +165,60 @@ impl RewritePattern for FoldDispatchPattern {
                 rewriter.replace_op(new_const.op_ref());
                 true
             }
+            FoldResult::Splice { body, results } => apply_splice(ctx, rewriter, op, body, results),
         }
     }
 
     fn name(&self) -> &'static str {
         "FoldDispatch"
     }
+}
+
+/// Apply a [`FoldResult::Splice`]: detach the listed body ops from
+/// their current parents, insert them before `op` in `op`'s parent
+/// block, drop everything still attached to `op`'s regions (typically
+/// terminators and the dead branch), then ask the rewriter to erase
+/// `op` while mapping its results to `results`.
+fn apply_splice(
+    ctx: &mut IrContext,
+    rewriter: &mut PatternRewriter<'_>,
+    op: OpRef,
+    body: Vec<OpRef>,
+    results: Vec<ValueRef>,
+) -> bool {
+    // Precondition: `results` must cover every result slot of the
+    // matched op. Check before any mutation so a buggy fold can't leave
+    // body ops spliced out and the matched op's regions emptied while
+    // the final RAUW fails arity checks deep in `rewriter.erase_op`.
+    if ctx.op_results(op).len() != results.len() {
+        return false;
+    }
+    let Some(parent_block) = ctx.op(op).parent_block else {
+        return false;
+    };
+    for body_op in body {
+        ctx.detach_op(body_op);
+        ctx.insert_op_before(parent_block, op, body_op);
+    }
+    // Sweep up anything left in the matched op's regions — chosen
+    // region's terminator (we already kept the body it preceded) plus
+    // the dead branch entirely.
+    let regions: Vec<RegionRef> = ctx.op(op).regions.iter().copied().collect();
+    for region in regions {
+        let blocks: Vec<BlockRef> = ctx.region(region).blocks.to_vec();
+        for block in blocks {
+            // Reverse so a block-internal op is removed before any op
+            // that depends on its results, satisfying `remove_op`'s
+            // "no remaining uses" precondition.
+            let remaining: Vec<OpRef> = ctx.block(block).ops.to_vec();
+            for orphan in remaining.into_iter().rev() {
+                ctx.detach_op(orphan);
+                ctx.remove_op(orphan);
+            }
+        }
+    }
+    rewriter.erase_op(results);
+    true
 }
 
 // =========================================================================
@@ -162,29 +234,6 @@ pub struct CanonicalizeFold {
     pub fold: FoldFn,
 }
 inventory::collect!(CanonicalizeFold);
-
-/// One inventory entry registering a full `RewritePattern` for the
-/// canonicalize pass — used as an escape hatch for rewrites that don't
-/// fit the fold shape (e.g. multi-op region splicing). Submitted via
-/// the [`canonicalize_pattern`](crate::canonicalize_pattern) attribute.
-///
-/// `make` is a `fn` (not a closure) so the entry meets `inventory`'s
-/// `'static + Sync` bound. The function builds a fresh boxed pattern
-/// every time the pass runs; any state should be in the pattern itself,
-/// not captured.
-///
-/// **Determinism warning**: `inventory::iter` order is unspecified
-/// (linker-dependent). With a single registered pattern this is
-/// harmless; the moment a *second* `CanonicalizePattern` is registered,
-/// add explicit ordering (e.g. `priority: i32` + `name: &'static str`
-/// fields and sort by `(priority, name)` in `canonicalize()`) so the
-/// first-match-wins behavior of `PatternApplicator` doesn't drift
-/// across builds. Folds are dispatched by op key in
-/// `FoldDispatchPattern`, so the ordering issue applies only here.
-pub struct CanonicalizePattern {
-    pub make: fn() -> Box<dyn RewritePattern>,
-}
-inventory::collect!(CanonicalizePattern);
 
 /// Iterate every fold registered via inventory, keyed by interned
 /// `(dialect, op_name)` symbols ready for [`FoldDispatchPattern::from_folds`].
@@ -220,9 +269,9 @@ pub(crate) fn folds_for_dialect(
 }
 
 // Registration is done via the `#[trunk_ir::canonicalize_fold(...)]`
-// and `#[trunk_ir::canonicalize_pattern]` proc-macro attributes (defined
-// in `trunk-ir-macros`). They emit `inventory::submit!` blocks adjacent
-// to the attributed function — no separate registration call needed.
+// proc-macro attribute (defined in `trunk-ir-macros`). It emits an
+// `inventory::submit!` block adjacent to the attributed function — no
+// separate registration call needed.
 
 // =========================================================================
 // Pass entry
@@ -244,11 +293,8 @@ pub struct CanonicalizeResult {
 
 /// Run canonicalization to a fixed point on `module`.
 pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
-    let mut applicator = PatternApplicator::new(TypeConverter::new())
+    let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern_box(Box::new(FoldDispatchPattern::from_inventory()));
-    for entry in inventory::iter::<CanonicalizePattern> {
-        applicator = applicator.add_pattern_box((entry.make)());
-    }
     let result = applicator.apply_partial(ctx, module);
     CanonicalizeResult {
         iterations: result.iterations,

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -1,11 +1,12 @@
 //! Canonicalization pass for TrunkIR.
 //!
 //! Greedy fixed-point pass that folds operations into a canonical form.
-//! Each dialect contributes per-op `fold` functions registered via
-//! [`crate::register_canonicalize_fold!`]; the pass discovers them at
-//! startup time through `inventory` rather than referencing each dialect
-//! by name. As a result this module knows nothing about which dialects
-//! exist — adding a new dialect's folds requires no edit here.
+//! Each dialect contributes per-op `fold` functions registered via the
+//! [`canonicalize_fold`](crate::canonicalize_fold) attribute; the pass
+//! discovers them at startup through `inventory` rather than referencing
+//! each dialect by name. As a result this module knows nothing about
+//! which dialects exist — adding a new dialect's folds requires no edit
+//! here.
 //!
 //! The driver dispatches each visited op to its fold (if any) by
 //! `(dialect, op_name)` HashMap lookup. A fold returns either a value
@@ -13,8 +14,8 @@
 //! materializes as `arith.const` of the op's result type.
 //!
 //! Multi-op rewrites that don't fit the fold shape (e.g. region splice
-//! for `scf.if(const)`) register as full [`RewritePattern`]s via
-//! [`crate::register_canonicalize_pattern!`] instead.
+//! for `scf.if(const)`) register as full [`RewritePattern`]s via the
+//! [`canonicalize_pattern`](crate::canonicalize_pattern) attribute.
 //!
 //! Currently registered (across `arith`, `core`):
 //!
@@ -152,9 +153,9 @@ impl RewritePattern for FoldDispatchPattern {
 // Inventory registration
 // =========================================================================
 
-/// One inventory entry registering a per-op fold function. Submitted via
-/// [`crate::register_canonicalize_fold!`] — never constructed directly
-/// from user code.
+/// One inventory entry registering a per-op fold function. Submitted
+/// via the [`canonicalize_fold`](crate::canonicalize_fold) attribute —
+/// never constructed directly from user code.
 pub struct CanonicalizeFold {
     pub dialect: &'static str,
     pub op_name: &'static str,
@@ -165,7 +166,7 @@ inventory::collect!(CanonicalizeFold);
 /// One inventory entry registering a full `RewritePattern` for the
 /// canonicalize pass — used as an escape hatch for rewrites that don't
 /// fit the fold shape (e.g. multi-op region splicing). Submitted via
-/// [`crate::register_canonicalize_pattern!`].
+/// the [`canonicalize_pattern`](crate::canonicalize_pattern) attribute.
 ///
 /// `make` is a `fn` (not a closure) so the entry meets `inventory`'s
 /// `'static + Sync` bound. The function builds a fresh boxed pattern
@@ -218,48 +219,10 @@ pub(crate) fn folds_for_dialect(
         })
 }
 
-/// Register a per-op fold for the canonicalize pass.
-///
-/// # Example
-/// ```text
-/// register_canonicalize_fold!(arith.addi => fold_addi);
-/// register_canonicalize_fold!(core.unrealized_conversion_cast => fold_uncc);
-/// ```
-///
-/// The dialect and op-name idents are stringified (handling raw
-/// identifiers like `r#const` correctly via `raw_ident_str!`). `$fold`
-/// is a path to a function with signature `fn(&IrContext, OpRef) ->
-/// Option<FoldResult>`.
-#[macro_export]
-macro_rules! register_canonicalize_fold {
-    ($dialect:ident . $op_name:ident => $fold:path) => {
-        ::inventory::submit! {
-            $crate::transforms::canonicalize::CanonicalizeFold {
-                dialect: $crate::raw_ident_str!($dialect),
-                op_name: $crate::raw_ident_str!($op_name),
-                fold: $fold,
-            }
-        }
-    };
-}
-
-/// Register a non-fold `RewritePattern` for the canonicalize pass.
-/// Use when the rewrite needs more than the fold shape allows
-/// (e.g. modifying multiple ops or splicing regions).
-///
-/// # Example
-/// ```text
-/// fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
-/// register_canonicalize_pattern!(make_if_const_fold);
-/// ```
-#[macro_export]
-macro_rules! register_canonicalize_pattern {
-    ($make:path) => {
-        ::inventory::submit! {
-            $crate::transforms::canonicalize::CanonicalizePattern { make: $make }
-        }
-    };
-}
+// Registration is done via the `#[trunk_ir::canonicalize_fold(...)]`
+// and `#[trunk_ir::canonicalize_pattern]` proc-macro attributes (defined
+// in `trunk-ir-macros`). They emit `inventory::submit!` blocks adjacent
+// to the attributed function — no separate registration call needed.
 
 // =========================================================================
 // Pass entry


### PR DESCRIPTION
## Summary

Replace the `register_canonicalize_fold!` / `register_canonicalize_pattern!` macro_rules! with two `#[proc_macro_attribute]`s, so registration sits on the function definition instead of in a separate registration block.

**Before**:
\`\`\`rust
crate::register_canonicalize_fold!(arith.addi => fold_addi);
pub(crate) fn fold_addi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { ... }
\`\`\`

**After**:
\`\`\`rust
#[trunk_ir::canonicalize_fold(arith.addi)]
pub(crate) fn fold_addi(ctx: &IrContext, op: OpRef) -> Option<FoldResult> { ... }
\`\`\`

A fold and its registration metadata can no longer drift apart, and the registration is the documentation: scrolling to the function tells you exactly which op it folds.

## Changes

- \`crates/trunk-ir-macros/src/canonicalize.rs\` (new): payload parser, function-name extraction, `inventory::submit!` codegen. Strips `r#` prefixes from raw identifiers so op names like `r#const` register as `\"const\"`. 5 unit tests.
- \`crates/trunk-ir-macros/src/lib.rs\`: two \`#[proc_macro_attribute]\` entry points + dispatch.
- \`crates/trunk-ir/src/lib.rs\`: re-export \`{canonicalize_fold, canonicalize_pattern}\`.
- \`crates/trunk-ir/src/transforms/canonicalize.rs\`: delete the two \`macro_rules!\` definitions; refresh module/struct doc references.
- 11 call sites migrated: 10 folds in \`arith.rs\`, 1 fold in \`core.rs\`, 1 pattern in \`scf.rs\`.

\`raw_ident_str!\` stays — still used by \`register_pure_op!\` / \`register_isolated_op!\` (out of scope).

Builds on #705 (extern crate self) — without that, the in-crate uses would still need a \`crate = crate\` knob.

## Test plan

- [x] \`cargo nextest run --workspace\` — 1329/1329 passed (1324 + 5 new tests in trunk-ir-macros).
- [x] \`.ci/lint.sh\` — rustfmt + clippy + markdownlint clean.
- [x] All canonicalize integration tests still pass — confirms \`inventory::iter::<CanonicalizeFold>()\` discovers the same 11 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new #[canonicalize_fold] attribute for registering per-op canonicalization folds.

* **Refactor**
  * Switched canonicalization registration from macro-based APIs to attribute/inventory-based discovery; canonicalization dispatch updated to use inventory-only fold registrations and a new splice result.

* **Tests**
  * Added and updated tests for attribute parsing, registration behavior, and canonicalize fold scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->