### PR TITLE
Anchor canonicalization and cleanup passes to functions

### DIFF
--- a/crates/trunk-ir/src/pass.rs
+++ b/crates/trunk-ir/src/pass.rs
@@ -53,6 +53,48 @@ pub trait Pass {
     fn run(&mut self, ctx: &mut IrContext, target: Self::Target) -> PassRunResult;
 }
 
+/// [`Pass`] adapter for a named function or closure.
+pub struct FnPass<T, F> {
+    name: &'static str,
+    f: F,
+    _target: std::marker::PhantomData<fn(T)>,
+}
+
+impl<T, F> FnPass<T, F> {
+    pub fn new(name: &'static str, f: F) -> Self {
+        Self {
+            name,
+            f,
+            _target: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, F> Pass for FnPass<T, F>
+where
+    T: DialectOp,
+    F: FnMut(&mut IrContext, T) -> PassRunResult,
+{
+    type Target = T;
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: T) -> PassRunResult {
+        (self.f)(ctx, target)
+    }
+}
+
+/// Build a named [`Pass`] from a function or closure.
+pub fn pass_fn<T, F>(name: &'static str, f: F) -> FnPass<T, F>
+where
+    T: DialectOp,
+    F: FnMut(&mut IrContext, T) -> PassRunResult,
+{
+    FnPass::new(name, f)
+}
+
 /// Object-safe view of [`Pass`] used inside [`PassManager`] storage.
 trait ErasedPass<T: DialectOp> {
     fn name(&self) -> &'static str;
@@ -593,6 +635,30 @@ mod tests {
         pm.run(&mut ctx, module).unwrap();
 
         assert_eq!(count.get(), 1);
+    }
+
+    #[test]
+    fn pass_fn_registers_named_closure_pass() {
+        let (mut ctx, loc) = test_ctx();
+        let module = empty_module(&mut ctx, loc);
+
+        let count = Rc::new(Cell::new(0));
+        let count_clone = count.clone();
+        let seen_name = Rc::new(RefCell::new(String::new()));
+        let seen_name_clone = seen_name.clone();
+
+        let mut pm = PassManager::new();
+        pm.add_pass(pass_fn("closure-pass", move |_ctx, _target| {
+            count_clone.set(count_clone.get() + 1);
+            Ok(())
+        }));
+        pm.with_instrumentation(move |_ctx, name, _op| {
+            seen_name_clone.replace(name.to_string());
+        });
+        pm.run(&mut ctx, module).unwrap();
+
+        assert_eq!(count.get(), 1);
+        assert_eq!(&*seen_name.borrow(), "closure-pass");
     }
 
     #[test]

--- a/crates/trunk-ir/src/pass.rs
+++ b/crates/trunk-ir/src/pass.rs
@@ -28,6 +28,7 @@ use derive_more::{Display, Error};
 
 use crate::context::IrContext;
 use crate::dialect::core;
+use crate::op_interface::IsolatedFromAboveOps;
 use crate::ops::DialectOp;
 use crate::refs::OpRef;
 use crate::walk::{WalkAction, walk_op};
@@ -203,6 +204,7 @@ impl<T: DialectOp + 'static> NestedRunner for TypedNested<T> {
             if !T::matches(ctx, target.op_ref()) {
                 continue;
             }
+            ensure_nested_anchor_is_isolated(ctx, target.op_ref())?;
             self.pm.run_on_target_with(ctx, target, hooks)?;
         }
         Ok(())
@@ -235,6 +237,23 @@ fn collect_targets<T: DialectOp>(ctx: &IrContext, root: OpRef) -> Vec<T> {
         ControlFlow::Continue(WalkAction::Advance)
     });
     found
+}
+
+fn ensure_nested_anchor_is_isolated(ctx: &IrContext, op: OpRef) -> PassResult {
+    if IsolatedFromAboveOps::is_isolated(ctx, op) {
+        return Ok(());
+    }
+
+    let data = ctx.op(op);
+    Err(PassError::verification(
+        "nested-pass-manager",
+        VerifyError {
+            message: format!(
+                "nested pass target `{}.{}` is not registered IsolatedFromAbove",
+                data.dialect, data.name
+            ),
+        },
+    ))
 }
 
 /// Orchestrates a sequence of [`Pass`] instances plus nested sub-managers.
@@ -417,7 +436,7 @@ mod tests {
 
     use super::*;
     use crate::context::{BlockData, OperationDataBuilder, RegionData};
-    use crate::dialect::{core, func};
+    use crate::dialect::{arith, core, func};
     use crate::location::Span;
     use crate::symbol::Symbol;
     use crate::types::{Attribute, Location};
@@ -841,6 +860,36 @@ mod tests {
 
         assert_eq!(error.pass_name(), "failing");
         assert_eq!(*order.borrow(), vec!["failing"]);
+    }
+
+    #[test]
+    fn nested_pass_requires_isolated_anchor() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %y = arith.addi %x, %x : core.i32
+    func.return %y
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let module =
+            core::Module::from_op(&ctx, module.op()).expect("test input must parse a core.module");
+        let count = Rc::new(Cell::new(0));
+
+        let mut pm = PassManager::new();
+        pm.nest::<arith::Addi>()
+            .add_pass(CountingPass::<arith::Addi>::new(count.clone()));
+
+        let error = pm.run(&mut ctx, module).unwrap_err();
+
+        assert_eq!(error.pass_name(), "nested-pass-manager");
+        assert!(matches!(error.kind(), PassErrorKind::Verification(_)));
+        assert_eq!(count.get(), 0);
+        assert!(
+            error
+                .to_string()
+                .contains("nested pass target `arith.addi` is not registered IsolatedFromAbove")
+        );
     }
 
     #[test]

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -12,9 +12,46 @@ use super::pattern::RewritePattern;
 use super::rewriter::{self, PatternRewriter};
 use super::type_converter::TypeConverter;
 use crate::context::IrContext;
-use crate::dialect::core;
+use crate::dialect::{core, func};
 use crate::ops::DialectOp;
 use crate::refs::{BlockRef, OpRef, RegionRef};
+
+/// Scope that bounds a pattern rewrite traversal.
+///
+/// A rewrite scope provides the regions to visit and, when the scope is a
+/// module, the module block that may receive `PatternRewriter::add_module_op`
+/// insertions. Function-scoped rewrites intentionally return no module block,
+/// keeping anchored rewrites inside the current function body.
+pub trait RewriteScope: Copy {
+    type Regions: Iterator<Item = RegionRef>;
+
+    fn regions(self, ctx: &IrContext) -> Self::Regions;
+    fn module_first_block(self, ctx: &IrContext) -> Option<BlockRef>;
+}
+
+impl RewriteScope for Module {
+    type Regions = std::option::IntoIter<RegionRef>;
+
+    fn regions(self, ctx: &IrContext) -> Self::Regions {
+        self.body(ctx).into_iter()
+    }
+
+    fn module_first_block(self, ctx: &IrContext) -> Option<BlockRef> {
+        self.first_block(ctx)
+    }
+}
+
+impl RewriteScope for func::Func {
+    type Regions = std::iter::Once<RegionRef>;
+
+    fn regions(self, ctx: &IrContext) -> Self::Regions {
+        std::iter::once(self.body(ctx))
+    }
+
+    fn module_first_block(self, _ctx: &IrContext) -> Option<BlockRef> {
+        None
+    }
+}
 
 /// Result of applying rewrite patterns.
 pub struct ApplyResult {
@@ -141,16 +178,17 @@ impl PatternApplicator {
         &self.type_converter
     }
 
-    /// Apply patterns without verification.
+    /// Apply patterns within a rewrite scope without verification.
     ///
     /// The configured target still skips operations classified as legal.
-    pub fn apply_partial(&self, ctx: &mut IrContext, module: Module) -> ApplyResult {
+    pub fn apply_partial<S: RewriteScope>(&self, ctx: &mut IrContext, scope: S) -> ApplyResult {
+        let module_first_block = scope.module_first_block(ctx);
         let mut total_changes = 0;
         let mut iterations = 0;
 
         for _ in 0..self.max_iterations {
             iterations += 1;
-            let changes = self.run_one_iteration(ctx, module);
+            let changes = self.run_one_iteration(ctx, scope, module_first_block);
             total_changes += changes;
             if changes == 0 {
                 return ApplyResult {
@@ -204,17 +242,18 @@ impl PatternApplicator {
         Ok(result)
     }
 
-    /// Run a single iteration over all operations.
-    fn run_one_iteration(&self, ctx: &mut IrContext, module: Module) -> usize {
+    /// Run a single iteration over all operations below the selected root.
+    fn run_one_iteration(
+        &self,
+        ctx: &mut IrContext,
+        scope: impl RewriteScope,
+        module_first_block: Option<BlockRef>,
+    ) -> usize {
         let mut changes = 0;
-        let module_first_block = module.first_block(ctx);
 
-        // Walk the module body region
-        let body = match module.body(ctx) {
-            Some(r) => r,
-            None => return 0,
-        };
-        changes += self.visit_region(ctx, body, module_first_block);
+        for region in scope.regions(ctx) {
+            changes += self.visit_region(ctx, region, module_first_block);
+        }
 
         changes
     }
@@ -343,7 +382,9 @@ impl PatternApplicator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dialect::func;
     use crate::location::Span;
+    use crate::ops::DialectOp;
     use crate::rewrite::conversion_target::ConversionTarget;
     use crate::symbol::Symbol;
     use crate::*;
@@ -405,6 +446,37 @@ mod tests {
                 .region(region)
                 .build(ctx);
         ctx.create_op(container_data)
+    }
+
+    fn make_func_container(
+        ctx: &mut IrContext,
+        loc: Location,
+        name: &'static str,
+        nested_ops: Vec<OpRef>,
+    ) -> func::Func {
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for op in nested_ops {
+            ctx.push_op(block, op);
+        }
+        let region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+        let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
+        let func_ty = crate::dialect::core::func(ctx, nil_ty, []).as_type_ref();
+        let func_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
+            .attr("sym_name", Attribute::Symbol(Symbol::new(name)))
+            .attr("type", Attribute::Type(func_ty))
+            .region(region)
+            .build(ctx);
+        let func_op = ctx.create_op(func_data);
+        func::Func::from_op(ctx, func_op).expect("test func should be valid")
     }
 
     fn first_nested_op(ctx: &IrContext, op: OpRef) -> OpRef {
@@ -608,6 +680,45 @@ mod tests {
         assert_eq!(result.total_changes, 0);
         let skipped = first_nested_op(&ctx, container);
         assert_eq!(ctx.op(skipped).name, Symbol::new("source"));
+    }
+
+    #[test]
+    fn apply_partial_rewrites_only_selected_typed_scope_regions() {
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+
+        let selected_nested =
+            OperationDataBuilder::new(loc, Symbol::new("test"), Symbol::new("source"))
+                .result(i32_ty)
+                .build(&mut ctx);
+        let selected_nested = ctx.create_op(selected_nested);
+        let selected_func = make_func_container(&mut ctx, loc, "selected", vec![selected_nested]);
+
+        let sibling_nested =
+            OperationDataBuilder::new(loc, Symbol::new("test"), Symbol::new("source"))
+                .result(i32_ty)
+                .build(&mut ctx);
+        let sibling_nested = ctx.create_op(sibling_nested);
+        let sibling_func = make_func_container(&mut ctx, loc, "sibling", vec![sibling_nested]);
+        let _module = make_module(
+            &mut ctx,
+            loc,
+            vec![selected_func.op_ref(), sibling_func.op_ref()],
+        );
+
+        let result = PatternApplicator::new(TypeConverter::new())
+            .add_pattern(RenamePattern)
+            .apply_partial(&mut ctx, selected_func);
+
+        assert_eq!(result.total_changes, 1);
+        assert_eq!(
+            ctx.op(first_nested_op(&ctx, selected_func.op_ref())).name,
+            Symbol::new("target")
+        );
+        assert_eq!(
+            ctx.op(first_nested_op(&ctx, sibling_func.op_ref())).name,
+            Symbol::new("source")
+        );
     }
 
     #[test]

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -11,7 +11,7 @@ pub mod rewriter;
 pub mod signature_conversion;
 pub mod type_converter;
 
-pub use applicator::{ApplyResult, PatternApplicator};
+pub use applicator::{ApplyResult, PatternApplicator, RewriteScope};
 pub use conversion_target::{
     ConversionError, ConversionMode, ConversionTarget, IllegalOp, LegalityCheck, LegalityDecision,
 };

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 
 use crate::context::IrContext;
 use crate::dialect::{arith, func};
-use crate::pass::{Pass, PassRunResult};
+use crate::pass::{Pass, pass_fn};
 use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use crate::rewrite::{
     PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter,
@@ -311,17 +311,9 @@ pub fn canonicalize<S: RewriteScope>(ctx: &mut IrContext, scope: S) -> Canonical
     result_from_apply(canonicalize_applicator().apply_partial(ctx, scope))
 }
 
-/// Function-anchored canonicalization pass.
-pub struct CanonicalizeFunc;
-
-impl Pass for CanonicalizeFunc {
-    type Target = func::Func;
-
-    fn name(&self) -> &'static str {
-        "canonicalize-func"
-    }
-
-    fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+/// Build a function-anchored canonicalization pass.
+pub fn canonicalize_pass() -> impl Pass<Target = func::Func> {
+    pass_fn("canonicalize-func", |ctx, target| {
         let result = canonicalize(ctx, target);
         if !result.reached_fixpoint {
             tracing::warn!(
@@ -331,7 +323,7 @@ impl Pass for CanonicalizeFunc {
             );
         }
         Ok(())
-    }
+    })
 }
 
 // =========================================================================

--- a/crates/trunk-ir/src/transforms/canonicalize.rs
+++ b/crates/trunk-ir/src/transforms/canonicalize.rs
@@ -34,9 +34,12 @@
 use std::collections::HashMap;
 
 use crate::context::IrContext;
-use crate::dialect::arith;
+use crate::dialect::{arith, func};
+use crate::pass::{Pass, PassRunResult};
 use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
-use crate::rewrite::{Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter};
+use crate::rewrite::{
+    PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter,
+};
 use crate::symbol::Symbol;
 use crate::types::Attribute;
 
@@ -290,15 +293,44 @@ pub struct CanonicalizeResult {
     pub reached_fixpoint: bool,
 }
 
-/// Run canonicalization to a fixed point on `module`.
-pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
-    let applicator = PatternApplicator::new(TypeConverter::new())
-        .add_pattern_box(Box::new(FoldDispatchPattern::from_inventory()));
-    let result = applicator.apply_partial(ctx, module);
+fn canonicalize_applicator() -> PatternApplicator {
+    PatternApplicator::new(TypeConverter::new())
+        .add_pattern_box(Box::new(FoldDispatchPattern::from_inventory()))
+}
+
+fn result_from_apply(result: crate::rewrite::ApplyResult) -> CanonicalizeResult {
     CanonicalizeResult {
         iterations: result.iterations,
         total_changes: result.total_changes,
         reached_fixpoint: result.reached_fixpoint,
+    }
+}
+
+/// Run canonicalization to a fixed point within one rewrite scope.
+pub fn canonicalize<S: RewriteScope>(ctx: &mut IrContext, scope: S) -> CanonicalizeResult {
+    result_from_apply(canonicalize_applicator().apply_partial(ctx, scope))
+}
+
+/// Function-anchored canonicalization pass.
+pub struct CanonicalizeFunc;
+
+impl Pass for CanonicalizeFunc {
+    type Target = func::Func;
+
+    fn name(&self) -> &'static str {
+        "canonicalize-func"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        let result = canonicalize(ctx, target);
+        if !result.reached_fixpoint {
+            tracing::warn!(
+                "canonicalize-func did not reach a fixed point: {} iterations, {} changes",
+                result.iterations,
+                result.total_changes
+            );
+        }
+        Ok(())
     }
 }
 
@@ -314,7 +346,9 @@ pub fn canonicalize(ctx: &mut IrContext, module: Module) -> CanonicalizeResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::DialectOp;
     use crate::parser::parse_test_module;
+    use crate::rewrite::Module;
     use crate::walk::{WalkAction, walk_op};
     use std::ops::ControlFlow;
 
@@ -323,6 +357,20 @@ mod tests {
         let name_sym = Symbol::from_dynamic(name);
         let mut count = 0usize;
         let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+            let data = ctx.op(op);
+            if data.dialect == dialect_sym && data.name == name_sym {
+                count += 1;
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        count
+    }
+
+    fn count_ops_under(ctx: &IrContext, root: OpRef, dialect: &str, name: &str) -> usize {
+        let dialect_sym = Symbol::from_dynamic(dialect);
+        let name_sym = Symbol::from_dynamic(name);
+        let mut count = 0usize;
+        let _ = walk_op::<()>(ctx, root, &mut |op| {
             let data = ctx.op(op);
             if data.dialect == dialect_sym && data.name == name_sym {
                 count += 1;
@@ -376,6 +424,36 @@ mod tests {
         assert!(result.reached_fixpoint);
         assert!(result.total_changes >= 2);
         assert_eq!(count_ops(&ctx, module, "arith", "addi"), 0);
+    }
+
+    #[test]
+    fn canonicalize_rewrites_only_selected_function_scope() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %z = arith.const {value = 0} : core.i32
+    %r = arith.addi %x, %z : core.i32
+    func.return %r
+  }
+  func.func @g(%x: core.i32) -> core.i32 {
+    %z = arith.const {value = 0} : core.i32
+    %r = arith.addi %x, %z : core.i32
+    func.return %r
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let funcs: Vec<func::Func> = module
+            .ops(&ctx)
+            .into_iter()
+            .map(|op| func::Func::from_op(&ctx, op).expect("test op must be func.func"))
+            .collect();
+
+        let result = canonicalize(&mut ctx, funcs[0]);
+
+        assert!(result.reached_fixpoint);
+        assert_eq!(count_ops_under(&ctx, funcs[0].op_ref(), "arith", "addi"), 0);
+        assert_eq!(count_ops_under(&ctx, funcs[1].op_ref(), "arith", "addi"), 1);
+        assert_eq!(count_ops(&ctx, module, "arith", "addi"), 1);
     }
 
     #[test]

--- a/crates/trunk-ir/src/transforms/mod.rs
+++ b/crates/trunk-ir/src/transforms/mod.rs
@@ -12,7 +12,7 @@ pub mod inline;
 pub mod scf_to_cf;
 
 pub use call_graph::{CallGraph, build_call_graph, recursive_functions, tarjan_scc};
-pub use canonicalize::{CanonicalizeResult, canonicalize};
+pub use canonicalize::{CanonicalizeFunc, CanonicalizeResult, canonicalize};
 pub use dce::{DceConfig, DceResult, eliminate_dead_code, eliminate_dead_code_with_config};
 pub use global_dce::{
     GlobalDceConfig, GlobalDceResult, eliminate_dead_functions,

--- a/crates/trunk-ir/src/transforms/mod.rs
+++ b/crates/trunk-ir/src/transforms/mod.rs
@@ -12,7 +12,7 @@ pub mod inline;
 pub mod scf_to_cf;
 
 pub use call_graph::{CallGraph, build_call_graph, recursive_functions, tarjan_scc};
-pub use canonicalize::{CanonicalizeFunc, CanonicalizeResult, canonicalize};
+pub use canonicalize::{CanonicalizeResult, canonicalize, canonicalize_pass};
 pub use dce::{DceConfig, DceResult, eliminate_dead_code, eliminate_dead_code_with_config};
 pub use global_dce::{
     GlobalDceConfig, GlobalDceResult, eliminate_dead_functions,

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -47,7 +47,7 @@ function creation or deletion, cross-function call rewrites, global DCE, and
 pipeline-boundary conversion checks.
 
 `PatternApplicator` supports `RewriteScope`-scoped application for these
-anchored passes. For example, `CanonicalizeFunc` runs generic canonicalization
+anchored passes. For example, `canonicalize_pass()` runs generic canonicalization
 under one `func.func` scope, while module-wide cleanup uses the same
 `canonicalize` entry point with a module scope.
 

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -46,6 +46,11 @@ matching operation. Module passes remain responsible for symbol-table changes,
 function creation or deletion, cross-function call rewrites, global DCE, and
 pipeline-boundary conversion checks.
 
+`PatternApplicator` supports `RewriteScope`-scoped application for these
+anchored passes. For example, `CanonicalizeFunc` runs generic canonicalization
+under one `func.func` scope, while module-wide cleanup uses the same
+`canonicalize` entry point with a module scope.
+
 ## Conversion Modes
 
 Use partial conversion when a pass only promises to remove a declared illegal

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -26,6 +26,26 @@ compiler pipeline. Verifier failures use the same path.
 Instrumentation runs only after a pass succeeds. The verifier then runs on the
 successful result; a verifier failure stops the pipeline before further work.
 
+## Operation-Anchored Scheduling
+
+Use nested pass managers for transformations whose contract is scoped to one
+operation instance instead of the whole module. In particular, intraprocedural
+passes should target `func.func` through `PassManager::nest::<func::Func>()`
+when they do not create, erase, or retarget sibling functions and do not need
+module-wide symbol or call-site decisions.
+
+Nested pass-manager anchors must be registered as `IsolatedFromAbove`.
+This keeps nested pipelines on operations whose regions can be reasoned about
+without capturing values from the parent scope. `func.func` and `core.module`
+are valid anchors; region-bearing control-flow operations such as `scf.if`
+remain part of their enclosing function pipeline unless a documented exception
+is added.
+
+Run a nested pipeline coherently for one anchor before advancing to the next
+matching operation. Module passes remain responsible for symbol-table changes,
+function creation or deletion, cross-function call rewrites, global DCE, and
+pipeline-boundary conversion checks.
+
 ## Conversion Modes
 
 Use partial conversion when a pass only promises to remove a declared illegal

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -554,7 +554,7 @@ fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
     if let Ok(core_module) = core_dialect::Module::from_op(ctx, m.op()) {
         let mut pm = PassManager::new();
         pm.nest::<func_dialect::Func>()
-            .add_pass(trunk_ir::transforms::CanonicalizeFunc);
+            .add_pass(trunk_ir::transforms::canonicalize_pass());
         if let Err(error) = pm.run(ctx, core_module) {
             tracing::warn!("cleanup canonicalize-func failed: {error}");
         }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -74,7 +74,7 @@ use tribute_passes::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverit
 use tribute_passes::generic_type_converter;
 use trunk_ir::Span;
 use trunk_ir::conversion::resolve_unrealized_casts;
-use trunk_ir::dialect::core as core_dialect;
+use trunk_ir::dialect::{core as core_dialect, func as func_dialect};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{PassError, PassManager, PassResult};
 use trunk_ir::rewrite::ConversionError;
@@ -551,13 +551,15 @@ fn run_lowering_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), DumpIrErr
 ///
 fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
     trunk_ir::transforms::global_dce::eliminate_dead_functions(ctx, m);
-    let result = trunk_ir::transforms::canonicalize::canonicalize(ctx, m);
-    if !result.reached_fixpoint {
-        tracing::warn!(
-            "canonicalize did not reach a fixed point: {} iterations, {} changes",
-            result.iterations,
-            result.total_changes,
-        );
+    if let Ok(core_module) = core_dialect::Module::from_op(ctx, m.op()) {
+        let mut pm = PassManager::new();
+        pm.nest::<func_dialect::Func>()
+            .add_pass(trunk_ir::transforms::CanonicalizeFunc);
+        if let Err(error) = pm.run(ctx, core_module) {
+            tracing::warn!("cleanup canonicalize-func failed: {error}");
+        }
+    } else {
+        tracing::warn!("cleanup skipped canonicalize-func: root op is not core.module");
     }
     let tc = generic_type_converter(ctx);
     resolve_unrealized_casts(ctx, m, &tc);


### PR DESCRIPTION
## Summary
- Add a named `FnPass` adapter so closures can be registered as passes with stable instrumentation names.
- Require nested pass-manager targets to be `IsolatedFromAbove`, and add a verification error when a nested anchor is not valid.
- Extend `PatternApplicator` with `RewriteScope` so canonicalization can run either on a module or on a single `func.func` scope.
- Introduce `canonicalize_pass()` and update cleanup to run canonicalization through a nested function pass manager.
- Document the new operation-anchored scheduling rules in `new-plans/lowering.md`.

## Testing
- Added unit coverage for named closure passes, isolated nested anchors, and function-scoped rewrite application.
- Added canonicalization coverage to verify only the selected function scope is rewritten.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scoped rewrite support, so certain transformations can now run on a selected function or other operation instead of the whole module.
  * Introduced a new function-anchored canonicalization pass for more targeted cleanup.
  * Updated nested pass handling to better enforce valid operation anchors.

* **Bug Fixes**
  * Fixed canonicalization and rewrite passes so they only affect the intended scope.
  * Improved cleanup pipeline behavior when canonicalization cannot be applied at the root level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->