### PR TITLE
Strengthen TrunkIR conversion legality foundations

### DIFF
--- a/crates/trunk-ir-cranelift-backend/src/lib.rs
+++ b/crates/trunk-ir-cranelift-backend/src/lib.rs
@@ -24,4 +24,4 @@ mod validation;
 
 pub use errors::{CompilationError, CompilationErrorKind, CompilationResult};
 pub use translate::{RodataEntry, emit_module_to_native};
-pub use validation::{ValidationError, validate_clif_ir};
+pub use validation::{ValidationError, native_backend_ready_target, validate_clif_ir};

--- a/crates/trunk-ir-cranelift-backend/src/validation.rs
+++ b/crates/trunk-ir-cranelift-backend/src/validation.rs
@@ -1,16 +1,16 @@
 //! IR validation for Cranelift backend.
 //!
 //! This module validates that IR is ready for emission:
-//! - All operations must be in the `clif` dialect (error)
+//! - All operations must be explicitly legal for the native backend boundary.
 //!
 //! Dialect validation errors prevent emission from proceeding.
 
-use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::refs::{BlockRef, OpRef, RegionRef};
-use trunk_ir::rewrite::Module;
+use trunk_ir::rewrite::{ConversionTarget, Module};
 
 use crate::{CompilationError, CompilationResult};
+
+const NATIVE_BACKEND_READY_BOUNDARY: &str = "native-backend-ready";
 
 /// Validation error details.
 #[derive(Debug)]
@@ -26,74 +26,105 @@ impl std::fmt::Display for ValidationError {
 
 /// Validate that a module's IR is ready for Cranelift emission.
 ///
-/// This function checks that all operations are in the `clif` dialect
-/// (except allowed exceptions like `core.module`).
+/// This function checks that all operations are explicitly legal for the
+/// native backend boundary.
 ///
 /// Returns an error if validation fails, preventing emission.
 pub fn validate_clif_ir(ctx: &IrContext, module: Module) -> CompilationResult<()> {
-    let mut errors: Vec<String> = Vec::new();
+    let Some(body) = module.body(ctx) else {
+        return Err(CompilationError::ir_validation("Module has no body region"));
+    };
 
-    if let Some(body) = module.body(ctx) {
-        validate_region(ctx, body, &mut errors);
-    } else {
-        errors.push("Module has no body region".to_string());
+    let target = native_backend_ready_target();
+    let failures = target.verify_full(ctx, body);
+
+    if failures.is_empty() {
+        return Ok(());
     }
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        let message = format!(
-            "IR validation failed with {} error(s):\n  - {}",
-            errors.len(),
-            errors.join("\n  - ")
-        );
-        Err(CompilationError::ir_validation(message))
-    }
+    let errors: Vec<String> = failures
+        .into_iter()
+        .map(|op| format!("{} in boundary {}", op, NATIVE_BACKEND_READY_BOUNDARY))
+        .collect();
+    let message = format!(
+        "IR validation failed for boundary {NATIVE_BACKEND_READY_BOUNDARY} with {} error(s):\n  - {}",
+        errors.len(),
+        errors.join("\n  - ")
+    );
+    Err(CompilationError::ir_validation(message))
 }
 
-fn validate_region(ctx: &IrContext, region: RegionRef, errors: &mut Vec<String>) {
-    let region_data = ctx.region(region);
-    for &block in &region_data.blocks {
-        validate_block(ctx, block, errors);
-    }
+/// Conversion target for IR that is ready for Cranelift emission.
+pub fn native_backend_ready_target() -> ConversionTarget {
+    let mut target = ConversionTarget::new();
+    target.add_legal_dialect("clif");
+    target.add_legal_op("core", "module");
+    target
 }
 
-fn validate_block(ctx: &IrContext, block: BlockRef, errors: &mut Vec<String>) {
-    let block_data = ctx.block(block);
-    for &op in &block_data.ops {
-        validate_operation(ctx, op, errors);
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::OperationDataBuilder;
+    use trunk_ir::context::{BlockData, IrContext, RegionData};
+    use trunk_ir::location::Span;
+    use trunk_ir::smallvec::smallvec;
+    use trunk_ir::symbol::Symbol;
+    use trunk_ir::types::{Attribute, Location};
 
-fn validate_operation(ctx: &IrContext, op: OpRef, errors: &mut Vec<String>) {
-    let op_data = ctx.op(op);
-    let dialect = op_data.dialect;
-    let name = op_data.name;
-
-    if !is_allowed_dialect(ctx, op) {
-        errors.push(format!("Non-clif operation found: {}.{}", dialect, name));
-    }
-
-    // Recursively validate nested regions
-    for &region in &op_data.regions {
-        validate_region(ctx, region, errors);
-    }
-}
-
-fn is_allowed_dialect(ctx: &IrContext, op: OpRef) -> bool {
-    let clif_dialect = Symbol::new("clif");
-    let core_dialect = Symbol::new("core");
-    let module_name = Symbol::new("module");
-    let op_data = ctx.op(op);
-
-    if op_data.dialect == clif_dialect {
-        return true;
+    fn test_ctx() -> (IrContext, Location) {
+        let mut ctx = IrContext::new();
+        let path = ctx.paths.intern("test.trb".to_owned());
+        let loc = Location::new(path, Span::new(0, 0));
+        (ctx, loc)
     }
 
-    // Allow core.module at the top level
-    if op_data.dialect == core_dialect && op_data.name == module_name {
-        return true;
+    fn make_module(ctx: &mut IrContext, loc: Location, dialect: &str, name: &str) -> Module {
+        let op_data = OperationDataBuilder::new(
+            loc,
+            Symbol::from_dynamic(dialect),
+            Symbol::from_dynamic(name),
+        )
+        .build(ctx);
+        let op = ctx.create_op(op_data);
+
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        ctx.push_op(block, op);
+        let region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+        let module_data =
+            OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
+                .attr("sym_name", Attribute::Symbol(Symbol::new("test")))
+                .region(region)
+                .build(ctx);
+        let module_op = ctx.create_op(module_data);
+        Module::new(ctx, module_op).expect("test module should be valid")
     }
 
-    false
+    #[test]
+    fn native_backend_ready_allows_clif_ops() {
+        let (mut ctx, loc) = test_ctx();
+        let module = make_module(&mut ctx, loc, "clif", "func");
+
+        validate_clif_ir(&ctx, module).unwrap();
+    }
+
+    #[test]
+    fn native_backend_ready_rejects_unknown_ops() {
+        let (mut ctx, loc) = test_ctx();
+        let module = make_module(&mut ctx, loc, "arith", "add");
+
+        let err = validate_clif_ir(&ctx, module).unwrap_err().to_string();
+        assert!(err.contains("native-backend-ready"));
+        assert!(err.contains("arith.add"));
+        assert!(err.contains("Unknown"));
+    }
 }

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -5,7 +5,7 @@
 //! `parent_block` validity to skip deleted ops.
 
 use super::Module;
-use super::conversion_target::{ConversionTarget, IllegalOp, LegalityCheck};
+use super::conversion_target::{ConversionMode, ConversionTarget, IllegalOp, LegalityCheck};
 use super::pattern::RewritePattern;
 use super::rewriter::{self, PatternRewriter};
 use super::type_converter::TypeConverter;
@@ -32,11 +32,32 @@ impl ApplyResult {
         module: Module,
         target: &ConversionTarget,
     ) -> Result<(), Vec<IllegalOp>> {
+        self.verify_mode(ctx, module, target, ConversionMode::Partial)
+    }
+
+    /// Verify that every operation is legal for the target.
+    pub fn verify_full(
+        &self,
+        ctx: &IrContext,
+        module: Module,
+        target: &ConversionTarget,
+    ) -> Result<(), Vec<IllegalOp>> {
+        self.verify_mode(ctx, module, target, ConversionMode::Full)
+    }
+
+    /// Verify the result under a specific conversion mode.
+    pub fn verify_mode(
+        &self,
+        ctx: &IrContext,
+        module: Module,
+        target: &ConversionTarget,
+        mode: ConversionMode,
+    ) -> Result<(), Vec<IllegalOp>> {
         let body = match module.body(ctx) {
             Some(r) => r,
             None => return Ok(()),
         };
-        let illegal = target.verify(ctx, body);
+        let illegal = target.verify_mode(ctx, body, mode);
         if illegal.is_empty() {
             Ok(())
         } else {
@@ -127,8 +148,24 @@ impl PatternApplicator {
         &self.type_converter
     }
 
-    /// Apply patterns and verify the result.
+    /// Apply patterns using partial conversion semantics.
+    ///
+    /// Verification fails only for operations that are explicitly illegal in
+    /// the target. Unknown operations may remain for later conversion passes.
     pub fn apply(
+        &self,
+        ctx: &mut IrContext,
+        module: Module,
+        target: &ConversionTarget,
+    ) -> Result<ApplyResult, Vec<IllegalOp>> {
+        self.apply_partial_conversion(ctx, module, target)
+    }
+
+    /// Apply patterns using partial conversion semantics.
+    ///
+    /// Verification fails only for operations that are explicitly illegal in
+    /// the target. Unknown operations may remain for later conversion passes.
+    pub fn apply_partial_conversion(
         &self,
         ctx: &mut IrContext,
         module: Module,
@@ -136,6 +173,21 @@ impl PatternApplicator {
     ) -> Result<ApplyResult, Vec<IllegalOp>> {
         let result = self.apply_partial(ctx, module);
         result.verify(ctx, module, target)?;
+        Ok(result)
+    }
+
+    /// Apply patterns using full conversion semantics.
+    ///
+    /// Verification fails for both explicitly illegal operations and unknown
+    /// operations. Use this at named pipeline boundaries.
+    pub fn apply_full_conversion(
+        &self,
+        ctx: &mut IrContext,
+        module: Module,
+        target: &ConversionTarget,
+    ) -> Result<ApplyResult, Vec<IllegalOp>> {
+        let result = self.apply_partial(ctx, module);
+        result.verify_full(ctx, module, target)?;
         Ok(result)
     }
 
@@ -429,5 +481,25 @@ mod tests {
         let new_result = ctx.op_result(ops[0], 0);
         let op2_operands = ctx.op_operands(ops[1]);
         assert_eq!(op2_operands[0], new_result);
+    }
+
+    #[test]
+    fn full_conversion_rejects_unknown_ops() {
+        let (mut ctx, loc) = test_ctx();
+
+        let op_data = OperationDataBuilder::new(loc, Symbol::new("unknown"), Symbol::new("op"))
+            .build(&mut ctx);
+        let op = ctx.create_op(op_data);
+        let module = make_module(&mut ctx, loc, vec![op]);
+
+        let applicator = PatternApplicator::new(TypeConverter::new());
+        let target = ConversionTarget::new();
+
+        let failures = match applicator.apply_full_conversion(&mut ctx, module, &target) {
+            Ok(_) => panic!("full conversion should reject unknown ops"),
+            Err(failures) => failures,
+        };
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].legality, LegalityCheck::Unknown);
     }
 }

--- a/crates/trunk-ir/src/rewrite/conversion_target.rs
+++ b/crates/trunk-ir/src/rewrite/conversion_target.rs
@@ -17,15 +17,31 @@ pub enum LegalityCheck {
     Legal,
     /// The operation is illegal (must be converted).
     Illegal,
+    /// The target has no rule for this operation.
+    Unknown,
 }
 
 /// Dynamic legality check function signature.
 type DynamicCheckFn = dyn Fn(&IrContext, OpRef) -> Option<LegalityCheck>;
 
+/// Conversion verification mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionMode {
+    /// Verify that no explicitly illegal operations remain.
+    ///
+    /// Unknown operations are allowed because another conversion pass may own
+    /// them.
+    Partial,
+    /// Verify that every operation is explicitly legal.
+    ///
+    /// Illegal and unknown operations both fail full conversion.
+    Full,
+}
+
 /// Conversion target — defines which ops/dialects are legal or illegal.
 ///
-/// After pattern application, `verify()` walks the module and checks that
-/// no illegal operations remain.
+/// After pattern application, partial verification checks that no illegal
+/// operations remain. Full verification additionally rejects unknown operations.
 pub struct ConversionTarget {
     /// Entire dialects marked as legal.
     legal_dialects: HashSet<Symbol>,
@@ -40,7 +56,10 @@ pub struct ConversionTarget {
 }
 
 impl ConversionTarget {
-    /// Create a new empty conversion target (everything is legal by default).
+    /// Create a new empty conversion target.
+    ///
+    /// Operations that do not match any target rule are reported as
+    /// [`LegalityCheck::Unknown`].
     pub fn new() -> Self {
         Self {
             legal_dialects: HashSet::new(),
@@ -98,7 +117,7 @@ impl ConversionTarget {
     /// 1. Dynamic checks (first non-None wins)
     /// 2. Specific op rules (legal_ops / illegal_ops)
     /// 3. Dialect rules (legal_dialects / illegal_dialects)
-    /// 4. Default: Legal
+    /// 4. Default: Unknown
     pub fn is_legal(&self, ctx: &IrContext, op: OpRef) -> LegalityCheck {
         // 1. Dynamic checks
         for check in &self.dynamic_checks {
@@ -127,28 +146,54 @@ impl ConversionTarget {
         }
 
         // 4. Default
-        LegalityCheck::Legal
+        LegalityCheck::Unknown
     }
 
     /// Verify that no illegal operations remain in the module.
     ///
-    /// Returns a list of illegal operations found.
+    /// This is partial conversion verification: unknown operations are allowed
+    /// because they may belong to dialects outside the current conversion step.
     pub fn verify(&self, ctx: &IrContext, module_body: crate::refs::RegionRef) -> Vec<IllegalOp> {
-        let mut illegal = Vec::new();
+        self.verify_mode(ctx, module_body, ConversionMode::Partial)
+    }
+
+    /// Verify that every operation in the module is legal for this target.
+    pub fn verify_full(
+        &self,
+        ctx: &IrContext,
+        module_body: crate::refs::RegionRef,
+    ) -> Vec<IllegalOp> {
+        self.verify_mode(ctx, module_body, ConversionMode::Full)
+    }
+
+    /// Verify a module body under the requested conversion mode.
+    pub fn verify_mode(
+        &self,
+        ctx: &IrContext,
+        module_body: crate::refs::RegionRef,
+        mode: ConversionMode,
+    ) -> Vec<IllegalOp> {
+        let mut failures = Vec::new();
 
         let _ = walk::walk_region::<()>(ctx, module_body, &mut |op| {
-            if self.is_legal(ctx, op) == LegalityCheck::Illegal {
+            let legality = self.is_legal(ctx, op);
+            let failed = match mode {
+                ConversionMode::Partial => legality == LegalityCheck::Illegal,
+                ConversionMode::Full => legality != LegalityCheck::Legal,
+            };
+            if failed {
                 let data = ctx.op(op);
-                illegal.push(IllegalOp {
+                failures.push(IllegalOp {
                     op,
                     dialect: data.dialect,
                     name: data.name,
+                    legality,
                 });
             }
             std::ops::ControlFlow::Continue(walk::WalkAction::Advance)
         });
 
-        illegal
+        failures
     }
 }
 
@@ -158,16 +203,92 @@ impl Default for ConversionTarget {
     }
 }
 
-/// An illegal operation found during verification.
+/// An operation that failed conversion target verification.
 #[derive(Debug)]
 pub struct IllegalOp {
     pub op: OpRef,
     pub dialect: Symbol,
     pub name: Symbol,
+    pub legality: LegalityCheck,
 }
 
 impl std::fmt::Display for IllegalOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{} ({})", self.dialect, self.name, self.op)
+        write!(
+            f,
+            "{}.{} ({}, {:?})",
+            self.dialect, self.name, self.op, self.legality
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OperationDataBuilder;
+    use crate::location::Span;
+    use crate::types::Location;
+
+    fn test_ctx() -> (IrContext, Location) {
+        let mut ctx = IrContext::new();
+        let path = ctx.paths.intern("test.trb".to_owned());
+        let loc = Location::new(path, Span::new(0, 0));
+        (ctx, loc)
+    }
+
+    fn make_op(ctx: &mut IrContext, loc: Location, dialect: Symbol, name: Symbol) -> OpRef {
+        let op_data = OperationDataBuilder::new(loc, dialect, name).build(ctx);
+        ctx.create_op(op_data)
+    }
+
+    fn make_region(ctx: &mut IrContext, loc: Location, ops: Vec<OpRef>) -> crate::refs::RegionRef {
+        use crate::context::{BlockData, RegionData};
+        use crate::smallvec::smallvec;
+
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for op in ops {
+            ctx.push_op(block, op);
+        }
+        ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        })
+    }
+
+    #[test]
+    fn unspecified_operations_are_unknown() {
+        let (mut ctx, loc) = test_ctx();
+        let op = make_op(&mut ctx, loc, Symbol::new("test"), Symbol::new("op"));
+        let target = ConversionTarget::new();
+
+        assert_eq!(target.is_legal(&ctx, op), LegalityCheck::Unknown);
+    }
+
+    #[test]
+    fn partial_verification_allows_unknown_operations() {
+        let (mut ctx, loc) = test_ctx();
+        let op = make_op(&mut ctx, loc, Symbol::new("test"), Symbol::new("op"));
+        let region = make_region(&mut ctx, loc, vec![op]);
+        let target = ConversionTarget::new();
+
+        assert!(target.verify(&ctx, region).is_empty());
+    }
+
+    #[test]
+    fn full_verification_rejects_unknown_operations() {
+        let (mut ctx, loc) = test_ctx();
+        let op = make_op(&mut ctx, loc, Symbol::new("test"), Symbol::new("op"));
+        let region = make_region(&mut ctx, loc, vec![op]);
+        let target = ConversionTarget::new();
+
+        let failures = target.verify_full(&ctx, region);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].legality, LegalityCheck::Unknown);
     }
 }

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -12,7 +12,7 @@ pub mod signature_conversion;
 pub mod type_converter;
 
 pub use applicator::{ApplyResult, PatternApplicator};
-pub use conversion_target::{ConversionTarget, LegalityCheck};
+pub use conversion_target::{ConversionMode, ConversionTarget, IllegalOp, LegalityCheck};
 pub use helpers::{erase_op, inline_region_blocks, split_block};
 pub use pattern::RewritePattern;
 pub use rewriter::PatternRewriter;

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -1,826 +1,140 @@
 # TrunkIR Design
 
-> 이 문서는 Tribute 컴파일러의 중간 표현(IR)인 TrunkIR의 설계를 정의한다.
+TrunkIR is Tribute's central intermediate representation between typed source
+programs and target-specific Wasm or native backends.
 
-## Overview
+## Principles
 
-TrunkIR은 Tribute 소스 코드에서 Wasm/네이티브 바이너리로 내려가는 중심 intermediate representation이다.
+- SSA-based, using block arguments instead of phi nodes.
+- Dialect namespaced: operations are written as `<dialect>.<operation>`.
+- Multi-level: high-level, mid-level, and low-level dialects may coexist.
+- Structured control flow is preferred until a backend requires CFG lowering.
+- Lowering boundaries are declared with `ConversionTarget`, not Rust phase
+  types such as `Module<Phase>`.
 
-### 설계 원칙
-
-- **SSA 기반**: Block arguments를 사용 (φ 노드 대신)
-- **Dialect 네임스페이싱**: 모든 연산은 `<dialect>.<operation>` 형태
-- **Multi-level**: 여러 수준의 dialect이 한 모듈 내에 공존
-- **Structured Control Flow**: 임의 CFG가 아닌 structured control flow 사용
-
-### Dialect 계층 구조
-
-```text
-┌─────────────────────────────────────────────────────────┐
-│ Infrastructure                                          │
-│   core             module, unrealized_conversion_cast   │
-│   type             struct, enum, ability 정의           │
-├─────────────────────────────────────────────────────────┤
-│ High-level (언어 의미론)                                 │
-│   src              미해소 호출, 추론 전 타입              │
-│   ability          handle, perform, resume, abort       │
-│   closure          new, func, env                       │
-│   adt              struct, variant, array, ref          │
-├─────────────────────────────────────────────────────────┤
-│ Mid-level (lowered, 타겟 독립)                          │
-│   func             func, call, call_indirect, constant  │
-│   scf              case, yield, (loop, continue, break) │
-│   arith            산술, 비교, 비트 연산                  │
-│   mem              data, load, store                    │
-├─────────────────────────────────────────────────────────┤
-│ Low-level (타겟 종속)                                   │
-│   wasm.*           Wasm 3.0 + WasmGC                    │
-│   clif.*           Cranelift                            │
-└─────────────────────────────────────────────────────────┘
-```
-
----
-
-## Infrastructure Dialects
-
-### core Dialect
-
-모듈 구조와 dialect 간 변환을 위한 기반 연산.
-
-#### 연산
+## Dialect Layers
 
 ```text
-core.module : (name: String, body: Region) -> Module
-    모듈 정의
+Infrastructure
+  core      module structure and conversion glue
 
-core.unrealized_conversion_cast : (value: T) -> U
-    Dialect 변환 중 임시 캐스트
-    lowering 완료 후 모두 제거되어야 함
+High-level
+  tribute   unresolved or source-level frontend constructs
+  ability   evidence and handler dispatch semantics
+  closure   closure construction and decomposition
+  adt       structs, variants, arrays, references, literals
+
+Mid-level
+  func      functions, calls, returns, function references
+  scf       structured control flow and region yields
+  arith     constants, arithmetic, comparisons, casts
+  mem       low-level memory/data operations
+
+Low-level
+  wasm.*    Wasm and WasmGC-oriented operations
+  clif.*    Cranelift-oriented operations
 ```
 
-#### 타입
+## Conversion Legality
+
+`ConversionTarget` classifies operations as `Legal`, `Illegal`, or `Unknown`.
+An unspecified operation is `Unknown`, not legal.
+
+Partial conversion may leave unknown operations for later passes. Full
+conversion boundaries, such as backend-ready native IR, must reject unknown
+operations.
+
+## Core Invariants
+
+- A `core.module` owns the top-level region for a compilation unit.
+- `core.unrealized_conversion_cast` is temporary conversion glue and must not
+  remain at backend-ready boundaries.
+- Operation and type names are interned `Symbol`s. Qualified paths are stored as
+  `::`-separated symbols.
+- Nested regions use normal SSA visibility rules: values defined inside a
+  nested region are not visible outside it unless yielded or otherwise modeled
+  by the operation.
+
+## High-Level Dialects
+
+`tribute.*` represents source-level constructs that should disappear after
+resolution, type checking, TDNR, and AST-to-IR lowering.
+
+`ability.*` represents effect evidence and handler dispatch. Ability operations
+are lowered through the effect pipeline; ability-related types may remain until
+their target-specific representation is selected.
+
+`closure.*` represents closure allocation and projection. Closures lower
+differently per backend: Wasm uses function references plus GC structures, while
+native uses function pointers plus heap environments.
+
+`adt.*` represents target-independent product, sum, array, reference, and
+literal operations.
+
+## Mid-Level Dialects
+
+`func.*` represents function definitions, direct calls, indirect calls, function
+references, returns, tail calls, and unreachable control flow.
+
+`scf.*` represents structured control flow, including pattern/case regions and
+region yields. Loop-like forms may be introduced by optimization passes such as
+tail-call lowering.
+
+`arith.*` represents constants, integer and floating arithmetic, comparisons,
+bit operations, and numeric conversions.
+
+`mem.*` represents low-level data, load, and store operations for runtime or FFI
+support.
+
+## Low-Level Dialects
+
+`wasm.*` is the Wasm backend dialect. It models Wasm control flow, calls,
+numeric operations, memory operations, and WasmGC constructs.
+
+`clif.*` is the native backend dialect. It models Cranelift-style functions,
+calls, arithmetic, CFG control flow, memory access, stack slots, symbol
+addresses, and numeric conversions.
+
+Backend-ready full conversion targets must explicitly list which infrastructure
+operations are still allowed next to the backend dialect.
+
+## Pipeline Shape
 
 ```text
-// 정수 (비트폭 명시)
-i1, i8, i16, i32, i64, i128, ...
-
-// 부동소수점
-f32, f64
-
-// 연속 메모리
-Bytes           // raw 바이트
-Array<T>        // 연속 배열
-
-// GC 참조
-ref<T>          // non-nullable
-ref<T>?         // nullable
+source
+  -> parse / AST
+  -> name resolution
+  -> type checking
+  -> TDNR
+  -> AST-to-IR
+  -> shared lowering and optimization
+  -> Wasm or native lowering
+  -> backend-ready full conversion target
+  -> emit
 ```
 
-#### 식별자 타입
-
-```rust
-/// Interned 문자열 (단순 이름 또는 qualified path)
-/// lasso::Spur로 구현되어 4바이트, O(1) 비교
-///
-/// Qualified path는 `::`로 구분된 문자열로 저장됨 (e.g., "std::List::map")
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "salsa", derive(salsa::Update))]
-pub struct Symbol(lasso::Spur);
-
-impl Symbol {
-    pub fn new(text: &'static str) -> Self;
-    pub fn from_dynamic(text: &str) -> Self;
-    pub fn with_str<R>(&self, f: impl FnOnce(&str) -> R) -> R;
-}
-```
-
-Qualified path 조작은 `tribute-ir`의 `ModulePathExt` trait을 통해 제공:
-
-```rust
-// tribute-ir/src/lib.rs
-pub trait ModulePathExt {
-    /// 마지막 segment 반환 (e.g., "std::List::map" → "map")
-    fn last_segment(&self) -> Symbol;
-
-    /// 부모 경로 반환 (e.g., "std::List::map" → Some("std::List"))
-    fn parent_path(&self) -> Option<Symbol>;
-
-    /// 두 경로 연결 (e.g., "std::List" + "map" → "std::List::map")
-    fn join_path(&self, other: Symbol) -> Symbol;
-
-    /// 단일 segment인지 확인 (`::`가 없으면 true)
-    fn is_simple(&self) -> bool;
-}
-
-impl ModulePathExt for Symbol { ... }
-```
-
-- `Symbol`: 단순 식별자 또는 qualified path, lasso로 interning되어 4바이트, 비교 O(1)
-- Qualified path는 `Symbol` 내부에 `::` 구분자로 저장
-- Path 조작이 필요한 곳에서는 `ModulePathExt` trait 사용 (`tribute-ir`에서 제공)
-
----
-
-## High-level Dialects
-
-### tribute Dialect
-
-파싱 직후의 미해소 상태와 Tribute 언어 레벨 연산/타입을 표현한다.
-타입 추론과 이름 해소 후 대부분 제거된다.
-
-#### 연산
-
-```text
-tribute.call : (name: Symbol, args...) -> T
-    Unqualified 호출 (foo(x, y) 형태), 미해소
-    name은 단순 이름 또는 qualified path (e.g., "foo" 또는 "math::double")
-
-tribute.var : (name: Symbol) -> T
-    변수 참조, 미해소
-
-tribute.lambda : (params: [(String, Type?)], body: Region) -> T
-    람다 (캡처 분석 전)
-
-tribute.case : (scrutinee) -> T { body }
-    패턴 매칭
-```
-
-#### 타입
-
-```text
-tribute.type     // 미해소 타입 참조
-tribute.int      // 정수 타입
-tribute.nat      // 자연수 타입
-```
-
-#### Invariant
-
-| Pass 완료 후 | 조건                                          |
-| ------------ | --------------------------------------------- |
-| Resolution   | 모든 이름 해소됨                              |
-| Type Check   | 타입 추론 변수 모두 해소 (front-end에서 처리) |
-
-### ability Dialect
-
-Evidence 기반 핸들러 디스패치 연산. 런타임 evidence 구조를 조작한다.
-
-```text
-ability.evidence_lookup : (evidence: EvidencePtr, ability_ref: Type) -> Marker
-    Evidence에서 ability marker 조회
-
-ability.evidence_extend : (evidence: EvidencePtr, ability_ref: Type, prompt_tag: PromptTag) -> EvidencePtr
-    새 marker로 evidence 확장
-
-ability.handler_table : (max_ops_per_handler: u32, entries: Region) -> ()
-    핸들러 테이블 정의 (ability별 핸들러 엔트리 목록)
-
-ability.handler_entry : (tag: u32, op_count: u32, funcs: Region) -> ()
-    핸들러 테이블의 개별 엔트리 (ability op 구현 함수 목록)
-```
-
-핸들러 lowering은 CPS closure + evidence extend + runtime 호출로 처리된다.
-
-### closure Dialect
-
-클로저 생성 및 분해 연산. 클로저는 함수 참조와 캡처된 환경의 조합이다.
-타겟별로 다르게 lowering된다 (wasm: funcref + struct, native: 함수 포인터 + 힙).
-
-```text
-closure.new : @func_ref(captures...) -> Closure<T>
-    클로저 생성 (캡처된 변수들 명시)
-
-closure.func : (closure: Closure<T>) -> FuncRef
-    클로저에서 funcref 추출
-
-closure.env : (closure: Closure<T>) -> Env
-    클로저에서 environment 추출
-```
-
-#### 클로저 호출 패턴
-
-클로저는 분해 후 `func.call_indirect`로 호출:
-
-```text
-%closure = closure.new @lambda_0, [%captured]
-%fn = closure.func %closure
-%env = closure.env %closure
-func.call_indirect %fn(%env, %args...)  // env가 첫 번째 인자
-```
-
-### adt Dialect
-
-Algebraic Data Type 연산. 타겟 독립적.
-
-#### Struct (Product Type)
-
-```text
-adt.struct_new : (type: StructType, fields...) -> ref<T>
-    struct 인스턴스 생성
-
-adt.struct_get : (ref: ref<T>, field: u32) -> FieldType
-    필드 읽기
-
-adt.struct_set : (ref: ref<T>, field: u32, value: FieldType) -> ()
-    필드 쓰기
-```
-
-#### Variant (Sum Type)
-
-```text
-adt.variant_new : (type: EnumType, tag: u32, fields...) -> ref<T>
-    variant 인스턴스 생성
-
-adt.variant_tag : (ref: ref<T>) -> u32
-    variant의 tag 읽기
-
-adt.variant_get : (ref: ref<T>, field: u32) -> FieldType
-    variant의 필드 읽기
-```
-
-#### Array
-
-```text
-adt.array_new : (type: ArrayType, size: i32, init?) -> ref<Array<T>>
-    배열 생성
-
-adt.array_get : (ref: ref<Array<T>>, index: i32) -> T
-    요소 읽기
-
-adt.array_set : (ref: ref<Array<T>>, index: i32, value: T) -> ()
-    요소 쓰기
-
-adt.array_len : (ref: ref<Array<T>>) -> i32
-    배열 길이
-```
-
-#### Reference
-
-```text
-adt.ref_null : (type: RefType) -> ref<T>?
-    null 참조 생성
-
-adt.ref_is_null : (ref: ref<T>?) -> i1
-    null 검사
-
-adt.ref_cast : (ref: ref<T>) -> ref<U>
-    참조 타입 캐스트 (런타임 검사)
-```
-
-#### 리터럴
-
-```text
-adt.text_const : (literal: Text) -> Text
-    텍스트 상수
-
-adt.bytes_const : (bytes: [u8]) -> Bytes
-    바이트열 상수
-```
-
----
-
-## Mid-level Dialects
-
-### func Dialect
-
-함수 정의 및 호출. MLIR 스타일을 따름.
-
-```text
-func.func : (name: Symbol, type: Type, body: Region) -> FuncDef
-    함수 정의
-
-func.call : @callee(args...) -> T
-    Direct call (callee는 symbol attribute)
-
-func.call_indirect : (callee: Value, args...) -> T
-    Indirect call (callee는 SSA value, plain funcref만)
-
-func.constant : @func_ref -> FuncValue
-    함수 심볼에서 일급 함수 값 생성 (indirect call용)
-
-func.tail_call : @callee(args...) -> !
-    Tail call (반환하지 않음)
-
-func.return : (value: T) -> !
-    함수에서 반환
-
-func.unreachable : () -> !
-    도달 불가 지점 (trap)
-```
-
-#### Direct vs Indirect Call
-
-```text
-// Direct call: callee가 컴파일 타임에 알려진 경우
-func.call @add(%x, %y) : (i32, i32) -> i32
-
-// Indirect call: callee가 런타임 값인 경우 (plain funcref)
-%f = func.constant @add : fn(i32, i32) -> i32
-func.call_indirect %f(%x, %y) : (i32, i32) -> i32
-```
-
-#### 람다 Lowering
-
-람다는 세 단계로 lowering된다:
-
-```text
-// 1. 파싱 직후 (캡처 분석 전)
-%f = tribute.lambda (%x) {
-    arith.add %x, %y        // %y는 외부 변수 (캡처 대상인지 아직 모름)
-} -> tribute.type_var
-
-// 2. 캡처 분석 후 (tribute → closure + func)
-//    별도 함수로 추출되고, 캡처 변수가 명시됨
-func.func @lambda_0(%env: ref<Env>, %x: i32) -> i32 {
-    %y = adt.struct_get %env, 0 : i32
-    %result = arith.add %x, %y : i32
-    func.return %result
-}
-...
-%f = closure.new @lambda_0, [%y] -> Closure<fn(i32) -> i32>
-
-// 클로저 호출 시 (closure dialect 사용)
-%fn = closure.func %f
-%env = closure.env %f
-func.call_indirect %fn(%env, %arg)
-
-// 3. 타겟별 lowering (closure → wasm/clif)
-//    Wasm: funcref + struct
-//    Cranelift: 함수 포인터 + 힙 환경
-```
-
-### scf Dialect
-
-Structured Control Flow. Tribute는 loop 구문이 없고 재귀만 사용한다.
-
-#### 기본 연산
-
-```text
-scf.case : (scrutinee: T, branches: [(Pattern, Region)]) -> U
-    패턴 매칭, 모든 Region이 같은 타입 U를 yield
-
-scf.yield : (values...) -> !
-    Region에서 값 반환
-```
-
-#### Tail Call Inlining 결과물 (최적화 패스 산출)
-
-```text
-scf.loop : (init: (T1, T2, ...), body: Region) -> U
-    루프 (tail recursion 최적화 결과)
-
-scf.continue : (values...) -> !
-    루프 처음으로, 새 인자 전달
-
-scf.break : (value: T) -> !
-    루프 탈출, 결과 반환
-```
-
-### arith Dialect
-
-산술, 비교, 비트 연산. 모든 정수/부동소수점 타입 지원.
-
-#### 산술
-
-```text
-arith.const : (value: Immediate) -> T
-    상수
-
-arith.add : (lhs: T, rhs: T) -> T
-arith.sub : (lhs: T, rhs: T) -> T
-arith.mul : (lhs: T, rhs: T) -> T
-arith.div : (lhs: T, rhs: T) -> T
-arith.rem : (lhs: T, rhs: T) -> T
-arith.neg : (value: T) -> T
-```
-
-#### 비교
-
-```text
-arith.cmp_eq  : (lhs: T, rhs: T) -> i1
-arith.cmp_ne  : (lhs: T, rhs: T) -> i1
-arith.cmp_lt  : (lhs: T, rhs: T) -> i1
-arith.cmp_le  : (lhs: T, rhs: T) -> i1
-arith.cmp_gt  : (lhs: T, rhs: T) -> i1
-arith.cmp_ge  : (lhs: T, rhs: T) -> i1
-```
-
-#### 비트 연산
-
-```text
-arith.and : (lhs: T, rhs: T) -> T
-arith.or  : (lhs: T, rhs: T) -> T
-arith.xor : (lhs: T, rhs: T) -> T
-arith.shl : (value: T, amount: T) -> T
-arith.shr : (value: T, amount: T) -> T    // arithmetic
-arith.shru : (value: T, amount: T) -> T   // logical
-```
-
-#### 타입 변환
-
-```text
-arith.cast    : (value: T) -> U    // 부호 확장/축소
-arith.trunc   : (value: T) -> U    // 절삭
-arith.extend  : (value: T) -> U    // 확장
-arith.convert : (value: T) -> U    // int ↔ float
-```
-
-### mem Dialect
-
-저수준 메모리 연산. FFI 및 런타임 지원용.
-
-```text
-mem.data : (bytes: [u8]) -> ptr
-    Data section에 바이트 배치, 포인터 반환
-
-mem.load : (ptr: ptr, offset: i32) -> T
-    메모리 읽기
-
-mem.store : (ptr: ptr, offset: i32, value: T) -> ()
-    메모리 쓰기
-```
-
----
-
-## Low-level Dialects
-
-### wasm Dialect
-
-Wasm 3.0 + WasmGC 타겟.
-
-#### Control
-
-```text
-wasm.block : (body: Region) -> T
-wasm.loop : (body: Region) -> ()
-wasm.if : (cond: i32, then: Region, else: Region?) -> T
-wasm.br : (target: BlockRef) -> !
-wasm.br_if : (cond: i32, target: BlockRef) -> ()
-wasm.return : (value: T) -> !
-wasm.return_call : (callee: FuncRef, args...) -> !
-```
-
-#### Arithmetic (예시)
-
-```text
-wasm.i32_add : (lhs: i32, rhs: i32) -> i32
-wasm.i32_sub : (lhs: i32, rhs: i32) -> i32
-wasm.i32_eq  : (lhs: i32, rhs: i32) -> i32
-...
-```
-
-#### WasmGC
-
-```text
-wasm.struct_new : (type: TypeIdx, fields...) -> ref
-wasm.struct_get : (ref: ref, field: u32) -> T
-wasm.struct_set : (ref: ref, field: u32, value: T) -> ()
-
-wasm.array_new : (type: TypeIdx, size: i32, init?) -> ref
-wasm.array_get : (ref: ref, index: i32) -> T
-wasm.array_set : (ref: ref, index: i32, value: T) -> ()
-wasm.array_len : (ref: ref) -> i32
-
-wasm.ref_null : (type: HeapType) -> ref?
-wasm.ref_is_null : (ref: ref?) -> i32
-wasm.ref_cast : (ref: ref) -> ref
-```
-
-### clif Dialect
-
-Cranelift IR과 1:1 대응하는 저수준 연산. `wasm.*`과 대칭 구조.
-
-```text
-// 모듈/함수 정의
-clif.func          : (sym_name, type) { body } — 함수 정의
-clif.call          : (callee: Symbol, args...) -> result — 직접 호출
-clif.call_indirect : (sig: Type, callee_ptr, args...) -> result — 간접 호출
-clif.return        : (values...) — 함수 반환
-
-// 상수
-clif.iconst        : (value: i64) -> result — 정수 상수
-clif.f32const      : (value: f32) -> result — f32 상수
-clif.f64const      : (value: f64) -> result — f64 상수
-
-// 정수 산술
-clif.iadd          : (lhs, rhs) -> result
-clif.isub          : (lhs, rhs) -> result
-clif.imul          : (lhs, rhs) -> result
-clif.sdiv          : (lhs, rhs) -> result
-clif.udiv          : (lhs, rhs) -> result
-clif.srem          : (lhs, rhs) -> result
-clif.urem          : (lhs, rhs) -> result
-clif.ineg          : (val) -> result
-
-// 부동소수점 산술
-clif.fadd          : (lhs, rhs) -> result
-clif.fsub          : (lhs, rhs) -> result
-clif.fmul          : (lhs, rhs) -> result
-clif.fdiv          : (lhs, rhs) -> result
-clif.fneg          : (val) -> result
-
-// 비교
-clif.icmp          : (cond: Cond, lhs, rhs) -> i8
-clif.fcmp          : (cond: Cond, lhs, rhs) -> i8
-
-// 비트 연산
-clif.band          : (lhs, rhs) -> result
-clif.bor           : (lhs, rhs) -> result
-clif.bxor          : (lhs, rhs) -> result
-clif.ishl          : (lhs, rhs) -> result
-clif.sshr          : (lhs, rhs) -> result
-clif.ushr          : (lhs, rhs) -> result
-
-// 제어 흐름
-clif.brif          : (cond, then_block, else_block) — 조건 분기
-clif.jump          : (target_block, args...) — 무조건 점프
-clif.br_table      : (index, targets...) — 테이블 분기
-
-// 메모리
-clif.load          : (addr, offset: i32) -> result
-clif.store         : (val, addr, offset: i32)
-clif.stack_slot    : (size: i32, align: i32) -> slot
-clif.stack_addr    : (slot) -> ptr
-clif.symbol_addr   : (sym: Symbol) -> ptr
-
-// 타입 변환
-clif.ireduce       : (val) -> result — 정수 축소
-clif.uextend       : (val) -> result — 부호 없는 확장
-clif.sextend       : (val) -> result — 부호 있는 확장
-clif.fpromote      : (val) -> result — 부동소수점 확장 (f32 → f64)
-clif.fdemote       : (val) -> result — 부동소수점 축소 (f64 → f32)
-clif.fcvt_to_sint  : (val) -> result — float → signed int
-clif.fcvt_from_sint: (val) -> result — signed int → float
-clif.fcvt_to_uint  : (val) -> result — float → unsigned int
-clif.fcvt_from_uint: (val) -> result — unsigned int → float
-```
-
-**`wasm.*`과 비교:**
-
-| 측면 | `wasm.*` | `clif.*` |
-| ---- | -------- | -------- |
-| GC 타입 (struct/array/ref) | 있음 | 없음 — 포인터 + load/store |
-| 제어 흐름 | Structured (block/loop/if) | CFG (brif/jump/br_table) |
-| 메모리 | Linear memory (i32 addr) | 포인터 기반 (i64 addr) |
-| 함수 참조 | funcref + table | 함수 포인터 |
-| 스택 할당 | 없음 | stack_slot |
-
-**타입:**
-
-```text
-clif.i8, clif.i16, clif.i32, clif.i64, clif.f32, clif.f64
-```
-
----
-
-## Block Arguments와 SSA
-
-TrunkIR은 SSA 기반이며, φ 노드 대신 block arguments를 사용한다.
-
-```text
-func.func @sum(%xs: ref<List>, %acc: i32) -> i32 {
-^entry:
-    %tag = adt.variant_tag %xs
-    scf.case %tag {
-        0 -> {  // Empty
-            scf.yield %acc
-        }
-        1 -> {  // Cons
-            %h = adt.variant_get %xs, 0 : i32
-            %t = adt.variant_get %xs, 1 : ref<List>
-            %new_acc = arith.add %acc, %h : i32
-            func.tail_call @sum(%t, %new_acc)
-        }
-    }
-}
-```
-
-Tail call inlining 후:
-
-```text
-func.func @sum(%xs: ref<List>, %acc: i32) -> i32 {
-    scf.loop (%xs, %acc) -> i32 {
-    ^body(%xs_cur: ref<List>, %acc_cur: i32):
-        %tag = adt.variant_tag %xs_cur
-        scf.case %tag {
-            0 -> {
-                scf.break %acc_cur
-            }
-            1 -> {
-                %h = adt.variant_get %xs_cur, 0 : i32
-                %t = adt.variant_get %xs_cur, 1 : ref<List>
-                %new_acc = arith.add %acc_cur, %h : i32
-                scf.continue %t, %new_acc
-            }
-        }
-    }
-}
-```
-
----
-
-## Compilation Pipeline
-
-```text
-Tribute Source
-    │
-    ▼ Parse (CST)
-    │
-    ▼ AST Lowering (astgen)
-    │
-AST (unresolved)
-    │
-    ▼ Name Resolution (resolve)
-    │   - qualified paths (List::empty)
-    │   - constructors (Some, None)
-    │   - 변수 바인딩
-    │
-AST (resolved)
-    │
-    ▼ Type Inference (typeck)
-    │   - constraint 수집 및 해소
-    │   - 모든 type variable 해소
-    │   - effect row 통합
-    │
-AST (typed)
-    │
-    ▼ TDNR (tdnr)
-    │   - xs.map(f) → List::map(xs, f)
-    │   - 첫 번째 인자 타입으로 함수 선택
-    │
-AST (UFCS resolved)
-    │
-    ▼ IR Lowering (ast_to_ir)
-    │
-TrunkIR [adt, ability, closure, func, scf, arith]
-    │
-    ▼ Boxing + Closure Lowering
-    │   - boxing: 다형성을 위한 box/unbox 삽입
-    │   - closure_lower: closure.* → func.call
-    │
-    ▼ Evidence Resolution
-    │   ability.* → CPS closures + func.call
-    │   (ability 타입은 유지, 연산만 lowering)
-    │
-TrunkIR [adt, func, scf, arith]
-    │
-    ▼ Optimization Passes
-    │   - Tail Call Inlining (func.tail_call → scf.loop)
-    │   - Inlining
-    │   - Dead Code Elimination
-    │   - Constant Folding
-    │
-    ├─────────────────────────────────────┐
-    │                                     │
-    ▼ Wasm Lowering                       ▼ Cranelift Lowering
-    │                                     │
-TrunkIR [wasm.*]                     TrunkIR [clif.*]
-    │                                     │
-    ▼ Emit                                ▼ Emit
-    │                                     │
-.wasm                                native binary
-```
-
-### Frontend Pipeline 상세
-
-Frontend는 순차적으로 실행되는 4단계로 구성된다:
-
-```text
-resolve → typeck → tdnr → ast_to_ir
-```
-
-**resolve (Name Resolution)**:
-
-- qualified paths 해소 (`List::empty`)
-- constructor 해소 (`Some`, `None`)
-- 변수 바인딩 (`foo`, `x`)
-- UFCS 호출(`xs.map(f)`)은 `MethodCall`로 남김
-
-**typeck (Type Inference)**:
-
-- bidirectional type checking
-- constraint 수집 및 unification
-- 모든 type variable 해소
-- effect row 통합
-
-**tdnr (Type-Directed Name Resolution)**:
-
-- UFCS 해소: `xs.map(f)` → `List::map(xs, f)`
-- 이미 해소된 타입 정보를 사용
-- `MethodCall` → `Call` 변환
-
-**타입이 UFCS 해소에 필요한 이유**:
-
-- `xs.map(f)`에서 `map`이 `List::map`인지 `Option::map`인지는 `xs`의 타입에 따라 결정됨
-
----
-
-## Pass Invariants
-
-각 pass가 완료된 후 만족해야 하는 조건:
-
-| Pass                      | Invariant                                         |
-| ------------------------- | ------------------------------------------------- |
-| Parse                     | 유효한 CST 구조                                   |
-| AST Lowering (astgen)     | 유효한 AST 구조                                   |
-| Name Resolution (resolve) | qualified path, constructor, 변수 이름 해소       |
-| Type Inference (typeck)   | 모든 type variable 해소, 타입 구체화              |
-| TDNR (tdnr)               | UFCS 해소 완료 (MethodCall → Call)                |
-| AST → IR (ast_to_ir)      | 유효한 TrunkIR 구조                               |
-| Boxing (boxing)           | 다형성을 위한 box/unbox 삽입                      |
-| Closure Lowering          | closure.* 없음                                    |
-| Evidence Resolution       | ability 연산 없음 (ability 타입은 유지)           |
-| Wasm Lowering             | wasm.\* 만 존재 (타겟이 Wasm일 때)                |
-| Cranelift Lowering        | clif.\* 만 존재 (타겟이 native일 때)              |
-
----
-
-## Data Types
-
-### Primitive vs Library
-
-| Primitive (core 타입)    | Library (adt로 정의) |
-| ------------------------ | -------------------- |
-| i1 ~ i128                | List (finger tree)   |
-| f32, f64                 | Text (rope)          |
-| Bytes                    | Option               |
-| Array\<T\> (연속 메모리) | Result               |
-| ref\<T\>, ref\<T\>?      | ...                  |
-
-### 변환
-
-```rust
-// Array ↔ List
-arr.to_list()
-list.to_array()
-
-// Bytes ↔ Text
-bytes.to_text_utf8()
-text.to_bytes()
-```
-
----
+Important stage invariants:
+
+| Stage | Required invariant |
+| ---- | ---- |
+| Resolution | Names, constructors, and variable references are resolved |
+| Type check | Type variables and effect rows are solved |
+| TDNR | Method-style calls are converted to resolved calls |
+| AST-to-IR | IR structure and SSA use chains are valid |
+| Shared lowering | Source-level and ability operations are removed at claimed boundaries |
+| Backend lowering | Backend-ready target verification succeeds |
+
+## Type Model
+
+Primitive scalar, pointer, reference, bytes, array, tuple, function, and nil
+types are represented in TrunkIR. Library data types such as `Option`, `Result`,
+`List`, and `Text` lower through ADT and runtime/library conventions rather than
+special IR phases.
 
 ## Open Questions
 
-1. **클로저 표현**: `func.closure_new`의 구체적인 환경 캡처 방식
-2. **Effect row 표현**: IR에서 effect polymorphism 표현 방식
-3. **디버그 정보**: Source map 생성 방식
-4. **WasmGC 재활성화 조건**: shared tail-call CPS IR을 WasmGC closure/table/evidence
-   representation으로 안정적으로 lowering하는 전략
-
-## Recent Changes
-
-### PatternRewriter 도입
-
-Rewrite infrastructure가 `RewriteResult` enum 기반에서 `PatternRewriter`
-mutation API 기반으로 전환되었다. 패턴은 `PatternRewriter`를 통해
-operand 접근(remap+cast 적용됨)과 mutation(`replace_op`, `insert_op`,
-`erase_op`, `add_module_op`)을 수행한다. `OpAdaptor`는 내부 구현으로
-감춰지고, 패턴은 `RewritePattern::match_and_rewrite`에서 `bool`을 반환한다.
-
-자세한 API는 `new-plans/lowering.md`의 "Pattern-based Rewriting" 참조.
-
-## Future Considerations
-
-### Persistent Data Structure for Block Operations
-
-현재 `Block::operations`는 `SmallVec`을 사용하지만, `im::Vector` 같은
-persistent data structure를 고려할 수 있다.
-
-**배경:**
-
-- TrunkIR은 arena 기반 IR (IrContext가 모든 데이터 소유)
-- 현재 rewrite는 블록 전체를 재구축 (O(n) 복사)
-- 대부분의 rewrite pass에서 변경되는 op은 소수
-
-**im::Vector 사용 시 이점:**
-
-- 구조적 공유로 변경된 부분만 새 노드 생성
-- `update(index, new_op)` O(log n)
-- 1000개 op 중 10개 변경 시: SmallVec은 1000개 복사, im::Vector는 ~100개 노드
-
-**고려사항:**
-
-- 작은 블록에서는 SmallVec이 캐시 지역성 면에서 유리
-- Rewriter 설계를 surgical update 방식으로 변경해야 최대 이점
-- 추가 의존성 (im crate)
-
-**결정 시점:** 프로파일링에서 블록 복사가 병목으로 확인되면 재검토
-
-### AST 제거하고 Tree-sitter CST에서 직접 TrunkIR로 lowering
-
-현재 파이프라인: `Tree-sitter CST → AST (tribute-ast) → TrunkIR`
-
-고려 사항:
-
-- AST가 상당히 thin함 (대부분 concrete syntax 제거 정도)
-- TrunkIR이 이미 `Location`으로 소스 위치 보존
-- 중간 표현 하나 제거 시 코드/메모리 절약 가능
-
-Trade-off:
-
-- Tree-sitter CST는 더 verbose하고 cursor 관리 필요
-- AST가 다른 도구들 (formatter, linter, IDE)에 유용할 수 있음
-- 에러 리포팅이 AST 수준에서 더 쉬울 수 있음
-
-결정 시점: AST의 다른 용도가 명확해지면 재검토
+- Final closure environment representation for each backend.
+- Exact effect ABI boundary names and reusable conversion targets.
+- Debug/source-map representation.
+- WasmGC reactivation strategy for lowering shared tail-call CPS IR into
+  closure, table, and evidence representations.

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -1,871 +1,103 @@
 # Lowering Pass Architecture
 
-> 이 문서는 TrunkIR에서 타겟 IR(wasm, clif 등)로의 lowering pass 아키텍처를 정의한다.
+TrunkIR lowering is dialect-based and incremental. Passes should lower one
+semantic layer at a time, keep mixed-dialect IR valid between steps, and verify
+the boundaries they claim to establish.
 
 ## Design Decisions
 
-### 결정 사항 요약
+| Topic | Decision |
+| ---- | ---- |
+| Pass shape | Dialect-specific passes, not one monolithic lowerer |
+| Rewriting | `PatternApplicator` fixpoint rewrites |
+| State | Precomputed analyses or immutable plans, not mutable pass state |
+| Boundaries | `ConversionTarget` verification, not `Module<Phase>` types |
 
-| 항목         | 선택                         | 대안 (채택하지 않음)    |
-| ------------ | ---------------------------- | ----------------------- |
-| Pass 구조    | Dialect별 분리               | 단일 monolithic lowerer |
-| 패턴 적용    | PatternApplicator (fixpoint) | 수동 트리 순회          |
-| State 관리   | Salsa tracked analysis       | 수동 캐싱/무효화        |
-| 세분화 수준  | Per-function analysis        | Module-level only       |
-| Planner 설계 | Immutable (analysis처럼)     | Mutable accumulator     |
+## Conversion Modes
 
----
+Use partial conversion when a pass only promises to remove a declared illegal
+set from one step. Unknown operations may remain for later passes.
 
-## Overview
+Use full conversion at pipeline boundaries. Full conversion fails on both
+illegal and unknown operations, so every allowed operation must be declared
+legal by the boundary target.
 
-### MLIR-style Dialect별 Pass
+Shared lowering passes must not call unchecked `apply_partial` when their API or
+name claims to complete a lowering stage. Use named `ConversionTarget`s for
+pipeline boundaries instead of open-coding legality rules per pass.
 
-Lowering을 단일 monolithic pass로 구현하지 않고, MLIR처럼 dialect별로 분리한다:
+## Pattern Rewriting
 
-```bash
-# MLIR 예시
-mlir-opt input.mlir \
-  -convert-scf-to-cf \
-  -convert-func-to-llvm \
-  -convert-arith-to-llvm
-```
+Patterns match one operation family and mutate through `PatternRewriter`.
+`PatternApplicator` walks nested regions, applies patterns to a fixpoint, and
+optionally performs conversion-target-aware type adaptation.
 
-```rust
-// Tribute: tribute-wasm-backend/src/pipeline.rs
-pub fn lower_to_wasm(db: &dyn Database, module: Module) -> Module {
-    let module = passes::adt_to_wasm::lower(db, module);
-    let module = passes::scf_to_wasm::lower(db, module);
-    let module = passes::func_to_wasm::lower(db, module);
-    let module = passes::arith_to_wasm::lower(db, module);
-    let module = passes::intrinsic_to_wasi::lower(db, module);
-    let module = passes::const_to_wasm::lower(db, module);
-    module
-}
-```
+Rules:
 
-### 장점
+- Keep patterns stateless except for read-only analysis data.
+- Prefer focused patterns over large manual tree walks.
+- Use explicit partial or full conversion entry points when legality matters.
+- Keep exact API behavior in Rustdoc near `ConversionTarget`,
+  `ConversionMode`, `PatternApplicator`, and `PatternRewriter`.
 
-1. **관심사 분리**: 각 pass는 단일 dialect만 처리
-2. **테스트 용이**: Pass별 독립 unit test 가능
-3. **재사용**: 다른 backend도 일부 pass 공유 가능
-4. **점진적 lowering**: 중간 상태 검사/디버깅 용이
-5. **PatternApplicator 활용**: Focused patterns로 fixpoint iteration
+## Wasm Lowering
 
----
+The Wasm pipeline lowers target-independent dialects into `wasm.*` while using
+analysis plans for type indices, function indices, data segments, imports, and
+memory layout.
 
-## Pass 목록
-
-### adt_to_wasm
-
-ADT 연산을 WasmGC 연산으로 변환.
+Typical pass order:
 
 ```text
-adt.struct_new  → wasm.struct_new
-adt.variant_new → wasm.struct_new + wasm.ref_cast
-adt.field_get   → wasm.struct_get
-adt.array_get   → wasm.array_get
-adt.array_set   → wasm.array_set
+adt_to_wasm
+scf_to_wasm
+func_to_wasm
+arith_to_wasm
+intrinsic_to_wasm
+const_to_wasm
 ```
 
-**필요 Analysis**: `TypeIndexAnalysis` (Type → wasm type index)
+Expected boundary: backend-ready Wasm IR contains `wasm.*` plus explicitly
+allowed infrastructure operations.
 
-### scf_to_wasm
+## Native Lowering
 
-Structured control flow를 Wasm control로 변환.
+The native pipeline lowers Tribute-specific runtime operations and
+target-independent dialects into `clif.*`, then validates the native backend
+boundary before emission.
+
+Typical pass groups:
 
 ```text
-scf.if    → wasm.if
-scf.while → wasm.block(wasm.loop(...))
-scf.for   → wasm.block(wasm.loop(...))
-scf.case  → wasm.br_table 또는 중첩 wasm.if
+effect/ability lowering
+native runtime lowering
+arith_to_clif
+scf_to_clif
+adt_to_clif
+func_to_clif
+const/intrinsic lowering
 ```
 
-**필요 Analysis**: 없음 (structural transformation only)
+Expected boundary: backend-ready native IR contains `clif.*` plus explicitly
+allowed infrastructure operations.
 
-### func_to_wasm
+## Analyses And Plans
 
-함수 정의 및 호출을 Wasm으로 변환.
+Module or function analyses should be pure computations over IR. Passes may use
+analysis results, but should not accumulate hidden mutable state that affects
+rewrite behavior.
 
-```text
-func.func          → wasm.func
-func.call          → wasm.call
-func.return        → wasm.return
-func.call_indirect → wasm.call_indirect
-func.tail_call     → wasm.return_call
-```
-
-**필요 Analysis**: `FunctionIndexAnalysis` (Symbol → function index)
-
-### arith_to_wasm
-
-산술 연산을 타입별 Wasm 명령어로 변환.
-
-```text
-arith.add(i32, i32) → wasm.i32_add
-arith.add(i64, i64) → wasm.i64_add
-arith.add(f64, f64) → wasm.f64_add
-arith.mul(...)      → wasm.{i32,i64,f32,f64}_mul
-```
-
-**필요 Analysis**: 없음 (type-directed dispatch)
-
-### intrinsic_to_wasi
-
-Intrinsic 함수 호출을 WASI import 호출로 변환.
-
-```text
-func.call @std::intrinsics::wasi::preview1::fd_write(...) → wasm.call $wasi_fd_write(...)
-func.call @std::intrinsics::wasi::preview1::fd_read(...)  → wasm.call $wasi_fd_read(...)
-func.call @std::intrinsics::wasm::memory_grow(...)        → wasm.memory_grow(...)
-```
-
-**Intrinsic 경로 규칙**:
-
-- `std::intrinsics::wasi::<version>::*` - WASI 스펙 함수 (버전별)
-- `std::intrinsics::wasm::*` - Core Wasm intrinsics (memory_grow 등)
-- `std::intrinsics::posix::*` - POSIX syscalls (Cranelift 타겟용)
-
-플랫폼 추상화(`print` 등)는 intrinsic이 아니라 표준 라이브러리에서 처리.
-
-**Note**: `src.call`은 resolve pass에서 이미 `func.call`로 변환됨.
-
-**필요 Analysis**: `WasiPlan`, `DataSegmentPlan`, `MemoryPlan`
-
-### const_to_wasm
-
-상수를 Wasm 상수 또는 data segment 참조로 변환.
-
-```text
-func.constant(int)    → wasm.i32_const / wasm.i64_const
-func.constant(string) → wasm.i32_const(data_offset)
-```
-
-**필요 Analysis**: `DataSegmentPlan`
-
----
-
-## Pattern-based Rewriting
-
-### PatternApplicator
-
-각 pass는 `PatternApplicator`를 사용하여 fixpoint iteration 수행:
-
-```rust
-// trunk-ir/src/rewrite/applicator.rs
-pub struct PatternApplicator<'db> {
-    patterns: Vec<Box<dyn RewritePattern<'db>>>,
-    max_iterations: usize,
-}
-
-impl<'db> PatternApplicator<'db> {
-    pub fn rewrite_module(
-        &mut self,
-        db: &'db dyn Database,
-        module: Module<'db>,
-    ) -> Module<'db> {
-        let mut ctx = RewriteContext::new();
-        // Fixpoint: patterns를 변화 없을 때까지 반복 적용
-        // 각 iteration 후 pending_module_ops를 처리하여
-        // 모듈에 추가하고 value remapping 적용
-        while self.iteration < self.max_iterations {
-            if !self.rewrite_operations(db, module, &mut ctx) {
-                break;
-            }
-        }
-        module
-    }
-}
-```
-
-### RewritePattern
-
-패턴은 단일 연산 종류를 처리. `op`는 원본 연산(매칭/속성 접근용)이고,
-operand 접근 및 mutation은 모두 `rewriter`를 통해 수행:
-
-```rust
-// trunk-ir/src/rewrite/pattern.rs
-pub trait RewritePattern<'db> {
-    fn match_and_rewrite(
-        &self,
-        db: &'db dyn Database,
-        op: Operation<'db>,
-        rewriter: &mut PatternRewriter<'db, '_>,
-    ) -> bool;
-}
-```
-
-`true`를 반환하면 패턴이 매칭되어 mutation이 기록된 것이고,
-`false`를 반환하면 매칭되지 않은 것이다.
-
-### PatternRewriter
-
-패턴이 사용하는 단일 인터페이스. Operand 접근(remap+cast 적용됨)과
-mutation 메서드를 결합:
-
-```rust
-// trunk-ir/src/rewrite/pattern_rewriter.rs
-pub struct PatternRewriter<'db, 'ctx> { /* ... */ }
-
-impl<'db, 'ctx> PatternRewriter<'db, 'ctx> {
-    // --- Operand access (remapped + cast applied) ---
-
-    /// i번째 operand 조회 (remap 적용됨)
-    pub fn operand(&self, i: usize) -> Value<'db>;
-
-    /// 모든 operands 조회
-    pub fn operands(&self) -> &[Value<'db>];
-
-    // --- Type access ---
-
-    /// i번째 operand의 타입 조회
-    pub fn operand_type(&self, i: usize) -> Type<'db>;
-
-    /// 원본 연산의 i번째 result 타입 조회
-    pub fn result_type(&self, db: &'db dyn Database, op: Operation<'db>, i: usize) -> Type<'db>;
-
-    /// 임의 value의 타입 조회
-    pub fn get_value_type(&self, db: &'db dyn Database, v: Value<'db>) -> Type<'db>;
-
-    // --- Value resolution ---
-
-    /// Value를 현재 매핑에서 조회
-    pub fn lookup_value(&self, v: Value<'db>) -> Value<'db>;
-
-    // --- Mutation methods ---
-
-    /// 현재 연산을 new_op으로 교체
-    pub fn replace_op(&mut self, new_op: Operation<'db>);
-
-    /// 교체 연산 앞에 prefix 연산 삽입
-    pub fn insert_op(&mut self, op: Operation<'db>);
-
-    /// 연산을 제거하고 results를 주어진 values로 매핑
-    pub fn erase_op(&mut self, vals: Vec<Value<'db>>);
-
-    /// 모듈 최상위에 연산 추가 (e.g., outlined 함수)
-    pub fn add_module_op(&mut self, op: Operation<'db>);
-}
-```
-
-**Note:** `OpAdaptor`는 `pub(crate)` 내부 구현이며 패턴에 노출되지 않는다.
-
-### RewriteContext
-
-Value 매핑을 자동 관리하고, module-level 추가 연산을 수집:
-
-```rust
-// trunk-ir/src/rewrite/context.rs
-pub struct RewriteContext<'db> {
-    value_map: HashMap<Value<'db>, Value<'db>>,
-    pending_module_ops: Vec<Operation<'db>>,
-}
-
-impl<'db> RewriteContext<'db> {
-    /// Old value → New value 매핑 조회
-    pub fn lookup(&self, value: Value<'db>) -> Value<'db> {
-        self.value_map.get(&value).copied().unwrap_or(value)
-    }
-
-    /// Old op의 results를 new op의 results로 매핑
-    pub fn map_results(
-        &mut self,
-        db: &'db dyn Database,
-        old_op: &Operation<'db>,
-        new_op: &Operation<'db>,
-    ) {
-        for (old_val, new_val) in old_op.results().zip(new_op.results()) {
-            self.value_map.insert(old_val, new_val);
-        }
-    }
-}
-```
-
-Applicator는 각 iteration 후 `pending_module_ops`를 처리하여 모듈에 추가하고,
-전체 value remapping을 적용한다.
-
-### Pass 예시
-
-```rust
-// tribute-wasm-backend/src/passes/adt_to_wasm.rs
-
-pub fn lower(db: &dyn Database, module: Module) -> Module {
-    // Analysis 조회 (Salsa cached)
-    let type_indices = analysis::type_index_analysis(db, module);
-
-    let patterns: Vec<Box<dyn RewritePattern>> = vec![
-        Box::new(StructNewPattern::new(type_indices.clone())),
-        Box::new(VariantNewPattern::new(type_indices.clone())),
-        Box::new(FieldGetPattern::new(type_indices.clone())),
-    ];
-
-    PatternApplicator::new(patterns).rewrite_module(db, module)
-}
-
-struct StructNewPattern {
-    type_indices: TypeIndexAnalysis,
-}
-
-impl RewritePattern for StructNewPattern {
-    fn match_and_rewrite(
-        &self,
-        db: &dyn Database,
-        op: Operation,
-        rewriter: &mut PatternRewriter,
-    ) -> bool {
-        let Ok(struct_new) = adt::StructNew::from_operation(db, op) else {
-            return false;
-        };
-
-        let ty = struct_new.struct_type(db);
-        let type_idx = self.type_indices.get(db, ty)
-            .expect("Type should be in analysis");
-
-        // adt.struct_new → wasm.struct_new
-        let new_op = wasm::struct_new(
-            db,
-            type_idx,
-            rewriter.operands(),
-        );
-
-        rewriter.replace_op(new_op);
-        true
-    }
-}
-```
-
----
-
-## Salsa-native Analysis
-
-### MLIR과의 비교
-
-MLIR은 C++이라 mutable IR + 수동 캐싱/무효화가 필요하지만, Tribute는 Salsa를 활용:
-
-| MLIR (C++)                          | Tribute (Salsa)                      |
-| ----------------------------------- | ------------------------------------ |
-| `AnalysisManager::getAnalysis<T>()` | `#[salsa::tracked] fn analysis(...)` |
-| 수동 캐싱                           | Salsa 자동 캐싱                      |
-| 수동 무효화 tracking                | Salsa dependency graph               |
-| `markAllAnalysesPreserved()`        | 필요 없음 (immutable IR)             |
-
-### Invalidation is Free
-
-TrunkIR의 Operation은 immutable Salsa tracked struct이므로, 무효화가 자동:
-
-```rust
-// Module이 바뀌면 Salsa가 자동으로 analysis 재계산
-let analysis_v1 = type_index_analysis(db, module_v1);  // 계산
-
-let module_v2 = adt_to_wasm::lower(db, module_v1);     // 새 module
-
-let analysis_v2 = type_index_analysis(db, module_v2);  // 재계산 (다른 module)
-// analysis_v1 캐시는 그대로 유지 (module_v1용)
-```
-
-### Analysis 정의
-
-```rust
-// tribute-wasm-backend/src/analysis/type_indices.rs
-
-/// Type → Wasm type index 매핑
-#[salsa::tracked]
-pub struct TypeIndexAnalysis<'db> {
-    #[returns(ref)]
-    type_to_index: HashMap<Type<'db>, u32>,
-}
-
-impl<'db> TypeIndexAnalysis<'db> {
-    pub fn get(&self, db: &'db dyn Database, ty: Type<'db>) -> Option<u32> {
-        self.type_to_index(db).get(&ty).copied()
-    }
-}
-
-#[salsa::tracked]
-pub fn type_index_analysis<'db>(
-    db: &'db dyn Database,
-    module: Module<'db>,
-) -> TypeIndexAnalysis<'db> {
-    let mut type_to_index = HashMap::new();
-    let mut next_index = 0;
-
-    // Per-function analysis 조합
-    for op in module.ops(db) {
-        if let Ok(func) = func::Func::from_operation(db, op) {
-            let func_types = function_type_analysis(db, func);
-
-            for ty in func_types.types_used(db) {
-                type_to_index.entry(*ty).or_insert_with(|| {
-                    let idx = next_index;
-                    next_index += 1;
-                    idx
-                });
-            }
-        }
-    }
-
-    TypeIndexAnalysis::new(db, type_to_index)
-}
-```
-
----
-
-## Fine-grained Analysis
-
-### Per-Function 세분화
-
-Module-level analysis 대신 function-level로 세분화하면 Salsa 캐싱 효율 극대화:
-
-```rust
-// Coarse-grained: 모든 함수 스캔
-#[salsa::tracked]
-fn module_type_analysis(db: &dyn Database, module: Module) -> ModuleTypeInfo {
-    for op in module.ops(db) {
-        // 모든 op 스캔
-    }
-}
-
-// Fine-grained: 함수별 분리
-#[salsa::tracked]
-fn function_type_analysis(db: &dyn Database, func: func::Func) -> FunctionTypeInfo {
-    // 이 함수 body만 스캔
-    let mut types_used = HashSet::new();
-    for block in func.body(db).blocks(db) {
-        for op in block.ops(db) {
-            // Collect types
-        }
-    }
-    FunctionTypeInfo::new(db, types_used)
-}
-
-// Module-level은 function-level 조합
-#[salsa::tracked]
-fn module_type_analysis(db: &dyn Database, module: Module) -> ModuleTypeInfo {
-    let mut all_types = HashSet::new();
-
-    for op in module.ops(db) {
-        if let Ok(func) = func::Func::from_operation(db, op) {
-            // Per-function analysis 재사용
-            let func_info = function_type_analysis(db, func);
-            all_types.extend(func_info.types_used(db).iter().copied());
-        }
-    }
-
-    ModuleTypeInfo::new(db, all_types)
-}
-```
-
-**Salsa의 마법:**
-
-- 100개 함수 중 1개만 바뀌면 → 99개는 캐시 재사용, 1개만 재계산
-- MLIR은 이를 수동 tracking 해야 하지만 Salsa는 자동
-
----
-
-## Planner as Analysis
-
-### Mutable Planner → Immutable Plan
-
-"Mutable planner"도 사실 pure function으로 계산 가능:
-
-```rust
-// Before: Mutable planner (안 좋음)
-struct DataSegmentPlanner {
-    segments: Vec<Vec<u8>>,
-    string_to_offset: HashMap<String, u32>,
-    next_offset: u32,
-}
-
-impl DataSegmentPlanner {
-    fn allocate_string(&mut self, s: &str) -> u32 {
-        // Mutates self
-    }
-}
-
-// After: Immutable plan (Salsa tracked)
-#[salsa::tracked]
-pub struct DataSegmentPlan<'db> {
-    #[returns(deref)]
-    segments: Vec<Vec<u8>>,
-
-    #[returns(ref)]
-    string_to_offset: HashMap<String, u32>,
-
-    total_size: u32,
-}
-
-#[salsa::tracked]
-pub fn data_segment_plan<'db>(
-    db: &'db dyn Database,
-    module: Module<'db>,
-) -> DataSegmentPlan<'db> {
-    // Pure function: module → plan
-    let mut segments = Vec::new();
-    let mut string_to_offset = HashMap::new();
-    let mut offset = 0;
-
-    for string_literal in collect_string_literals(db, module) {
-        if !string_to_offset.contains_key(&string_literal) {
-            string_to_offset.insert(string_literal.clone(), offset);
-            let bytes = string_literal.into_bytes();
-            offset += bytes.len() as u32;
-            segments.push(bytes);
-        }
-    }
-
-    DataSegmentPlan::new(db, segments, string_to_offset, offset)
-}
-```
-
-### WasiPlan
-
-```rust
-#[salsa::tracked]
-pub struct WasiPlan<'db> {
-    /// 필요한 WASI import 목록 (e.g., "fd_write", "fd_read")
-    #[returns(ref)]
-    required_imports: HashSet<Symbol<'db>>,
-}
-
-impl<'db> WasiPlan<'db> {
-    pub fn needs(&self, db: &'db dyn Database, name: &str) -> bool {
-        let sym = Symbol::new(db, name);
-        self.required_imports(db).contains(&sym)
-    }
-}
-
-#[salsa::tracked]
-pub fn wasi_plan<'db>(
-    db: &'db dyn Database,
-    module: Module<'db>,
-) -> WasiPlan<'db> {
-    let mut required = HashSet::new();
-
-    // WASI prefix (Symbol에 "::"로 구분된 경로로 저장됨)
-    let wasi_prefix = "std::intrinsics::wasi::preview1::";
-
-    for op in module.all_operations(db) {
-        if let Ok(call) = func::Call::from_operation(db, op) {
-            let callee = call.callee(db);  // Symbol
-            callee.with_str(|s| {
-                if let Some(name) = s.strip_prefix(wasi_prefix) {
-                    // name: 마지막 segment (e.g., "fd_write")
-                    required.insert(Symbol::from_dynamic(name));
-                }
-            });
-        }
-    }
-
-    WasiPlan::new(db, required)
-}
-```
-
-### MemoryPlan
-
-```rust
-#[salsa::tracked]
-pub struct MemoryPlan<'db> {
-    needs_memory: bool,
-    initial_pages: u32,
-    max_pages: Option<u32>,
-}
-
-#[salsa::tracked]
-pub fn memory_plan<'db>(
-    db: &'db dyn Database,
-    module: Module<'db>,
-) -> MemoryPlan<'db> {
-    let data_plan = data_segment_plan(db, module);
-    let wasi = wasi_plan(db, module);
-
-    // 메모리가 필요한 조건: data segment 있거나 메모리 사용하는 WASI 함수
-    let needs_memory = data_plan.total_size(db) > 0
-        || wasi.needs(db, "fd_write")
-        || wasi.needs(db, "fd_read");
-
-    let initial_pages = if needs_memory {
-        // data segment 크기 기반으로 초기 페이지 계산
-        ((data_plan.total_size(db) as usize + 65535) / 65536).max(1) as u32
-    } else {
-        0
-    };
-
-    MemoryPlan::new(db, needs_memory, initial_pages, None)
-}
-```
-
----
-
-## Analysis 모듈 구조
-
-```text
-tribute-wasm-backend/
-├── src/
-│   ├── lib.rs
-│   ├── pipeline.rs           # lower_to_wasm entry point
-│   │
-│   ├── analysis/
-│   │   ├── mod.rs            # re-exports
-│   │   ├── type_indices.rs   # TypeIndexAnalysis
-│   │   ├── func_indices.rs   # FunctionIndexAnalysis
-│   │   ├── data_segments.rs  # DataSegmentPlan
-│   │   ├── wasi.rs           # WasiPlan
-│   │   ├── memory.rs         # MemoryPlan
-│   │   └── function_info.rs  # Per-function analysis
-│   │
-│   └── passes/
-│       ├── mod.rs
-│       ├── adt_to_wasm.rs
-│       ├── scf_to_wasm.rs
-│       ├── func_to_wasm.rs
-│       ├── arith_to_wasm.rs
-│       ├── intrinsic_to_wasi.rs
-│       └── const_to_wasm.rs
-```
-
----
-
-## Pass Pipeline
-
-### Salsa Tracked Pipeline
-
-```rust
-// tribute-wasm-backend/src/pipeline.rs
-
-#[salsa::tracked]
-pub fn lower_to_wasm<'db>(
-    db: &'db dyn Database,
-    module: Module<'db>,
-) -> Module<'db> {
-    // Analysis는 각 pass 내에서 필요할 때 조회
-    // Salsa가 자동으로 캐싱 및 의존성 추적
-
-    let module = passes::adt_to_wasm::lower(db, module);
-    let module = passes::scf_to_wasm::lower(db, module);
-    let module = passes::func_to_wasm::lower(db, module);
-    let module = passes::arith_to_wasm::lower(db, module);
-    let module = passes::intrinsic_to_wasi::lower(db, module);
-    let module = passes::const_to_wasm::lower(db, module);
-
-    module
-}
-
-/// 최종 emission에 필요한 metadata 조회
-pub fn wasm_metadata<'db>(
-    db: &'db dyn Database,
-    module: Module<'db>,
-) -> WasmMetadata<'db> {
-    WasmMetadata {
-        type_indices: analysis::type_index_analysis(db, module),
-        func_indices: analysis::function_index_analysis(db, module),
-        data_segments: analysis::data_segment_plan(db, module),
-        wasi_plan: analysis::wasi_plan(db, module),
-        memory_plan: analysis::memory_plan(db, module),
-    }
-}
-```
-
-### 점진적 Lowering
-
-```text
-High-level IR
-    │ [adt.struct_new, adt.variant_new, scf.if, func.call, arith.add]
-    │
-    ▼ adt_to_wasm
-    │ [wasm.struct_new, scf.if, func.call, arith.add]
-    │
-    ▼ scf_to_wasm
-    │ [wasm.struct_new, wasm.if, func.call, arith.add]
-    │
-    ▼ func_to_wasm
-    │ [wasm.struct_new, wasm.if, wasm.call, arith.add]
-    │
-    ▼ arith_to_wasm
-    │ [wasm.struct_new, wasm.if, wasm.call, wasm.i32_add]
-    │
-    ▼ intrinsic_to_wasi
-    │ [wasm.* only, WASI imports configured]
-    │
-    ▼ const_to_wasm
-    │ [wasm.* only, data segments allocated]
-    │
-Pure wasm IR
-```
-
----
-
-## Native (Cranelift) Lowering Passes
-
-WASM lowering과 대칭 구조로 native 타겟을 위한 pass를 정의한다.
-
-### func_to_clif
-
-함수 정의 및 호출을 Cranelift 연산으로 변환.
-
-```text
-func.func          → clif.func
-func.call          → clif.call
-func.return        → clif.return
-func.call_indirect → clif.call_indirect
-func.constant      → clif.symbol_addr (함수 포인터)
-```
-
-**필요 Analysis**: 없음
-
-### arith_to_clif
-
-산술 연산을 타입별 Cranelift 명령어로 변환.
-
-```text
-arith.add(i32, i32) → clif.iadd
-arith.add(f64, f64) → clif.fadd
-arith.mul(...)      → clif.imul / clif.fmul
-arith.const(int)    → clif.iconst
-arith.const(float)  → clif.f64const
-```
-
-**필요 Analysis**: 없음 (type-directed dispatch)
-
-### scf_to_clif
-
-Structured control flow를 CFG 기반 제어 흐름으로 변환.
-
-```text
-scf.if    → clif.brif + then/else/merge blocks
-scf.while → loop_header + body + clif.jump
-scf.for   → loop_header + body + clif.jump
-scf.case  → clif.br_table 또는 연쇄 clif.brif
-```
-
-WASM의 structured control flow와 달리 Cranelift는 CFG를 직접 사용하므로
-block/loop 래핑이 불필요하다.
-
-**필요 Analysis**: 없음 (structural transformation only)
-
-### adt_to_clif
-
-ADT 연산을 포인터 기반 메모리 연산으로 변환.
-
-```text
-adt.struct_new(fields...) → clif.call @malloc + clif.store at offsets
-adt.struct_get(ref, field) → clif.load(ref, offset)
-adt.variant_new(tag, payload) → clif.call @malloc + clif.store tag + payload
-adt.array_get(ref, index) → clif.load(ref, index * elem_size + header_size)
-```
-
-**ADT 메모리 레이아웃:**
-
-```text
-Struct: [fields in order, naturally aligned]
-Enum:   [tag: i32] [padding] [payload: max(variant sizes)]
-Array:  [length: i64] [elements...]
-```
-
-**필요 Analysis**: `StructLayoutAnalysis` (타입 → 필드 오프셋/크기)
-
-### intrinsic_to_posix
-
-Intrinsic 함수 호출을 POSIX syscall로 변환.
-
-```text
-func.call @std::intrinsics::posix::write(...) → clif.call @write(...)
-func.call @std::intrinsics::posix::read(...)  → clif.call @read(...)
-```
-
-**필요 Analysis**: 없음
-
-### const_to_clif
-
-상수를 Cranelift 상수 또는 data section 참조로 변환.
-
-```text
-func.constant(int)    → clif.iconst
-func.constant(float)  → clif.f64const
-func.constant(string) → clif.symbol_addr(@data_symbol)
-```
-
-**필요 Analysis**: `DataSectionPlan` (문자열 → data symbol)
-
-### Native Pass Pipeline
-
-```mermaid
-flowchart TB
-    input["TrunkIR Module\n(func.*, arith.*, scf.*, adt.*, mem.*, evidence runtime calls)"]
-    arith["arith_to_clif\nclif.iadd, clif.iconst 등"]
-    scf["scf_to_clif\nclif.brif, clif.jump, clif.br_table"]
-    adt["adt_to_clif\nclif.load, clif.store, clif.call @malloc"]
-    func["func_to_clif\nclif.func, clif.call, clif.return"]
-    intrinsic["intrinsic_to_posix\nclif.call @write 등"]
-    const_pass["const_to_clif\nclif.* only"]
-    output["Pure clif IR"]
-
-    input --> arith --> scf --> adt --> func --> intrinsic --> const_pass --> output
-```
-
----
-
-## PatternApplicator 설계 철학
-
-### Stateless by Design
-
-PatternApplicator는 의도적으로 stateless:
-
-1. **Composability**: 패턴들이 독립적이고 조합 가능
-2. **Predictability**: 패턴 적용 순서가 상태에 의존하지 않음
-3. **Testability**: 각 패턴을 독립적으로 테스트 가능
-
-### State는 Analysis로 분리
-
-```rust
-// ❌ 잘못된 접근: Pattern 내부에 mutable state
-struct BadPattern {
-    counter: RefCell<u32>,  // 상태 누적
-}
-
-// ✅ 올바른 접근: Analysis에서 미리 계산
-struct GoodPattern {
-    type_indices: TypeIndexAnalysis,  // Immutable, 미리 계산됨
-}
-```
-
-### 왜 수동 lowering 대신 PatternApplicator?
-
-이전에 수동 `WasmLowerer`를 사용했던 이유:
-
-1. Module-level state 필요 (type_registry, data_segments 등)
-2. 복잡한 structural transformation (1-to-many)
-3. Tree 순회 vs flat operation list
-
-하지만 Analysis 분리 후:
-
-1. State는 Salsa analysis로 분리 → 읽기 전용
-2. 1-to-many expansion은 `insert_op()` + `replace_op()` 조합으로 처리
-3. Module-level 추가(outlined 함수 등)는 `add_module_op()`으로 처리
-4. PatternApplicator가 자동으로 region 재귀
-
----
+Planner-style data, such as data segments, WASI imports, memory layout, or
+native layout metadata, should be represented as immutable plans that can be
+computed before the pass that consumes them.
 
 ## Open Questions
 
-1. **Per-operation Analysis**: Operation 단위 분석이 필요한 경우?
-    - 현재는 function/module 단위
-    - 너무 세분화하면 오버헤드
-
-2. **Analysis Dependencies**: Analysis 간 의존성 관리
-    - `memory_plan`이 `data_segment_plan`과 `wasi_plan`에 의존
-    - Salsa가 자동 처리하지만 순환 의존 주의
-
-3. **Parallel Pattern Application**: 여러 패턴 병렬 적용?
-    - 현재는 순차 적용
-    - 패턴 간 충돌 가능성 고려 필요
-
-4. **Verification Pass**: Lowering 완료 후 검증?
-    - 모든 high-level ops가 제거되었는지 확인
-    - Dialect invariant 검사
-
----
+- Which effect/ability boundary targets should be public reusable APIs?
+- Which Wasm backend boundary should be restored when that backend is revisited?
+- Whether an analysis-only conversion mode is useful enough to add.
 
 ## References
 
-- [MLIR: A Compiler Infrastructure for the End of Moore's Law](https://arxiv.org/abs/2002.11054)
+- [MLIR Dialect Conversion](https://mlir.llvm.org/docs/DialectConversion/)
 - [MLIR Pattern Rewriting](https://mlir.llvm.org/docs/PatternRewriter/)
-- [Salsa: A generic framework for on-demand, incrementalized computation](https://github.com/salsa-rs/salsa)


### PR DESCRIPTION
## Summary

- add `Unknown` legality and explicit partial/full conversion verification to `ConversionTarget`
- add explicit `PatternApplicator` partial/full conversion entry points
- switch native backend-ready validation to a reusable full conversion target
- condense `new-plans/ir.md` and `new-plans/lowering.md` so they keep stable design invariants instead of stale implementation sketches

## Notes

This is an intermediate PR for #726. It establishes the legality model and native backend boundary, but does not yet migrate all shared lowering passes away from unchecked `apply_partial`.

## Verification

- `cargo nextest run -p trunk-ir`
- `cargo nextest run -p trunk-ir-cranelift-backend`
- `cargo check --workspace`
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added support for partial and full conversion verification modes, enabling flexible control over IR validation strictness.
  - Enhanced IR validation with boundary-based legality checking and improved error reporting.

* **Documentation**
  - Reorganized IR and lowering architecture documentation with refined design overview, dialect layering, and compilation pipeline stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->