### PR TITLE
Fix nested effectful CPS lowering

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/lower/case.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/case.rs
@@ -15,11 +15,7 @@ use crate::ast::{Arm, Expr, LiteralPattern, Pattern, PatternKind, ResolvedRef, T
 use super::super::context::IrLoweringCtx;
 use super::{IrBuilder, get_or_create_tuple_type, is_irrefutable_pattern, resolve_enum_type_attr};
 
-/// Lower an arm body to the value yielded by its `scf.if` region.
-///
-/// A CPS call inside the arm must first produce the arm's value, so isolate it
-/// from the continuation surrounding the whole case expression.
-fn lower_case_arm_body<'db>(
+fn lower_case_region_expr_with_local_done_k<'db>(
     builder: &mut IrBuilder<'_, 'db>,
     location: Location,
     expr: Expr<TypedRef<'db>>,
@@ -32,6 +28,29 @@ fn lower_case_arm_body<'db>(
     let result = super::expr::lower_block_cps_for_expr(builder, expr).map(|(value, _)| value);
     builder.ctx.done_k = outer_done_k;
     result
+}
+
+/// Lower an arm body to the value yielded by its `scf.if` region.
+///
+/// A CPS call inside the arm must first produce the arm's value, so isolate it
+/// from the continuation surrounding the whole case expression.
+fn lower_case_arm_body<'db>(
+    builder: &mut IrBuilder<'_, 'db>,
+    location: Location,
+    expr: Expr<TypedRef<'db>>,
+) -> Option<ValueRef> {
+    lower_case_region_expr_with_local_done_k(builder, location, expr)
+}
+
+/// Lower a guard condition inside the already-matched arm region.
+fn lower_case_guard_condition<'db>(
+    builder: &mut IrBuilder<'_, 'db>,
+    location: Location,
+    expr: Expr<TypedRef<'db>>,
+) -> Option<ValueRef> {
+    let bool_ty = builder.ctx.bool_type(builder.ir);
+    let value = lower_case_region_expr_with_local_done_k(builder, location, expr)?;
+    Some(builder.cast_if_needed(location, value, bool_ty))
 }
 
 /// Lower a case expression as a chain of `scf.if` operations.
@@ -300,7 +319,7 @@ fn build_guarded_arm_region<'db>(
         // 2. Evaluate guard condition
         let guard_cond = {
             let mut builder = IrBuilder::new(&mut scope, ir, block);
-            super::expr::lower_expr(&mut builder, guard_expr.clone())
+            lower_case_guard_condition(&mut builder, location, guard_expr.clone())
         };
         let guard_cond = match guard_cond {
             Some(v) => v,

--- a/crates/tribute-front/src/ast_to_ir/lower/case.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/case.rs
@@ -15,6 +15,25 @@ use crate::ast::{Arm, Expr, LiteralPattern, Pattern, PatternKind, ResolvedRef, T
 use super::super::context::IrLoweringCtx;
 use super::{IrBuilder, get_or_create_tuple_type, is_irrefutable_pattern, resolve_enum_type_attr};
 
+/// Lower an arm body to the value yielded by its `scf.if` region.
+///
+/// A CPS call inside the arm must first produce the arm's value, so isolate it
+/// from the continuation surrounding the whole case expression.
+fn lower_case_arm_body<'db>(
+    builder: &mut IrBuilder<'_, 'db>,
+    location: Location,
+    expr: Expr<TypedRef<'db>>,
+) -> Option<ValueRef> {
+    let outer_done_k = builder.ctx.done_k;
+    if outer_done_k.is_some() && super::expr::contains_cps_call_in_evaluation(builder.ctx, &expr) {
+        let identity_done_k = super::create_identity_done_k(builder, location);
+        builder.ctx.done_k = Some(identity_done_k);
+    }
+    let result = super::expr::lower_block_cps_for_expr(builder, expr).map(|(value, _)| value);
+    builder.ctx.done_k = outer_done_k;
+    result
+}
+
 /// Lower a case expression as a chain of `scf.if` operations.
 pub(super) fn lower_case_chain<'db>(
     builder: &mut IrBuilder<'_, 'db>,
@@ -48,7 +67,7 @@ pub(super) fn lower_case_chain<'db>(
                 &last.pattern,
             );
             let mut builder = IrBuilder::new(&mut scope, builder.ir, builder.block);
-            super::expr::lower_expr(&mut builder, last.body.clone())
+            lower_case_arm_body(&mut builder, location, last.body.clone())
         }
         [first, rest @ ..] => {
             // Multi-arm: pattern check → then/else regions → scf.if
@@ -303,7 +322,7 @@ fn build_guarded_arm_region<'db>(
             });
             let result = {
                 let mut builder = IrBuilder::new(&mut scope, ir, inner_block);
-                let val = super::expr::lower_expr(&mut builder, arm.body.clone());
+                let val = lower_case_arm_body(&mut builder, location, arm.body.clone());
                 val.map(|v| builder.cast_if_needed(location, v, result_ty))
             };
             let yield_val = match result {
@@ -374,7 +393,7 @@ fn build_arm_region<'db>(
         bind_pattern_fields(&mut scope, ir, block, location, scrutinee, &arm.pattern);
 
         let mut builder = IrBuilder::new(&mut scope, ir, block);
-        let val = super::expr::lower_expr(&mut builder, arm.body.clone());
+        let val = lower_case_arm_body(&mut builder, location, arm.body.clone());
         val.map(|v| builder.cast_if_needed(location, v, result_ty))
     };
 

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -1767,7 +1767,10 @@ fn build_short_circuit_rhs_region<'db>(
     };
 
     let yield_val = match rhs_val {
-        Some(v) => v,
+        Some(v) => {
+            let mut builder = IrBuilder::new(builder.ctx, builder.ir, block);
+            builder.cast_if_needed(location, v, bool_ty)
+        }
         None => {
             let op = arith::r#const(builder.ir, location, bool_ty, Attribute::Bool(false));
             builder.ir.push_op(block, op.op_ref());

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -844,7 +844,7 @@ fn lower_block_cps<'db>(
     let mut stmts_iter = stmts.into_iter().peekable();
 
     while let Some(stmt) = stmts_iter.peek() {
-        if builder.ctx.done_k.is_some()
+        if can_lower_cps_call_in_current_context(builder.ctx)
             && let Some((lifted_stmt, rebuilt_stmt)) =
                 lift_nested_cps_call_from_stmt(builder.ctx, stmt.clone())
         {
@@ -865,9 +865,7 @@ fn lower_block_cps<'db>(
 
         // CPS-transform effectful calls and closure calls when done_k is set.
         // Skip in handler arm bodies (cps_handler_mode) — need scf.yield terminator.
-        if builder.ctx.done_k.is_some()
-            && !builder.ctx.cps_handler_mode
-            && is_cps_call_stmt(builder.ctx, stmt)
+        if can_lower_cps_call_in_current_context(builder.ctx) && is_cps_call_stmt(builder.ctx, stmt)
         {
             let stmt = stmts_iter.next().unwrap();
             let remaining: Vec<_> = stmts_iter.collect();
@@ -887,8 +885,7 @@ fn lower_block_cps<'db>(
     // If so, treat it as a CPS call: done_k is passed to the callee, which will
     // call it internally. The caller must NOT call done_k again (is_cps = true).
     // Skip in handler arm context (cps_handler_mode) — result flows to scf.yield.
-    if builder.ctx.done_k.is_some()
-        && !builder.ctx.cps_handler_mode
+    if can_lower_cps_call_in_current_context(builder.ctx)
         && let ExprKind::Call { callee: c, .. } = &*value.kind
         && let ExprKind::Var(tr) = &*c.kind
         && !matches!(&tr.resolved, ResolvedRef::AbilityOp { .. })
@@ -898,8 +895,7 @@ fn lower_block_cps<'db>(
         return Some((result, true));
     }
     // All local closure calls are CPS (closures always have done_k)
-    if builder.ctx.done_k.is_some()
-        && !builder.ctx.cps_handler_mode
+    if can_lower_cps_call_in_current_context(builder.ctx)
         && let ExprKind::Call { callee: c, .. } = &*value.kind
         && let ExprKind::Var(tr) = &*c.kind
         && matches!(&tr.resolved, ResolvedRef::Local { .. })
@@ -908,15 +904,12 @@ fn lower_block_cps<'db>(
         let result = lower_expr(builder, value)?;
         return Some((result, true));
     }
-    if builder.ctx.done_k.is_some()
-        && !builder.ctx.cps_handler_mode
-        && is_cps_call_expr(builder.ctx, &value)
-    {
+    if can_lower_cps_call_in_current_context(builder.ctx) && is_cps_call_expr(builder.ctx, &value) {
         let result = lower_expr(builder, value)?;
         return Some((result, true));
     }
 
-    if builder.ctx.done_k.is_some()
+    if can_lower_cps_call_in_current_context(builder.ctx)
         && let Some((lifted_stmt, rebuilt_value)) =
             lift_nested_cps_call(builder.ctx, value.clone(), false)
     {
@@ -928,6 +921,10 @@ fn lower_block_cps<'db>(
     }
 
     lower_expr(builder, value).map(|r| (r, false))
+}
+
+fn can_lower_cps_call_in_current_context(ctx: &super::super::context::IrLoweringCtx<'_>) -> bool {
+    ctx.done_k.is_some() && !ctx.cps_handler_mode
 }
 
 fn is_cps_call_expr<'db>(
@@ -1453,6 +1450,7 @@ fn lower_cps_call<'db>(
     let ExprKind::Call { callee, args } = *call_expr.kind else {
         unreachable!("ICE: lower_cps_call called with non-call expression");
     };
+    let callee_id = callee.id;
     let callee_kind = *callee.kind;
 
     // Lower arguments
@@ -1534,7 +1532,7 @@ fn lower_cps_call<'db>(
             _ => unreachable!("ICE: lower_cps_call with unexpected callee kind"),
         },
         callee_kind => {
-            let callee = Expr::new(call_expr_id, callee_kind);
+            let callee = Expr::new(callee_id, callee_kind);
             let callee_val = lower_expr(builder, callee)?;
             let mut cps_param_types = vec![anyref_ty];
             cps_param_types.extend(arg_values.iter().map(|v| builder.ir.value_ty(*v)));

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -13,7 +13,9 @@ use trunk_ir::refs::{TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, Location};
 use trunk_ir::{BlockData, RegionData};
 
-use crate::ast::{BinOpKind, Expr, ExprKind, PatternKind, ResolvedRef, Stmt, TypeKind, TypedRef};
+use crate::ast::{
+    BinOpKind, Expr, ExprKind, Pattern, PatternKind, ResolvedRef, Stmt, TypeKind, TypedRef,
+};
 
 use tribute_ir::dialect::{ability, closure};
 
@@ -720,35 +722,68 @@ pub(super) fn lower_expr<'db>(
     }
 }
 
-/// CPS-lower an expression (used by handle body lowering).
+fn evaluated_expr_any<'db>(
+    expr: &Expr<TypedRef<'db>>,
+    predicate: &mut impl FnMut(&Expr<TypedRef<'db>>) -> bool,
+) -> bool {
+    if predicate(expr) {
+        return true;
+    }
+
+    match &*expr.kind {
+        ExprKind::Call { callee, args } => {
+            evaluated_expr_any(callee, predicate)
+                || args.iter().any(|arg| evaluated_expr_any(arg, predicate))
+        }
+        ExprKind::Cons { args, .. } | ExprKind::Tuple(args) | ExprKind::List(args) => {
+            args.iter().any(|arg| evaluated_expr_any(arg, predicate))
+        }
+        ExprKind::Record { fields, spread, .. } => {
+            spread
+                .as_ref()
+                .is_some_and(|expr| evaluated_expr_any(expr, predicate))
+                || fields
+                    .iter()
+                    .any(|(_, expr)| evaluated_expr_any(expr, predicate))
+        }
+        ExprKind::Block { stmts, value } => {
+            stmts.iter().any(|stmt| match stmt {
+                Stmt::Let { value, .. } => evaluated_expr_any(value, predicate),
+                Stmt::Expr { expr, .. } => evaluated_expr_any(expr, predicate),
+            }) || evaluated_expr_any(value, predicate)
+        }
+        ExprKind::BinOp { lhs, rhs, .. } => {
+            evaluated_expr_any(lhs, predicate) || evaluated_expr_any(rhs, predicate)
+        }
+        ExprKind::Case { scrutinee, arms } => {
+            evaluated_expr_any(scrutinee, predicate)
+                || arms.iter().any(|arm| {
+                    arm.guard
+                        .as_ref()
+                        .is_some_and(|guard| evaluated_expr_any(guard, predicate))
+                        || evaluated_expr_any(&arm.body, predicate)
+                })
+        }
+        ExprKind::Resume { arg, .. } => evaluated_expr_any(arg, predicate),
+        ExprKind::MethodCall { receiver, args, .. } => {
+            evaluated_expr_any(receiver, predicate)
+                || args.iter().any(|arg| evaluated_expr_any(arg, predicate))
+        }
+        // These introduce independently lowered evaluation domains.
+        ExprKind::Lambda { .. } | ExprKind::Handle { .. } => false,
+        _ => false,
+    }
+}
+
+/// Check whether evaluating an expression can execute a call that needs CPS.
 ///
-/// Like `lower_block_cps` but works on a single expression, wrapping it in
-/// a trivial block if needed.
-/// Check if an expression (or its sub-block) contains calls that need CPS
-/// transformation (effectful function calls or closure calls).
-pub(super) fn body_contains_cps_call<'db>(
+/// This does not descend into lambdas or handlers, which establish their own
+/// lowering domains.
+pub(super) fn contains_cps_call_in_evaluation<'db>(
     ctx: &super::super::context::IrLoweringCtx<'db>,
     expr: &Expr<TypedRef<'db>>,
 ) -> bool {
-    match &*expr.kind {
-        ExprKind::Block { stmts, value } => {
-            stmts.iter().any(|s| is_cps_call_stmt(ctx, s)) || body_contains_cps_call(ctx, value)
-        }
-        ExprKind::Call { callee, .. } => {
-            if let ExprKind::Var(tr) = &*callee.kind {
-                if matches!(&tr.resolved, ResolvedRef::AbilityOp { .. }) {
-                    return false; // Handled by existing CPS
-                }
-                // All closure calls need CPS
-                if matches!(&tr.resolved, ResolvedRef::Local { .. }) {
-                    return !matches!(tr.ty.kind(ctx.db), TypeKind::Continuation { .. });
-                }
-                return is_callee_effectful_by_definition(ctx, tr);
-            }
-            false
-        }
-        _ => false,
-    }
+    evaluated_expr_any(expr, &mut |expr| is_cps_call_expr(ctx, expr))
 }
 
 /// Lower a function body expression with CPS transformation for effectful functions.
@@ -759,49 +794,21 @@ pub(super) fn lower_block_cps_for_body<'db>(
     builder: &mut IrBuilder<'_, 'db>,
     expr: Expr<TypedRef<'db>>,
 ) -> Option<(ValueRef, bool)> {
-    // Delegate to lower_block_cps_for_expr — effectful call detection
-    // is already integrated into lower_block_cps via is_effectful_call_stmt.
+    // Effectful call detection is already integrated into lower_block_cps.
     lower_block_cps_for_expr(builder, expr)
 }
 
+/// CPS-lower an expression, using an empty statement list for non-block forms.
+///
+/// This keeps direct-call handling and nested-call lifting in the same block
+/// CPS state machine instead of maintaining a second expression-only path.
 pub(super) fn lower_block_cps_for_expr<'db>(
     builder: &mut IrBuilder<'_, 'db>,
     expr: Expr<TypedRef<'db>>,
 ) -> Option<(ValueRef, bool)> {
     match *expr.kind {
         ExprKind::Block { stmts, value } => lower_block_cps(builder, stmts, value),
-        _ => {
-            // Non-block expression: check if it's a direct ability op call
-            if let Some(result) = super::expr::try_lower_value_ability_op(builder, &expr) {
-                return Some((result, true));
-            }
-            // Check if it's an effectful named function call (needs CPS with done_k)
-            if builder.ctx.done_k.is_some()
-                && let ExprKind::Call { callee: c, .. } = &*expr.kind
-                && let ExprKind::Var(tr) = &*c.kind
-                && !matches!(&tr.resolved, ResolvedRef::AbilityOp { .. })
-                && is_callee_effectful_by_definition(builder.ctx, tr)
-                && let Some(result) = try_lower_value_effectful_call(builder, expr.clone())
-            {
-                return Some((result, true));
-            }
-            // Reject nested ability-op subexpressions that would bypass CPS.
-            // Full expression-level CPS lifting is not yet implemented.
-            if contains_nested_ability_op(&expr) {
-                let location = builder.location(expr.id);
-                Diagnostic::new(
-                    "ability operation in nested expression position is not yet supported; \
-                          extract to a let binding",
-                    location.span,
-                    DiagnosticSeverity::Error,
-                    CompilationPhase::Lowering,
-                )
-                .accumulate(builder.db());
-                return None;
-            }
-            let result = lower_expr(builder, expr)?;
-            Some((result, false))
-        }
+        _ => lower_block_cps(builder, vec![], expr),
     }
 }
 
@@ -837,6 +844,19 @@ fn lower_block_cps<'db>(
     let mut stmts_iter = stmts.into_iter().peekable();
 
     while let Some(stmt) = stmts_iter.peek() {
+        if builder.ctx.done_k.is_some()
+            && let Some((lifted_stmt, rebuilt_stmt)) =
+                lift_nested_cps_call_from_stmt(builder.ctx, stmt.clone())
+        {
+            let mut remaining = vec![rebuilt_stmt];
+            remaining.extend(stmts_iter.skip(1));
+            return if is_direct_ability_op_stmt(&lifted_stmt) {
+                lower_cps_ability_op(builder, lifted_stmt, remaining, value).map(|r| (r, true))
+            } else {
+                lower_cps_call(builder, lifted_stmt, remaining, value).map(|r| (r, true))
+            };
+        }
+
         if is_direct_ability_op_stmt(stmt) {
             let stmt = stmts_iter.next().unwrap();
             let remaining: Vec<_> = stmts_iter.collect();
@@ -888,8 +908,214 @@ fn lower_block_cps<'db>(
         let result = lower_expr(builder, value)?;
         return Some((result, true));
     }
+    if builder.ctx.done_k.is_some()
+        && !builder.ctx.cps_handler_mode
+        && is_cps_call_expr(builder.ctx, &value)
+    {
+        let result = lower_expr(builder, value)?;
+        return Some((result, true));
+    }
+
+    if builder.ctx.done_k.is_some()
+        && let Some((lifted_stmt, rebuilt_value)) =
+            lift_nested_cps_call(builder.ctx, value.clone(), false)
+    {
+        return if is_direct_ability_op_stmt(&lifted_stmt) {
+            lower_cps_ability_op(builder, lifted_stmt, vec![], rebuilt_value).map(|r| (r, true))
+        } else {
+            lower_cps_call(builder, lifted_stmt, vec![], rebuilt_value).map(|r| (r, true))
+        };
+    }
 
     lower_expr(builder, value).map(|r| (r, false))
+}
+
+fn is_cps_call_expr<'db>(
+    ctx: &super::super::context::IrLoweringCtx<'db>,
+    expr: &Expr<TypedRef<'db>>,
+) -> bool {
+    let ExprKind::Call { callee, .. } = &*expr.kind else {
+        return false;
+    };
+    let ExprKind::Var(tr) = &*callee.kind else {
+        return true;
+    };
+    match &tr.resolved {
+        ResolvedRef::AbilityOp {
+            kind: crate::ast::OpDeclKind::Op,
+            ..
+        } => true,
+        ResolvedRef::AbilityOp { .. } => false,
+        ResolvedRef::Local { .. } => !matches!(tr.ty.kind(ctx.db), TypeKind::Continuation { .. }),
+        _ => is_callee_effectful_by_definition(ctx, tr),
+    }
+}
+
+fn make_lifted_call<'db>(
+    ctx: &mut super::super::context::IrLoweringCtx<'db>,
+    call: Expr<TypedRef<'db>>,
+) -> Option<(Stmt<TypedRef<'db>>, Expr<TypedRef<'db>>)> {
+    let ty = *ctx.get_node_type(call.id)?;
+    let local_id = ctx.next_local_id();
+    let name = Symbol::new("__cps_tmp");
+    let pattern = Pattern::new(
+        call.id,
+        PatternKind::Bind {
+            name,
+            local_id: Some(local_id),
+        },
+    );
+    let replacement = Expr::new(
+        call.id,
+        ExprKind::Var(TypedRef::new(ResolvedRef::local(local_id, name), ty)),
+    );
+    let stmt = Stmt::Let {
+        id: call.id,
+        pattern,
+        ty: None,
+        value: call,
+    };
+    Some((stmt, replacement))
+}
+
+fn lift_nested_cps_call_from_stmt<'db>(
+    ctx: &mut super::super::context::IrLoweringCtx<'db>,
+    stmt: Stmt<TypedRef<'db>>,
+) -> Option<(Stmt<TypedRef<'db>>, Stmt<TypedRef<'db>>)> {
+    match stmt {
+        Stmt::Let {
+            id,
+            pattern,
+            ty,
+            value,
+        } => {
+            let (lifted, value) = lift_nested_cps_call(ctx, value, false)?;
+            Some((
+                lifted,
+                Stmt::Let {
+                    id,
+                    pattern,
+                    ty,
+                    value,
+                },
+            ))
+        }
+        Stmt::Expr { id, expr } => {
+            let (lifted, expr) = lift_nested_cps_call(ctx, expr, false)?;
+            Some((lifted, Stmt::Expr { id, expr }))
+        }
+    }
+}
+
+fn lift_nested_cps_call<'db>(
+    ctx: &mut super::super::context::IrLoweringCtx<'db>,
+    expr: Expr<TypedRef<'db>>,
+    include_self: bool,
+) -> Option<(Stmt<TypedRef<'db>>, Expr<TypedRef<'db>>)> {
+    let id = expr.id;
+    let original = expr.clone();
+    let rebuilt = match *expr.kind {
+        ExprKind::Call { callee, mut args } => {
+            if let Some((lifted, callee)) = lift_nested_cps_call(ctx, callee.clone(), true) {
+                return Some((lifted, Expr::new(id, ExprKind::Call { callee, args })));
+            }
+            for index in 0..args.len() {
+                if let Some((lifted, arg)) = lift_nested_cps_call(ctx, args[index].clone(), true) {
+                    args[index] = arg;
+                    return Some((lifted, Expr::new(id, ExprKind::Call { callee, args })));
+                }
+            }
+            Expr::new(id, ExprKind::Call { callee, args })
+        }
+        ExprKind::Cons { ctor, mut args } => {
+            for index in 0..args.len() {
+                if let Some((lifted, arg)) = lift_nested_cps_call(ctx, args[index].clone(), true) {
+                    args[index] = arg;
+                    return Some((lifted, Expr::new(id, ExprKind::Cons { ctor, args })));
+                }
+            }
+            Expr::new(id, ExprKind::Cons { ctor, args })
+        }
+        ExprKind::Tuple(mut elements) => {
+            for index in 0..elements.len() {
+                if let Some((lifted, element)) =
+                    lift_nested_cps_call(ctx, elements[index].clone(), true)
+                {
+                    elements[index] = element;
+                    return Some((lifted, Expr::new(id, ExprKind::Tuple(elements))));
+                }
+            }
+            Expr::new(id, ExprKind::Tuple(elements))
+        }
+        ExprKind::Record {
+            type_name,
+            mut fields,
+            spread,
+        } => {
+            let mut spread = spread;
+            if let Some(spread_expr) = spread.clone()
+                && let Some((lifted, replacement)) = lift_nested_cps_call(ctx, spread_expr, true)
+            {
+                spread = Some(replacement);
+                return Some((
+                    lifted,
+                    Expr::new(
+                        id,
+                        ExprKind::Record {
+                            type_name,
+                            fields,
+                            spread,
+                        },
+                    ),
+                ));
+            }
+            for index in 0..fields.len() {
+                if let Some((lifted, field)) =
+                    lift_nested_cps_call(ctx, fields[index].1.clone(), true)
+                {
+                    fields[index].1 = field;
+                    return Some((
+                        lifted,
+                        Expr::new(
+                            id,
+                            ExprKind::Record {
+                                type_name,
+                                fields,
+                                spread,
+                            },
+                        ),
+                    ));
+                }
+            }
+            Expr::new(
+                id,
+                ExprKind::Record {
+                    type_name,
+                    fields,
+                    spread,
+                },
+            )
+        }
+        ExprKind::BinOp { op, lhs, rhs } => {
+            if let Some((lifted, lhs)) = lift_nested_cps_call(ctx, lhs.clone(), true) {
+                return Some((lifted, Expr::new(id, ExprKind::BinOp { op, lhs, rhs })));
+            }
+            Expr::new(id, ExprKind::BinOp { op, lhs, rhs })
+        }
+        ExprKind::Case { scrutinee, arms } => {
+            if let Some((lifted, scrutinee)) = lift_nested_cps_call(ctx, scrutinee.clone(), true) {
+                return Some((lifted, Expr::new(id, ExprKind::Case { scrutinee, arms })));
+            }
+            Expr::new(id, ExprKind::Case { scrutinee, arms })
+        }
+        _ => original.clone(),
+    };
+
+    if include_self && is_cps_call_expr(ctx, &rebuilt) {
+        make_lifted_call(ctx, rebuilt)
+    } else {
+        None
+    }
 }
 
 /// Try to CPS-transform a value expression that is a direct ability op call.
@@ -997,81 +1223,6 @@ fn try_lower_value_effectful_call<'db>(
     Some(call_result)
 }
 
-/// Check if an expression contains a nested CPS ability op call (not at the top level).
-///
-/// Returns true if any subexpression (argument, operand, etc.) is a call to
-/// an `op` ability operation (which requires CPS). `fn` operations are excluded
-/// because they use direct calls without CPS.
-fn contains_nested_ability_op<'db>(expr: &Expr<TypedRef<'db>>) -> bool {
-    match &*expr.kind {
-        ExprKind::Call { callee, args } => {
-            // Check args (not callee — a direct call is fine, handled elsewhere)
-            let callee_is_cps_ability_op = matches!(
-                &*callee.kind,
-                ExprKind::Var(tr) if matches!(
-                    &tr.resolved,
-                    ResolvedRef::AbilityOp { kind: crate::ast::OpDeclKind::Op, .. }
-                )
-            );
-            if !callee_is_cps_ability_op {
-                // Non-CPS-ability-op call: check callee (e.g. foo(bar)(emit()))
-                // and args for nested ability ops
-                contains_ability_op(callee) || args.iter().any(contains_ability_op)
-            } else {
-                // Direct CPS ability op call at top level — not "nested"
-                false
-            }
-        }
-        ExprKind::BinOp { lhs, rhs, .. } => contains_ability_op(lhs) || contains_ability_op(rhs),
-        ExprKind::Tuple(elems) => elems.iter().any(contains_ability_op),
-        ExprKind::Block { stmts, value } => {
-            stmts.iter().any(|s| match s {
-                Stmt::Let { value, .. } => contains_ability_op(value),
-                Stmt::Expr { expr, .. } => contains_ability_op(expr),
-            }) || contains_ability_op(value)
-        }
-        ExprKind::Case { scrutinee, arms } => {
-            contains_ability_op(scrutinee) || arms.iter().any(|a| contains_ability_op(&a.body))
-        }
-        ExprKind::Record { fields, .. } => fields.iter().any(|(_, v)| contains_ability_op(v)),
-        _ => false,
-    }
-}
-
-/// Check if an expression IS or CONTAINS an `op` ability op call (CPS-requiring).
-///
-/// `fn` operations use direct calls and do not trigger CPS transformation.
-fn contains_ability_op<'db>(expr: &Expr<TypedRef<'db>>) -> bool {
-    match &*expr.kind {
-        ExprKind::Call { callee, args } => {
-            if let ExprKind::Var(tr) = &*callee.kind
-                && matches!(
-                    &tr.resolved,
-                    ResolvedRef::AbilityOp {
-                        kind: crate::ast::OpDeclKind::Op,
-                        ..
-                    }
-                )
-            {
-                return true;
-            }
-            contains_ability_op(callee) || args.iter().any(contains_ability_op)
-        }
-        ExprKind::BinOp { lhs, rhs, .. } => contains_ability_op(lhs) || contains_ability_op(rhs),
-        ExprKind::Block { stmts, value } => {
-            stmts.iter().any(|s| match s {
-                Stmt::Let { value, .. } => contains_ability_op(value),
-                Stmt::Expr { expr, .. } => contains_ability_op(expr),
-            }) || contains_ability_op(value)
-        }
-        ExprKind::Tuple(elems) => elems.iter().any(contains_ability_op),
-        ExprKind::Case { scrutinee, arms } => {
-            contains_ability_op(scrutinee) || arms.iter().any(|a| contains_ability_op(&a.body))
-        }
-        _ => false,
-    }
-}
-
 /// Check if a statement contains a direct ability op call that requires CPS.
 ///
 /// `fn` operations are excluded because they use direct calls (no CPS).
@@ -1116,23 +1267,7 @@ fn is_cps_call_stmt<'db>(
         Stmt::Let { value, .. } => value,
         Stmt::Expr { expr, .. } => expr,
     };
-    let ExprKind::Call { callee, .. } = &*call_expr.kind else {
-        return false;
-    };
-    let ExprKind::Var(tr) = &*callee.kind else {
-        return false;
-    };
-    // Skip ability ops — they are handled by is_direct_ability_op_stmt
-    if matches!(&tr.resolved, ResolvedRef::AbilityOp { .. }) {
-        return false;
-    }
-    // All local closure calls need CPS (closures always have done_k)
-    if matches!(&tr.resolved, ResolvedRef::Local { .. }) {
-        // But skip continuation resume calls
-        return !matches!(tr.ty.kind(ctx.db), TypeKind::Continuation { .. });
-    }
-    // For named functions, check if effectful by definition
-    is_callee_effectful_by_definition(ctx, tr)
+    is_cps_call_expr(ctx, call_expr) && !is_direct_ability_op_stmt(stmt)
 }
 
 /// Check if a callee is effectful based on its function **definition** (TypeScheme),
@@ -1318,9 +1453,7 @@ fn lower_cps_call<'db>(
     let ExprKind::Call { callee, args } = *call_expr.kind else {
         unreachable!("ICE: lower_cps_call called with non-call expression");
     };
-    let ExprKind::Var(typed_ref) = *callee.kind else {
-        unreachable!("ICE: lower_cps_call called with non-var callee");
-    };
+    let callee_kind = *callee.kind;
 
     // Lower arguments
     let mut arg_values = builder.collect_args(args)?;
@@ -1330,7 +1463,10 @@ fn lower_cps_call<'db>(
         .ctx
         .get_node_type(call_expr_id)
         .map(|t| builder.ctx.convert_type(builder.ir, *t))
-        .unwrap_or_else(|| builder.call_result_type(&typed_ref.ty));
+        .unwrap_or_else(|| match &callee_kind {
+            ExprKind::Var(typed_ref) => builder.call_result_type(&typed_ref.ty),
+            _ => builder.ctx.anyref_type(builder.ir),
+        });
 
     let anyref_ty = builder.ctx.anyref_type(builder.ir);
 
@@ -1345,38 +1481,62 @@ fn lower_cps_call<'db>(
         value,
     )?;
 
-    match &typed_ref.resolved {
-        ResolvedRef::Function { id } => {
-            let callee_name = id.qualified(builder.db());
+    match callee_kind {
+        ExprKind::Var(typed_ref) => match &typed_ref.resolved {
+            ResolvedRef::Function { id } => {
+                let callee_name = id.qualified(builder.db());
 
-            // Insert casts for arguments using type scheme information
-            cast_args_from_signature(builder, location, callee_name, &mut arg_values);
+                // Insert casts for arguments using type scheme information
+                cast_args_from_signature(builder, location, callee_name, &mut arg_values);
 
-            // Call effectful function with evidence + continuation as first args
-            let evidence = super::get_or_create_evidence(builder, location);
-            let mut cps_args = vec![evidence, continuation];
-            cps_args.append(&mut arg_values);
+                // Call effectful function with evidence + continuation as first args
+                let evidence = super::get_or_create_evidence(builder, location);
+                let mut cps_args = vec![evidence, continuation];
+                cps_args.append(&mut arg_values);
 
-            let call_op = func::call(builder.ir, location, cps_args, anyref_ty, callee_name);
-            builder.ir.push_op(builder.block, call_op.op_ref());
-            Some(call_op.result(builder.ir))
-        }
-        ResolvedRef::Local { id, .. } => {
-            let callee_val = builder.ctx.lookup(*id)?;
+                let call_op = func::call(builder.ir, location, cps_args, anyref_ty, callee_name);
+                builder.ir.push_op(builder.block, call_op.op_ref());
+                Some(call_op.result(builder.ir))
+            }
+            ResolvedRef::Local { id, .. } => {
+                let callee_val = builder.ctx.lookup(*id)?;
 
-            // Insert casts for arguments
-            if let TypeKind::Func { params, .. } = typed_ref.ty.kind(builder.db()) {
-                for (i, param_ty) in params.iter().enumerate() {
-                    if i < arg_values.len() {
-                        let target_ty = builder.ctx.convert_type(builder.ir, *param_ty);
-                        arg_values[i] = builder.cast_if_needed(location, arg_values[i], target_ty);
+                // Insert casts for arguments
+                if let TypeKind::Func { params, .. } = typed_ref.ty.kind(builder.db()) {
+                    for (i, param_ty) in params.iter().enumerate() {
+                        if i < arg_values.len() {
+                            let target_ty = builder.ctx.convert_type(builder.ir, *param_ty);
+                            arg_values[i] =
+                                builder.cast_if_needed(location, arg_values[i], target_ty);
+                        }
                     }
                 }
-            }
 
-            // Cast callee to CPS closure type so closure_lower extracts
-            // the correct return type (anyref, not the source-level type).
-            let mut cps_param_types = vec![anyref_ty]; // done_k
+                // Cast callee to CPS closure type so closure_lower extracts
+                // the correct return type (anyref, not the source-level type).
+                let mut cps_param_types = vec![anyref_ty]; // done_k
+                cps_param_types.extend(arg_values.iter().map(|v| builder.ir.value_ty(*v)));
+                let cps_func_ty = builder
+                    .ctx
+                    .func_type(builder.ir, &cps_param_types, anyref_ty);
+                let cps_closure_ty = builder.ctx.closure_type(builder.ir, cps_func_ty);
+                let callee_cps = builder.cast_if_needed(location, callee_val, cps_closure_ty);
+
+                // Call closure with continuation as first arg (done_k)
+                let mut cps_args = vec![continuation];
+                cps_args.append(&mut arg_values);
+
+                let call_op =
+                    func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty);
+                builder.ir.push_op(builder.block, call_op.op_ref());
+                Some(call_op.result(builder.ir))
+            }
+            _ => unreachable!("ICE: lower_cps_call with unexpected callee kind"),
+        },
+        callee_kind => {
+            let callee = Expr::new(call_expr_id, callee_kind);
+            let callee_val = lower_expr(builder, callee)?;
+            let mut cps_param_types = vec![anyref_ty];
             cps_param_types.extend(arg_values.iter().map(|v| builder.ir.value_ty(*v)));
             let cps_func_ty = builder
                 .ctx
@@ -1384,16 +1544,13 @@ fn lower_cps_call<'db>(
             let cps_closure_ty = builder.ctx.closure_type(builder.ir, cps_func_ty);
             let callee_cps = builder.cast_if_needed(location, callee_val, cps_closure_ty);
 
-            // Call closure with continuation as first arg (done_k)
             let mut cps_args = vec![continuation];
             cps_args.append(&mut arg_values);
-
             let call_op =
                 func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty);
             builder.ir.push_op(builder.block, call_op.op_ref());
             Some(call_op.result(builder.ir))
         }
-        _ => unreachable!("ICE: lower_cps_call with unexpected callee kind"),
     }
 }
 
@@ -1599,7 +1756,14 @@ fn build_short_circuit_rhs_region<'db>(
 
     let rhs_val = {
         let mut inner = IrBuilder::new(builder.ctx, builder.ir, block);
-        lower_expr(&mut inner, rhs)
+        let outer_done_k = inner.ctx.done_k;
+        if outer_done_k.is_some() && contains_cps_call_in_evaluation(inner.ctx, &rhs) {
+            let identity_done_k = super::create_identity_done_k(&mut inner, location);
+            inner.ctx.done_k = Some(identity_done_k);
+        }
+        let result = lower_block_cps_for_expr(&mut inner, rhs).map(|(value, _)| value);
+        inner.ctx.done_k = outer_done_k;
+        result
     };
 
     let yield_val = match rhs_val {

--- a/crates/tribute-front/src/ast_to_ir/lower/handle.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/handle.rs
@@ -235,7 +235,7 @@ fn build_cps_body<'db>(
     }
 
     // Check if the body contains effectful function calls that need CPS.
-    let body_needs_done_k = super::expr::body_contains_cps_call(builder.ctx, body);
+    let body_needs_done_k = super::expr::contains_cps_call_in_evaluation(builder.ctx, body);
     let anyref_ty = builder.ctx.anyref_type(builder.ir);
 
     // Build body closure entry block.
@@ -583,7 +583,8 @@ fn build_cps_suspend_handler_region<'db>(
         // Evaluate the handler body
         let body_result = {
             let mut builder = IrBuilder::new(&mut scope, ir, block);
-            super::expr::lower_expr(&mut builder, handler.body.clone())
+            super::expr::lower_block_cps_for_expr(&mut builder, handler.body.clone())
+                .map(|(value, _)| value)
         };
 
         scope.done_k = prev_done_k;
@@ -989,7 +990,8 @@ fn build_fn_handler_arm_for_dispatch<'db>(
         // Evaluate the handler body
         {
             let mut inner_builder = IrBuilder::new(&mut scope, ir, block);
-            super::expr::lower_expr(&mut inner_builder, handler.body.clone())
+            super::expr::lower_block_cps_for_expr(&mut inner_builder, handler.body.clone())
+                .map(|(value, _)| value)
         }
     };
 

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -127,6 +127,191 @@ fn main() { }
     assert_snapshot!(ir_text);
 }
 
+/// An effectful named call nested inside another call must be lifted into a
+/// continuation before the outer expression is evaluated.
+#[salsa_test]
+fn test_nested_effectful_call_in_argument(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+fn read() ->{State(Int)} Int {
+    State::get()
+}
+
+fn add_one(value: Int) -> Int {
+    value + 1
+}
+
+fn run() ->{State(Int)} Int {
+    add_one(read())
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
+/// Local closures use the CPS calling convention even when the call is nested
+/// inside a larger expression.
+#[salsa_test]
+fn test_nested_effectful_closure_call(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+fn run() ->{State(Int)} Int {
+    let read = fn() { State::get() }
+    read() + 1
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
+/// CPS lifting in a case arm stays inside that arm rather than executing
+/// before the branch is selected.
+#[salsa_test]
+fn test_nested_effectful_call_in_case_arm(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+fn read() ->{State(Int)} Int {
+    State::get()
+}
+
+fn run(flag: Bool) ->{State(Int)} Int {
+    case flag {
+        True -> read() + 1
+        False -> 0
+    }
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
+/// Short-circuit RHS lowering must keep the effectful call inside the selected
+/// region.
+#[salsa_test]
+fn test_nested_effectful_call_in_short_circuit_rhs(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Flag {
+    op get() -> Bool
+}
+
+fn read() ->{Flag} Bool {
+    Flag::get()
+}
+
+fn run() ->{Flag} Bool {
+    False && read()
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
+/// A nested effectful call in a handle body must use the handle body's local
+/// continuation and stay inside the installed handler boundary.
+#[salsa_test]
+fn test_nested_effectful_call_in_handle_body(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+fn read() ->{State(Int)} Int {
+    State::get()
+}
+
+fn run() -> Int {
+    handle read() + 1 {
+        do result { result }
+        op State::get() { resume +41 }
+    }
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
+/// Handler operation arms use a region-local identity continuation for nested
+/// effectful calls before resuming the captured continuation.
+#[salsa_test]
+fn test_nested_effectful_call_in_handler_arm(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+ability Log {
+    op value() -> Int
+}
+
+fn read_log() ->{Log} Int {
+    Log::value()
+}
+
+fn run() ->{Log} Int {
+    handle State::get() {
+        do result { result }
+        op State::get() {
+            let value = read_log() + 1
+            resume value
+        }
+    }
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
 // ========================================================================
 // Handle Expression Tests
 // ========================================================================

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_argument.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_argument.snap
@@ -1,0 +1,34 @@
+---
+source: crates/tribute-front/tests/cps_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+
+  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @add_one(%0: core.i32) -> core.i32 {
+      %1 = arith.const {value = 1} : core.i32
+      %2 = func.call %0, %1 {callee = @"Int::+"} : core.i32
+      func.return %2
+  }
+  func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
+          %4 = core.unrealized_conversion_cast %3 : core.i32
+          %5 = func.call %4 {callee = @add_one} : core.i32
+          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
+          %7 = core.unrealized_conversion_cast %1 : !t1
+          %8 = func.call_indirect %7, %6 : tribute_rt.anyref
+          func.return %8
+      }
+      %9 = func.call %0, %2 {callee = @read} : tribute_rt.anyref
+      func.return %9
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_case_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_case_arm.snap
@@ -1,0 +1,46 @@
+---
+source: crates/tribute-front/tests/cps_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+
+  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @run(%0: !t0, %1: tribute_rt.anyref, %2: core.i1) -> tribute_rt.anyref {
+      %3 = arith.const {value = true} : core.i1
+      %4 = arith.cmpi %2, %3 {predicate = @eq} : core.i1
+      %5 = scf.if %4 : core.i32 {
+          %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %7 = closure.new %6 {func_ref = @"test::__lambda_0"} : !t1
+          %8 = closure.lambda(%9: tribute_rt.anyref) -> tribute_rt.anyref [%7] {
+              %10 = core.unrealized_conversion_cast %9 : core.i32
+              %11 = arith.const {value = 1} : core.i32
+              %12 = func.call %10, %11 {callee = @"Int::+"} : core.i32
+              %13 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
+              %14 = func.call_indirect %7, %13 : tribute_rt.anyref
+              func.return %14
+          }
+          %15 = func.call %0, %8 {callee = @read} : tribute_rt.anyref
+          %16 = core.unrealized_conversion_cast %15 : core.i32
+          scf.yield %16
+      } {
+          %17 = arith.const {value = 0} : core.i32
+          scf.yield %17
+      }
+      %18 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %1 : !t1
+      %20 = func.call_indirect %19, %18 : tribute_rt.anyref
+      func.return %20
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
@@ -1,0 +1,80 @@
+---
+source: crates/tribute-front/tests/cps_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+
+  func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @run() -> core.i32 {
+      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
+          %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
+              %4 = core.unrealized_conversion_cast %3 : core.i32
+              %5 = arith.const {value = 1} : core.i32
+              %6 = func.call %4, %5 {callee = @"Int::+"} : core.i32
+              %7 = core.unrealized_conversion_cast %6 : tribute_rt.anyref
+              %8 = core.unrealized_conversion_cast %1 : !t0
+              %9 = func.call_indirect %8, %7 : tribute_rt.anyref
+              func.return %9
+          }
+          %10 = adt.ref_null {type = !t1} : !t1
+          %11 = func.call %10, %2 {callee = @read} : tribute_rt.anyref
+          func.return %11
+      }
+      %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %13 = closure.new %12 {func_ref = @"test::__lambda_0"} : !t0
+      %14 = func.call_indirect %0, %13 : tribute_rt.anyref
+      %15 = closure.lambda(%16: tribute_rt.anyref, %17: core.i32, %18: tribute_rt.anyref) -> tribute_rt.anyref {
+          %19 = arith.const {value = 1} : core.i1
+          %20 = scf.if %19 : tribute_rt.anyref {
+              %21 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %22 = closure.new %21 {func_ref = @"test::__lambda_2"} : !t0
+              %23 = arith.const {value = 41} : core.i32
+              %24 = core.unrealized_conversion_cast %23 : tribute_rt.anyref
+              %25 = core.unrealized_conversion_cast %16 : !t0
+              %26 = func.call_indirect %25, %24 : tribute_rt.anyref
+              scf.yield %26
+          } {
+              func.unreachable
+          }
+          func.return %20
+      }
+      %27 = arith.const {value = 0} : tribute_rt.anyref
+      %28 = ability.handle_dispatch %14, %15, %27 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+          ability.done {
+            ^bb7(%29: tribute_rt.anyref):
+              %30 = core.unrealized_conversion_cast %29 : core.i32
+              scf.yield %30
+          }
+          ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
+            ^bb8(%31: tribute_rt.anyref, %32: tribute_rt.anyref):
+              %33 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %34 = closure.new %33 {func_ref = @"test::__lambda_1"} : !t0
+              %35 = arith.const {value = 41} : core.i32
+              %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
+              %37 = core.unrealized_conversion_cast %31 : !t0
+              %38 = func.call_indirect %37, %36 : tribute_rt.anyref
+              scf.yield %38
+          }
+      }
+      %39 = core.unrealized_conversion_cast %28 : core.i32
+      func.return %39
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
@@ -32,50 +32,42 @@ core.module @test {
           %13 = scf.if %12 : tribute_rt.anyref {
               %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
-              %16 = closure.lambda(%17: tribute_rt.anyref) -> tribute_rt.anyref [%9, %15] {
-                  %18 = core.unrealized_conversion_cast %17 : core.i32
-                  %19 = arith.const {value = 1} : core.i32
-                  %20 = func.call %18, %19 {callee = @"Int::+"} : core.i32
-                  %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
-                  %22 = core.unrealized_conversion_cast %9 : !t0
-                  %23 = func.call_indirect %22, %21 : tribute_rt.anyref
-                  %24 = func.call_indirect %15, %23 : tribute_rt.anyref
-                  func.return %24
-              }
-              %25 = func.call %0, %16 {callee = @read_log} : tribute_rt.anyref
-              scf.yield %25
+              %16 = func.call %0, %15 {callee = @read_log} : tribute_rt.anyref
+              %17 = arith.const {value = 1} : core.i32
+              %18 = core.unrealized_conversion_cast %16 : core.i32
+              %19 = func.call %18, %17 {callee = @"Int::+"} : core.i32
+              %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
+              %21 = core.unrealized_conversion_cast %9 : !t0
+              %22 = func.call_indirect %21, %20 : tribute_rt.anyref
+              scf.yield %22
           } {
               func.unreachable
           }
           func.return %13
       }
-      %26 = arith.const {value = 0} : tribute_rt.anyref
-      %27 = ability.handle_dispatch %7, %8, %26 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %23 = arith.const {value = 0} : tribute_rt.anyref
+      %24 = ability.handle_dispatch %7, %8, %23 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb7(%28: tribute_rt.anyref):
-              scf.yield %28
+            ^bb6(%25: tribute_rt.anyref):
+              scf.yield %25
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb8(%29: tribute_rt.anyref, %30: tribute_rt.anyref):
-              %31 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %32 = closure.new %31 {func_ref = @"test::__lambda_1"} : !t0
-              %33 = closure.lambda(%34: tribute_rt.anyref) -> tribute_rt.anyref [%29, %32] {
-                  %35 = core.unrealized_conversion_cast %34 : core.i32
-                  %36 = arith.const {value = 1} : core.i32
-                  %37 = func.call %35, %36 {callee = @"Int::+"} : core.i32
-                  %38 = core.unrealized_conversion_cast %37 : tribute_rt.anyref
-                  %39 = core.unrealized_conversion_cast %29 : !t0
-                  %40 = func.call_indirect %39, %38 : tribute_rt.anyref
-                  %41 = func.call_indirect %32, %40 : tribute_rt.anyref
-                  func.return %41
-              }
-              %42 = func.call %0, %33 {callee = @read_log} : tribute_rt.anyref
-              scf.yield %42
+            ^bb7(%26: tribute_rt.anyref, %27: tribute_rt.anyref):
+              %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %29 = closure.new %28 {func_ref = @"test::__lambda_1"} : !t0
+              %30 = func.call %0, %29 {callee = @read_log} : tribute_rt.anyref
+              %31 = arith.const {value = 1} : core.i32
+              %32 = core.unrealized_conversion_cast %30 : core.i32
+              %33 = func.call %32, %31 {callee = @"Int::+"} : core.i32
+              %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
+              %35 = core.unrealized_conversion_cast %26 : !t0
+              %36 = func.call_indirect %35, %34 : tribute_rt.anyref
+              scf.yield %36
           }
       }
-      %43 = core.unrealized_conversion_cast %1 : !t0
-      %44 = func.call_indirect %43, %27 : tribute_rt.anyref
-      func.return %44
+      %37 = core.unrealized_conversion_cast %1 : !t0
+      %38 = func.call_indirect %37, %24 : tribute_rt.anyref
+      func.return %38
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
@@ -1,0 +1,84 @@
+---
+source: crates/tribute-front/tests/cps_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+
+  func.func @read_log(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Log}, op_name = @value} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @run(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
+          %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          func.return %4
+      }
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = closure.new %5 {func_ref = @"test::__lambda_0"} : !t0
+      %7 = func.call_indirect %2, %6 : tribute_rt.anyref
+      %8 = closure.lambda(%9: tribute_rt.anyref, %10: core.i32, %11: tribute_rt.anyref) -> tribute_rt.anyref {
+          %12 = arith.const {value = 1} : core.i1
+          %13 = scf.if %12 : tribute_rt.anyref {
+              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
+              %16 = closure.lambda(%17: tribute_rt.anyref) -> tribute_rt.anyref [%9, %15] {
+                  %18 = core.unrealized_conversion_cast %17 : core.i32
+                  %19 = arith.const {value = 1} : core.i32
+                  %20 = func.call %18, %19 {callee = @"Int::+"} : core.i32
+                  %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
+                  %22 = core.unrealized_conversion_cast %9 : !t0
+                  %23 = func.call_indirect %22, %21 : tribute_rt.anyref
+                  %24 = func.call_indirect %15, %23 : tribute_rt.anyref
+                  func.return %24
+              }
+              %25 = func.call %0, %16 {callee = @read_log} : tribute_rt.anyref
+              scf.yield %25
+          } {
+              func.unreachable
+          }
+          func.return %13
+      }
+      %26 = arith.const {value = 0} : tribute_rt.anyref
+      %27 = ability.handle_dispatch %7, %8, %26 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+          ability.done {
+            ^bb7(%28: tribute_rt.anyref):
+              scf.yield %28
+          }
+          ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
+            ^bb8(%29: tribute_rt.anyref, %30: tribute_rt.anyref):
+              %31 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %32 = closure.new %31 {func_ref = @"test::__lambda_1"} : !t0
+              %33 = closure.lambda(%34: tribute_rt.anyref) -> tribute_rt.anyref [%29, %32] {
+                  %35 = core.unrealized_conversion_cast %34 : core.i32
+                  %36 = arith.const {value = 1} : core.i32
+                  %37 = func.call %35, %36 {callee = @"Int::+"} : core.i32
+                  %38 = core.unrealized_conversion_cast %37 : tribute_rt.anyref
+                  %39 = core.unrealized_conversion_cast %29 : !t0
+                  %40 = func.call_indirect %39, %38 : tribute_rt.anyref
+                  %41 = func.call_indirect %32, %40 : tribute_rt.anyref
+                  func.return %41
+              }
+              %42 = func.call %0, %33 {callee = @read_log} : tribute_rt.anyref
+              scf.yield %42
+          }
+      }
+      %43 = core.unrealized_conversion_cast %1 : !t0
+      %44 = func.call_indirect %43, %27 : tribute_rt.anyref
+      func.return %44
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
@@ -1,0 +1,36 @@
+---
+source: crates/tribute-front/tests/cps_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+
+  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @get} : tribute_rt.anyref
+      func.return %2
+  }
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+  func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = arith.const {value = false} : core.i1
+      %3 = scf.if %2 : core.i1 {
+          %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t1
+          %6 = func.call %0, %5 {callee = @read} : tribute_rt.anyref
+          scf.yield %6
+      } {
+          %7 = arith.const {value = false} : core.i1
+          scf.yield %7
+      }
+      %8 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %9 = core.unrealized_conversion_cast %1 : !t1
+      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
+      func.return %10
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
@@ -19,15 +19,16 @@ core.module @test {
           %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
           %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t1
           %6 = func.call %0, %5 {callee = @read} : tribute_rt.anyref
-          scf.yield %6
-      } {
-          %7 = arith.const {value = false} : core.i1
+          %7 = core.unrealized_conversion_cast %6 : core.i1
           scf.yield %7
+      } {
+          %8 = arith.const {value = false} : core.i1
+          scf.yield %8
       }
-      %8 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %9 = core.unrealized_conversion_cast %1 : !t1
-      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
-      func.return %10
+      %9 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %10 = core.unrealized_conversion_cast %1 : !t1
+      %11 = func.call_indirect %10, %9 : tribute_rt.anyref
+      func.return %11
   }
   func.func @main() -> core.nil {
       %0 = arith.const {value = unit} : core.nil

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_closure_call.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_closure_call.snap
@@ -1,0 +1,29 @@
+---
+source: crates/tribute-front/tests/cps_lowering.rs
+expression: ir_text
+---
+core.module @test {
+  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+
+  func.func @run(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
+          %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          func.return %4
+      }
+      %5 = closure.lambda(%6: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
+          %7 = core.unrealized_conversion_cast %6 : core.i32
+          %8 = arith.const {value = 1} : core.i32
+          %9 = func.call %7, %8 {callee = @"Int::+"} : core.i32
+          %10 = core.unrealized_conversion_cast %9 : tribute_rt.anyref
+          %11 = core.unrealized_conversion_cast %1 : !t0
+          %12 = func.call_indirect %11, %10 : tribute_rt.anyref
+          func.return %12
+      }
+      %13 = func.call_indirect %2, %5 : tribute_rt.anyref
+      func.return %13
+  }
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = unit} : core.nil
+      func.return %0
+  }
+}

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -58,6 +58,35 @@ func.return %result
 Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므로,
 `ability.perform` 이후의 같은 function-body ops는 dead code가 된다.
 
+### 중첩 표현식의 CPS lifting
+
+CPS 호출이 더 큰 표현식 안에 중첩된 경우 `ast_to_ir`는 호출을 직접
+lowering하지 않는다. 대신 현재 평가 영역 안에서 첫 CPS 호출을 synthetic
+let binding으로 끌어올린 뒤 기존 block CPS lowering을 적용한다.
+
+```text
+consume(effectful(), pure_arg)
+
+→ let __cps_tmp = effectful()
+  consume(__cps_tmp, pure_arg)
+```
+
+이 변환은 소스의 좌에서 우 평가 순서를 보존한다. 호출 callee와 arguments,
+tuple/constructor/record 요소, case scrutinee처럼 항상 평가되는 strict
+subexpression만 현재 영역으로 끌어올린다.
+
+다음 위치는 별도의 control-flow 또는 effect 경계이므로 바깥 영역으로
+hoist하지 않는다.
+
+- short-circuit 연산의 RHS
+- case arm과 guard
+- lambda body
+- handle body와 handler arm
+
+각 영역은 진입 시 자체적으로 같은 CPS lifting을 수행한다. 따라서 실행되지
+않을 branch의 effectful call이 미리 실행되거나, handler boundary 밖의
+continuation에 잘못 포함되어서는 안 된다.
+
 ### `handle`: evidence extension + handler closures
 
 `handle` lowering은 두 종류의 dispatch closure를 만든다.


### PR DESCRIPTION
## Summary
- Handle nested effectful calls during CPS lowering in expressions, case arms, and handler bodies
- Update lowering logic so effectful subexpressions are preserved correctly inside arguments, short-circuit branches, closures, and handler/case contexts
- Add regression coverage for the nested CPS scenarios captured in the new snapshots
- Document the effect-lowering direction in `new-plans/cps-effects.md`

## Testing
- Added focused CPS lowering regression tests with snapshot coverage for nested effectful call cases
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPS-lowering correctness for nested effectful expressions, including short-circuit boolean RHS, case arm bodies and guard conditions, and effect handler body/arm evaluation.
* **Documentation**
  * Updated guidance describing CPS continuation lifting behavior for nested expressions and key control/effect boundaries.
* **Tests**
  * Added new snapshot tests covering nested effectful calls across calls, closures, case arms, short-circuit conditions, and handle/handler arm scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->