### PR TITLE
fix(trunk-ir): erase disposed ops in transforms (#710 step 2b)

### DIFF
--- a/crates/trunk-ir/src/conversion/resolve_unrealized_casts.rs
+++ b/crates/trunk-ir/src/conversion/resolve_unrealized_casts.rs
@@ -153,10 +153,10 @@ impl CastResolver {
         // Get the cast result value
         let cast_result = ctx.op_result(op, 0);
 
-        // If types are the same, just RAUW and remove the cast
+        // If types are the same, just RAUW and erase the cast
         if from_type == to_type {
             ctx.replace_all_uses(cast_result, input_value);
-            ctx.remove_op_from_block(block, op);
+            crate::rewrite::erase_op(ctx, op);
             self.resolved_count += 1;
             return;
         }
@@ -172,7 +172,7 @@ impl CastResolver {
                 }
                 // RAUW the cast result with the materialized value
                 ctx.replace_all_uses(cast_result, mat.value);
-                ctx.remove_op_from_block(block, op);
+                crate::rewrite::erase_op(ctx, op);
                 self.resolved_count += 1;
             }
             None => {

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -207,13 +207,12 @@ fn apply_splice(
     for region in regions {
         let blocks: Vec<BlockRef> = ctx.region(region).blocks.to_vec();
         for block in blocks {
-            // Reverse so a block-internal op is removed before any op
-            // that depends on its results, satisfying `remove_op`'s
-            // "no remaining uses" precondition.
+            // Reverse so a block-internal op is erased before any op that
+            // depends on its results, satisfying `remove_op`'s "no remaining
+            // uses" precondition.
             let remaining: Vec<OpRef> = ctx.block(block).ops.to_vec();
             for orphan in remaining.into_iter().rev() {
-                ctx.detach_op(orphan);
-                ctx.remove_op(orphan);
+                crate::rewrite::erase_op(ctx, orphan);
             }
         }
     }

--- a/crates/trunk-ir/src/transforms/global_dce.rs
+++ b/crates/trunk-ir/src/transforms/global_dce.rs
@@ -381,10 +381,12 @@ impl GlobalDcePass {
                     && !reachable.contains(&func_name)
                 {
                     removed.push(func_name);
-                    ctx.remove_op_from_block(block, op);
-                    // Note: we don't call ctx.remove_op because the func
-                    // has regions/results that may have complex ownership.
-                    // Detaching from the block is sufficient for DCE.
+                    // Erase the unreachable function: `erase_op` clears the
+                    // operand use-chains of the func and its body subtree, so
+                    // dead funcs don't leave stale uses behind (#710). Func
+                    // scopes are independent (SSA), so clearing the body's
+                    // operand uses cannot affect other reachable functions.
+                    crate::rewrite::erase_op(ctx, op);
                 }
             }
         }

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -84,15 +84,17 @@ pub fn inline_single_call(
             .ok_or(InlineError::CallOpDetached)?;
         let new_ret = func::r#return(ctx, call_loc, ret_values);
         ctx.insert_op_before(caller_block, call_op, new_ret.op_ref());
-        ctx.detach_op(call_op);
+        // tail call is a terminator (no results), so erasing it clears its
+        // operand use-chain without dangling-result concerns. #710
+        crate::rewrite::erase_op(ctx, call_op);
     } else {
         // Regular call: RAUW each call result with its mapped return value,
-        // then detach the original call op.
+        // then erase the original call op (clears its operand use-chain). #710
         let call_results: Vec<_> = ctx.op_results(call_op).to_vec();
         for (call_result, ret_val) in call_results.iter().zip(ret_values.iter()) {
             ctx.replace_all_uses(*call_result, *ret_val);
         }
-        ctx.detach_op(call_op);
+        crate::rewrite::erase_op(ctx, call_op);
     }
 
     Ok(())

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -445,7 +445,7 @@ fn replace_yield_with_br(
                 let br = cf::br(ctx, loc, values, target);
 
                 // Replace yield with br in-place
-                ctx.remove_op_from_block(block, op);
+                crate::rewrite::erase_op(ctx, op);
                 ctx.push_op(block, br.op_ref());
             }
         }
@@ -470,13 +470,13 @@ fn replace_continue_break(
                 let cont_op = scf::Continue::from_op(ctx, op).unwrap();
                 let values: Vec<_> = cont_op.values(ctx).to_vec();
                 let br = cf::br(ctx, loc, values, header);
-                ctx.remove_op_from_block(block, op);
+                crate::rewrite::erase_op(ctx, op);
                 ctx.push_op(block, br.op_ref());
             } else if scf::Break::matches(ctx, op) {
                 let break_op = scf::Break::from_op(ctx, op).unwrap();
                 let value = break_op.value(ctx);
                 let br = cf::br(ctx, loc, [value], exit);
-                ctx.remove_op_from_block(block, op);
+                crate::rewrite::erase_op(ctx, op);
                 ctx.push_op(block, br.op_ref());
             } else {
                 // Recurse into nested regions for continue/break replacement,


### PR DESCRIPTION
## Summary

trunk-ir transforms (backend lowering, outside the shared-pipeline verifier guard from #713) disposed of ops with `remove_op_from_block`/`detach_op` only, leaving their operand use-chain entries on still-live values (#710 **Class A**). This PR switches the dispose-intent sites to `erase_op` (= detach + the step-1-strengthened `remove_op`).

## Changes

- **`inline`** — regular call (RAUW'd) and tail call (terminator, no results).
- **`resolve_unrealized_casts`** — same-type and materialized cast replacements (RAUW'd).
- **`scf_to_cf`** — yield/continue/break → `br` replacements (terminators).
- **`global_dce`** — unreachable `func.func` removal; `erase_op` now also clears the dead body's operand use-chains. Func scopes are independent (SSA), so this can't affect reachable functions.
- **`canonicalize`** — collapse the existing `detach_op` + `remove_op` orphan cleanup to `erase_op` for consistency.

## Excluded (move/reorder — must NOT erase)

- `scf_to_cf` scf-op disposal at 156/201/277: `detach_op` happens **before** `inline_region_blocks` moves its region blocks into the parent, so `erase_op` would clear the moved ops' use-chains.
- `canonicalize` body-op hoisting (re-attached, not disposed).

## Verification

- [x] `cargo nextest run --workspace` (1356) green — including `e2e_native`/wasm e2e that exercise these backend transforms, and `inline`/`scf_to_cf`/`global_dce` unit tests.
- [x] Risk sites (inline tail-call, global_dce func) erase without tripping `remove_op`'s result-use assertion.
- [x] Pre-commit hook (clippy + fmt + full suite) — passed.

Behavior-preserving.

## Scope

Completes #710 Class A across the codebase: step 2 (#712, tribute-passes) + this step 2b (trunk-ir transforms). Class B was fixed in step 1 (#711); the shared pipeline is guarded by step 3 (#713).

Part of #710.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal operation removal logic across compiler passes to use a centralized removal function, improving consistency and maintainability in the IR transformation pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->