### PR TITLE
fix(tribute-passes): erase disposed ops to clear use-chains (#710 step 2)

### DIFF
--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -32,7 +32,7 @@ use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, erase_op,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -591,9 +591,9 @@ fn transform_closure_calls_in_block(
         let new_result = ctx.op_result(new_call.op_ref(), 0);
         ctx.replace_all_uses(old_result, new_result);
 
-        // Insert new call and remove old one
+        // Insert new call and erase old one (clears its operand use-chain, #710)
         ctx.insert_op_before(block, op, new_call.op_ref());
-        ctx.remove_op_from_block(block, op);
+        erase_op(ctx, op);
     }
 }
 

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -29,7 +29,7 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, erase_op,
 };
 use trunk_ir::types::Attribute;
 
@@ -227,8 +227,13 @@ impl RewritePattern for LowerPerformPattern {
                 };
                 ops[idx + 1..].to_vec()
             };
-            for dead_op in dead_ops {
-                ctx.remove_op_from_block(block, dead_op);
+            // Erase unreachable ops after the perform in reverse order
+            // (consumer before producer) so `erase_op`'s result-use check never
+            // trips on a later dead op still consuming an earlier one. Unlike
+            // the previous detach-only loop, this also clears the dead ops'
+            // operand use-chains (#710).
+            for dead_op in dead_ops.into_iter().rev() {
+                erase_op(ctx, dead_op);
             }
         }
 

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -31,7 +31,7 @@ use trunk_ir::ir_mapping::IrMapping;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
-use trunk_ir::rewrite::Module;
+use trunk_ir::rewrite::{Module, erase_op};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 use tribute_ir::dialect::ability as arena_ability;
@@ -213,8 +213,10 @@ fn lower_single_lambda(
     let new_result = closure_new_op.result(ctx);
     ctx.replace_all_uses(old_result, new_result);
 
-    // Remove the original closure.lambda op.
-    ctx.remove_op_from_block(parent_block, lambda_ref);
+    // Erase the original closure.lambda op. `erase_op` clears the operand
+    // use-chains of the lambda and its (now-cloned) body subtree, not just
+    // detaches it — see #710.
+    erase_op(ctx, lambda_ref);
 }
 
 // ============================================================================

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -21,7 +21,7 @@ use trunk_ir::dialect::func;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::pass::Pass;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
-use trunk_ir::rewrite::Module;
+use trunk_ir::rewrite::{Module, erase_op};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 // ============================================================================
@@ -567,7 +567,7 @@ fn update_calls_in_region(
             }
 
             ctx.insert_op_before(block, op, new_call.op_ref());
-            ctx.remove_op_from_block(block, op);
+            erase_op(ctx, op);
         }
     }
 }
@@ -758,7 +758,7 @@ fn transform_shifts_in_block(
                             ctx.replace_all_uses(old_result, new_result);
                             // Insert new call before handle_dispatch (after evidence extension)
                             ctx.insert_op_before(block, op, new_call.op_ref());
-                            ctx.remove_op_from_block(block, candidate);
+                            erase_op(ctx, candidate);
                         }
                         break;
                     }
@@ -815,7 +815,7 @@ fn transform_shifts_in_block(
                     }
 
                     ctx.insert_op_before(block, op, new_call.op_ref());
-                    ctx.remove_op_from_block(block, op);
+                    erase_op(ctx, op);
                     continue;
                 }
             }
@@ -846,7 +846,7 @@ fn transform_shifts_in_block(
                     }
 
                     ctx.insert_op_before(block, op, new_call.op_ref());
-                    ctx.remove_op_from_block(block, op);
+                    erase_op(ctx, op);
                     continue;
                 }
             }
@@ -882,7 +882,7 @@ fn transform_shifts_in_block(
             // Replace uses of old result with new marker
             let old_result = ctx.op_result(op, 0);
             ctx.replace_all_uses(old_result, new_marker);
-            ctx.remove_op_from_block(block, op);
+            erase_op(ctx, op);
             continue;
         }
 


### PR DESCRIPTION
## Summary

Several shared middle-end passes disposed of ops with `remove_op_from_block` only, which detaches the op but leaves its operand use-chain entries on still-live values (#710 **Class A**). This PR switches the dispose-intent sites in **tribute-passes** to `erase_op` (= detach + the step-1-strengthened `remove_op`), so both the op's own operands and its body subtree are cleared.

## Changes

- **`lower_closure_lambda`** — the lifted lambda (the original #710 trigger). Its body is cloned into the lifted function, so erasing now also clears the discarded original body subtree.
- **`closure_lower`**, **`resolve_evidence`** (5 sites) — RAUW'd call/marker replacements.
- **`lower_ability_perform`** — unreachable ops after a `perform` are now erased in **reverse order** (consumer before producer) so `erase_op`'s own-result-use check never trips on a later dead op still consuming an earlier one.

## Scope (#710 step 2 of 3)

- **This PR — Class A, tribute-passes only.**
- **Excluded (move/reorder, left on `remove_op_from_block`)**: `native/rtti` (274,339), `native/rc_insertion` (748), `native/rc_lowering` (204,296) — these re-attach the op via `push_op`.
- **Follow-up**: trunk-ir transforms (`inline`, `scf_to_cf` yield/continue/break, `resolve_unrealized_casts`, `global_dce`). Note `scf_to_cf` detaches an op *before* moving its region blocks out, so it must NOT use `erase_op`.
- **step 3**: wire `validate_use_chains` as a debug `PassManager` verifier (regression guard) — now meaningful since the shared pipeline is clean.

## Verification

With a temporary `validate_use_chains` verifier on the shared `PassManager`, all 7 passes report **0** use-chain errors compiling `lang-examples/ability_core.trb` — down from 32 after step 1 (PR #711).

- [x] `cargo nextest run` — 365 passed
- [x] Pre-commit hook (clippy + fmt + full suite, 1353 tests) — passed
- [x] `ability_core.trb` compiles to a native executable; behavior-preserving

Part of #710.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler operation cleanup during intermediate representation transformation passes. Operations removed during closure resolution, ability handling, and lambda lowering are now properly erased with use-chains cleared, preventing potential issues with dead code elimination and use-tracking conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->