### PR TITLE
Add active pipeline golden snapshots for ability handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "derive_more",
  "fluent-uri",
  "insta",
+ "itertools",
  "lsp-server",
  "lsp-types",
  "ropey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ trunk-ir-wasm-backend.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+itertools.workspace = true
 salsa-test-macros = { path = "crates/salsa-test-macros" }
 serde.workspace = true
 

--- a/tests/active_pipeline_goldens.rs
+++ b/tests/active_pipeline_goldens.rs
@@ -3,7 +3,10 @@
 //! These snapshots intentionally target textual IR at named pipeline stages:
 //! shared middle-end IR and native-target IR.
 
+use std::fmt::Write;
+
 use insta::assert_snapshot;
+use itertools::Itertools;
 use salsa_test_macros::salsa_test;
 use tribute::Diagnostic;
 use tribute::pipeline::{compile_with_diagnostics, dump_ir};
@@ -14,11 +17,12 @@ fn assert_no_diagnostics(stage: &str, diagnostics: &[Diagnostic]) {
     assert!(
         diagnostics.is_empty(),
         "{stage} emitted diagnostics:\n{}",
-        diagnostics
-            .iter()
-            .map(|diagnostic| format!("  - [{}] {}", diagnostic.phase, diagnostic.inner.message))
-            .collect::<Vec<_>>()
-            .join("\n")
+        diagnostics.iter().format_with("\n", |diagnostic, f| {
+            f(&format_args!(
+                "  - [{}] {}",
+                diagnostic.phase, diagnostic.inner.message
+            ))
+        })
     );
 }
 
@@ -59,13 +63,20 @@ fn brace_delta(line: &str) -> isize {
     })
 }
 
+fn append_line(output: &mut String, line: &str) {
+    if !output.is_empty() {
+        output.push('\n');
+    }
+    write!(output, "{line}").expect("fmt::Write to String never fails");
+}
+
 fn filter_ir_for_active_pipeline(ir_text: &str) -> String {
-    let mut output = Vec::new();
+    let mut output = String::new();
     let mut lines = ir_text.lines().peekable();
 
     while let Some(line) = lines.next() {
         if line.starts_with("core.module ") || line.trim_start().starts_with('!') {
-            output.push(line.to_owned());
+            append_line(&mut output, line);
             continue;
         }
 
@@ -74,27 +85,28 @@ fn filter_ir_for_active_pipeline(ir_text: &str) -> String {
         }
 
         let include_function = is_active_pipeline_function(line);
-        let mut function_lines = vec![line.to_owned()];
         let mut depth = brace_delta(line);
+
+        if include_function {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            append_line(&mut output, line);
+        }
 
         while depth > 0 {
             let body_line = lines
                 .next()
                 .expect("function body should close before the module ends");
             depth += brace_delta(body_line);
-            function_lines.push(body_line.to_owned());
-        }
-
-        if include_function {
-            if !output.last().is_some_and(|line| line.is_empty()) {
-                output.push(String::new());
+            if include_function {
+                append_line(&mut output, body_line);
             }
-            output.extend(function_lines);
         }
     }
 
-    output.push("}".to_owned());
-    output.join("\n")
+    append_line(&mut output, "}");
+    output
 }
 
 fn snapshot_shared_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str) -> String {

--- a/tests/active_pipeline_goldens.rs
+++ b/tests/active_pipeline_goldens.rs
@@ -44,6 +44,7 @@ fn is_active_pipeline_function(header: &str) -> bool {
         "\"direct_fn_native::__lambda",
         "\"resumptive_op::__lambda",
         "\"resumptive_op_native::__lambda",
+        "\"mixed_nested::__lambda",
         "\"mixed_nested_native::__lambda",
     ];
 
@@ -68,7 +69,7 @@ fn filter_ir_for_active_pipeline(ir_text: &str) -> String {
             continue;
         }
 
-        if !line.starts_with("  func.func ") {
+        if !line.trim_start().starts_with("func.func ") {
             continue;
         }
 
@@ -217,6 +218,12 @@ fn shared_pipeline_direct_fn_ability_call(db: &salsa::DatabaseImpl) {
 #[salsa_test]
 fn shared_pipeline_resumptive_op_continuation(db: &salsa::DatabaseImpl) {
     let ir_text = snapshot_shared_pipeline_ir(db, "resumptive_op.trb", RESUMPTIVE_OP_SOURCE);
+    assert_snapshot!(ir_text);
+}
+
+#[salsa_test]
+fn shared_pipeline_mixed_nested_handler_boundary(db: &salsa::DatabaseImpl) {
+    let ir_text = snapshot_shared_pipeline_ir(db, "mixed_nested.trb", MIXED_NESTED_SOURCE);
     assert_snapshot!(ir_text);
 }
 

--- a/tests/active_pipeline_goldens.rs
+++ b/tests/active_pipeline_goldens.rs
@@ -1,0 +1,239 @@
+//! Golden tests for the active ability lowering pipeline.
+//!
+//! These snapshots intentionally target textual IR at named pipeline stages:
+//! shared middle-end IR and native-target IR.
+
+use insta::assert_snapshot;
+use salsa_test_macros::salsa_test;
+use tribute::Diagnostic;
+use tribute::pipeline::{compile_with_diagnostics, dump_ir};
+use tribute_front::SourceCst;
+use trunk_ir::printer::print_module;
+
+fn assert_no_diagnostics(stage: &str, diagnostics: &[Diagnostic]) {
+    assert!(
+        diagnostics.is_empty(),
+        "{stage} emitted diagnostics:\n{}",
+        diagnostics
+            .iter()
+            .map(|diagnostic| format!("  - [{}] {}", diagnostic.phase, diagnostic.inner.message))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+fn is_active_pipeline_function(header: &str) -> bool {
+    let selected_names = [
+        "@__tribute_evidence_",
+        "@__tribute_next_tag",
+        "@main",
+        "@use_console",
+        "@run",
+        "@run_state",
+        "@run_state_with_console",
+        "@run_all",
+        "@bump",
+        "@step",
+        "\"run::",
+        "\"run_state::",
+        "\"run_state_with_console::",
+        "\"run_all::",
+        "\"bump::",
+        "\"step::",
+        "\"direct_fn::__lambda",
+        "\"direct_fn_native::__lambda",
+        "\"resumptive_op::__lambda",
+        "\"resumptive_op_native::__lambda",
+        "\"mixed_nested_native::__lambda",
+    ];
+
+    selected_names.iter().any(|name| header.contains(name))
+}
+
+fn brace_delta(line: &str) -> isize {
+    line.chars().fold(0, |delta, ch| match ch {
+        '{' => delta + 1,
+        '}' => delta - 1,
+        _ => delta,
+    })
+}
+
+fn filter_ir_for_active_pipeline(ir_text: &str) -> String {
+    let mut output = Vec::new();
+    let mut lines = ir_text.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        if line.starts_with("core.module ") || line.trim_start().starts_with('!') {
+            output.push(line.to_owned());
+            continue;
+        }
+
+        if !line.starts_with("  func.func ") {
+            continue;
+        }
+
+        let include_function = is_active_pipeline_function(line);
+        let mut function_lines = vec![line.to_owned()];
+        let mut depth = brace_delta(line);
+
+        while depth > 0 {
+            let body_line = lines
+                .next()
+                .expect("function body should close before the module ends");
+            depth += brace_delta(body_line);
+            function_lines.push(body_line.to_owned());
+        }
+
+        if include_function {
+            if !output.last().is_some_and(|line| line.is_empty()) {
+                output.push(String::new());
+            }
+            output.extend(function_lines);
+        }
+    }
+
+    output.push("}".to_owned());
+    output.join("\n")
+}
+
+fn snapshot_shared_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str) -> String {
+    let source = SourceCst::from_source_str(db, name, code);
+    let result = compile_with_diagnostics(db, source);
+    assert_no_diagnostics("shared pipeline", &result.diagnostics);
+
+    let (ctx, module) = result
+        .module
+        .expect("shared pipeline should produce a module when diagnostics are empty");
+    filter_ir_for_active_pipeline(&print_module(&ctx, module.op()))
+}
+
+fn snapshot_native_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str) -> String {
+    let source = SourceCst::from_source_str(db, name, code);
+    let ir_text = dump_ir(db, source, true).expect("native pipeline dump should succeed");
+    let diagnostics: Vec<Diagnostic> = dump_ir::accumulated::<Diagnostic>(db, source, true)
+        .into_iter()
+        .cloned()
+        .collect();
+    assert_no_diagnostics("native pipeline", &diagnostics);
+    filter_ir_for_active_pipeline(&ir_text)
+}
+
+const DIRECT_FN_SOURCE: &str = r#"
+ability Console {
+    fn read() -> Int
+    fn print(value: Int) -> Nil
+}
+
+fn use_console() ->{Console} Int {
+    let n = Console::read()
+    Console::print(n)
+    n
+}
+
+fn run() -> Int {
+    handle use_console() {
+        do result { result }
+        fn Console::read() { +41 }
+        fn Console::print(value) { Nil }
+    }
+}
+
+fn main() {
+    let _ = run()
+}
+"#;
+
+const RESUMPTIVE_OP_SOURCE: &str = r#"
+ability State(s) {
+    op get() -> s
+    op set(value: s) -> Nil
+}
+
+fn bump() ->{State(Int)} Int {
+    let n = State::get()
+    State::set(n + +1)
+    n
+}
+
+fn run_state() -> Int {
+    handle bump() {
+        do result { result }
+        op State::get() { resume +10 }
+        op State::set(value) { resume Nil }
+    }
+}
+
+fn main() {
+    let _ = run_state()
+}
+"#;
+
+const MIXED_NESTED_SOURCE: &str = r#"
+ability Console {
+    fn read() -> Int
+    fn print(value: Int) -> Nil
+}
+
+ability State(s) {
+    op get() -> s
+    op set(value: s) -> Nil
+}
+
+fn step() ->{Console, State(Int)} Int {
+    let base = Console::read()
+    let current = State::get()
+    State::set(current + base)
+    Console::print(current)
+    current + base
+}
+
+fn run_state_with_console() ->{Console} Int {
+    handle step() {
+        do result { result }
+        op State::get() { resume +7 }
+        op State::set(value) { resume Nil }
+    }
+}
+
+fn run_all() -> Int {
+    handle run_state_with_console() {
+        do result { result }
+        fn Console::read() { +3 }
+        fn Console::print(value) { Nil }
+    }
+}
+
+fn main() {
+    let _ = run_all()
+}
+"#;
+
+#[salsa_test]
+fn shared_pipeline_direct_fn_ability_call(db: &salsa::DatabaseImpl) {
+    let ir_text = snapshot_shared_pipeline_ir(db, "direct_fn.trb", DIRECT_FN_SOURCE);
+    assert_snapshot!(ir_text);
+}
+
+#[salsa_test]
+fn shared_pipeline_resumptive_op_continuation(db: &salsa::DatabaseImpl) {
+    let ir_text = snapshot_shared_pipeline_ir(db, "resumptive_op.trb", RESUMPTIVE_OP_SOURCE);
+    assert_snapshot!(ir_text);
+}
+
+#[salsa_test]
+fn native_pipeline_direct_fn_ability_call(db: &salsa::DatabaseImpl) {
+    let ir_text = snapshot_native_pipeline_ir(db, "direct_fn_native.trb", DIRECT_FN_SOURCE);
+    assert_snapshot!(ir_text);
+}
+
+#[salsa_test]
+fn native_pipeline_resumptive_op_continuation(db: &salsa::DatabaseImpl) {
+    let ir_text = snapshot_native_pipeline_ir(db, "resumptive_op_native.trb", RESUMPTIVE_OP_SOURCE);
+    assert_snapshot!(ir_text);
+}
+
+#[salsa_test]
+fn native_pipeline_mixed_nested_handler_boundary(db: &salsa::DatabaseImpl) {
+    let ir_text = snapshot_native_pipeline_ir(db, "mixed_nested_native.trb", MIXED_NESTED_SOURCE);
+    assert_snapshot!(ir_text);
+}

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -1,0 +1,139 @@
+---
+source: tests/active_pipeline_goldens.rs
+expression: ir_text
+---
+core.module @direct_fn_native {
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+
+  func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup_tr(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_empty() -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_extend(%0: core.ptr, %1: core.i32, %2: core.i32, %3: core.ptr, %4: core.ptr) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup(%0: core.ptr, %1: core.i32) -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @"direct_fn_native::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"direct_fn_native::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"direct_fn_native::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = 0} : core.i32
+      %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run::__clam_0"} : !t1
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = func.constant {func_ref = @"direct_fn_native::__lambda_5"} : !t1
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %15 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
+      %17 = func.call {callee = @__tribute_next_tag} : core.i32
+      %18 = core.unrealized_conversion_cast %16 : core.ptr
+      %19 = core.unrealized_conversion_cast %13 : core.ptr
+      %20 = arith.const {value = 2616163639} : core.i32
+      %21 = func.call %1, %20, %17, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
+      %22 = func.call_indirect %9, %21, %10, %8 : tribute_rt.anyref
+      %23 = tribute_rt.unbox_int %22 : core.i32
+      %24 = tribute_rt.unbox_int %22 : core.i32
+      %25 = arith.const {value = unit} : core.nil
+      func.return %25
+  }
+
+  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %4 = arith.const {value = 2616163639} : core.i32
+      %5 = func.call %0, %4 {callee = @__tribute_evidence_lookup} : core.i32
+      %6 = func.call %0, %4 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %7 = arith.const {value = 664197438} : core.i32
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = func.call_indirect %9, %0, %10, %7, %8 : tribute_rt.anyref
+      %12 = tribute_rt.unbox_int %11 : core.i32
+      %13 = arith.const {value = 2616163639} : core.i32
+      %14 = func.call %0, %13 {callee = @__tribute_evidence_lookup} : core.i32
+      %15 = func.call %0, %13 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %16 = arith.const {value = 2110389019} : core.i32
+      %17 = adt.struct_get %15 {field = 0, type = !_closure} : core.i32
+      %18 = adt.struct_get %15 {field = 1, type = !_closure} : tribute_rt.anyref
+      %19 = func.call_indirect %17, %0, %18, %16, %11 : tribute_rt.anyref
+      %20 = core.unrealized_conversion_cast %19 : core.nil
+      %21 = core.unrealized_conversion_cast %2 : closure.closure(!t1)
+      %22 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
+      %23 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
+      %24 = func.call_indirect %22, %0, %23, %11 : tribute_rt.anyref
+      func.return %24
+  }
+
+  func.func @"run::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 664197438} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"direct_fn_native::__lambda_8"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 41} : core.i32
+          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
+          scf.yield %12
+      } {
+          %13 = arith.const {value = 1} : core.i1
+          %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %15 = func.constant {func_ref = @"direct_fn_native::__lambda_9"} : !t1
+          %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
+          %17 = arith.const {value = unit} : core.nil
+          %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
+          scf.yield %18
+      }
+      func.return %7
+  }
+
+  func.func @"run::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
+      %4 = arith.const {value = 664197438} : core.i32
+      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
+      %6 = scf.if %5 : tribute_rt.anyref {
+          %7 = arith.const {value = 41} : core.i32
+          %8 = tribute_rt.box_int %7 : tribute_rt.anyref
+          scf.yield %8
+      } {
+          %9 = arith.const {value = 1} : core.i1
+          %10 = arith.const {value = unit} : core.nil
+          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+          scf.yield %11
+      }
+      func.return %6
+  }
+}

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -1,0 +1,256 @@
+---
+source: tests/active_pipeline_goldens.rs
+expression: ir_text
+---
+core.module @mixed_nested_native {
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
+  !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
+  !t2 = closure.closure(!t1)
+  !t3 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+
+  func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup_tr(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_empty() -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_extend(%0: core.ptr, %1: core.i32, %2: core.i32, %3: core.ptr, %4: core.ptr) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup(%0: core.ptr, %1: core.i32) -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @"mixed_nested_native::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested_native::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested_native::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested_native::__lambda_10"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested_native::__lambda_13"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested_native::__lambda_14"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = 0} : core.i32
+      %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = func.constant {func_ref = @"mixed_nested_native::__lambda_10"} : !t1
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = func.constant {func_ref = @"run_all::__clam_1"} : !t3
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %15 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
+      %17 = func.call {callee = @__tribute_next_tag} : core.i32
+      %18 = core.unrealized_conversion_cast %16 : core.ptr
+      %19 = core.unrealized_conversion_cast %13 : core.ptr
+      %20 = arith.const {value = 2616163639} : core.i32
+      %21 = func.call %1, %20, %17, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
+      %22 = func.call_indirect %9, %21, %10, %8 : tribute_rt.anyref
+      %23 = tribute_rt.unbox_int %22 : core.i32
+      %24 = tribute_rt.unbox_int %22 : core.i32
+      %25 = arith.const {value = unit} : core.nil
+      func.return %25
+  }
+
+  func.func @"step::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::env"} : core.i32
+      %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::env"} : tribute_rt.anyref
+      %6 = tribute_rt.unbox_int %2 : core.i32
+      %7 = arith.addi %6, %4 : core.i32
+      %8 = adt.struct_new %6, %4, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
+      %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t1
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = arith.const {value = 80204913} : core.i32
+      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : core.i32
+      %13 = func.call %0, %11 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %14 = arith.const {value = 1348736788} : core.i32
+      %15 = tribute_rt.box_int %7 : tribute_rt.anyref
+      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %18 = func.call_indirect %16, %0, %17, %10, %14, %15 : tribute_rt.anyref
+      func.return %18
+  }
+
+  func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = arith.const {value = 2616163639} : core.i32
+      %4 = func.call %0, %3 {callee = @__tribute_evidence_lookup} : core.i32
+      %5 = func.call %0, %3 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %6 = arith.const {value = 664197438} : core.i32
+      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %10 = func.call_indirect %8, %0, %9, %6, %7 : tribute_rt.anyref
+      %11 = tribute_rt.unbox_int %10 : core.i32
+      %12 = adt.struct_new %11, %2 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %13 = func.constant {func_ref = @"step::__clam_0"} : !t1
+      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
+      %15 = arith.const {value = 80204913} : core.i32
+      %16 = func.call %0, %15 {callee = @__tribute_evidence_lookup} : core.i32
+      %17 = func.call %0, %15 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %18 = arith.const {value = 1972422014} : core.i32
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
+      %21 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
+      %22 = func.call_indirect %20, %0, %21, %14, %18, %19 : tribute_rt.anyref
+      func.return %22
+  }
+
+  func.func @"run_state_with_console::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 1972422014} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"mixed_nested_native::__lambda_8"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 7} : core.i32
+          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
+          %13 = core.unrealized_conversion_cast %2 : !t2
+          %14 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+          %15 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %12 : tribute_rt.anyref
+          scf.yield %16
+      } {
+          %17 = arith.const {value = 1} : core.i1
+          %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %19 = func.constant {func_ref = @"mixed_nested_native::__lambda_9"} : !t1
+          %20 = adt.struct_new %19, %18 {type = !_closure} : !_closure
+          %21 = arith.const {value = unit} : core.nil
+          %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
+          %23 = core.unrealized_conversion_cast %2 : !t2
+          %24 = adt.struct_get %23 {field = 0, type = !_closure} : core.i32
+          %25 = adt.struct_get %23 {field = 1, type = !_closure} : tribute_rt.anyref
+          %26 = func.call_indirect %24, %0, %25, %22 : tribute_rt.anyref
+          scf.yield %26
+      }
+      func.return %7
+  }
+
+  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
+      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
+      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %8 = func.constant {func_ref = @"mixed_nested_native::__lambda_5"} : !t1
+      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
+      %10 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+      %11 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+      %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %13 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t3
+      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
+      %15 = arith.const {value = 0} : tribute_rt.anyref
+      %16 = func.call {callee = @__tribute_next_tag} : core.i32
+      %17 = core.unrealized_conversion_cast %15 : core.ptr
+      %18 = core.unrealized_conversion_cast %14 : core.ptr
+      %19 = arith.const {value = 80204913} : core.i32
+      %20 = func.call %0, %19, %16, %17, %18 {callee = @__tribute_evidence_extend} : core.ptr
+      %21 = func.call_indirect %10, %20, %11, %9 : tribute_rt.anyref
+      %22 = tribute_rt.unbox_int %21 : core.i32
+      %23 = tribute_rt.unbox_int %21 : core.i32
+      %24 = core.unrealized_conversion_cast %2 : !t2
+      %25 = adt.struct_get %24 {field = 0, type = !_closure} : core.i32
+      %26 = adt.struct_get %24 {field = 1, type = !_closure} : tribute_rt.anyref
+      %27 = func.call_indirect %25, %0, %26, %21 : tribute_rt.anyref
+      func.return %27
+  }
+
+  func.func @"run_all::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 664197438} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"mixed_nested_native::__lambda_13"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 3} : core.i32
+          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
+          scf.yield %12
+      } {
+          %13 = arith.const {value = 1} : core.i1
+          %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %15 = func.constant {func_ref = @"mixed_nested_native::__lambda_14"} : !t1
+          %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
+          %17 = arith.const {value = unit} : core.nil
+          %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
+          scf.yield %18
+      }
+      func.return %7
+  }
+
+  func.func @"run_all::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
+      %4 = arith.const {value = 664197438} : core.i32
+      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
+      %6 = scf.if %5 : tribute_rt.anyref {
+          %7 = arith.const {value = 3} : core.i32
+          %8 = tribute_rt.box_int %7 : tribute_rt.anyref
+          scf.yield %8
+      } {
+          %9 = arith.const {value = 1} : core.i1
+          %10 = arith.const {value = unit} : core.nil
+          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+          scf.yield %11
+      }
+      func.return %6
+  }
+
+  func.func @"step::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::__clam_0::env"} : core.i32
+      %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::__clam_0::env"} : core.i32
+      %6 = adt.struct_get %3 {field = 2, type = !"step::__clam_0::__clam_0::env"} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %2 : core.nil
+      %8 = arith.const {value = 2616163639} : core.i32
+      %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup} : core.i32
+      %10 = func.call %0, %8 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %11 = arith.const {value = 2110389019} : core.i32
+      %12 = tribute_rt.box_int %4 : tribute_rt.anyref
+      %13 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
+      %14 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
+      %15 = func.call_indirect %13, %0, %14, %11, %12 : tribute_rt.anyref
+      %16 = core.unrealized_conversion_cast %15 : core.nil
+      %17 = arith.addi %4, %5 : core.i32
+      %18 = tribute_rt.box_int %17 : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %6 : !t2
+      %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
+      %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
+      %22 = func.call_indirect %20, %0, %21, %18 : tribute_rt.anyref
+      func.return %22
+  }
+}

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -1,0 +1,155 @@
+---
+source: tests/active_pipeline_goldens.rs
+expression: ir_text
+---
+core.module @resumptive_op_native {
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
+  !t2 = closure.closure(!t1)
+
+  func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup_tr(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_empty() -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_extend(%0: core.ptr, %1: core.i32, %2: core.i32, %3: core.ptr, %4: core.ptr) -> core.ptr attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup(%0: core.ptr, %1: core.i32) -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @"resumptive_op_native::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"resumptive_op_native::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"resumptive_op_native::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = 0} : core.i32
+      %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = func.constant {func_ref = @"resumptive_op_native::__lambda_5"} : !t1
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = arith.const {value = 0} : tribute_rt.anyref
+      %15 = func.call {callee = @__tribute_next_tag} : core.i32
+      %16 = core.unrealized_conversion_cast %14 : core.ptr
+      %17 = core.unrealized_conversion_cast %13 : core.ptr
+      %18 = arith.const {value = 80204913} : core.i32
+      %19 = func.call %1, %18, %15, %16, %17 {callee = @__tribute_evidence_extend} : core.ptr
+      %20 = func.call_indirect %9, %19, %10, %8 : tribute_rt.anyref
+      %21 = tribute_rt.unbox_int %20 : core.i32
+      %22 = tribute_rt.unbox_int %20 : core.i32
+      %23 = arith.const {value = unit} : core.nil
+      func.return %23
+  }
+
+  func.func @"bump::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::env"} : tribute_rt.anyref
+      %5 = tribute_rt.unbox_int %2 : core.i32
+      %6 = arith.const {value = 1} : core.i32
+      %7 = arith.addi %5, %6 : core.i32
+      %8 = adt.struct_new %5, %4 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
+      %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t1
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = arith.const {value = 80204913} : core.i32
+      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : core.i32
+      %13 = func.call %0, %11 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %14 = arith.const {value = 1348736788} : core.i32
+      %15 = tribute_rt.box_int %7 : tribute_rt.anyref
+      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %18 = func.call_indirect %16, %0, %17, %10, %14, %15 : tribute_rt.anyref
+      func.return %18
+  }
+
+  func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %4 = adt.struct_new %2 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
+      %5 = func.constant {func_ref = @"bump::__clam_0"} : !t1
+      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
+      %7 = arith.const {value = 80204913} : core.i32
+      %8 = func.call %0, %7 {callee = @__tribute_evidence_lookup} : core.i32
+      %9 = func.call %0, %7 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %10 = arith.const {value = 1972422014} : core.i32
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
+      %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
+      %14 = func.call_indirect %12, %0, %13, %6, %10, %11 : tribute_rt.anyref
+      func.return %14
+  }
+
+  func.func @"run_state::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 1972422014} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"resumptive_op_native::__lambda_8"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 10} : core.i32
+          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
+          %13 = core.unrealized_conversion_cast %2 : !t2
+          %14 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+          %15 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %12 : tribute_rt.anyref
+          scf.yield %16
+      } {
+          %17 = arith.const {value = 1} : core.i1
+          %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %19 = func.constant {func_ref = @"resumptive_op_native::__lambda_9"} : !t1
+          %20 = adt.struct_new %19, %18 {type = !_closure} : !_closure
+          %21 = arith.const {value = unit} : core.nil
+          %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
+          %23 = core.unrealized_conversion_cast %2 : !t2
+          %24 = adt.struct_get %23 {field = 0, type = !_closure} : core.i32
+          %25 = adt.struct_get %23 {field = 1, type = !_closure} : tribute_rt.anyref
+          %26 = func.call_indirect %24, %0, %25, %22 : tribute_rt.anyref
+          scf.yield %26
+      }
+      func.return %7
+  }
+
+  func.func @"bump::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::__clam_0::env"} : core.i32
+      %5 = adt.struct_get %3 {field = 1, type = !"bump::__clam_0::__clam_0::env"} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %2 : core.nil
+      %7 = tribute_rt.box_int %4 : tribute_rt.anyref
+      %8 = core.unrealized_conversion_cast %5 : !t2
+      %9 = adt.struct_get %8 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %8 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = func.call_indirect %9, %0, %10, %7 : tribute_rt.anyref
+      func.return %11
+  }
+}

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -1,0 +1,170 @@
+---
+source: tests/active_pipeline_goldens.rs
+expression: ir_text
+---
+core.module @direct_fn {
+  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !t0 = core.array(!_Marker)
+  !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
+  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+
+  func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
+      func.unreachable
+  }
+
+  func.func @use_console(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = arith.const {value = 2616163639} : core.i32
+      %3 = func.call %0, %2 {callee = @__tribute_evidence_lookup} : !_Marker
+      %4 = adt.struct_get %3 {field = 2, type = !_Marker} : !_closure
+      %5 = arith.const {value = 664197438} : core.i32
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %9 = func.call_indirect %7, %0, %8, %5, %6 : tribute_rt.anyref
+      %10 = core.unrealized_conversion_cast %9 : core.i32
+      %11 = arith.const {value = 2616163639} : core.i32
+      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : !_Marker
+      %13 = adt.struct_get %12 {field = 2, type = !_Marker} : !_closure
+      %14 = arith.const {value = 2110389019} : core.i32
+      %15 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %18 = func.call_indirect %16, %0, %17, %14, %15 : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %18 : core.nil
+      %20 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+      %21 = core.unrealized_conversion_cast %1 : closure.closure(!t1)
+      %22 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
+      %23 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
+      %24 = func.call_indirect %22, %0, %23, %20 : tribute_rt.anyref
+      func.return %24
+  }
+
+  func.func @"direct_fn::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"direct_fn::__lambda_6"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"direct_fn::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"direct_fn::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"direct_fn::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @run() -> core.i32 {
+      %0 = arith.const {value = 0} : core.i32
+      %1 = adt.array_new %0 {type = !t0} : !t0
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run::__clam_0"} : !t1
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = func.constant {func_ref = @"direct_fn::__lambda_5"} : !t1
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %15 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
+      %17 = func.call {callee = @__tribute_next_tag} : core.i32
+      %18 = core.unrealized_conversion_cast %16 : core.ptr
+      %19 = core.unrealized_conversion_cast %13 : core.ptr
+      %20 = arith.const {value = 2616163639} : core.i32
+      %21 = adt.struct_new %20, %17, %18, %19 {type = !_Marker} : !_Marker
+      %22 = func.call %1, %21 {callee = @__tribute_evidence_extend} : !t0
+      %23 = func.call_indirect %9, %22, %10, %8 : tribute_rt.anyref
+      %24 = core.unrealized_conversion_cast %23 : core.i32
+      %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
+      %26 = core.unrealized_conversion_cast %25 : core.i32
+      func.return %26
+  }
+
+  func.func @main() -> core.nil {
+      %0 = func.call {callee = @run} : core.i32
+      %1 = arith.const {value = unit} : core.nil
+      func.return %1
+  }
+
+  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_null {type = !t0} : !t0
+      %4 = func.call %0, %2 {callee = @use_console} : tribute_rt.anyref
+      func.return %4
+  }
+
+  func.func @"run::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 664197438} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"direct_fn::__lambda_8"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 41} : core.i32
+          %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+          scf.yield %12
+      } {
+          %13 = arith.const {value = 1} : core.i1
+          %14 = scf.if %13 : tribute_rt.anyref {
+              %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %16 = func.constant {func_ref = @"direct_fn::__lambda_9"} : !t1
+              %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
+              %18 = arith.const {value = unit} : core.nil
+              %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
+              scf.yield %19
+          } {
+              func.unreachable
+          }
+          scf.yield %14
+      }
+      func.return %7
+  }
+
+  func.func @"run::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
+      %4 = arith.const {value = 664197438} : core.i32
+      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
+      %6 = scf.if %5 : tribute_rt.anyref {
+          %7 = arith.const {value = 41} : core.i32
+          %8 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+          scf.yield %8
+      } {
+          %9 = arith.const {value = 1} : core.i1
+          %10 = scf.if %9 : tribute_rt.anyref {
+              %11 = arith.const {value = unit} : core.nil
+              %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+              scf.yield %12
+          } {
+              func.unreachable
+          }
+          scf.yield %10
+      }
+      func.return %6
+  }
+}

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -1,0 +1,308 @@
+---
+source: tests/active_pipeline_goldens.rs
+expression: ir_text
+---
+core.module @mixed_nested {
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !t0 = core.array(!_Marker)
+  !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
+  !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
+  !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
+  !t3 = closure.closure(!t1)
+  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !t4 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+
+  func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
+      func.unreachable
+  }
+
+  func.func @step(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = arith.const {value = 2616163639} : core.i32
+      %3 = func.call %0, %2 {callee = @__tribute_evidence_lookup} : !_Marker
+      %4 = adt.struct_get %3 {field = 2, type = !_Marker} : !_closure
+      %5 = arith.const {value = 664197438} : core.i32
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %9 = func.call_indirect %7, %0, %8, %5, %6 : tribute_rt.anyref
+      %10 = core.unrealized_conversion_cast %9 : core.i32
+      %11 = adt.struct_new %10, %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %12 = func.constant {func_ref = @"step::__clam_0"} : !t1
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = arith.const {value = 80204913} : core.i32
+      %15 = func.call %0, %14 {callee = @__tribute_evidence_lookup} : !_Marker
+      %16 = adt.struct_get %15 {field = 3, type = !_Marker} : !_closure
+      %17 = arith.const {value = 1972422014} : core.i32
+      %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %13 : tribute_rt.anyref
+      %20 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
+      %21 = adt.struct_get %16 {field = 1, type = !_closure} : tribute_rt.anyref
+      %22 = func.call_indirect %20, %0, %21, %19, %17, %18 : tribute_rt.anyref
+      func.return %22
+  }
+
+  func.func @"mixed_nested::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_6"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @run_state_with_console(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = func.constant {func_ref = @"mixed_nested::__lambda_5"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t4
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = arith.const {value = 0} : tribute_rt.anyref
+      %14 = func.call {callee = @__tribute_next_tag} : core.i32
+      %15 = core.unrealized_conversion_cast %13 : core.ptr
+      %16 = core.unrealized_conversion_cast %12 : core.ptr
+      %17 = arith.const {value = 80204913} : core.i32
+      %18 = adt.struct_new %17, %14, %15, %16 {type = !_Marker} : !_Marker
+      %19 = func.call %0, %18 {callee = @__tribute_evidence_extend} : !t0
+      %20 = func.call_indirect %8, %19, %9, %7 : tribute_rt.anyref
+      %21 = core.unrealized_conversion_cast %20 : core.i32
+      %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
+      %23 = core.unrealized_conversion_cast %22 : core.i32
+      %24 = core.unrealized_conversion_cast %23 : tribute_rt.anyref
+      %25 = core.unrealized_conversion_cast %1 : !t3
+      %26 = adt.struct_get %25 {field = 0, type = !_closure} : core.i32
+      %27 = adt.struct_get %25 {field = 1, type = !_closure} : tribute_rt.anyref
+      %28 = func.call_indirect %26, %0, %27, %24 : tribute_rt.anyref
+      func.return %28
+  }
+
+  func.func @"mixed_nested::__lambda_10"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_11"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_12"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_13"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"mixed_nested::__lambda_14"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @run_all() -> core.i32 {
+      %0 = arith.const {value = 0} : core.i32
+      %1 = adt.array_new %0 {type = !t0} : !t0
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = func.constant {func_ref = @"mixed_nested::__lambda_10"} : !t1
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = func.constant {func_ref = @"run_all::__clam_1"} : !t4
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %15 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
+      %17 = func.call {callee = @__tribute_next_tag} : core.i32
+      %18 = core.unrealized_conversion_cast %16 : core.ptr
+      %19 = core.unrealized_conversion_cast %13 : core.ptr
+      %20 = arith.const {value = 2616163639} : core.i32
+      %21 = adt.struct_new %20, %17, %18, %19 {type = !_Marker} : !_Marker
+      %22 = func.call %1, %21 {callee = @__tribute_evidence_extend} : !t0
+      %23 = func.call_indirect %9, %22, %10, %8 : tribute_rt.anyref
+      %24 = core.unrealized_conversion_cast %23 : core.i32
+      %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
+      %26 = core.unrealized_conversion_cast %25 : core.i32
+      func.return %26
+  }
+
+  func.func @main() -> core.nil {
+      %0 = func.call {callee = @run_all} : core.i32
+      %1 = arith.const {value = unit} : core.nil
+      func.return %1
+  }
+
+  func.func @"step::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::env"} : core.i32
+      %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::env"} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %2 : core.i32
+      %7 = arith.addi %6, %4 : core.i32
+      %8 = adt.struct_new %6, %4, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
+      %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t1
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = arith.const {value = 80204913} : core.i32
+      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : !_Marker
+      %13 = adt.struct_get %12 {field = 3, type = !_Marker} : !_closure
+      %14 = arith.const {value = 1348736788} : core.i32
+      %15 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+      %16 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+      %17 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %18 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %19 = func.call_indirect %17, %0, %18, %16, %14, %15 : tribute_rt.anyref
+      func.return %19
+  }
+
+  func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = func.call %0, %2 {callee = @step} : tribute_rt.anyref
+      func.return %3
+  }
+
+  func.func @"run_state_with_console::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 1972422014} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"mixed_nested::__lambda_8"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 7} : core.i32
+          %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+          %13 = core.unrealized_conversion_cast %2 : !t3
+          %14 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+          %15 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %12 : tribute_rt.anyref
+          scf.yield %16
+      } {
+          %17 = arith.const {value = 1} : core.i1
+          %18 = scf.if %17 : tribute_rt.anyref {
+              %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %20 = func.constant {func_ref = @"mixed_nested::__lambda_9"} : !t1
+              %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+              %22 = arith.const {value = unit} : core.nil
+              %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
+              %24 = core.unrealized_conversion_cast %2 : !t3
+              %25 = adt.struct_get %24 {field = 0, type = !_closure} : core.i32
+              %26 = adt.struct_get %24 {field = 1, type = !_closure} : tribute_rt.anyref
+              %27 = func.call_indirect %25, %0, %26, %23 : tribute_rt.anyref
+              scf.yield %27
+          } {
+              func.unreachable
+          }
+          scf.yield %18
+      }
+      func.return %7
+  }
+
+  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_null {type = !t0} : !t0
+      %4 = func.call %0, %2 {callee = @run_state_with_console} : tribute_rt.anyref
+      func.return %4
+  }
+
+  func.func @"run_all::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 664197438} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"mixed_nested::__lambda_13"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 3} : core.i32
+          %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+          scf.yield %12
+      } {
+          %13 = arith.const {value = 1} : core.i1
+          %14 = scf.if %13 : tribute_rt.anyref {
+              %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %16 = func.constant {func_ref = @"mixed_nested::__lambda_14"} : !t1
+              %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
+              %18 = arith.const {value = unit} : core.nil
+              %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
+              scf.yield %19
+          } {
+              func.unreachable
+          }
+          scf.yield %14
+      }
+      func.return %7
+  }
+
+  func.func @"run_all::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
+      %4 = arith.const {value = 664197438} : core.i32
+      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
+      %6 = scf.if %5 : tribute_rt.anyref {
+          %7 = arith.const {value = 3} : core.i32
+          %8 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+          scf.yield %8
+      } {
+          %9 = arith.const {value = 1} : core.i1
+          %10 = scf.if %9 : tribute_rt.anyref {
+              %11 = arith.const {value = unit} : core.nil
+              %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+              scf.yield %12
+          } {
+              func.unreachable
+          }
+          scf.yield %10
+      }
+      func.return %6
+  }
+
+  func.func @"step::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::__clam_0::env"} : core.i32
+      %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::__clam_0::env"} : core.i32
+      %6 = adt.struct_get %3 {field = 2, type = !"step::__clam_0::__clam_0::env"} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %2 : core.nil
+      %8 = arith.const {value = 2616163639} : core.i32
+      %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup} : !_Marker
+      %10 = adt.struct_get %9 {field = 2, type = !_Marker} : !_closure
+      %11 = arith.const {value = 2110389019} : core.i32
+      %12 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      %13 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
+      %14 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
+      %15 = func.call_indirect %13, %0, %14, %11, %12 : tribute_rt.anyref
+      %16 = core.unrealized_conversion_cast %15 : core.nil
+      %17 = arith.addi %4, %5 : core.i32
+      %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %6 : !t3
+      %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
+      %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
+      %22 = func.call_indirect %20, %0, %21, %18 : tribute_rt.anyref
+      func.return %22
+  }
+}

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -1,0 +1,181 @@
+---
+source: tests/active_pipeline_goldens.rs
+expression: ir_text
+---
+core.module @resumptive_op {
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !t0 = core.array(!_Marker)
+  !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
+  !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
+  !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
+  !t3 = closure.closure(!t1)
+  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+
+  func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
+      func.unreachable
+  }
+
+  func.func @bump(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = adt.struct_new %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
+      %3 = func.constant {func_ref = @"bump::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = arith.const {value = 80204913} : core.i32
+      %6 = func.call %0, %5 {callee = @__tribute_evidence_lookup} : !_Marker
+      %7 = adt.struct_get %6 {field = 3, type = !_Marker} : !_closure
+      %8 = arith.const {value = 1972422014} : core.i32
+      %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %10 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      %11 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
+      %12 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
+      %13 = func.call_indirect %11, %0, %12, %10, %8, %9 : tribute_rt.anyref
+      func.return %13
+  }
+
+  func.func @"resumptive_op::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"resumptive_op::__lambda_6"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"resumptive_op::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"resumptive_op::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @"resumptive_op::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
+  func.func @run_state() -> core.i32 {
+      %0 = arith.const {value = 0} : core.i32
+      %1 = adt.array_new %0 {type = !t0} : !t0
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = func.constant {func_ref = @"resumptive_op::__lambda_5"} : !t1
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = arith.const {value = 0} : tribute_rt.anyref
+      %15 = func.call {callee = @__tribute_next_tag} : core.i32
+      %16 = core.unrealized_conversion_cast %14 : core.ptr
+      %17 = core.unrealized_conversion_cast %13 : core.ptr
+      %18 = arith.const {value = 80204913} : core.i32
+      %19 = adt.struct_new %18, %15, %16, %17 {type = !_Marker} : !_Marker
+      %20 = func.call %1, %19 {callee = @__tribute_evidence_extend} : !t0
+      %21 = func.call_indirect %9, %20, %10, %8 : tribute_rt.anyref
+      %22 = core.unrealized_conversion_cast %21 : core.i32
+      %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
+      %24 = core.unrealized_conversion_cast %23 : core.i32
+      func.return %24
+  }
+
+  func.func @main() -> core.nil {
+      %0 = func.call {callee = @run_state} : core.i32
+      %1 = arith.const {value = unit} : core.nil
+      func.return %1
+  }
+
+  func.func @"bump::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::env"} : tribute_rt.anyref
+      %5 = core.unrealized_conversion_cast %2 : core.i32
+      %6 = arith.const {value = 1} : core.i32
+      %7 = arith.addi %5, %6 : core.i32
+      %8 = adt.struct_new %5, %4 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
+      %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t1
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = arith.const {value = 80204913} : core.i32
+      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : !_Marker
+      %13 = adt.struct_get %12 {field = 3, type = !_Marker} : !_closure
+      %14 = arith.const {value = 1348736788} : core.i32
+      %15 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+      %16 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+      %17 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %18 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %19 = func.call_indirect %17, %0, %18, %16, %14, %15 : tribute_rt.anyref
+      func.return %19
+  }
+
+  func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_null {type = !t0} : !t0
+      %4 = func.call %0, %2 {callee = @bump} : tribute_rt.anyref
+      func.return %4
+  }
+
+  func.func @"run_state::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
+      %5 = arith.const {value = 1972422014} : core.i32
+      %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
+      %7 = scf.if %6 : tribute_rt.anyref {
+          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+          %9 = func.constant {func_ref = @"resumptive_op::__lambda_8"} : !t1
+          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+          %11 = arith.const {value = 10} : core.i32
+          %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+          %13 = core.unrealized_conversion_cast %2 : !t3
+          %14 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+          %15 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %12 : tribute_rt.anyref
+          scf.yield %16
+      } {
+          %17 = arith.const {value = 1} : core.i1
+          %18 = scf.if %17 : tribute_rt.anyref {
+              %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %20 = func.constant {func_ref = @"resumptive_op::__lambda_9"} : !t1
+              %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+              %22 = arith.const {value = unit} : core.nil
+              %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
+              %24 = core.unrealized_conversion_cast %2 : !t3
+              %25 = adt.struct_get %24 {field = 0, type = !_closure} : core.i32
+              %26 = adt.struct_get %24 {field = 1, type = !_closure} : tribute_rt.anyref
+              %27 = func.call_indirect %25, %0, %26, %23 : tribute_rt.anyref
+              scf.yield %27
+          } {
+              func.unreachable
+          }
+          scf.yield %18
+      }
+      func.return %7
+  }
+
+  func.func @"bump::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      %3 = adt.ref_cast %1 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
+      %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::__clam_0::env"} : core.i32
+      %5 = adt.struct_get %3 {field = 1, type = !"bump::__clam_0::__clam_0::env"} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %2 : core.nil
+      %7 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      %8 = core.unrealized_conversion_cast %5 : !t3
+      %9 = adt.struct_get %8 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %8 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = func.call_indirect %9, %0, %10, %7 : tribute_rt.anyref
+      func.return %11
+  }
+}


### PR DESCRIPTION
## Summary
- Add and update active pipeline golden snapshots for native and shared pipeline cases
- Cover direct ability calls, resumptive op continuations, and nested handler boundaries
- Keep the expected pipeline output in sync with current lowering behavior

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new insta golden tests for the active ability lowering pipeline with snapshot-based IR validation.
  * Validates outputs for direct ability calls, resumptive operation continuation, and mixed nested handler boundaries.
  * Includes utilities to ensure compilation/dump steps emit no diagnostics and to snapshot only the IR functions relevant to the active pipeline.
* **Chores**
  * Updated development-only dependencies to support the new test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->