### PR TITLE
refactor(canonicalize): fold IfConstFold pattern into FoldResult::Splice

### DIFF
--- a/crates/trunk-ir-macros/src/canonicalize.rs
+++ b/crates/trunk-ir-macros/src/canonicalize.rs
@@ -1,7 +1,7 @@
-//! Proc-macro attributes for the canonicalize pass: `#[canonicalize_fold]`
-//! and `#[canonicalize_pattern]`. They submit `inventory` entries the
-//! pass discovers at startup, so the registration sits next to the
-//! function definition rather than in a separate macro_rules! call.
+//! Proc-macro attribute for the canonicalize pass:
+//! `#[canonicalize_fold]`. It submits an `inventory` entry the pass
+//! discovers at startup, so the registration sits next to the function
+//! definition rather than in a separate macro_rules! call.
 
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::quote;
@@ -19,24 +19,6 @@ pub fn gen_fold(attr: TokenStream, item: TokenStream) -> Result<TokenStream, Str
                 dialect: #dialect,
                 op_name: #op_name,
                 fold: #fn_ident,
-            }
-        }
-    })
-}
-
-/// Generate the expanded form for `#[canonicalize_pattern]`.
-pub fn gen_pattern(attr: TokenStream, item: TokenStream) -> Result<TokenStream, String> {
-    if !attr.is_empty() {
-        return Err("`#[canonicalize_pattern]` does not accept arguments".to_string());
-    }
-    let (fn_attrs, fn_ident) = extract_fn_attrs_and_ident(&item)?;
-    Ok(quote! {
-        #item
-
-        #fn_attrs
-        ::trunk_ir::inventory::submit! {
-            ::trunk_ir::transforms::canonicalize::CanonicalizePattern {
-                make: #fn_ident,
             }
         }
     })
@@ -183,27 +165,6 @@ mod tests {
             Ok(_) => panic!("expected parse error"),
         };
         assert!(err.contains("expected `.`"), "got: {err}");
-    }
-
-    #[test]
-    fn pattern_emits_inventory_submit() {
-        let item: TokenStream = quote! {
-            fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
-        };
-        let out = gen_pattern(TokenStream::new(), item).unwrap().to_string();
-        assert!(out.contains("CanonicalizePattern"), "got: {out}");
-        assert!(out.contains("make : make_if_const_fold"), "got: {out}");
-    }
-
-    #[test]
-    fn pattern_rejects_attr_args() {
-        let attr: TokenStream = quote! { foo };
-        let item: TokenStream = quote! { fn f() {} };
-        let err = match gen_pattern(attr, item) {
-            Err(e) => e,
-            Ok(_) => panic!("expected error"),
-        };
-        assert!(err.contains("does not accept arguments"), "got: {err}");
     }
 
     #[test]

--- a/crates/trunk-ir-macros/src/lib.rs
+++ b/crates/trunk-ir-macros/src/lib.rs
@@ -1,9 +1,8 @@
 //! Proc macros for trunk-ir dialect definitions.
 //!
 //! Provides `#[dialect]` for defining dialect operations with type-safe
-//! wrappers/accessors/constructors, plus `#[canonicalize_fold]` and
-//! `#[canonicalize_pattern]` for registering canonicalize-pass entries
-//! next to the function definition.
+//! wrappers/accessors/constructors, plus `#[canonicalize_fold]` for
+//! registering canonicalize-pass folds next to the function definition.
 
 use proc_macro::TokenStream as ProcTokenStream;
 
@@ -79,26 +78,6 @@ fn dialect_impl(
 #[proc_macro_attribute]
 pub fn canonicalize_fold(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream {
     match canonicalize::gen_fold(attr.into(), item.into()) {
-        Ok(tokens) => tokens.into(),
-        Err(msg) => quote::quote!(compile_error!(#msg);).into(),
-    }
-}
-
-/// Register a full `RewritePattern` for the canonicalize pass — used
-/// when a rewrite needs more than the per-op fold shape allows
-/// (e.g. multi-op region splicing).
-///
-/// ```ignore
-/// #[trunk_ir::canonicalize_pattern]
-/// fn make_if_const_fold() -> Box<dyn RewritePattern> { Box::new(IfConstFold) }
-/// ```
-///
-/// The attribute takes no arguments. The original function item is
-/// preserved unchanged; the macro only emits an adjacent
-/// `inventory::submit!` block.
-#[proc_macro_attribute]
-pub fn canonicalize_pattern(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream {
-    match canonicalize::gen_pattern(attr.into(), item.into()) {
         Ok(tokens) => tokens.into(),
         Err(msg) => quote::quote!(compile_error!(#msg);).into(),
     }

--- a/crates/trunk-ir/src/dialect/arith.rs
+++ b/crates/trunk-ir/src/dialect/arith.rs
@@ -370,7 +370,7 @@ pub(crate) fn const_int_value(ctx: &IrContext, value: ValueRef) -> Option<i128> 
 /// carrying attributes, names that don't follow the `i{N}` shape, or
 /// widths outside `[1, 128]` (the upper bound is what
 /// `wrap_signed_to_width` can represent in i128).
-fn core_int_width(ctx: &IrContext, ty: TypeRef) -> Option<u32> {
+pub(crate) fn core_int_width(ctx: &IrContext, ty: TypeRef) -> Option<u32> {
     let data = ctx.types.get(ty);
     if data.dialect != Symbol::new("core") || !data.params.is_empty() || !data.attrs.is_empty() {
         return None;

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -73,10 +73,14 @@ pub(crate) fn fold_if(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
         return None;
     }
     let cond_value = const_int_value(ctx, cond)?;
-    let active_region = if cond_value != 0 {
-        if_op.then_region(ctx)
-    } else {
-        if_op.else_region(ctx)
+    // We've gated on cond's type being `core.i1`; the only valid
+    // payloads are 0 and 1. Reject anything else (e.g.
+    // `arith.const value=2 : core.i1`) so the validator surfaces the
+    // malformed const instead of the fold silently picking a branch.
+    let active_region = match cond_value {
+        0 => if_op.else_region(ctx),
+        1 => if_op.then_region(ctx),
+        _ => return None,
     };
 
     // Active region must be a single block whose terminator is `scf.yield`.
@@ -224,6 +228,30 @@ mod canonicalize_tests {
         let input = r#"core.module @test {
   func.func @f(%x: core.i32) -> core.i32 {
     %bad = arith.const {value = 2} : core.i32
+    %r = scf.if %bad : core.i32 {
+      scf.yield %x
+    } {
+      scf.yield %x
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_scf_patterns(&mut ctx, module);
+        assert_eq!(result.total_changes, 0);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 1);
+    }
+
+    #[test]
+    fn if_malformed_i1_payload_is_not_folded() {
+        // Cond is i1-typed but carries a payload outside {0, 1}.
+        // The fold must bail so validation flags the bad const rather
+        // than the rewrite picking the then-branch by truthiness.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %bad = arith.const {value = 2} : core.i1
     %r = scf.if %bad : core.i32 {
       scf.yield %x
     } {

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -42,7 +42,7 @@ mod scf {
 // =========================================================================
 
 use crate::context::IrContext;
-use crate::dialect::arith::const_int_value;
+use crate::dialect::arith::{const_int_value, core_int_width};
 use crate::ops::DialectOp;
 use crate::refs::{OpRef, ValueRef};
 use crate::transforms::canonicalize::FoldResult;
@@ -65,6 +65,13 @@ use crate::transforms::canonicalize::FoldResult;
 pub(crate) fn fold_if(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
     let if_op = If::from_op(ctx, op).ok()?;
     let cond = if_op.cond(ctx);
+    // Guard against malformed IR: only fold when the cond's type is
+    // `core.i1`. Without this, an `arith.const value=2 : core.i32`
+    // wired into the cond slot would be treated as truthy here,
+    // burning the dead branch before the validator gets to reject it.
+    if core_int_width(ctx, ctx.value_ty(cond)) != Some(1) {
+        return None;
+    }
     let cond_value = const_int_value(ctx, cond)?;
     let active_region = if cond_value != 0 {
         if_op.then_region(ctx)
@@ -194,6 +201,30 @@ mod canonicalize_tests {
         let input = r#"core.module @test {
   func.func @f(%cond: core.i1, %x: core.i32) -> core.i32 {
     %r = scf.if %cond : core.i32 {
+      scf.yield %x
+    } {
+      scf.yield %x
+    }
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        let result = run_scf_patterns(&mut ctx, module);
+        assert_eq!(result.total_changes, 0);
+        assert_eq!(count_ops(&ctx, module, "scf", "if"), 1);
+    }
+
+    #[test]
+    fn if_non_i1_const_cond_is_not_folded() {
+        // Malformed IR: the cond slot is wired to a `core.i32` constant
+        // instead of `core.i1`. The fold must bail and leave the op for
+        // validation rather than picking a branch by truthiness.
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %bad = arith.const {value = 2} : core.i32
+    %r = scf.if %bad : core.i32 {
       scf.yield %x
     } {
       scf.yield %x

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -38,115 +38,61 @@ mod scf {
 }
 
 // =========================================================================
-// Canonicalization patterns
-//
-// `scf.if(arith.const Int(_) : core.i1)` is the first user of the
-// non-fold escape hatch in `transforms::canonicalize`: the rewrite
-// splices the chosen region's body into the parent block — a multi-op
-// mutation that doesn't fit the single-op `FoldResult` shape.
+// Canonicalization folds
 // =========================================================================
 
 use crate::context::IrContext;
 use crate::dialect::arith::const_int_value;
 use crate::ops::DialectOp;
 use crate::refs::{OpRef, ValueRef};
-use crate::rewrite::{PatternRewriter, RewritePattern};
-
-#[trunk_ir::canonicalize_pattern]
-fn make_if_const_fold() -> Box<dyn RewritePattern> {
-    Box::new(IfConstFold)
-}
+use crate::transforms::canonicalize::FoldResult;
 
 /// `scf.if(arith.const Int(c) : core.i1)` → splice the chosen region's
 /// body into the parent block.
 ///
 /// When the condition is a compile-time constant, exactly one branch
 /// runs; the other is dead. The chosen region's `scf.yield <values>`
-/// supplies the if op's results, so:
+/// supplies the if op's results, so the fold names the body ops to
+/// keep and the values that should take over the if op's result slots
+/// — the canonicalize dispatcher does the splice + cleanup of the
+/// dead branch and the chosen region's yield via [`FoldResult::Splice`].
 ///
-/// 1. Move every non-terminator op out of the active region's single
-///    block, into the parent block, in original order, immediately
-///    before the `scf.if` op. Captured operands stay valid because the
-///    cloned ops keep referencing the same `ValueRef`s.
-/// 2. RAUW the if op's results with the yield's operands.
-/// 3. Erase the `scf.if`. Its other (dead) region is dropped along
-///    with the orphaned yield from the active region.
-///
-/// Multi-block regions are left alone — they only appear post-`scf_to_cf`,
-/// where this pattern doesn't run anyway. The pattern self-filters on
-/// `scf.if` and bails out on any structural mismatch (yield arity,
-/// non-`i1` const, malformed regions).
-pub struct IfConstFold;
+/// Multi-block regions are left alone — they only appear
+/// post-`scf_to_cf`, where this pass doesn't run anyway. Bails out on
+/// any structural mismatch (yield arity, non-`i1` const, malformed
+/// regions).
+#[trunk_ir::canonicalize_fold(scf.r#if)]
+pub(crate) fn fold_if(ctx: &IrContext, op: OpRef) -> Option<FoldResult> {
+    let if_op = If::from_op(ctx, op).ok()?;
+    let cond = if_op.cond(ctx);
+    let cond_value = const_int_value(ctx, cond)?;
+    let active_region = if cond_value != 0 {
+        if_op.then_region(ctx)
+    } else {
+        if_op.else_region(ctx)
+    };
 
-impl RewritePattern for IfConstFold {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        if !If::matches(ctx, op) {
-            return false;
-        }
-        let if_op = match If::from_op(ctx, op) {
-            Ok(o) => o,
-            Err(_) => return false,
-        };
-        let cond = if_op.cond(ctx);
-
-        let Some(cond_value) = const_int_value(ctx, cond) else {
-            return false;
-        };
-        let active_region = if cond_value != 0 {
-            if_op.then_region(ctx)
-        } else {
-            if_op.else_region(ctx)
-        };
-
-        // Active region must be a single block whose terminator is `scf.yield`.
-        let blocks = ctx.region(active_region).blocks.to_vec();
-        let [active_block] = blocks.as_slice() else {
-            return false;
-        };
-        let active_block = *active_block;
-        let region_ops: Vec<OpRef> = ctx.block(active_block).ops.to_vec();
-        let Some((yield_op, body_ops)) = region_ops.split_last() else {
-            return false;
-        };
-        if !Yield::matches(ctx, *yield_op) {
-            return false;
-        }
-
-        // Yield arity must match the if op's result count.
-        let yield_operands: Vec<ValueRef> = ctx.op_operands(*yield_op).to_vec();
-        let if_result_count = ctx.op_results(op).len();
-        if yield_operands.len() != if_result_count {
-            return false;
-        }
-
-        // Splice body ops out into the parent block, before `op`.
-        let parent_block = match ctx.op(op).parent_block {
-            Some(b) => b,
-            None => return false,
-        };
-        for body_op in body_ops {
-            ctx.detach_op(*body_op);
-            ctx.insert_op_before(parent_block, op, *body_op);
-        }
-
-        // Detach + destroy the yield — its only user was the implicit
-        // edge to the if op's results, which we are about to erase.
-        ctx.detach_op(*yield_op);
-        ctx.remove_op(*yield_op);
-
-        // Erase the if op, mapping its results to the yield's operands.
-        rewriter.erase_op(yield_operands);
-        true
+    // Active region must be a single block whose terminator is `scf.yield`.
+    let blocks = ctx.region(active_region).blocks.to_vec();
+    let [active_block] = blocks.as_slice() else {
+        return None;
+    };
+    let region_ops: Vec<OpRef> = ctx.block(*active_block).ops.to_vec();
+    let (yield_op, body_ops) = region_ops.split_last()?;
+    if !Yield::matches(ctx, *yield_op) {
+        return None;
     }
 
-    fn name(&self) -> &'static str {
-        "IfConstFold"
+    // Yield arity must match the if op's result count.
+    let yield_operands: Vec<ValueRef> = ctx.op_operands(*yield_op).to_vec();
+    if yield_operands.len() != ctx.op_results(op).len() {
+        return None;
     }
+
+    Some(FoldResult::Splice {
+        body: body_ops.to_vec(),
+        results: yield_operands,
+    })
 }
 
 // =========================================================================
@@ -160,15 +106,17 @@ mod canonicalize_tests {
     use crate::printer::print_module;
     use crate::rewrite::{ApplyResult, Module, PatternApplicator, TypeConverter};
     use crate::symbol::Symbol;
+    use crate::transforms::canonicalize::{FoldDispatchPattern, folds_for_dialect};
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
-    /// Run only `IfConstFold` on `module`. Tests stay focused on this
-    /// pattern even though the production `canonicalize` pass aggregates
-    /// every registered fold and pattern.
-    fn run_if_const_fold(ctx: &mut IrContext, module: Module) -> ApplyResult {
+    /// Run only this dialect's folds on `module` via a single
+    /// [`FoldDispatchPattern`] — mirrors `arith.rs::run_arith_patterns`
+    /// to keep per-dialect tests isolated from other dialects' folds.
+    fn run_scf_patterns(ctx: &mut IrContext, module: Module) -> ApplyResult {
+        let dispatcher = FoldDispatchPattern::from_folds(folds_for_dialect("scf"));
         PatternApplicator::new(TypeConverter::new())
-            .add_pattern(IfConstFold)
+            .add_pattern_box(Box::new(dispatcher))
             .apply_partial(ctx, module)
     }
 
@@ -206,7 +154,7 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
         assert!(result.total_changes >= 1);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
         // The then-region's `arith.addi` is now at the parent block.
@@ -233,7 +181,7 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
         assert!(result.total_changes >= 1);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
         assert_eq!(count_ops(&ctx, module, "arith", "addi"), 1);
@@ -256,7 +204,7 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
         assert_eq!(result.total_changes, 0);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 1);
     }
@@ -280,7 +228,7 @@ mod canonicalize_tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
 
-        let result = run_if_const_fold(&mut ctx, module);
+        let result = run_scf_patterns(&mut ctx, module);
         assert!(result.total_changes >= 1);
         assert_eq!(count_ops(&ctx, module, "scf", "if"), 0);
         // The else region's addi was dropped along with the if op (it

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -58,9 +58,9 @@ pub use trunk_ir_macros::dialect;
 /// Deprecated alias for [`dialect`].
 pub use trunk_ir_macros::arena_dialect;
 
-// Re-export proc macros for canonicalize-pass registration. Each
-// emits an `inventory::submit!` block alongside the user's function.
-pub use trunk_ir_macros::{canonicalize_fold, canonicalize_pattern};
+// Re-export proc macro for canonicalize-pass registration. Emits an
+// `inventory::submit!` block alongside the user's function.
+pub use trunk_ir_macros::canonicalize_fold;
 
 // Re-export `inventory` so the proc-macro–generated submit blocks
 // resolve `::trunk_ir::inventory::submit!` without requiring consumer

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -9,13 +9,17 @@
 //! here.
 //!
 //! The driver dispatches each visited op to its fold (if any) by
-//! `(dialect, op_name)` HashMap lookup. A fold returns either a value
-//! to forward (RAUW the op's result) or an `Attribute` that the driver
-//! materializes as `arith.const` of the op's result type.
+//! `(dialect, op_name)` HashMap lookup. A fold returns one of:
 //!
-//! Multi-op rewrites that don't fit the fold shape (e.g. region splice
-//! for `scf.if(const)`) register as full [`RewritePattern`]s via the
-//! [`canonicalize_pattern`](crate::canonicalize_pattern) attribute.
+//! - [`FoldResult::Forward`] — RAUW the op's result with an existing
+//!   value.
+//! - [`FoldResult::ArithConst`] — replace with a fresh `arith.const`
+//!   of the op's result type.
+//! - [`FoldResult::Splice`] — splice a body of ops into the parent
+//!   block before the matched op and RAUW its results with the
+//!   supplied values; the dispatcher additionally drops anything
+//!   still attached to the matched op's regions (e.g. yields and the
+//!   dead branch in `scf.if(const)`).
 //!
 //! Currently registered (across `arith`, `core`):
 //!
@@ -31,7 +35,7 @@ use std::collections::HashMap;
 
 use crate::context::IrContext;
 use crate::dialect::arith;
-use crate::refs::{OpRef, ValueRef};
+use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use crate::rewrite::{Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter};
 use crate::symbol::Symbol;
 use crate::types::Attribute;
@@ -57,6 +61,26 @@ pub enum FoldResult {
     /// const-producing dialects require an explicit new variant — the
     /// driver currently knows only how to build `arith.const`.
     ArithConst(Attribute),
+    /// Splice a sequence of body ops into the matched op's parent block
+    /// (in order, immediately before the matched op), then erase the
+    /// matched op while RAUW'ing its results to `results`.
+    ///
+    /// Used by region-bearing ops whose canonicalization is "pick one
+    /// region's body and inline it" — `scf.if(const)` being the seed
+    /// case. The dispatcher additionally drops any ops still attached
+    /// to the matched op's regions (typically the chosen region's
+    /// yield + the dead branch's body); fold authors only have to name
+    /// the ops they want to *keep* (`body`) and the values that should
+    /// take over the matched op's result slots (`results`).
+    Splice {
+        /// Ops to detach from their current parent and insert in the
+        /// matched op's parent block, in order, immediately before the
+        /// matched op.
+        body: Vec<OpRef>,
+        /// Values to RAUW the matched op's results with. Length must
+        /// match the matched op's result count.
+        results: Vec<ValueRef>,
+    },
 }
 
 /// Per-op fold function. `&IrContext` is read-only; mutation happens in
@@ -141,12 +165,53 @@ impl RewritePattern for FoldDispatchPattern {
                 rewriter.replace_op(new_const.op_ref());
                 true
             }
+            FoldResult::Splice { body, results } => apply_splice(ctx, rewriter, op, body, results),
         }
     }
 
     fn name(&self) -> &'static str {
         "FoldDispatch"
     }
+}
+
+/// Apply a [`FoldResult::Splice`]: detach the listed body ops from
+/// their current parents, insert them before `op` in `op`'s parent
+/// block, drop everything still attached to `op`'s regions (typically
+/// terminators and the dead branch), then ask the rewriter to erase
+/// `op` while mapping its results to `results`.
+fn apply_splice(
+    ctx: &mut IrContext,
+    rewriter: &mut PatternRewriter<'_>,
+    op: OpRef,
+    body: Vec<OpRef>,
+    results: Vec<ValueRef>,
+) -> bool {
+    let Some(parent_block) = ctx.op(op).parent_block else {
+        return false;
+    };
+    for body_op in body {
+        ctx.detach_op(body_op);
+        ctx.insert_op_before(parent_block, op, body_op);
+    }
+    // Sweep up anything left in the matched op's regions — chosen
+    // region's terminator (we already kept the body it preceded) plus
+    // the dead branch entirely.
+    let regions: Vec<RegionRef> = ctx.op(op).regions.iter().copied().collect();
+    for region in regions {
+        let blocks: Vec<BlockRef> = ctx.region(region).blocks.to_vec();
+        for block in blocks {
+            // Reverse so a block-internal op is removed before any op
+            // that depends on its results, satisfying `remove_op`'s
+            // "no remaining uses" precondition.
+            let remaining: Vec<OpRef> = ctx.block(block).ops.to_vec();
+            for orphan in remaining.into_iter().rev() {
+                ctx.detach_op(orphan);
+                ctx.remove_op(orphan);
+            }
+        }
+    }
+    rewriter.erase_op(results);
+    true
 }
 
 // =========================================================================
@@ -162,29 +227,6 @@ pub struct CanonicalizeFold {
     pub fold: FoldFn,
 }
 inventory::collect!(CanonicalizeFold);
-
-/// One inventory entry registering a full `RewritePattern` for the
-/// canonicalize pass — used as an escape hatch for rewrites that don't
-/// fit the fold shape (e.g. multi-op region splicing). Submitted via
-/// the [`canonicalize_pattern`](crate::canonicalize_pattern) attribute.
-///
-/// `make` is a `fn` (not a closure) so the entry meets `inventory`'s
-/// `'static + Sync` bound. The function builds a fresh boxed pattern
-/// every time the pass runs; any state should be in the pattern itself,
-/// not captured.
-///
-/// **Determinism warning**: `inventory::iter` order is unspecified
-/// (linker-dependent). With a single registered pattern this is
-/// harmless; the moment a *second* `CanonicalizePattern` is registered,
-/// add explicit ordering (e.g. `priority: i32` + `name: &'static str`
-/// fields and sort by `(priority, name)` in `canonicalize()`) so the
-/// first-match-wins behavior of `PatternApplicator` doesn't drift
-/// across builds. Folds are dispatched by op key in
-/// `FoldDispatchPattern`, so the ordering issue applies only here.
-pub struct CanonicalizePattern {
-    pub make: fn() -> Box<dyn RewritePattern>,
-}
-inventory::collect!(CanonicalizePattern);
 
 /// Iterate every fold registered via inventory, keyed by interned
 /// `(dialect, op_name)` symbols ready for [`FoldDispatchPattern::from_folds`].
@@ -220,9 +262,9 @@ pub(crate) fn folds_for_dialect(
 }
 
 // Registration is done via the `#[trunk_ir::canonicalize_fold(...)]`
-// and `#[trunk_ir::canonicalize_pattern]` proc-macro attributes (defined
-// in `trunk-ir-macros`). They emit `inventory::submit!` blocks adjacent
-// to the attributed function — no separate registration call needed.
+// proc-macro attribute (defined in `trunk-ir-macros`). It emits an
+// `inventory::submit!` block adjacent to the attributed function — no
+// separate registration call needed.
 
 // =========================================================================
 // Pass entry
@@ -244,11 +286,8 @@ pub struct CanonicalizeResult {
 
 /// Run canonicalization to a fixed point on `module`.
 pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
-    let mut applicator = PatternApplicator::new(TypeConverter::new())
+    let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern_box(Box::new(FoldDispatchPattern::from_inventory()));
-    for entry in inventory::iter::<CanonicalizePattern> {
-        applicator = applicator.add_pattern_box((entry.make)());
-    }
     let result = applicator.apply_partial(ctx, module);
     CanonicalizeResult {
         iterations: result.iterations,

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -186,6 +186,13 @@ fn apply_splice(
     body: Vec<OpRef>,
     results: Vec<ValueRef>,
 ) -> bool {
+    // Precondition: `results` must cover every result slot of the
+    // matched op. Check before any mutation so a buggy fold can't leave
+    // body ops spliced out and the matched op's regions emptied while
+    // the final RAUW fails arity checks deep in `rewriter.erase_op`.
+    if ctx.op_results(op).len() != results.len() {
+        return false;
+    }
     let Some(parent_block) = ctx.op(op).parent_block else {
         return false;
     };


### PR DESCRIPTION
## Summary

Drop the `#[canonicalize_pattern]` escape hatch and unify on a single registration mechanism. The one user — `IfConstFold` — needed a multi-op rewrite (splice the chosen branch's body into the parent block, drop the dead branch). Express that as a new `FoldResult` variant:

\`\`\`rust
pub enum FoldResult {
    Forward(ValueRef),
    ArithConst(Attribute),
    Splice {
        body: Vec<OpRef>,        // splice into parent before matched op
        results: Vec<ValueRef>,  // RAUW the matched op's results
    },
}
\`\`\`

The `FoldDispatchPattern` handles the splice + RAUW + automatic cleanup of anything still attached to the matched op's regions (typically the chosen region's yield + the dead branch entirely), so fold authors only name the ops they want to *keep* and the values that should take over the matched op's result slots.

## Changes

- \`crates/trunk-ir/src/transforms/canonicalize.rs\`: add \`FoldResult::Splice\` + \`apply_splice\` dispatcher helper; remove \`CanonicalizePattern\` struct, its \`inventory::collect!\`, and the per-pattern iteration in \`canonicalize()\`.
- \`crates/trunk-ir/src/dialect/scf.rs\`: rewrite \`IfConstFold\` (a \`RewritePattern\`) as \`fold_if\` (a \`#[canonicalize_fold(scf.r#if)]\` fold returning \`Splice\`). Tests now use \`FoldDispatchPattern::from_folds(folds_for_dialect(\"scf\"))\`.
- \`crates/trunk-ir-macros/src/{canonicalize,lib}.rs\`: remove the \`canonicalize_pattern\` proc-macro attribute, its \`gen_pattern\` helper, and the two associated unit tests.
- \`crates/trunk-ir/src/lib.rs\`: drop the \`canonicalize_pattern\` re-export.

## Why

- One escape hatch with a single user is hard to justify; the splice shape captures the substantive thing \`IfConstFold\` was doing.
- Folding by op key (dispatcher pre-filter) replaces the in-pattern \`If::matches\` check.
- Removes the \`inventory::iter\` ordering caveat that \`canonicalize_pattern\` came with.
- The \`Splice\` shape is general enough for future region-bearing ops with the same shape (loop unroll, dead-branch elim, scf.while const condition).

Stacked on top of #706.

## Test plan

- [x] \`cargo nextest run --workspace\` — 1331/1331 passed (was 1333; net −2 because the two \`gen_pattern\` macro tests are gone).
- [x] \`.ci/lint.sh\` — rustfmt + clippy + markdownlint clean.
- [x] \`if_const_collaborates_with_arith_folds\` integration test still passes — confirms the new splice + adjacent fold composition end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the `canonicalize_pattern` macro from the public API; fold-based registration is now the standard approach.

* **New Features**
  * Added constant-folding optimization for `scf.if` operations with compile-time constant conditions, enabling automatic active region extraction and result replacement.

* **Refactor**
  * Upgraded canonicalization infrastructure with an inventory-based fold dispatch system and region-splice support for sophisticated transformation patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->