### PR TITLE
Adopt explicit conversion targets in lowering passes

### DIFF
--- a/crates/tribute-passes/src/native/adt_rc_header.rs
+++ b/crates/tribute-passes/src/native/adt_rc_header.rs
@@ -64,11 +64,12 @@ pub fn lower(
             i32_ty,
         });
 
-    let mut target = ConversionTarget::new();
-    target.add_illegal_op("adt", "struct_new");
-    target.add_illegal_op("adt", "variant_new");
+    let target = ConversionTarget::new()
+        .illegal_op("adt", "struct_new")
+        .illegal_op("adt", "variant_new");
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .with_target(target)
+        .apply_partial_conversion(ctx, module)
         .expect("adt_rc_header should remove ADT constructors it owns");
 }
 

--- a/crates/tribute-passes/src/native/adt_rc_header.rs
+++ b/crates/tribute-passes/src/native/adt_rc_header.rs
@@ -26,7 +26,7 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::rewriter::PatternRewriter;
 use trunk_ir::rewrite::type_converter::TypeConverter;
-use trunk_ir::rewrite::{Module, PatternApplicator, RewritePattern};
+use trunk_ir::rewrite::{ConversionTarget, Module, PatternApplicator, RewritePattern};
 use trunk_ir::types::TypeDataBuilder;
 
 /// Name of the runtime allocation function.
@@ -64,7 +64,12 @@ pub fn lower(
             i32_ty,
         });
 
-    applicator.apply_partial(ctx, module);
+    let mut target = ConversionTarget::new();
+    target.add_illegal_op("adt", "struct_new");
+    target.add_illegal_op("adt", "variant_new");
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("adt_rc_header should remove ADT constructors it owns");
 }
 
 /// Pattern for `adt.struct_new(fields...)` -> heap allocation + RC header + stores.

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -240,11 +240,12 @@ pub fn lower(ctx: &mut IrContext, module: Module, analysis: &NativeConstAnalysis
         });
     }
 
-    let mut target = ConversionTarget::new();
-    target.add_illegal_op("adt", "bytes_const");
-    target.add_illegal_op("adt", "string_const");
+    let target = ConversionTarget::new()
+        .illegal_op("adt", "bytes_const")
+        .illegal_op("adt", "string_const");
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .with_target(target)
+        .apply_partial_conversion(ctx, module)
         .expect("const_to_native should remove native constant operations it owns");
 }
 

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -25,7 +25,7 @@ use trunk_ir::dialect::core as arena_core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -240,7 +240,12 @@ pub fn lower(ctx: &mut IrContext, module: Module, analysis: &NativeConstAnalysis
         });
     }
 
-    applicator.apply_partial(ctx, module);
+    let mut target = ConversionTarget::new();
+    target.add_illegal_op("adt", "bytes_const");
+    target.add_illegal_op("adt", "string_const");
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("const_to_native should remove native constant operations it owns");
 }
 
 /// Emit clif ops to allocate an RC-managed TributeBytes from a rodata symbol.

--- a/crates/tribute-passes/src/native/intrinsic_to_native.rs
+++ b/crates/tribute-passes/src/native/intrinsic_to_native.rs
@@ -34,8 +34,7 @@ pub fn lower(ctx: &mut IrContext, module: Module) {
                 intrinsic_names: intrinsic_names.clone(),
             });
 
-    let mut target = ConversionTarget::new();
-    target.add_dynamic_check(move |ctx, op| {
+    let target = ConversionTarget::new().dynamic_check(move |ctx, op| {
         if let Ok(call_op) = arena_func::Call::from_op(ctx, op)
             && intrinsic_names.contains(&call_op.callee(ctx))
         {
@@ -57,7 +56,8 @@ pub fn lower(ctx: &mut IrContext, module: Module) {
     });
 
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .with_target(target)
+        .apply_partial_conversion(ctx, module)
         .expect("intrinsic_to_native should remove native intrinsics it owns");
 }
 

--- a/crates/tribute-passes/src/native/intrinsic_to_native.rs
+++ b/crates/tribute-passes/src/native/intrinsic_to_native.rs
@@ -15,7 +15,8 @@ use trunk_ir::dialect::mem;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionTarget, LegalityCheck, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -26,10 +27,38 @@ pub fn lower(ctx: &mut IrContext, module: Module) {
     let intrinsic_names: HashSet<Symbol> = [Symbol::from_dynamic("__bytes_get_or_panic")].into();
 
     let mut applicator = PatternApplicator::new(TypeConverter::new());
-    applicator = applicator
-        .add_pattern(BytesGetOrPanicPattern)
-        .add_pattern(BytesIntrinsicFuncDeclPattern { intrinsic_names });
-    applicator.apply_partial(ctx, module);
+    applicator =
+        applicator
+            .add_pattern(BytesGetOrPanicPattern)
+            .add_pattern(BytesIntrinsicFuncDeclPattern {
+                intrinsic_names: intrinsic_names.clone(),
+            });
+
+    let mut target = ConversionTarget::new();
+    target.add_dynamic_check(move |ctx, op| {
+        if let Ok(call_op) = arena_func::Call::from_op(ctx, op)
+            && intrinsic_names.contains(&call_op.callee(ctx))
+        {
+            return Some(LegalityCheck::Illegal);
+        }
+
+        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+            let attrs = &ctx.op(op).attributes;
+            let is_intrinsic = matches!(
+                attrs.get(&Symbol::new("abi")),
+                Some(Attribute::String(s)) if s == "intrinsic"
+            );
+            if is_intrinsic && intrinsic_names.contains(&func_op.sym_name(ctx)) {
+                return Some(LegalityCheck::Illegal);
+            }
+        }
+
+        None
+    });
+
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("intrinsic_to_native should remove native intrinsics it owns");
 }
 
 /// Pattern that lowers `func.call @__bytes_get_or_panic(bytes, index)` to

--- a/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
+++ b/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
@@ -149,22 +149,18 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         })
         .add_pattern(UnboxBoolPattern { i32_ty });
 
-    applicator.apply_partial(ctx, module);
+    let target = tribute_rt_to_clif_target();
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("tribute_rt_to_clif should remove all illegal tribute_rt operations");
+}
 
-    // Verify: tribute_rt.* ops (except retain/release) should be gone
+fn tribute_rt_to_clif_target() -> ConversionTarget {
     let mut target = ConversionTarget::new();
     target.add_illegal_dialect("tribute_rt");
     target.add_legal_op("tribute_rt", "retain");
     target.add_legal_op("tribute_rt", "release");
-
-    if let Some(body) = module.body(ctx) {
-        let illegal = target.verify(ctx, body);
-        assert!(
-            illegal.is_empty(),
-            "lower (tribute_rt_to_clif): unconverted tribute_rt.* ops remain: {:?}",
-            illegal,
-        );
-    }
+    target
 }
 
 // =============================================================================

--- a/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
+++ b/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
@@ -151,16 +151,16 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
 
     let target = tribute_rt_to_clif_target();
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .with_target(target)
+        .apply_partial_conversion(ctx, module)
         .expect("tribute_rt_to_clif should remove all illegal tribute_rt operations");
 }
 
 fn tribute_rt_to_clif_target() -> ConversionTarget {
-    let mut target = ConversionTarget::new();
-    target.add_illegal_dialect("tribute_rt");
-    target.add_legal_op("tribute_rt", "retain");
-    target.add_legal_op("tribute_rt", "release");
-    target
+    ConversionTarget::new()
+        .illegal_dialect("tribute_rt")
+        .legal_op("tribute_rt", "retain")
+        .legal_op("tribute_rt", "release")
 }
 
 // =============================================================================

--- a/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
@@ -34,7 +34,7 @@ use trunk_ir::dialect::core as arena_core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::types::TypeDataBuilder;
 
@@ -46,14 +46,10 @@ use trunk_ir::types::TypeDataBuilder;
 /// The `type_converter` parameter is used to determine field sizes for
 /// layout computation.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    use trunk_ir::rewrite::ConversionTarget;
-
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("adt");
+    let target = adt_to_clif_target();
 
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(target)
+        .with_target(adt_to_clif_target())
         .add_pattern(StructGetPattern)
         .add_pattern(StructSetPattern)
         .add_pattern(VariantIsPattern)
@@ -62,7 +58,24 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(RefNullPattern)
         .add_pattern(RefCastPattern)
         .add_pattern(RefIsNullPattern);
-    applicator.apply_partial(ctx, module);
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("adt_to_clif should remove all illegal ADT operations it owns");
+}
+
+fn adt_to_clif_target() -> ConversionTarget {
+    let mut target = ConversionTarget::new();
+    target.add_legal_dialect("clif");
+    target.add_illegal_dialect("adt");
+    target.add_legal_op("adt", "struct_new");
+    target.add_legal_op("adt", "variant_new");
+    target.add_legal_op("adt", "array_new");
+    target.add_legal_op("adt", "array_get");
+    target.add_legal_op("adt", "array_set");
+    target.add_legal_op("adt", "array_len");
+    target.add_legal_op("adt", "string_const");
+    target.add_legal_op("adt", "bytes_const");
+    target
 }
 
 fn intern_i32_type(ctx: &mut IrContext) -> TypeRef {

--- a/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
@@ -46,10 +46,8 @@ use trunk_ir::types::TypeDataBuilder;
 /// The `type_converter` parameter is used to determine field sizes for
 /// layout computation.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    let target = adt_to_clif_target();
-
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(adt_to_clif_target())
+        .with_auto_type_conversion(true)
         .add_pattern(StructGetPattern)
         .add_pattern(StructSetPattern)
         .add_pattern(VariantIsPattern)
@@ -57,25 +55,25 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(VariantGetPattern)
         .add_pattern(RefNullPattern)
         .add_pattern(RefCastPattern)
-        .add_pattern(RefIsNullPattern);
+        .add_pattern(RefIsNullPattern)
+        .with_target(adt_to_clif_target());
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .apply_partial_conversion(ctx, module)
         .expect("adt_to_clif should remove all illegal ADT operations it owns");
 }
 
 fn adt_to_clif_target() -> ConversionTarget {
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("adt");
-    target.add_legal_op("adt", "struct_new");
-    target.add_legal_op("adt", "variant_new");
-    target.add_legal_op("adt", "array_new");
-    target.add_legal_op("adt", "array_get");
-    target.add_legal_op("adt", "array_set");
-    target.add_legal_op("adt", "array_len");
-    target.add_legal_op("adt", "string_const");
-    target.add_legal_op("adt", "bytes_const");
-    target
+    ConversionTarget::new()
+        .legal_dialect("clif")
+        .illegal_dialect("adt")
+        .legal_op("adt", "struct_new")
+        .legal_op("adt", "variant_new")
+        .legal_op("adt", "array_new")
+        .legal_op("adt", "array_get")
+        .legal_op("adt", "array_set")
+        .legal_op("adt", "array_len")
+        .legal_op("adt", "string_const")
+        .legal_op("adt", "bytes_const")
 }
 
 fn intern_i32_type(ctx: &mut IrContext) -> TypeRef {

--- a/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
@@ -15,27 +15,32 @@ use trunk_ir::dialect::clif as arena_clif;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 /// Lower arith dialect to clif dialect.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    use trunk_ir::rewrite::ConversionTarget;
-
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("arith");
+    let target = arith_to_clif_target();
 
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(target)
+        .with_target(arith_to_clif_target())
         .add_pattern(ArithConstPattern)
         .add_pattern(ArithBinOpPattern)
         .add_pattern(ArithCmpPattern)
         .add_pattern(ArithNegPattern)
         .add_pattern(ArithBitwisePattern)
         .add_pattern(ArithConversionPattern);
-    applicator.apply_partial(ctx, module);
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("arith_to_clif should remove all illegal arith operations");
+}
+
+fn arith_to_clif_target() -> ConversionTarget {
+    let mut target = ConversionTarget::new();
+    target.add_legal_dialect("clif");
+    target.add_illegal_dialect("arith");
+    target
 }
 
 /// Classify arena type into integer vs float category (for clif lowering).

--- a/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
@@ -21,26 +21,24 @@ use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 /// Lower arith dialect to clif dialect.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    let target = arith_to_clif_target();
-
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(arith_to_clif_target())
+        .with_auto_type_conversion(true)
         .add_pattern(ArithConstPattern)
         .add_pattern(ArithBinOpPattern)
         .add_pattern(ArithCmpPattern)
         .add_pattern(ArithNegPattern)
         .add_pattern(ArithBitwisePattern)
-        .add_pattern(ArithConversionPattern);
+        .add_pattern(ArithConversionPattern)
+        .with_target(arith_to_clif_target());
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .apply_partial_conversion(ctx, module)
         .expect("arith_to_clif should remove all illegal arith operations");
 }
 
 fn arith_to_clif_target() -> ConversionTarget {
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("arith");
-    target
+    ConversionTarget::new()
+        .legal_dialect("clif")
+        .illegal_dialect("arith")
 }
 
 /// Classify arena type into integer vs float category (for clif lowering).

--- a/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
@@ -16,22 +16,20 @@ use trunk_ir::rewrite::{
 
 /// Lower cf dialect to clif dialect.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    let target = cf_to_clif_target();
-
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(cf_to_clif_target())
+        .with_auto_type_conversion(true)
         .add_pattern(CfBrPattern)
-        .add_pattern(CfCondBrPattern);
+        .add_pattern(CfCondBrPattern)
+        .with_target(cf_to_clif_target());
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .apply_partial_conversion(ctx, module)
         .expect("cf_to_clif should remove all illegal cf operations");
 }
 
 fn cf_to_clif_target() -> ConversionTarget {
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("cf");
-    target
+    ConversionTarget::new()
+        .legal_dialect("clif")
+        .illegal_dialect("cf")
 }
 
 /// Pattern: `cf.br` -> `clif.jump`

--- a/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
@@ -11,22 +11,27 @@ use trunk_ir::dialect::cf as arena_cf;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 
 /// Lower cf dialect to clif dialect.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    use trunk_ir::rewrite::ConversionTarget;
+    let target = cf_to_clif_target();
 
+    let applicator = PatternApplicator::new(type_converter)
+        .with_target(cf_to_clif_target())
+        .add_pattern(CfBrPattern)
+        .add_pattern(CfCondBrPattern);
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("cf_to_clif should remove all illegal cf operations");
+}
+
+fn cf_to_clif_target() -> ConversionTarget {
     let mut target = ConversionTarget::new();
     target.add_legal_dialect("clif");
     target.add_illegal_dialect("cf");
-
-    let applicator = PatternApplicator::new(type_converter)
-        .with_target(target)
-        .add_pattern(CfBrPattern)
-        .add_pattern(CfCondBrPattern);
-    applicator.apply_partial(ctx, module);
+    target
 }
 
 /// Pattern: `cf.br` -> `clif.jump`

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -26,27 +26,25 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
     adapt_closure_structs(ctx, module);
 
     // Phase 2: Lower func dialect to clif dialect
-    let target = func_to_clif_target();
-
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(func_to_clif_target())
+        .with_auto_type_conversion(true)
         .add_pattern(FuncFuncPattern)
         .add_pattern(FuncCallPattern)
         .add_pattern(FuncCallIndirectPattern)
         .add_pattern(FuncReturnPattern)
         .add_pattern(FuncTailCallPattern)
         .add_pattern(FuncUnreachablePattern)
-        .add_pattern(FuncConstantPattern);
+        .add_pattern(FuncConstantPattern)
+        .with_target(func_to_clif_target());
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .apply_partial_conversion(ctx, module)
         .expect("func_to_clif should remove all illegal func operations");
 }
 
 fn func_to_clif_target() -> ConversionTarget {
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("func");
-    target
+    ConversionTarget::new()
+        .legal_dialect("clif")
+        .illegal_dialect("func")
 }
 
 fn adapt_closure_structs(ctx: &mut IrContext, module: Module) {

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -16,24 +16,20 @@ use trunk_ir::dialect::func as arena_func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::types::Attribute;
 
 /// Lower func dialect to clif dialect.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    use trunk_ir::rewrite::ConversionTarget;
-
     // Phase 1: Adapt closure structs for native backend
     adapt_closure_structs(ctx, module);
 
     // Phase 2: Lower func dialect to clif dialect
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("func");
+    let target = func_to_clif_target();
 
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(target)
+        .with_target(func_to_clif_target())
         .add_pattern(FuncFuncPattern)
         .add_pattern(FuncCallPattern)
         .add_pattern(FuncCallIndirectPattern)
@@ -41,7 +37,16 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(FuncTailCallPattern)
         .add_pattern(FuncUnreachablePattern)
         .add_pattern(FuncConstantPattern);
-    applicator.apply_partial(ctx, module);
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("func_to_clif should remove all illegal func operations");
+}
+
+fn func_to_clif_target() -> ConversionTarget {
+    let mut target = ConversionTarget::new();
+    target.add_legal_dialect("clif");
+    target.add_illegal_dialect("func");
+    target
 }
 
 fn adapt_closure_structs(ctx: &mut IrContext, module: Module) {

--- a/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
@@ -9,22 +9,27 @@ use trunk_ir::dialect::mem;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 
 /// Lower mem dialect to clif dialect.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    use trunk_ir::rewrite::ConversionTarget;
+    let target = mem_to_clif_target();
 
+    let applicator = PatternApplicator::new(type_converter)
+        .with_target(mem_to_clif_target())
+        .add_pattern(MemLoadPattern)
+        .add_pattern(MemStorePattern);
+    applicator
+        .apply_partial_conversion(ctx, module, &target)
+        .expect("mem_to_clif should remove all illegal mem operations");
+}
+
+fn mem_to_clif_target() -> ConversionTarget {
     let mut target = ConversionTarget::new();
     target.add_legal_dialect("clif");
     target.add_illegal_dialect("mem");
-
-    let applicator = PatternApplicator::new(type_converter)
-        .with_target(target)
-        .add_pattern(MemLoadPattern)
-        .add_pattern(MemStorePattern);
-    applicator.apply_partial(ctx, module);
+    target
 }
 
 struct MemLoadPattern;

--- a/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
@@ -14,22 +14,20 @@ use trunk_ir::rewrite::{
 
 /// Lower mem dialect to clif dialect.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    let target = mem_to_clif_target();
-
     let applicator = PatternApplicator::new(type_converter)
-        .with_target(mem_to_clif_target())
+        .with_auto_type_conversion(true)
         .add_pattern(MemLoadPattern)
-        .add_pattern(MemStorePattern);
+        .add_pattern(MemStorePattern)
+        .with_target(mem_to_clif_target());
     applicator
-        .apply_partial_conversion(ctx, module, &target)
+        .apply_partial_conversion(ctx, module)
         .expect("mem_to_clif should remove all illegal mem operations");
 }
 
 fn mem_to_clif_target() -> ConversionTarget {
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_illegal_dialect("mem");
-    target
+    ConversionTarget::new()
+        .legal_dialect("clif")
+        .illegal_dialect("mem")
 }
 
 struct MemLoadPattern;

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -71,16 +71,10 @@ pub struct PatternApplicator {
     patterns: Vec<Box<dyn RewritePattern>>,
     max_iterations: usize,
     type_converter: TypeConverter,
-    /// Optional conversion target for legality checks.
-    /// When set, legal operations are skipped for cast insertion and pattern matching.
-    target: Option<ConversionTarget>,
+    /// Conversion target used for legality-aware rewriting and verification.
+    target: ConversionTarget,
     /// Whether to automatically convert block argument types and insert
     /// `unrealized_conversion_cast` for operand type mismatches.
-    ///
-    /// This is automatically enabled when a conversion target is set via
-    /// `with_target()`, since dialect conversion always implies type conversion.
-    /// Non-conversion passes that only use the type converter for pattern queries
-    /// should leave this disabled (the default).
     auto_type_conversion: bool,
 }
 
@@ -91,21 +85,20 @@ impl PatternApplicator {
             patterns: Vec::new(),
             max_iterations: 10,
             type_converter,
-            target: None,
+            target: ConversionTarget::default(),
             auto_type_conversion: false,
         }
     }
 
-    /// Set the conversion target for legality-aware processing.
-    ///
-    /// When a target is set, the applicator skips cast insertion and
-    /// pattern matching for operations that are already legal.
-    /// Also enables automatic type conversion (block arg conversion +
-    /// cast insertion).
+    /// Set the conversion target for legality-aware rewriting and verification.
     pub fn with_target(mut self, target: ConversionTarget) -> Self {
-        self.target = Some(target);
-        self.auto_type_conversion = true;
+        self.target = target;
         self
+    }
+
+    /// Mutably access the configured conversion target.
+    pub fn conversion_target_mut(&mut self) -> &mut ConversionTarget {
+        &mut self.target
     }
 
     /// Add a rewrite pattern.
@@ -128,10 +121,8 @@ impl PatternApplicator {
     ///
     /// When enabled, block argument types are converted and
     /// `unrealized_conversion_cast` ops are inserted for operand type
-    /// mismatches before pattern matching.  This is automatically enabled
-    /// by [`with_target()`](Self::with_target), but can also be set
-    /// independently for passes that need type conversion without a
-    /// conversion target.
+    /// mismatches before pattern matching. This is independent of conversion
+    /// target legality and must be enabled explicitly by passes that need it.
     pub fn with_auto_type_conversion(mut self, enable: bool) -> Self {
         self.auto_type_conversion = enable;
         self
@@ -148,50 +139,9 @@ impl PatternApplicator {
         &self.type_converter
     }
 
-    /// Apply patterns using partial conversion semantics.
-    ///
-    /// Verification fails only for operations that are explicitly illegal in
-    /// the target. Unknown operations may remain for later conversion passes.
-    pub fn apply(
-        &self,
-        ctx: &mut IrContext,
-        module: Module,
-        target: &ConversionTarget,
-    ) -> Result<ApplyResult, Vec<IllegalOp>> {
-        self.apply_partial_conversion(ctx, module, target)
-    }
-
-    /// Apply patterns using partial conversion semantics.
-    ///
-    /// Verification fails only for operations that are explicitly illegal in
-    /// the target. Unknown operations may remain for later conversion passes.
-    pub fn apply_partial_conversion(
-        &self,
-        ctx: &mut IrContext,
-        module: Module,
-        target: &ConversionTarget,
-    ) -> Result<ApplyResult, Vec<IllegalOp>> {
-        let result = self.apply_partial(ctx, module);
-        result.verify(ctx, module, target)?;
-        Ok(result)
-    }
-
-    /// Apply patterns using full conversion semantics.
-    ///
-    /// Verification fails for both explicitly illegal operations and unknown
-    /// operations. Use this at named pipeline boundaries.
-    pub fn apply_full_conversion(
-        &self,
-        ctx: &mut IrContext,
-        module: Module,
-        target: &ConversionTarget,
-    ) -> Result<ApplyResult, Vec<IllegalOp>> {
-        let result = self.apply_partial(ctx, module);
-        result.verify_full(ctx, module, target)?;
-        Ok(result)
-    }
-
     /// Apply patterns without verification.
+    ///
+    /// The configured target still skips operations classified as legal.
     pub fn apply_partial(&self, ctx: &mut IrContext, module: Module) -> ApplyResult {
         let mut total_changes = 0;
         let mut iterations = 0;
@@ -214,6 +164,34 @@ impl PatternApplicator {
             total_changes,
             reached_fixpoint: false,
         }
+    }
+
+    /// Apply patterns using partial conversion semantics.
+    ///
+    /// Verification fails only for operations that are explicitly illegal in
+    /// the target. Unknown operations may remain for later conversion passes.
+    pub fn apply_partial_conversion(
+        &self,
+        ctx: &mut IrContext,
+        module: Module,
+    ) -> Result<ApplyResult, Vec<IllegalOp>> {
+        let result = self.apply_partial(ctx, module);
+        result.verify(ctx, module, &self.target)?;
+        Ok(result)
+    }
+
+    /// Apply patterns using full conversion semantics.
+    ///
+    /// Verification fails for both explicitly illegal operations and unknown
+    /// operations. Use this at named pipeline boundaries.
+    pub fn apply_full_conversion(
+        &self,
+        ctx: &mut IrContext,
+        module: Module,
+    ) -> Result<ApplyResult, Vec<IllegalOp>> {
+        let result = self.apply_partial(ctx, module);
+        result.verify_full(ctx, module, &self.target)?;
+        Ok(result)
     }
 
     /// Run a single iteration over all operations.
@@ -290,9 +268,8 @@ impl PatternApplicator {
             }
 
             // Skip cast insertion and pattern matching for legal operations
-            let is_legal = self.target.as_ref().is_some_and(|t| {
-                t.has_constraints() && t.is_legal(ctx, op) == LegalityCheck::Legal
-            });
+            let is_legal = self.target.has_constraints()
+                && self.target.is_legal(ctx, op) == LegalityCheck::Legal;
 
             if !is_legal {
                 // Step 2: Insert conversion casts for operand type mismatches.
@@ -439,7 +416,10 @@ mod tests {
         target.add_legal_dialect("test");
         target.add_illegal_op("test", "source");
 
-        let result = applicator.apply(&mut ctx, module, &target).unwrap();
+        let result = applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
         assert!(result.reached_fixpoint);
         assert_eq!(result.total_changes, 1);
 
@@ -472,7 +452,10 @@ mod tests {
         let applicator = PatternApplicator::new(TypeConverter::new()).add_pattern(RenamePattern);
 
         let target = ConversionTarget::new();
-        applicator.apply(&mut ctx, module, &target).unwrap();
+        applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
 
         // op2's operand should now point to the replacement op's result
         let ops = module.ops(&ctx);
@@ -495,11 +478,47 @@ mod tests {
         let applicator = PatternApplicator::new(TypeConverter::new());
         let target = ConversionTarget::new();
 
-        let failures = match applicator.apply_full_conversion(&mut ctx, module, &target) {
+        let failures = match applicator
+            .with_target(target)
+            .apply_full_conversion(&mut ctx, module)
+        {
             Ok(_) => panic!("full conversion should reject unknown ops"),
             Err(failures) => failures,
         };
         assert_eq!(failures.len(), 1);
         assert_eq!(failures[0].legality, LegalityCheck::Unknown);
+    }
+
+    #[test]
+    fn mutable_conversion_target_skips_legal_ops() {
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let op_data = OperationDataBuilder::new(loc, Symbol::new("test"), Symbol::new("source"))
+            .result(i32_ty)
+            .build(&mut ctx);
+        let op = ctx.create_op(op_data);
+        let module = make_module(&mut ctx, loc, vec![op]);
+
+        let mut applicator =
+            PatternApplicator::new(TypeConverter::new()).add_pattern(RenamePattern);
+        applicator
+            .conversion_target_mut()
+            .add_legal_op("test", "source");
+
+        let result = applicator
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
+
+        assert_eq!(result.total_changes, 0);
+        assert_eq!(ctx.op(module.ops(&ctx)[0]).name, Symbol::new("source"));
+    }
+
+    #[test]
+    fn conversion_target_does_not_enable_auto_type_conversion() {
+        let applicator = PatternApplicator::new(TypeConverter::new());
+        let applicator = applicator.with_target(ConversionTarget::new());
+
+        assert!(!applicator.auto_type_conversion);
     }
 }

--- a/crates/trunk-ir/src/rewrite/conversion_target.rs
+++ b/crates/trunk-ir/src/rewrite/conversion_target.rs
@@ -70,6 +70,39 @@ impl ConversionTarget {
         }
     }
 
+    /// Mark an entire dialect as legal and return the updated target.
+    pub fn legal_dialect(mut self, dialect: &str) -> Self {
+        self.add_legal_dialect(dialect);
+        self
+    }
+
+    /// Mark an entire dialect as illegal and return the updated target.
+    pub fn illegal_dialect(mut self, dialect: &str) -> Self {
+        self.add_illegal_dialect(dialect);
+        self
+    }
+
+    /// Mark a specific operation as legal and return the updated target.
+    pub fn legal_op(mut self, dialect: &str, op_name: &str) -> Self {
+        self.add_legal_op(dialect, op_name);
+        self
+    }
+
+    /// Mark a specific operation as illegal and return the updated target.
+    pub fn illegal_op(mut self, dialect: &str, op_name: &str) -> Self {
+        self.add_illegal_op(dialect, op_name);
+        self
+    }
+
+    /// Add a dynamic legality check and return the updated target.
+    pub fn dynamic_check(
+        mut self,
+        f: impl Fn(&IrContext, OpRef) -> Option<LegalityCheck> + 'static,
+    ) -> Self {
+        self.add_dynamic_check(f);
+        self
+    }
+
     /// Mark an entire dialect as legal.
     pub fn add_legal_dialect(&mut self, dialect: &str) {
         self.legal_dialects.insert(Symbol::from_dynamic(dialect));
@@ -268,6 +301,19 @@ mod tests {
         let target = ConversionTarget::new();
 
         assert_eq!(target.is_legal(&ctx, op), LegalityCheck::Unknown);
+    }
+
+    #[test]
+    fn fluent_rules_preserve_operation_precedence() {
+        let (mut ctx, loc) = test_ctx();
+        let allowed = make_op(&mut ctx, loc, Symbol::new("test"), Symbol::new("allowed"));
+        let rejected = make_op(&mut ctx, loc, Symbol::new("test"), Symbol::new("rejected"));
+        let target = ConversionTarget::new()
+            .illegal_dialect("test")
+            .legal_op("test", "allowed");
+
+        assert_eq!(target.is_legal(&ctx, allowed), LegalityCheck::Legal);
+        assert_eq!(target.is_legal(&ctx, rejected), LegalityCheck::Illegal);
     }
 
     #[test]

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -344,7 +344,10 @@ mod tests {
         let applicator = PatternApplicator::new(tc).add_pattern(FuncSignatureConversionPattern);
         let target = ConversionTarget::new();
 
-        let result = applicator.apply(&mut ctx, module, &target).unwrap();
+        let result = applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
         assert!(result.reached_fixpoint);
         // 1 block arg converted by applicator + 1 pattern match
         assert!(result.total_changes >= 1);
@@ -383,7 +386,10 @@ mod tests {
         let applicator = PatternApplicator::new(tc).add_pattern(FuncSignatureConversionPattern);
         let target = ConversionTarget::new();
 
-        let result = applicator.apply(&mut ctx, module, &target).unwrap();
+        let result = applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
         assert!(result.reached_fixpoint);
         assert_eq!(result.total_changes, 0);
     }
@@ -402,7 +408,10 @@ mod tests {
         let applicator = PatternApplicator::new(tc).add_pattern(WasmFuncSignatureConversionPattern);
         let target = ConversionTarget::new();
 
-        let result = applicator.apply(&mut ctx, module, &target).unwrap();
+        let result = applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
         assert!(result.reached_fixpoint);
         // 2 block args converted by applicator + 1 pattern match
         assert!(result.total_changes >= 1);
@@ -439,7 +448,10 @@ mod tests {
         let applicator = PatternApplicator::new(tc).add_pattern(FuncSignatureConversionPattern);
         let target = ConversionTarget::new();
 
-        let result = applicator.apply(&mut ctx, module, &target).unwrap();
+        let result = applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
         // 1 block arg converted + 1 pattern match
         assert!(result.total_changes >= 1);
 
@@ -465,7 +477,10 @@ mod tests {
         let applicator = PatternApplicator::new(tc).add_pattern(WasmFuncSignatureConversionPattern);
         let target = ConversionTarget::new();
 
-        let result = applicator.apply(&mut ctx, module, &target).unwrap();
+        let result = applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
         // Pattern should not match due to arity mismatch.
         // Block arg type still gets converted by the applicator.
         assert!(result.reached_fixpoint);
@@ -491,7 +506,10 @@ mod tests {
         let applicator = PatternApplicator::new(tc).add_pattern(FuncSignatureConversionPattern);
         let target = ConversionTarget::new();
 
-        let result = applicator.apply(&mut ctx, module, &target).unwrap();
+        let result = applicator
+            .with_target(target)
+            .apply_partial_conversion(&mut ctx, module)
+            .unwrap();
         // Pattern should not match due to arity mismatch.
         // Block arg type still gets converted by the applicator.
         assert!(result.reached_fixpoint);

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -10,6 +10,8 @@ the boundaries they claim to establish.
 | ---- | ---- |
 | Pass shape | Dialect-specific passes, not one monolithic lowerer |
 | Rewriting | `PatternApplicator` fixpoint rewrites |
+| Conversion | One configured target controls rewriting and verification |
+| Type adaptation | Explicit opt-in, independent of conversion legality |
 | State | Precomputed analyses or immutable plans, not mutable pass state |
 | Boundaries | `ConversionTarget` verification, not `Module<Phase>` types |
 
@@ -29,8 +31,9 @@ pipeline boundaries instead of open-coding legality rules per pass.
 ## Pattern Rewriting
 
 Patterns match one operation family and mutate through `PatternRewriter`.
-`PatternApplicator` walks nested regions, applies patterns to a fixpoint, and
-optionally performs conversion-target-aware type adaptation.
+`PatternApplicator` walks nested regions and applies patterns to a fixpoint. Its
+conversion target controls legality-aware rewriting and final verification.
+Type adaptation is enabled separately when a pass needs it.
 
 Rules:
 


### PR DESCRIPTION
## Summary
- Switch native and backend lowering passes from partial rewrite application to explicit partial conversion with conversion targets.
- Add pass-specific legality checks so each lowering step asserts the ops it owns are removed.
- Centralize target construction in helper functions and tighten the remaining legal/illegal op sets.

## Testing
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized legality-aware lowering across multiple compiler passes to run conversions under a configured legality policy.
  * Centralized per-dialect legality setup into shared helpers, reducing duplication and improving consistency.
  * Added stronger checks during lowering to ensure all operations owned by each pass are properly eliminated.
* **Tests**
  * Updated rewrite and signature-conversion tests to use the new partial-conversion flow.
  * Extended coverage for legality precedence and conversion-target behavior.
* **Documentation**
  * Clarified lowering design decisions around how conversion targets control rewriting/verification and how type adaptation is enabled separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->