### PR TITLE
Fix pass failure lowering across effect and backend rewrites

### DIFF
--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -29,7 +29,7 @@ use trunk_ir::dialect::adt;
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
 use trunk_ir::ops::{DialectOp, DialectType};
-use trunk_ir::pass::Pass;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, erase_op,
@@ -637,7 +637,8 @@ impl Pass for LowerClosures {
         "lower-closures"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
         lower_closures(ctx, target.into());
+        Ok(())
     }
 }

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -12,7 +12,7 @@ use trunk_ir::dialect::arith;
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectOp;
-use trunk_ir::pass::Pass;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
@@ -46,8 +46,9 @@ impl Pass for LowerIntrinsicToArith {
         "lower-intrinsic-to-arith"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
         lower_intrinsic_to_arith(ctx, target.into());
+        Ok(())
     }
 }
 

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -28,7 +28,7 @@ use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{adt, arith, core, func};
 use trunk_ir::ops::DialectOp;
-use trunk_ir::pass::Pass;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, erase_op,
@@ -80,8 +80,9 @@ impl Pass for LowerAbilityPerform {
         "lower-ability-perform"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
         lower_ability_perform(ctx, target.into());
+        Ok(())
     }
 }
 

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -29,7 +29,7 @@ use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, core, func};
 use trunk_ir::ir_mapping::IrMapping;
 use trunk_ir::ops::DialectOp;
-use trunk_ir::pass::Pass;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{Module, erase_op};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
@@ -73,8 +73,9 @@ impl Pass for LowerClosureLambda {
         "lower-closure-lambda"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
         lower_closure_lambda(ctx, target.into());
+        Ok(())
     }
 }
 

--- a/crates/tribute-passes/src/lower_handle_dispatch.rs
+++ b/crates/tribute-passes/src/lower_handle_dispatch.rs
@@ -12,10 +12,11 @@ use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{core, scf};
 use trunk_ir::ir_mapping::IrMapping;
 use trunk_ir::ops::DialectOp;
-use trunk_ir::pass::Pass;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
-    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 use trunk_ir::types::Location;
 
@@ -32,20 +33,15 @@ pub fn ability_lowered_target() -> ConversionTarget {
 ///
 /// The final partial conversion rejects every residual `ability.*` operation
 /// while allowing unknown operations owned by later lowering stages.
-pub(crate) fn lower_handle_dispatch(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_handle_dispatch(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), ConversionError> {
     let applicator = PatternApplicator::new(TypeConverter::new())
         .with_target(ability_lowered_target())
         .add_pattern(LowerHandleDispatchPattern);
-    applicator
-        .apply_partial_conversion(ctx, module)
-        .unwrap_or_else(|failures| {
-            let errors: Vec<String> = failures.into_iter().map(|op| op.to_string()).collect();
-            panic!(
-                "IR conversion failed for boundary {ABILITY_LOWERED_BOUNDARY} with {} error(s):\n  - {}",
-                errors.len(),
-                errors.join("\n  - ")
-            );
-        });
+    applicator.apply_partial_conversion(ctx, module, ABILITY_LOWERED_BOUNDARY)?;
+    Ok(())
 }
 
 /// PassManager-friendly wrapper for [`lower_handle_dispatch`].
@@ -58,8 +54,8 @@ impl Pass for LowerHandleDispatch {
         "lower-handle-dispatch"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
-        lower_handle_dispatch(ctx, target.into());
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
+        lower_handle_dispatch(ctx, target.into()).map_err(Into::into)
     }
 }
 
@@ -175,9 +171,11 @@ fn inline_done_body(
 mod tests {
     use super::*;
     use insta::assert_snapshot;
+    use trunk_ir::Symbol;
     use trunk_ir::context::IrContext;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
+    use trunk_ir::rewrite::LegalityCheck;
 
     /// Basic handle_dispatch with a done handler that passes through the result.
     #[test]
@@ -205,7 +203,7 @@ mod tests {
 }"#,
         );
 
-        lower_handle_dispatch(&mut ctx, module);
+        lower_handle_dispatch(&mut ctx, module).unwrap();
 
         let ir_text = print_module(&ctx, module.op());
         assert_snapshot!(ir_text);
@@ -236,7 +234,7 @@ mod tests {
 }"#,
         );
 
-        lower_handle_dispatch(&mut ctx, module);
+        lower_handle_dispatch(&mut ctx, module).unwrap();
 
         let ir_text = print_module(&ctx, module.op());
         assert_snapshot!(ir_text);
@@ -264,7 +262,7 @@ mod tests {
 }"#,
         );
 
-        lower_handle_dispatch(&mut ctx, module);
+        lower_handle_dispatch(&mut ctx, module).unwrap();
 
         let ir_text = print_module(&ctx, module.op());
         assert_snapshot!(ir_text);
@@ -283,7 +281,7 @@ mod tests {
 }"#,
         );
 
-        lower_handle_dispatch(&mut ctx, module);
+        lower_handle_dispatch(&mut ctx, module).unwrap();
     }
 
     #[test]
@@ -299,18 +297,13 @@ mod tests {
 }"#,
         );
 
-        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            lower_handle_dispatch(&mut ctx, module);
-        }))
-        .expect_err("residual ability operation should fail final conversion");
-        let message = panic
-            .downcast_ref::<String>()
-            .map(String::as_str)
-            .or_else(|| panic.downcast_ref::<&str>().copied())
-            .expect("conversion failure should use a string panic payload");
+        let error = lower_handle_dispatch(&mut ctx, module)
+            .expect_err("residual ability operation should fail final conversion");
 
-        assert!(message.contains("ability-lowered"));
-        assert!(message.contains("ability.perform"));
-        assert!(message.contains("Illegal"));
+        assert_eq!(error.boundary(), "ability-lowered");
+        assert_eq!(error.operations().len(), 1);
+        assert_eq!(error.operations()[0].dialect, Symbol::new("ability"));
+        assert_eq!(error.operations()[0].name, Symbol::new("perform"));
+        assert_eq!(error.operations()[0].legality, LegalityCheck::Illegal);
     }
 }

--- a/crates/tribute-passes/src/native/adt_rc_header.rs
+++ b/crates/tribute-passes/src/native/adt_rc_header.rs
@@ -26,7 +26,9 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::rewriter::PatternRewriter;
 use trunk_ir::rewrite::type_converter::TypeConverter;
-use trunk_ir::rewrite::{ConversionTarget, Module, PatternApplicator, RewritePattern};
+use trunk_ir::rewrite::{
+    ConversionError, ConversionTarget, Module, PatternApplicator, RewritePattern,
+};
 use trunk_ir::types::TypeDataBuilder;
 
 /// Name of the runtime allocation function.
@@ -40,7 +42,7 @@ pub fn lower(
     module: Module,
     type_converter: TypeConverter,
     rtti_map: &HashMap<TypeRef, u32>,
-) {
+) -> Result<(), ConversionError> {
     // Pre-intern types
     let ptr_ty = arena_core::ptr(ctx).as_type_ref();
     let i64_ty = ctx
@@ -69,8 +71,8 @@ pub fn lower(
         .illegal_op("adt", "variant_new");
     applicator
         .with_target(target)
-        .apply_partial_conversion(ctx, module)
-        .expect("adt_rc_header should remove ADT constructors it owns");
+        .apply_partial_conversion(ctx, module, "adt-rc-header")?;
+    Ok(())
 }
 
 /// Pattern for `adt.struct_new(fields...)` -> heap allocation + RC header + stores.
@@ -440,7 +442,7 @@ mod tests {
         let rtti = crate::native::rtti::generate_rtti(ctx, module, &tc);
 
         // Run adt_rc_header pass
-        lower(ctx, module, tc, &rtti.type_to_idx);
+        lower(ctx, module, tc, &rtti.type_to_idx).unwrap();
 
         print_module(ctx, module.op())
     }

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -25,7 +25,8 @@ use trunk_ir::dialect::core as arena_core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
-    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -206,9 +207,13 @@ pub fn analyze_consts(ctx: &IrContext, module: Module) -> NativeConstAnalysis {
 ///
 /// `adt.string_const("hello")` becomes the above bytes lowering +
 /// `adt.variant_new(type=String, tag=Leaf, %bytes_payload)`
-pub fn lower(ctx: &mut IrContext, module: Module, analysis: &NativeConstAnalysis) {
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    analysis: &NativeConstAnalysis,
+) -> Result<(), ConversionError> {
     if analysis.is_empty() {
-        return;
+        return Ok(());
     }
 
     let ptr_ty = arena_core::ptr(ctx).as_type_ref();
@@ -245,8 +250,8 @@ pub fn lower(ctx: &mut IrContext, module: Module, analysis: &NativeConstAnalysis
         .illegal_op("adt", "string_const");
     applicator
         .with_target(target)
-        .apply_partial_conversion(ctx, module)
-        .expect("const_to_native should remove native constant operations it owns");
+        .apply_partial_conversion(ctx, module, "const-to-native")?;
+    Ok(())
 }
 
 /// Emit clif ops to allocate an RC-managed TributeBytes from a rodata symbol.

--- a/crates/tribute-passes/src/native/intrinsic_to_native.rs
+++ b/crates/tribute-passes/src/native/intrinsic_to_native.rs
@@ -15,15 +15,15 @@ use trunk_ir::dialect::mem;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
 use trunk_ir::rewrite::{
-    ConversionTarget, LegalityCheck, Module, PatternApplicator, PatternRewriter, RewritePattern,
-    TypeConverter,
+    ConversionError, ConversionTarget, LegalityCheck, Module, PatternApplicator, PatternRewriter,
+    RewritePattern, TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 /// Lower bytes intrinsic calls to native mem operations.
 ///
 /// Also removes `func.func` declarations for bytes intrinsics.
-pub fn lower(ctx: &mut IrContext, module: Module) {
+pub fn lower(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError> {
     let intrinsic_names: HashSet<Symbol> = [Symbol::from_dynamic("__bytes_get_or_panic")].into();
 
     let mut applicator = PatternApplicator::new(TypeConverter::new());
@@ -57,8 +57,8 @@ pub fn lower(ctx: &mut IrContext, module: Module) {
 
     applicator
         .with_target(target)
-        .apply_partial_conversion(ctx, module)
-        .expect("intrinsic_to_native should remove native intrinsics it owns");
+        .apply_partial_conversion(ctx, module, "intrinsic-to-native")?;
+    Ok(())
 }
 
 /// Pattern that lowers `func.call @__bytes_get_or_panic(bytes, index)` to

--- a/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
+++ b/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
@@ -26,7 +26,9 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::rewriter::PatternRewriter;
 use trunk_ir::rewrite::type_converter::TypeConverter;
-use trunk_ir::rewrite::{ConversionTarget, Module, PatternApplicator, RewritePattern};
+use trunk_ir::rewrite::{
+    ConversionError, ConversionTarget, Module, PatternApplicator, RewritePattern,
+};
 use trunk_ir::types::{Location, TypeDataBuilder};
 
 /// Name of the runtime allocation function.
@@ -105,7 +107,11 @@ fn box_value(
 ///
 /// This is a partial lowering: only box/unbox operations are converted.
 /// `retain`/`release` ops pass through (handled by a future RC lowering pass).
-pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: TypeConverter,
+) -> Result<(), ConversionError> {
     // Pre-intern types for patterns
     let ptr_ty = arena_core::ptr(ctx).as_type_ref();
     let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
@@ -152,8 +158,8 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
     let target = tribute_rt_to_clif_target();
     applicator
         .with_target(target)
-        .apply_partial_conversion(ctx, module)
-        .expect("tribute_rt_to_clif should remove all illegal tribute_rt operations");
+        .apply_partial_conversion(ctx, module, "tribute-rt-to-clif")?;
+    Ok(())
 }
 
 fn tribute_rt_to_clif_target() -> ConversionTarget {
@@ -451,7 +457,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
         let (tc, _) = crate::native::type_converter::native_type_converter(&mut ctx);
-        lower(&mut ctx, module, tc);
+        lower(&mut ctx, module, tc).unwrap();
         print_module(&ctx, module.op())
     }
 
@@ -571,7 +577,7 @@ mod tests {
 }"#;
         let module = parse_test_module(&mut ctx, ir);
         let (tc, _) = crate::native::type_converter::native_type_converter(&mut ctx);
-        lower(&mut ctx, module, tc);
+        lower(&mut ctx, module, tc).unwrap();
 
         let output = print_module(&ctx, module.op());
         assert!(

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -19,7 +19,7 @@ use trunk_ir::dialect::arith;
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
 use trunk_ir::ops::{DialectOp, DialectType};
-use trunk_ir::pass::Pass;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{Module, erase_op};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
@@ -970,8 +970,9 @@ impl Pass for ResolveEvidenceDispatch {
         "resolve-evidence-dispatch"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
         resolve_evidence_dispatch(ctx, target.into());
+        Ok(())
     }
 }
 

--- a/crates/tribute-passes/src/tail_resumptive.rs
+++ b/crates/tribute-passes/src/tail_resumptive.rs
@@ -15,7 +15,7 @@ use trunk_ir::context::IrContext;
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::scf;
 use trunk_ir::ops::DialectOp;
-use trunk_ir::pass::Pass;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
@@ -154,8 +154,9 @@ impl Pass for ConvertTailResumptive {
         "convert-tail-resumptive"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
         convert_tail_resumptive(ctx, target.into());
+        Ok(())
     }
 }
 

--- a/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
@@ -34,7 +34,8 @@ use trunk_ir::dialect::core as arena_core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
-    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 use trunk_ir::types::TypeDataBuilder;
 
@@ -45,7 +46,11 @@ use trunk_ir::types::TypeDataBuilder;
 ///
 /// The `type_converter` parameter is used to determine field sizes for
 /// layout computation.
-pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: TypeConverter,
+) -> Result<(), ConversionError> {
     let applicator = PatternApplicator::new(type_converter)
         .with_auto_type_conversion(true)
         .add_pattern(StructGetPattern)
@@ -57,9 +62,8 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(RefCastPattern)
         .add_pattern(RefIsNullPattern)
         .with_target(adt_to_clif_target());
-    applicator
-        .apply_partial_conversion(ctx, module)
-        .expect("adt_to_clif should remove all illegal ADT operations it owns");
+    applicator.apply_partial_conversion(ctx, module, "adt-to-clif")?;
+    Ok(())
 }
 
 fn adt_to_clif_target() -> ConversionTarget {
@@ -394,7 +398,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
         let type_converter = TypeConverter::new();
-        super::lower(&mut ctx, module, type_converter);
+        super::lower(&mut ctx, module, type_converter).unwrap();
         print_module(&ctx, module.op())
     }
 

--- a/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
@@ -15,12 +15,17 @@ use trunk_ir::dialect::clif as arena_clif;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
-    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 /// Lower arith dialect to clif dialect.
-pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: TypeConverter,
+) -> Result<(), ConversionError> {
     let applicator = PatternApplicator::new(type_converter)
         .with_auto_type_conversion(true)
         .add_pattern(ArithConstPattern)
@@ -30,9 +35,8 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(ArithBitwisePattern)
         .add_pattern(ArithConversionPattern)
         .with_target(arith_to_clif_target());
-    applicator
-        .apply_partial_conversion(ctx, module)
-        .expect("arith_to_clif should remove all illegal arith operations");
+    applicator.apply_partial_conversion(ctx, module, "arith-to-clif")?;
+    Ok(())
 }
 
 fn arith_to_clif_target() -> ConversionTarget {
@@ -505,7 +509,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
         let type_converter = TypeConverter::new();
-        super::lower(&mut ctx, module, type_converter);
+        super::lower(&mut ctx, module, type_converter).unwrap();
         print_module(&ctx, module.op())
     }
 

--- a/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
@@ -11,19 +11,23 @@ use trunk_ir::dialect::cf as arena_cf;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
 use trunk_ir::rewrite::{
-    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 
 /// Lower cf dialect to clif dialect.
-pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: TypeConverter,
+) -> Result<(), ConversionError> {
     let applicator = PatternApplicator::new(type_converter)
         .with_auto_type_conversion(true)
         .add_pattern(CfBrPattern)
         .add_pattern(CfCondBrPattern)
         .with_target(cf_to_clif_target());
-    applicator
-        .apply_partial_conversion(ctx, module)
-        .expect("cf_to_clif should remove all illegal cf operations");
+    applicator.apply_partial_conversion(ctx, module, "cf-to-clif")?;
+    Ok(())
 }
 
 fn cf_to_clif_target() -> ConversionTarget {

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -16,12 +16,17 @@ use trunk_ir::dialect::func as arena_func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
-    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 use trunk_ir::types::Attribute;
 
 /// Lower func dialect to clif dialect.
-pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: TypeConverter,
+) -> Result<(), ConversionError> {
     // Phase 1: Adapt closure structs for native backend
     adapt_closure_structs(ctx, module);
 
@@ -36,9 +41,8 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(FuncUnreachablePattern)
         .add_pattern(FuncConstantPattern)
         .with_target(func_to_clif_target());
-    applicator
-        .apply_partial_conversion(ctx, module)
-        .expect("func_to_clif should remove all illegal func operations");
+    applicator.apply_partial_conversion(ctx, module, "func-to-clif")?;
+    Ok(())
 }
 
 fn func_to_clif_target() -> ConversionTarget {
@@ -428,7 +432,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
         let type_converter = TypeConverter::new();
-        super::lower(&mut ctx, module, type_converter);
+        super::lower(&mut ctx, module, type_converter).unwrap();
         print_module(&ctx, module.op())
     }
 

--- a/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
@@ -9,19 +9,23 @@ use trunk_ir::dialect::mem;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
 use trunk_ir::rewrite::{
-    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
 };
 
 /// Lower mem dialect to clif dialect.
-pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: TypeConverter,
+) -> Result<(), ConversionError> {
     let applicator = PatternApplicator::new(type_converter)
         .with_auto_type_conversion(true)
         .add_pattern(MemLoadPattern)
         .add_pattern(MemStorePattern)
         .with_target(mem_to_clif_target());
-    applicator
-        .apply_partial_conversion(ctx, module)
-        .expect("mem_to_clif should remove all illegal mem operations");
+    applicator.apply_partial_conversion(ctx, module, "mem-to-clif")?;
+    Ok(())
 }
 
 fn mem_to_clif_target() -> ConversionTarget {

--- a/crates/trunk-ir/src/pass.rs
+++ b/crates/trunk-ir/src/pass.rs
@@ -18,10 +18,13 @@
 //! let mut pm = PassManager::new();
 //! pm.add_pass(MyModulePass);
 //! pm.nest::<func::Func>().add_pass(MyFunctionPass);
-//! pm.run(&mut ctx, root_module);
+//! pm.run(&mut ctx, root_module)?;
 //! ```
 use std::any::Any;
+use std::error::Error;
 use std::ops::ControlFlow;
+
+use derive_more::{Display, Error};
 
 use crate::context::IrContext;
 use crate::dialect::core;
@@ -46,41 +49,97 @@ pub trait Pass {
 
     fn name(&self) -> &'static str;
 
-    fn run(&mut self, ctx: &mut IrContext, target: Self::Target);
+    fn run(&mut self, ctx: &mut IrContext, target: Self::Target) -> PassRunResult;
 }
 
 /// Object-safe view of [`Pass`] used inside [`PassManager`] storage.
 trait ErasedPass<T: DialectOp> {
     fn name(&self) -> &'static str;
-    fn run(&mut self, ctx: &mut IrContext, target: T);
+    fn run(&mut self, ctx: &mut IrContext, target: T) -> PassRunResult;
 }
 
 impl<P: Pass> ErasedPass<P::Target> for P {
     fn name(&self) -> &'static str {
         Pass::name(self)
     }
-    fn run(&mut self, ctx: &mut IrContext, target: P::Target) {
+    fn run(&mut self, ctx: &mut IrContext, target: P::Target) -> PassRunResult {
         Pass::run(self, ctx, target)
     }
 }
 
+/// Source error returned by an individual [`Pass`] before manager context is attached.
+pub type PassRunError = Box<dyn Error + Send + Sync + 'static>;
+
+/// Result returned by an individual [`Pass`] before manager context is attached.
+pub type PassRunResult = Result<(), PassRunError>;
+
 /// Error returned by a verifier when a pass leaves the IR in an invalid state.
 ///
-/// The [`PassManager`] turns an `Err` into a panic that names the offending
-/// pass, so the verifier itself only describes *what* is wrong (typically a
-/// summary of one or more validation failures), not *how* to react.
-#[derive(Debug)]
+/// The verifier only describes *what* is wrong. [`PassManager`] attaches the
+/// offending pass name and returns a [`PassError`].
+#[derive(Debug, Display, Error)]
+#[display("{message}")]
 pub struct VerifyError {
     pub message: String,
 }
 
-impl std::fmt::Display for VerifyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.message)
+/// Stage of a pass-manager failure.
+#[derive(Debug, Display)]
+pub enum PassErrorKind {
+    #[display("failed: {_0}")]
+    Execution(PassRunError),
+    #[display("broke an IR invariant: {_0}")]
+    Verification(VerifyError),
+}
+
+/// Error returned by [`PassManager`] with the failing pass name attached.
+#[derive(Debug)]
+pub struct PassError {
+    pass_name: &'static str,
+    kind: PassErrorKind,
+}
+
+impl PassError {
+    fn execution(pass_name: &'static str, error: PassRunError) -> Self {
+        Self {
+            pass_name,
+            kind: PassErrorKind::Execution(error),
+        }
+    }
+
+    fn verification(pass_name: &'static str, error: VerifyError) -> Self {
+        Self {
+            pass_name,
+            kind: PassErrorKind::Verification(error),
+        }
+    }
+
+    pub fn pass_name(&self) -> &'static str {
+        self.pass_name
+    }
+
+    pub fn kind(&self) -> &PassErrorKind {
+        &self.kind
     }
 }
 
-impl std::error::Error for VerifyError {}
+impl std::fmt::Display for PassError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "pass `{}` {}", self.pass_name, self.kind)
+    }
+}
+
+impl Error for PassError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            PassErrorKind::Execution(error) => Some(error.as_ref()),
+            PassErrorKind::Verification(error) => Some(error),
+        }
+    }
+}
+
+/// Result returned by pass-manager APIs.
+pub type PassResult<T = ()> = Result<T, PassError>;
 
 /// Verifier callback invoked after each pass to check IR invariants.
 ///
@@ -88,7 +147,7 @@ impl std::error::Error for VerifyError {}
 /// the violation. In debug builds, callers typically register a checker (e.g.
 /// wrapping [`crate::validation::validate_use_chains`]) so any pass that breaks
 /// an invariant is blamed immediately rather than masked by a later pass; the
-/// [`PassManager`] panics with the offending pass's name on `Err`.
+/// [`PassManager`] returns a [`PassError`] with the offending pass's name.
 type VerifierFn = dyn Fn(&IrContext, OpRef) -> Result<(), VerifyError>;
 
 /// Observation-only hook invoked after each pass, mirroring the verifier's
@@ -115,7 +174,12 @@ struct PostPassHooks<'a> {
 /// manager once per target-typed op. Wraps [`PassManager<T>`] for any
 /// `T: DialectOp + 'static`.
 trait NestedRunner: Any {
-    fn run(&mut self, ctx: &mut IrContext, parent_op: OpRef, hooks: PostPassHooks<'_>);
+    fn run(
+        &mut self,
+        ctx: &mut IrContext,
+        parent_op: OpRef,
+        hooks: PostPassHooks<'_>,
+    ) -> PassResult;
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
@@ -124,7 +188,12 @@ struct TypedNested<T: DialectOp + 'static> {
 }
 
 impl<T: DialectOp + 'static> NestedRunner for TypedNested<T> {
-    fn run(&mut self, ctx: &mut IrContext, parent_op: OpRef, hooks: PostPassHooks<'_>) {
+    fn run(
+        &mut self,
+        ctx: &mut IrContext,
+        parent_op: OpRef,
+        hooks: PostPassHooks<'_>,
+    ) -> PassResult {
         // Collect targets fresh on each entry so passes that erase or
         // append ops don't leave stale refs in our worklist.
         let targets = collect_targets::<T>(ctx, parent_op);
@@ -134,8 +203,9 @@ impl<T: DialectOp + 'static> NestedRunner for TypedNested<T> {
             if !T::matches(ctx, target.op_ref()) {
                 continue;
             }
-            self.pm.run_on_target_with(ctx, target, hooks);
+            self.pm.run_on_target_with(ctx, target, hooks)?;
         }
+        Ok(())
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
@@ -258,7 +328,7 @@ impl<Root: DialectOp + 'static> PassManager<Root> {
     /// Run all registered passes (and recursively nested managers) on
     /// `target`. Pass-level ordering is registration order; nested
     /// managers run after the parent's own passes.
-    pub fn run(&mut self, ctx: &mut IrContext, target: Root) {
+    pub fn run(&mut self, ctx: &mut IrContext, target: Root) -> PassResult {
         // Split-borrow the hooks from `passes`/`nested` so we can hand
         // their references down to nested runners while iterating the pass
         // vec mutably.
@@ -272,12 +342,17 @@ impl<Root: DialectOp + 'static> PassManager<Root> {
             verifier: verifier.as_deref(),
             instrumentation: instrumentation.as_deref(),
         };
-        Self::run_passes(ctx, target, passes, nested, hooks);
+        Self::run_passes(ctx, target, passes, nested, hooks)
     }
 
     /// Entry point used by nested managers, threading parent-supplied hooks
     /// through the call tree.
-    fn run_on_target_with(&mut self, ctx: &mut IrContext, target: Root, parent: PostPassHooks<'_>) {
+    fn run_on_target_with(
+        &mut self,
+        ctx: &mut IrContext,
+        target: Root,
+        parent: PostPassHooks<'_>,
+    ) -> PassResult {
         let Self {
             passes,
             nested,
@@ -291,7 +366,7 @@ impl<Root: DialectOp + 'static> PassManager<Root> {
             verifier: verifier.as_deref().or(parent.verifier),
             instrumentation: instrumentation.as_deref().or(parent.instrumentation),
         };
-        Self::run_passes(ctx, target, passes, nested, hooks);
+        Self::run_passes(ctx, target, passes, nested, hooks)
     }
 
     fn run_passes(
@@ -300,7 +375,7 @@ impl<Root: DialectOp + 'static> PassManager<Root> {
         passes: &mut [Box<dyn ErasedPass<Root>>],
         nested: &mut [Box<dyn NestedRunner>],
         hooks: PostPassHooks<'_>,
-    ) {
+    ) -> PassResult {
         // Capture attachment state at entry so we can detect a pass that
         // detaches/erases its own target (parent_block went from Some→None).
         // A top-level root op (e.g. `core.module`) has no parent block by
@@ -310,12 +385,13 @@ impl<Root: DialectOp + 'static> PassManager<Root> {
         for pass in passes.iter_mut() {
             let span = tracing::debug_span!("pass", name = pass.name());
             let _enter = span.enter();
-            pass.run(ctx, target);
+            pass.run(ctx, target)
+                .map_err(|failure| PassError::execution(pass.name(), failure))?;
             if !target_still_alive::<Root>(ctx, target.op_ref(), pre_attached) {
                 // The pass erased or retagged its own target. Subsequent
                 // passes, the verifier, and nested managers would all see
                 // a stale OpRef, so stop dispatch here.
-                return;
+                return Ok(());
             }
             if let Some(inst) = hooks.instrumentation {
                 inst(ctx, pass.name(), target.op_ref());
@@ -323,13 +399,14 @@ impl<Root: DialectOp + 'static> PassManager<Root> {
             if let Some(v) = hooks.verifier
                 && let Err(e) = v(ctx, target.op_ref())
             {
-                panic!("pass `{}` broke an IR invariant: {}", pass.name(), e);
+                return Err(PassError::verification(pass.name(), e));
             }
         }
         let parent_op = target.op_ref();
         for n in nested.iter_mut() {
-            n.run(ctx, parent_op, hooks);
+            n.run(ctx, parent_op, hooks)?;
         }
+        Ok(())
     }
 }
 
@@ -345,6 +422,17 @@ mod tests {
     use crate::symbol::Symbol;
     use crate::types::{Attribute, Location};
     use smallvec::smallvec;
+
+    #[derive(Debug)]
+    struct TestFailure(&'static str);
+
+    impl std::fmt::Display for TestFailure {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    impl Error for TestFailure {}
 
     fn test_ctx() -> (IrContext, Location) {
         let mut ctx = IrContext::new();
@@ -402,8 +490,9 @@ mod tests {
         fn name(&self) -> &'static str {
             "recorder"
         }
-        fn run(&mut self, _ctx: &mut IrContext, _target: T) {
+        fn run(&mut self, _ctx: &mut IrContext, _target: T) -> PassRunResult {
             self.order.borrow_mut().push(self.tag);
+            Ok(())
         }
     }
 
@@ -413,6 +502,31 @@ mod tests {
     ) -> Recorder<T> {
         Recorder {
             tag,
+            order,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    struct FailingPass<T: DialectOp> {
+        order: Rc<RefCell<Vec<&'static str>>>,
+        _marker: std::marker::PhantomData<T>,
+    }
+
+    impl<T: DialectOp + 'static> Pass for FailingPass<T> {
+        type Target = T;
+
+        fn name(&self) -> &'static str {
+            "failing"
+        }
+
+        fn run(&mut self, _ctx: &mut IrContext, _target: T) -> PassRunResult {
+            self.order.borrow_mut().push("failing");
+            Err(Box::new(TestFailure("boom")))
+        }
+    }
+
+    fn failing<T: DialectOp + 'static>(order: Rc<RefCell<Vec<&'static str>>>) -> FailingPass<T> {
+        FailingPass {
             order,
             _marker: std::marker::PhantomData,
         }
@@ -442,9 +556,10 @@ mod tests {
         fn name(&self) -> &'static str {
             "counting"
         }
-        fn run(&mut self, _ctx: &mut IrContext, _target: T) {
+        fn run(&mut self, _ctx: &mut IrContext, _target: T) -> PassRunResult {
             self.count += 1;
             self.mirror.set(self.count);
+            Ok(())
         }
     }
 
@@ -456,7 +571,7 @@ mod tests {
         let count = Rc::new(Cell::new(0));
         let mut pm = PassManager::new();
         pm.add_pass(CountingPass::<core::Module>::new(count.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         assert_eq!(count.get(), 1);
     }
@@ -473,7 +588,7 @@ mod tests {
         let mut pm = PassManager::new();
         pm.nest::<func::Func>()
             .add_pass(CountingPass::<func::Func>::new(count.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         assert_eq!(count.get(), 3);
     }
@@ -487,7 +602,7 @@ mod tests {
         let mut pm = PassManager::new();
         pm.nest::<func::Func>()
             .add_pass(CountingPass::<func::Func>::new(count.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         assert_eq!(count.get(), 0);
     }
@@ -503,7 +618,7 @@ mod tests {
         pm.add_pass(recorder::<core::Module>("module", order.clone()));
         pm.nest::<func::Func>()
             .add_pass(recorder::<func::Func>("func", order.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         assert_eq!(*order.borrow(), vec!["module", "func"]);
     }
@@ -523,11 +638,12 @@ mod tests {
             fn name(&self) -> &'static str {
                 "erase-first"
             }
-            fn run(&mut self, ctx: &mut IrContext, target: core::Module) {
+            fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
                 let region = target.body(ctx);
                 let block = ctx.region(region).blocks[0];
                 let first_op = ctx.block(block).ops[0];
                 crate::rewrite::erase_op(ctx, first_op);
+                Ok(())
             }
         }
 
@@ -536,7 +652,7 @@ mod tests {
         pm.add_pass(EraseFirst);
         pm.nest::<func::Func>()
             .add_pass(CountingPass::<func::Func>::new(count.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // One func remains after erase; counting pass sees it once.
         assert_eq!(count.get(), 1);
@@ -558,8 +674,9 @@ mod tests {
             fn name(&self) -> &'static str {
                 "erase-self"
             }
-            fn run(&mut self, ctx: &mut IrContext, target: func::Func) {
+            fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
                 crate::rewrite::erase_op(ctx, target.op_ref());
+                Ok(())
             }
         }
 
@@ -574,7 +691,7 @@ mod tests {
             .with_instrumentation(move |_ctx, _name, _op| {
                 inv_clone.set(inv_clone.get() + 1);
             });
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // EraseSelf runs once per func (f1, f2) and invalidates the target
         // each time, so the following pass and the instrumentation hook must
@@ -597,7 +714,7 @@ mod tests {
         let mut pm = PassManager::new();
         pm.nest::<func::Func>()
             .add_pass(CountingPass::<func::Func>::new(mirror.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // Mirror reflects the pass's internal counter after 3 calls,
         // proving `&mut self` mutation is observable across invocations.
@@ -619,7 +736,7 @@ mod tests {
         pm.with_instrumentation(move |_ctx, _name, _op| {
             inv_clone.set(inv_clone.get() + 1);
         });
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // Instrumentation fires once after each of the 2 module-level passes.
         assert_eq!(invocations.get(), 2);
@@ -643,7 +760,7 @@ mod tests {
         pm.with_instrumentation(move |_ctx, _name, _op| {
             inv_clone.set(inv_clone.get() + 1);
         });
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // 1 module pass + 2 funcs * 1 nested pass = 3 instrumentation calls.
         assert_eq!(invocations.get(), 3);
@@ -656,7 +773,7 @@ mod tests {
         let (mut ctx, loc) = test_ctx();
         let module = empty_module(&mut ctx, loc);
         let mut pm: PassManager = PassManager::new();
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
     }
 
     #[test]
@@ -669,9 +786,61 @@ mod tests {
         pm.add_pass(recorder::<core::Module>("a", order.clone()));
         pm.add_pass(recorder::<core::Module>("b", order.clone()));
         pm.add_pass(recorder::<core::Module>("c", order.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         assert_eq!(*order.borrow(), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn pass_failure_stops_later_passes() {
+        let (mut ctx, loc) = test_ctx();
+        let module = empty_module(&mut ctx, loc);
+
+        let order: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+        let instrumentation_count = Rc::new(Cell::new(0));
+        let verifier_count = Rc::new(Cell::new(0));
+        let instrumentation_count_clone = instrumentation_count.clone();
+        let verifier_count_clone = verifier_count.clone();
+        let mut pm = PassManager::new();
+        pm.add_pass(recorder::<core::Module>("before", order.clone()));
+        pm.add_pass(failing::<core::Module>(order.clone()));
+        pm.add_pass(recorder::<core::Module>("after", order.clone()));
+        pm.with_instrumentation(move |_ctx, _name, _op| {
+            instrumentation_count_clone.set(instrumentation_count_clone.get() + 1);
+        });
+        pm.with_verifier(move |_ctx, _op| {
+            verifier_count_clone.set(verifier_count_clone.get() + 1);
+            Ok(())
+        });
+
+        let error = pm.run(&mut ctx, module).unwrap_err();
+
+        assert_eq!(error.pass_name(), "failing");
+        assert!(matches!(error.kind(), PassErrorKind::Execution(_)));
+        assert_eq!(error.to_string(), "pass `failing` failed: boom");
+        assert_eq!(*order.borrow(), vec!["before", "failing"]);
+        assert_eq!(instrumentation_count.get(), 1);
+        assert_eq!(verifier_count.get(), 1);
+    }
+
+    #[test]
+    fn nested_pass_failure_stops_targets_and_sibling_managers() {
+        let (mut ctx, loc) = test_ctx();
+        let module = empty_module(&mut ctx, loc);
+        append_func(&mut ctx, module, loc, "f1");
+        append_func(&mut ctx, module, loc, "f2");
+
+        let order: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+        let mut pm = PassManager::new();
+        pm.nest::<func::Func>()
+            .add_pass(failing::<func::Func>(order.clone()));
+        pm.nest::<func::Func>()
+            .add_pass(recorder::<func::Func>("sibling", order.clone()));
+
+        let error = pm.run(&mut ctx, module).unwrap_err();
+
+        assert_eq!(error.pass_name(), "failing");
+        assert_eq!(*order.borrow(), vec!["failing"]);
     }
 
     #[test]
@@ -687,7 +856,7 @@ mod tests {
             .add_pass(recorder::<func::Func>("first", order.clone()));
         pm.nest::<func::Func>()
             .add_pass(recorder::<func::Func>("second", order.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // Each nested manager re-walks the module independently, so
         // labels are grouped by manager rather than interleaved per func.
@@ -717,7 +886,7 @@ mod tests {
         pm.with_instrumentation(move |_ctx, _name, _op| {
             root_clone.set(root_clone.get() + 1);
         });
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // Root instrumentation fires only for the module-level pass (1 call),
         // because the nested manager installs its own and does not inherit
@@ -746,7 +915,7 @@ mod tests {
         pm.with_instrumentation(move |_ctx, name, op| {
             seen_clone.borrow_mut().push((name.to_string(), op));
         });
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // Module pass → hook("counting", module_op), then nested manager walks
         // for func ops → hook("counting", f1), hook("counting", f2).
@@ -773,7 +942,7 @@ mod tests {
         pm.add_pass(CountingPass::<core::Module>::new(count.clone()));
         pm.nest::<func::Func>()
             .add_pass(CountingPass::<func::Func>::new(count.clone()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // Both passes ran (each holds its own counter; the mirror
         // reflects the most recent set, which here is the func pass's
@@ -782,27 +951,39 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "pass `counting` broke an IR invariant: boom")]
-    fn verifier_err_panics_naming_the_pass() {
+    fn verifier_err_returns_error_naming_the_pass() {
         let (mut ctx, loc) = test_ctx();
         let module = empty_module(&mut ctx, loc);
 
         let dummy = Rc::new(Cell::new(0));
+        let after = Rc::new(Cell::new(0));
+        let instrumentation_count = Rc::new(Cell::new(0));
+        let instrumentation_count_clone = instrumentation_count.clone();
         let mut pm = PassManager::new();
         pm.add_pass(CountingPass::<core::Module>::new(dummy.clone()));
+        pm.add_pass(CountingPass::<core::Module>::new(after.clone()));
+        pm.with_instrumentation(move |_ctx, _name, _op| {
+            instrumentation_count_clone.set(instrumentation_count_clone.get() + 1);
+        });
         pm.with_verifier(|_ctx, _op| {
             Err(VerifyError {
                 message: "boom".to_string(),
             })
         });
-        // The verifier returns Err after the pass; the PassManager must panic
-        // and name the offending pass.
-        pm.run(&mut ctx, module);
+        let error = pm.run(&mut ctx, module).unwrap_err();
+
+        assert_eq!(error.pass_name(), "counting");
+        assert!(matches!(error.kind(), PassErrorKind::Verification(_)));
+        assert_eq!(
+            error.to_string(),
+            "pass `counting` broke an IR invariant: boom"
+        );
+        assert_eq!(after.get(), 0);
+        assert_eq!(instrumentation_count.get(), 1);
     }
 
     #[test]
-    #[should_panic(expected = "pass `counting` broke an IR invariant")]
-    fn verifier_err_in_nested_pass_panics() {
+    fn verifier_err_in_nested_pass_propagates() {
         // A verifier installed on the root propagates into nested managers and
         // still fails the run when a nested pass leaves the IR invalid.
         let (mut ctx, loc) = test_ctx();
@@ -818,7 +999,13 @@ mod tests {
                 message: "nested boom".to_string(),
             })
         });
-        pm.run(&mut ctx, module);
+        let error = pm.run(&mut ctx, module).unwrap_err();
+
+        assert_eq!(error.pass_name(), "counting");
+        assert_eq!(
+            error.to_string(),
+            "pass `counting` broke an IR invariant: nested boom"
+        );
     }
 
     #[test]
@@ -834,7 +1021,7 @@ mod tests {
         pm.add_pass(recorder::<core::Module>("a", order.clone()));
         pm.add_pass(recorder::<core::Module>("b", order.clone()));
         pm.with_verifier(|_ctx, _op| Ok(()));
-        pm.run(&mut ctx, module);
+        pm.run(&mut ctx, module).unwrap();
 
         // Both module passes ran, in registration order.
         assert_eq!(*order.borrow(), vec!["a", "b"]);

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -5,7 +5,9 @@
 //! `parent_block` validity to skip deleted ops.
 
 use super::Module;
-use super::conversion_target::{ConversionMode, ConversionTarget, IllegalOp, LegalityCheck};
+use super::conversion_target::{
+    ConversionError, ConversionMode, ConversionTarget, IllegalOp, LegalityCheck,
+};
 use super::pattern::RewritePattern;
 use super::rewriter::{self, PatternRewriter};
 use super::type_converter::TypeConverter;
@@ -166,31 +168,39 @@ impl PatternApplicator {
         }
     }
 
-    /// Apply patterns using partial conversion semantics.
+    /// Apply patterns using partial conversion semantics at a named boundary.
     ///
     /// Verification fails only for operations that are explicitly illegal in
     /// the target. Unknown operations may remain for later conversion passes.
+    /// Failures are reported as [`ConversionError`] with `boundary` attached.
     pub fn apply_partial_conversion(
         &self,
         ctx: &mut IrContext,
         module: Module,
-    ) -> Result<ApplyResult, Vec<IllegalOp>> {
+        boundary: &'static str,
+    ) -> Result<ApplyResult, ConversionError> {
         let result = self.apply_partial(ctx, module);
-        result.verify(ctx, module, &self.target)?;
+        result
+            .verify(ctx, module, &self.target)
+            .map_err(|operations| ConversionError::new(boundary, operations))?;
         Ok(result)
     }
 
-    /// Apply patterns using full conversion semantics.
+    /// Apply patterns using full conversion semantics at a named boundary.
     ///
     /// Verification fails for both explicitly illegal operations and unknown
-    /// operations. Use this at named pipeline boundaries.
+    /// operations. Use this at named pipeline boundaries. Failures are reported
+    /// as [`ConversionError`] with `boundary` attached.
     pub fn apply_full_conversion(
         &self,
         ctx: &mut IrContext,
         module: Module,
-    ) -> Result<ApplyResult, Vec<IllegalOp>> {
+        boundary: &'static str,
+    ) -> Result<ApplyResult, ConversionError> {
         let result = self.apply_partial(ctx, module);
-        result.verify_full(ctx, module, &self.target)?;
+        result
+            .verify_full(ctx, module, &self.target)
+            .map_err(|operations| ConversionError::new(boundary, operations))?;
         Ok(result)
     }
 
@@ -418,7 +428,7 @@ mod tests {
 
         let result = applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
         assert!(result.reached_fixpoint);
         assert_eq!(result.total_changes, 1);
@@ -454,7 +464,7 @@ mod tests {
         let target = ConversionTarget::new();
         applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
 
         // op2's operand should now point to the replacement op's result
@@ -478,15 +488,17 @@ mod tests {
         let applicator = PatternApplicator::new(TypeConverter::new());
         let target = ConversionTarget::new();
 
-        let failures = match applicator
-            .with_target(target)
-            .apply_full_conversion(&mut ctx, module)
-        {
+        let error = match applicator.with_target(target).apply_full_conversion(
+            &mut ctx,
+            module,
+            "test-boundary",
+        ) {
             Ok(_) => panic!("full conversion should reject unknown ops"),
-            Err(failures) => failures,
+            Err(error) => error,
         };
-        assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].legality, LegalityCheck::Unknown);
+        assert_eq!(error.boundary(), "test-boundary");
+        assert_eq!(error.operations().len(), 1);
+        assert_eq!(error.operations()[0].legality, LegalityCheck::Unknown);
     }
 
     #[test]
@@ -507,7 +519,7 @@ mod tests {
             .add_legal_op("test", "source");
 
         let result = applicator
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
 
         assert_eq!(result.total_changes, 0);

--- a/crates/trunk-ir/src/rewrite/conversion_target.rs
+++ b/crates/trunk-ir/src/rewrite/conversion_target.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashSet;
 
+use derive_more::Error;
+
 use crate::context::IrContext;
 use crate::refs::OpRef;
 use crate::symbol::Symbol;
@@ -252,6 +254,45 @@ impl std::fmt::Display for IllegalOp {
             "{}.{} ({}, {:?})",
             self.dialect, self.name, self.op, self.legality
         )
+    }
+}
+
+/// Error at a named conversion boundary.
+#[derive(Debug, Error)]
+pub struct ConversionError {
+    boundary: &'static str,
+    operations: Vec<IllegalOp>,
+}
+
+impl ConversionError {
+    pub fn new(boundary: &'static str, operations: Vec<IllegalOp>) -> Self {
+        Self {
+            boundary,
+            operations,
+        }
+    }
+
+    pub fn boundary(&self) -> &'static str {
+        self.boundary
+    }
+
+    pub fn operations(&self) -> &[IllegalOp] {
+        &self.operations
+    }
+}
+
+impl std::fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "conversion boundary `{}` failed with {} error(s):",
+            self.boundary,
+            self.operations.len()
+        )?;
+        for operation in &self.operations {
+            writeln!(f, "  - {operation}")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -12,7 +12,9 @@ pub mod signature_conversion;
 pub mod type_converter;
 
 pub use applicator::{ApplyResult, PatternApplicator};
-pub use conversion_target::{ConversionMode, ConversionTarget, IllegalOp, LegalityCheck};
+pub use conversion_target::{
+    ConversionError, ConversionMode, ConversionTarget, IllegalOp, LegalityCheck,
+};
 pub use helpers::{erase_op, inline_region_blocks, split_block};
 pub use pattern::RewritePattern;
 pub use rewriter::PatternRewriter;

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -346,7 +346,7 @@ mod tests {
 
         let result = applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
         assert!(result.reached_fixpoint);
         // 1 block arg converted by applicator + 1 pattern match
@@ -388,7 +388,7 @@ mod tests {
 
         let result = applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
         assert!(result.reached_fixpoint);
         assert_eq!(result.total_changes, 0);
@@ -410,7 +410,7 @@ mod tests {
 
         let result = applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
         assert!(result.reached_fixpoint);
         // 2 block args converted by applicator + 1 pattern match
@@ -450,7 +450,7 @@ mod tests {
 
         let result = applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
         // 1 block arg converted + 1 pattern match
         assert!(result.total_changes >= 1);
@@ -479,7 +479,7 @@ mod tests {
 
         let result = applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
         // Pattern should not match due to arity mismatch.
         // Block arg type still gets converted by the applicator.
@@ -508,7 +508,7 @@ mod tests {
 
         let result = applicator
             .with_target(target)
-            .apply_partial_conversion(&mut ctx, module)
+            .apply_partial_conversion(&mut ctx, module, "test-boundary")
             .unwrap();
         // Pattern should not match due to arity mismatch.
         // Block arg type still gets converted by the applicator.

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -14,6 +14,17 @@ the boundaries they claim to establish.
 | Type adaptation | Explicit opt-in, independent of conversion legality |
 | State | Precomputed analyses or immutable plans, not mutable pass state |
 | Boundaries | `ConversionTarget` verification, not `Module<Phase>` types |
+| Failure | Structured pass errors propagated by `PassManager` |
+
+## Pass Failures
+
+Expected pass failures return a typed source through the pass `run` result; they
+do not panic. `PassManager` attaches the failing pass name as `PassError`, stops
+before later passes or nested managers, and propagates `PassResult<T>` to the
+compiler pipeline. Verifier failures use the same path.
+
+Instrumentation runs only after a pass succeeds. The verifier then runs on the
+successful result; a verifier failure stops the pipeline before further work.
 
 ## Conversion Modes
 
@@ -27,6 +38,7 @@ legal by the boundary target.
 Shared lowering passes must not call unchecked `apply_partial` when their API or
 name claims to complete a lowering stage. Use named `ConversionTarget`s for
 pipeline boundaries instead of open-coding legality rules per pass.
+Failed boundaries report `rewrite::ConversionError`.
 
 The shared effect pipeline establishes the `ability-lowered` partial boundary
 after `LowerHandleDispatch`: residual `ability.*` operations are illegal, while

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -78,27 +78,22 @@ use trunk_ir::Span;
 use trunk_ir::conversion::resolve_unrealized_casts;
 use trunk_ir::dialect::core as core_dialect;
 use trunk_ir::ops::DialectOp;
-use trunk_ir::pass::PassManager;
+use trunk_ir::pass::{PassError, PassManager, PassResult};
+use trunk_ir::rewrite::ConversionError;
 use trunk_ir::{IrContext, Module};
-/// Error when illegal operations remain after lowering.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConversionError {
-    illegal_ops: Vec<IllegalOp>,
+
+/// Error returned while dumping shared or target-specific IR.
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, derive_more::Error)]
+#[display("{message}")]
+pub struct DumpIrError {
+    message: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IllegalOp {
-    dialect: String,
-    name: String,
-}
-
-impl std::fmt::Display for ConversionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Illegal operations remain after lowering:")?;
-        for op in &self.illegal_ops {
-            writeln!(f, "  - {}.{}", op.dialect, op.name)?;
+impl From<PassError> for DumpIrError {
+    fn from(error: PassError) -> Self {
+        Self {
+            message: error.to_string(),
         }
-        Ok(())
     }
 }
 
@@ -416,15 +411,17 @@ fn compile_to_wasm(ctx: &mut IrContext, module: Module) -> WasmCompilationResult
 pub fn run_through_evidence_params(
     db: &dyn salsa::Database,
     source: SourceCst,
-) -> Option<(IrContext, Module)> {
-    let (mut ctx, m) = compile_frontend(db, source)?;
+) -> PassResult<Option<(IrContext, Module)>> {
+    let Some((mut ctx, m)) = compile_frontend(db, source) else {
+        return Ok(None);
+    };
     let core_module =
         core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
     let mut pm = PassManager::new();
     pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
         .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith);
-    pm.run(&mut ctx, core_module);
-    Some((ctx, m))
+    pm.run(&mut ctx, core_module)?;
+    Ok(Some((ctx, m)))
 }
 
 /// Run pipeline through closure lower (for testing).
@@ -434,16 +431,18 @@ pub fn run_through_evidence_params(
 pub fn run_through_closure_lower(
     db: &dyn salsa::Database,
     source: SourceCst,
-) -> Option<(IrContext, Module)> {
-    let (mut ctx, m) = compile_frontend(db, source)?;
+) -> PassResult<Option<(IrContext, Module)>> {
+    let Some((mut ctx, m)) = compile_frontend(db, source) else {
+        return Ok(None);
+    };
     let core_module =
         core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
     let mut pm = PassManager::new();
     pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
         .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
         .add_pass(tribute_passes::closure_lower::LowerClosures);
-    pm.run(&mut ctx, core_module);
-    Some((ctx, m))
+    pm.run(&mut ctx, core_module)?;
+    Ok(Some((ctx, m)))
 }
 
 // =============================================================================
@@ -457,8 +456,13 @@ pub fn run_through_closure_lower(
 ///
 /// Returns the arena session so that backend-specific pipelines can continue
 /// without a Salsa↔Arena round-trip.
-fn run_shared_pipeline(db: &dyn salsa::Database, source: SourceCst) -> Option<(IrContext, Module)> {
-    let (mut ctx, m) = compile_frontend(db, source)?;
+fn run_shared_pipeline(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+) -> PassResult<Option<(IrContext, Module)>> {
+    let Some((mut ctx, m)) = compile_frontend(db, source) else {
+        return Ok(None);
+    };
 
     // Middle-end passes, sequenced through the PassManager (#268).
     // Registration order == execution order.
@@ -480,8 +484,8 @@ fn run_shared_pipeline(db: &dyn salsa::Database, source: SourceCst) -> Option<(I
     // Debug-only regression guard: re-check use-chain consistency after every
     // shared pass. step 1+2 (#710) made this invariant hold across the shared
     // middle-end; this catches any future pass that reintroduces a leak. The
-    // verifier only reports; the PassManager panics with the offending pass's
-    // name on `Err`. Compiled out in release.
+    // verifier only reports; the PassManager returns the offending pass's name
+    // with the verification error. Compiled out in release.
     if cfg!(debug_assertions) {
         pm.with_verifier(|ctx, op| {
             let Some(module) = Module::new(ctx, op) else {
@@ -504,9 +508,9 @@ fn run_shared_pipeline(db: &dyn salsa::Database, source: SourceCst) -> Option<(I
             })
         });
     }
-    pm.run(&mut ctx, core_module);
+    pm.run(&mut ctx, core_module)?;
 
-    Some((ctx, m))
+    Ok(Some((ctx, m)))
 }
 
 /// Validate call arity and report mismatches as diagnostics.
@@ -520,10 +524,20 @@ fn validate_and_report_arity(db: &dyn salsa::Database, ctx: &IrContext, m: Modul
     }
 }
 
+fn report_pass_error(db: &dyn salsa::Database, error: &PassError) {
+    Diagnostic::new(
+        format!("Pipeline failed: {error}"),
+        Span::new(0, 0),
+        DiagnosticSeverity::Error,
+        CompilationPhase::Lowering,
+    )
+    .accumulate(db);
+}
+
 /// Lower continuation ops and run cleanup passes shared by both backends.
 ///
 /// Effects are handled via tail-call CPS through handler_dispatch closures.
-fn run_lowering_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), ConversionError> {
+fn run_lowering_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), DumpIrError> {
     // Validation runs in debug mode.
     if cfg!(debug_assertions) {
         let result = trunk_ir::validation::validate_value_integrity(ctx, m);
@@ -552,7 +566,7 @@ fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
 }
 
 /// Run the WASM target pipeline: lowering + cleanup.
-fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), ConversionError> {
+fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), DumpIrError> {
     run_lowering_pipeline(ctx, m)?;
 
     // General function inlining. The pass is single-block-only and cf-free,
@@ -566,7 +580,7 @@ fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Conver
 }
 
 /// Run the native target pipeline: lowering + evidence_to_native + cleanup.
-fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), ConversionError> {
+fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), DumpIrError> {
     run_lowering_pipeline(ctx, m)?;
 
     // General function inlining. Single-block-only (no `cf` dialect
@@ -601,8 +615,8 @@ pub fn dump_ir(
     db: &dyn salsa::Database,
     source: SourceCst,
     native: bool,
-) -> Result<String, ConversionError> {
-    let Some((mut ctx, m)) = run_shared_pipeline(db, source) else {
+) -> Result<String, DumpIrError> {
+    let Some((mut ctx, m)) = run_shared_pipeline(db, source)? else {
         return Ok(String::new());
     };
     validate_and_report_arity(db, &ctx, m);
@@ -624,7 +638,14 @@ pub fn dump_ir(
 /// Returns the raw WASM bytes on success, or `None` with diagnostics accumulated.
 #[salsa::tracked]
 pub fn compile_to_wasm_binary(db: &dyn salsa::Database, source: SourceCst) -> Option<Vec<u8>> {
-    let (mut ctx, m) = run_shared_pipeline(db, source)?;
+    let (mut ctx, m) = match run_shared_pipeline(db, source) {
+        Ok(Some(result)) => result,
+        Ok(None) => return None,
+        Err(error) => {
+            report_pass_error(db, &error);
+            return None;
+        }
+    };
     validate_and_report_arity(db, &ctx, m);
 
     if let Err(e) = run_wasm_target_pipeline(&mut ctx, m) {
@@ -681,10 +702,12 @@ fn compile_module_to_native(
     // Lower adt.string_const → adt.variant_new + bytes alloc,
     // and adt.bytes_const → clif alloc + rodata reference.
     let const_analysis = tribute_passes::native::const_to_native::analyze_consts(ctx, module);
-    tribute_passes::native::const_to_native::lower(ctx, module, &const_analysis);
+    tribute_passes::native::const_to_native::lower(ctx, module, &const_analysis)
+        .map_err(native_conversion_failure)?;
 
     // Phase -0.3 - Lower bytes intrinsic calls to mem.load operations
-    tribute_passes::native::intrinsic_to_native::lower(ctx, module);
+    tribute_passes::native::intrinsic_to_native::lower(ctx, module)
+        .map_err(native_conversion_failure)?;
 
     // Phase 0 - Lower structured control flow to CFG-based control flow
     trunk_ir::transforms::scf_to_cf::lower_scf_to_cf(ctx, module);
@@ -693,14 +716,14 @@ fn compile_module_to_native(
     {
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
-        func_to_clif::lower(ctx, module, type_converter);
+        func_to_clif::lower(ctx, module, type_converter).map_err(native_conversion_failure)?;
     }
 
     // Phase 1.5 - Lower cf dialect to clif dialect
     {
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
-        cf_to_clif::lower(ctx, module, type_converter);
+        cf_to_clif::lower(ctx, module, type_converter).map_err(native_conversion_failure)?;
     }
 
     // Phase 1.9-1.95 - RTTI + ADT RC header
@@ -713,35 +736,37 @@ fn compile_module_to_native(
             module,
             type_converter,
             &rtti_map.type_to_idx,
-        );
+        )
+        .map_err(native_conversion_failure)?;
     }
 
     // Phase 2 - Lower ADT struct access operations to clif dialect
     {
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
-        adt_to_clif::lower(ctx, module, type_converter);
+        adt_to_clif::lower(ctx, module, type_converter).map_err(native_conversion_failure)?;
     }
 
     // Phase 2.5 - Lower arith dialect to clif dialect
     {
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
-        arith_to_clif::lower(ctx, module, type_converter);
+        arith_to_clif::lower(ctx, module, type_converter).map_err(native_conversion_failure)?;
     }
 
     // Phase 2.6 - Lower mem dialect to clif dialect
     {
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
-        mem_to_clif::lower(ctx, module, type_converter);
+        mem_to_clif::lower(ctx, module, type_converter).map_err(native_conversion_failure)?;
     }
 
     // Phase 2.7-2.8 - tribute_rt_to_clif + RC insertion
     {
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
-        tribute_passes::native::tribute_rt_to_clif::lower(ctx, module, type_converter);
+        tribute_passes::native::tribute_rt_to_clif::lower(ctx, module, type_converter)
+            .map_err(native_conversion_failure)?;
         tribute_passes::native::rc_insertion::insert_rc(ctx, module);
     }
 
@@ -789,6 +814,12 @@ fn compile_module_to_native(
     emit_module_to_native(ctx, module, &rodata)
 }
 
+fn native_conversion_failure(
+    error: ConversionError,
+) -> trunk_ir_cranelift_backend::CompilationError {
+    trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string())
+}
+
 /// Compile to native object bytes.
 ///
 /// Runs the full pipeline (frontend → shared passes → native lowering → emit)
@@ -801,7 +832,14 @@ pub fn compile_to_native_binary<'db>(
     source: SourceCst,
     config: CompilationConfig,
 ) -> Option<Vec<u8>> {
-    let (mut ctx, m) = run_shared_pipeline(db, source)?;
+    let (mut ctx, m) = match run_shared_pipeline(db, source) {
+        Ok(Some(result)) => result,
+        Ok(None) => return None,
+        Err(error) => {
+            report_pass_error(db, &error);
+            return None;
+        }
+    };
     validate_and_report_arity(db, &ctx, m);
 
     if let Err(e) = run_native_target_pipeline(&mut ctx, m) {
@@ -916,8 +954,10 @@ pub fn parse_and_lower_ast<'db>(
 #[salsa::tracked]
 fn compile_ast_tracked(db: &dyn salsa::Database, source: SourceCst) {
     // Run the shared pipeline; diagnostics are accumulated as side effects
-    if let Some((ctx, m)) = run_shared_pipeline(db, source) {
-        validate_and_report_arity(db, &ctx, m);
+    match run_shared_pipeline(db, source) {
+        Ok(Some((ctx, m))) => validate_and_report_arity(db, &ctx, m),
+        Ok(None) => {}
+        Err(error) => report_pass_error(db, &error),
     }
 }
 
@@ -927,7 +967,10 @@ fn compile_ast_tracked(db: &dyn salsa::Database, source: SourceCst) {
 /// resolve-evidence passes) and returns arena IR. Does NOT run
 /// target-specific passes (WASM/native), making it suitable for
 /// diagnostic-only compilation ("none" target).
-pub fn compile_ast(db: &dyn salsa::Database, source: SourceCst) -> Option<(IrContext, Module)> {
+pub fn compile_ast(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+) -> PassResult<Option<(IrContext, Module)>> {
     run_shared_pipeline(db, source)
 }
 
@@ -945,7 +988,7 @@ pub fn compile_with_diagnostics(db: &dyn salsa::Database, source: SourceCst) -> 
         .collect();
 
     // Run the pipeline again for the actual result (Salsa memoizes, so this is cheap)
-    let module = run_shared_pipeline(db, source);
+    let module = run_shared_pipeline(db, source).ok().flatten();
 
     CompilationResult {
         module,
@@ -1025,7 +1068,7 @@ mod tests {
     fn test_full_pipeline(db: &salsa::DatabaseImpl) {
         let source = source_from_str("test.trb", "fn compute() -> Int { 42 }\nfn main() { }");
 
-        let result = compile_ast(db, source);
+        let result = compile_ast(db, source).expect("pipeline should not fail");
         assert!(result.is_some(), "Should compile successfully");
         let (ctx, m) = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));

--- a/tests/diagnostic_snapshots.rs
+++ b/tests/diagnostic_snapshots.rs
@@ -156,7 +156,6 @@ fn test() -> Point {
 // =============================================================================
 
 #[salsa_test]
-#[should_panic(expected = "IR conversion failed for boundary ability-lowered")]
 fn diag_unhandled_effect_in_main(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,
@@ -172,7 +171,6 @@ fn main() -> Int {
 "#,
     );
     let result = compile_with_diagnostics(db, source);
-    // TODO(#739): restore the diagnostic snapshot once pass failures propagate.
     assert!(!result.diagnostics.is_empty());
     insta::assert_yaml_snapshot!(result.diagnostics);
 }
@@ -198,7 +196,6 @@ fn test() ->{MyEffec} Int {
 }
 
 #[salsa_test]
-#[should_panic(expected = "IR conversion failed for boundary ability-lowered")]
 fn diag_unhandled_effect_multiple(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,
@@ -219,7 +216,6 @@ fn main() -> Nil {
 "#,
     );
     let result = compile_with_diagnostics(db, source);
-    // TODO(#739): restore the diagnostic snapshot once pass failures propagate.
     assert!(!result.diagnostics.is_empty());
     insta::assert_yaml_snapshot!(result.diagnostics);
 }

--- a/tests/e2e_add.rs
+++ b/tests/e2e_add.rs
@@ -204,7 +204,8 @@ fn main() { }
 
         // Run through evidence params to get arena IR
         let (ctx, m) = run_through_evidence_params(db, source_file)
-            .expect("run_through_evidence_params should succeed");
+            .expect("run_through_evidence_params should succeed")
+            .expect("frontend should produce a module");
 
         // Check for func.call_indirect in the module
         let has_call_indirect = check_for_call_indirect_in_module(&ctx, m);
@@ -404,7 +405,8 @@ fn main() { }
 
         // Run through evidence params to get arena IR for structural checks
         let (ctx, m) = run_through_evidence_params(db, source_file)
-            .expect("run_through_evidence_params should succeed");
+            .expect("run_through_evidence_params should succeed")
+            .expect("frontend should produce a module");
 
         // Verify the module has a lifted function (name starts with __lambda_)
         let func_dialect = Symbol::new("func");
@@ -466,7 +468,8 @@ fn main() { }
 
         // Run through evidence params to get arena IR
         let (ctx, m) = run_through_evidence_params(db, source_file)
-            .expect("run_through_evidence_params should succeed");
+            .expect("run_through_evidence_params should succeed")
+            .expect("frontend should produce a module");
 
         // Check for closure.new in the output
         let has_closure_new = check_for_closure_new_in_module(&ctx, m);
@@ -550,7 +553,8 @@ fn main() { }
 
         // Run through evidence params to get arena IR
         let (ctx, m) = run_through_evidence_params(db, source_file)
-            .expect("run_through_evidence_params should succeed");
+            .expect("run_through_evidence_params should succeed")
+            .expect("frontend should produce a module");
 
         // Check for func.call_indirect in the module
         let has_call_indirect = check_for_call_indirect_in_module(&ctx, m);
@@ -600,7 +604,8 @@ fn main() { }
 
         // Run through evidence params to get arena IR
         let (ctx, m) = run_through_evidence_params(db, source_file)
-            .expect("run_through_evidence_params should succeed");
+            .expect("run_through_evidence_params should succeed")
+            .expect("frontend should produce a module");
 
         // Check that apply function has func.call_indirect
         let has_call_indirect = check_for_call_indirect_in_module(&ctx, m);
@@ -692,7 +697,8 @@ fn main() { }
 
         // Run through closure lower to get arena IR
         let (ctx, m) = run_through_closure_lower(db, source_file)
-            .expect("run_through_closure_lower should succeed");
+            .expect("run_through_closure_lower should succeed")
+            .expect("frontend should produce a module");
 
         // Check that closure operations are lowered
         let lowered_ops = check_for_lowered_closure_ops_in_module(&ctx, m);

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -27,7 +27,7 @@ fn compile_to_ir(db: &dyn salsa::Database, code: &str, name: &str) -> (IrContext
         .expect("frontend output must be a core.module");
     let mut pm = trunk_ir::pass::PassManager::new();
     pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda);
-    pm.run(&mut ctx, core_module);
+    pm.run(&mut ctx, core_module).unwrap();
     (ctx, m)
 }
 

--- a/tests/snapshots/diagnostic_snapshots__diag_unhandled_effect_in_main.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_unhandled_effect_in_main.snap
@@ -2,6 +2,12 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
+- message: "Pipeline failed: pass `lower-handle-dispatch` failed: conversion boundary `ability-lowered` failed with 1 error(s):\n  - ability.call (op335, Illegal)\n"
+  span:
+    start: 0
+    end: 0
+  severity: Error
+  phase: Lowering
 - message: "function 'main' must return Nil, but returns `Int`"
   span:
     start: 52

--- a/tests/snapshots/diagnostic_snapshots__diag_unhandled_effect_multiple.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_unhandled_effect_multiple.snap
@@ -2,6 +2,12 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
+- message: "Pipeline failed: pass `lower-handle-dispatch` failed: conversion boundary `ability-lowered` failed with 1 error(s):\n  - ability.perform (op343, Illegal)\n"
+  span:
+    start: 0
+    end: 0
+  severity: Error
+  phase: Lowering
 - message: "function 'main' has unhandled effects: Foo, Bar"
   span:
     start: 75


### PR DESCRIPTION
## Summary
- Fix several pass-failure paths in closure, evidence, effect handler, and native lowering.
- Tighten rewrite/signature conversion plumbing in trunk-ir and the Cranelift backend.
- Update lowering docs and diagnostic snapshots for unhandled effect cases.
- Add and adjust end-to-end coverage around evidence and addition paths.

## Testing
- Added or updated snapshot coverage for diagnostic failures.
- Extended e2e and evidence-lambda tests to cover the new lowering behavior.
- Local validation of the touched pass pipeline and backend rewrites was performed as part of the test updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compilation and lowering now report structured errors instead of failing abruptly, making failures easier to understand and diagnose.

* **Bug Fixes**
  * Improved handling of partial conversions so invalid transformations are surfaced cleanly.
  * Pass execution now stops immediately on failures, reducing cascading errors and inconsistent output.
  * Diagnostic snapshots and end-to-end tests were updated for more reliable failure reporting.

* **Documentation**
  * Added clearer guidance on how pass failures are reported and how the pipeline responds to them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->