### PR TITLE
Add effect ABI dialect scaffolding and lower perform calls

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -6,12 +6,12 @@
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
-use tribute_ir::dialect::closure as arena_closure;
-use tribute_ir::dialect::tribute_rt as arena_tribute_rt;
+use tribute_ir::dialect::closure;
+use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
 use trunk_ir::SymbolVec;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::core;
 use trunk_ir::refs::{BlockRef, PathRef, TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 
@@ -423,7 +423,7 @@ impl<'db> IrLoweringCtx<'db> {
 
     /// Get the `core.nil` type.
     pub fn nil_type(&self, ir: &mut IrContext) -> TypeRef {
-        arena_core::nil(ir).as_type_ref()
+        core::nil(ir).as_type_ref()
     }
 
     /// Get the `core.i1` (bool) type.
@@ -440,19 +440,19 @@ impl<'db> IrLoweringCtx<'db> {
 
     /// Get the `core.bytes` type.
     pub fn bytes_type(&self, ir: &mut IrContext) -> TypeRef {
-        arena_core::bytes(ir).as_type_ref()
+        core::bytes(ir).as_type_ref()
     }
 
     /// Get the `tribute_rt.anyref` type.
     pub fn anyref_type(&self, ir: &mut IrContext) -> TypeRef {
-        arena_tribute_rt::anyref(ir).as_type_ref()
+        tribute_rt::anyref(ir).as_type_ref()
     }
 
     /// Create a `core.func` type with params and result.
     ///
     /// Layout follows Salsa `core::Func`: `params[0] = result, params[1..] = param_types`.
     pub fn func_type(&self, ir: &mut IrContext, params: &[TypeRef], result: TypeRef) -> TypeRef {
-        arena_core::func(ir, result, params.iter().copied()).as_type_ref()
+        core::func(ir, result, params.iter().copied()).as_type_ref()
     }
 
     /// Create a `core.ability_ref` type.
@@ -548,7 +548,7 @@ impl<'db> IrLoweringCtx<'db> {
 
     /// Create the `closure.closure` type wrapping a function type.
     pub fn closure_type(&self, ir: &mut IrContext, func_type: TypeRef) -> TypeRef {
-        arena_closure::closure(ir, func_type).as_type_ref()
+        closure::closure(ir, func_type).as_type_ref()
     }
 
     /// Check if a type is a `closure.closure` type.

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -177,7 +177,7 @@ inventory::submit! { trunk_ir::op_interface::IsolatedFromAboveOps::register("abi
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::core;
 use trunk_ir::refs::TypeRef;
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -338,7 +338,7 @@ pub fn marker_adt_type_ref(ctx: &mut IrContext) -> TypeRef {
 /// Get the canonical Evidence ADT type — `core.array(Marker)`.
 pub fn evidence_adt_type_ref(ctx: &mut IrContext) -> TypeRef {
     let marker_ty = marker_adt_type_ref(ctx);
-    arena_core::array(ctx, marker_ty).as_type_ref()
+    core::array(ctx, marker_ty).as_type_ref()
 }
 
 /// Check if a type is the marker ADT type (`adt.struct("_Marker", ...)`).
@@ -503,7 +503,7 @@ mod tests {
         let i32_ty = ctx
             .types
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
-        let other_array = arena_core::array(&mut ctx, i32_ty).as_type_ref();
+        let other_array = core::array(&mut ctx, i32_ty).as_type_ref();
         assert!(!is_evidence_type_ref(&ctx, other_array));
 
         // Non-array type should return false

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -113,6 +113,57 @@ pub fn compute_op_idx(ability_ref: Option<Symbol>, op_name: Option<Symbol>) -> u
     (hasher.finish() % 0x7FFFFFFF) as u32
 }
 
+/// Compute the stable runtime ability ID for an ability reference type.
+pub fn compute_ability_id(ctx: &IrContext, ability_ref: TypeRef) -> u32 {
+    let data = ctx.types.get(ability_ref);
+    let ability_name = match data.attrs.get(&Symbol::new("name")) {
+        Some(Attribute::Symbol(s)) => *s,
+        _ => panic!(
+            "ICE: compute_ability_id: ability type has no name: {:?}",
+            data
+        ),
+    };
+
+    let mut hash: u32 = ability_name.with_str(|s| {
+        let mut h: u32 = 0;
+        for byte in s.bytes() {
+            h = h.wrapping_mul(31).wrapping_add(byte as u32);
+        }
+        h
+    });
+
+    for &param in data.params.iter() {
+        hash = hash.wrapping_mul(37);
+        hash = hash.wrapping_add(hash_type(ctx, param));
+    }
+
+    hash
+}
+
+fn hash_type(ctx: &IrContext, ty: TypeRef) -> u32 {
+    let data = ctx.types.get(ty);
+    let mut hash: u32 = 0;
+
+    data.dialect.with_str(|s| {
+        for byte in s.bytes() {
+            hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
+        }
+    });
+
+    data.name.with_str(|s| {
+        for byte in s.bytes() {
+            hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
+        }
+    });
+
+    for &param in data.params.iter() {
+        hash = hash.wrapping_mul(37);
+        hash = hash.wrapping_add(hash_type(ctx, param));
+    }
+
+    hash
+}
+
 // === Pure operation registrations ===
 
 inventory::submit! { trunk_ir::op_interface::PureOps::register("ability", "evidence_lookup") }

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -115,53 +115,61 @@ pub fn compute_op_idx(ability_ref: Option<Symbol>, op_name: Option<Symbol>) -> u
 
 /// Compute the stable runtime ability ID for an ability reference type.
 pub fn compute_ability_id(ctx: &IrContext, ability_ref: TypeRef) -> u32 {
+    use std::hash::{Hash, Hasher};
+
     let data = ctx.types.get(ability_ref);
-    let ability_name = match data.attrs.get(&Symbol::new("name")) {
-        Some(Attribute::Symbol(s)) => *s,
+    let name = match ability_name(ctx, ability_ref) {
+        Some(s) => s,
         _ => panic!(
             "ICE: compute_ability_id: ability type has no name: {:?}",
             data
         ),
     };
 
-    let mut hash: u32 = ability_name.with_str(|s| {
-        let mut h: u32 = 0;
-        for byte in s.bytes() {
-            h = h.wrapping_mul(31).wrapping_add(byte as u32);
-        }
-        h
-    });
+    let mut hasher = rustc_hash::FxHasher::default();
+    name.hash(&mut hasher);
+    data.params.len().hash(&mut hasher);
 
     for &param in data.params.iter() {
-        hash = hash.wrapping_mul(37);
-        hash = hash.wrapping_add(hash_type(ctx, param));
+        hash_type(ctx, param).hash(&mut hasher);
     }
 
-    hash
+    hasher.finish() as u32
+}
+
+/// Return the source-level ability name attached to an ability reference type.
+pub fn ability_name(ctx: &IrContext, ability_ref: TypeRef) -> Option<Symbol> {
+    match ctx.types.get(ability_ref).attrs.get(&Symbol::new("name")) {
+        Some(Attribute::Symbol(s)) => Some(*s),
+        _ => None,
+    }
+}
+
+/// Build an `arith.const` for the stable runtime ability ID.
+pub fn ability_id_const(
+    ctx: &mut IrContext,
+    loc: Location,
+    i32_ty: TypeRef,
+    ability_ref: TypeRef,
+) -> arith::Const {
+    let ability_id = compute_ability_id(ctx, ability_ref);
+    arith::r#const(ctx, loc, i32_ty, Attribute::Int(ability_id as i128))
 }
 
 fn hash_type(ctx: &IrContext, ty: TypeRef) -> u32 {
+    use std::hash::{Hash, Hasher};
+
     let data = ctx.types.get(ty);
-    let mut hash: u32 = 0;
-
-    data.dialect.with_str(|s| {
-        for byte in s.bytes() {
-            hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
-        }
-    });
-
-    data.name.with_str(|s| {
-        for byte in s.bytes() {
-            hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
-        }
-    });
+    let mut hasher = rustc_hash::FxHasher::default();
+    data.dialect.hash(&mut hasher);
+    data.name.hash(&mut hasher);
+    data.params.len().hash(&mut hasher);
 
     for &param in data.params.iter() {
-        hash = hash.wrapping_mul(37);
-        hash = hash.wrapping_add(hash_type(ctx, param));
+        hash_type(ctx, param).hash(&mut hasher);
     }
 
-    hash
+    hasher.finish() as u32
 }
 
 // === Pure operation registrations ===
@@ -177,9 +185,10 @@ inventory::submit! { trunk_ir::op_interface::IsolatedFromAboveOps::register("abi
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
+use trunk_ir::dialect::arith;
 use trunk_ir::dialect::core;
 use trunk_ir::refs::TypeRef;
-use trunk_ir::types::{Attribute, TypeDataBuilder};
+use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 
 /// Canonical field identifiers for the `_Marker` ADT used by ability evidence.
 #[repr(u32)]

--- a/crates/tribute-ir/src/dialect/closure.rs
+++ b/crates/tribute-ir/src/dialect/closure.rs
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn test_closure_lambda_round_trip() {
         use trunk_ir::context::{BlockArgData, BlockData, RegionData};
-        use trunk_ir::dialect::func as arena_func;
+        use trunk_ir::dialect::func;
 
         let mut ctx = IrContext::new();
         let loc = dummy_location();
@@ -406,7 +406,7 @@ mod tests {
             parent_region: None,
         });
         let x_val = ctx.block_arg(entry, 0);
-        let ret_op = arena_func::r#return(&mut ctx, loc, [x_val]);
+        let ret_op = func::r#return(&mut ctx, loc, [x_val]);
         ctx.push_op(entry, ret_op.op_ref());
 
         let body_region = ctx.create_region(RegionData {

--- a/crates/tribute-ir/src/dialect/effect.rs
+++ b/crates/tribute-ir/src/dialect/effect.rs
@@ -1,0 +1,154 @@
+//! Target-independent effect ABI dialect.
+//!
+//! The `effect` dialect sits between high-level `ability` operations and
+//! backend-specific evidence/callable representations. It preserves effect
+//! dispatch semantics without exposing Marker fields, handler-table storage, or
+//! closure function/environment layout to shared lowering passes.
+
+#[trunk_ir::dialect]
+mod effect {
+    /// Extend the current evidence with a handler for one ability.
+    ///
+    /// Operands are semantic ABI values:
+    /// - `evidence`: current evidence value.
+    /// - `prompt_tag`: runtime tag associated with the handler installation.
+    /// - `tr_dispatch_fn`: tail-resumptive dispatch closure, or null.
+    /// - `handler_dispatch`: full CPS dispatch closure, or null.
+    #[attr(ability_ref: Type)]
+    fn extend(evidence: (), prompt_tag: (), tr_dispatch_fn: (), handler_dispatch: ()) -> result {}
+
+    /// Dispatch a tail-resumptive `fn` ability operation.
+    ///
+    /// The operation carries ability identity and operation name as attributes,
+    /// while the backend chooses the concrete lookup and callable layout.
+    #[attr(ability_ref: Type, op_name: Symbol)]
+    fn dispatch_tail(evidence: (), payload: ()) -> result {}
+
+    /// Dispatch a general CPS `op` ability operation.
+    ///
+    /// `continuation` is the already-constructed continuation closure and
+    /// `payload` is the single packed operation argument value.
+    #[attr(ability_ref: Type, op_name: Symbol)]
+    fn dispatch_cps(evidence: (), continuation: (), payload: ()) -> result {}
+}
+
+inventory::submit! { trunk_ir::op_interface::PureOps::register("effect", "extend") }
+
+#[cfg(test)]
+mod tests {
+    use trunk_ir::ops::DialectOp;
+    use trunk_ir::printer::print_op;
+    use trunk_ir::refs::PathRef;
+    use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
+    use trunk_ir::{IrContext, Span, Symbol};
+
+    fn dummy_location() -> Location {
+        Location::new(PathRef::from_u32(0), Span::default())
+    }
+
+    fn type_ref(ctx: &mut IrContext, dialect: &str, name: &str) -> trunk_ir::TypeRef {
+        ctx.types.intern(
+            TypeDataBuilder::new(Symbol::from_dynamic(dialect), Symbol::from_dynamic(name)).build(),
+        )
+    }
+
+    fn ability_ref(ctx: &mut IrContext, name: &str) -> trunk_ir::TypeRef {
+        ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("ability_ref"))
+                .attr("name", Attribute::Symbol(Symbol::from_dynamic(name)))
+                .build(),
+        )
+    }
+
+    fn const_i32(
+        ctx: &mut IrContext,
+        loc: Location,
+        ty: trunk_ir::TypeRef,
+        value: i128,
+    ) -> trunk_ir::ValueRef {
+        trunk_ir::dialect::arith::r#const(ctx, loc, ty, Attribute::Int(value)).result(ctx)
+    }
+
+    #[test]
+    fn extend_round_trips_through_typed_wrapper() {
+        let mut ctx = IrContext::new();
+        let loc = dummy_location();
+        let i32_ty = type_ref(&mut ctx, "core", "i32");
+        let ptr_ty = type_ref(&mut ctx, "core", "ptr");
+        let evidence_ty = type_ref(&mut ctx, "core", "ptr");
+        let ability = ability_ref(&mut ctx, "State");
+
+        let evidence = const_i32(&mut ctx, loc, ptr_ty, 0);
+        let prompt_tag = const_i32(&mut ctx, loc, i32_ty, 7);
+        let tr_dispatch_fn = const_i32(&mut ctx, loc, ptr_ty, 0);
+        let handler_dispatch = const_i32(&mut ctx, loc, ptr_ty, 1);
+
+        let op = super::extend(
+            &mut ctx,
+            loc,
+            evidence,
+            prompt_tag,
+            tr_dispatch_fn,
+            handler_dispatch,
+            evidence_ty,
+            ability,
+        );
+        let wrapper = super::Extend::from_op(&ctx, op.op_ref()).expect("effect.extend matches");
+
+        assert_eq!(wrapper.evidence(&ctx), evidence);
+        assert_eq!(wrapper.prompt_tag(&ctx), prompt_tag);
+        assert_eq!(wrapper.tr_dispatch_fn(&ctx), tr_dispatch_fn);
+        assert_eq!(wrapper.handler_dispatch(&ctx), handler_dispatch);
+        assert_eq!(wrapper.ability_ref(&ctx), ability);
+        assert_eq!(ctx.value_ty(wrapper.result(&ctx)), evidence_ty);
+    }
+
+    #[test]
+    fn dispatch_ops_round_trip_and_print_generically() {
+        let mut ctx = IrContext::new();
+        let loc = dummy_location();
+        let ptr_ty = type_ref(&mut ctx, "core", "ptr");
+        let anyref_ty = type_ref(&mut ctx, "tribute_rt", "anyref");
+        let ability = ability_ref(&mut ctx, "Console");
+        let evidence = const_i32(&mut ctx, loc, ptr_ty, 0);
+        let payload = const_i32(&mut ctx, loc, anyref_ty, 1);
+        let continuation = const_i32(&mut ctx, loc, anyref_ty, 2);
+
+        let tail = super::dispatch_tail(
+            &mut ctx,
+            loc,
+            evidence,
+            payload,
+            anyref_ty,
+            ability,
+            Symbol::new("print"),
+        );
+        let cps = super::dispatch_cps(
+            &mut ctx,
+            loc,
+            evidence,
+            continuation,
+            payload,
+            anyref_ty,
+            ability,
+            Symbol::new("get"),
+        );
+
+        let tail_wrapper =
+            super::DispatchTail::from_op(&ctx, tail.op_ref()).expect("effect.dispatch_tail");
+        let cps_wrapper =
+            super::DispatchCps::from_op(&ctx, cps.op_ref()).expect("effect.dispatch_cps");
+
+        assert_eq!(tail_wrapper.evidence(&ctx), evidence);
+        assert_eq!(tail_wrapper.payload(&ctx), payload);
+        assert_eq!(tail_wrapper.ability_ref(&ctx), ability);
+        assert_eq!(tail_wrapper.op_name(&ctx), Symbol::new("print"));
+        assert_eq!(cps_wrapper.continuation(&ctx), continuation);
+        assert_eq!(cps_wrapper.op_name(&ctx), Symbol::new("get"));
+
+        let tail_printed = print_op(&ctx, tail.op_ref());
+        assert!(tail_printed.contains("effect.dispatch_tail"));
+        assert!(tail_printed.contains("ability_ref"));
+        assert!(tail_printed.contains("op_name = @print"));
+    }
+}

--- a/crates/tribute-ir/src/dialect/mod.rs
+++ b/crates/tribute-ir/src/dialect/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod ability;
 pub mod closure;
+pub mod effect;
 pub mod tribute_rt;

--- a/crates/tribute-passes/src/evidence.rs
+++ b/crates/tribute-passes/src/evidence.rs
@@ -2,10 +2,10 @@
 //!
 //! Helpers for working with evidence parameters on function types.
 
-use tribute_ir::dialect::ability as arena_ability;
+use tribute_ir::dialect::ability;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 
@@ -19,7 +19,7 @@ pub fn has_evidence_first_param(ctx: &IrContext, func_ty: TypeRef) -> bool {
     if data.params.len() < 2 {
         return false;
     }
-    arena_ability::is_evidence_type_ref(ctx, data.params[1])
+    ability::is_evidence_type_ref(ctx, data.params[1])
 }
 
 /// Build a new `core.func` TypeRef with evidence prepended to params.
@@ -56,11 +56,11 @@ pub fn find_enclosing_evidence(ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
         let block = ctx.op(current).parent_block?;
         let region = ctx.block(block).parent_region?;
         let parent_op = ctx.region(region).parent_op?;
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, parent_op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, parent_op) {
             let body = func_op.body(ctx);
             let entry = ctx.region(body).blocks[0];
             let args = ctx.block_args(entry);
-            if !args.is_empty() && arena_ability::is_evidence_type_ref(ctx, ctx.value_ty(args[0])) {
+            if !args.is_empty() && ability::is_evidence_type_ref(ctx, ctx.value_ty(args[0])) {
                 return Some(args[0]);
             }
             return None;

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -1,4 +1,4 @@
-//! Lower `ability.perform` operations to handler_dispatch calls.
+//! Lower `ability.perform` and `ability.call` operations to the effect ABI.
 //!
 //! In CPS-based effect handling, `ability.perform` carries an explicit
 //! continuation closure. This pass converts it to:
@@ -9,14 +9,10 @@
 //!   { ability_ref: @State, op_name: @get }
 //!
 //! // Output:
-//! %marker = ability.evidence_lookup %evidence { ability_ref: @State }
-//! %handler = adt.struct_get %marker, MarkerField::HandlerDispatch
-//! %fn_ptr = adt.struct_get %handler, 0       // closure function pointer
-//! %env = adt.struct_get %handler, 1          // closure environment
-//! %op_idx = arith.const <hash(ability, op)>
-//! %shift_value = cast %args to anyref (or null)
+//! %payload = cast %args to anyref (or null)
 //! %cont = cast %continuation to anyref
-//! %result = func.call_indirect %fn_ptr, (%ev, %env, %cont, %op_idx, %shift_value)
+//! %result = effect.dispatch_cps %evidence, %cont, %payload
+//!   { ability_ref: @State, op_name: @get }
 //! func.return %result
 //! ```
 //!
@@ -26,34 +22,28 @@
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{adt, arith, core, func};
+use trunk_ir::dialect::{adt, core, func};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, erase_op,
 };
-use trunk_ir::types::Attribute;
 
 use tribute_ir::dialect::ability;
-use tribute_ir::dialect::ability::{MarkerField, compute_op_idx};
+use tribute_ir::dialect::effect;
 use tribute_ir::dialect::tribute_rt;
 
 /// Cached common type references used by the perform lowering pattern.
 #[derive(Clone, Copy)]
 struct CommonTypes {
     anyref: TypeRef,
-    i32: TypeRef,
 }
 
 impl CommonTypes {
     fn new(ctx: &mut IrContext) -> Self {
         Self {
             anyref: tribute_rt::anyref(ctx).as_type_ref(),
-            i32: ctx.types.intern(
-                trunk_ir::types::TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32"))
-                    .build(),
-            ),
         }
     }
 }
@@ -86,7 +76,7 @@ impl Pass for LowerAbilityPerform {
     }
 }
 
-/// Pattern: `ability.perform` → evidence lookup + handler_dispatch call + return.
+/// Pattern: `ability.perform` → `effect.dispatch_cps` + return.
 struct LowerPerformPattern {
     types: CommonTypes,
 }
@@ -116,45 +106,14 @@ impl RewritePattern for LowerPerformPattern {
         // Find evidence parameter from enclosing func's entry block.
         let evidence_val = find_evidence_from_op(ctx, op);
 
-        // === 1. Evidence lookup → marker ===
-        let marker_ty = ability::marker_adt_type_ref(ctx);
+        // === 1. Find evidence ===
         let Some(evidence_val) = evidence_val else {
             // Missing evidence means the frontend detected unhandled effects
             // and emitted a diagnostic. Skip this op gracefully.
             return false;
         };
-        let lookup =
-            ability::evidence_lookup(ctx, location, evidence_val, marker_ty, ability_ref_type);
-        rewriter.insert_op(lookup.op_ref());
-        let marker_val = lookup.result(ctx);
 
-        // === 2. Extract handler_dispatch from marker ===
-        // The Marker ADT declares this field as core.ptr, but we read it with
-        // closure_ty because evidence_to_native replaces this struct_get entirely
-        // with a __tribute_evidence_lookup_handler call before type conversion.
-        let closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
-        let handler_get = adt::struct_get(
-            ctx,
-            location,
-            marker_val,
-            closure_ty,
-            marker_ty,
-            MarkerField::HandlerDispatch.index(),
-        );
-        rewriter.insert_op(handler_get.op_ref());
-        let handler_dispatch_val = handler_get.result(ctx);
-
-        // === 3. Compute op_idx ===
-        let ability_data = ctx.types.get(ability_ref_type);
-        let ability_name = match ability_data.attrs.get(&Symbol::new("name")) {
-            Some(Attribute::Symbol(s)) => Some(*s),
-            _ => None,
-        };
-        let op_idx = compute_op_idx(ability_name, Some(op_name_sym));
-        let op_idx_const = arith::r#const(ctx, location, t.i32, Attribute::Int(op_idx as i128));
-        rewriter.insert_op(op_idx_const.op_ref());
-
-        // === 4. Build shift value (pack args or null) ===
+        // === 2. Build payload (pack args or null) ===
         assert!(
             value_operands.len() <= 1,
             "ability.perform expects at most 1 value operand (multi-arg should be tuple-packed), \
@@ -171,42 +130,28 @@ impl RewritePattern for LowerPerformPattern {
             null_op.result(ctx)
         };
 
-        // === 5. Cast continuation closure to anyref ===
+        // === 3. Cast continuation closure to anyref ===
         let cont_anyref =
             core::unrealized_conversion_cast(ctx, location, continuation_val, t.anyref);
         rewriter.insert_op(cont_anyref.op_ref());
 
-        // === 6. Decompose handler_dispatch closure and call ===
-        let fn_ptr_get = adt::struct_get(ctx, location, handler_dispatch_val, t.i32, closure_ty, 0);
-        rewriter.insert_op(fn_ptr_get.op_ref());
-        let fn_ptr = fn_ptr_get.result(ctx);
-
-        let env_get = adt::struct_get(ctx, location, handler_dispatch_val, t.anyref, closure_ty, 1);
-        rewriter.insert_op(env_get.op_ref());
-        let env_val = env_get.result(ctx);
-
-        // Placeholder evidence for resolve_evidence to replace later.
-        let placeholder_ev = evidence_val;
-
-        let call_op = func::call_indirect(
+        // === 4. Dispatch through target-independent effect ABI ===
+        let dispatch_op = effect::dispatch_cps(
             ctx,
             location,
-            fn_ptr,
-            vec![
-                placeholder_ev,
-                env_val,
-                cont_anyref.result(ctx),
-                op_idx_const.result(ctx),
-                shift_value_val,
-            ],
+            evidence_val,
+            cont_anyref.result(ctx),
+            shift_value_val,
             t.anyref,
+            ability_ref_type,
+            op_name_sym,
         );
-        rewriter.insert_op(call_op.op_ref());
+        rewriter.insert_op(dispatch_op.op_ref());
 
-        // === 7. Return the handler's result (cast to function return type) ===
+        // === 5. Return the dispatch result (cast to function return type) ===
         let block = ctx.op(op).parent_block.unwrap();
         if is_in_func_body(ctx, block) {
-            let result_val = call_op.result(ctx);
+            let result_val = dispatch_op.result(ctx);
             let func_ret_ty = find_enclosing_func_return_type(ctx, block);
             let ret_op = if let Some(ret_ty) = func_ret_ty {
                 if is_nil_type(ctx, ret_ty) {
@@ -225,8 +170,8 @@ impl RewritePattern for LowerPerformPattern {
             rewriter.insert_op(ret_op.op_ref());
         }
 
-        // Erase perform op, mapping its result to the call_indirect result.
-        rewriter.erase_op(vec![call_op.result(ctx)]);
+        // Erase perform op, mapping its result to the dispatch result.
+        rewriter.erase_op(vec![dispatch_op.result(ctx)]);
 
         // Remove dead code after the perform op in the same block.
         // Only do this when we inserted a func.return terminator (i.e., in
@@ -254,7 +199,7 @@ impl RewritePattern for LowerPerformPattern {
     }
 }
 
-/// Pattern: `ability.call` → evidence lookup + tr_dispatch_fn call (no CPS).
+/// Pattern: `ability.call` → `effect.dispatch_tail` (no CPS).
 struct LowerCallPattern {
     types: CommonTypes,
 }
@@ -283,42 +228,14 @@ impl RewritePattern for LowerCallPattern {
         // Find evidence parameter from enclosing func's entry block.
         let evidence_val = find_evidence_from_op(ctx, op);
 
-        // === 1. Evidence lookup → marker ===
-        let marker_ty = ability::marker_adt_type_ref(ctx);
+        // === 1. Find evidence ===
         let Some(evidence_val) = evidence_val else {
             // Missing evidence means the frontend detected unhandled effects
             // and emitted a diagnostic. Skip this op gracefully.
             return false;
         };
-        let lookup =
-            ability::evidence_lookup(ctx, location, evidence_val, marker_ty, ability_ref_type);
-        rewriter.insert_op(lookup.op_ref());
-        let marker_val = lookup.result(ctx);
 
-        // === 2. Extract tr_dispatch_fn from marker ===
-        let closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
-        let tr_fn_get = adt::struct_get(
-            ctx,
-            location,
-            marker_val,
-            closure_ty,
-            marker_ty,
-            MarkerField::TrDispatchFn.index(),
-        );
-        rewriter.insert_op(tr_fn_get.op_ref());
-        let tr_dispatch_fn_val = tr_fn_get.result(ctx);
-
-        // === 3. Compute op_idx ===
-        let ability_data = ctx.types.get(ability_ref_type);
-        let ability_name = match ability_data.attrs.get(&Symbol::new("name")) {
-            Some(Attribute::Symbol(s)) => Some(*s),
-            _ => None,
-        };
-        let op_idx = compute_op_idx(ability_name, Some(op_name_sym));
-        let op_idx_const = arith::r#const(ctx, location, t.i32, Attribute::Int(op_idx as i128));
-        rewriter.insert_op(op_idx_const.op_ref());
-
-        // === 4. Build shift value (pack args or null) ===
+        // === 2. Build payload (pack args or null) ===
         assert!(
             value_operands.len() <= 1,
             "ability.call expects at most 1 value operand (multi-arg should be tuple-packed), \
@@ -335,34 +252,20 @@ impl RewritePattern for LowerCallPattern {
             null_op.result(ctx)
         };
 
-        // === 5. Decompose tr_dispatch_fn closure and call ===
-        let fn_ptr_get = adt::struct_get(ctx, location, tr_dispatch_fn_val, t.i32, closure_ty, 0);
-        rewriter.insert_op(fn_ptr_get.op_ref());
-        let fn_ptr = fn_ptr_get.result(ctx);
-
-        let env_get = adt::struct_get(ctx, location, tr_dispatch_fn_val, t.anyref, closure_ty, 1);
-        rewriter.insert_op(env_get.op_ref());
-        let env_val = env_get.result(ctx);
-
-        // Placeholder evidence for resolve_evidence to replace later.
-        let placeholder_ev = evidence_val;
-
-        let call_result = func::call_indirect(
+        // === 3. Dispatch through target-independent effect ABI ===
+        let dispatch_op = effect::dispatch_tail(
             ctx,
             location,
-            fn_ptr,
-            vec![
-                placeholder_ev,
-                env_val,
-                op_idx_const.result(ctx),
-                shift_value_val,
-            ],
+            evidence_val,
+            shift_value_val,
             t.anyref,
+            ability_ref_type,
+            op_name_sym,
         );
-        rewriter.insert_op(call_result.op_ref());
+        rewriter.insert_op(dispatch_op.op_ref());
 
-        // === 6. Erase ability.call, mapping its result to the call_indirect result ===
-        rewriter.erase_op(vec![call_result.result(ctx)]);
+        // === 4. Erase ability.call, mapping its result to the dispatch result ===
+        rewriter.erase_op(vec![dispatch_op.result(ctx)]);
 
         true
     }
@@ -482,6 +385,31 @@ mod tests {
     %k = arith.const {{value = 0}} : tribute_rt.anyref
     %yr = ability.perform %k, %val {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}} : tribute_rt.anyref
     func.return %yr
+  }}
+}}"#
+            ),
+        );
+
+        lower_ability_perform(&mut ctx, module);
+
+        let ir_text = print_module(&ctx, module.op());
+        assert_snapshot!(ir_text);
+    }
+
+    #[test]
+    fn test_lower_call_to_effect_dispatch_tail() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  func.func @test_fn(%ev: {ev_ty}) -> tribute_rt.anyref {{
+    %msg = arith.const {{value = 1}} : tribute_rt.anyref
+    %result = ability.call %msg {{ability_ref = core.ability_ref() {{name = @Console}}, op_name = @print}} : tribute_rt.anyref
+    func.return %result
   }}
 }}"#
             ),

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -34,8 +34,8 @@ use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{Module, erase_op};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
-use tribute_ir::dialect::ability as arena_ability;
-use tribute_ir::dialect::closure as arena_closure;
+use tribute_ir::dialect::ability;
+use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
 
 /// Lower all `closure.lambda` ops in the module to `func.func` + `closure.new`.
@@ -93,7 +93,7 @@ fn collect_closure_lambdas(ctx: &IrContext, module: Module) -> Vec<OpRef> {
 }
 
 fn collect_lambdas_in_op(ctx: &IrContext, op: OpRef, result: &mut Vec<OpRef>) {
-    if arena_closure::Lambda::matches(ctx, op) {
+    if closure::Lambda::matches(ctx, op) {
         // Don't recurse into the lambda body — nested lambdas will be
         // found on the next iteration after this one is lowered.
         result.push(op);
@@ -118,7 +118,7 @@ fn lower_single_lambda(
     lambda_ref: OpRef,
     namer: &mut LambdaNamer,
 ) {
-    let Ok(lambda_op) = arena_closure::Lambda::from_op(ctx, lambda_ref) else {
+    let Ok(lambda_op) = closure::Lambda::from_op(ctx, lambda_ref) else {
         return;
     };
 
@@ -146,7 +146,7 @@ fn lower_single_lambda(
     let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
     let func_result_ty = extract_return_type_from_closure(ctx, result_ty)
         .expect("closure.lambda result type must be closure.closure<core.func<...>>");
-    let evidence_ty = arena_ability::evidence_adt_type_ref(ctx);
+    let evidence_ty = ability::evidence_adt_type_ref(ctx);
 
     // Build env struct type for captures.
     let env_struct_ty = if captures.is_empty() {
@@ -205,8 +205,8 @@ fn lower_single_lambda(
     // Create closure.new replacing the lambda.
     let closure_func_ty =
         core::func(ctx, func_result_ty, orig_param_types.iter().copied()).as_type_ref();
-    let closure_ty = arena_closure::closure(ctx, closure_func_ty).as_type_ref();
-    let closure_new_op = arena_closure::new(ctx, location, closure_env, closure_ty, lifted_name);
+    let closure_ty = closure::closure(ctx, closure_func_ty).as_type_ref();
+    let closure_new_op = closure::new(ctx, location, closure_env, closure_ty, lifted_name);
     ctx.insert_op_before(parent_block, lambda_ref, closure_new_op.op_ref());
 
     // RAUW: lambda result → closure.new result.
@@ -451,7 +451,7 @@ fn make_bind_name_attrs(name: &str) -> std::collections::BTreeMap<Symbol, Attrib
 mod tests {
     use super::*;
     use trunk_ir::context::RegionData;
-    use trunk_ir::dialect::{arith, core as arena_core};
+    use trunk_ir::dialect::{arith, core};
     use trunk_ir::refs::PathRef;
     use trunk_ir::types::Location;
     use trunk_ir::{Attribute, IrContext, OperationDataBuilder, Span};
@@ -527,11 +527,11 @@ mod tests {
         });
 
         // closure type: closure.closure<core.func<i32, i32>>
-        let func_ty = arena_core::func(&mut ctx, i32_ty, [i32_ty]).as_type_ref();
-        let closure_ty = arena_closure::closure(&mut ctx, func_ty).as_type_ref();
+        let func_ty = core::func(&mut ctx, i32_ty, [i32_ty]).as_type_ref();
+        let closure_ty = closure::closure(&mut ctx, func_ty).as_type_ref();
 
         // closure.lambda [] { ... } -> closure_ty
-        let lambda_op = arena_closure::lambda(
+        let lambda_op = closure::lambda(
             &mut ctx,
             loc,
             Vec::<ValueRef>::new(),
@@ -554,7 +554,7 @@ mod tests {
             parent_op: None,
         });
         let outer_func_ty =
-            arena_core::func(&mut ctx, anyref_ty, std::iter::empty::<TypeRef>()).as_type_ref();
+            core::func(&mut ctx, anyref_ty, std::iter::empty::<TypeRef>()).as_type_ref();
         let outer_func = func::func(
             &mut ctx,
             loc,
@@ -581,7 +581,7 @@ mod tests {
         assert!(test_fn_ops.len() >= 2, "expected at least 2 ops in test_fn");
         let last_op = test_fn_ops[test_fn_ops.len() - 1];
         assert!(
-            arena_closure::New::matches(&ctx, last_op),
+            closure::New::matches(&ctx, last_op),
             "last op should be closure.new"
         );
 
@@ -652,12 +652,11 @@ mod tests {
             parent_op: None,
         });
 
-        let func_ty = arena_core::func(&mut ctx, i32_ty, [i32_ty]).as_type_ref();
-        let closure_ty = arena_closure::closure(&mut ctx, func_ty).as_type_ref();
+        let func_ty = core::func(&mut ctx, i32_ty, [i32_ty]).as_type_ref();
+        let closure_ty = closure::closure(&mut ctx, func_ty).as_type_ref();
 
         // closure.lambda [%a] { ... }
-        let lambda_op =
-            arena_closure::lambda(&mut ctx, loc, vec![a_val], closure_ty, lambda_body_region);
+        let lambda_op = closure::lambda(&mut ctx, loc, vec![a_val], closure_ty, lambda_body_region);
         ctx.push_op(outer_entry, lambda_op.op_ref());
 
         let outer_body = ctx.create_region(RegionData {
@@ -665,7 +664,7 @@ mod tests {
             blocks: trunk_ir::smallvec::smallvec![outer_entry],
             parent_op: None,
         });
-        let outer_func_ty = arena_core::func(&mut ctx, anyref_ty, [i32_ty]).as_type_ref();
+        let outer_func_ty = core::func(&mut ctx, anyref_ty, [i32_ty]).as_type_ref();
         let outer_func = func::func(
             &mut ctx,
             loc,
@@ -695,7 +694,7 @@ mod tests {
 
         let has_closure_new = test_fn_ops
             .iter()
-            .any(|&op| arena_closure::New::matches(&ctx, op));
+            .any(|&op| closure::New::matches(&ctx, op));
         assert!(has_closure_new, "should have closure.new");
 
         // Lifted function body should reference env extraction, not the original capture.

--- a/crates/tribute-passes/src/native/adt_rc_header.rs
+++ b/crates/tribute-passes/src/native/adt_rc_header.rs
@@ -21,7 +21,7 @@ use trunk_ir::adt_layout::{compute_enum_layout, compute_struct_layout, find_vari
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::adt;
 use trunk_ir::dialect::clif;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::rewriter::PatternRewriter;
@@ -44,7 +44,7 @@ pub fn lower(
     rtti_map: &HashMap<TypeRef, u32>,
 ) -> Result<(), ConversionError> {
     // Pre-intern types
-    let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+    let ptr_ty = core::ptr(ctx).as_type_ref();
     let i64_ty = ctx
         .types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i64")).build());
@@ -343,7 +343,7 @@ mod tests {
     use std::collections::BTreeMap;
     use trunk_ir::Span;
     use trunk_ir::context::{BlockArgData, BlockData, IrContext, OperationDataBuilder, RegionData};
-    use trunk_ir::dialect::func as arena_func;
+    use trunk_ir::dialect::func;
     use trunk_ir::printer::print_module;
     use trunk_ir::rewrite::Module;
     use trunk_ir::smallvec::smallvec;
@@ -371,7 +371,7 @@ mod tests {
         let ptr_ty = intern_ty(ctx, "core", "ptr");
 
         // Build function type: (field_types...) -> ptr
-        let func_ty = arena_core::func(ctx, ptr_ty, field_types.iter().copied()).as_type_ref();
+        let func_ty = core::func(ctx, ptr_ty, field_types.iter().copied()).as_type_ref();
 
         // Create entry block with field arguments
         let args: Vec<BlockArgData> = field_types
@@ -404,7 +404,7 @@ mod tests {
         let struct_result = ctx.op_result(struct_new_ref, 0);
         ctx.push_op(entry, struct_new_ref);
 
-        let ret = arena_func::r#return(ctx, loc, [struct_result]);
+        let ret = func::r#return(ctx, loc, [struct_result]);
         ctx.push_op(entry, ret.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -412,7 +412,7 @@ mod tests {
             blocks: smallvec![entry],
             parent_op: None,
         });
-        let func_op = arena_func::func(ctx, loc, Symbol::new("create_struct"), func_ty, body);
+        let func_op = func::func(ctx, loc, Symbol::new("create_struct"), func_ty, body);
 
         // Build module
         let module_block = ctx.create_block(BlockData {

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -19,9 +19,9 @@ use std::collections::HashMap;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt as arena_adt;
-use trunk_ir::dialect::clif as arena_clif;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::adt;
+use trunk_ir::dialect::clif;
+use trunk_ir::dialect::core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -130,7 +130,7 @@ impl ConstCollector {
     fn visit_op(&mut self, ctx: &IrContext, op: OpRef) {
         let data = ctx.op(op);
 
-        if data.dialect == arena_adt::DIALECT_NAME() {
+        if data.dialect == adt::DIALECT_NAME() {
             if data.name == Symbol::new("string_const") {
                 if let Some(Attribute::String(s)) = data.attributes.get(&Symbol::new("value")) {
                     let bytes = s.clone().into_bytes();
@@ -216,7 +216,7 @@ pub fn lower(
         return Ok(());
     }
 
-    let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+    let ptr_ty = core::ptr(ctx).as_type_ref();
     let i64_ty = ctx
         .types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i64")).build());
@@ -270,21 +270,21 @@ fn emit_bytes_alloc(
     let mut ops: Vec<OpRef> = Vec::new();
 
     // 1. Get rodata address
-    let data_ptr_op = arena_clif::symbol_addr(ctx, loc, ptr_ty, data_sym);
+    let data_ptr_op = clif::symbol_addr(ctx, loc, ptr_ty, data_sym);
     ops.push(data_ptr_op.op_ref());
     let data_ptr = data_ptr_op.result(ctx);
 
     // 2. Length constant
-    let len_op = arena_clif::iconst(ctx, loc, i64_ty, content_len as i64);
+    let len_op = clif::iconst(ctx, loc, i64_ty, content_len as i64);
     ops.push(len_op.op_ref());
     let len_val = len_op.result(ctx);
 
     // 3. Allocate RC header (8) + TributeBytes payload (ptr=8 + len=8 = 16) = 24 bytes
     let alloc_size = RC_HEADER_SIZE + 16; // ptr(8) + len(8)
-    let size_op = arena_clif::iconst(ctx, loc, i64_ty, alloc_size as i64);
+    let size_op = clif::iconst(ctx, loc, i64_ty, alloc_size as i64);
     ops.push(size_op.op_ref());
 
-    let call_op = arena_clif::call(
+    let call_op = clif::call(
         ctx,
         loc,
         [size_op.result(ctx)],
@@ -295,9 +295,9 @@ fn emit_bytes_alloc(
     let raw_ptr = call_op.result(ctx);
 
     // 4. Store RC header: refcount=1, rtti_idx=0
-    let rc_one = arena_clif::iconst(ctx, loc, i32_ty, 1);
+    let rc_one = clif::iconst(ctx, loc, i32_ty, 1);
     ops.push(rc_one.op_ref());
-    let store_rc = arena_clif::store(
+    let store_rc = clif::store(
         ctx,
         loc,
         rc_one.result(ctx),
@@ -306,9 +306,9 @@ fn emit_bytes_alloc(
     );
     ops.push(store_rc.op_ref());
 
-    let rtti_zero = arena_clif::iconst(ctx, loc, i32_ty, 0);
+    let rtti_zero = clif::iconst(ctx, loc, i32_ty, 0);
     ops.push(rtti_zero.op_ref());
-    let store_rtti = arena_clif::store(
+    let store_rtti = clif::store(
         ctx,
         loc,
         rtti_zero.result(ctx),
@@ -318,24 +318,24 @@ fn emit_bytes_alloc(
     ops.push(store_rtti.op_ref());
 
     // 5. Compute payload pointer = raw + 8
-    let hdr_size = arena_clif::iconst(ctx, loc, i64_ty, RC_HEADER_SIZE as i64);
+    let hdr_size = clif::iconst(ctx, loc, i64_ty, RC_HEADER_SIZE as i64);
     ops.push(hdr_size.op_ref());
-    let payload_op = arena_clif::iadd(ctx, loc, raw_ptr, hdr_size.result(ctx), ptr_ty);
+    let payload_op = clif::iadd(ctx, loc, raw_ptr, hdr_size.result(ctx), ptr_ty);
     ops.push(payload_op.op_ref());
     let payload = payload_op.result(ctx);
 
     // 6. Store TributeBytes fields: ptr at payload+0, len at payload+8
-    let store_ptr = arena_clif::store(ctx, loc, data_ptr, payload, 0);
+    let store_ptr = clif::store(ctx, loc, data_ptr, payload, 0);
     ops.push(store_ptr.op_ref());
 
-    let store_len = arena_clif::store(ctx, loc, len_val, payload, 8);
+    let store_len = clif::store(ctx, loc, len_val, payload, 8);
     ops.push(store_len.op_ref());
 
     // 7. Identity iadd(payload, 0) to produce a fresh SSA value that the
     //    rewrite pattern can use as the replacement result.
-    let zero_op = arena_clif::iconst(ctx, loc, i64_ty, 0);
+    let zero_op = clif::iconst(ctx, loc, i64_ty, 0);
     ops.push(zero_op.op_ref());
-    let identity_op = arena_clif::iadd(ctx, loc, payload, zero_op.result(ctx), ptr_ty);
+    let identity_op = clif::iadd(ctx, loc, payload, zero_op.result(ctx), ptr_ty);
     ops.push(identity_op.op_ref());
 
     let last = ops.pop().unwrap();
@@ -357,7 +357,7 @@ impl RewritePattern for BytesConstNativePattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(bytes_const) = arena_adt::BytesConst::from_op(ctx, op) else {
+        let Ok(bytes_const) = adt::BytesConst::from_op(ctx, op) else {
             return false;
         };
 
@@ -406,7 +406,7 @@ impl RewritePattern for StringConstNativePattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(string_const) = arena_adt::StringConst::from_op(ctx, op) else {
+        let Ok(string_const) = adt::StringConst::from_op(ctx, op) else {
             return false;
         };
 
@@ -434,7 +434,7 @@ impl RewritePattern for StringConstNativePattern {
             self.i64_ty,
             self.i32_ty,
         );
-        let bytes_payload = arena_clif::Iadd::from_op(ctx, bytes_last_op)
+        let bytes_payload = clif::Iadd::from_op(ctx, bytes_last_op)
             .expect("last op is iadd")
             .result(ctx);
 
@@ -444,7 +444,7 @@ impl RewritePattern for StringConstNativePattern {
         // Create adt.variant_new(type=String, tag=Leaf, bytes_payload)
         // Use the actual String enum type for the type attribute so that
         // adt_rc_header can compute the correct enum layout.
-        let variant_new = arena_adt::variant_new(
+        let variant_new = adt::variant_new(
             ctx,
             loc,
             [bytes_payload],

--- a/crates/tribute-passes/src/native/entrypoint.rs
+++ b/crates/tribute-passes/src/native/entrypoint.rs
@@ -7,8 +7,8 @@
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockData, IrContext, RegionData};
 use trunk_ir::dialect::arith;
-use trunk_ir::dialect::core as arena_core;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::Module;
@@ -46,7 +46,7 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
     let asan_init_sym = Symbol::new("__asan_init");
 
     for &op in &ops {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, op) {
             let name = func_op.sym_name(ctx);
             if name == main_sym {
                 found_main = true;
@@ -87,7 +87,7 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
     let i32_ty = ctx
         .types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
-    let nil_ty = arena_core::nil(ctx).as_type_ref();
+    let nil_ty = core::nil(ctx).as_type_ref();
 
     let tribute_main_return_ty = main_return_ty.unwrap_or_else(|| {
         panic!(
@@ -98,7 +98,7 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
 
     // Step 1: Rename main -> _tribute_main (in-place attribute mutation)
     for &op in &ops {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op)
+        if let Ok(func_op) = func::Func::from_op(ctx, op)
             && func_op.sym_name(ctx) == main_sym
         {
             ctx.op_mut(op)
@@ -199,7 +199,7 @@ fn build_entrypoint(
     sanitize: bool,
 ) -> OpRef {
     // Build func type: () -> i32
-    let func_ty = arena_core::func(ctx, i32_ty, []).as_type_ref();
+    let func_ty = core::func(ctx, i32_ty, []).as_type_ref();
 
     // Create entry block
     let entry_block = ctx.create_block(BlockData {
@@ -211,16 +211,16 @@ fn build_entrypoint(
 
     // Initialize ASan before anything else
     if sanitize {
-        let asan_call = arena_func::call(ctx, loc, [], nil_ty, Symbol::new("__asan_init"));
+        let asan_call = func::call(ctx, loc, [], nil_ty, Symbol::new("__asan_init"));
         ctx.push_op(entry_block, asan_call.op_ref());
     }
 
     // Initialize runtime TLS before any ability use
-    let init_call = arena_func::call(ctx, loc, [], nil_ty, Symbol::new("__tribute_init"));
+    let init_call = func::call(ctx, loc, [], nil_ty, Symbol::new("__tribute_init"));
     ctx.push_op(entry_block, init_call.op_ref());
 
     // Call _tribute_main() — result is ignored
-    let main_call = arena_func::call(
+    let main_call = func::call(
         ctx,
         loc,
         [],
@@ -233,7 +233,7 @@ fn build_entrypoint(
     let zero = arith::r#const(ctx, loc, i32_ty, Attribute::Int(0));
     ctx.push_op(entry_block, zero.op_ref());
 
-    let ret = arena_func::r#return(ctx, loc, [zero.result(ctx)]);
+    let ret = func::r#return(ctx, loc, [zero.result(ctx)]);
     ctx.push_op(entry_block, ret.op_ref());
 
     // Create body region
@@ -247,7 +247,7 @@ fn build_entrypoint(
     // NOTE: No "abi" attribute here — `abi` marks extern (imported) functions.
     // The Cranelift backend treats functions named "main" as Export linkage,
     // but functions with `abi` attribute are treated as Import and skipped.
-    let main_func = arena_func::func(ctx, loc, Symbol::new("main"), func_ty, body);
+    let main_func = func::func(ctx, loc, Symbol::new("main"), func_ty, body);
 
     main_func.op_ref()
 }
@@ -258,31 +258,31 @@ mod tests {
     use trunk_ir::Span;
     use trunk_ir::context::{BlockData, IrContext, RegionData};
     use trunk_ir::dialect::arith;
-    use trunk_ir::dialect::func as arena_func;
+    use trunk_ir::dialect::func;
     use trunk_ir::ops::DialectOp;
     use trunk_ir::rewrite::Module;
     use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 
-    fn arena_test_ctx() -> (IrContext, Location) {
+    fn test_ctx() -> (IrContext, Location) {
         let mut ctx = IrContext::new();
         let path = ctx.paths.intern("file:///test.trb".to_owned());
         let loc = Location::new(path, Span::new(0, 0));
         (ctx, loc)
     }
 
-    fn arena_i32_type(ctx: &mut IrContext) -> trunk_ir::refs::TypeRef {
+    fn i32_type(ctx: &mut IrContext) -> trunk_ir::refs::TypeRef {
         ctx.types
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
     }
 
-    fn arena_nil_type(ctx: &mut IrContext) -> trunk_ir::refs::TypeRef {
-        arena_core::nil(ctx).as_type_ref()
+    fn nil_type(ctx: &mut IrContext) -> trunk_ir::refs::TypeRef {
+        core::nil(ctx).as_type_ref()
     }
 
     /// Build an arena module with a single main function returning i32.
-    fn make_arena_main_module(ctx: &mut IrContext, loc: Location) -> Module {
-        let i32_ty = arena_i32_type(ctx);
-        let func_ty = arena_core::func(ctx, i32_ty, []).as_type_ref();
+    fn make_main_module(ctx: &mut IrContext, loc: Location) -> Module {
+        let i32_ty = i32_type(ctx);
+        let func_ty = core::func(ctx, i32_ty, []).as_type_ref();
 
         // Build main function: const 42, return
         let entry = ctx.create_block(BlockData {
@@ -293,7 +293,7 @@ mod tests {
         });
         let c42 = arith::r#const(ctx, loc, i32_ty, Attribute::Int(42));
         ctx.push_op(entry, c42.op_ref());
-        let ret = arena_func::r#return(ctx, loc, [c42.result(ctx)]);
+        let ret = func::r#return(ctx, loc, [c42.result(ctx)]);
         ctx.push_op(entry, ret.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -301,7 +301,7 @@ mod tests {
             blocks: smallvec![entry],
             parent_op: None,
         });
-        let main_fn = arena_func::func(ctx, loc, Symbol::new("main"), func_ty, body);
+        let main_fn = func::func(ctx, loc, Symbol::new("main"), func_ty, body);
 
         // Build module
         let module_block = ctx.create_block(BlockData {
@@ -332,16 +332,16 @@ mod tests {
     }
 
     #[test]
-    fn arena_entrypoint_renames_main() {
-        let (mut ctx, loc) = arena_test_ctx();
-        let module = make_arena_main_module(&mut ctx, loc);
+    fn entrypoint_renames_main() {
+        let (mut ctx, loc) = test_ctx();
+        let module = make_main_module(&mut ctx, loc);
 
         generate_native_entrypoint(&mut ctx, module, false);
 
         let ops = module.ops(&ctx);
         let mut names: Vec<String> = Vec::new();
         for &op in &ops {
-            if let Ok(f) = arena_func::Func::from_op(&ctx, op) {
+            if let Ok(f) = func::Func::from_op(&ctx, op) {
                 names.push(f.sym_name(&ctx).to_string());
             }
         }
@@ -370,10 +370,10 @@ mod tests {
     }
 
     #[test]
-    fn arena_entrypoint_no_main() {
-        let (mut ctx, loc) = arena_test_ctx();
-        let i32_ty = arena_i32_type(&mut ctx);
-        let func_ty = arena_core::func(&mut ctx, i32_ty, []).as_type_ref();
+    fn entrypoint_no_main() {
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+        let func_ty = core::func(&mut ctx, i32_ty, []).as_type_ref();
 
         // Build helper function (not main)
         let entry = ctx.create_block(BlockData {
@@ -385,7 +385,7 @@ mod tests {
         let c1 = arith::r#const(&mut ctx, loc, i32_ty, Attribute::Int(1));
         ctx.push_op(entry, c1.op_ref());
         let c1_val = c1.result(&ctx);
-        let ret = arena_func::r#return(&mut ctx, loc, [c1_val]);
+        let ret = func::r#return(&mut ctx, loc, [c1_val]);
         ctx.push_op(entry, ret.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -393,7 +393,7 @@ mod tests {
             blocks: smallvec![entry],
             parent_op: None,
         });
-        let helper_fn = arena_func::func(&mut ctx, loc, Symbol::new("helper"), func_ty, body);
+        let helper_fn = func::func(&mut ctx, loc, Symbol::new("helper"), func_ty, body);
 
         // Build module
         let module_block = ctx.create_block(BlockData {
@@ -426,17 +426,17 @@ mod tests {
         // Should be unchanged — only helper
         let ops = module.ops(&ctx);
         assert_eq!(ops.len(), 1);
-        let f = arena_func::Func::from_op(&ctx, ops[0]).unwrap();
+        let f = func::Func::from_op(&ctx, ops[0]).unwrap();
         assert_eq!(f.sym_name(&ctx).to_string(), "helper");
     }
 
     #[test]
-    fn arena_entrypoint_wrapper_returns_i32() {
-        let (mut ctx, loc) = arena_test_ctx();
+    fn entrypoint_wrapper_returns_i32() {
+        let (mut ctx, loc) = test_ctx();
 
         // Build module with main returning nil
-        let nil_ty = arena_nil_type(&mut ctx);
-        let func_ty = arena_core::func(&mut ctx, nil_ty, []).as_type_ref();
+        let nil_ty = nil_type(&mut ctx);
+        let func_ty = core::func(&mut ctx, nil_ty, []).as_type_ref();
 
         let entry = ctx.create_block(BlockData {
             location: loc,
@@ -444,7 +444,7 @@ mod tests {
             ops: smallvec![],
             parent_region: None,
         });
-        let ret = arena_func::r#return(&mut ctx, loc, []);
+        let ret = func::r#return(&mut ctx, loc, []);
         ctx.push_op(entry, ret.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -452,7 +452,7 @@ mod tests {
             blocks: smallvec![entry],
             parent_op: None,
         });
-        let main_fn = arena_func::func(&mut ctx, loc, Symbol::new("main"), func_ty, body);
+        let main_fn = func::func(&mut ctx, loc, Symbol::new("main"), func_ty, body);
 
         let module_block = ctx.create_block(BlockData {
             location: loc,
@@ -481,11 +481,11 @@ mod tests {
 
         generate_native_entrypoint(&mut ctx, module, false);
 
-        let i32_ty = arena_i32_type(&mut ctx);
+        let i32_ty = i32_type(&mut ctx);
 
         // Find the new main wrapper and check its return type
         for &op in &module.ops(&ctx) {
-            if let Ok(f) = arena_func::Func::from_op(&ctx, op)
+            if let Ok(f) = func::Func::from_op(&ctx, op)
                 && f.sym_name(&ctx) == Symbol::new("main")
             {
                 let func_ty_ref = f.r#type(&ctx);
@@ -502,16 +502,16 @@ mod tests {
     }
 
     #[test]
-    fn arena_entrypoint_with_sanitize() {
-        let (mut ctx, loc) = arena_test_ctx();
-        let module = make_arena_main_module(&mut ctx, loc);
+    fn entrypoint_with_sanitize() {
+        let (mut ctx, loc) = test_ctx();
+        let module = make_main_module(&mut ctx, loc);
 
         generate_native_entrypoint(&mut ctx, module, true);
 
         let ops = module.ops(&ctx);
         let mut names: Vec<String> = Vec::new();
         for &op in &ops {
-            if let Ok(f) = arena_func::Func::from_op(&ctx, op) {
+            if let Ok(f) = func::Func::from_op(&ctx, op) {
                 names.push(f.sym_name(&ctx).to_string());
             }
         }

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -29,8 +29,8 @@ use tribute_ir::dialect::ability::{
 use tribute_ir::dialect::{effect, tribute_rt};
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::func as arena_func;
-use trunk_ir::dialect::{adt as arena_adt, arith as arena_arith, core as arena_core};
+use trunk_ir::dialect::func;
+use trunk_ir::dialect::{adt, arith, core};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::Module;
@@ -70,7 +70,7 @@ fn replace_stubs_and_add_empty(ctx: &mut IrContext, module: Module) {
     let lookup_handler_sym = Symbol::new(evidence_abi::LOOKUP_HANDLER);
 
     for &op in &ops {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, op) {
             let name = func_op.sym_name(ctx);
             if name == lookup_sym {
                 stubs_to_replace.push((op, evidence_abi::LOOKUP));
@@ -218,7 +218,7 @@ fn rewrite_evidence_ops_in_module(ctx: &mut IrContext, module: Module) {
     let ops: Vec<OpRef> = ctx.block(first_block).ops.to_vec();
 
     for op in ops {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, op) {
             let name = func_op.sym_name(ctx);
             if is_evidence_runtime_fn(name) {
                 continue;
@@ -258,9 +258,9 @@ fn ability_id_const(
     loc: Location,
     i32_ty: TypeRef,
     ability_ref: TypeRef,
-) -> arena_arith::Const {
+) -> arith::Const {
     let ability_id = ability::compute_ability_id(ctx, ability_ref);
-    arena_arith::r#const(ctx, loc, i32_ty, Attribute::Int(ability_id as i128))
+    arith::r#const(ctx, loc, i32_ty, Attribute::Int(ability_id as i128))
 }
 
 fn op_idx_const(
@@ -269,9 +269,9 @@ fn op_idx_const(
     i32_ty: TypeRef,
     ability_ref: TypeRef,
     op_name: Symbol,
-) -> arena_arith::Const {
+) -> arith::Const {
     let op_idx = compute_op_idx(ability_name(ctx, ability_ref), Some(op_name));
-    arena_arith::r#const(ctx, loc, i32_ty, Attribute::Int(op_idx as i128))
+    arith::r#const(ctx, loc, i32_ty, Attribute::Int(op_idx as i128))
 }
 
 fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
@@ -307,7 +307,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let result_types = ctx.op_result_types(op).to_vec();
             if !result_types.is_empty() && is_evidence_type(ctx, result_types[0]) {
                 let old_result = ctx.op_result(op, 0);
-                let call = arena_func::call(ctx, loc, [], ptr_ty, Symbol::new(evidence_abi::EMPTY));
+                let call = func::call(ctx, loc, [], ptr_ty, Symbol::new(evidence_abi::EMPTY));
                 let new_result = call.result(ctx);
                 ctx.insert_op_before(block, op, call.op_ref());
                 ctx.replace_all_uses(old_result, new_result);
@@ -330,7 +330,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
                      should not reach this pass."
                 );
                 let old_result = ctx.op_result(op, 0);
-                let call = arena_func::call(ctx, loc, [], ptr_ty, Symbol::new(evidence_abi::EMPTY));
+                let call = func::call(ctx, loc, [], ptr_ty, Symbol::new(evidence_abi::EMPTY));
                 let new_result = call.result(ctx);
                 ctx.insert_op_before(block, op, call.op_ref());
                 ctx.replace_all_uses(old_result, new_result);
@@ -357,24 +357,16 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let ability_id_val = ability_id_const.result(ctx);
             ctx.insert_op_before(block, op, ability_id_const.op_ref());
 
-            let tr_dispatch_ptr = arena_core::unrealized_conversion_cast(
-                ctx,
-                loc,
-                extend_op.tr_dispatch_fn(ctx),
-                ptr_ty,
-            );
+            let tr_dispatch_ptr =
+                core::unrealized_conversion_cast(ctx, loc, extend_op.tr_dispatch_fn(ctx), ptr_ty);
             ctx.insert_op_before(block, op, tr_dispatch_ptr.op_ref());
 
-            let handler_dispatch_ptr = arena_core::unrealized_conversion_cast(
-                ctx,
-                loc,
-                extend_op.handler_dispatch(ctx),
-                ptr_ty,
-            );
+            let handler_dispatch_ptr =
+                core::unrealized_conversion_cast(ctx, loc, extend_op.handler_dispatch(ctx), ptr_ty);
             ctx.insert_op_before(block, op, handler_dispatch_ptr.op_ref());
 
             let old_result = extend_op.result(ctx);
-            let extend_call = arena_func::call(
+            let extend_call = func::call(
                 ctx,
                 loc,
                 [
@@ -401,7 +393,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let ability_id_val = ability_id_const.result(ctx);
             ctx.insert_op_before(block, op, ability_id_const.op_ref());
 
-            let dispatch_closure = arena_func::call(
+            let dispatch_closure = func::call(
                 ctx,
                 loc,
                 [dispatch_op.evidence(ctx), ability_id_val],
@@ -416,16 +408,16 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let op_idx_val = op_idx_const.result(ctx);
             ctx.insert_op_before(block, op, op_idx_const.op_ref());
 
-            let fn_ptr_get = arena_adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
+            let fn_ptr_get = adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
             let fn_ptr = fn_ptr_get.result(ctx);
             ctx.insert_op_before(block, op, fn_ptr_get.op_ref());
 
-            let env_get = arena_adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
+            let env_get = adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
             let env_val = env_get.result(ctx);
             ctx.insert_op_before(block, op, env_get.op_ref());
 
             let result_ty = ctx.op_result_types(op)[0];
-            let call = arena_func::call_indirect(
+            let call = func::call_indirect(
                 ctx,
                 loc,
                 fn_ptr,
@@ -452,7 +444,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let ability_id_val = ability_id_const.result(ctx);
             ctx.insert_op_before(block, op, ability_id_const.op_ref());
 
-            let dispatch_closure = arena_func::call(
+            let dispatch_closure = func::call(
                 ctx,
                 loc,
                 [dispatch_op.evidence(ctx), ability_id_val],
@@ -467,16 +459,16 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let op_idx_val = op_idx_const.result(ctx);
             ctx.insert_op_before(block, op, op_idx_const.op_ref());
 
-            let fn_ptr_get = arena_adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
+            let fn_ptr_get = adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
             let fn_ptr = fn_ptr_get.result(ctx);
             ctx.insert_op_before(block, op, fn_ptr_get.op_ref());
 
-            let env_get = arena_adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
+            let env_get = adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
             let env_val = env_get.result(ctx);
             ctx.insert_op_before(block, op, env_get.op_ref());
 
             let result_ty = ctx.op_result_types(op)[0];
-            let call = arena_func::call_indirect(
+            let call = func::call_indirect(
                 ctx,
                 loc,
                 fn_ptr,
@@ -500,7 +492,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
         // --- Rewrite func.call @__tribute_evidence_lookup → returns i32 ---
         if dialect == Symbol::new("func")
             && name == Symbol::new("call")
-            && let Ok(call_op) = arena_func::Call::from_op(ctx, op)
+            && let Ok(call_op) = func::Call::from_op(ctx, op)
         {
             let callee = call_op.callee(ctx);
 
@@ -509,7 +501,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
                 let ev_val = operands[0];
                 let ability_id_val = operands[1];
                 let old_result = ctx.op_result(op, 0);
-                let new_call = arena_func::call(
+                let new_call = func::call(
                     ctx,
                     loc,
                     operands,
@@ -547,7 +539,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
                     args.extend_from_slice(fields);
                     let old_result = ctx.op_result(op, 0);
                     let new_call =
-                        arena_func::call(ctx, loc, args, ptr_ty, Symbol::new(evidence_abi::EXTEND));
+                        func::call(ctx, loc, args, ptr_ty, Symbol::new(evidence_abi::EXTEND));
                     let new_result = new_call.result(ctx);
                     ctx.insert_op_before(block, op, new_call.op_ref());
                     ctx.replace_all_uses(old_result, new_result);
@@ -581,7 +573,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
                         field if field == i128::from(MarkerField::TrDispatchFn.index()) => {
                             // tr_dispatch_fn — call __tribute_evidence_lookup_tr
                             let old_result = ctx.op_result(op, 0);
-                            let tr_call = arena_func::call(
+                            let tr_call = func::call(
                                 ctx,
                                 loc,
                                 [ev_val, ability_id_val],
@@ -596,7 +588,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
                         field if field == i128::from(MarkerField::HandlerDispatch.index()) => {
                             // handler_dispatch — call __tribute_evidence_lookup_handler
                             let old_result = ctx.op_result(op, 0);
-                            let handler_call = arena_func::call(
+                            let handler_call = func::call(
                                 ctx,
                                 loc,
                                 [ev_val, ability_id_val],

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -246,23 +246,6 @@ fn is_marker_type(ctx: &IrContext, ty: TypeRef) -> bool {
     tribute_ir::dialect::ability::is_marker_type_ref(ctx, ty)
 }
 
-fn ability_name(ctx: &IrContext, ability_ref: TypeRef) -> Option<Symbol> {
-    match ctx.types.get(ability_ref).attrs.get(&Symbol::new("name")) {
-        Some(Attribute::Symbol(s)) => Some(*s),
-        _ => None,
-    }
-}
-
-fn ability_id_const(
-    ctx: &mut IrContext,
-    loc: Location,
-    i32_ty: TypeRef,
-    ability_ref: TypeRef,
-) -> arith::Const {
-    let ability_id = ability::compute_ability_id(ctx, ability_ref);
-    arith::r#const(ctx, loc, i32_ty, Attribute::Int(ability_id as i128))
-}
-
 fn op_idx_const(
     ctx: &mut IrContext,
     loc: Location,
@@ -270,7 +253,7 @@ fn op_idx_const(
     ability_ref: TypeRef,
     op_name: Symbol,
 ) -> arith::Const {
-    let op_idx = compute_op_idx(ability_name(ctx, ability_ref), Some(op_name));
+    let op_idx = compute_op_idx(ability::ability_name(ctx, ability_ref), Some(op_name));
     arith::r#const(ctx, loc, i32_ty, Attribute::Int(op_idx as i128))
 }
 
@@ -353,9 +336,10 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
 
         // --- effect.extend → func.call @__tribute_evidence_extend native ABI ---
         if let Ok(extend_op) = effect::Extend::from_op(ctx, op) {
-            let ability_id_const = ability_id_const(ctx, loc, i32_ty, extend_op.ability_ref(ctx));
-            let ability_id_val = ability_id_const.result(ctx);
-            ctx.insert_op_before(block, op, ability_id_const.op_ref());
+            let ability_id_op =
+                ability::ability_id_const(ctx, loc, i32_ty, extend_op.ability_ref(ctx));
+            let ability_id_val = ability_id_op.result(ctx);
+            ctx.insert_op_before(block, op, ability_id_op.op_ref());
 
             let tr_dispatch_ptr =
                 core::unrealized_conversion_cast(ctx, loc, extend_op.tr_dispatch_fn(ctx), ptr_ty);
@@ -389,9 +373,9 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
         // --- effect.dispatch_tail → lookup TR dispatch closure and call it ---
         if let Ok(dispatch_op) = effect::DispatchTail::from_op(ctx, op) {
             let ability_ref = dispatch_op.ability_ref(ctx);
-            let ability_id_const = ability_id_const(ctx, loc, i32_ty, ability_ref);
-            let ability_id_val = ability_id_const.result(ctx);
-            ctx.insert_op_before(block, op, ability_id_const.op_ref());
+            let ability_id_op = ability::ability_id_const(ctx, loc, i32_ty, ability_ref);
+            let ability_id_val = ability_id_op.result(ctx);
+            ctx.insert_op_before(block, op, ability_id_op.op_ref());
 
             let dispatch_closure = func::call(
                 ctx,
@@ -403,10 +387,9 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let dispatch_val = dispatch_closure.result(ctx);
             ctx.insert_op_before(block, op, dispatch_closure.op_ref());
 
-            let op_idx_const =
-                op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
-            let op_idx_val = op_idx_const.result(ctx);
-            ctx.insert_op_before(block, op, op_idx_const.op_ref());
+            let op_idx_op = op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
+            let op_idx_val = op_idx_op.result(ctx);
+            ctx.insert_op_before(block, op, op_idx_op.op_ref());
 
             let fn_ptr_get = adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
             let fn_ptr = fn_ptr_get.result(ctx);
@@ -440,9 +423,9 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
         // --- effect.dispatch_cps → lookup CPS dispatch closure and call it ---
         if let Ok(dispatch_op) = effect::DispatchCps::from_op(ctx, op) {
             let ability_ref = dispatch_op.ability_ref(ctx);
-            let ability_id_const = ability_id_const(ctx, loc, i32_ty, ability_ref);
-            let ability_id_val = ability_id_const.result(ctx);
-            ctx.insert_op_before(block, op, ability_id_const.op_ref());
+            let ability_id_op = ability::ability_id_const(ctx, loc, i32_ty, ability_ref);
+            let ability_id_val = ability_id_op.result(ctx);
+            ctx.insert_op_before(block, op, ability_id_op.op_ref());
 
             let dispatch_closure = func::call(
                 ctx,
@@ -454,10 +437,9 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
             let dispatch_val = dispatch_closure.result(ctx);
             ctx.insert_op_before(block, op, dispatch_closure.op_ref());
 
-            let op_idx_const =
-                op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
-            let op_idx_val = op_idx_const.result(ctx);
-            ctx.insert_op_before(block, op, op_idx_const.op_ref());
+            let op_idx_op = op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
+            let op_idx_val = op_idx_op.result(ctx);
+            ctx.insert_op_before(block, op, op_idx_op.op_ref());
 
             let fn_ptr_get = adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
             let fn_ptr = fn_ptr_get.result(ctx);

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -14,21 +14,23 @@
 //! 2. **Empty evidence** — `adt.array_new(0, evidence_ty)` →
 //!    `func.call @__tribute_evidence_empty()`.
 //!
-//! 3. **Extend call-site rewrite** — the 2-arg call
-//!    `func.call @__tribute_evidence_extend(ev, marker)` where `marker` is
-//!    produced by `adt.struct_new(ability_id, prompt_tag, tr_dispatch_fn, handler_dispatch)` is
-//!    rewritten to a 5-arg call passing the fields directly, and the now-dead
-//!    `adt.struct_new` is removed.
+//! 3. **Effect ABI lowering** — `effect.extend`, `effect.dispatch_tail`, and
+//!    `effect.dispatch_cps` are lowered to the native evidence runtime ABI and
+//!    closure indirect calls.
 //!
 //! 4. **TR dispatch field** — `adt.struct_get(marker, MarkerField::TrDispatchFn)` on evidence_lookup
 //!    results is rewritten to `func.call @__tribute_evidence_lookup_tr(ev, ability_id)`.
 
 use std::collections::HashMap;
 
-use tribute_ir::dialect::ability::{MarkerField, evidence_abi, evidence_runtime_symbols};
+use tribute_ir::dialect::ability::{
+    self, MarkerField, compute_op_idx, evidence_abi, evidence_runtime_symbols,
+};
+use tribute_ir::dialect::{effect, tribute_rt};
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::{adt as arena_adt, arith as arena_arith, core as arena_core};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::Module;
@@ -244,6 +246,34 @@ fn is_marker_type(ctx: &IrContext, ty: TypeRef) -> bool {
     tribute_ir::dialect::ability::is_marker_type_ref(ctx, ty)
 }
 
+fn ability_name(ctx: &IrContext, ability_ref: TypeRef) -> Option<Symbol> {
+    match ctx.types.get(ability_ref).attrs.get(&Symbol::new("name")) {
+        Some(Attribute::Symbol(s)) => Some(*s),
+        _ => None,
+    }
+}
+
+fn ability_id_const(
+    ctx: &mut IrContext,
+    loc: Location,
+    i32_ty: TypeRef,
+    ability_ref: TypeRef,
+) -> arena_arith::Const {
+    let ability_id = ability::compute_ability_id(ctx, ability_ref);
+    arena_arith::r#const(ctx, loc, i32_ty, Attribute::Int(ability_id as i128))
+}
+
+fn op_idx_const(
+    ctx: &mut IrContext,
+    loc: Location,
+    i32_ty: TypeRef,
+    ability_ref: TypeRef,
+    op_name: Symbol,
+) -> arena_arith::Const {
+    let op_idx = compute_op_idx(ability_name(ctx, ability_ref), Some(op_name));
+    arena_arith::r#const(ctx, loc, i32_ty, Attribute::Int(op_idx as i128))
+}
+
 fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
     let ptr_ty = ctx
         .types
@@ -251,6 +281,8 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
     let i32_ty = ctx
         .types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+    let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+    let closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
 
     // Track Marker struct_new results → their operands
     let mut marker_struct_operands: HashMap<ValueRef, Vec<ValueRef>> = HashMap::new();
@@ -317,6 +349,152 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
                 ops_to_erase.push(op);
                 continue;
             }
+        }
+
+        // --- effect.extend → func.call @__tribute_evidence_extend native ABI ---
+        if let Ok(extend_op) = effect::Extend::from_op(ctx, op) {
+            let ability_id_const = ability_id_const(ctx, loc, i32_ty, extend_op.ability_ref(ctx));
+            let ability_id_val = ability_id_const.result(ctx);
+            ctx.insert_op_before(block, op, ability_id_const.op_ref());
+
+            let tr_dispatch_ptr = arena_core::unrealized_conversion_cast(
+                ctx,
+                loc,
+                extend_op.tr_dispatch_fn(ctx),
+                ptr_ty,
+            );
+            ctx.insert_op_before(block, op, tr_dispatch_ptr.op_ref());
+
+            let handler_dispatch_ptr = arena_core::unrealized_conversion_cast(
+                ctx,
+                loc,
+                extend_op.handler_dispatch(ctx),
+                ptr_ty,
+            );
+            ctx.insert_op_before(block, op, handler_dispatch_ptr.op_ref());
+
+            let old_result = extend_op.result(ctx);
+            let extend_call = arena_func::call(
+                ctx,
+                loc,
+                [
+                    extend_op.evidence(ctx),
+                    ability_id_val,
+                    extend_op.prompt_tag(ctx),
+                    tr_dispatch_ptr.result(ctx),
+                    handler_dispatch_ptr.result(ctx),
+                ],
+                ptr_ty,
+                Symbol::new(evidence_abi::EXTEND),
+            );
+            let new_result = extend_call.result(ctx);
+            ctx.insert_op_before(block, op, extend_call.op_ref());
+            ctx.replace_all_uses(old_result, new_result);
+            ops_to_erase.push(op);
+            continue;
+        }
+
+        // --- effect.dispatch_tail → lookup TR dispatch closure and call it ---
+        if let Ok(dispatch_op) = effect::DispatchTail::from_op(ctx, op) {
+            let ability_ref = dispatch_op.ability_ref(ctx);
+            let ability_id_const = ability_id_const(ctx, loc, i32_ty, ability_ref);
+            let ability_id_val = ability_id_const.result(ctx);
+            ctx.insert_op_before(block, op, ability_id_const.op_ref());
+
+            let dispatch_closure = arena_func::call(
+                ctx,
+                loc,
+                [dispatch_op.evidence(ctx), ability_id_val],
+                ptr_ty,
+                Symbol::new(evidence_abi::LOOKUP_TR),
+            );
+            let dispatch_val = dispatch_closure.result(ctx);
+            ctx.insert_op_before(block, op, dispatch_closure.op_ref());
+
+            let op_idx_const =
+                op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
+            let op_idx_val = op_idx_const.result(ctx);
+            ctx.insert_op_before(block, op, op_idx_const.op_ref());
+
+            let fn_ptr_get = arena_adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
+            let fn_ptr = fn_ptr_get.result(ctx);
+            ctx.insert_op_before(block, op, fn_ptr_get.op_ref());
+
+            let env_get = arena_adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
+            let env_val = env_get.result(ctx);
+            ctx.insert_op_before(block, op, env_get.op_ref());
+
+            let result_ty = ctx.op_result_types(op)[0];
+            let call = arena_func::call_indirect(
+                ctx,
+                loc,
+                fn_ptr,
+                [
+                    dispatch_op.evidence(ctx),
+                    env_val,
+                    op_idx_val,
+                    dispatch_op.payload(ctx),
+                ],
+                result_ty,
+            );
+            let old_result = dispatch_op.result(ctx);
+            let new_result = call.result(ctx);
+            ctx.insert_op_before(block, op, call.op_ref());
+            ctx.replace_all_uses(old_result, new_result);
+            ops_to_erase.push(op);
+            continue;
+        }
+
+        // --- effect.dispatch_cps → lookup CPS dispatch closure and call it ---
+        if let Ok(dispatch_op) = effect::DispatchCps::from_op(ctx, op) {
+            let ability_ref = dispatch_op.ability_ref(ctx);
+            let ability_id_const = ability_id_const(ctx, loc, i32_ty, ability_ref);
+            let ability_id_val = ability_id_const.result(ctx);
+            ctx.insert_op_before(block, op, ability_id_const.op_ref());
+
+            let dispatch_closure = arena_func::call(
+                ctx,
+                loc,
+                [dispatch_op.evidence(ctx), ability_id_val],
+                ptr_ty,
+                Symbol::new(evidence_abi::LOOKUP_HANDLER),
+            );
+            let dispatch_val = dispatch_closure.result(ctx);
+            ctx.insert_op_before(block, op, dispatch_closure.op_ref());
+
+            let op_idx_const =
+                op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
+            let op_idx_val = op_idx_const.result(ctx);
+            ctx.insert_op_before(block, op, op_idx_const.op_ref());
+
+            let fn_ptr_get = arena_adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
+            let fn_ptr = fn_ptr_get.result(ctx);
+            ctx.insert_op_before(block, op, fn_ptr_get.op_ref());
+
+            let env_get = arena_adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
+            let env_val = env_get.result(ctx);
+            ctx.insert_op_before(block, op, env_get.op_ref());
+
+            let result_ty = ctx.op_result_types(op)[0];
+            let call = arena_func::call_indirect(
+                ctx,
+                loc,
+                fn_ptr,
+                [
+                    dispatch_op.evidence(ctx),
+                    env_val,
+                    dispatch_op.continuation(ctx),
+                    op_idx_val,
+                    dispatch_op.payload(ctx),
+                ],
+                result_ty,
+            );
+            let old_result = dispatch_op.result(ctx);
+            let new_result = call.result(ctx);
+            ctx.insert_op_before(block, op, call.op_ref());
+            ctx.replace_all_uses(old_result, new_result);
+            ops_to_erase.push(op);
+            continue;
         }
 
         // --- Rewrite func.call @__tribute_evidence_lookup → returns i32 ---

--- a/crates/tribute-passes/src/native/intrinsic_to_native.rs
+++ b/crates/tribute-passes/src/native/intrinsic_to_native.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::dialect::mem;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
@@ -40,7 +40,7 @@ pub fn lower(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError>
     let func_intrinsic_names = Rc::clone(&intrinsic_names);
     let target = ConversionTarget::new()
         .dynamic_op("func", "call", move |ctx, op| {
-            if let Ok(call_op) = arena_func::Call::from_op(ctx, op)
+            if let Ok(call_op) = func::Call::from_op(ctx, op)
                 && call_intrinsic_names.contains(&call_op.callee(ctx))
             {
                 return LegalityDecision::Illegal;
@@ -49,7 +49,7 @@ pub fn lower(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError>
             LegalityDecision::Defer
         })
         .dynamic_op("func", "func", move |ctx, op| {
-            if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+            if let Ok(func_op) = func::Func::from_op(ctx, op) {
                 let attrs = &ctx.op(op).attributes;
                 let is_intrinsic = matches!(
                     attrs.get(&Symbol::new("abi")),
@@ -90,7 +90,7 @@ impl RewritePattern for BytesGetOrPanicPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(call_op) = arena_func::Call::from_op(ctx, op) else {
+        let Ok(call_op) = func::Call::from_op(ctx, op) else {
             return false;
         };
         if call_op.callee(ctx) != Symbol::from_dynamic("__bytes_get_or_panic") {
@@ -152,7 +152,7 @@ impl RewritePattern for BytesIntrinsicFuncDeclPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, op) else {
+        let Ok(func_op) = func::Func::from_op(ctx, op) else {
             return false;
         };
 

--- a/crates/tribute-passes/src/native/mod.rs
+++ b/crates/tribute-passes/src/native/mod.rs
@@ -26,8 +26,8 @@ pub mod type_converter;
 use std::collections::BTreeMap;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
-use trunk_ir::dialect::core as arena_core;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::smallvec::smallvec;
 use trunk_ir::types::{Attribute, Location};
@@ -43,7 +43,7 @@ pub(crate) fn build_extern_func(
     params: &[TypeRef],
     result: TypeRef,
 ) -> OpRef {
-    let func_ty = arena_core::func(ctx, result, params.iter().copied()).as_type_ref();
+    let func_ty = core::func(ctx, result, params.iter().copied()).as_type_ref();
 
     let args: Vec<BlockArgData> = params
         .iter()
@@ -53,7 +53,7 @@ pub(crate) fn build_extern_func(
         })
         .collect();
 
-    let unreachable_op = arena_func::unreachable(ctx, loc);
+    let unreachable_op = func::unreachable(ctx, loc);
     let entry = ctx.create_block(BlockData {
         location: loc,
         args,
@@ -68,7 +68,7 @@ pub(crate) fn build_extern_func(
         parent_op: None,
     });
 
-    let func_op = arena_func::func(ctx, loc, Symbol::from_dynamic(name), func_ty, body);
+    let func_op = func::func(ctx, loc, Symbol::from_dynamic(name), func_ty, body);
     ctx.op_mut(func_op.op_ref())
         .attributes
         .insert(Symbol::new("abi"), Attribute::String("C".to_string()));

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -37,13 +37,13 @@ use std::collections::{HashMap, HashSet};
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::clif as arena_clif;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::clif;
+use trunk_ir::dialect::core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::rewrite::Module;
 use trunk_ir::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 
-use tribute_ir::dialect::tribute_rt as arena_tribute_rt;
+use tribute_ir::dialect::tribute_rt;
 
 /// Check if a type is `tribute_rt.anyref` (RC-managed reference type).
 fn is_anyref_type(ctx: &IrContext, ty: TypeRef) -> bool {
@@ -58,12 +58,12 @@ fn is_anyref_value(ctx: &IrContext, value: ValueRef) -> bool {
 
 /// Check if an op is a block terminator.
 fn is_terminator_op(ctx: &IrContext, op: OpRef) -> bool {
-    arena_clif::Return::matches(ctx, op)
-        || arena_clif::Jump::matches(ctx, op)
-        || arena_clif::Brif::matches(ctx, op)
-        || arena_clif::Trap::matches(ctx, op)
-        || arena_clif::ReturnCall::matches(ctx, op)
-        || arena_clif::BrTable::matches(ctx, op)
+    clif::Return::matches(ctx, op)
+        || clif::Jump::matches(ctx, op)
+        || clif::Brif::matches(ctx, op)
+        || clif::Trap::matches(ctx, op)
+        || clif::ReturnCall::matches(ctx, op)
+        || clif::BrTable::matches(ctx, op)
 }
 
 /// Check if a value is a static pointer (not RC-managed).
@@ -71,12 +71,12 @@ fn is_static_ptr(ctx: &IrContext, value: ValueRef) -> bool {
     let ValueDef::OpResult(def_op, _) = ctx.value_def(value) else {
         return false;
     };
-    if arena_clif::SymbolAddr::matches(ctx, def_op) {
+    if clif::SymbolAddr::matches(ctx, def_op) {
         return true;
     }
-    if arena_clif::Iconst::matches(ctx, def_op) && is_anyref_type(ctx, ctx.value_ty(value)) {
+    if clif::Iconst::matches(ctx, def_op) && is_anyref_type(ctx, ctx.value_ty(value)) {
         // Only treat null (zero) constants as unmanaged
-        if let Ok(iconst) = arena_clif::Iconst::from_op(ctx, def_op)
+        if let Ok(iconst) = clif::Iconst::from_op(ctx, def_op)
             && iconst.value(ctx) == 0
         {
             return true;
@@ -91,16 +91,16 @@ fn is_alloc_intermediate(ctx: &IrContext, value: ValueRef) -> bool {
     let ValueDef::OpResult(def_op, _) = ctx.value_def(value) else {
         return false;
     };
-    if let Ok(call_op) = arena_clif::Call::from_op(ctx, def_op) {
+    if let Ok(call_op) = clif::Call::from_op(ctx, def_op) {
         return call_op.callee(ctx) == Symbol::new("__tribute_alloc");
     }
-    if let Ok(_iadd_op) = arena_clif::Iadd::from_op(ctx, def_op) {
+    if let Ok(_iadd_op) = clif::Iadd::from_op(ctx, def_op) {
         let operands = ctx.op_operands(def_op).to_vec();
         if let Some(&lhs) = operands.first() {
             let ValueDef::OpResult(lhs_op, _) = ctx.value_def(lhs) else {
                 return false;
             };
-            if let Ok(call_op) = arena_clif::Call::from_op(ctx, lhs_op) {
+            if let Ok(call_op) = clif::Call::from_op(ctx, lhs_op) {
                 return call_op.callee(ctx) == Symbol::new("__tribute_alloc");
             }
         }
@@ -113,8 +113,8 @@ fn infer_alloc_size(ctx: &IrContext, value: ValueRef) -> u64 {
     let ValueDef::OpResult(def_op, _) = ctx.value_def(value) else {
         return 0;
     };
-    let Ok(call_op) = arena_clif::Call::from_op(ctx, def_op) else {
-        if let Ok(_iadd_op) = arena_clif::Iadd::from_op(ctx, def_op) {
+    let Ok(call_op) = clif::Call::from_op(ctx, def_op) else {
+        if let Ok(_iadd_op) = clif::Iadd::from_op(ctx, def_op) {
             let operands = ctx.op_operands(def_op).to_vec();
             if let Some(&lhs) = operands.first() {
                 return infer_alloc_size(ctx, lhs);
@@ -132,7 +132,7 @@ fn infer_alloc_size(ctx: &IrContext, value: ValueRef) -> u64 {
     let ValueDef::OpResult(size_op, _) = ctx.value_def(size_val) else {
         return 0;
     };
-    if let Ok(iconst_op) = arena_clif::Iconst::from_op(ctx, size_op) {
+    if let Ok(iconst_op) = clif::Iconst::from_op(ctx, size_op) {
         return iconst_op.value(ctx) as u64;
     }
     0
@@ -197,7 +197,7 @@ fn build_ptr_alias_map(
 
     for &block in &blocks {
         for &op in &ctx.block(block).ops.to_vec() {
-            if arena_core::UnrealizedConversionCast::matches(ctx, op) {
+            if core::UnrealizedConversionCast::matches(ctx, op) {
                 let operands = ctx.op_operands(op).to_vec();
                 if let Some(&input) = operands.first() {
                     let root = if ptr_values.contains(&input) {
@@ -374,7 +374,7 @@ pub fn insert_rc(ctx: &mut IrContext, module: Module) {
     let module_ops: Vec<OpRef> = ctx.block(first_block).ops.to_vec();
 
     for op in &module_ops {
-        if let Ok(func_op) = arena_clif::Func::from_op(ctx, *op) {
+        if let Ok(func_op) = clif::Func::from_op(ctx, *op) {
             let sym = func_op.sym_name(ctx);
             if sym.with_str(|s| s.starts_with(super::rtti::RELEASE_FN_PREFIX)) {
                 continue;
@@ -395,7 +395,7 @@ pub fn insert_rc(ctx: &mut IrContext, module: Module) {
 /// distinction is no longer needed. All anyref types are lowered to core.ptr
 /// so that subsequent passes (resolve_casts, Cranelift emit) see only core types.
 fn lower_anyref_to_ptr(ctx: &mut IrContext, module: Module) {
-    let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+    let ptr_ty = core::ptr(ctx).as_type_ref();
     let anyref_ty = ctx.types.intern(
         trunk_ir::TypeDataBuilder::new(Symbol::new("tribute_rt"), Symbol::new("anyref")).build(),
     );
@@ -405,7 +405,7 @@ fn lower_anyref_to_ptr(ctx: &mut IrContext, module: Module) {
     let module_ops: Vec<OpRef> = ctx.block(first_block).ops.to_vec();
 
     for op in module_ops {
-        if let Ok(func_op) = arena_clif::Func::from_op(ctx, op) {
+        if let Ok(func_op) = clif::Func::from_op(ctx, op) {
             // Rewrite function type attribute (anyref → ptr in params/return)
             let func_type = func_op.r#type(ctx);
             let new_func_type = rewrite_func_type(ctx, func_type, anyref_ty, ptr_ty);
@@ -574,7 +574,7 @@ fn insert_rc_in_block(
 ) {
     let ops: Vec<OpRef> = ctx.block(block).ops.to_vec();
     let loc = ctx.block(block).location;
-    let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+    let ptr_ty = core::ptr(ctx).as_type_ref();
 
     let live_in = liveness.live_in.get(&block).cloned().unwrap_or_default();
     let live_out = liveness.live_out.get(&block).cloned().unwrap_or_default();
@@ -595,7 +595,7 @@ fn insert_rc_in_block(
     // Returned values
     let mut returned_values: HashSet<ValueRef> = HashSet::new();
     if let Some(&last_op) = ops.last()
-        && arena_clif::Return::matches(ctx, last_op)
+        && clif::Return::matches(ctx, last_op)
     {
         for &operand in ctx.op_operands(last_op) {
             if ptr_values.contains(&operand) {
@@ -616,7 +616,7 @@ fn insert_rc_in_block(
         let args: Vec<ValueRef> = ctx.block_args(block).to_vec();
         for arg_val in args {
             if is_anyref_type(ctx, ctx.value_ty(arg_val)) {
-                let retain_op = arena_tribute_rt::retain(ctx, loc, arg_val, ptr_ty);
+                let retain_op = tribute_rt::retain(ctx, loc, arg_val, ptr_ty);
                 plan.at_start.push(retain_op.op_ref());
             }
         }
@@ -624,14 +624,14 @@ fn insert_rc_in_block(
 
     // 2. Retain before store of ptr, retain after load of ptr
     for (op_idx, &op) in ops.iter().enumerate() {
-        if let Ok(_store_op) = arena_clif::Store::from_op(ctx, op) {
+        if let Ok(_store_op) = clif::Store::from_op(ctx, op) {
             let operands = ctx.op_operands(op).to_vec();
             if let Some(&stored_val) = operands.first()
                 && is_anyref_value(ctx, stored_val)
                 && !is_static_ptr(ctx, stored_val)
             {
                 let op_loc = ctx.op(op).location;
-                let retain_op = arena_tribute_rt::retain(ctx, op_loc, stored_val, ptr_ty);
+                let retain_op = tribute_rt::retain(ctx, op_loc, stored_val, ptr_ty);
                 plan.before
                     .entry(op_idx)
                     .or_default()
@@ -639,12 +639,12 @@ fn insert_rc_in_block(
             }
         }
 
-        if arena_clif::Load::matches(ctx, op) {
+        if clif::Load::matches(ctx, op) {
             let result_ty = ctx.op_result_types(op).first().copied();
             if result_ty.is_some_and(|ty| is_anyref_type(ctx, ty)) {
                 let load_result = ctx.op_result(op, 0);
                 let op_loc = ctx.op(op).location;
-                let retain_op = arena_tribute_rt::retain(ctx, op_loc, load_result, ptr_ty);
+                let retain_op = tribute_rt::retain(ctx, op_loc, load_result, ptr_ty);
                 plan.after
                     .entry(op_idx)
                     .or_default()
@@ -682,14 +682,14 @@ fn insert_rc_in_block(
     for v in &dying_sorted {
         if let Some(&last_use_idx) = last_use_in_block.get(v) {
             let last_op = ops[last_use_idx];
-            if arena_clif::Return::matches(ctx, last_op) {
+            if clif::Return::matches(ctx, last_op) {
                 continue;
             }
             let alloc_size = infer_alloc_size(ctx, *v);
             let op_loc = ctx.op(last_op).location;
-            let release_op = arena_tribute_rt::release(ctx, op_loc, *v, alloc_size);
+            let release_op = tribute_rt::release(ctx, op_loc, *v, alloc_size);
             if is_terminator_op(ctx, last_op) {
-                if arena_clif::Jump::matches(ctx, last_op) {
+                if clif::Jump::matches(ctx, last_op) {
                     continue;
                 }
                 plan.before
@@ -704,14 +704,14 @@ fn insert_rc_in_block(
             }
         } else if live_in.contains(v) {
             let alloc_size = infer_alloc_size(ctx, *v);
-            let release_op = arena_tribute_rt::release(ctx, loc, *v, alloc_size);
+            let release_op = tribute_rt::release(ctx, loc, *v, alloc_size);
             plan.at_start.push(release_op.op_ref());
         } else if let ValueDef::OpResult(def_op, _) = ctx.value_def(*v) {
             for (op_idx, &op) in ops.iter().enumerate() {
                 if op == def_op {
                     let alloc_size = infer_alloc_size(ctx, *v);
                     let op_loc = ctx.op(op).location;
-                    let release_op = arena_tribute_rt::release(ctx, op_loc, *v, alloc_size);
+                    let release_op = tribute_rt::release(ctx, op_loc, *v, alloc_size);
                     plan.after
                         .entry(op_idx)
                         .or_default()
@@ -721,7 +721,7 @@ fn insert_rc_in_block(
             }
         } else if let ValueDef::BlockArg(_, _) = ctx.value_def(*v) {
             let alloc_size = infer_alloc_size(ctx, *v);
-            let release_op = arena_tribute_rt::release(ctx, loc, *v, alloc_size);
+            let release_op = tribute_rt::release(ctx, loc, *v, alloc_size);
             plan.at_start.push(release_op.op_ref());
         }
     }

--- a/crates/tribute-passes/src/native/rtti.rs
+++ b/crates/tribute-passes/src/native/rtti.rs
@@ -32,9 +32,9 @@ use trunk_ir::adt_layout::{
     compute_enum_layout, compute_struct_layout, get_enum_variants, get_struct_fields,
 };
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
-use trunk_ir::dialect::adt as arena_adt;
-use trunk_ir::dialect::clif as arena_clif;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::adt;
+use trunk_ir::dialect::clif;
+use trunk_ir::dialect::core;
 use trunk_ir::location::Span;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::rewrite::{Module, TypeConverter};
@@ -43,7 +43,7 @@ use trunk_ir::types::Location;
 use trunk_ir::walk::WalkAction;
 use trunk_ir::{BlockRef, OpRef, TypeRef, ValueRef};
 
-use tribute_ir::dialect::tribute_rt as arena_tribute_rt;
+use tribute_ir::dialect::tribute_rt;
 
 /// Commonly used CLIF primitive types, pre-interned for convenience.
 struct ClifTypes {
@@ -170,7 +170,7 @@ fn collect_types(ctx: &IrContext, module: Module, rtti_map: &mut RttiMap) {
         let name = op_data.name;
 
         if dialect == Symbol::new("adt") && name == Symbol::new("struct_new") {
-            if let Ok(struct_new) = arena_adt::StructNew::from_op(ctx, op) {
+            if let Ok(struct_new) = adt::StructNew::from_op(ctx, op) {
                 let struct_ty = struct_new.r#type(ctx);
                 if get_struct_fields(ctx, struct_ty).is_some() {
                     rtti_map.get_or_insert(struct_ty);
@@ -178,7 +178,7 @@ fn collect_types(ctx: &IrContext, module: Module, rtti_map: &mut RttiMap) {
             }
         } else if dialect == Symbol::new("adt")
             && name == Symbol::new("variant_new")
-            && let Ok(variant_new) = arena_adt::VariantNew::from_op(ctx, op)
+            && let Ok(variant_new) = adt::VariantNew::from_op(ctx, op)
         {
             let enum_ty = variant_new.r#type(ctx);
             if get_enum_variants(ctx, enum_ty).is_some() {
@@ -212,7 +212,7 @@ fn generate_release_function_for_struct(
     let func_name = format!("{}{}", RELEASE_FN_PREFIX, rtti_idx);
 
     // Function type: (core.ptr) -> core.nil
-    let func_ty = arena_core::func(ctx, nil_ty, [ptr_ty]).as_type_ref();
+    let func_ty = core::func(ctx, nil_ty, [ptr_ty]).as_type_ref();
 
     // Collect pointer field offsets (skip func_ptr fields)
     let func_ptr_sym = Symbol::new("func_ptr");
@@ -281,7 +281,7 @@ fn generate_release_function_for_struct(
             parent_op: None,
         });
 
-        let func_op = arena_clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
+        let func_op = clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
         return func_op.op_ref();
     }
 
@@ -297,11 +297,11 @@ fn generate_release_function_for_struct(
             ops: smallvec![],
             parent_region: None,
         });
-        let reload = arena_clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
+        let reload = clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
         ctx.push_op(release_block, reload.op_ref());
-        let release = arena_tribute_rt::release(ctx, loc, reload.result(ctx), 0);
+        let release = tribute_rt::release(ctx, loc, reload.result(ctx), 0);
         ctx.push_op(release_block, release.op_ref());
-        let jump = arena_clif::jump(ctx, loc, [], next_block);
+        let jump = clif::jump(ctx, loc, [], next_block);
         ctx.push_op(release_block, jump.op_ref());
 
         // Check block: load field, null check, branch
@@ -311,11 +311,11 @@ fn generate_release_function_for_struct(
             ops: smallvec![],
             parent_region: None,
         });
-        let load = arena_clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
+        let load = clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
         ctx.push_op(check_block, load.op_ref());
-        let null_const = arena_clif::iconst(ctx, loc, ptr_ty, 0);
+        let null_const = clif::iconst(ctx, loc, ptr_ty, 0);
         ctx.push_op(check_block, null_const.op_ref());
-        let is_null = arena_clif::icmp(
+        let is_null = clif::icmp(
             ctx,
             loc,
             load.result(ctx),
@@ -324,7 +324,7 @@ fn generate_release_function_for_struct(
             Symbol::new("eq"),
         );
         ctx.push_op(check_block, is_null.op_ref());
-        let brif = arena_clif::brif(ctx, loc, is_null.result(ctx), next_block, release_block);
+        let brif = clif::brif(ctx, loc, is_null.result(ctx), next_block, release_block);
         ctx.push_op(check_block, brif.op_ref());
 
         blocks_after_entry.push(release_block);
@@ -350,7 +350,7 @@ fn generate_release_function_for_struct(
         parent_op: None,
     });
 
-    let func_op = arena_clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
+    let func_op = clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
     func_op.op_ref()
 }
 
@@ -368,16 +368,16 @@ fn gen_dealloc_and_return(
 ) {
     use tribute_ir::dialect::tribute_rt::RC_HEADER_SIZE;
 
-    let hdr_sz = arena_clif::iconst(ctx, loc, i64_ty, RC_HEADER_SIZE as i64);
+    let hdr_sz = clif::iconst(ctx, loc, i64_ty, RC_HEADER_SIZE as i64);
     ctx.push_op(block, hdr_sz.op_ref());
-    let raw_ptr = arena_clif::isub(ctx, loc, payload_ptr, hdr_sz.result(ctx), ptr_ty);
+    let raw_ptr = clif::isub(ctx, loc, payload_ptr, hdr_sz.result(ctx), ptr_ty);
     ctx.push_op(block, raw_ptr.op_ref());
 
     let alloc_size = layout.total_size as u64 + RC_HEADER_SIZE;
-    let size_op = arena_clif::iconst(ctx, loc, i64_ty, alloc_size as i64);
+    let size_op = clif::iconst(ctx, loc, i64_ty, alloc_size as i64);
     ctx.push_op(block, size_op.op_ref());
 
-    let dealloc_call = arena_clif::call(
+    let dealloc_call = clif::call(
         ctx,
         loc,
         [raw_ptr.result(ctx), size_op.result(ctx)],
@@ -386,7 +386,7 @@ fn gen_dealloc_and_return(
     );
     ctx.push_op(block, dealloc_call.op_ref());
 
-    let ret_op = arena_clif::r#return(ctx, loc, []);
+    let ret_op = clif::r#return(ctx, loc, []);
     ctx.push_op(block, ret_op.op_ref());
 }
 
@@ -425,7 +425,7 @@ fn generate_release_function_for_enum(
     let i8_ty = tys.i8;
 
     let func_name = format!("{}{}", RELEASE_FN_PREFIX, rtti_idx);
-    let func_ty = arena_core::func(ctx, nil_ty, [ptr_ty]).as_type_ref();
+    let func_ty = core::func(ctx, nil_ty, [ptr_ty]).as_type_ref();
 
     let entry_block = ctx.create_block(BlockData {
         location: loc,
@@ -483,16 +483,16 @@ fn generate_release_function_for_enum(
     {
         use tribute_ir::dialect::tribute_rt::RC_HEADER_SIZE;
 
-        let hdr_sz = arena_clif::iconst(ctx, loc, i64_ty, RC_HEADER_SIZE as i64);
+        let hdr_sz = clif::iconst(ctx, loc, i64_ty, RC_HEADER_SIZE as i64);
         ctx.push_op(dealloc_block, hdr_sz.op_ref());
-        let raw_ptr = arena_clif::isub(ctx, loc, payload_ptr, hdr_sz.result(ctx), ptr_ty);
+        let raw_ptr = clif::isub(ctx, loc, payload_ptr, hdr_sz.result(ctx), ptr_ty);
         ctx.push_op(dealloc_block, raw_ptr.op_ref());
 
         let alloc_size = layout.total_size as u64 + RC_HEADER_SIZE;
-        let size_op = arena_clif::iconst(ctx, loc, i64_ty, alloc_size as i64);
+        let size_op = clif::iconst(ctx, loc, i64_ty, alloc_size as i64);
         ctx.push_op(dealloc_block, size_op.op_ref());
 
-        let dealloc_call = arena_clif::call(
+        let dealloc_call = clif::call(
             ctx,
             loc,
             [raw_ptr.result(ctx), size_op.result(ctx)],
@@ -501,13 +501,13 @@ fn generate_release_function_for_enum(
         );
         ctx.push_op(dealloc_block, dealloc_call.op_ref());
 
-        let ret_op = arena_clif::r#return(ctx, loc, []);
+        let ret_op = clif::r#return(ctx, loc, []);
         ctx.push_op(dealloc_block, ret_op.op_ref());
     }
 
     if variants_with_ptrs.is_empty() {
         // No pointer fields: entry jumps straight to dealloc
-        let jump = arena_clif::jump(ctx, loc, [], dealloc_block);
+        let jump = clif::jump(ctx, loc, [], dealloc_block);
         ctx.push_op(entry_block, jump.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -515,7 +515,7 @@ fn generate_release_function_for_enum(
             blocks: smallvec![entry_block, dealloc_block],
             parent_op: None,
         });
-        let func_op = arena_clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
+        let func_op = clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
         return func_op.op_ref();
     }
 
@@ -537,11 +537,11 @@ fn generate_release_function_for_enum(
                 ops: smallvec![],
                 parent_region: None,
             });
-            let reload = arena_clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
+            let reload = clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
             ctx.push_op(rel_block, reload.op_ref());
-            let release_op = arena_tribute_rt::release(ctx, loc, reload.result(ctx), 0);
+            let release_op = tribute_rt::release(ctx, loc, reload.result(ctx), 0);
             ctx.push_op(rel_block, release_op.op_ref());
-            let jump = arena_clif::jump(ctx, loc, [], next_block);
+            let jump = clif::jump(ctx, loc, [], next_block);
             ctx.push_op(rel_block, jump.op_ref());
 
             // Check block: load field, null check, branch
@@ -551,11 +551,11 @@ fn generate_release_function_for_enum(
                 ops: smallvec![],
                 parent_region: None,
             });
-            let load_op = arena_clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
+            let load_op = clif::load(ctx, loc, payload_ptr, ptr_ty, offset);
             ctx.push_op(chk_block, load_op.op_ref());
-            let null_const = arena_clif::iconst(ctx, loc, ptr_ty, 0);
+            let null_const = clif::iconst(ctx, loc, ptr_ty, 0);
             ctx.push_op(chk_block, null_const.op_ref());
-            let is_null = arena_clif::icmp(
+            let is_null = clif::icmp(
                 ctx,
                 loc,
                 load_op.result(ctx),
@@ -564,7 +564,7 @@ fn generate_release_function_for_enum(
                 Symbol::new("eq"),
             );
             ctx.push_op(chk_block, is_null.op_ref());
-            let brif = arena_clif::brif(ctx, loc, is_null.result(ctx), next_block, rel_block);
+            let brif = clif::brif(ctx, loc, is_null.result(ctx), next_block, rel_block);
             ctx.push_op(chk_block, brif.op_ref());
 
             extra_blocks.push(rel_block);
@@ -583,7 +583,7 @@ fn generate_release_function_for_enum(
     let num_variants = variants_with_ptrs.len();
 
     // Load tag in entry block
-    let tag_load = arena_clif::load(ctx, loc, payload_ptr, i32_ty, 0);
+    let tag_load = clif::load(ctx, loc, payload_ptr, i32_ty, 0);
     ctx.push_op(entry_block, tag_load.op_ref());
     let tag_val = tag_load.result(ctx);
 
@@ -596,9 +596,9 @@ fn generate_release_function_for_enum(
             ops: smallvec![],
             parent_region: None,
         });
-        let expected = arena_clif::iconst(ctx, loc, i32_ty, vr.tag_value as i64);
+        let expected = clif::iconst(ctx, loc, i32_ty, vr.tag_value as i64);
         ctx.push_op(check_block, expected.op_ref());
-        let cmp_op = arena_clif::icmp(
+        let cmp_op = clif::icmp(
             ctx,
             loc,
             tag_val,
@@ -607,7 +607,7 @@ fn generate_release_function_for_enum(
             Symbol::new("eq"),
         );
         ctx.push_op(check_block, cmp_op.op_ref());
-        let brif_op = arena_clif::brif(
+        let brif_op = clif::brif(
             ctx,
             loc,
             cmp_op.result(ctx),
@@ -623,9 +623,9 @@ fn generate_release_function_for_enum(
 
     // Entry block: check first variant
     let first_vr = &variants_with_ptrs[0];
-    let expected = arena_clif::iconst(ctx, loc, i32_ty, first_vr.tag_value as i64);
+    let expected = clif::iconst(ctx, loc, i32_ty, first_vr.tag_value as i64);
     ctx.push_op(entry_block, expected.op_ref());
-    let cmp_op = arena_clif::icmp(
+    let cmp_op = clif::icmp(
         ctx,
         loc,
         tag_val,
@@ -634,7 +634,7 @@ fn generate_release_function_for_enum(
         Symbol::new("eq"),
     );
     ctx.push_op(entry_block, cmp_op.op_ref());
-    let brif_op = arena_clif::brif(
+    let brif_op = clif::brif(
         ctx,
         loc,
         cmp_op.result(ctx),
@@ -661,7 +661,7 @@ fn generate_release_function_for_enum(
         blocks: all_blocks.into(),
         parent_op: None,
     });
-    let func_op = arena_clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
+    let func_op = clif::func(ctx, loc, Symbol::from_dynamic(&func_name), func_ty, body);
     func_op.op_ref()
 }
 
@@ -671,7 +671,7 @@ mod tests {
     use std::collections::BTreeMap;
     use trunk_ir::Span;
     use trunk_ir::context::{BlockArgData, BlockData, IrContext, OperationDataBuilder};
-    use trunk_ir::dialect::func as arena_func;
+    use trunk_ir::dialect::func;
     use trunk_ir::printer::print_module;
     use trunk_ir::rewrite::Module;
     use trunk_ir::types::Attribute;
@@ -696,7 +696,7 @@ mod tests {
         field_types: &[TypeRef],
     ) -> Module {
         // Build function type: (field_types...) -> struct_ty
-        let func_ty = arena_core::func(ctx, struct_ty, field_types.iter().copied()).as_type_ref();
+        let func_ty = core::func(ctx, struct_ty, field_types.iter().copied()).as_type_ref();
 
         // Create entry block with field arguments
         let args: Vec<BlockArgData> = field_types
@@ -729,7 +729,7 @@ mod tests {
         let struct_result = ctx.op_result(struct_new_ref, 0);
         ctx.push_op(entry, struct_new_ref);
 
-        let ret = arena_func::r#return(ctx, loc, [struct_result]);
+        let ret = func::r#return(ctx, loc, [struct_result]);
         ctx.push_op(entry, ret.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -737,7 +737,7 @@ mod tests {
             blocks: smallvec![entry],
             parent_op: None,
         });
-        let func_op = arena_func::func(ctx, loc, Symbol::new("create_struct"), func_ty, body);
+        let func_op = func::func(ctx, loc, Symbol::new("create_struct"), func_ty, body);
 
         // Build module
         let module_block = ctx.create_block(BlockData {
@@ -839,7 +839,7 @@ mod tests {
         let node_ty = make_struct_type(&mut ctx, &[("value", i32_ty), ("next", ptr_ty)]);
 
         // Build module with two struct_new ops
-        let func_ty = arena_core::func(&mut ctx, ptr_ty, [i32_ty, i32_ty, ptr_ty]).as_type_ref();
+        let func_ty = core::func(&mut ctx, ptr_ty, [i32_ty, i32_ty, ptr_ty]).as_type_ref();
 
         let entry = ctx.create_block(BlockData {
             location: loc,
@@ -884,7 +884,7 @@ mod tests {
         let sn2_result = ctx.op_result(sn2_ref, 0);
         ctx.push_op(entry, sn2_ref);
 
-        let ret = arena_func::r#return(&mut ctx, loc, [sn2_result]);
+        let ret = func::r#return(&mut ctx, loc, [sn2_result]);
         ctx.push_op(entry, ret.op_ref());
 
         let body = ctx.create_region(RegionData {
@@ -892,7 +892,7 @@ mod tests {
             blocks: smallvec![entry],
             parent_op: None,
         });
-        let func_op = arena_func::func(&mut ctx, loc, Symbol::new("create"), func_ty, body);
+        let func_op = func::func(&mut ctx, loc, Symbol::new("create"), func_ty, body);
 
         let module_block = ctx.create_block(BlockData {
             location: loc,

--- a/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
+++ b/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
@@ -21,7 +21,7 @@ use tribute_ir::dialect::tribute_rt::{RC_HEADER_SIZE, REFCOUNT_OFFSET, RTTI_IDX_
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::clif;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::rewriter::PatternRewriter;
@@ -113,7 +113,7 @@ pub fn lower(
     type_converter: TypeConverter,
 ) -> Result<(), ConversionError> {
     // Pre-intern types for patterns
-    let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+    let ptr_ty = core::ptr(ctx).as_type_ref();
     let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
     let i64_ty = ctx
         .types

--- a/crates/tribute-passes/src/native/type_converter.rs
+++ b/crates/tribute-passes/src/native/type_converter.rs
@@ -27,12 +27,12 @@
 //! types, the native backend uses opaque pointers (`core.ptr`) for all
 //! reference types. Most conversions between pointer types are no-ops.
 
-use tribute_ir::dialect::tribute_rt as arena_tribute_rt;
+use tribute_ir::dialect::tribute_rt;
 use tribute_ir::dialect::tribute_rt::{RC_HEADER_SIZE, REFCOUNT_OFFSET, RTTI_IDX_OFFSET};
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::clif as arena_clif;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::clif;
+use trunk_ir::dialect::core;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::TypeConverter;
 use trunk_ir::types::{Location, TypeDataBuilder};
@@ -41,7 +41,7 @@ use trunk_ir::types::{Location, TypeDataBuilder};
 const ALLOC_FN: &str = "__tribute_alloc";
 
 // =============================================================================
-// Arena versions
+// Native type conversion
 // =============================================================================
 
 /// Pre-interned types for the arena native type converter.
@@ -74,14 +74,14 @@ pub struct NativeTypeRefs {
 impl NativeTypeRefs {
     /// Pre-intern all types needed by the native type converter.
     pub fn new(ctx: &mut IrContext) -> Self {
-        use tribute_ir::dialect::ability as arena_ability;
+        use tribute_ir::dialect::ability;
         Self {
-            tribute_rt_int: arena_tribute_rt::int(ctx).as_type_ref(),
-            tribute_rt_nat: arena_tribute_rt::nat(ctx).as_type_ref(),
-            tribute_rt_bool: arena_tribute_rt::bool(ctx).as_type_ref(),
-            tribute_rt_float: arena_tribute_rt::float(ctx).as_type_ref(),
-            tribute_rt_intref: arena_tribute_rt::intref(ctx).as_type_ref(),
-            tribute_rt_anyref: arena_tribute_rt::anyref(ctx).as_type_ref(),
+            tribute_rt_int: tribute_rt::int(ctx).as_type_ref(),
+            tribute_rt_nat: tribute_rt::nat(ctx).as_type_ref(),
+            tribute_rt_bool: tribute_rt::bool(ctx).as_type_ref(),
+            tribute_rt_float: tribute_rt::float(ctx).as_type_ref(),
+            tribute_rt_intref: tribute_rt::intref(ctx).as_type_ref(),
+            tribute_rt_anyref: tribute_rt::anyref(ctx).as_type_ref(),
             core_i1: ctx
                 .types
                 .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i1")).build()),
@@ -95,22 +95,21 @@ impl NativeTypeRefs {
             core_f64: ctx
                 .types
                 .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("f64")).build()),
-            core_ptr: arena_core::ptr(ctx).as_type_ref(),
-            core_nil: arena_core::nil(ctx).as_type_ref(),
+            core_ptr: core::ptr(ctx).as_type_ref(),
+            core_nil: core::nil(ctx).as_type_ref(),
             core_i8: ctx
                 .types
                 .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i8")).build()),
 
-            evidence_ty: arena_ability::evidence_adt_type_ref(ctx),
-            marker_ty: arena_ability::marker_adt_type_ref(ctx),
+            evidence_ty: ability::evidence_adt_type_ref(ctx),
+            marker_ty: ability::marker_adt_type_ref(ctx),
         }
     }
 }
 
 /// Create an `TypeConverter` configured for native backend type conversions.
 ///
-/// Arena version of `native_type_converter()`. All type checks use pre-interned
-/// `TypeRef` comparisons for efficiency.
+/// All type checks use pre-interned `TypeRef` comparisons for efficiency.
 pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeRefs) {
     let refs = NativeTypeRefs::new(ctx);
 
@@ -165,7 +164,7 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
     tc.set_materializer(move |ctx, location, value, from_ty, to_ty| {
         // Same type: no-op
         if from_ty == to_ty {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
 
         // Primitive equivalences (NoOp)
@@ -175,34 +174,34 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
             || from_ty == r.core_i1)
             && to_ty == r.core_i32
         {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         if from_ty == r.tribute_rt_float && to_ty == r.core_f64 {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         if from_ty == r.tribute_rt_intref && to_ty == r.core_ptr {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         // anyref → ptr: no-op (same representation)
         if from_ty == r.tribute_rt_anyref && to_ty == r.core_ptr {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         // ptr → anyref: no-op (same representation)
         if from_ty == r.core_ptr && to_ty == r.tribute_rt_anyref {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         if from_ty == r.evidence_ty && to_ty == r.core_ptr {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         if from_ty == r.core_ptr && to_ty == r.evidence_ty {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         // core.bytes ↔ ptr: no-op (same representation in native)
         if is_bytes_type(ctx, from_ty) && to_ty == r.core_ptr {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
         if from_ty == r.core_ptr && is_bytes_type(ctx, to_ty) {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
 
         // Pointer equivalences: ptr-like ↔ ptr ↔ anyref
@@ -215,7 +214,7 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
             || (from_is_ptr && to_ptr_like)
             || (from_ptr_like && to_ptr_like)
         {
-            return Some(arena_materialize_result_noop(value));
+            return Some(materialize_result_noop(value));
         }
 
         // Boxing: primitive → ptr/anyref
@@ -241,7 +240,7 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
                 ));
             }
             if from_ty == r.core_nil {
-                let null_op = arena_clif::iconst(ctx, location, ptr_ty, 0);
+                let null_op = clif::iconst(ctx, location, ptr_ty, 0);
                 return Some(trunk_ir::rewrite::type_converter::MaterializeResult {
                     value: null_op.result(ctx),
                     ops: vec![null_op.op_ref()],
@@ -253,28 +252,28 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
         let from_is_ptr_or_any = from_ty == r.core_ptr || from_ty == r.tribute_rt_anyref;
         if from_is_ptr_or_any {
             if to_ty == r.core_i32 || to_ty == r.tribute_rt_int {
-                let load = arena_clif::load(ctx, location, value, r.core_i32, 0);
+                let load = clif::load(ctx, location, value, r.core_i32, 0);
                 return Some(trunk_ir::rewrite::type_converter::MaterializeResult {
                     value: load.result(ctx),
                     ops: vec![load.op_ref()],
                 });
             }
             if to_ty == r.core_i64 {
-                let load = arena_clif::load(ctx, location, value, r.core_i64, 0);
+                let load = clif::load(ctx, location, value, r.core_i64, 0);
                 return Some(trunk_ir::rewrite::type_converter::MaterializeResult {
                     value: load.result(ctx),
                     ops: vec![load.op_ref()],
                 });
             }
             if to_ty == r.core_f64 {
-                let load = arena_clif::load(ctx, location, value, r.core_f64, 0);
+                let load = clif::load(ctx, location, value, r.core_f64, 0);
                 return Some(trunk_ir::rewrite::type_converter::MaterializeResult {
                     value: load.result(ctx),
                     ops: vec![load.op_ref()],
                 });
             }
             if to_ty == r.core_nil {
-                return Some(arena_materialize_result_noop(value));
+                return Some(materialize_result_noop(value));
             }
         }
 
@@ -285,13 +284,13 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
 }
 
 /// NoOp materialization result (pass value through unchanged).
-fn arena_materialize_result_noop(
+fn materialize_result_noop(
     value: ValueRef,
 ) -> trunk_ir::rewrite::type_converter::MaterializeResult {
     trunk_ir::rewrite::type_converter::MaterializeResult { value, ops: vec![] }
 }
 
-/// Generate boxing operations in arena IR: allocate + store RC header + store value.
+/// Generate boxing operations: allocate + store RC header + store value.
 fn box_primitive(
     ctx: &mut IrContext,
     location: Location,
@@ -305,11 +304,11 @@ fn box_primitive(
 
     // 1. Allocation size (payload + RC header)
     let alloc_size = payload_size + RC_HEADER_SIZE;
-    let size_op = arena_clif::iconst(ctx, location, i64_ty, alloc_size as i64);
+    let size_op = clif::iconst(ctx, location, i64_ty, alloc_size as i64);
     ops.push(size_op.op_ref());
 
     // 2. Allocate heap memory
-    let call_op = arena_clif::call(
+    let call_op = clif::call(
         ctx,
         location,
         [size_op.result(ctx)],
@@ -320,9 +319,9 @@ fn box_primitive(
     let raw_ptr = call_op.result(ctx);
 
     // 3. Store refcount = 1
-    let rc_one = arena_clif::iconst(ctx, location, i32_ty, 1);
+    let rc_one = clif::iconst(ctx, location, i32_ty, 1);
     ops.push(rc_one.op_ref());
-    let store_rc = arena_clif::store(
+    let store_rc = clif::store(
         ctx,
         location,
         rc_one.result(ctx),
@@ -332,9 +331,9 @@ fn box_primitive(
     ops.push(store_rc.op_ref());
 
     // 4. Store rtti_idx = 0
-    let rtti_zero = arena_clif::iconst(ctx, location, i32_ty, 0);
+    let rtti_zero = clif::iconst(ctx, location, i32_ty, 0);
     ops.push(rtti_zero.op_ref());
-    let store_rtti = arena_clif::store(
+    let store_rtti = clif::store(
         ctx,
         location,
         rtti_zero.result(ctx),
@@ -344,19 +343,19 @@ fn box_primitive(
     ops.push(store_rtti.op_ref());
 
     // 5. Compute payload pointer = raw_ptr + 8
-    let hdr_size = arena_clif::iconst(ctx, location, i64_ty, RC_HEADER_SIZE as i64);
+    let hdr_size = clif::iconst(ctx, location, i64_ty, RC_HEADER_SIZE as i64);
     ops.push(hdr_size.op_ref());
-    let payload_ptr = arena_clif::iadd(ctx, location, raw_ptr, hdr_size.result(ctx), ptr_ty);
+    let payload_ptr = clif::iadd(ctx, location, raw_ptr, hdr_size.result(ctx), ptr_ty);
     ops.push(payload_ptr.op_ref());
 
     // 6. Store value at payload offset 0
-    let store_val = arena_clif::store(ctx, location, value, payload_ptr.result(ctx), 0);
+    let store_val = clif::store(ctx, location, value, payload_ptr.result(ctx), 0);
     ops.push(store_val.op_ref());
 
     // 7. Identity pass-through so the last op produces the payload ptr result
-    let zero_op = arena_clif::iconst(ctx, location, ptr_ty, 0);
+    let zero_op = clif::iconst(ctx, location, ptr_ty, 0);
     ops.push(zero_op.op_ref());
-    let identity_op = arena_clif::iadd(
+    let identity_op = clif::iadd(
         ctx,
         location,
         payload_ptr.result(ctx),

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -763,14 +763,11 @@ fn transform_shifts_in_block(
         if let Ok(lookup_op) = ability::EvidenceLookup::from_op(ctx, op) {
             let loc = ctx.op(op).location;
             let ability_ref = lookup_op.ability_ref(ctx);
-            let ability_id = ability::compute_ability_id(ctx, ability_ref);
-
             let marker_ty = ability::marker_adt_type_ref(ctx);
             let i32_ty = i32_type_ref(ctx);
 
             // %ability_id_const = arith.const ability_id
-            let ability_id_const =
-                arith::r#const(ctx, loc, i32_ty, Attribute::Int(ability_id as i128));
+            let ability_id_const = ability::ability_id_const(ctx, loc, i32_ty, ability_ref);
             let ability_id_val = ctx.op_result(ability_id_const.op_ref(), 0);
             ctx.insert_op_before(block, op, ability_id_const.op_ref());
 

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -12,6 +12,7 @@
 use std::collections::{HashMap, HashSet};
 
 use tribute_ir::dialect::ability::{self, evidence_abi};
+use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::adt;
@@ -283,60 +284,6 @@ fn collect_abilities_from_body_region(ctx: &IrContext, body: RegionRef) -> Vec<T
         }
     }
     abilities
-}
-
-/// Compute ability ID from a TypeRef.
-fn compute_ability_id(ctx: &IrContext, ability_ref: TypeRef) -> u32 {
-    let data = ctx.types.get(ability_ref);
-    // ability_ref is core.ability_ref type
-    let ability_name = match data.attrs.get(&Symbol::new("name")) {
-        Some(Attribute::Symbol(s)) => *s,
-        _ => panic!(
-            "ICE: compute_ability_id: ability type has no name: {:?}",
-            data
-        ),
-    };
-
-    let mut hash: u32 = ability_name.with_str(|s| {
-        let mut h: u32 = 0;
-        for byte in s.bytes() {
-            h = h.wrapping_mul(31).wrapping_add(byte as u32);
-        }
-        h
-    });
-
-    // Include type parameters
-    for &param in data.params.iter() {
-        hash = hash.wrapping_mul(37);
-        hash = hash.wrapping_add(hash_type(ctx, param));
-    }
-
-    hash
-}
-
-/// Hash a type for ability ID computation.
-fn hash_type(ctx: &IrContext, ty: TypeRef) -> u32 {
-    let data = ctx.types.get(ty);
-    let mut hash: u32 = 0;
-
-    data.dialect.with_str(|s| {
-        for byte in s.bytes() {
-            hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
-        }
-    });
-
-    data.name.with_str(|s| {
-        for byte in s.bytes() {
-            hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
-        }
-    });
-
-    for &param in data.params.iter() {
-        hash = hash.wrapping_mul(37);
-        hash = hash.wrapping_add(hash_type(ctx, param));
-    }
-
-    hash
 }
 
 // ============================================================================
@@ -641,10 +588,8 @@ fn transform_shifts_in_block(
             let mut current_ev = ev_value;
 
             if !abilities.is_empty() {
-                let i32_ty = i32_type_ref(ctx);
                 let evidence_ty = ability::evidence_adt_type_ref(ctx);
-                let marker_ty = ability::marker_adt_type_ref(ctx);
-                let ptr_ty = core::ptr(ctx).as_type_ref();
+                let i32_ty = i32_type_ref(ctx);
 
                 // All evidence extension ops are inserted before handle_dispatch.
                 // The body closure call (which needs extended evidence) is moved
@@ -661,59 +606,32 @@ fn transform_shifts_in_block(
                 let tag_val = ctx.op_result(tag_call.op_ref(), 0);
                 ctx.insert_op_before(block, op, tag_call.op_ref());
 
-                // Extract handler_fn and tr_dispatch_fn from handle_dispatch operands
+                // Extract handler_fn and tr_dispatch_fn from handle_dispatch operands.
+                // Keep them as semantic closure values; backend-specific lowering
+                // chooses the concrete function/environment representation.
                 let operands = ctx.op_operands(op).to_vec();
 
-                let tr_dispatch_fn_val = {
-                    let tr_fn_val = operands
-                        .get(2)
-                        .expect("handle_dispatch must have operand[2] (tr_dispatch_fn)");
-                    let cast = core::unrealized_conversion_cast(ctx, loc, *tr_fn_val, ptr_ty);
-                    ctx.insert_op_before(block, op, cast.op_ref());
-                    cast.result(ctx)
-                };
-
-                let handler_dispatch_val = {
-                    let handler_val = operands
-                        .get(1)
-                        .expect("handle_dispatch must have operand[1] (handler closure)");
-                    let cast = core::unrealized_conversion_cast(ctx, loc, *handler_val, ptr_ty);
-                    ctx.insert_op_before(block, op, cast.op_ref());
-                    cast.result(ctx)
-                };
+                let tr_dispatch_fn_val = *operands
+                    .get(2)
+                    .expect("handle_dispatch must have operand[2] (tr_dispatch_fn)");
+                let handler_dispatch_val = *operands
+                    .get(1)
+                    .expect("handle_dispatch must have operand[1] (handler closure)");
 
                 // Extend evidence for each ability
                 for &ability_ref in &abilities {
-                    let ability_id = compute_ability_id(ctx, ability_ref);
-                    let ability_id_const =
-                        arith::r#const(ctx, loc, i32_ty, Attribute::Int(ability_id as i128));
-                    let ability_id_val = ctx.op_result(ability_id_const.op_ref(), 0);
-                    ctx.insert_op_before(block, op, ability_id_const.op_ref());
-
-                    let marker_struct = adt::struct_new(
+                    let extend_op = effect::extend(
                         ctx,
                         loc,
-                        vec![
-                            ability_id_val,
-                            tag_val,
-                            tr_dispatch_fn_val,
-                            handler_dispatch_val,
-                        ],
-                        marker_ty,
-                        marker_ty,
-                    );
-                    let marker_val = ctx.op_result(marker_struct.op_ref(), 0);
-                    ctx.insert_op_before(block, op, marker_struct.op_ref());
-
-                    let extend_call = func::call(
-                        ctx,
-                        loc,
-                        vec![current_ev, marker_val],
+                        current_ev,
+                        tag_val,
+                        tr_dispatch_fn_val,
+                        handler_dispatch_val,
                         evidence_ty,
-                        Symbol::new(evidence_abi::EXTEND),
+                        ability_ref,
                     );
-                    current_ev = ctx.op_result(extend_call.op_ref(), 0);
-                    ctx.insert_op_before(block, op, extend_call.op_ref());
+                    current_ev = extend_op.result(ctx);
+                    ctx.insert_op_before(block, op, extend_op.op_ref());
                 }
 
                 // Find the body closure call and move it after evidence extension.
@@ -845,7 +763,7 @@ fn transform_shifts_in_block(
         if let Ok(lookup_op) = ability::EvidenceLookup::from_op(ctx, op) {
             let loc = ctx.op(op).location;
             let ability_ref = lookup_op.ability_ref(ctx);
-            let ability_id = compute_ability_id(ctx, ability_ref);
+            let ability_id = ability::compute_ability_id(ctx, ability_ref);
 
             let marker_ty = ability::marker_adt_type_ref(ctx);
             let i32_ty = i32_type_ref(ctx);
@@ -988,8 +906,8 @@ mod tests {
                 .build(),
         );
 
-        let state_id = compute_ability_id(&ctx, state_ref);
-        let console_id = compute_ability_id(&ctx, console_ref);
+        let state_id = ability::compute_ability_id(&ctx, state_ref);
+        let console_id = ability::compute_ability_id(&ctx, console_ref);
 
         // Same ability should have same ID (interning gives same TypeRef)
         let state_ref2 = ctx.types.intern(
@@ -997,7 +915,7 @@ mod tests {
                 .attr("name", Attribute::Symbol(Symbol::new("State")))
                 .build(),
         );
-        let state_id2 = compute_ability_id(&ctx, state_ref2);
+        let state_id2 = ability::compute_ability_id(&ctx, state_ref2);
         assert_eq!(state_id, state_id2);
 
         // Different abilities should have different IDs
@@ -1025,8 +943,8 @@ mod tests {
                 .build(),
         );
 
-        let id_with_params = compute_ability_id(&ctx, state_i32);
-        let id_no_params = compute_ability_id(&ctx, state_no_params);
+        let id_with_params = ability::compute_ability_id(&ctx, state_i32);
+        let id_no_params = ability::compute_ability_id(&ctx, state_no_params);
 
         // Same ability name but different type params should produce different IDs
         assert_ne!(id_with_params, id_no_params);

--- a/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_call_to_effect_dispatch_tail.snap
+++ b/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_call_to_effect_dispatch_tail.snap
@@ -1,0 +1,12 @@
+---
+source: crates/tribute-passes/src/lower_ability_perform.rs
+expression: ir_text
+---
+core.module @test {
+  func.func @test_fn(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> tribute_rt.anyref {
+      %1 = arith.const {value = 1} : tribute_rt.anyref
+      %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
+      %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
+      func.return %3
+  }
+}

--- a/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_basic.snap
+++ b/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_basic.snap
@@ -3,19 +3,11 @@ source: crates/tribute-passes/src/lower_ability_perform.rs
 expression: ir_text
 ---
 core.module @test {
-  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
-
-  func.func @test_fn(%0: core.array(!_Marker)) -> tribute_rt.anyref {
+  func.func @test_fn(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> tribute_rt.anyref {
       %1 = arith.const {value = 0} : tribute_rt.anyref
-      %2 = ability.evidence_lookup %0 {ability_ref = core.ability_ref() {name = @State}} : !_Marker
-      %3 = adt.struct_get %2 {field = 3, type = !_Marker} : !_closure
-      %4 = arith.const {value = 1972422014} : core.i32
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
-      %7 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-      %8 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %6, %4, %5 : tribute_rt.anyref
-      func.return %9
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
+      %4 = effect.dispatch_cps %0, %3, %2 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      func.return %4
   }
 }

--- a/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_with_args.snap
+++ b/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_with_args.snap
@@ -3,20 +3,12 @@ source: crates/tribute-passes/src/lower_ability_perform.rs
 expression: ir_text
 ---
 core.module @test {
-  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
-
-  func.func @test_fn(%0: core.array(!_Marker)) -> tribute_rt.anyref {
+  func.func @test_fn(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> tribute_rt.anyref {
       %1 = arith.const {value = 42} : core.i32
       %2 = arith.const {value = 0} : tribute_rt.anyref
-      %3 = ability.evidence_lookup %0 {ability_ref = core.ability_ref() {name = @State}} : !_Marker
-      %4 = adt.struct_get %3 {field = 3, type = !_Marker} : !_closure
-      %5 = arith.const {value = 1348736788} : core.i32
-      %6 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-      %10 = func.call_indirect %8, %0, %9, %7, %5, %6 : tribute_rt.anyref
-      func.return %10
+      %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
+      %4 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      %5 = effect.dispatch_cps %0, %4, %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      func.return %5
   }
 }

--- a/crates/tribute-passes/src/type_converter.rs
+++ b/crates/tribute-passes/src/type_converter.rs
@@ -17,7 +17,7 @@
 //! `tribute_rt.anyref` → `wasm.anyref`) are handled by backend-specific
 //! type converters.
 
-use tribute_ir::dialect::tribute_rt as arena_tribute_rt;
+use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::refs::TypeRef;
@@ -129,7 +129,7 @@ pub fn generic_type_converter(ctx: &mut IrContext) -> TypeConverter {
         if to_ty == tribute_rt_anyref {
             // Int/Nat/I32 → any: use tribute_rt.box_int
             if from_ty == tribute_rt_int || from_ty == tribute_rt_nat || from_ty == core_i32 {
-                let box_op = arena_tribute_rt::box_int(ctx, location, value, tribute_rt_anyref);
+                let box_op = tribute_rt::box_int(ctx, location, value, tribute_rt_anyref);
                 return Some(MaterializeResult {
                     value: box_op.result(ctx),
                     ops: vec![box_op.op_ref()],
@@ -138,7 +138,7 @@ pub fn generic_type_converter(ctx: &mut IrContext) -> TypeConverter {
 
             // Bool/I1 → any: use tribute_rt.box_bool
             if from_ty == tribute_rt_bool || from_ty == core_i1 {
-                let box_op = arena_tribute_rt::box_bool(ctx, location, value, tribute_rt_anyref);
+                let box_op = tribute_rt::box_bool(ctx, location, value, tribute_rt_anyref);
                 return Some(MaterializeResult {
                     value: box_op.result(ctx),
                     ops: vec![box_op.op_ref()],
@@ -147,7 +147,7 @@ pub fn generic_type_converter(ctx: &mut IrContext) -> TypeConverter {
 
             // Float/F64 → any: use tribute_rt.box_float
             if from_ty == tribute_rt_float || from_ty == core_f64 {
-                let box_op = arena_tribute_rt::box_float(ctx, location, value, tribute_rt_anyref);
+                let box_op = tribute_rt::box_float(ctx, location, value, tribute_rt_anyref);
                 return Some(MaterializeResult {
                     value: box_op.result(ctx),
                     ops: vec![box_op.op_ref()],
@@ -166,7 +166,7 @@ pub fn generic_type_converter(ctx: &mut IrContext) -> TypeConverter {
         if from_ty == tribute_rt_anyref {
             // any → Int/I32: use tribute_rt.unbox_int
             if to_ty == tribute_rt_int || to_ty == core_i32 {
-                let unbox_op = arena_tribute_rt::unbox_int(ctx, location, value, to_ty);
+                let unbox_op = tribute_rt::unbox_int(ctx, location, value, to_ty);
                 return Some(MaterializeResult {
                     value: unbox_op.result(ctx),
                     ops: vec![unbox_op.op_ref()],
@@ -175,7 +175,7 @@ pub fn generic_type_converter(ctx: &mut IrContext) -> TypeConverter {
 
             // any → Nat: use tribute_rt.unbox_nat
             if to_ty == tribute_rt_nat {
-                let unbox_op = arena_tribute_rt::unbox_nat(ctx, location, value, to_ty);
+                let unbox_op = tribute_rt::unbox_nat(ctx, location, value, to_ty);
                 return Some(MaterializeResult {
                     value: unbox_op.result(ctx),
                     ops: vec![unbox_op.op_ref()],
@@ -184,7 +184,7 @@ pub fn generic_type_converter(ctx: &mut IrContext) -> TypeConverter {
 
             // any → Bool/I1: use tribute_rt.unbox_bool
             if to_ty == tribute_rt_bool || to_ty == core_i1 {
-                let unbox_op = arena_tribute_rt::unbox_bool(ctx, location, value, to_ty);
+                let unbox_op = tribute_rt::unbox_bool(ctx, location, value, to_ty);
                 return Some(MaterializeResult {
                     value: unbox_op.result(ctx),
                     ops: vec![unbox_op.op_ref()],
@@ -193,7 +193,7 @@ pub fn generic_type_converter(ctx: &mut IrContext) -> TypeConverter {
 
             // any → Float/F64: use tribute_rt.unbox_float
             if to_ty == tribute_rt_float || to_ty == core_f64 {
-                let unbox_op = arena_tribute_rt::unbox_float(ctx, location, value, to_ty);
+                let unbox_op = tribute_rt::unbox_float(ctx, location, value, to_ty);
                 return Some(MaterializeResult {
                     value: unbox_op.result(ctx),
                     ops: vec![unbox_op.op_ref()],

--- a/crates/tribute-passes/src/wasm/const_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/const_to_wasm.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt as arena_adt;
+use trunk_ir::dialect::adt;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef};
@@ -94,7 +94,7 @@ impl ConstCollector {
     fn visit_op(&mut self, ctx: &IrContext, op: OpRef) {
         let data = ctx.op(op);
 
-        if data.dialect == arena_adt::DIALECT_NAME() {
+        if data.dialect == adt::DIALECT_NAME() {
             if data.name == Symbol::new("string_const") {
                 if let Some(Attribute::String(s)) = data.attributes.get(&Symbol::new("value")) {
                     let bytes = s.clone().into_bytes();
@@ -198,7 +198,7 @@ impl RewritePattern for StringConstPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(string_const) = arena_adt::StringConst::from_op(ctx, op) else {
+        let Ok(string_const) = adt::StringConst::from_op(ctx, op) else {
             return false;
         };
 
@@ -256,7 +256,7 @@ impl RewritePattern for BytesConstPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(bytes_const) = arena_adt::BytesConst::from_op(ctx, op) else {
+        let Ok(bytes_const) = adt::BytesConst::from_op(ctx, op) else {
             return false;
         };
 

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -22,10 +22,10 @@
 
 use std::collections::BTreeMap;
 
-use tribute_ir::dialect::ability::{self as arena_ability, MarkerField, evidence_abi};
+use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
-use trunk_ir::dialect::{core as arena_core, wasm as wasm_dialect};
+use trunk_ir::dialect::{core, wasm as wasm_dialect};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
@@ -112,7 +112,7 @@ impl RewritePattern for EvidenceLookupPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(lookup_op) = arena_ability::EvidenceLookup::from_op(ctx, op) else {
+        let Ok(lookup_op) = ability::EvidenceLookup::from_op(ctx, op) else {
             return false;
         };
 
@@ -165,7 +165,7 @@ impl RewritePattern for EvidenceExtendPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(extend_op) = arena_ability::EvidenceExtend::from_op(ctx, op) else {
+        let Ok(extend_op) = ability::EvidenceExtend::from_op(ctx, op) else {
             return false;
         };
 
@@ -188,8 +188,8 @@ impl RewritePattern for EvidenceExtendPattern {
         let prompt_tag_attr = extend_op.prompt_tag(ctx);
 
         let i32_ty = intern_i32(ctx);
-        let ptr_ty = arena_core::ptr(ctx).as_type_ref();
-        let marker_ty = arena_ability::marker_adt_type_ref(ctx);
+        let ptr_ty = core::ptr(ctx).as_type_ref();
+        let marker_ty = ability::marker_adt_type_ref(ctx);
 
         // Create: %ability_id = wasm.i32_const(ability_id)
         let ability_id_const = wasm_dialect::i32_const(ctx, loc, i32_ty, ability_id);
@@ -204,16 +204,12 @@ impl RewritePattern for EvidenceExtendPattern {
         // Create a core.ptr-typed null for tr_dispatch_fn (unused for now).
         let tr_dispatch_zero = wasm_dialect::i32_const(ctx, loc, i32_ty, 0);
         let tr_dispatch_null =
-            arena_core::unrealized_conversion_cast(ctx, loc, tr_dispatch_zero.result(ctx), ptr_ty);
+            core::unrealized_conversion_cast(ctx, loc, tr_dispatch_zero.result(ctx), ptr_ty);
 
         // Create a core.ptr-typed null for handler_dispatch (unused for now).
         let handler_dispatch_zero = wasm_dialect::i32_const(ctx, loc, i32_ty, 0);
-        let handler_dispatch_null = arena_core::unrealized_conversion_cast(
-            ctx,
-            loc,
-            handler_dispatch_zero.result(ctx),
-            ptr_ty,
-        );
+        let handler_dispatch_null =
+            core::unrealized_conversion_cast(ctx, loc, handler_dispatch_zero.result(ctx), ptr_ty);
 
         // Create: %marker = wasm.struct_new(MARKER_IDX, %ability_id, %prompt_tag, %tr_dispatch_fn, %handler_dispatch)
         let marker_op = wasm_dialect::struct_new(
@@ -274,7 +270,7 @@ mod locals {
 fn generate_evidence_lookup_function(ctx: &mut IrContext, location: Location) -> OpRef {
     let evidence_ty = evidence_ref_type(ctx);
     let i32_ty = intern_i32(ctx);
-    let marker_sig_ty = arena_ability::marker_adt_type_ref(ctx);
+    let marker_sig_ty = ability::marker_adt_type_ref(ctx);
 
     let func_ty = intern_func_type(ctx, &[evidence_ty, i32_ty], marker_sig_ty);
 
@@ -345,7 +341,7 @@ fn build_lookup_loop_body(
     i32_ty: TypeRef,
 ) -> RegionRef {
     let nil_ty = trunk_ir::dialect::core::nil(ctx).as_type_ref();
-    let marker_ty = arena_ability::marker_adt_type_ref(ctx);
+    let marker_ty = ability::marker_adt_type_ref(ctx);
 
     let block = ctx.create_block(BlockData {
         location,
@@ -549,7 +545,7 @@ fn build_lookup_loop_body(
 fn generate_evidence_extend_function(ctx: &mut IrContext, location: Location) -> OpRef {
     let evidence_ty = evidence_ref_type(ctx);
     let i32_ty = intern_i32(ctx);
-    let marker_sig_ty = arena_ability::marker_adt_type_ref(ctx);
+    let marker_sig_ty = ability::marker_adt_type_ref(ctx);
 
     let func_ty = intern_func_type(ctx, &[evidence_ty, marker_sig_ty], evidence_ty);
 
@@ -801,7 +797,7 @@ fn build_extend_search_loop(
     i32_ty: TypeRef,
 ) -> RegionRef {
     let nil_ty = trunk_ir::dialect::core::nil(ctx).as_type_ref();
-    let marker_ty = arena_ability::marker_adt_type_ref(ctx);
+    let marker_ty = ability::marker_adt_type_ref(ctx);
 
     let block = ctx.create_block(BlockData {
         location,

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -934,20 +934,11 @@ fn intern_func_type(ctx: &mut IrContext, params: &[TypeRef], ret: TypeRef) -> Ty
     trunk_ir::dialect::core::func(ctx, ret, params.iter().copied()).as_type_ref()
 }
 
-/// Compute a stable ability ID hash from an ability type reference.
-///
-/// Uses the same hashing strategy as the Salsa-based pass: a deterministic
-/// hash of the ability type data.
+/// Compute a stable ability ID as a WASM i32 immediate.
 fn compute_ability_id(ctx: &IrContext, ability_ty: TypeRef) -> i32 {
-    use std::hash::{Hash, Hasher};
-    let data = ctx.types.get(ability_ty);
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    data.dialect.hash(&mut hasher);
-    data.name.hash(&mut hasher);
-    // Use the first few params for more specific hashing
-    for param in &data.params {
-        param.hash(&mut hasher);
-    }
-    // Truncate to i32 and ensure positive for wasm i32 comparisons
-    (hasher.finish() as i32).wrapping_abs()
+    ability_id_as_wasm_i32(ability::compute_ability_id(ctx, ability_ty))
+}
+
+fn ability_id_as_wasm_i32(ability_id: u32) -> i32 {
+    i32::from_ne_bytes(ability_id.to_ne_bytes())
 }

--- a/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use tribute_ir::ModulePathExt;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::core;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
@@ -50,8 +50,8 @@ fn extract_bytes_fields(
     let i8_ty = ctx
         .types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i8")).build());
-    let array_ty = arena_core::array(ctx, i8_ty).as_type_ref();
-    let array_ref_ty = arena_core::r#ref(ctx, array_ty, false).as_type_ref();
+    let array_ty = core::array(ctx, i8_ty).as_type_ref();
+    let array_ref_ty = core::r#ref(ctx, array_ty, false).as_type_ref();
 
     let get_data = wasm_dialect::struct_get(
         ctx,
@@ -341,7 +341,7 @@ impl RewritePattern for PrintLinePattern {
 
         // Emit all operations
         let result_types = ctx.op_result_types(op).to_vec();
-        let nil_ty = arena_core::nil(ctx).as_type_ref();
+        let nil_ty = core::nil(ctx).as_type_ref();
         if result_types.is_empty() || (result_types.len() == 1 && result_types[0] == nil_ty) {
             // Void: emit operations and drop the fd_write result
             rewriter.insert_op(fd_const.op_ref());
@@ -457,8 +457,8 @@ impl RewritePattern for BytesGetOrPanicPattern {
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i8")).build());
 
         // Get data array ref (field 0)
-        let array_ty = arena_core::array(ctx, i8_ty).as_type_ref();
-        let array_ref_ty = arena_core::r#ref(ctx, array_ty, false).as_type_ref();
+        let array_ty = core::array(ctx, i8_ty).as_type_ref();
+        let array_ref_ty = core::r#ref(ctx, array_ty, false).as_type_ref();
         let get_data = wasm_dialect::struct_get(
             ctx,
             location,
@@ -532,9 +532,9 @@ impl RewritePattern for BytesConcatPattern {
         let i8_ty = ctx
             .types
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i8")).build());
-        let bytes_ty = arena_core::bytes(ctx).as_type_ref();
-        let array_ty = arena_core::array(ctx, i8_ty).as_type_ref();
-        let array_ref_ty = arena_core::r#ref(ctx, array_ty, false).as_type_ref();
+        let bytes_ty = core::bytes(ctx).as_type_ref();
+        let array_ty = core::array(ctx, i8_ty).as_type_ref();
+        let array_ref_ty = core::r#ref(ctx, array_ty, false).as_type_ref();
 
         // Extract fields from left and right Bytes structs
         let (left_fields, left_ops) = extract_bytes_fields(ctx, location, left);

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -8,8 +8,8 @@ use tracing::{error, warn};
 use tribute_ir::ModulePathExt;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockData, IrContext, RegionData};
-use trunk_ir::dialect::core as arena_core;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{Module, PatternApplicator, WasmFuncSignatureConversionPattern};
@@ -147,7 +147,7 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
         for &op in ctx.block(block).ops.iter() {
             let data = ctx.op(op);
             // Check for func.func or wasm.func operations
-            if data.dialect == arena_func::DIALECT_NAME() && data.name == Symbol::new("func") {
+            if data.dialect == func::DIALECT_NAME() && data.name == Symbol::new("func") {
                 if let Some(Attribute::Type(fn_ty)) = data.attributes.get(&Symbol::new("type")) {
                     let fn_data = ctx.types.get(*fn_ty);
                     let params: Vec<_> = fn_data
@@ -218,7 +218,7 @@ fn intern_type(ctx: &mut IrContext, dialect: &'static str, name: &'static str) -
 }
 
 fn intern_func_type(ctx: &mut IrContext, params: Vec<TypeRef>, result: TypeRef) -> TypeRef {
-    arena_core::func(ctx, result, params).as_type_ref()
+    core::func(ctx, result, params).as_type_ref()
 }
 
 fn is_type(ctx: &IrContext, ty: TypeRef, dialect: &'static str, name: &'static str) -> bool {

--- a/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
+++ b/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
@@ -28,7 +28,7 @@
 use tracing::debug;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -125,7 +125,7 @@ impl RewritePattern for NormalizeCallPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(call_op) = arena_func::Call::from_op(ctx, op) else {
+        let Ok(call_op) = func::Call::from_op(ctx, op) else {
             return false;
         };
 
@@ -148,7 +148,7 @@ impl RewritePattern for NormalizeCallPattern {
         let callee = call_op.callee(ctx);
         let args: Vec<_> = call_op.args(ctx).to_vec();
 
-        let new_op = arena_func::call(ctx, loc, args, new_result_ty, callee);
+        let new_op = func::call(ctx, loc, args, new_result_ty, callee);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -168,7 +168,7 @@ impl RewritePattern for NormalizeCallIndirectPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(_call_op) = arena_func::CallIndirect::from_op(ctx, op) else {
+        let Ok(_call_op) = func::CallIndirect::from_op(ctx, op) else {
             return false;
         };
 
@@ -191,7 +191,7 @@ impl RewritePattern for NormalizeCallIndirectPattern {
             .expect("NormalizeCallIndirectPattern: func.call_indirect matched but has no operands");
         let args: Vec<_> = operands[1..].to_vec();
 
-        let new_op = arena_func::call_indirect(ctx, loc, callee, args, new_result_ty);
+        let new_op = func::call_indirect(ctx, loc, callee, args, new_result_ty);
         rewriter.replace_op(new_op.op_ref());
         true
     }

--- a/crates/tribute-passes/src/wasm/tribute_rt_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/tribute_rt_to_wasm.rs
@@ -19,10 +19,10 @@
 //! - `tribute_rt.intref` -> `wasm.i31ref`
 //! - `tribute_rt.anyref` -> `wasm.anyref`
 
-use tribute_ir::dialect::tribute_rt as arena_tribute_rt;
+use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt as arena_adt;
+use trunk_ir::dialect::adt;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
@@ -106,7 +106,7 @@ impl RewritePattern for BoxIntPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(box_op) = arena_tribute_rt::BoxInt::from_op(ctx, op) else {
+        let Ok(box_op) = tribute_rt::BoxInt::from_op(ctx, op) else {
             return false;
         };
 
@@ -139,7 +139,7 @@ impl RewritePattern for UnboxIntPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(unbox_op) = arena_tribute_rt::UnboxInt::from_op(ctx, op) else {
+        let Ok(unbox_op) = tribute_rt::UnboxInt::from_op(ctx, op) else {
             return false;
         };
 
@@ -169,7 +169,7 @@ impl RewritePattern for BoxNatPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(box_op) = arena_tribute_rt::BoxNat::from_op(ctx, op) else {
+        let Ok(box_op) = tribute_rt::BoxNat::from_op(ctx, op) else {
             return false;
         };
 
@@ -199,7 +199,7 @@ impl RewritePattern for UnboxNatPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(unbox_op) = arena_tribute_rt::UnboxNat::from_op(ctx, op) else {
+        let Ok(unbox_op) = tribute_rt::UnboxNat::from_op(ctx, op) else {
             return false;
         };
 
@@ -230,7 +230,7 @@ impl RewritePattern for BoxFloatPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(box_op) = arena_tribute_rt::BoxFloat::from_op(ctx, op) else {
+        let Ok(box_op) = tribute_rt::BoxFloat::from_op(ctx, op) else {
             return false;
         };
 
@@ -240,7 +240,7 @@ impl RewritePattern for BoxFloatPattern {
         let boxed_f64_ty = boxed_f64_type(ctx);
 
         // adt.struct_new creates BoxedF64 struct with the f64 value
-        let struct_op = arena_adt::struct_new(ctx, location, vec![value], anyref_ty, boxed_f64_ty);
+        let struct_op = adt::struct_new(ctx, location, vec![value], anyref_ty, boxed_f64_ty);
 
         rewriter.replace_op(struct_op.op_ref());
         true
@@ -263,7 +263,7 @@ impl RewritePattern for UnboxFloatPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(unbox_op) = arena_tribute_rt::UnboxFloat::from_op(ctx, op) else {
+        let Ok(unbox_op) = tribute_rt::UnboxFloat::from_op(ctx, op) else {
             return false;
         };
 
@@ -274,11 +274,11 @@ impl RewritePattern for UnboxFloatPattern {
         let f64_ty = f64_type(ctx);
 
         // Cast anyref to BoxedF64 struct first
-        let cast_op = arena_adt::ref_cast(ctx, location, value, boxed_f64_ty, boxed_f64_ty);
+        let cast_op = adt::ref_cast(ctx, location, value, boxed_f64_ty, boxed_f64_ty);
         let cast_result = cast_op.result(ctx);
 
         // adt.struct_get extracts field 0 (the f64 value) from BoxedF64
-        let get_op = arena_adt::struct_get(ctx, location, cast_result, f64_ty, boxed_f64_ty, 0);
+        let get_op = adt::struct_get(ctx, location, cast_result, f64_ty, boxed_f64_ty, 0);
 
         rewriter.insert_op(cast_op.op_ref());
         rewriter.replace_op(get_op.op_ref());
@@ -302,7 +302,7 @@ impl RewritePattern for BoxBoolPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(box_op) = arena_tribute_rt::BoxBool::from_op(ctx, op) else {
+        let Ok(box_op) = tribute_rt::BoxBool::from_op(ctx, op) else {
             return false;
         };
 
@@ -332,7 +332,7 @@ impl RewritePattern for UnboxBoolPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(unbox_op) = arena_tribute_rt::UnboxBool::from_op(ctx, op) else {
+        let Ok(unbox_op) = tribute_rt::UnboxBool::from_op(ctx, op) else {
             return false;
         };
 

--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -11,7 +11,7 @@ use cranelift_codegen::isa::CallConv;
 use cranelift_frontend::FunctionBuilder;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::clif as arena_clif;
+use trunk_ir::dialect::clif;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 
@@ -235,7 +235,7 @@ impl<'a> FunctionTranslator<'a> {
         let ctx = self.ctx;
 
         // === Constants ===
-        if let Ok(c) = arena_clif::Iconst::from_op(ctx, op) {
+        if let Ok(c) = clif::Iconst::from_op(ctx, op) {
             let result_ty = ctx.op_result_types(op)[0];
             // Nil constants have no runtime representation — skip emission.
             let td = ctx.types.get(result_ty);
@@ -248,13 +248,13 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(result, val);
             return Ok(());
         }
-        if let Ok(c) = arena_clif::F32const::from_op(ctx, op) {
+        if let Ok(c) = clif::F32const::from_op(ctx, op) {
             let val = self.builder.ins().f32const(c.value(ctx));
             let result = ctx.op_result(op, 0);
             self.values.insert(result, val);
             return Ok(());
         }
-        if let Ok(c) = arena_clif::F64const::from_op(ctx, op) {
+        if let Ok(c) = clif::F64const::from_op(ctx, op) {
             let val = self.builder.ins().f64const(c.value(ctx));
             let result = ctx.op_result(op, 0);
             self.values.insert(result, val);
@@ -262,63 +262,63 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Integer Arithmetic ===
-        if arena_clif::Iadd::from_op(ctx, op).is_ok() {
+        if clif::Iadd::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().iadd(a, c));
         }
-        if arena_clif::Isub::from_op(ctx, op).is_ok() {
+        if clif::Isub::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().isub(a, c));
         }
-        if arena_clif::Imul::from_op(ctx, op).is_ok() {
+        if clif::Imul::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().imul(a, c));
         }
-        if arena_clif::Sdiv::from_op(ctx, op).is_ok() {
+        if clif::Sdiv::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().sdiv(a, c));
         }
-        if arena_clif::Udiv::from_op(ctx, op).is_ok() {
+        if clif::Udiv::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().udiv(a, c));
         }
-        if arena_clif::Srem::from_op(ctx, op).is_ok() {
+        if clif::Srem::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().srem(a, c));
         }
-        if arena_clif::Urem::from_op(ctx, op).is_ok() {
+        if clif::Urem::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().urem(a, c));
         }
-        if arena_clif::Ineg::from_op(ctx, op).is_ok() {
+        if clif::Ineg::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_unary(ops[0], op, |b, v| b.ins().ineg(v));
         }
 
         // === Floating Point Arithmetic ===
-        if arena_clif::Fadd::from_op(ctx, op).is_ok() {
+        if clif::Fadd::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().fadd(a, c));
         }
-        if arena_clif::Fsub::from_op(ctx, op).is_ok() {
+        if clif::Fsub::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().fsub(a, c));
         }
-        if arena_clif::Fmul::from_op(ctx, op).is_ok() {
+        if clif::Fmul::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().fmul(a, c));
         }
-        if arena_clif::Fdiv::from_op(ctx, op).is_ok() {
+        if clif::Fdiv::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().fdiv(a, c));
         }
-        if arena_clif::Fneg::from_op(ctx, op).is_ok() {
+        if clif::Fneg::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_unary(ops[0], op, |b, v| b.ins().fneg(v));
         }
 
         // === Call ===
-        if let Ok(call) = arena_clif::Call::from_op(ctx, op) {
+        if let Ok(call) = clif::Call::from_op(ctx, op) {
             let callee_sym = call.callee(ctx);
             let func_ref = self
                 .func_refs
@@ -342,7 +342,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Return ===
-        if arena_clif::Return::from_op(ctx, op).is_ok() {
+        if clif::Return::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let mut vals = Vec::new();
             for &v in operands {
@@ -359,7 +359,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Control Flow ===
-        if arena_clif::Jump::from_op(ctx, op).is_ok() {
+        if clif::Jump::from_op(ctx, op).is_ok() {
             let op_data = ctx.op(op);
             let ir_dest = op_data.successors[0];
             let cl_dest = self.lookup_block(ir_dest)?;
@@ -379,7 +379,7 @@ impl<'a> FunctionTranslator<'a> {
             self.builder.ins().jump(cl_dest, &args);
             return Ok(());
         }
-        if arena_clif::Brif::from_op(ctx, op).is_ok() {
+        if clif::Brif::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let cond = self.lookup(operands[0])?;
             let op_data = ctx.op(op);
@@ -390,7 +390,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Comparisons ===
-        if let Ok(o) = arena_clif::Icmp::from_op(ctx, op) {
+        if let Ok(o) = clif::Icmp::from_op(ctx, op) {
             let cond = parse_int_cc(o.cond(ctx))?;
             let operands = ctx.op_operands(op);
             let lhs = self.lookup(operands[0])?;
@@ -400,7 +400,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(result, val);
             return Ok(());
         }
-        if let Ok(o) = arena_clif::Fcmp::from_op(ctx, op) {
+        if let Ok(o) = clif::Fcmp::from_op(ctx, op) {
             let cond = parse_float_cc(o.cond(ctx))?;
             let operands = ctx.op_operands(op);
             let lhs = self.lookup(operands[0])?;
@@ -412,7 +412,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Memory ===
-        if let Ok(load) = arena_clif::Load::from_op(ctx, op) {
+        if let Ok(load) = clif::Load::from_op(ctx, op) {
             let result_ty = ctx.op_result_types(op)[0];
             let td = ctx.types.get(result_ty);
             if td.dialect == Symbol::new("core") && td.name == Symbol::new("nil") {
@@ -429,7 +429,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(result, val);
             return Ok(());
         }
-        if let Ok(store) = arena_clif::Store::from_op(ctx, op) {
+        if let Ok(store) = clif::Store::from_op(ctx, op) {
             let operands = ctx.op_operands(op);
             if self.is_nil_typed(operands[0]) {
                 return Ok(());
@@ -442,7 +442,7 @@ impl<'a> FunctionTranslator<'a> {
             return Ok(());
         }
 
-        if let Ok(armw) = arena_clif::AtomicRmw::from_op(ctx, op) {
+        if let Ok(armw) = clif::AtomicRmw::from_op(ctx, op) {
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
             let operands = ctx.op_operands(op);
@@ -463,7 +463,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Symbol Address ===
-        if let Ok(sym_addr) = arena_clif::SymbolAddr::from_op(ctx, op) {
+        if let Ok(sym_addr) = clif::SymbolAddr::from_op(ctx, op) {
             let sym = sym_addr.sym(ctx);
             // Check function refs first, then data refs
             let val = if let Some(&func_ref) = self.func_refs.get(&sym) {
@@ -482,13 +482,13 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Trap ===
-        if arena_clif::Trap::from_op(ctx, op).is_ok() {
+        if clif::Trap::from_op(ctx, op).is_ok() {
             self.builder.ins().trap(TrapCode::unwrap_user(1));
             return Ok(());
         }
 
         // === Return Call (tail call) ===
-        if let Ok(rc) = arena_clif::ReturnCall::from_op(ctx, op) {
+        if let Ok(rc) = clif::ReturnCall::from_op(ctx, op) {
             let callee_sym = rc.callee(ctx);
             let func_ref = self
                 .func_refs
@@ -507,7 +507,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Return Call Indirect (indirect tail call) ===
-        if let Ok(rci) = arena_clif::ReturnCallIndirect::from_op(ctx, op) {
+        if let Ok(rci) = clif::ReturnCallIndirect::from_op(ctx, op) {
             let operands = ctx.op_operands(op);
             let callee = self.lookup(operands[0])?;
             let args: Vec<cl_ir::Value> = operands[1..]
@@ -526,7 +526,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Indirect Call ===
-        if let Ok(call_ind) = arena_clif::CallIndirect::from_op(ctx, op) {
+        if let Ok(call_ind) = clif::CallIndirect::from_op(ctx, op) {
             let operands = ctx.op_operands(op);
             let callee = self.lookup(operands[0])?;
             let args: Vec<cl_ir::Value> = operands[1..]
@@ -548,7 +548,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Type Conversions ===
-        if arena_clif::Ireduce::from_op(ctx, op).is_ok() {
+        if clif::Ireduce::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -557,7 +557,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::Uextend::from_op(ctx, op).is_ok() {
+        if clif::Uextend::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -566,7 +566,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::Sextend::from_op(ctx, op).is_ok() {
+        if clif::Sextend::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -575,7 +575,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::Fpromote::from_op(ctx, op).is_ok() {
+        if clif::Fpromote::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -584,7 +584,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::Fdemote::from_op(ctx, op).is_ok() {
+        if clif::Fdemote::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -593,7 +593,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::FcvtToSint::from_op(ctx, op).is_ok() {
+        if clif::FcvtToSint::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -602,7 +602,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::FcvtFromSint::from_op(ctx, op).is_ok() {
+        if clif::FcvtFromSint::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -611,7 +611,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::FcvtToUint::from_op(ctx, op).is_ok() {
+        if clif::FcvtToUint::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -620,7 +620,7 @@ impl<'a> FunctionTranslator<'a> {
             self.values.insert(ctx.op_result(op, 0), cl_val);
             return Ok(());
         }
-        if arena_clif::FcvtFromUint::from_op(ctx, op).is_ok() {
+        if clif::FcvtFromUint::from_op(ctx, op).is_ok() {
             let operands = ctx.op_operands(op);
             let result_ty = ctx.op_result_types(op)[0];
             let ty = translate_type(ctx, result_ty, self.ptr_ty)?;
@@ -631,27 +631,27 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // === Bitwise Operations ===
-        if arena_clif::Band::from_op(ctx, op).is_ok() {
+        if clif::Band::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().band(a, c));
         }
-        if arena_clif::Bor::from_op(ctx, op).is_ok() {
+        if clif::Bor::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().bor(a, c));
         }
-        if arena_clif::Bxor::from_op(ctx, op).is_ok() {
+        if clif::Bxor::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().bxor(a, c));
         }
-        if arena_clif::Ishl::from_op(ctx, op).is_ok() {
+        if clif::Ishl::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().ishl(a, c));
         }
-        if arena_clif::Sshr::from_op(ctx, op).is_ok() {
+        if clif::Sshr::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().sshr(a, c));
         }
-        if arena_clif::Ushr::from_op(ctx, op).is_ok() {
+        if clif::Ushr::from_op(ctx, op).is_ok() {
             let ops = ctx.op_operands(op);
             return self.emit_binary(ops[0], ops[1], op, |b, a, c| b.ins().ushr(a, c));
         }

--- a/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
@@ -28,9 +28,9 @@ use crate::adt_layout::{
 };
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt as arena_adt;
-use trunk_ir::dialect::clif as arena_clif;
-use trunk_ir::dialect::core as arena_core;
+use trunk_ir::dialect::adt;
+use trunk_ir::dialect::clif;
+use trunk_ir::dialect::core;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -99,7 +99,7 @@ impl RewritePattern for StructGetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(struct_get) = arena_adt::StructGet::from_op(ctx, op) else {
+        let Ok(struct_get) = adt::StructGet::from_op(ctx, op) else {
             return false;
         };
 
@@ -130,7 +130,7 @@ impl RewritePattern for StructGetPattern {
         };
         let result_ty = tc.convert_type_or_identity(ctx, result_ty);
 
-        let load_op = arena_clif::load(ctx, loc, ref_val, result_ty, offset);
+        let load_op = clif::load(ctx, loc, ref_val, result_ty, offset);
         rewriter.replace_op(load_op.op_ref());
         true
     }
@@ -145,7 +145,7 @@ impl RewritePattern for StructSetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(struct_set) = arena_adt::StructSet::from_op(ctx, op) else {
+        let Ok(struct_set) = adt::StructSet::from_op(ctx, op) else {
             return false;
         };
 
@@ -168,7 +168,7 @@ impl RewritePattern for StructSetPattern {
         let ref_val = struct_set.r#ref(ctx);
         let value_val = struct_set.value(ctx);
 
-        let store_op = arena_clif::store(ctx, loc, value_val, ref_val, offset);
+        let store_op = clif::store(ctx, loc, value_val, ref_val, offset);
         rewriter.replace_op(store_op.op_ref());
         true
     }
@@ -183,7 +183,7 @@ impl RewritePattern for VariantIsPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(variant_is) = arena_adt::VariantIs::from_op(ctx, op) else {
+        let Ok(variant_is) = adt::VariantIs::from_op(ctx, op) else {
             return false;
         };
 
@@ -207,12 +207,12 @@ impl RewritePattern for VariantIsPattern {
         let ref_val = variant_is.r#ref(ctx);
 
         // Load tag from payload_ptr + 0
-        let tag_load = arena_clif::load(ctx, loc, ref_val, i32_ty, 0);
+        let tag_load = clif::load(ctx, loc, ref_val, i32_ty, 0);
         let tag_val = tag_load.result(ctx);
 
         // Compare with expected discriminant
-        let expected = arena_clif::iconst(ctx, loc, i32_ty, variant_layout.tag_value as i64);
-        let cmp_op = arena_clif::icmp(
+        let expected = clif::iconst(ctx, loc, i32_ty, variant_layout.tag_value as i64);
+        let cmp_op = clif::icmp(
             ctx,
             loc,
             tag_val,
@@ -237,7 +237,7 @@ impl RewritePattern for VariantCastPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(variant_cast) = arena_adt::VariantCast::from_op(ctx, op) else {
+        let Ok(variant_cast) = adt::VariantCast::from_op(ctx, op) else {
             return false;
         };
         let ref_val = variant_cast.r#ref(ctx);
@@ -255,7 +255,7 @@ impl RewritePattern for VariantGetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(variant_get) = arena_adt::VariantGet::from_op(ctx, op) else {
+        let Ok(variant_get) = adt::VariantGet::from_op(ctx, op) else {
             return false;
         };
 
@@ -310,7 +310,7 @@ impl RewritePattern for VariantGetPattern {
             return false;
         };
 
-        let load_op = arena_clif::load(ctx, loc, ref_val, load_ty, offset);
+        let load_op = clif::load(ctx, loc, ref_val, load_ty, offset);
         rewriter.replace_op(load_op.op_ref());
         true
     }
@@ -325,12 +325,12 @@ impl RewritePattern for RefNullPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_adt::RefNull::from_op(ctx, op).is_err() {
+        if adt::RefNull::from_op(ctx, op).is_err() {
             return false;
         }
         let loc = ctx.op(op).location;
-        let ptr_ty = arena_core::ptr(ctx).as_type_ref();
-        let iconst_op = arena_clif::iconst(ctx, loc, ptr_ty, 0);
+        let ptr_ty = core::ptr(ctx).as_type_ref();
+        let iconst_op = clif::iconst(ctx, loc, ptr_ty, 0);
         rewriter.replace_op(iconst_op.op_ref());
         true
     }
@@ -345,7 +345,7 @@ impl RewritePattern for RefCastPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(ref_cast) = arena_adt::RefCast::from_op(ctx, op) else {
+        let Ok(ref_cast) = adt::RefCast::from_op(ctx, op) else {
             return false;
         };
         let ref_val = ref_cast.r#ref(ctx);
@@ -363,17 +363,17 @@ impl RewritePattern for RefIsNullPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(ref_is_null) = arena_adt::RefIsNull::from_op(ctx, op) else {
+        let Ok(ref_is_null) = adt::RefIsNull::from_op(ctx, op) else {
             return false;
         };
 
         let loc = ctx.op(op).location;
-        let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+        let ptr_ty = core::ptr(ctx).as_type_ref();
         let i1_ty = intern_i1_type(ctx);
         let ref_val = ref_is_null.r#ref(ctx);
 
-        let null_op = arena_clif::iconst(ctx, loc, ptr_ty, 0);
-        let icmp_op = arena_clif::icmp(
+        let null_op = clif::iconst(ctx, loc, ptr_ty, 0);
+        let icmp_op = clif::icmp(
             ctx,
             loc,
             ref_val,

--- a/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/arith_to_clif.rs
@@ -11,7 +11,7 @@
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::arith;
-use trunk_ir::dialect::clif as arena_clif;
+use trunk_ir::dialect::clif;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -139,7 +139,7 @@ impl RewritePattern for ArithConstPattern {
         let value = const_op.value(ctx);
 
         if category == "nil" {
-            let new_op = arena_clif::iconst(ctx, loc, result_ty, 0);
+            let new_op = clif::iconst(ctx, loc, result_ty, 0);
             rewriter.replace_op(new_op.op_ref());
             return true;
         }
@@ -149,23 +149,23 @@ impl RewritePattern for ArithConstPattern {
                 let Attribute::FloatBits(v) = value else {
                     return false;
                 };
-                arena_clif::f32const(ctx, loc, result_ty, f32::from_bits(v as u32)).op_ref()
+                clif::f32const(ctx, loc, result_ty, f32::from_bits(v as u32)).op_ref()
             }
             "f64" => {
                 let Attribute::FloatBits(v) = value else {
                     return false;
                 };
-                arena_clif::f64const(ctx, loc, result_ty, f64::from_bits(v)).op_ref()
+                clif::f64const(ctx, loc, result_ty, f64::from_bits(v)).op_ref()
             }
             _ => match value {
                 Attribute::Int(v) => {
                     let Some(v) = i64::try_from(v).ok() else {
                         return false;
                     };
-                    arena_clif::iconst(ctx, loc, result_ty, v).op_ref()
+                    clif::iconst(ctx, loc, result_ty, v).op_ref()
                 }
                 Attribute::Bool(b) => {
-                    arena_clif::iconst(ctx, loc, result_ty, if b { 1 } else { 0 }).op_ref()
+                    clif::iconst(ctx, loc, result_ty, if b { 1 } else { 0 }).op_ref()
                 }
                 _ => return false,
             },
@@ -201,27 +201,27 @@ impl RewritePattern for ArithBinOpPattern {
         let name = data.name;
 
         let new_op = if name == Symbol::new("addi") {
-            arena_clif::iadd(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::iadd(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("addf") {
-            arena_clif::fadd(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::fadd(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("subi") {
-            arena_clif::isub(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::isub(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("subf") {
-            arena_clif::fsub(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::fsub(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("muli") {
-            arena_clif::imul(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::imul(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("mulf") {
-            arena_clif::fmul(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::fmul(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("divsi") {
-            arena_clif::sdiv(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::sdiv(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("divui") {
-            arena_clif::udiv(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::udiv(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("divf") {
-            arena_clif::fdiv(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::fdiv(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("remsi") {
-            arena_clif::srem(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::srem(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("remui") {
-            arena_clif::urem(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::urem(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else {
             return false;
         };
@@ -248,7 +248,7 @@ fn finalize_cmp(
         rewriter.replace_op(cmp_op);
     } else {
         rewriter.insert_op(cmp_op);
-        let ext_op = arena_clif::uextend(ctx, loc, cmp_result, result_ty).op_ref();
+        let ext_op = clif::uextend(ctx, loc, cmp_result, result_ty).op_ref();
         rewriter.replace_op(ext_op);
     }
 }
@@ -277,7 +277,7 @@ impl RewritePattern for ArithCmpPattern {
             let lhs = cmpi.lhs(ctx);
             let rhs = cmpi.rhs(ctx);
             let cond = cmpi.predicate(ctx);
-            let cmp_op = arena_clif::icmp(ctx, loc, lhs, rhs, i8_ty, cond);
+            let cmp_op = clif::icmp(ctx, loc, lhs, rhs, i8_ty, cond);
             finalize_cmp(
                 ctx,
                 loc,
@@ -303,7 +303,7 @@ impl RewritePattern for ArithCmpPattern {
                 "oge" => Symbol::new("ge"),
                 _ => predicate,
             };
-            let cmp_op = arena_clif::fcmp(ctx, loc, lhs, rhs, i8_ty, cond);
+            let cmp_op = clif::fcmp(ctx, loc, lhs, rhs, i8_ty, cond);
             finalize_cmp(
                 ctx,
                 loc,
@@ -336,11 +336,11 @@ impl RewritePattern for ArithNegPattern {
 
         if let Ok(negi) = arith::Negi::from_op(ctx, op) {
             let operand = negi.operand(ctx);
-            rewriter.replace_op(arena_clif::ineg(ctx, loc, operand, ty).op_ref());
+            rewriter.replace_op(clif::ineg(ctx, loc, operand, ty).op_ref());
             true
         } else if let Ok(negf) = arith::Negf::from_op(ctx, op) {
             let operand = negf.operand(ctx);
-            rewriter.replace_op(arena_clif::fneg(ctx, loc, operand, ty).op_ref());
+            rewriter.replace_op(clif::fneg(ctx, loc, operand, ty).op_ref());
             true
         } else {
             false
@@ -383,17 +383,17 @@ impl RewritePattern for ArithBitwisePattern {
         let loc = ctx.op(op).location;
 
         let new_op = if name == Symbol::new("and") {
-            arena_clif::band(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::band(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("or") {
-            arena_clif::bor(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::bor(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("xor") {
-            arena_clif::bxor(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::bxor(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("shl") {
-            arena_clif::ishl(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::ishl(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("shr") {
-            arena_clif::sshr(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::sshr(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else if name == Symbol::new("shru") {
-            arena_clif::ushr(ctx, loc, lhs, rhs, result_ty).op_ref()
+            clif::ushr(ctx, loc, lhs, rhs, result_ty).op_ref()
         } else {
             return false;
         };
@@ -447,46 +447,40 @@ impl RewritePattern for ArithConversionPattern {
             match (src_cat, dst_cat) {
                 ("int", "int") => {
                     if is_wider_int(ctx, dst_ty, Some(src_ty)) {
-                        arena_clif::sextend(ctx, loc, operand, dst_ty).op_ref()
+                        clif::sextend(ctx, loc, operand, dst_ty).op_ref()
                     } else {
-                        arena_clif::ireduce(ctx, loc, operand, dst_ty).op_ref()
+                        clif::ireduce(ctx, loc, operand, dst_ty).op_ref()
                     }
                 }
                 _ => return false,
             }
         } else if name == Symbol::new("trunc") {
             match (src_cat, dst_cat) {
-                ("f32" | "f64", "int") => {
-                    arena_clif::fcvt_to_sint(ctx, loc, operand, dst_ty).op_ref()
-                }
-                ("int", "int") => arena_clif::ireduce(ctx, loc, operand, dst_ty).op_ref(),
+                ("f32" | "f64", "int") => clif::fcvt_to_sint(ctx, loc, operand, dst_ty).op_ref(),
+                ("int", "int") => clif::ireduce(ctx, loc, operand, dst_ty).op_ref(),
                 _ => return false,
             }
         } else if name == Symbol::new("extend") {
             match (src_cat, dst_cat) {
                 ("int", "int") if is_unsigned_int(ctx, Some(src_ty)) => {
-                    arena_clif::uextend(ctx, loc, operand, dst_ty).op_ref()
+                    clif::uextend(ctx, loc, operand, dst_ty).op_ref()
                 }
-                ("int", "int") => arena_clif::sextend(ctx, loc, operand, dst_ty).op_ref(),
-                ("f32", "f64") => arena_clif::fpromote(ctx, loc, operand, dst_ty).op_ref(),
+                ("int", "int") => clif::sextend(ctx, loc, operand, dst_ty).op_ref(),
+                ("f32", "f64") => clif::fpromote(ctx, loc, operand, dst_ty).op_ref(),
                 _ => return false,
             }
         } else if name == Symbol::new("convert") {
             match (src_cat, dst_cat) {
                 ("int", "f32" | "f64") if is_unsigned_int(ctx, Some(src_ty)) => {
-                    arena_clif::fcvt_from_uint(ctx, loc, operand, dst_ty).op_ref()
+                    clif::fcvt_from_uint(ctx, loc, operand, dst_ty).op_ref()
                 }
-                ("int", "f32" | "f64") => {
-                    arena_clif::fcvt_from_sint(ctx, loc, operand, dst_ty).op_ref()
-                }
+                ("int", "f32" | "f64") => clif::fcvt_from_sint(ctx, loc, operand, dst_ty).op_ref(),
                 ("f32" | "f64", "int") if is_unsigned_int(ctx, raw_dst_ty) => {
-                    arena_clif::fcvt_to_uint(ctx, loc, operand, dst_ty).op_ref()
+                    clif::fcvt_to_uint(ctx, loc, operand, dst_ty).op_ref()
                 }
-                ("f32" | "f64", "int") => {
-                    arena_clif::fcvt_to_sint(ctx, loc, operand, dst_ty).op_ref()
-                }
-                ("f32", "f64") => arena_clif::fpromote(ctx, loc, operand, dst_ty).op_ref(),
-                ("f64", "f32") => arena_clif::fdemote(ctx, loc, operand, dst_ty).op_ref(),
+                ("f32" | "f64", "int") => clif::fcvt_to_sint(ctx, loc, operand, dst_ty).op_ref(),
+                ("f32", "f64") => clif::fpromote(ctx, loc, operand, dst_ty).op_ref(),
+                ("f64", "f32") => clif::fdemote(ctx, loc, operand, dst_ty).op_ref(),
                 _ => return false,
             }
         } else {

--- a/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/cf_to_clif.rs
@@ -7,7 +7,7 @@
 use trunk_ir::OperationDataBuilder;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::cf as arena_cf;
+use trunk_ir::dialect::cf;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
 use trunk_ir::rewrite::{
@@ -46,7 +46,7 @@ impl RewritePattern for CfBrPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_cf::Br::from_op(ctx, op).is_err() {
+        if cf::Br::from_op(ctx, op).is_err() {
             return false;
         }
 
@@ -66,7 +66,7 @@ impl RewritePattern for CfCondBrPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_cf::CondBr::from_op(ctx, op).is_err() {
+        if cf::CondBr::from_op(ctx, op).is_err() {
             return false;
         }
 

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -10,9 +10,9 @@
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::clif as arena_clif;
-use trunk_ir::dialect::core as arena_core;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::clif;
+use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -75,7 +75,7 @@ fn native_closure_struct_type(ctx: &mut IrContext) -> TypeRef {
     let i64_ty = ctx
         .types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i64")).build());
-    let ptr_ty = arena_core::ptr(ctx).as_type_ref();
+    let ptr_ty = core::ptr(ctx).as_type_ref();
     let mut builder = TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("struct"));
     builder = builder.param(i64_ty).param(ptr_ty);
     builder = builder.attr(
@@ -99,7 +99,7 @@ fn native_closure_struct_type(ctx: &mut IrContext) -> TypeRef {
 }
 
 fn intern_ptr_type(ctx: &mut IrContext) -> TypeRef {
-    arena_core::ptr(ctx).as_type_ref()
+    core::ptr(ctx).as_type_ref()
 }
 
 fn intern_i64_type(ctx: &mut IrContext) -> TypeRef {
@@ -118,7 +118,7 @@ impl RewritePattern for FuncFuncPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_func::Func::from_op(ctx, op).is_err() {
+        if func::Func::from_op(ctx, op).is_err() {
             return false;
         }
 
@@ -161,9 +161,8 @@ impl RewritePattern for FuncFuncPattern {
                 let new_ret = ret_ty.map(|r| tc.convert_type_or_identity(ctx, r));
 
                 // Build new func type in Layout A: params[0] = return type
-                let ret_ty = new_ret.unwrap_or_else(|| arena_core::nil(ctx).as_type_ref());
-                let new_func_ty =
-                    arena_core::func(ctx, ret_ty, new_params.iter().copied()).as_type_ref();
+                let ret_ty = new_ret.unwrap_or_else(|| core::nil(ctx).as_type_ref());
+                let new_func_ty = core::func(ctx, ret_ty, new_params.iter().copied()).as_type_ref();
                 new_attrs.insert(Symbol::new("type"), Attribute::Type(new_func_ty));
             }
         }
@@ -192,7 +191,7 @@ impl RewritePattern for FuncCallPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(call_op) = arena_func::Call::from_op(ctx, op) else {
+        let Ok(call_op) = func::Call::from_op(ctx, op) else {
             return false;
         };
 
@@ -221,7 +220,7 @@ impl RewritePattern for FuncCallIndirectPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_func::CallIndirect::from_op(ctx, op).is_err() {
+        if func::CallIndirect::from_op(ctx, op).is_err() {
             return false;
         }
 
@@ -239,8 +238,8 @@ impl RewritePattern for FuncCallIndirectPattern {
 
         // Build sig type matching translate_signature layout:
         // params[0] = return type, params[1..] = parameter types
-        let ret_ty = result_ty.unwrap_or_else(|| arena_core::nil(ctx).as_type_ref());
-        let sig_ty = arena_core::func(ctx, ret_ty, param_types.iter().copied()).as_type_ref();
+        let ret_ty = result_ty.unwrap_or_else(|| core::nil(ctx).as_type_ref());
+        let sig_ty = core::func(ctx, ret_ty, param_types.iter().copied()).as_type_ref();
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,
@@ -266,7 +265,7 @@ impl RewritePattern for FuncReturnPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_func::Return::from_op(ctx, op).is_err() {
+        if func::Return::from_op(ctx, op).is_err() {
             return false;
         }
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
@@ -290,7 +289,7 @@ impl RewritePattern for FuncTailCallPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(tail_call) = arena_func::TailCall::from_op(ctx, op) else {
+        let Ok(tail_call) = func::TailCall::from_op(ctx, op) else {
             return false;
         };
 
@@ -319,11 +318,11 @@ impl RewritePattern for FuncUnreachablePattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if arena_func::Unreachable::from_op(ctx, op).is_err() {
+        if func::Unreachable::from_op(ctx, op).is_err() {
             return false;
         }
         let loc = ctx.op(op).location;
-        let new_op = arena_clif::trap(ctx, loc, Symbol::new("unreachable"));
+        let new_op = clif::trap(ctx, loc, Symbol::new("unreachable"));
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -339,14 +338,14 @@ impl RewritePattern for FuncConstantPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(const_op) = arena_func::Constant::from_op(ctx, op) else {
+        let Ok(const_op) = func::Constant::from_op(ctx, op) else {
             return false;
         };
 
         let func_ref = const_op.func_ref(ctx);
         let loc = ctx.op(op).location;
         let ptr_ty = intern_ptr_type(ctx);
-        let new_op = arena_clif::symbol_addr(ctx, loc, ptr_ty, func_ref);
+        let new_op = clif::symbol_addr(ctx, loc, ptr_ty, func_ref);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -362,12 +361,12 @@ impl RewritePattern for ClosureStructAdaptPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        use trunk_ir::dialect::adt as arena_adt;
+        use trunk_ir::dialect::adt;
 
         let native_ty = native_closure_struct_type(ctx);
 
         // Handle adt.struct_new on _closure
-        if let Ok(struct_new) = arena_adt::StructNew::from_op(ctx, op) {
+        if let Ok(struct_new) = adt::StructNew::from_op(ctx, op) {
             let ty = struct_new.r#type(ctx);
             if !is_closure_struct(ctx, ty) || ty == native_ty {
                 return false;
@@ -391,7 +390,7 @@ impl RewritePattern for ClosureStructAdaptPattern {
         }
 
         // Handle adt.struct_get on _closure
-        if let Ok(struct_get) = arena_adt::StructGet::from_op(ctx, op) {
+        if let Ok(struct_get) = adt::StructGet::from_op(ctx, op) {
             let ty = struct_get.r#type(ctx);
             if !is_closure_struct(ctx, ty) || ty == native_ty {
                 return false;

--- a/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/mem_to_clif.rs
@@ -4,7 +4,7 @@
 //! - `mem.store(ptr, value, offset)` → `clif.store(value, ptr, offset)`
 
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::clif as arena_clif;
+use trunk_ir::dialect::clif;
 use trunk_ir::dialect::mem;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
@@ -54,7 +54,7 @@ impl RewritePattern for MemLoadPattern {
         let Ok(offset) = i32::try_from(load_op.offset(ctx)) else {
             return false;
         };
-        let new_op = arena_clif::load(ctx, loc, ptr, result_ty, offset).op_ref();
+        let new_op = clif::load(ctx, loc, ptr, result_ty, offset).op_ref();
         rewriter.replace_op(new_op);
         true
     }
@@ -79,7 +79,7 @@ impl RewritePattern for MemStorePattern {
             return false;
         };
         // clif.store operand order: (value, addr)
-        let new_op = arena_clif::store(ctx, loc, value, ptr, offset).op_ref();
+        let new_op = clif::store(ctx, loc, value, ptr, offset).op_ref();
         rewriter.replace_op(new_op);
         true
     }

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -17,7 +17,7 @@ use cranelift_object::{ObjectBuilder, ObjectModule};
 use target_lexicon::{OperatingSystem, Triple};
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::clif as arena_clif;
+use trunk_ir::dialect::clif;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef};
 use trunk_ir::rewrite::Module;
@@ -369,7 +369,7 @@ fn emit_module_impl(
     let all_func_ops = collect_clif_funcs(ctx, module);
 
     for &func_op in &all_func_ops {
-        let func_wrapped = arena_clif::Func::from_op(ctx, func_op)
+        let func_wrapped = clif::Func::from_op(ctx, func_op)
             .map_err(|_| CompilationError::codegen("expected clif.func op"))?;
         let name_sym = func_wrapped.sym_name(ctx);
         let func_type_ref = func_wrapped.r#type(ctx);
@@ -442,7 +442,7 @@ fn emit_module_impl(
             continue;
         }
 
-        let func_wrapped = arena_clif::Func::from_op(ctx, func_op)
+        let func_wrapped = clif::Func::from_op(ctx, func_op)
             .map_err(|_| CompilationError::codegen("expected clif.func op"))?;
         let name_sym = func_wrapped.sym_name(ctx);
         let func_type_ref = func_wrapped.r#type(ctx);
@@ -601,7 +601,7 @@ fn collect_clif_funcs_from_region(ctx: &IrContext, region: RegionRef, funcs: &mu
     for &block in &region_data.blocks {
         let block_data = ctx.block(block);
         for &op in &block_data.ops {
-            if arena_clif::Func::from_op(ctx, op).is_ok() {
+            if clif::Func::from_op(ctx, op).is_ok() {
                 funcs.push(op);
             } else {
                 let op_data = ctx.op(op);

--- a/crates/trunk-ir-macros/src/lib.rs
+++ b/crates/trunk-ir-macros/src/lib.rs
@@ -48,12 +48,6 @@ pub fn dialect(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream 
     }
 }
 
-/// Deprecated alias for [`dialect`]. Use `#[dialect]` instead.
-#[proc_macro_attribute]
-pub fn arena_dialect(attr: ProcTokenStream, item: ProcTokenStream) -> ProcTokenStream {
-    dialect(attr, item)
-}
-
 fn dialect_impl(
     attr: proc_macro2::TokenStream,
     item: proc_macro2::TokenStream,

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use trunk_ir::IrContext;
 use trunk_ir::Module;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{RegionRef, TypeRef};
@@ -115,7 +115,7 @@ pub(crate) fn collect_call_indirect_types(
                         debug!("collect_call_indirect_types: wasm.func r#type is not core.func");
                         None
                     }
-                } else if let Ok(func) = arena_func::Func::from_op(ctx, op) {
+                } else if let Ok(func) = func::Func::from_op(ctx, op) {
                     // Also check for func.func (in case IR isn't fully lowered)
                     let func_type = func.r#type(ctx);
                     helpers::func_type_parts(ctx, func_type).map(|(_, ret_ty)| ret_ty)

--- a/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
@@ -254,7 +254,7 @@ pub(crate) fn extract_element_def(
     for &block_ref in &ctx.region(funcs_region).blocks {
         for &inner_op in &ctx.block(block_ref).ops {
             // Look for func.constant or wasm.ref_func operations
-            if let Ok(const_op) = arena_func::Constant::from_op(ctx, inner_op) {
+            if let Ok(const_op) = func::Constant::from_op(ctx, inner_op) {
                 funcs.push(const_op.func_ref(ctx));
             } else if let Ok(ref_func_op) = wasm_dialect::RefFunc::from_op(ctx, inner_op) {
                 funcs.push(ref_func_op.func_name(ctx));

--- a/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
@@ -42,7 +42,7 @@
 use tracing::warn;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt as arena_adt;
+use trunk_ir::dialect::adt;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
@@ -84,7 +84,7 @@ impl RewritePattern for StructNewPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(struct_new) = arena_adt::StructNew::from_op(ctx, op) else {
+        let Ok(struct_new) = adt::StructNew::from_op(ctx, op) else {
             return false;
         };
 
@@ -114,7 +114,7 @@ impl RewritePattern for StructGetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(struct_get) = arena_adt::StructGet::from_op(ctx, op) else {
+        let Ok(struct_get) = adt::StructGet::from_op(ctx, op) else {
             return false;
         };
 
@@ -141,7 +141,7 @@ impl RewritePattern for StructSetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(struct_set) = arena_adt::StructSet::from_op(ctx, op) else {
+        let Ok(struct_set) = adt::StructSet::from_op(ctx, op) else {
             return false;
         };
 
@@ -171,7 +171,7 @@ impl RewritePattern for VariantNewPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(variant_new) = arena_adt::VariantNew::from_op(ctx, op) else {
+        let Ok(variant_new) = adt::VariantNew::from_op(ctx, op) else {
             return false;
         };
 
@@ -248,7 +248,7 @@ impl RewritePattern for VariantIsPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(variant_is) = arena_adt::VariantIs::from_op(ctx, op) else {
+        let Ok(variant_is) = adt::VariantIs::from_op(ctx, op) else {
             return false;
         };
 
@@ -289,7 +289,7 @@ impl RewritePattern for VariantCastPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(variant_cast) = arena_adt::VariantCast::from_op(ctx, op) else {
+        let Ok(variant_cast) = adt::VariantCast::from_op(ctx, op) else {
             return false;
         };
 
@@ -332,7 +332,7 @@ impl RewritePattern for VariantGetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(variant_get) = arena_adt::VariantGet::from_op(ctx, op) else {
+        let Ok(variant_get) = adt::VariantGet::from_op(ctx, op) else {
             return false;
         };
 
@@ -359,7 +359,7 @@ impl RewritePattern for ArrayNewPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(array_new) = arena_adt::ArrayNew::from_op(ctx, op) else {
+        let Ok(array_new) = adt::ArrayNew::from_op(ctx, op) else {
             return false;
         };
 
@@ -403,7 +403,7 @@ impl RewritePattern for ArrayGetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(array_get) = arena_adt::ArrayGet::from_op(ctx, op) else {
+        let Ok(array_get) = adt::ArrayGet::from_op(ctx, op) else {
             return false;
         };
 
@@ -428,7 +428,7 @@ impl RewritePattern for ArraySetPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(array_set) = arena_adt::ArraySet::from_op(ctx, op) else {
+        let Ok(array_set) = adt::ArraySet::from_op(ctx, op) else {
             return false;
         };
 
@@ -453,7 +453,7 @@ impl RewritePattern for ArrayLenPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(array_len) = arena_adt::ArrayLen::from_op(ctx, op) else {
+        let Ok(array_len) = adt::ArrayLen::from_op(ctx, op) else {
             return false;
         };
 
@@ -477,7 +477,7 @@ impl RewritePattern for RefNullPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(ref_null) = arena_adt::RefNull::from_op(ctx, op) else {
+        let Ok(ref_null) = adt::RefNull::from_op(ctx, op) else {
             return false;
         };
 
@@ -504,7 +504,7 @@ impl RewritePattern for RefIsNullPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(ref_is_null) = arena_adt::RefIsNull::from_op(ctx, op) else {
+        let Ok(ref_is_null) = adt::RefIsNull::from_op(ctx, op) else {
             return false;
         };
 
@@ -528,7 +528,7 @@ impl RewritePattern for RefCastPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(ref_cast) = arena_adt::RefCast::from_op(ctx, op) else {
+        let Ok(ref_cast) = adt::RefCast::from_op(ctx, op) else {
             return false;
         };
 

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
@@ -101,7 +101,7 @@ fn collect_refs_in_region(ctx: &IrContext, region: RegionRef, refs: &mut Vec<Sym
     for &block in ctx.region(region).blocks.iter() {
         for &op in ctx.block(block).ops.iter() {
             // Check for func.constant
-            if let Ok(const_op) = arena_func::Constant::from_op(ctx, op) {
+            if let Ok(const_op) = func::Constant::from_op(ctx, op) {
                 refs.push(const_op.func_ref(ctx));
             }
 
@@ -179,7 +179,7 @@ impl RewritePattern for FuncFuncPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(func_op) = arena_func::Func::from_op(ctx, op) else {
+        let Ok(func_op) = func::Func::from_op(ctx, op) else {
             return false;
         };
 
@@ -207,7 +207,7 @@ impl RewritePattern for FuncCallPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(call_op) = arena_func::Call::from_op(ctx, op) else {
+        let Ok(call_op) = func::Call::from_op(ctx, op) else {
             return false;
         };
 
@@ -235,7 +235,7 @@ impl RewritePattern for FuncCallIndirectPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(_call_indirect) = arena_func::CallIndirect::from_op(ctx, op) else {
+        let Ok(_call_indirect) = func::CallIndirect::from_op(ctx, op) else {
             return false;
         };
 
@@ -261,7 +261,7 @@ impl RewritePattern for FuncReturnPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(_return_op) = arena_func::Return::from_op(ctx, op) else {
+        let Ok(_return_op) = func::Return::from_op(ctx, op) else {
             return false;
         };
 
@@ -284,7 +284,7 @@ impl RewritePattern for FuncTailCallPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(tail_call_op) = arena_func::TailCall::from_op(ctx, op) else {
+        let Ok(tail_call_op) = func::TailCall::from_op(ctx, op) else {
             return false;
         };
 
@@ -308,7 +308,7 @@ impl RewritePattern for FuncUnreachablePattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(_unreachable_op) = arena_func::Unreachable::from_op(ctx, op) else {
+        let Ok(_unreachable_op) = func::Unreachable::from_op(ctx, op) else {
             return false;
         };
 
@@ -335,7 +335,7 @@ impl RewritePattern for FuncConstantPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(const_op) = arena_func::Constant::from_op(ctx, op) else {
+        let Ok(const_op) = func::Constant::from_op(ctx, op) else {
             return false;
         };
 

--- a/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
@@ -8,8 +8,8 @@
 //! - `scf.break` -> `wasm.br(target=2)` (branch to outer block, past if and loop)
 
 use trunk_ir::context::{BlockData, IrContext, RegionData};
-use trunk_ir::dialect::core as arena_core;
-use trunk_ir::dialect::scf as arena_scf;
+use trunk_ir::dialect::core;
+use trunk_ir::dialect::scf;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::OpRef;
@@ -42,7 +42,7 @@ impl RewritePattern for ScfIfPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(scf_if_op) = arena_scf::If::from_op(ctx, op) else {
+        let Ok(scf_if_op) = scf::If::from_op(ctx, op) else {
             return false;
         };
 
@@ -56,7 +56,7 @@ impl RewritePattern for ScfIfPattern {
         let result_ty = result_types
             .first()
             .copied()
-            .unwrap_or_else(|| arena_core::nil(ctx).as_type_ref());
+            .unwrap_or_else(|| core::nil(ctx).as_type_ref());
 
         // Get the condition operand
         let cond = scf_if_op.cond(ctx);
@@ -88,7 +88,7 @@ impl RewritePattern for ScfLoopPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(loop_op) = arena_scf::Loop::from_op(ctx, op) else {
+        let Ok(loop_op) = scf::Loop::from_op(ctx, op) else {
             return false;
         };
 
@@ -102,7 +102,7 @@ impl RewritePattern for ScfLoopPattern {
         let result_ty = result_types
             .first()
             .copied()
-            .unwrap_or_else(|| arena_core::nil(ctx).as_type_ref());
+            .unwrap_or_else(|| core::nil(ctx).as_type_ref());
 
         // Get init operands
         let init: Vec<_> = loop_op.init(ctx).to_vec();
@@ -153,7 +153,7 @@ impl RewritePattern for ScfYieldPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if !arena_scf::Yield::matches(ctx, op) {
+        if !scf::Yield::matches(ctx, op) {
             return false;
         }
 
@@ -193,7 +193,7 @@ impl RewritePattern for ScfContinuePattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if !arena_scf::Continue::matches(ctx, op) {
+        if !scf::Continue::matches(ctx, op) {
             return false;
         }
 
@@ -245,7 +245,7 @@ impl RewritePattern for ScfBreakPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(break_op) = arena_scf::Break::from_op(ctx, op) else {
+        let Ok(break_op) = scf::Break::from_op(ctx, op) else {
             return false;
         };
 

--- a/crates/trunk-ir/src/conversion/resolve_unrealized_casts.rs
+++ b/crates/trunk-ir/src/conversion/resolve_unrealized_casts.rs
@@ -9,7 +9,7 @@
 //! If any casts cannot be resolved, the pass returns the unresolved list.
 
 use crate::context::IrContext;
-use crate::dialect::core as arena_core;
+use crate::dialect::core;
 use crate::ops::DialectOp;
 use crate::refs::{BlockRef, OpRef, RegionRef, TypeRef};
 use crate::rewrite::{Module, TypeConverter};
@@ -103,7 +103,7 @@ impl CastResolver {
             }
 
             // Check if this is an unrealized_conversion_cast
-            if arena_core::UnrealizedConversionCast::matches(ctx, op) {
+            if core::UnrealizedConversionCast::matches(ctx, op) {
                 self.try_resolve_cast(ctx, tc, block, op);
                 continue;
             }
@@ -190,12 +190,12 @@ impl CastResolver {
 
 #[cfg(test)]
 mod tests {
-    mod arena_tests {
+    mod resolve_unrealized_casts_tests {
         use crate::OperationDataBuilder;
         use crate::context::{BlockData, IrContext, RegionData};
         use crate::conversion::resolve_unrealized_casts;
         use crate::dialect::arith;
-        use crate::dialect::core as arena_core;
+        use crate::dialect::core;
         use crate::location::Span;
         use crate::refs::{OpRef, TypeRef};
         use crate::rewrite::{Module, TypeConverter};
@@ -245,7 +245,7 @@ mod tests {
         }
 
         #[test]
-        fn arena_resolve_no_materializer() {
+        fn resolve_no_materializer() {
             let (mut ctx, loc) = test_ctx();
             let i32_ty = i32_type(&mut ctx);
             let i64_ty = i64_type(&mut ctx);
@@ -255,8 +255,7 @@ mod tests {
             let const_result = const_op.result(&ctx);
 
             // unrealized_conversion_cast(const_result) -> i64
-            let cast_op =
-                arena_core::unrealized_conversion_cast(&mut ctx, loc, const_result, i64_ty);
+            let cast_op = core::unrealized_conversion_cast(&mut ctx, loc, const_result, i64_ty);
 
             let module = make_module(&mut ctx, loc, vec![const_op.op_ref(), cast_op.op_ref()]);
 
@@ -269,7 +268,7 @@ mod tests {
         }
 
         #[test]
-        fn arena_resolve_same_type_noop() {
+        fn resolve_same_type_noop() {
             let (mut ctx, loc) = test_ctx();
             let i32_ty = i32_type(&mut ctx);
 
@@ -278,8 +277,7 @@ mod tests {
             let const_result = const_op.result(&ctx);
 
             // unrealized_conversion_cast(const_result) -> i32 (same type)
-            let cast_op =
-                arena_core::unrealized_conversion_cast(&mut ctx, loc, const_result, i32_ty);
+            let cast_op = core::unrealized_conversion_cast(&mut ctx, loc, const_result, i32_ty);
 
             let module = make_module(&mut ctx, loc, vec![const_op.op_ref(), cast_op.op_ref()]);
 
@@ -297,7 +295,7 @@ mod tests {
         }
 
         #[test]
-        fn arena_resolve_with_materializer() {
+        fn resolve_with_materializer() {
             let (mut ctx, loc) = test_ctx();
             let i32_ty = i32_type(&mut ctx);
             let i64_ty = i64_type(&mut ctx);
@@ -307,8 +305,7 @@ mod tests {
             let const_result = const_op.result(&ctx);
 
             // unrealized_conversion_cast(const_result) -> i64
-            let cast_op =
-                arena_core::unrealized_conversion_cast(&mut ctx, loc, const_result, i64_ty);
+            let cast_op = core::unrealized_conversion_cast(&mut ctx, loc, const_result, i64_ty);
             let cast_result = cast_op.result(&ctx);
 
             // A user of the cast result

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -56,9 +56,6 @@ pub mod parser;
 // Re-export proc macro for dialect definitions
 pub use trunk_ir_macros::dialect;
 
-/// Deprecated alias for [`dialect`].
-pub use trunk_ir_macros::arena_dialect;
-
 // Re-export proc macro for canonicalize-pass registration. Emits an
 // `inventory::submit!` block alongside the user's function.
 pub use trunk_ir_macros::canonicalize_fold;

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -12,7 +12,7 @@ use super::pattern::RewritePattern;
 use super::rewriter::{self, PatternRewriter};
 use super::type_converter::TypeConverter;
 use crate::context::IrContext;
-use crate::dialect::core as arena_core;
+use crate::dialect::core;
 use crate::ops::DialectOp;
 use crate::refs::{BlockRef, OpRef, RegionRef};
 
@@ -316,7 +316,7 @@ impl PatternApplicator {
     /// infinite loops.
     fn insert_conversion_casts(&self, ctx: &mut IrContext, block: BlockRef, op: OpRef) -> usize {
         // Skip unrealized_conversion_cast itself to avoid infinite loops
-        if arena_core::UnrealizedConversionCast::from_op(ctx, op).is_ok() {
+        if core::UnrealizedConversionCast::from_op(ctx, op).is_ok() {
             return 0;
         }
 
@@ -328,7 +328,7 @@ impl PatternApplicator {
                 && target_ty != raw_ty
             {
                 let loc = ctx.op(op).location;
-                let cast = arena_core::unrealized_conversion_cast(ctx, loc, operand, target_ty);
+                let cast = core::unrealized_conversion_cast(ctx, loc, operand, target_ty);
                 let cast_ref = cast.op_ref();
                 let cast_result = cast.result(ctx);
                 ctx.insert_op_before(block, op, cast_ref);

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -110,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn arena_module_new_rejects_non_module_op() {
+    fn module_new_rejects_non_module_op() {
         let (mut ctx, loc) = test_ctx();
         let op_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
             .build(&mut ctx);
@@ -120,7 +120,7 @@ mod tests {
     }
 
     #[test]
-    fn arena_module_body_returns_none_without_regions() {
+    fn module_body_returns_none_without_regions() {
         let (mut ctx, loc) = test_ctx();
         // Create a core.module op without any regions.
         let op_data = OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
@@ -135,7 +135,7 @@ mod tests {
     }
 
     #[test]
-    fn arena_module_body_returns_region() {
+    fn module_body_returns_region() {
         let (mut ctx, loc) = test_ctx();
         let block = ctx.create_block(BlockData {
             location: loc,

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -18,7 +18,16 @@ lowering은 현재 경로가 아니다.
   { ability_ref = @Console, op_name = @print }
 ```
 
-`lower_ability_perform`는 이를 다음 형태로 낮춘다:
+Shared lowering converts it to a target-independent effect ABI operation:
+
+```text
+%payload = cast %arg to anyref
+%result = effect.dispatch_tail %ev, %payload
+  { ability_ref = @Console, op_name = @print }
+```
+
+Native lowering then lowers that ABI operation to the current evidence lookup
+and indirect-call representation:
 
 ```text
 %marker = ability.evidence_lookup %ev { ability_ref = @Console }
@@ -42,8 +51,17 @@ lowering은 현재 경로가 아니다.
   { ability_ref = @State, op_name = @get }
 ```
 
-`lower_ability_perform`는 evidence에서 `handler_dispatch` closure를 찾고,
-그 closure로 tail-call한다:
+Shared lowering converts it to a target-independent effect ABI operation:
+
+```text
+%payload = cast %arg to anyref
+%cont = cast %continuation to anyref
+%result = effect.dispatch_cps %ev, %cont, %payload
+  { ability_ref = @State, op_name = @get }
+```
+
+Native lowering then finds the `handler_dispatch` closure in evidence and
+tail-calls it:
 
 ```text
 %marker = ability.evidence_lookup %ev { ability_ref = @State }
@@ -100,6 +118,17 @@ continuation에 잘못 포함되어서는 안 된다.
 
 `resolve_evidence`는 handler boundary에서 새 marker를 만들어 evidence를
 확장한다.
+
+Shared evidence resolution represents handler installation with the same effect
+ABI instead of constructing the concrete Marker layout directly:
+
+```text
+%ev2 = effect.extend %ev, %prompt_tag, %tr_dispatch_fn, %handler_dispatch
+  { ability_ref = @State }
+```
+
+Backends lower `effect.extend` to their own evidence representation. The native
+backend maps it to the current `__tribute_evidence_extend` ABI.
 
 ```text
 struct Marker {
@@ -167,21 +196,50 @@ ast_to_ir
 → convert_tail_resumptive
 → resolve_evidence
 → lower_handle_dispatch
+→ effect ABI verification
 → backend-specific lowering
 ```
 
 `ast_to_ir` 단계에서 effectful function과 closure는 evidence parameter와
-CPS calling convention을 반영한 IR로 생성된다. 이후 backend는 이미 lowered된
-`func.call_indirect`, evidence runtime calls, closure representation을 각 타겟에
-맞게 낮춘다.
+CPS calling convention을 반영한 IR로 생성된다. Shared lowering removes
+high-level dispatch operations and emits `effect.*` ABI operations. Backends
+then lower `effect.*` into evidence runtime calls, closure decomposition, and
+target-specific indirect calls.
+
+## Effect ABI Boundary
+
+The `effect` dialect is the target-independent boundary between language
+semantics and concrete runtime layout.
+
+Initial operations:
+
+- `effect.extend(evidence, prompt_tag, tr_dispatch_fn, handler_dispatch)
+  { ability_ref } -> evidence`
+- `effect.dispatch_tail(evidence, payload) { ability_ref, op_name } -> result`
+- `effect.dispatch_cps(evidence, continuation, payload)
+  { ability_ref, op_name } -> result`
+
+Rules:
+
+- `ability.perform` and `ability.call` are illegal after the shared
+  ability-dispatch lowering boundary.
+- `effect.*` operations may remain after shared lowering and before
+  backend-specific effect ABI lowering.
+- Backend-ready conversion targets must reject residual `effect.*` operations.
+- Shared passes must not inspect Marker field numbers, handler-table storage
+  layout, closure field positions, or backend function-pointer representation.
+- Payload values are already packed into a single value by the frontend or
+  earlier shared lowering. Missing payloads are represented explicitly by a
+  target-independent null/empty value before reaching `effect.*`.
 
 ## Backend Implications
 
 ### Native
 
 Native target은 현재 주 개발 경로다. Evidence runtime은 `tribute-runtime`의
-`__tribute_evidence_*` C ABI 함수로 제공되고, native lowering은 marker field
-접근을 runtime lookup helper로 바꾼다.
+`__tribute_evidence_*` C ABI 함수로 제공되고, native effect ABI lowering은
+`effect.*`를 marker lookup helper, runtime evidence extension, closure
+decomposition, and indirect calls로 변환한다.
 
 ### WasmGC
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -21,6 +21,7 @@ Infrastructure
 High-level
   tribute   unresolved or source-level frontend constructs
   ability   evidence and handler dispatch semantics
+  effect    target-independent effect ABI
   closure   closure construction and decomposition
   adt       structs, variants, arrays, references, literals
 
@@ -63,6 +64,13 @@ resolution, type checking, TDNR, and AST-to-IR lowering.
 `ability.*` represents effect evidence and handler dispatch. Ability operations
 are lowered through the effect pipeline; ability-related types may remain until
 their target-specific representation is selected.
+
+`effect.*` represents the target-independent ABI between high-level ability
+semantics and backend-specific evidence/callable layouts. It carries semantic
+inputs such as evidence, ability identity, operation name, payload,
+continuation, and handler closures. It must not expose Marker field indices,
+handler-table storage layout, closure field positions, or backend function
+pointer representation.
 
 `closure.*` represents closure allocation and projection. Closures lower
 differently per backend: Wasm uses function references plus GC structures, while
@@ -121,8 +129,9 @@ Important stage invariants:
 | Type check | Type variables and effect rows are solved |
 | TDNR | Method-style calls are converted to resolved calls |
 | AST-to-IR | IR structure and SSA use chains are valid |
-| Shared lowering | Source-level and ability operations are removed at claimed boundaries |
-| Backend lowering | Backend-ready target verification succeeds |
+| Shared lowering | Source-level and high-level ability dispatch operations are removed at claimed boundaries |
+| Effect ABI | `effect.*` operations preserve dispatch semantics without backend layout details |
+| Backend lowering | Backend-ready target verification succeeds and no `effect.*` operations remain |
 
 ## Type Model
 

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -44,6 +44,12 @@ The shared effect pipeline establishes the `ability-lowered` partial boundary
 after `LowerHandleDispatch`: residual `ability.*` operations are illegal, while
 operations owned by later lowering stages remain unknown and are allowed.
 
+The effect ABI boundary is represented by `effect.*` operations. Shared ability
+lowering may produce `effect.extend`, `effect.dispatch_tail`, and
+`effect.dispatch_cps`; backend-specific lowering must eliminate them before a
+backend-ready full conversion target. Shared passes must not lower these
+operations by inspecting concrete Marker fields or backend closure layouts.
+
 ## Legality Precedence
 
 `ConversionTarget` legality is structural, not callback-order based:
@@ -118,6 +124,7 @@ Typical pass groups:
 
 ```text
 effect/ability lowering
+effect ABI to native runtime lowering
 native runtime lowering
 arith_to_clif
 scf_to_clif

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -12,7 +12,7 @@ use tribute::database::parse_with_thread_local;
 use tribute_front::SourceCst;
 use tribute_passes::evidence::has_evidence_first_param;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::func as arena_func;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::rewrite::Module;
 
@@ -35,7 +35,7 @@ fn compile_to_ir(db: &dyn salsa::Database, code: &str, name: &str) -> (IrContext
 fn get_functions_with_evidence(ctx: &IrContext, module: &Module) -> Vec<(String, bool)> {
     let mut results = Vec::new();
     for op in module.ops(ctx) {
-        if let Ok(func_op) = arena_func::Func::from_op(ctx, op) {
+        if let Ok(func_op) = func::Func::from_op(ctx, op) {
             let name = func_op.sym_name(ctx).to_string();
             let func_ty = func_op.r#type(ctx);
             let has_evidence = has_evidence_first_param(ctx, func_ty);
@@ -213,7 +213,7 @@ fn main() { }
 
         // Count evidence params per function via block args
         for op in module.ops(&ctx) {
-            if let Ok(func_op) = arena_func::Func::from_op(&ctx, op) {
+            if let Ok(func_op) = func::Func::from_op(&ctx, op) {
                 let name = func_op.sym_name(&ctx).to_string();
                 let body = func_op.body(&ctx);
                 let blocks = &ctx.region(body).blocks;

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -62,10 +62,10 @@ core.module @direct_fn_native {
       %15 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = core.unrealized_conversion_cast %16 : core.ptr
-      %19 = core.unrealized_conversion_cast %13 : core.ptr
-      %20 = arith.const {value = 2616163639} : core.i32
-      %21 = func.call %1, %20, %17, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
+      %18 = arith.const {value = 2616163639} : core.i32
+      %19 = core.unrealized_conversion_cast %16 : core.ptr
+      %20 = core.unrealized_conversion_cast %13 : core.ptr
+      %21 = func.call %1, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
       %22 = func.call_indirect %9, %21, %10, %8 : tribute_rt.anyref
       %23 = tribute_rt.unbox_int %22 : core.i32
       %24 = tribute_rt.unbox_int %22 : core.i32
@@ -75,28 +75,26 @@ core.module @direct_fn_native {
 
   func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %4 = arith.const {value = 2616163639} : core.i32
-      %5 = func.call %0, %4 {callee = @__tribute_evidence_lookup} : core.i32
-      %6 = func.call %0, %4 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = arith.const {value = 2616163639} : core.i32
+      %6 = func.call %0, %5 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %7 = arith.const {value = 664197438} : core.i32
-      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %9 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = func.call_indirect %9, %0, %10, %7, %8 : tribute_rt.anyref
-      %12 = tribute_rt.unbox_int %11 : core.i32
-      %13 = arith.const {value = 2616163639} : core.i32
-      %14 = func.call %0, %13 {callee = @__tribute_evidence_lookup} : core.i32
-      %15 = func.call %0, %13 {callee = @__tribute_evidence_lookup_tr} : core.ptr
-      %16 = arith.const {value = 2110389019} : core.i32
-      %17 = adt.struct_get %15 {field = 0, type = !_closure} : core.i32
-      %18 = adt.struct_get %15 {field = 1, type = !_closure} : tribute_rt.anyref
-      %19 = func.call_indirect %17, %0, %18, %16, %11 : tribute_rt.anyref
-      %20 = core.unrealized_conversion_cast %19 : core.nil
-      %21 = core.unrealized_conversion_cast %2 : closure.closure(!t1)
-      %22 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
-      %23 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
-      %24 = func.call_indirect %22, %0, %23, %11 : tribute_rt.anyref
-      func.return %24
+      %8 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+      %10 = func.call_indirect %8, %0, %9, %7, %4 : tribute_rt.anyref
+      %11 = tribute_rt.unbox_int %10 : core.i32
+      %12 = arith.const {value = 2616163639} : core.i32
+      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %14 = arith.const {value = 2110389019} : core.i32
+      %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %17 = func.call_indirect %15, %0, %16, %14, %10 : tribute_rt.anyref
+      %18 = core.unrealized_conversion_cast %17 : core.nil
+      %19 = core.unrealized_conversion_cast %2 : closure.closure(!t1)
+      %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
+      %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
+      %22 = func.call_indirect %20, %0, %21, %10 : tribute_rt.anyref
+      func.return %22
   }
 
   func.func @"run::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -62,7 +62,7 @@ core.module @direct_fn_native {
       %15 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = arith.const {value = 2616163639} : core.i32
+      %18 = arith.const {value = 1361557906} : core.i32
       %19 = core.unrealized_conversion_cast %16 : core.ptr
       %20 = core.unrealized_conversion_cast %13 : core.ptr
       %21 = func.call %1, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
@@ -76,14 +76,14 @@ core.module @direct_fn_native {
   func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = arith.const {value = 2616163639} : core.i32
+      %5 = arith.const {value = 1361557906} : core.i32
       %6 = func.call %0, %5 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %7 = arith.const {value = 664197438} : core.i32
       %8 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
       %9 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
       %10 = func.call_indirect %8, %0, %9, %7, %4 : tribute_rt.anyref
       %11 = tribute_rt.unbox_int %10 : core.i32
-      %12 = arith.const {value = 2616163639} : core.i32
+      %12 = arith.const {value = 1361557906} : core.i32
       %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %14 = arith.const {value = 2110389019} : core.i32
       %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -78,7 +78,7 @@ core.module @mixed_nested_native {
       %15 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = arith.const {value = 2616163639} : core.i32
+      %18 = arith.const {value = 1361557906} : core.i32
       %19 = core.unrealized_conversion_cast %16 : core.ptr
       %20 = core.unrealized_conversion_cast %13 : core.ptr
       %21 = func.call %1, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
@@ -99,7 +99,7 @@ core.module @mixed_nested_native {
       %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t1
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
       %11 = tribute_rt.box_int %7 : tribute_rt.anyref
-      %12 = arith.const {value = 80204913} : core.i32
+      %12 = arith.const {value = 3214451656} : core.i32
       %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_handler} : core.ptr
       %14 = arith.const {value = 1348736788} : core.i32
       %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
@@ -110,7 +110,7 @@ core.module @mixed_nested_native {
 
   func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = arith.const {value = 2616163639} : core.i32
+      %4 = arith.const {value = 1361557906} : core.i32
       %5 = func.call %0, %4 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %6 = arith.const {value = 664197438} : core.i32
       %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
@@ -121,7 +121,7 @@ core.module @mixed_nested_native {
       %12 = func.constant {func_ref = @"step::__clam_0"} : !t1
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
       %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = arith.const {value = 80204913} : core.i32
+      %15 = arith.const {value = 3214451656} : core.i32
       %16 = func.call %0, %15 {callee = @__tribute_evidence_lookup_handler} : core.ptr
       %17 = arith.const {value = 1972422014} : core.i32
       %18 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
@@ -175,7 +175,7 @@ core.module @mixed_nested_native {
       %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
       %15 = arith.const {value = 0} : tribute_rt.anyref
       %16 = func.call {callee = @__tribute_next_tag} : core.i32
-      %17 = arith.const {value = 80204913} : core.i32
+      %17 = arith.const {value = 3214451656} : core.i32
       %18 = core.unrealized_conversion_cast %15 : core.ptr
       %19 = core.unrealized_conversion_cast %14 : core.ptr
       %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
@@ -234,7 +234,7 @@ core.module @mixed_nested_native {
       %6 = adt.struct_get %3 {field = 2, type = !"step::__clam_0::__clam_0::env"} : tribute_rt.anyref
       %7 = core.unrealized_conversion_cast %2 : core.nil
       %8 = tribute_rt.box_int %4 : tribute_rt.anyref
-      %9 = arith.const {value = 2616163639} : core.i32
+      %9 = arith.const {value = 1361557906} : core.i32
       %10 = func.call %0, %9 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %11 = arith.const {value = 2110389019} : core.i32
       %12 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -78,10 +78,10 @@ core.module @mixed_nested_native {
       %15 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = core.unrealized_conversion_cast %16 : core.ptr
-      %19 = core.unrealized_conversion_cast %13 : core.ptr
-      %20 = arith.const {value = 2616163639} : core.i32
-      %21 = func.call %1, %20, %17, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
+      %18 = arith.const {value = 2616163639} : core.i32
+      %19 = core.unrealized_conversion_cast %16 : core.ptr
+      %20 = core.unrealized_conversion_cast %13 : core.ptr
+      %21 = func.call %1, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
       %22 = func.call_indirect %9, %21, %10, %8 : tribute_rt.anyref
       %23 = tribute_rt.unbox_int %22 : core.i32
       %24 = tribute_rt.unbox_int %22 : core.i32
@@ -98,39 +98,36 @@ core.module @mixed_nested_native {
       %8 = adt.struct_new %6, %4, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
       %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t1
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = arith.const {value = 80204913} : core.i32
-      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : core.i32
-      %13 = func.call %0, %11 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %11 = tribute_rt.box_int %7 : tribute_rt.anyref
+      %12 = arith.const {value = 80204913} : core.i32
+      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_handler} : core.ptr
       %14 = arith.const {value = 1348736788} : core.i32
-      %15 = tribute_rt.box_int %7 : tribute_rt.anyref
-      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %18 = func.call_indirect %16, %0, %17, %10, %14, %15 : tribute_rt.anyref
-      func.return %18
+      %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %17 = func.call_indirect %15, %0, %16, %10, %14, %11 : tribute_rt.anyref
+      func.return %17
   }
 
   func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = arith.const {value = 2616163639} : core.i32
-      %4 = func.call %0, %3 {callee = @__tribute_evidence_lookup} : core.i32
-      %5 = func.call %0, %3 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = arith.const {value = 2616163639} : core.i32
+      %5 = func.call %0, %4 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %6 = arith.const {value = 664197438} : core.i32
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %10 = func.call_indirect %8, %0, %9, %6, %7 : tribute_rt.anyref
-      %11 = tribute_rt.unbox_int %10 : core.i32
-      %12 = adt.struct_new %11, %2 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
-      %13 = func.constant {func_ref = @"step::__clam_0"} : !t1
-      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
+      %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %9 = func.call_indirect %7, %0, %8, %6, %3 : tribute_rt.anyref
+      %10 = tribute_rt.unbox_int %9 : core.i32
+      %11 = adt.struct_new %10, %2 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %12 = func.constant {func_ref = @"step::__clam_0"} : !t1
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %15 = arith.const {value = 80204913} : core.i32
-      %16 = func.call %0, %15 {callee = @__tribute_evidence_lookup} : core.i32
-      %17 = func.call %0, %15 {callee = @__tribute_evidence_lookup_handler} : core.ptr
-      %18 = arith.const {value = 1972422014} : core.i32
-      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %20 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
-      %21 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
-      %22 = func.call_indirect %20, %0, %21, %14, %18, %19 : tribute_rt.anyref
-      func.return %22
+      %16 = func.call %0, %15 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %17 = arith.const {value = 1972422014} : core.i32
+      %18 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
+      %19 = adt.struct_get %16 {field = 1, type = !_closure} : tribute_rt.anyref
+      %20 = func.call_indirect %18, %0, %19, %13, %17, %14 : tribute_rt.anyref
+      func.return %20
   }
 
   func.func @"run_state_with_console::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -178,10 +175,10 @@ core.module @mixed_nested_native {
       %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
       %15 = arith.const {value = 0} : tribute_rt.anyref
       %16 = func.call {callee = @__tribute_next_tag} : core.i32
-      %17 = core.unrealized_conversion_cast %15 : core.ptr
-      %18 = core.unrealized_conversion_cast %14 : core.ptr
-      %19 = arith.const {value = 80204913} : core.i32
-      %20 = func.call %0, %19, %16, %17, %18 {callee = @__tribute_evidence_extend} : core.ptr
+      %17 = arith.const {value = 80204913} : core.i32
+      %18 = core.unrealized_conversion_cast %15 : core.ptr
+      %19 = core.unrealized_conversion_cast %14 : core.ptr
+      %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
       %21 = func.call_indirect %10, %20, %11, %9 : tribute_rt.anyref
       %22 = tribute_rt.unbox_int %21 : core.i32
       %23 = tribute_rt.unbox_int %21 : core.i32
@@ -236,21 +233,20 @@ core.module @mixed_nested_native {
       %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::__clam_0::env"} : core.i32
       %6 = adt.struct_get %3 {field = 2, type = !"step::__clam_0::__clam_0::env"} : tribute_rt.anyref
       %7 = core.unrealized_conversion_cast %2 : core.nil
-      %8 = arith.const {value = 2616163639} : core.i32
-      %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup} : core.i32
-      %10 = func.call %0, %8 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %8 = tribute_rt.box_int %4 : tribute_rt.anyref
+      %9 = arith.const {value = 2616163639} : core.i32
+      %10 = func.call %0, %9 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %11 = arith.const {value = 2110389019} : core.i32
-      %12 = tribute_rt.box_int %4 : tribute_rt.anyref
-      %13 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
-      %14 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
-      %15 = func.call_indirect %13, %0, %14, %11, %12 : tribute_rt.anyref
-      %16 = core.unrealized_conversion_cast %15 : core.nil
-      %17 = arith.addi %4, %5 : core.i32
-      %18 = tribute_rt.box_int %17 : tribute_rt.anyref
-      %19 = core.unrealized_conversion_cast %6 : !t2
-      %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-      %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-      %22 = func.call_indirect %20, %0, %21, %18 : tribute_rt.anyref
-      func.return %22
+      %12 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
+      %13 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
+      %14 = func.call_indirect %12, %0, %13, %11, %8 : tribute_rt.anyref
+      %15 = core.unrealized_conversion_cast %14 : core.nil
+      %16 = arith.addi %4, %5 : core.i32
+      %17 = tribute_rt.box_int %16 : tribute_rt.anyref
+      %18 = core.unrealized_conversion_cast %6 : !t2
+      %19 = adt.struct_get %18 {field = 0, type = !_closure} : core.i32
+      %20 = adt.struct_get %18 {field = 1, type = !_closure} : tribute_rt.anyref
+      %21 = func.call_indirect %19, %0, %20, %17 : tribute_rt.anyref
+      func.return %21
   }
 }

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -63,7 +63,7 @@ core.module @resumptive_op_native {
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
       %14 = arith.const {value = 0} : tribute_rt.anyref
       %15 = func.call {callee = @__tribute_next_tag} : core.i32
-      %16 = arith.const {value = 80204913} : core.i32
+      %16 = arith.const {value = 3214451656} : core.i32
       %17 = core.unrealized_conversion_cast %14 : core.ptr
       %18 = core.unrealized_conversion_cast %13 : core.ptr
       %19 = func.call %1, %16, %15, %17, %18 {callee = @__tribute_evidence_extend} : core.ptr
@@ -84,7 +84,7 @@ core.module @resumptive_op_native {
       %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t1
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
       %11 = tribute_rt.box_int %7 : tribute_rt.anyref
-      %12 = arith.const {value = 80204913} : core.i32
+      %12 = arith.const {value = 3214451656} : core.i32
       %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_handler} : core.ptr
       %14 = arith.const {value = 1348736788} : core.i32
       %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
@@ -99,7 +99,7 @@ core.module @resumptive_op_native {
       %5 = func.constant {func_ref = @"bump::__clam_0"} : !t1
       %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
       %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = arith.const {value = 80204913} : core.i32
+      %8 = arith.const {value = 3214451656} : core.i32
       %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup_handler} : core.ptr
       %10 = arith.const {value = 1972422014} : core.i32
       %11 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -63,10 +63,10 @@ core.module @resumptive_op_native {
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
       %14 = arith.const {value = 0} : tribute_rt.anyref
       %15 = func.call {callee = @__tribute_next_tag} : core.i32
-      %16 = core.unrealized_conversion_cast %14 : core.ptr
-      %17 = core.unrealized_conversion_cast %13 : core.ptr
-      %18 = arith.const {value = 80204913} : core.i32
-      %19 = func.call %1, %18, %15, %16, %17 {callee = @__tribute_evidence_extend} : core.ptr
+      %16 = arith.const {value = 80204913} : core.i32
+      %17 = core.unrealized_conversion_cast %14 : core.ptr
+      %18 = core.unrealized_conversion_cast %13 : core.ptr
+      %19 = func.call %1, %16, %15, %17, %18 {callee = @__tribute_evidence_extend} : core.ptr
       %20 = func.call_indirect %9, %19, %10, %8 : tribute_rt.anyref
       %21 = tribute_rt.unbox_int %20 : core.i32
       %22 = tribute_rt.unbox_int %20 : core.i32
@@ -83,15 +83,14 @@ core.module @resumptive_op_native {
       %8 = adt.struct_new %5, %4 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
       %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t1
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = arith.const {value = 80204913} : core.i32
-      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : core.i32
-      %13 = func.call %0, %11 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %11 = tribute_rt.box_int %7 : tribute_rt.anyref
+      %12 = arith.const {value = 80204913} : core.i32
+      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_handler} : core.ptr
       %14 = arith.const {value = 1348736788} : core.i32
-      %15 = tribute_rt.box_int %7 : tribute_rt.anyref
-      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %18 = func.call_indirect %16, %0, %17, %10, %14, %15 : tribute_rt.anyref
-      func.return %18
+      %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %17 = func.call_indirect %15, %0, %16, %10, %14, %11 : tribute_rt.anyref
+      func.return %17
   }
 
   func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -99,15 +98,14 @@ core.module @resumptive_op_native {
       %4 = adt.struct_new %2 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
       %5 = func.constant {func_ref = @"bump::__clam_0"} : !t1
       %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = arith.const {value = 80204913} : core.i32
-      %8 = func.call %0, %7 {callee = @__tribute_evidence_lookup} : core.i32
-      %9 = func.call %0, %7 {callee = @__tribute_evidence_lookup_handler} : core.ptr
+      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %8 = arith.const {value = 80204913} : core.i32
+      %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup_handler} : core.ptr
       %10 = arith.const {value = 1972422014} : core.i32
-      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-      %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = func.call_indirect %12, %0, %13, %6, %10, %11 : tribute_rt.anyref
-      func.return %14
+      %11 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
+      %12 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
+      %13 = func.call_indirect %11, %0, %12, %6, %10, %7 : tribute_rt.anyref
+      func.return %13
   }
 
   func.func @"run_state::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -8,12 +8,12 @@ core.module @direct_fn {
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
-  !t0 = core.array(!_Marker)
   !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !t0 = core.array(!_Marker)
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -31,30 +31,18 @@ core.module @direct_fn {
   }
 
   func.func @use_console(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = arith.const {value = 2616163639} : core.i32
-      %3 = func.call %0, %2 {callee = @__tribute_evidence_lookup} : !_Marker
-      %4 = adt.struct_get %3 {field = 2, type = !_Marker} : !_closure
-      %5 = arith.const {value = 664197438} : core.i32
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %8 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %5, %6 : tribute_rt.anyref
-      %10 = core.unrealized_conversion_cast %9 : core.i32
-      %11 = arith.const {value = 2616163639} : core.i32
-      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : !_Marker
-      %13 = adt.struct_get %12 {field = 2, type = !_Marker} : !_closure
-      %14 = arith.const {value = 2110389019} : core.i32
-      %15 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %18 = func.call_indirect %16, %0, %17, %14, %15 : tribute_rt.anyref
-      %19 = core.unrealized_conversion_cast %18 : core.nil
-      %20 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %21 = core.unrealized_conversion_cast %1 : closure.closure(!t1)
-      %22 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
-      %23 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
-      %24 = func.call_indirect %22, %0, %23, %20 : tribute_rt.anyref
-      func.return %24
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
+      %4 = core.unrealized_conversion_cast %3 : core.i32
+      %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      %6 = effect.dispatch_tail %0, %5 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.nil
+      %8 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      %9 = core.unrealized_conversion_cast %1 : closure.closure(!t1)
+      %10 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
+      %11 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
+      %12 = func.call_indirect %10, %0, %11, %8 : tribute_rt.anyref
+      func.return %12
   }
 
   func.func @"direct_fn::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -96,16 +84,12 @@ core.module @direct_fn {
       %15 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = core.unrealized_conversion_cast %16 : core.ptr
-      %19 = core.unrealized_conversion_cast %13 : core.ptr
-      %20 = arith.const {value = 2616163639} : core.i32
-      %21 = adt.struct_new %20, %17, %18, %19 {type = !_Marker} : !_Marker
-      %22 = func.call %1, %21 {callee = @__tribute_evidence_extend} : !t0
-      %23 = func.call_indirect %9, %22, %10, %8 : tribute_rt.anyref
-      %24 = core.unrealized_conversion_cast %23 : core.i32
-      %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
-      %26 = core.unrealized_conversion_cast %25 : core.i32
-      func.return %26
+      %18 = effect.extend %1, %17, %16, %13 {ability_ref = core.ability_ref() {name = @Console}} : !t0
+      %19 = func.call_indirect %9, %18, %10, %8 : tribute_rt.anyref
+      %20 = core.unrealized_conversion_cast %19 : core.i32
+      %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
+      %22 = core.unrealized_conversion_cast %21 : core.i32
+      func.return %22
   }
 
   func.func @main() -> core.nil {

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -8,8 +8,6 @@ core.module @mixed_nested {
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
-  !t0 = core.array(!_Marker)
   !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
   !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
   !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
@@ -18,6 +16,8 @@ core.module @mixed_nested {
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !t4 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !t0 = core.array(!_Marker)
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -35,28 +35,16 @@ core.module @mixed_nested {
   }
 
   func.func @step(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = arith.const {value = 2616163639} : core.i32
-      %3 = func.call %0, %2 {callee = @__tribute_evidence_lookup} : !_Marker
-      %4 = adt.struct_get %3 {field = 2, type = !_Marker} : !_closure
-      %5 = arith.const {value = 664197438} : core.i32
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %8 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %5, %6 : tribute_rt.anyref
-      %10 = core.unrealized_conversion_cast %9 : core.i32
-      %11 = adt.struct_new %10, %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
-      %12 = func.constant {func_ref = @"step::__clam_0"} : !t1
-      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
-      %14 = arith.const {value = 80204913} : core.i32
-      %15 = func.call %0, %14 {callee = @__tribute_evidence_lookup} : !_Marker
-      %16 = adt.struct_get %15 {field = 3, type = !_Marker} : !_closure
-      %17 = arith.const {value = 1972422014} : core.i32
-      %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %19 = core.unrealized_conversion_cast %13 : tribute_rt.anyref
-      %20 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
-      %21 = adt.struct_get %16 {field = 1, type = !_closure} : tribute_rt.anyref
-      %22 = func.call_indirect %20, %0, %21, %19, %17, %18 : tribute_rt.anyref
-      func.return %22
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
+      %4 = core.unrealized_conversion_cast %3 : core.i32
+      %5 = adt.struct_new %4, %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %6 = func.constant {func_ref = @"step::__clam_0"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+      %10 = effect.dispatch_cps %0, %9, %8 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      func.return %10
   }
 
   func.func @"mixed_nested::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -93,21 +81,17 @@ core.module @mixed_nested {
       %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
       %13 = arith.const {value = 0} : tribute_rt.anyref
       %14 = func.call {callee = @__tribute_next_tag} : core.i32
-      %15 = core.unrealized_conversion_cast %13 : core.ptr
-      %16 = core.unrealized_conversion_cast %12 : core.ptr
-      %17 = arith.const {value = 80204913} : core.i32
-      %18 = adt.struct_new %17, %14, %15, %16 {type = !_Marker} : !_Marker
-      %19 = func.call %0, %18 {callee = @__tribute_evidence_extend} : !t0
-      %20 = func.call_indirect %8, %19, %9, %7 : tribute_rt.anyref
-      %21 = core.unrealized_conversion_cast %20 : core.i32
-      %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
-      %23 = core.unrealized_conversion_cast %22 : core.i32
-      %24 = core.unrealized_conversion_cast %23 : tribute_rt.anyref
-      %25 = core.unrealized_conversion_cast %1 : !t3
-      %26 = adt.struct_get %25 {field = 0, type = !_closure} : core.i32
-      %27 = adt.struct_get %25 {field = 1, type = !_closure} : tribute_rt.anyref
-      %28 = func.call_indirect %26, %0, %27, %24 : tribute_rt.anyref
-      func.return %28
+      %15 = effect.extend %0, %14, %13, %12 {ability_ref = core.ability_ref() {name = @State}} : !t0
+      %16 = func.call_indirect %8, %15, %9, %7 : tribute_rt.anyref
+      %17 = core.unrealized_conversion_cast %16 : core.i32
+      %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %18 : core.i32
+      %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
+      %21 = core.unrealized_conversion_cast %1 : !t3
+      %22 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
+      %23 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
+      %24 = func.call_indirect %22, %0, %23, %20 : tribute_rt.anyref
+      func.return %24
   }
 
   func.func @"mixed_nested::__lambda_10"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -149,16 +133,12 @@ core.module @mixed_nested {
       %15 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = core.unrealized_conversion_cast %16 : core.ptr
-      %19 = core.unrealized_conversion_cast %13 : core.ptr
-      %20 = arith.const {value = 2616163639} : core.i32
-      %21 = adt.struct_new %20, %17, %18, %19 {type = !_Marker} : !_Marker
-      %22 = func.call %1, %21 {callee = @__tribute_evidence_extend} : !t0
-      %23 = func.call_indirect %9, %22, %10, %8 : tribute_rt.anyref
-      %24 = core.unrealized_conversion_cast %23 : core.i32
-      %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
-      %26 = core.unrealized_conversion_cast %25 : core.i32
-      func.return %26
+      %18 = effect.extend %1, %17, %16, %13 {ability_ref = core.ability_ref() {name = @Console}} : !t0
+      %19 = func.call_indirect %9, %18, %10, %8 : tribute_rt.anyref
+      %20 = core.unrealized_conversion_cast %19 : core.i32
+      %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
+      %22 = core.unrealized_conversion_cast %21 : core.i32
+      func.return %22
   }
 
   func.func @main() -> core.nil {
@@ -176,16 +156,10 @@ core.module @mixed_nested {
       %8 = adt.struct_new %6, %4, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
       %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t1
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = arith.const {value = 80204913} : core.i32
-      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : !_Marker
-      %13 = adt.struct_get %12 {field = 3, type = !_Marker} : !_closure
-      %14 = arith.const {value = 1348736788} : core.i32
-      %15 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-      %16 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %17 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %18 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %19 = func.call_indirect %17, %0, %18, %16, %14, %15 : tribute_rt.anyref
-      func.return %19
+      %11 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+      %12 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+      %13 = effect.dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      func.return %13
   }
 
   func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -288,21 +262,15 @@ core.module @mixed_nested {
       %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::__clam_0::env"} : core.i32
       %6 = adt.struct_get %3 {field = 2, type = !"step::__clam_0::__clam_0::env"} : tribute_rt.anyref
       %7 = core.unrealized_conversion_cast %2 : core.nil
-      %8 = arith.const {value = 2616163639} : core.i32
-      %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup} : !_Marker
-      %10 = adt.struct_get %9 {field = 2, type = !_Marker} : !_closure
-      %11 = arith.const {value = 2110389019} : core.i32
-      %12 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %13 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
-      %14 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
-      %15 = func.call_indirect %13, %0, %14, %11, %12 : tribute_rt.anyref
-      %16 = core.unrealized_conversion_cast %15 : core.nil
-      %17 = arith.addi %4, %5 : core.i32
-      %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
-      %19 = core.unrealized_conversion_cast %6 : !t3
-      %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-      %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-      %22 = func.call_indirect %20, %0, %21, %18 : tribute_rt.anyref
-      func.return %22
+      %8 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      %9 = effect.dispatch_tail %0, %8 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
+      %10 = core.unrealized_conversion_cast %9 : core.nil
+      %11 = arith.addi %4, %5 : core.i32
+      %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+      %13 = core.unrealized_conversion_cast %6 : !t3
+      %14 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
+      %15 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
+      %16 = func.call_indirect %14, %0, %15, %12 : tribute_rt.anyref
+      func.return %16
   }
 }

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -3,13 +3,11 @@ source: tests/active_pipeline_goldens.rs
 expression: ir_text
 ---
 core.module @resumptive_op {
-  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
-  !t0 = core.array(!_Marker)
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
   !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
   !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
@@ -17,6 +15,8 @@ core.module @resumptive_op {
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !t0 = core.array(!_Marker)
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -37,16 +37,10 @@ core.module @resumptive_op {
       %2 = adt.struct_new %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
       %3 = func.constant {func_ref = @"bump::__clam_0"} : !t1
       %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = arith.const {value = 80204913} : core.i32
-      %6 = func.call %0, %5 {callee = @__tribute_evidence_lookup} : !_Marker
-      %7 = adt.struct_get %6 {field = 3, type = !_Marker} : !_closure
-      %8 = arith.const {value = 1972422014} : core.i32
-      %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %10 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %11 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
-      %12 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %13 = func.call_indirect %11, %0, %12, %10, %8, %9 : tribute_rt.anyref
-      func.return %13
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+      %7 = effect.dispatch_cps %0, %6, %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      func.return %7
   }
 
   func.func @"resumptive_op::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -86,16 +80,12 @@ core.module @resumptive_op {
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
       %14 = arith.const {value = 0} : tribute_rt.anyref
       %15 = func.call {callee = @__tribute_next_tag} : core.i32
-      %16 = core.unrealized_conversion_cast %14 : core.ptr
-      %17 = core.unrealized_conversion_cast %13 : core.ptr
-      %18 = arith.const {value = 80204913} : core.i32
-      %19 = adt.struct_new %18, %15, %16, %17 {type = !_Marker} : !_Marker
-      %20 = func.call %1, %19 {callee = @__tribute_evidence_extend} : !t0
-      %21 = func.call_indirect %9, %20, %10, %8 : tribute_rt.anyref
-      %22 = core.unrealized_conversion_cast %21 : core.i32
-      %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
-      %24 = core.unrealized_conversion_cast %23 : core.i32
-      func.return %24
+      %16 = effect.extend %1, %15, %14, %13 {ability_ref = core.ability_ref() {name = @State}} : !t0
+      %17 = func.call_indirect %9, %16, %10, %8 : tribute_rt.anyref
+      %18 = core.unrealized_conversion_cast %17 : core.i32
+      %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
+      %20 = core.unrealized_conversion_cast %19 : core.i32
+      func.return %20
   }
 
   func.func @main() -> core.nil {
@@ -113,16 +103,10 @@ core.module @resumptive_op {
       %8 = adt.struct_new %5, %4 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
       %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t1
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = arith.const {value = 80204913} : core.i32
-      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup} : !_Marker
-      %13 = adt.struct_get %12 {field = 3, type = !_Marker} : !_closure
-      %14 = arith.const {value = 1348736788} : core.i32
-      %15 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-      %16 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %17 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %18 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %19 = func.call_indirect %17, %0, %18, %16, %14, %15 : tribute_rt.anyref
-      func.return %19
+      %11 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
+      %12 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+      %13 = effect.dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      func.return %13
   }
 
   func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {


### PR DESCRIPTION
## Summary
- Introduce the effect ABI dialect structures in `tribute-ir` and wire them into the dialect module.
- Update evidence resolution and lowering so `perform` calls flow through the new effect-dispatch path.
- Refresh CPS/effects and lowering design docs to match the implementation.
- Update snapshot coverage for ability-call and handler-boundary pipeline cases.

## Testing
- Updated and verified snapshot tests for lowering and pipeline golden outputs.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared `effect` ABI dispatch layer for ability operations, including tail-call and CPS-style entrypoints.
  * Implemented stable ability ID computation for consistent runtime resolution.
* **Bug Fixes**
  * Updated ability lowering to use effect-based dispatch and to safely skip rewrites when evidence is missing.
  * Refreshed native evidence lowering to follow the new dispatch flow.
* **Documentation**
  * Expanded lowering pipeline docs to define the effect ABI boundary and verification step.
* **Refactor**
  * Migrated many passes and backends away from deprecated dialect aliases, and removed the deprecated `arena_dialect` macro.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->