### PR TITLE
Add TDNR integration tests for method resolution

### DIFF
--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -116,7 +116,7 @@ fn tdnr_function_summary_inner<'db>(
     db: &'db dyn salsa::Database,
     source: SourceCst,
     function_name: String,
-) -> String {
+) -> TdnrSummary {
     let parsed = tribute_front::query::parsed_ast(db, source);
     assert!(parsed.is_some(), "Should parse successfully");
 
@@ -142,7 +142,7 @@ fn tdnr_function_summary_inner<'db>(
     let body = function_body(&module, &function_name);
     let mut summary = TdnrSummary::default();
     collect_tdnr_summary(db, body, &mut summary);
-    format!("methods: {:?}\ncalls: {:?}", summary.methods, summary.calls)
+    summary
 }
 
 /// Run the AST pipeline through TDNR and summarize one function body.
@@ -153,7 +153,7 @@ pub fn tdnr_function_summary(
     db: &dyn salsa::Database,
     source: SourceCst,
     function_name: &str,
-) -> String {
+) -> TdnrSummary {
     tdnr_function_summary_inner(db, source, function_name.to_owned())
 }
 
@@ -168,10 +168,16 @@ fn function_body<'db>(module: &'db Module<TypedRef<'db>>, name: &str) -> &'db Ex
         .expect("function should exist")
 }
 
-#[derive(Default)]
-struct TdnrSummary {
-    methods: Vec<String>,
-    calls: Vec<String>,
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, salsa::Update)]
+pub struct TdnrSummary {
+    pub method_calls: Vec<String>,
+    pub calls: Vec<TdnrCall>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub struct TdnrCall {
+    pub target: String,
+    pub arg_count: usize,
 }
 
 fn collect_tdnr_summary<'db>(
@@ -186,7 +192,10 @@ fn collect_tdnr_summary<'db>(
                 ..
             }) = &*callee.kind
             {
-                summary.calls.push(id.qualified(db).to_string());
+                summary.calls.push(TdnrCall {
+                    target: id.qualified(db).to_string(),
+                    arg_count: args.len(),
+                });
             }
             collect_tdnr_summary(db, callee, summary);
             for arg in args {
@@ -198,7 +207,7 @@ fn collect_tdnr_summary<'db>(
             method,
             args,
         } => {
-            summary.methods.push(method.to_string());
+            summary.method_calls.push(method.to_string());
             collect_tdnr_summary(db, receiver, summary);
             for arg in args {
                 collect_tdnr_summary(db, arg, summary);

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -3,6 +3,7 @@
 
 use tribute_core::diagnostic::Diagnostic;
 use tribute_front::SourceCst;
+use tribute_front::ast::{Decl, Expr, ExprKind, Module, ResolvedRef, Stmt, TypedRef};
 use trunk_ir::context::IrContext;
 use trunk_ir::printer::print_module;
 
@@ -108,6 +109,161 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
         node_types_map,
     );
     print_module(&ir, module.op())
+}
+
+#[salsa::tracked]
+fn tdnr_function_summary_inner<'db>(
+    db: &'db dyn salsa::Database,
+    source: SourceCst,
+    function_name: String,
+) -> String {
+    let parsed = tribute_front::query::parsed_ast(db, source);
+    assert!(parsed.is_some(), "Should parse successfully");
+
+    let parsed = parsed.unwrap();
+    let ast = parsed.module(db).clone();
+    let span_map = parsed.span_map(db).clone();
+
+    let prelude = load_prelude(db);
+
+    let mut env = tribute_front::resolve::build_env(db, &ast);
+    if let Some(ref p) = prelude {
+        env.merge(&p.env);
+    }
+    let resolved = tribute_front::resolve::resolve_with_env(db, ast, env, span_map.clone());
+
+    let mut checker = tribute_front::typeck::TypeChecker::new(db, span_map);
+    if let Some(ref p) = prelude {
+        checker.inject_prelude(&p.exports);
+    }
+    let result = checker.check_module(resolved);
+
+    let module = tribute_front::tdnr::resolve_tdnr(db, result.module, std::iter::empty());
+    let body = function_body(&module, &function_name);
+    let mut summary = TdnrSummary::default();
+    collect_tdnr_summary(db, body, &mut summary);
+    format!("methods: {:?}\ncalls: {:?}", summary.methods, summary.calls)
+}
+
+/// Run the AST pipeline through TDNR and summarize one function body.
+///
+/// This intentionally stops before IR lowering so tests can inspect unresolved
+/// `MethodCall` nodes. IR lowering panics on those nodes by design.
+pub fn tdnr_function_summary(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+    function_name: &str,
+) -> String {
+    tdnr_function_summary_inner(db, source, function_name.to_owned())
+}
+
+fn function_body<'db>(module: &'db Module<TypedRef<'db>>, name: &str) -> &'db Expr<TypedRef<'db>> {
+    module
+        .decls
+        .iter()
+        .find_map(|decl| match decl {
+            Decl::Function(func) if func.name.to_string() == name => Some(&func.body),
+            _ => None,
+        })
+        .expect("function should exist")
+}
+
+#[derive(Default)]
+struct TdnrSummary {
+    methods: Vec<String>,
+    calls: Vec<String>,
+}
+
+fn collect_tdnr_summary<'db>(
+    db: &'db dyn salsa::Database,
+    expr: &Expr<TypedRef<'db>>,
+    summary: &mut TdnrSummary,
+) {
+    match &*expr.kind {
+        ExprKind::Call { callee, args } => {
+            if let ExprKind::Var(TypedRef {
+                resolved: ResolvedRef::Function { id },
+                ..
+            }) = &*callee.kind
+            {
+                summary.calls.push(id.qualified(db).to_string());
+            }
+            collect_tdnr_summary(db, callee, summary);
+            for arg in args {
+                collect_tdnr_summary(db, arg, summary);
+            }
+        }
+        ExprKind::MethodCall {
+            receiver,
+            method,
+            args,
+        } => {
+            summary.methods.push(method.to_string());
+            collect_tdnr_summary(db, receiver, summary);
+            for arg in args {
+                collect_tdnr_summary(db, arg, summary);
+            }
+        }
+        ExprKind::Record { fields, spread, .. } => {
+            for (_, field) in fields {
+                collect_tdnr_summary(db, field, summary);
+            }
+            if let Some(spread) = spread {
+                collect_tdnr_summary(db, spread, summary);
+            }
+        }
+        ExprKind::Block { stmts, value } => {
+            for stmt in stmts {
+                match stmt {
+                    Stmt::Let { value, .. } | Stmt::Expr { expr: value, .. } => {
+                        collect_tdnr_summary(db, value, summary);
+                    }
+                }
+            }
+            collect_tdnr_summary(db, value, summary);
+        }
+        ExprKind::BinOp { lhs, rhs, .. } => {
+            collect_tdnr_summary(db, lhs, summary);
+            collect_tdnr_summary(db, rhs, summary);
+        }
+        ExprKind::Case { scrutinee, arms } => {
+            collect_tdnr_summary(db, scrutinee, summary);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    collect_tdnr_summary(db, guard, summary);
+                }
+                collect_tdnr_summary(db, &arm.body, summary);
+            }
+        }
+        ExprKind::Lambda { body, .. } => collect_tdnr_summary(db, body, summary),
+        ExprKind::Handle { body, handlers } => {
+            collect_tdnr_summary(db, body, summary);
+            for handler in handlers {
+                collect_tdnr_summary(db, &handler.body, summary);
+            }
+        }
+        ExprKind::Resume { arg, .. } => collect_tdnr_summary(db, arg, summary),
+        ExprKind::Tuple(elements) | ExprKind::List(elements) => {
+            for element in elements {
+                collect_tdnr_summary(db, element, summary);
+            }
+        }
+        ExprKind::Cons { args, .. } => {
+            for arg in args {
+                collect_tdnr_summary(db, arg, summary);
+            }
+        }
+        ExprKind::Var(_)
+        | ExprKind::NatLit(_)
+        | ExprKind::IntLit(_)
+        | ExprKind::FloatLit(_)
+        | ExprKind::StringLit(_)
+        | ExprKind::BytesLit(_)
+        | ExprKind::BoolLit(_)
+        | ExprKind::Nil
+        | ExprKind::RuneLit(_)
+        | ExprKind::Error => {}
+    }
 }
 
 /// Run the full AST pipeline (parse -> resolve -> typecheck -> TDNR -> IR)

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -162,7 +162,7 @@ fn function_body<'db>(module: &'db Module<TypedRef<'db>>, name: &str) -> &'db Ex
         .decls
         .iter()
         .find_map(|decl| match decl {
-            Decl::Function(func) if func.name.to_string() == name => Some(&func.body),
+            Decl::Function(func) if func.name == name => Some(&func.body),
             _ => None,
         })
         .expect("function should exist")

--- a/crates/tribute-front/tests/ufcs_method_call.rs
+++ b/crates/tribute-front/tests/ufcs_method_call.rs
@@ -7,7 +7,9 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline, run_ast_pipeline_with_ir, tdnr_function_summary};
+use self::common::{
+    TdnrCall, TdnrSummary, run_ast_pipeline, run_ast_pipeline_with_ir, tdnr_function_summary,
+};
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
 use tribute_front::SourceCst;
@@ -128,7 +130,13 @@ fn test(p: Point) -> Nat {
 
     assert_eq!(
         tdnr_function_summary(db, field_accessor, "test"),
-        "methods: []\ncalls: [\"Point::x\"]"
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![TdnrCall {
+                target: "Point::x".to_owned(),
+                arg_count: 1,
+            }],
+        }
     );
 
     let user_defined = SourceCst::from_source_str(
@@ -151,7 +159,13 @@ fn test(c: Counter) -> Nat {
 
     assert_eq!(
         tdnr_function_summary(db, user_defined, "test"),
-        "methods: []\ncalls: [\"Counter::add\"]"
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![TdnrCall {
+                target: "Counter::add".to_owned(),
+                arg_count: 2,
+            }],
+        }
     );
 
     let ambiguous = SourceCst::from_source_str(
@@ -176,7 +190,10 @@ fn test(t: Thing) -> Nat {
 
     assert_eq!(
         tdnr_function_summary(db, ambiguous, "test"),
-        "methods: [\"pick\"]\ncalls: []"
+        TdnrSummary {
+            method_calls: vec!["pick".to_owned()],
+            calls: vec![],
+        }
     );
 
     let unresolved = SourceCst::from_source_str(
@@ -193,7 +210,10 @@ fn test(t: Thing) -> Nat {
 
     assert_eq!(
         tdnr_function_summary(db, unresolved, "test"),
-        "methods: [\"missing\"]\ncalls: []"
+        TdnrSummary {
+            method_calls: vec!["missing".to_owned()],
+            calls: vec![],
+        }
     );
 
     let nested_module = SourceCst::from_source_str(
@@ -216,7 +236,13 @@ fn test(i: Item) -> Nat {
 
     assert_eq!(
         tdnr_function_summary(db, nested_module, "test"),
-        "methods: []\ncalls: [\"Outer::score\"]"
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![TdnrCall {
+                target: "Outer::score".to_owned(),
+                arg_count: 1,
+            }],
+        }
     );
 }
 

--- a/crates/tribute-front/tests/ufcs_method_call.rs
+++ b/crates/tribute-front/tests/ufcs_method_call.rs
@@ -7,7 +7,7 @@
 
 mod common;
 
-use self::common::{run_ast_pipeline, run_ast_pipeline_with_ir};
+use self::common::{run_ast_pipeline, run_ast_pipeline_with_ir, tdnr_function_summary};
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
 use tribute_front::SourceCst;
@@ -105,6 +105,119 @@ fn test() -> Nat {
     );
 
     run_ast_pipeline(db, source);
+}
+
+// ========================================================================
+// TDNR AST Tests (verify MethodCall -> Call before IR lowering)
+// ========================================================================
+
+/// Covers TDNR's resolved, ambiguous, unresolved, and nested-module paths.
+#[salsa_test]
+fn test_tdnr_method_resolution_cases(db: &salsa::DatabaseImpl) {
+    let field_accessor = SourceCst::from_source_str(
+        db,
+        "field_accessor.trb",
+        r#"
+struct Point { x: Nat, y: Nat }
+
+fn test(p: Point) -> Nat {
+    p.x
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, field_accessor, "test"),
+        "methods: []\ncalls: [\"Point::x\"]"
+    );
+
+    let user_defined = SourceCst::from_source_str(
+        db,
+        "user_defined.trb",
+        r#"
+struct Counter { value: Nat }
+
+pub mod Counter {
+    pub fn add(c: Counter, n: Nat) -> Nat {
+        c.value
+    }
+}
+
+fn test(c: Counter) -> Nat {
+    c.add(2)
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, user_defined, "test"),
+        "methods: []\ncalls: [\"Counter::add\"]"
+    );
+
+    let ambiguous = SourceCst::from_source_str(
+        db,
+        "ambiguous.trb",
+        r#"
+struct Thing { value: Nat }
+
+pub mod A {
+    pub fn pick(t: Thing) -> Nat { t.value }
+}
+
+pub mod B {
+    pub fn pick(t: Thing) -> Nat { t.value }
+}
+
+fn test(t: Thing) -> Nat {
+    t.pick()
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, ambiguous, "test"),
+        "methods: [\"pick\"]\ncalls: []"
+    );
+
+    let unresolved = SourceCst::from_source_str(
+        db,
+        "unresolved.trb",
+        r#"
+struct Thing { value: Nat }
+
+fn test(t: Thing) -> Nat {
+    t.missing()
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, unresolved, "test"),
+        "methods: [\"missing\"]\ncalls: []"
+    );
+
+    let nested_module = SourceCst::from_source_str(
+        db,
+        "nested_module.trb",
+        r#"
+struct Item { value: Nat }
+
+pub mod Outer {
+    pub fn score(i: Item) -> Nat {
+        i.value
+    }
+}
+
+fn test(i: Item) -> Nat {
+    i.score()
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, nested_module, "test"),
+        "methods: []\ncalls: [\"Outer::score\"]"
+    );
 }
 
 // ========================================================================


### PR DESCRIPTION
## Summary
- Add a TDNR-focused test helper that returns structured call-resolution data instead of a formatted string.
- Cover the main `MethodCall` resolution paths: struct field accessors, user-defined methods, ambiguous matches, unresolved calls, and nested-module methods.
- Verify both the resolved target and the forwarded argument count so the `receiver.method(args)` -> `method(receiver, args)` transformation stays intact.

## Testing
- `cargo fmt`
- `cargo test -p tribute-front --test ufcs_method_call`
- `cargo test -p tribute-front --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added TDNR-focused test helpers that produce summaries of unresolved call patterns (method names, call targets and argument counts).
  * Added comprehensive tests exercising method-resolution scenarios: resolved field access, user-defined targets (UFCS), ambiguous calls, unresolved calls, and nested-module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->