### PR TITLE
feat(pipeline): migrate remaining shared middle-end passes to PassManager

### DIFF
--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -616,7 +616,7 @@ fn transform_closure_calls_in_block(
 ///
 /// Phase 2 (Post-processing):
 /// - Transform ALL closure calls to pass evidence from the enclosing function
-pub fn lower_closures(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) {
     // Collect ALL closure calls before pattern application
     let all_closure_calls = collect_all_closure_calls(ctx, module);
 

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -29,6 +29,7 @@ use trunk_ir::dialect::adt as arena_adt;
 use trunk_ir::dialect::core as arena_core;
 use trunk_ir::dialect::func as arena_func;
 use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::pass::Pass;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
@@ -630,4 +631,21 @@ pub fn lower_closures(ctx: &mut IrContext, module: Module) {
 
     // Phase 2: Evidence passing for closure calls
     transform_closure_calls_with_evidence(ctx, module, &all_closure_calls);
+}
+
+/// PassManager-friendly wrapper for [`lower_closures`].
+pub struct LowerClosures;
+
+impl Pass for LowerClosures {
+    type Target = arena_core::Module;
+
+    fn name(&self) -> &'static str {
+        "lower-closures"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: arena_core::Module) {
+        let module = Module::new(ctx, target.op_ref())
+            .expect("core::Module wrapper guarantees core.module op");
+        lower_closures(ctx, module);
+    }
 }

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -644,8 +644,6 @@ impl Pass for LowerClosures {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: arena_core::Module) {
-        let module = Module::new(ctx, target.op_ref())
-            .expect("core::Module wrapper guarantees core.module op");
-        lower_closures(ctx, module);
+        lower_closures(ctx, target.into());
     }
 }

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -21,13 +21,13 @@
 
 use std::collections::HashSet;
 
-use tribute_ir::dialect::closure as arena_closure;
+use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt as arena_adt;
-use trunk_ir::dialect::core as arena_core;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::adt;
+use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
@@ -71,16 +71,16 @@ fn is_any_closure_value(ctx: &IrContext, value: ValueRef) -> bool {
 
     // Direct check for closure.new result
     if let ValueDef::OpResult(op, _) = ctx.value_def(value)
-        && arena_closure::New::from_op(ctx, op).is_ok()
+        && closure::New::from_op(ctx, op).is_ok()
     {
         return true;
     }
 
     // Check type
-    if arena_closure::Closure::matches(ctx, ty) {
+    if closure::Closure::matches(ctx, ty) {
         return true;
     }
-    if arena_core::Func::matches(ctx, ty) {
+    if core::Func::matches(ctx, ty) {
         // core.func in func.call_indirect is always a closure value.
         // Direct function calls use func.call; call_indirect operates on
         // closure values (block args, env captures, etc.).
@@ -97,7 +97,7 @@ fn is_any_closure_value(ctx: &IrContext, value: ValueRef) -> bool {
 fn collect_all_closure_calls(ctx: &IrContext, module: Module) -> HashSet<(usize, usize)> {
     let mut closure_calls = HashSet::new();
     for op in module.ops(ctx) {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, op) {
             let body = func_op.body(ctx);
             collect_closure_calls_in_region(ctx, body, &mut closure_calls);
         }
@@ -123,7 +123,7 @@ fn collect_closure_calls_in_op(
     closure_calls: &mut HashSet<(usize, usize)>,
 ) {
     // Check if this is a call_indirect with a closure callee
-    if arena_func::CallIndirect::from_op(ctx, op).is_ok() {
+    if func::CallIndirect::from_op(ctx, op).is_ok() {
         let operands = ctx.op_operands(op);
         if let Some(&callee) = operands.first()
             && is_any_closure_value(ctx, callee)
@@ -153,7 +153,7 @@ impl RewritePattern for UpdateFuncSignatureArena {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, op) else {
+        let Ok(func_op) = func::Func::from_op(ctx, op) else {
             return false;
         };
 
@@ -176,9 +176,9 @@ impl RewritePattern for UpdateFuncSignatureArena {
         new_params.push(params[0]); // return type
 
         for &param_ty in &params[1..] {
-            if arena_core::Func::matches(ctx, param_ty) {
+            if core::Func::matches(ctx, param_ty) {
                 // Convert core.func to closure.closure wrapping the func type
-                let closure_ty = arena_closure::closure(ctx, param_ty).as_type_ref();
+                let closure_ty = closure::closure(ctx, param_ty).as_type_ref();
                 new_params.push(closure_ty);
                 needs_update = true;
             } else {
@@ -192,15 +192,14 @@ impl RewritePattern for UpdateFuncSignatureArena {
 
         // Build new func type
         let return_ty = new_params[0];
-        let new_func_ty =
-            arena_core::func(ctx, return_ty, new_params[1..].iter().copied()).as_type_ref();
+        let new_func_ty = core::func(ctx, return_ty, new_params[1..].iter().copied()).as_type_ref();
 
         // Rebuild the function with new type
         let func_name = func_op.sym_name(ctx);
         let body = func_op.body(ctx);
         let loc = ctx.op(op).location;
         ctx.detach_region(body);
-        let new_op = arena_func::func(ctx, loc, func_name, new_func_ty, body).op_ref();
+        let new_op = func::func(ctx, loc, func_name, new_func_ty, body).op_ref();
         rewriter.replace_op(new_op);
         true
     }
@@ -220,7 +219,7 @@ impl RewritePattern for LowerClosureNewArena {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(closure_new) = arena_closure::New::from_op(ctx, op) else {
+        let Ok(closure_new) = closure::New::from_op(ctx, op) else {
             return false;
         };
 
@@ -230,18 +229,17 @@ impl RewritePattern for LowerClosureNewArena {
 
         // Extract function type from closure.closure result type
         let result_ty = ctx.op_result_types(op)[0];
-        let func_ty = arena_closure::Closure::from_type_ref(ctx, result_ty)
+        let func_ty = closure::Closure::from_type_ref(ctx, result_ty)
             .map(|c| c.func_type(ctx))
             .expect("closure.new result type must contain a valid func type (from func.constant)");
 
         // Generate: %funcref = func.constant @func_ref : func_type
-        let constant_op = arena_func::constant(ctx, loc, func_ty, func_ref);
+        let constant_op = func::constant(ctx, loc, func_ty, func_ref);
         let funcref = ctx.op_result(constant_op.op_ref(), 0);
 
         // Generate: %closure = adt.struct_new(%funcref, %env) : closure_struct_type
         let struct_ty = closure_struct_type_ref(ctx);
-        let struct_new_op =
-            arena_adt::struct_new(ctx, loc, vec![funcref, env], struct_ty, struct_ty);
+        let struct_new_op = adt::struct_new(ctx, loc, vec![funcref, env], struct_ty, struct_ty);
 
         rewriter.insert_op(constant_op.op_ref());
         rewriter.replace_op(struct_new_op.op_ref());
@@ -263,7 +261,7 @@ impl RewritePattern for LowerClosureCallArena {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_func::CallIndirect::from_op(ctx, op).is_err() {
+        if func::CallIndirect::from_op(ctx, op).is_err() {
             return false;
         }
 
@@ -275,12 +273,12 @@ impl RewritePattern for LowerClosureCallArena {
         let callee_ty = ctx.value_ty(callee);
 
         // Determine if callee is a closure
-        let callee_is_closure = if arena_closure::Closure::matches(ctx, callee_ty) {
+        let callee_is_closure = if closure::Closure::matches(ctx, callee_ty) {
             true
         } else if is_closure_struct_type_ref(ctx, callee_ty) {
             // Already lowered closure struct
             true
-        } else if arena_core::Func::matches(ctx, callee_ty) {
+        } else if core::Func::matches(ctx, callee_ty) {
             // core.func in func.call_indirect is always a closure value.
             // Direct function calls use func.call; call_indirect operates on
             // closure values (block args, env captures, etc.).
@@ -288,7 +286,7 @@ impl RewritePattern for LowerClosureCallArena {
         } else {
             // Fallback: check if result of closure.new
             if let trunk_ir::refs::ValueDef::OpResult(def_op, _) = ctx.value_def(callee) {
-                arena_closure::New::from_op(ctx, def_op).is_ok()
+                closure::New::from_op(ctx, def_op).is_ok()
             } else {
                 false
             }
@@ -314,17 +312,17 @@ impl RewritePattern for LowerClosureCallArena {
             extract_return_type_from_callee(ctx, callee_ty).unwrap_or(caller_result_ty);
 
         // Generate: %table_idx = closure.func %closure
-        let table_idx_op = arena_closure::func(ctx, loc, callee, i32_ty);
+        let table_idx_op = closure::func(ctx, loc, callee, i32_ty);
         let table_idx = ctx.op_result(table_idx_op.op_ref(), 0);
 
         // Generate: %env = closure.env %closure
-        let env_op = arena_closure::env(ctx, loc, callee, anyref_ty);
+        let env_op = closure::env(ctx, loc, callee, anyref_ty);
         let env = ctx.op_result(env_op.op_ref(), 0);
 
         // Generate: %result = func.call_indirect %table_idx, [%env, %args...]
         let mut new_args = vec![env];
         new_args.extend(args);
-        let new_call = arena_func::call_indirect(ctx, loc, table_idx, new_args, callee_return_ty);
+        let new_call = func::call_indirect(ctx, loc, table_idx, new_args, callee_return_ty);
 
         rewriter.insert_op(table_idx_op.op_ref());
         rewriter.insert_op(env_op.op_ref());
@@ -332,12 +330,8 @@ impl RewritePattern for LowerClosureCallArena {
         // If the closure's return type differs from the caller's expected type,
         // insert a cast so downstream code sees the expected type.
         if callee_return_ty != caller_result_ty {
-            let cast = arena_core::unrealized_conversion_cast(
-                ctx,
-                loc,
-                new_call.result(ctx),
-                caller_result_ty,
-            );
+            let cast =
+                core::unrealized_conversion_cast(ctx, loc, new_call.result(ctx), caller_result_ty);
             rewriter.insert_op(new_call.op_ref());
             rewriter.replace_op(cast.op_ref());
         } else {
@@ -361,7 +355,7 @@ impl RewritePattern for LowerClosureFuncArena {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_closure::Func::from_op(ctx, op).is_err() {
+        if closure::Func::from_op(ctx, op).is_err() {
             return false;
         }
 
@@ -372,7 +366,7 @@ impl RewritePattern for LowerClosureFuncArena {
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
         let struct_ty = closure_struct_type_ref(ctx);
 
-        let get_op = arena_adt::struct_get(ctx, loc, closure_value, i32_ty, struct_ty, 0);
+        let get_op = adt::struct_get(ctx, loc, closure_value, i32_ty, struct_ty, 0);
         rewriter.replace_op(get_op.op_ref());
         true
     }
@@ -392,7 +386,7 @@ impl RewritePattern for LowerClosureEnvArena {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_closure::Env::from_op(ctx, op).is_err() {
+        if closure::Env::from_op(ctx, op).is_err() {
             return false;
         }
 
@@ -401,7 +395,7 @@ impl RewritePattern for LowerClosureEnvArena {
         let result_ty = ctx.op_result_types(op)[0];
         let struct_ty = closure_struct_type_ref(ctx);
 
-        let get_op = arena_adt::struct_get(ctx, loc, closure_value, result_ty, struct_ty, 1);
+        let get_op = adt::struct_get(ctx, loc, closure_value, result_ty, struct_ty, 1);
         rewriter.replace_op(get_op.op_ref());
         true
     }
@@ -448,7 +442,7 @@ fn transform_closure_calls_with_evidence(
 
     let func_ops: Vec<OpRef> = module.ops(ctx);
     for func_op_ref in func_ops {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, func_op_ref) else {
+        let Ok(func_op) = func::Func::from_op(ctx, func_op_ref) else {
             continue;
         };
 
@@ -532,7 +526,7 @@ fn transform_closure_calls_in_block(
         }
 
         // Check if this is a closure call_indirect that needs evidence
-        if arena_func::CallIndirect::from_op(ctx, op).is_err() {
+        if func::CallIndirect::from_op(ctx, op).is_err() {
             continue;
         }
 
@@ -563,7 +557,7 @@ fn transform_closure_calls_in_block(
             // Create null evidence lazily
             if null_ev_value.is_none() {
                 let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
-                let null_op = arena_adt::ref_null(ctx, func_location, evidence_ty, evidence_ty);
+                let null_op = adt::ref_null(ctx, func_location, evidence_ty, evidence_ty);
                 let ev = ctx.op_result(null_op.op_ref(), 0);
                 // Insert null evidence at the beginning of the block
                 let first_op_in_block = ctx.block(block).ops.first().copied();
@@ -590,7 +584,7 @@ fn transform_closure_calls_in_block(
         let mut new_args = vec![evidence];
         new_args.extend(rest_args);
 
-        let new_call = arena_func::call_indirect(ctx, loc, table_idx, new_args, result_ty);
+        let new_call = func::call_indirect(ctx, loc, table_idx, new_args, result_ty);
 
         // Replace old result uses with new result
         let old_result = ctx.op_result(op, 0);
@@ -637,13 +631,13 @@ pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) {
 pub struct LowerClosures;
 
 impl Pass for LowerClosures {
-    type Target = arena_core::Module;
+    type Target = core::Module;
 
     fn name(&self) -> &'static str {
         "lower-closures"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: arena_core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
         lower_closures(ctx, target.into());
     }
 }

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -10,7 +10,7 @@ use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::arith;
 use trunk_ir::dialect::core;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
@@ -179,7 +179,7 @@ impl RewritePattern for ArithIntrinsicPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(call_op) = arena_func::Call::from_op(ctx, op) else {
+        let Ok(call_op) = func::Call::from_op(ctx, op) else {
             return false;
         };
         let callee = call_op.callee(ctx);
@@ -230,7 +230,7 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, op) else {
+        let Ok(func_op) = func::Func::from_op(ctx, op) else {
             return false;
         };
 
@@ -288,7 +288,7 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
         ctx.push_op(body_block, result_op);
 
         let result_val = ctx.op_results(result_op)[0];
-        let ret_op = arena_func::r#return(ctx, loc, [result_val]);
+        let ret_op = func::r#return(ctx, loc, [result_val]);
         ctx.push_op(body_block, ret_op.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -301,7 +301,7 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
         let old_body = func_op.body(ctx);
         ctx.detach_region(old_body);
 
-        let new_func = arena_func::func(ctx, loc, sym_name, func_ty, body).op_ref();
+        let new_func = func::func(ctx, loc, sym_name, func_ty, body).op_ref();
         // Do NOT copy the "intrinsic" abi — this is now a real function
         rewriter.replace_op(new_func);
         true

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -25,7 +25,7 @@ use trunk_ir::types::{Attribute, Location};
 /// `arith.addi`). Intrinsic `func.func` declarations — which originally
 /// contain only `func.unreachable` — are given a real body so they remain
 /// valid when used as first-class values (closures, `func.constant`, etc.).
-pub fn lower_intrinsic_to_arith(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_intrinsic_to_arith(ctx: &mut IrContext, module: Module) {
     let pattern = ArithIntrinsicPattern::new();
     let intrinsic_map: HashMap<Symbol, ArithMapping> = pattern.map.clone();
 

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -47,9 +47,7 @@ impl Pass for LowerIntrinsicToArith {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
-        let module = Module::new(ctx, target.op_ref())
-            .expect("core::Module wrapper guarantees core.module op");
-        lower_intrinsic_to_arith(ctx, module);
+        lower_intrinsic_to_arith(ctx, target.into());
     }
 }
 

--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -26,9 +26,6 @@ pub mod type_converter;
 pub mod wasm;
 
 // Re-exports
-pub use closure_lower::lower_closures;
 pub use diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
-pub use lower_closure_lambda::lower_closure_lambda;
-pub use resolve_evidence::resolve_evidence_dispatch;
 pub use trunk_ir::rewrite::{ApplyResult, PatternApplicator, PatternRewriter, RewritePattern};
 pub use type_converter::generic_type_converter;

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -76,9 +76,7 @@ impl Pass for LowerAbilityPerform {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
-        let module = Module::new(ctx, target.op_ref())
-            .expect("core::Module wrapper guarantees core.module op");
-        lower_ability_perform(ctx, module);
+        lower_ability_perform(ctx, target.into());
     }
 }
 

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -26,6 +26,7 @@ use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{adt, arith, core, func};
 use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
@@ -62,6 +63,23 @@ pub fn lower_ability_perform(ctx: &mut IrContext, module: Module) {
         .add_pattern(LowerPerformPattern { types })
         .add_pattern(LowerCallPattern { types });
     applicator.apply_partial(ctx, module);
+}
+
+/// PassManager-friendly wrapper for [`lower_ability_perform`].
+pub struct LowerAbilityPerform;
+
+impl Pass for LowerAbilityPerform {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "lower-ability-perform"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+        let module = Module::new(ctx, target.op_ref())
+            .expect("core::Module wrapper guarantees core.module op");
+        lower_ability_perform(ctx, module);
+    }
 }
 
 /// Pattern: `ability.perform` → evidence lookup + handler_dispatch call + return.

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -57,7 +57,7 @@ impl CommonTypes {
 }
 
 /// Lower all `ability.perform` and `ability.call` ops in the module.
-pub fn lower_ability_perform(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_ability_perform(ctx: &mut IrContext, module: Module) {
     let types = CommonTypes::new(ctx);
     let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern(LowerPerformPattern { types })

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -74,9 +74,7 @@ impl Pass for LowerClosureLambda {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
-        let module = Module::new(ctx, target.op_ref())
-            .expect("core::Module wrapper guarantees core.module op");
-        lower_closure_lambda(ctx, module);
+        lower_closure_lambda(ctx, target.into());
     }
 }
 

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -39,7 +39,7 @@ use tribute_ir::dialect::closure as arena_closure;
 use tribute_ir::dialect::tribute_rt;
 
 /// Lower all `closure.lambda` ops in the module to `func.func` + `closure.new`.
-pub fn lower_closure_lambda(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_closure_lambda(ctx: &mut IrContext, module: Module) {
     let module_block = match module.first_block(ctx) {
         Some(b) => b,
         None => return,

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -29,6 +29,7 @@ use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, core, func};
 use trunk_ir::ir_mapping::IrMapping;
 use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::Module;
 use trunk_ir::types::{Attribute, TypeDataBuilder};
@@ -59,6 +60,23 @@ pub fn lower_closure_lambda(ctx: &mut IrContext, module: Module) {
         for lambda_ref in lambdas {
             lower_single_lambda(ctx, module_block, lambda_ref, &mut namer);
         }
+    }
+}
+
+/// PassManager-friendly wrapper for [`lower_closure_lambda`].
+pub struct LowerClosureLambda;
+
+impl Pass for LowerClosureLambda {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "lower-closure-lambda"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+        let module = Module::new(ctx, target.op_ref())
+            .expect("core::Module wrapper guarantees core.module op");
+        lower_closure_lambda(ctx, module);
     }
 }
 

--- a/crates/tribute-passes/src/lower_handle_dispatch.rs
+++ b/crates/tribute-passes/src/lower_handle_dispatch.rs
@@ -21,7 +21,7 @@ use trunk_ir::types::Location;
 use tribute_ir::dialect::ability;
 
 /// Lower all `ability.handle_dispatch` ops in the module.
-pub fn lower_handle_dispatch(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_handle_dispatch(ctx: &mut IrContext, module: Module) {
     let applicator =
         PatternApplicator::new(TypeConverter::new()).add_pattern(LowerHandleDispatchPattern);
     applicator.apply_partial(ctx, module);

--- a/crates/tribute-passes/src/lower_handle_dispatch.rs
+++ b/crates/tribute-passes/src/lower_handle_dispatch.rs
@@ -38,9 +38,7 @@ impl Pass for LowerHandleDispatch {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
-        let module = Module::new(ctx, target.op_ref())
-            .expect("core::Module wrapper guarantees core.module op");
-        lower_handle_dispatch(ctx, module);
+        lower_handle_dispatch(ctx, target.into());
     }
 }
 

--- a/crates/tribute-passes/src/lower_handle_dispatch.rs
+++ b/crates/tribute-passes/src/lower_handle_dispatch.rs
@@ -11,6 +11,7 @@ use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{core, scf};
 use trunk_ir::ir_mapping::IrMapping;
 use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
@@ -24,6 +25,23 @@ pub fn lower_handle_dispatch(ctx: &mut IrContext, module: Module) {
     let applicator =
         PatternApplicator::new(TypeConverter::new()).add_pattern(LowerHandleDispatchPattern);
     applicator.apply_partial(ctx, module);
+}
+
+/// PassManager-friendly wrapper for [`lower_handle_dispatch`].
+pub struct LowerHandleDispatch;
+
+impl Pass for LowerHandleDispatch {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "lower-handle-dispatch"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+        let module = Module::new(ctx, target.op_ref())
+            .expect("core::Module wrapper guarantees core.module op");
+        lower_handle_dispatch(ctx, module);
+    }
 }
 
 /// Pattern: `ability.handle_dispatch` → inline done handler body.

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -973,9 +973,7 @@ impl Pass for ResolveEvidenceDispatch {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: arena_core::Module) {
-        let module = Module::new(ctx, target.op_ref())
-            .expect("core::Module wrapper guarantees core.module op");
-        resolve_evidence_dispatch(ctx, module);
+        resolve_evidence_dispatch(ctx, target.into());
     }
 }
 

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -19,6 +19,7 @@ use trunk_ir::dialect::arith;
 use trunk_ir::dialect::core as arena_core;
 use trunk_ir::dialect::func as arena_func;
 use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::Module;
 use trunk_ir::types::{Attribute, TypeDataBuilder};
@@ -958,6 +959,23 @@ pub fn resolve_evidence_dispatch(ctx: &mut IrContext, module: Module) {
         if !non_root_evidence_fns.is_empty() {
             transform_shifts_in_module(ctx, module, &non_root_evidence_fns);
         }
+    }
+}
+
+/// PassManager-friendly wrapper for [`resolve_evidence_dispatch`].
+pub struct ResolveEvidenceDispatch;
+
+impl Pass for ResolveEvidenceDispatch {
+    type Target = arena_core::Module;
+
+    fn name(&self) -> &'static str {
+        "resolve-evidence-dispatch"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: arena_core::Module) {
+        let module = Module::new(ctx, target.op_ref())
+            .expect("core::Module wrapper guarantees core.module op");
+        resolve_evidence_dispatch(ctx, module);
     }
 }
 

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -927,7 +927,7 @@ fn transform_shifts_in_region(
 /// Transforms `ability.evidence_lookup` and `ability.handle_dispatch`
 /// into evidence-based dispatch using runtime function calls. This enables
 /// proper handler dispatch at runtime.
-pub fn resolve_evidence_dispatch(ctx: &mut IrContext, module: Module) {
+pub(crate) fn resolve_evidence_dispatch(ctx: &mut IrContext, module: Module) {
     // Ensure runtime helpers exist
     ensure_runtime_functions(ctx, module);
 

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -14,10 +14,10 @@ use std::collections::{HashMap, HashSet};
 use tribute_ir::dialect::ability;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt as arena_adt;
+use trunk_ir::dialect::adt;
 use trunk_ir::dialect::arith;
-use trunk_ir::dialect::core as arena_core;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
@@ -46,7 +46,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
     let mut has_next_tag = false;
 
     for op in &ops {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, *op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, *op) {
             let name = func_op.sym_name(ctx);
             if name == Symbol::new("__tribute_evidence_lookup") {
                 has_lookup = true;
@@ -75,7 +75,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
         let marker_ty = ability::marker_adt_type_ref(ctx);
 
         // fn __tribute_evidence_lookup(ev: Evidence, ability_id: i32) -> Marker
-        let func_ty = arena_core::func(ctx, marker_ty, [evidence_ty, i32_ty]).as_type_ref();
+        let func_ty = core::func(ctx, marker_ty, [evidence_ty, i32_ty]).as_type_ref();
 
         // Body with unreachable
         let body_block = ctx.create_block(trunk_ir::context::BlockData {
@@ -93,14 +93,14 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
             ops: Default::default(),
             parent_region: None,
         });
-        let unreachable_op = arena_func::unreachable(ctx, loc);
+        let unreachable_op = func::unreachable(ctx, loc);
         ctx.push_op(body_block, unreachable_op.op_ref());
         let body = ctx.create_region(trunk_ir::context::RegionData {
             location: loc,
             blocks: trunk_ir::smallvec::smallvec![body_block],
             parent_op: None,
         });
-        let func_op = arena_func::func(
+        let func_op = func::func(
             ctx,
             loc,
             Symbol::new("__tribute_evidence_lookup"),
@@ -119,7 +119,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
         let marker_ty = ability::marker_adt_type_ref(ctx);
 
         // fn __tribute_evidence_extend(ev: Evidence, marker: Marker) -> Evidence
-        let func_ty = arena_core::func(ctx, evidence_ty, [evidence_ty, marker_ty]).as_type_ref();
+        let func_ty = core::func(ctx, evidence_ty, [evidence_ty, marker_ty]).as_type_ref();
 
         let body_block = ctx.create_block(trunk_ir::context::BlockData {
             location: loc,
@@ -136,14 +136,14 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
             ops: Default::default(),
             parent_region: None,
         });
-        let unreachable_op = arena_func::unreachable(ctx, loc);
+        let unreachable_op = func::unreachable(ctx, loc);
         ctx.push_op(body_block, unreachable_op.op_ref());
         let body = ctx.create_region(trunk_ir::context::RegionData {
             location: loc,
             blocks: trunk_ir::smallvec::smallvec![body_block],
             parent_op: None,
         });
-        let func_op = arena_func::func(
+        let func_op = func::func(
             ctx,
             loc,
             Symbol::new("__tribute_evidence_extend"),
@@ -163,7 +163,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
         let i32_ty = i32_type_ref(ctx);
 
         // fn __tribute_next_tag() -> i32
-        let func_ty = arena_core::func(ctx, i32_ty, std::iter::empty()).as_type_ref();
+        let func_ty = core::func(ctx, i32_ty, std::iter::empty()).as_type_ref();
 
         let body_block = ctx.create_block(trunk_ir::context::BlockData {
             location: loc,
@@ -171,14 +171,14 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
             ops: Default::default(),
             parent_region: None,
         });
-        let unreachable_op = arena_func::unreachable(ctx, loc);
+        let unreachable_op = func::unreachable(ctx, loc);
         ctx.push_op(body_block, unreachable_op.op_ref());
         let body = ctx.create_region(trunk_ir::context::RegionData {
             location: loc,
             blocks: trunk_ir::smallvec::smallvec![body_block],
             parent_op: None,
         });
-        let func_op = arena_func::func(ctx, loc, Symbol::new("__tribute_next_tag"), func_ty, body);
+        let func_op = func::func(ctx, loc, Symbol::new("__tribute_next_tag"), func_ty, body);
         // Mark as C ABI extern function
         ctx.op_mut(func_op.op_ref())
             .attributes
@@ -196,7 +196,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
 fn collect_functions_with_evidence(ctx: &IrContext, module: Module) -> HashSet<Symbol> {
     let mut fns_with_evidence = HashSet::new();
     for op in module.ops(ctx) {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, op) {
             let func_ty = func_op.r#type(ctx);
             if has_evidence_first_param(ctx, func_ty) {
                 fns_with_evidence.insert(func_op.sym_name(ctx));
@@ -208,7 +208,7 @@ fn collect_functions_with_evidence(ctx: &IrContext, module: Module) -> HashSet<S
 
 /// Check if a `core.func` type has evidence as its first parameter.
 fn has_evidence_first_param(ctx: &IrContext, func_ty: TypeRef) -> bool {
-    let Some(func) = arena_core::Func::from_type_ref(ctx, func_ty) else {
+    let Some(func) = core::Func::from_type_ref(ctx, func_ty) else {
         return false;
     };
     let params = func.params(ctx);
@@ -226,7 +226,7 @@ fn collect_handler_root_functions(
 ) -> HashSet<Symbol> {
     let mut handler_roots = HashSet::new();
     for op in module.ops(ctx) {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, op) {
             let func_name = func_op.sym_name(ctx);
             if fns_with_evidence.contains(&func_name) {
                 continue;
@@ -372,7 +372,7 @@ fn transform_handler_roots(
     // see the updated signature.
     let mut polymorphic_roots: HashSet<Symbol> = HashSet::new();
     for &func_op_ref in &func_ops {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, func_op_ref) else {
+        let Ok(func_op) = func::Func::from_op(ctx, func_op_ref) else {
             continue;
         };
         let func_name = func_op.sym_name(ctx);
@@ -396,7 +396,7 @@ fn transform_handler_roots(
     // Phase 2: Transform all handler root functions.
     let func_ops: Vec<OpRef> = module.ops(ctx);
     for func_op_ref in func_ops {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, func_op_ref) else {
+        let Ok(func_op) = func::Func::from_op(ctx, func_op_ref) else {
             continue;
         };
         let func_name = func_op.sym_name(ctx);
@@ -421,7 +421,7 @@ fn transform_handler_roots(
         } else {
             // Create empty evidence for non-polymorphic handler roots
             let zero_const = arith::r#const(ctx, loc, i32_ty, Attribute::Int(0));
-            let empty_evidence = arena_adt::array_new(
+            let empty_evidence = adt::array_new(
                 ctx,
                 loc,
                 vec![ctx.op_result(zero_const.op_ref(), 0)],
@@ -483,7 +483,7 @@ fn update_calls_to_newly_evidenced(
 
     let func_ops: Vec<OpRef> = module.ops(ctx);
     for func_op_ref in func_ops {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, func_op_ref) else {
+        let Ok(func_op) = func::Func::from_op(ctx, func_op_ref) else {
             continue;
         };
         let func_name = func_op.sym_name(ctx);
@@ -514,7 +514,7 @@ fn update_calls_in_region(
                 update_calls_in_region(ctx, r, newly_evidenced, evidence_ty, i32_ty);
             }
 
-            let Ok(call_op) = arena_func::Call::from_op(ctx, op) else {
+            let Ok(call_op) = func::Call::from_op(ctx, op) else {
                 continue;
             };
             let callee = call_op.callee(ctx);
@@ -536,7 +536,7 @@ fn update_calls_in_region(
                 enclosing
             } else {
                 let zero = arith::r#const(ctx, loc, i32_ty, Attribute::Int(0));
-                let empty = arena_adt::array_new(
+                let empty = adt::array_new(
                     ctx,
                     loc,
                     vec![ctx.op_result(zero.op_ref(), 0)],
@@ -556,9 +556,9 @@ fn update_calls_in_region(
                 .op_result_types(op)
                 .first()
                 .copied()
-                .unwrap_or_else(|| arena_core::nil(ctx).as_type_ref());
+                .unwrap_or_else(|| core::nil(ctx).as_type_ref());
 
-            let new_call = arena_func::call(ctx, loc, new_args, result_ty, callee);
+            let new_call = func::call(ctx, loc, new_args, result_ty, callee);
 
             if !ctx.op_results(op).is_empty() {
                 let old_result = ctx.op_result(op, 0);
@@ -580,7 +580,7 @@ fn transform_shifts_in_module(
 ) {
     let func_ops: Vec<OpRef> = module.ops(ctx);
     for func_op_ref in func_ops {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, func_op_ref) else {
+        let Ok(func_op) = func::Func::from_op(ctx, func_op_ref) else {
             continue;
         };
         let func_name = func_op.sym_name(ctx);
@@ -656,14 +656,14 @@ fn transform_shifts_in_block(
                 let i32_ty = i32_type_ref(ctx);
                 let evidence_ty = ability::evidence_adt_type_ref(ctx);
                 let marker_ty = ability::marker_adt_type_ref(ctx);
-                let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+                let ptr_ty = core::ptr(ctx).as_type_ref();
 
                 // All evidence extension ops are inserted before handle_dispatch.
                 // The body closure call (which needs extended evidence) is moved
                 // to after the extension, also before handle_dispatch.
 
                 // Generate runtime tag
-                let tag_call = arena_func::call(
+                let tag_call = func::call(
                     ctx,
                     loc,
                     std::iter::empty::<ValueRef>(),
@@ -680,7 +680,7 @@ fn transform_shifts_in_block(
                     let tr_fn_val = operands
                         .get(2)
                         .expect("handle_dispatch must have operand[2] (tr_dispatch_fn)");
-                    let cast = arena_core::unrealized_conversion_cast(ctx, loc, *tr_fn_val, ptr_ty);
+                    let cast = core::unrealized_conversion_cast(ctx, loc, *tr_fn_val, ptr_ty);
                     ctx.insert_op_before(block, op, cast.op_ref());
                     cast.result(ctx)
                 };
@@ -689,8 +689,7 @@ fn transform_shifts_in_block(
                     let handler_val = operands
                         .get(1)
                         .expect("handle_dispatch must have operand[1] (handler closure)");
-                    let cast =
-                        arena_core::unrealized_conversion_cast(ctx, loc, *handler_val, ptr_ty);
+                    let cast = core::unrealized_conversion_cast(ctx, loc, *handler_val, ptr_ty);
                     ctx.insert_op_before(block, op, cast.op_ref());
                     cast.result(ctx)
                 };
@@ -703,7 +702,7 @@ fn transform_shifts_in_block(
                     let ability_id_val = ctx.op_result(ability_id_const.op_ref(), 0);
                     ctx.insert_op_before(block, op, ability_id_const.op_ref());
 
-                    let marker_struct = arena_adt::struct_new(
+                    let marker_struct = adt::struct_new(
                         ctx,
                         loc,
                         vec![
@@ -718,7 +717,7 @@ fn transform_shifts_in_block(
                     let marker_val = ctx.op_result(marker_struct.op_ref(), 0);
                     ctx.insert_op_before(block, op, marker_struct.op_ref());
 
-                    let extend_call = arena_func::call(
+                    let extend_call = func::call(
                         ctx,
                         loc,
                         vec![current_ev, marker_val],
@@ -740,12 +739,12 @@ fn transform_shifts_in_block(
                     let results = ctx.op_results(candidate);
                     if !results.is_empty()
                         && results[0] == yr_operand
-                        && arena_func::CallIndirect::from_op(ctx, candidate).is_ok()
+                        && func::CallIndirect::from_op(ctx, candidate).is_ok()
                     {
                         let operands = ctx.op_operands(candidate).to_vec();
                         // Replace evidence arg (index 1: [table_idx, evidence, ...rest])
                         if operands.len() >= 2 {
-                            let new_call = arena_func::call_indirect(
+                            let new_call = func::call_indirect(
                                 ctx,
                                 loc,
                                 operands[0],
@@ -780,7 +779,7 @@ fn transform_shifts_in_block(
         }
 
         // Handle func.call to effectful functions: update evidence argument.
-        if let Ok(call_op) = arena_func::Call::from_op(ctx, op) {
+        if let Ok(call_op) = func::Call::from_op(ctx, op) {
             let callee = call_op.callee(ctx);
             if fns_with_evidence.contains(&callee) {
                 let current_operands = ctx.op_operands(op).to_vec();
@@ -791,7 +790,7 @@ fn transform_shifts_in_block(
                         .op_result_types(op)
                         .first()
                         .copied()
-                        .unwrap_or_else(|| arena_core::nil(ctx).as_type_ref());
+                        .unwrap_or_else(|| core::nil(ctx).as_type_ref());
 
                     let new_args = if prepend_evidence {
                         // Handler root: evidence_calls couldn't add evidence,
@@ -807,7 +806,7 @@ fn transform_shifts_in_block(
                         args
                     };
 
-                    let new_call = arena_func::call(ctx, loc, new_args, result_ty, callee);
+                    let new_call = func::call(ctx, loc, new_args, result_ty, callee);
 
                     if !ctx.op_results(op).is_empty() {
                         let old_result = ctx.op_result(op, 0);
@@ -823,7 +822,7 @@ fn transform_shifts_in_block(
         }
 
         // Handle func.call_indirect: replace evidence argument (index 1)
-        if arena_func::CallIndirect::from_op(ctx, op).is_ok() {
+        if func::CallIndirect::from_op(ctx, op).is_ok() {
             let current_operands = ctx.op_operands(op).to_vec();
             if current_operands.len() >= 2 {
                 let current_ev = current_operands[1];
@@ -833,13 +832,12 @@ fn transform_shifts_in_block(
                         .op_result_types(op)
                         .first()
                         .copied()
-                        .unwrap_or_else(|| arena_core::nil(ctx).as_type_ref());
+                        .unwrap_or_else(|| core::nil(ctx).as_type_ref());
                     let table_idx = current_operands[0];
                     let mut new_args = vec![ev_value];
                     new_args.extend(current_operands[2..].iter().copied());
 
-                    let new_call =
-                        arena_func::call_indirect(ctx, loc, table_idx, new_args, result_ty);
+                    let new_call = func::call_indirect(ctx, loc, table_idx, new_args, result_ty);
 
                     if !ctx.op_results(op).is_empty() {
                         let old_result = ctx.op_result(op, 0);
@@ -871,7 +869,7 @@ fn transform_shifts_in_block(
             ctx.insert_op_before(block, op, ability_id_const.op_ref());
 
             // %marker = func.call @__tribute_evidence_lookup(%ev, %ability_id)
-            let lookup_call = arena_func::call(
+            let lookup_call = func::call(
                 ctx,
                 loc,
                 vec![ev_value, ability_id_val],
@@ -966,13 +964,13 @@ pub(crate) fn resolve_evidence_dispatch(ctx: &mut IrContext, module: Module) {
 pub struct ResolveEvidenceDispatch;
 
 impl Pass for ResolveEvidenceDispatch {
-    type Target = arena_core::Module;
+    type Target = core::Module;
 
     fn name(&self) -> &'static str {
         "resolve-evidence-dispatch"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: arena_core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
         resolve_evidence_dispatch(ctx, target.into());
     }
 }

--- a/crates/tribute-passes/src/tail_resumptive.rs
+++ b/crates/tribute-passes/src/tail_resumptive.rs
@@ -155,9 +155,7 @@ impl Pass for ConvertTailResumptive {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
-        let module = Module::new(ctx, target.op_ref())
-            .expect("core::Module wrapper guarantees core.module op");
-        convert_tail_resumptive(ctx, module);
+        convert_tail_resumptive(ctx, target.into());
     }
 }
 

--- a/crates/tribute-passes/src/tail_resumptive.rs
+++ b/crates/tribute-passes/src/tail_resumptive.rs
@@ -138,7 +138,7 @@ impl RewritePattern for SuspendToYieldPattern {
 ///
 /// Uses `PatternApplicator` to walk all operations and replace eligible
 /// `ability.suspend` ops with `ability.yield`.
-pub fn convert_tail_resumptive(ctx: &mut IrContext, module: Module) {
+pub(crate) fn convert_tail_resumptive(ctx: &mut IrContext, module: Module) {
     let applicator =
         PatternApplicator::new(TypeConverter::new()).add_pattern(SuspendToYieldPattern);
     applicator.apply_partial(ctx, module);

--- a/crates/tribute-passes/src/tail_resumptive.rs
+++ b/crates/tribute-passes/src/tail_resumptive.rs
@@ -12,8 +12,10 @@
 //! 3. The result of `ability.resume` flows directly to `scf.yield` (tail position)
 
 use trunk_ir::context::IrContext;
+use trunk_ir::dialect::core;
 use trunk_ir::dialect::scf as arena_scf;
 use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::Pass;
 use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
@@ -140,6 +142,23 @@ pub fn convert_tail_resumptive(ctx: &mut IrContext, module: Module) {
     let applicator =
         PatternApplicator::new(TypeConverter::new()).add_pattern(SuspendToYieldPattern);
     applicator.apply_partial(ctx, module);
+}
+
+/// PassManager-friendly wrapper for [`convert_tail_resumptive`].
+pub struct ConvertTailResumptive;
+
+impl Pass for ConvertTailResumptive {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "convert-tail-resumptive"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+        let module = Module::new(ctx, target.op_ref())
+            .expect("core::Module wrapper guarantees core.module op");
+        convert_tail_resumptive(ctx, module);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tribute-passes/src/tail_resumptive.rs
+++ b/crates/tribute-passes/src/tail_resumptive.rs
@@ -13,7 +13,7 @@
 
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::core;
-use trunk_ir::dialect::scf as arena_scf;
+use trunk_ir::dialect::scf;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
@@ -76,7 +76,7 @@ pub fn is_tail_resumptive(ctx: &IrContext, suspend_body: RegionRef) -> Option<Ta
     }
 
     let yield_op = resume_uses[0].user;
-    if !arena_scf::Yield::matches(ctx, yield_op) {
+    if !scf::Yield::matches(ctx, yield_op) {
         return None;
     }
 

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -84,6 +84,14 @@ impl Module {
     }
 }
 
+impl From<crate::dialect::core::Module> for Module {
+    /// Infallible: `core::Module` already guarantees a `core.module` op,
+    /// so the dialect/name re-validation in [`Module::new`] is redundant.
+    fn from(m: crate::dialect::core::Module) -> Self {
+        Module(crate::ops::DialectOp::op_ref(&m))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -156,4 +156,23 @@ mod tests {
         assert_eq!(module.body(&ctx), Some(region));
         assert_eq!(module.first_block(&ctx), Some(block));
     }
+
+    #[test]
+    fn from_core_module_preserves_op_and_matches_new() {
+        use crate::ops::DialectOp;
+
+        let (mut ctx, loc) = test_ctx();
+        let op_data = OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
+            .attr("sym_name", Attribute::Symbol(Symbol::new("m")))
+            .build(&mut ctx);
+        let op = ctx.create_op(op_data);
+
+        let dialect_module =
+            crate::dialect::core::Module::from_op(&ctx, op).expect("should accept core.module");
+        // Conversion is infallible and must yield the same underlying op as
+        // the validating Module::new path.
+        let converted: Module = dialect_module.into();
+        assert_eq!(converted.op(), op);
+        assert_eq!(converted.op(), Module::new(&ctx, op).unwrap().op());
+    }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -418,8 +418,12 @@ pub fn run_through_evidence_params(
     source: SourceCst,
 ) -> Option<(IrContext, Module)> {
     let (mut ctx, m) = compile_frontend(db, source)?;
-    tribute_passes::lower_closure_lambda::lower_closure_lambda(&mut ctx, m);
-    tribute_passes::intrinsic_to_arith::lower_intrinsic_to_arith(&mut ctx, m);
+    let core_module =
+        core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
+    let mut pm = PassManager::new();
+    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
+        .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith);
+    pm.run(&mut ctx, core_module);
     Some((ctx, m))
 }
 
@@ -432,9 +436,13 @@ pub fn run_through_closure_lower(
     source: SourceCst,
 ) -> Option<(IrContext, Module)> {
     let (mut ctx, m) = compile_frontend(db, source)?;
-    tribute_passes::lower_closure_lambda::lower_closure_lambda(&mut ctx, m);
-    tribute_passes::intrinsic_to_arith::lower_intrinsic_to_arith(&mut ctx, m);
-    tribute_passes::closure_lower::lower_closures(&mut ctx, m);
+    let core_module =
+        core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
+    let mut pm = PassManager::new();
+    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
+        .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
+        .add_pass(tribute_passes::closure_lower::LowerClosures);
+    pm.run(&mut ctx, core_module);
     Some((ctx, m))
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -452,26 +452,24 @@ pub fn run_through_closure_lower(
 fn run_shared_pipeline(db: &dyn salsa::Database, source: SourceCst) -> Option<(IrContext, Module)> {
     let (mut ctx, m) = compile_frontend(db, source)?;
 
-    // Middle-end passes
-    tribute_passes::lower_closure_lambda::lower_closure_lambda(&mut ctx, m);
-
-    // Demonstrate PassManager wiring (#268). Other passes still run via
-    // direct calls until they are migrated in follow-up PRs.
+    // Middle-end passes, sequenced through the PassManager (#268).
+    // Registration order == execution order.
     let core_module =
         core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
     let mut pm = PassManager::new();
-    pm.add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith);
+    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
+        .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
+        // Evidence params are now inserted directly during ast_to_ir lowering.
+        .add_pass(tribute_passes::closure_lower::LowerClosures)
+        // CPS effect handling: lower_ability_perform produces
+        // ability.evidence_lookup ops that resolve_evidence needs to process.
+        // lower_handle_dispatch consumes handle_dispatch ops, so it must run
+        // AFTER resolve_evidence expands evidence.
+        .add_pass(tribute_passes::lower_ability_perform::LowerAbilityPerform)
+        .add_pass(tribute_passes::tail_resumptive::ConvertTailResumptive)
+        .add_pass(tribute_passes::resolve_evidence::ResolveEvidenceDispatch)
+        .add_pass(tribute_passes::lower_handle_dispatch::LowerHandleDispatch);
     pm.run(&mut ctx, core_module);
-
-    // Evidence params are now inserted directly during ast_to_ir lowering.
-    tribute_passes::closure_lower::lower_closures(&mut ctx, m);
-    // CPS effect handling: lower_ability_perform produces ability.evidence_lookup ops
-    // that resolve_evidence needs to process. lower_handle_dispatch consumes
-    // handle_dispatch ops, so it must run AFTER resolve_evidence expands evidence.
-    tribute_passes::lower_ability_perform::lower_ability_perform(&mut ctx, m);
-    tribute_passes::tail_resumptive::convert_tail_resumptive(&mut ctx, m);
-    tribute_passes::resolve_evidence::resolve_evidence_dispatch(&mut ctx, m);
-    tribute_passes::lower_handle_dispatch::lower_handle_dispatch(&mut ctx, m);
 
     Some((ctx, m))
 }

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -23,7 +23,11 @@ fn compile_to_ir(db: &dyn salsa::Database, code: &str, name: &str) -> (IrContext
     let source_file = SourceCst::from_path(db, name, source_code.clone(), tree);
     let (mut ctx, m) =
         tribute::pipeline::compile_frontend(db, source_file).expect("compilation should succeed");
-    tribute_passes::lower_closure_lambda::lower_closure_lambda(&mut ctx, m);
+    let core_module = trunk_ir::dialect::core::Module::from_op(&ctx, m.op())
+        .expect("frontend output must be a core.module");
+    let mut pm = trunk_ir::pass::PassManager::new();
+    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda);
+    pm.run(&mut ctx, core_module);
     (ctx, m)
 }
 


### PR DESCRIPTION
## Summary

- Added `Pass<Target = core::Module>` wrapper structs for the 6 remaining shared passes: `LowerClosureLambda`, `LowerClosures`, `LowerAbilityPerform`, `ConvertTailResumptive`, `ResolveEvidenceDispatch`, `LowerHandleDispatch`
- Replaced the "1-pass manager + direct calls" half-state in `run_shared_pipeline` with a single 7-pass `PassManager` chain, preserving the exact prior execution order
- Existing free functions (`lower_*`) stay public and unchanged so other callers (`run_through_evidence_params`, `run_through_closure_lower`, tests) keep working
- Added infallible `From<core::Module> for rewrite::Module`; collapsed all wrapper bodies to `target.into()`, removing the redundant re-validation boilerplate

## Why

#708 introduced the `PassManager` abstraction but wired only one demo pass (`LowerIntrinsicToArith`), leaving a hybrid "manager + direct calls coexist" state. This PR routes the entire shared middle-end through the manager, making pass ordering explicit (registration order = execution order) and removing the half-migrated state.

Mechanical, behavior-preserving migration — no func-nesting, no verifier wiring, no diagnostics/Salsa changes (deferred follow-ups).

Part of #268.

## Test plan

- [x] `cargo build` (workspace) — clean
- [x] `cargo nextest run` — 365 passed, 0 failed
- [x] `cargo nextest run --test e2e_ability_core` — 28 passed (exercises full shared pipeline: closures → abilities → evidence → handle dispatch)
- [x] Pre-commit hook (clippy + fmt + full test suite) — passed on commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pipeline orchestration now runs intermediate lowering steps through a unified pass manager for ordered, consistent execution.

* **New Features**
  * Added pass-manager-compatible wrappers for multiple lowering/conversion passes to standardize registration and execution.

* **Chores**
  * Several internal lowering helpers made crate-private and removed from public re-exports.
  * Added a module-wrapper conversion helper.

* **Tests**
  * Updated tests to invoke lowering via the pass manager.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kroisse/tribute/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->