### PR TITLE
Anchor local cleanup passes to functions

### DIFF
--- a/crates/trunk-ir/src/transforms/dce.rs
+++ b/crates/trunk-ir/src/transforms/dce.rs
@@ -6,9 +6,11 @@
 //! liveness analysis.
 
 use crate::context::IrContext;
+use crate::dialect::func;
 use crate::op_interface::PureOps;
+use crate::pass::{Pass, pass_fn};
 use crate::refs::{BlockRef, OpRef, RegionRef};
-use crate::rewrite::Module;
+use crate::rewrite::RewriteScope;
 
 /// Configuration for dead code elimination.
 #[derive(Debug, Clone)]
@@ -38,15 +40,10 @@ pub struct DceResult {
     pub reached_fixpoint: bool,
 }
 
-/// Eliminate dead code from a module using default configuration.
-pub fn eliminate_dead_code(ctx: &mut IrContext, module: Module) -> DceResult {
-    eliminate_dead_code_with_config(ctx, module, DceConfig::default())
-}
-
-/// Eliminate dead code with custom configuration.
-pub fn eliminate_dead_code_with_config(
+/// Eliminate dead code from one rewrite scope.
+pub fn eliminate_dead_code<S: RewriteScope>(
     ctx: &mut IrContext,
-    module: Module,
+    scope: S,
     config: DceConfig,
 ) -> DceResult {
     let max_iterations = if config.max_iterations == 0 {
@@ -58,7 +55,7 @@ pub fn eliminate_dead_code_with_config(
     let mut total_removed = 0;
 
     for iteration in 0..max_iterations {
-        let removed = sweep_module(ctx, module, &config);
+        let removed = sweep_scope(ctx, scope, &config);
 
         if removed == 0 {
             return DceResult {
@@ -78,14 +75,28 @@ pub fn eliminate_dead_code_with_config(
     }
 }
 
-/// Sweep all top-level functions in a module, removing dead ops.
+/// Build a function-anchored DCE pass.
+pub fn dce_pass(config: DceConfig) -> impl Pass<Target = func::Func> {
+    pass_fn("dce-func", move |ctx, target| {
+        let result = eliminate_dead_code(ctx, target, config.clone());
+        if !result.reached_fixpoint {
+            tracing::warn!(
+                "dce-func did not reach a fixed point: {} iterations, {} removed",
+                result.iterations,
+                result.removed_count
+            );
+        }
+        Ok(())
+    })
+}
+
+/// Sweep all regions in a rewrite scope, removing dead ops.
 /// Returns the number of ops removed in this sweep.
-fn sweep_module(ctx: &mut IrContext, module: Module, config: &DceConfig) -> usize {
-    let body = match module.body(ctx) {
-        Some(r) => r,
-        None => return 0,
-    };
-    sweep_region(ctx, body, config)
+fn sweep_scope<S: RewriteScope>(ctx: &mut IrContext, scope: S, config: &DceConfig) -> usize {
+    scope
+        .regions(ctx)
+        .map(|region| sweep_region(ctx, region, config))
+        .sum()
 }
 
 /// Sweep all blocks in a region. Returns the number of ops removed.
@@ -157,6 +168,10 @@ mod tests {
     use super::*;
     use crate::dialect::{arith, func};
     use crate::location::Span;
+    use crate::ops::DialectOp;
+    use crate::parser::parse_test_module;
+    use crate::printer::print_module;
+    use crate::rewrite::Module;
     use crate::symbol::Symbol;
     use crate::*;
     use smallvec::smallvec;
@@ -244,7 +259,7 @@ mod tests {
         });
         let module = build_module(&mut ctx, loc, vec![func_op]);
 
-        let result = eliminate_dead_code(&mut ctx, module);
+        let result = eliminate_dead_code(&mut ctx, module, DceConfig::default());
 
         assert_eq!(result.removed_count, 1);
         assert!(result.reached_fixpoint);
@@ -270,7 +285,7 @@ mod tests {
         });
         let module = build_module(&mut ctx, loc, vec![func_op]);
 
-        let result = eliminate_dead_code(&mut ctx, module);
+        let result = eliminate_dead_code(&mut ctx, module, DceConfig::default());
 
         assert_eq!(result.removed_count, 0);
     }
@@ -296,7 +311,7 @@ mod tests {
         });
         let module = build_module(&mut ctx, loc, vec![func_op]);
 
-        let result = eliminate_dead_code(&mut ctx, module);
+        let result = eliminate_dead_code(&mut ctx, module, DceConfig::default());
 
         // All 3 pure ops should be removed (reverse iteration cascades in one pass)
         assert_eq!(result.removed_count, 3);
@@ -320,9 +335,43 @@ mod tests {
         });
         let module = build_module(&mut ctx, loc, vec![func_op]);
 
-        let result = eliminate_dead_code(&mut ctx, module);
+        let result = eliminate_dead_code(&mut ctx, module, DceConfig::default());
 
         assert_eq!(result.removed_count, 0);
+    }
+
+    #[test]
+    fn function_scope_rewrites_only_selected_function() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @selected() -> core.nil {
+    %dead = arith.const {value = 1} : core.i32
+    func.return
+  }
+  func.func @untouched() -> core.nil {
+    %dead = arith.const {value = 2} : core.i32
+    func.return
+  }
+}"#,
+        );
+        let funcs: Vec<_> = module
+            .ops(&ctx)
+            .into_iter()
+            .filter_map(|op| func::Func::from_op(&ctx, op).ok())
+            .collect();
+        let selected = funcs[0];
+        let untouched = funcs[1];
+
+        let result = eliminate_dead_code(&mut ctx, selected, DceConfig::default());
+
+        assert_eq!(result.removed_count, 1);
+        let selected_block = ctx.region(selected.body(&ctx)).blocks[0];
+        let untouched_block = ctx.region(untouched.body(&ctx)).blocks[0];
+        assert_eq!(ctx.block(selected_block).ops.len(), 1);
+        assert_eq!(ctx.block(untouched_block).ops.len(), 2);
+        insta::assert_snapshot!(print_module(&ctx, module.op()));
     }
 
     #[test]
@@ -330,7 +379,7 @@ mod tests {
         let (mut ctx, loc) = test_ctx();
         let module = build_module(&mut ctx, loc, vec![]);
 
-        let result = eliminate_dead_code(&mut ctx, module);
+        let result = eliminate_dead_code(&mut ctx, module, DceConfig::default());
 
         assert_eq!(result.removed_count, 0);
         assert!(result.reached_fixpoint);
@@ -373,7 +422,7 @@ mod tests {
         });
         let module = build_module(&mut ctx, loc, vec![func_op]);
 
-        let result = eliminate_dead_code(&mut ctx, module);
+        let result = eliminate_dead_code(&mut ctx, module, DceConfig::default());
 
         // The dead const in the nested region should be removed
         assert_eq!(result.removed_count, 1);
@@ -398,7 +447,7 @@ mod tests {
             max_iterations: 1,
             recursive: true,
         };
-        let result = eliminate_dead_code_with_config(&mut ctx, module, config);
+        let result = eliminate_dead_code(&mut ctx, module, config);
 
         assert_eq!(result.removed_count, 1);
     }
@@ -441,7 +490,7 @@ mod tests {
             max_iterations: 100,
             recursive: false,
         };
-        let result = eliminate_dead_code_with_config(&mut ctx, module, config);
+        let result = eliminate_dead_code(&mut ctx, module, config);
 
         // With recursive=false, the inner dead const should NOT be removed
         assert_eq!(result.removed_count, 0);

--- a/crates/trunk-ir/src/transforms/mod.rs
+++ b/crates/trunk-ir/src/transforms/mod.rs
@@ -13,7 +13,7 @@ pub mod scf_to_cf;
 
 pub use call_graph::{CallGraph, build_call_graph, recursive_functions, tarjan_scc};
 pub use canonicalize::{CanonicalizeResult, canonicalize, canonicalize_pass};
-pub use dce::{DceConfig, DceResult, eliminate_dead_code, eliminate_dead_code_with_config};
+pub use dce::{DceConfig, DceResult, dce_pass, eliminate_dead_code};
 pub use global_dce::{
     GlobalDceConfig, GlobalDceResult, eliminate_dead_functions,
     eliminate_dead_functions_with_config,
@@ -22,4 +22,4 @@ pub use inline::{
     InlineConfig, InlineError, InlineResult, inline_functions, inline_functions_with_config,
     inline_single_call,
 };
-pub use scf_to_cf::lower_scf_to_cf;
+pub use scf_to_cf::{lower_scf_to_cf, lower_scf_to_cf_func, scf_to_cf_pass};

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -34,8 +34,9 @@ use std::collections::BTreeMap;
 use smallvec::SmallVec;
 
 use crate::context::{BlockArgData, BlockData, IrContext};
-use crate::dialect::{arith, cf, core, scf};
+use crate::dialect::{arith, cf, core, func, scf};
 use crate::ops::{DialectOp, DialectType};
+use crate::pass::{Pass, pass_fn};
 use crate::refs::{BlockRef, OpRef, RegionRef};
 use crate::rewrite::Module;
 use crate::rewrite::helpers::{inline_region_blocks, split_block};
@@ -49,6 +50,19 @@ pub fn lower_scf_to_cf(ctx: &mut IrContext, module: Module) {
         None => return,
     };
     transform_region(ctx, body);
+}
+
+/// Lower all `scf` operations in one function to `cf` operations.
+pub fn lower_scf_to_cf_func(ctx: &mut IrContext, func: func::Func) {
+    transform_region(ctx, func.body(ctx));
+}
+
+/// Build a function-anchored SCF-to-CF lowering pass.
+pub fn scf_to_cf_pass() -> impl Pass<Target = func::Func> {
+    pass_fn("scf-to-cf-func", |ctx, target| {
+        lower_scf_to_cf_func(ctx, target);
+        Ok(())
+    })
 }
 
 /// Transform all blocks in a region, lowering scf ops to cf.
@@ -571,6 +585,70 @@ mod tests {
         ctx.region(region).blocks.len()
     }
 
+    fn build_void_if_func(ctx: &mut IrContext, loc: Location, name: &'static str) -> func::Func {
+        let nil_ty = nil_type(ctx);
+        let i1_ty = i1_type(ctx);
+        let fn_ty = fn_type(ctx);
+
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+
+        let cond_const = arith::r#const(ctx, loc, i1_ty, Attribute::Bool(true));
+        ctx.push_op(entry, cond_const.op_ref());
+
+        let then_block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let then_yield = scf::r#yield(ctx, loc, std::iter::empty());
+        ctx.push_op(then_block, then_yield.op_ref());
+        let then_region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![then_block],
+            parent_op: None,
+        });
+
+        let else_block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let else_yield = scf::r#yield(ctx, loc, std::iter::empty());
+        ctx.push_op(else_block, else_yield.op_ref());
+        let else_region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![else_block],
+            parent_op: None,
+        });
+
+        let if_op = scf::r#if(
+            ctx,
+            loc,
+            cond_const.result(ctx),
+            nil_ty,
+            then_region,
+            else_region,
+        );
+        ctx.push_op(entry, if_op.op_ref());
+
+        let ret = func::r#return(ctx, loc, std::iter::empty());
+        ctx.push_op(entry, ret.op_ref());
+
+        let body_region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        func::func(ctx, loc, Symbol::new(name), fn_ty, body_region)
+    }
+
     #[test]
     fn lower_scf_if_basic() {
         let (mut ctx, loc) = test_ctx();
@@ -666,6 +744,32 @@ mod tests {
 
         // Should have 4 blocks: entry, then, else, merge
         assert_eq!(count_blocks(&ctx, func_body), 4);
+    }
+
+    #[test]
+    fn lower_scf_to_cf_func_rewrites_only_selected_function() {
+        let (mut ctx, loc) = test_ctx();
+        let selected = build_void_if_func(&mut ctx, loc, "selected");
+        let untouched = build_void_if_func(&mut ctx, loc, "untouched");
+        let _module = build_module(&mut ctx, loc, vec![selected.op_ref(), untouched.op_ref()]);
+
+        lower_scf_to_cf_func(&mut ctx, selected);
+
+        let selected_names = collect_op_names(&ctx, selected.body(&ctx));
+        let untouched_names = collect_op_names(&ctx, untouched.body(&ctx));
+
+        assert!(
+            !selected_names.iter().any(|n| n.starts_with("scf.")),
+            "selected function still has scf ops: {selected_names:?}"
+        );
+        assert!(
+            selected_names.iter().any(|n| n == "cf.cond_br"),
+            "selected function should contain cf.cond_br: {selected_names:?}"
+        );
+        assert!(
+            untouched_names.iter().any(|n| n.starts_with("scf.")),
+            "untouched function should retain scf ops: {untouched_names:?}"
+        );
     }
 
     #[test]

--- a/crates/trunk-ir/src/transforms/snapshots/trunk_ir__transforms__dce__tests__function_scope_rewrites_only_selected_function.snap
+++ b/crates/trunk-ir/src/transforms/snapshots/trunk_ir__transforms__dce__tests__function_scope_rewrites_only_selected_function.snap
@@ -1,0 +1,14 @@
+---
+source: crates/trunk-ir/src/transforms/dce.rs
+assertion_line: 384
+expression: "print_module(&ctx, module.op())"
+---
+core.module @test {
+  func.func @selected() -> core.nil {
+      func.return
+  }
+  func.func @untouched() -> core.nil {
+      %0 = arith.const {value = 2} : core.i32
+      func.return
+  }
+}

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -591,7 +591,8 @@ flowchart TB
 | **Backend effect ABI** | `native/evidence` | effect.* | native runtime calls + call_indirect | |
 | | `wasm/evidence_to_wasm` | effect.* | wasm evidence helpers + wasm.call_indirect | |
 | **Lowering** | `lower_case` | tribute.case | scf.if | |
-| | `dce` | all funcs | reachable funcs | |
+| | `canonicalize`, local `dce`, `scf_to_cf` | func.func body | canonical body / cf blocks | function-anchored |
+| | `global_dce` | module symbols | reachable funcs | module-wide |
 
 ### 점진적 개선 방향: Fine-Grained Queries
 

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -46,10 +46,13 @@ matching operation. Module passes remain responsible for symbol-table changes,
 function creation or deletion, cross-function call rewrites, global DCE, and
 pipeline-boundary conversion checks.
 
-`PatternApplicator` supports `RewriteScope`-scoped application for these
-anchored passes. For example, `canonicalize_pass()` runs generic canonicalization
-under one `func.func` scope, while module-wide cleanup uses the same
-`canonicalize` entry point with a module scope.
+`PatternApplicator` and local region transforms support `func.func`-anchored
+application for these passes. For example, `canonicalize_pass()` and
+`dce_pass(DceConfig::default())` run cleanup under one `func.func` scope, and
+`scf_to_cf_pass()` lowers structured control flow inside one function.
+Module-wide entry points remain available for compatibility and tests, but
+pipeline scheduling should prefer nested function passes whenever the transform
+does not create functions, delete functions, or rewrite cross-function symbols.
 
 ## Conversion Modes
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -554,12 +554,15 @@ fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
     if let Ok(core_module) = core_dialect::Module::from_op(ctx, m.op()) {
         let mut pm = PassManager::new();
         pm.nest::<func_dialect::Func>()
-            .add_pass(trunk_ir::transforms::canonicalize_pass());
+            .add_pass(trunk_ir::transforms::canonicalize_pass())
+            .add_pass(trunk_ir::transforms::dce_pass(
+                trunk_ir::transforms::DceConfig::default(),
+            ));
         if let Err(error) = pm.run(ctx, core_module) {
-            tracing::warn!("cleanup canonicalize-func failed: {error}");
+            tracing::warn!("cleanup function passes failed: {error}");
         }
     } else {
-        tracing::warn!("cleanup skipped canonicalize-func: root op is not core.module");
+        tracing::warn!("cleanup skipped function passes: root op is not core.module");
     }
     let tc = generic_type_converter(ctx);
     resolve_unrealized_casts(ctx, m, &tc);
@@ -710,7 +713,14 @@ fn compile_module_to_native(
         .map_err(native_conversion_failure)?;
 
     // Phase 0 - Lower structured control flow to CFG-based control flow
-    trunk_ir::transforms::scf_to_cf::lower_scf_to_cf(ctx, module);
+    if let Ok(core_module) = core_dialect::Module::from_op(ctx, module.op()) {
+        let mut pm = PassManager::new();
+        pm.nest::<func_dialect::Func>()
+            .add_pass(trunk_ir::transforms::scf_to_cf_pass());
+        pm.run(ctx, core_module).map_err(native_pass_failure)?;
+    } else {
+        trunk_ir::transforms::scf_to_cf::lower_scf_to_cf(ctx, module);
+    }
 
     // Phase 1 - Lower func dialect to clif dialect
     {
@@ -817,6 +827,10 @@ fn compile_module_to_native(
 fn native_conversion_failure(
     error: ConversionError,
 ) -> trunk_ir_cranelift_backend::CompilationError {
+    trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string())
+}
+
+fn native_pass_failure(error: PassError) -> trunk_ir_cranelift_backend::CompilationError {
     trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string())
 }
 

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -44,33 +44,32 @@ core.module @direct_fn_native {
   }
 
   func.func @main() -> core.nil {
-      %0 = arith.const {value = 0} : core.i32
+      %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = func.constant {func_ref = @"run::__clam_0"} : !t1
-      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = func.constant {func_ref = @"direct_fn_native::__lambda_5"} : !t1
-      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
-      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %12 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-      %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = arith.const {value = 1361557906} : core.i32
-      %19 = core.unrealized_conversion_cast %16 : core.ptr
-      %20 = core.unrealized_conversion_cast %13 : core.ptr
-      %21 = func.call %1, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
-      %22 = func.call_indirect %9, %21, %10, %8 : tribute_rt.anyref
-      %23 = tribute_rt.unbox_int %22 : core.i32
-      %24 = tribute_rt.unbox_int %22 : core.i32
-      %25 = arith.const {value = unit} : core.nil
-      func.return %25
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = func.constant {func_ref = @"run::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = func.constant {func_ref = @"direct_fn_native::__lambda_5"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = func.call {callee = @__tribute_next_tag} : core.i32
+      %17 = arith.const {value = 1361557906} : core.i32
+      %18 = core.unrealized_conversion_cast %15 : core.ptr
+      %19 = core.unrealized_conversion_cast %12 : core.ptr
+      %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
+      %21 = func.call_indirect %8, %20, %9, %7 : tribute_rt.anyref
+      %22 = tribute_rt.unbox_int %21 : core.i32
+      %23 = tribute_rt.unbox_int %21 : core.i32
+      %24 = arith.const {value = unit} : core.nil
+      func.return %24
   }
 
   func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -101,20 +100,13 @@ core.module @direct_fn_native {
       %5 = arith.const {value = 664197438} : core.i32
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
-          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"direct_fn_native::__lambda_8"} : !t1
-          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-          %11 = arith.const {value = 41} : core.i32
-          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
-          scf.yield %12
+          %8 = arith.const {value = 41} : core.i32
+          %9 = tribute_rt.box_int %8 : tribute_rt.anyref
+          scf.yield %9
       } {
-          %13 = arith.const {value = 1} : core.i1
-          %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %15 = func.constant {func_ref = @"direct_fn_native::__lambda_9"} : !t1
-          %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-          %17 = arith.const {value = unit} : core.nil
-          %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
-          scf.yield %18
+          %10 = arith.const {value = unit} : core.nil
+          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+          scf.yield %11
       }
       func.return %7
   }
@@ -127,10 +119,9 @@ core.module @direct_fn_native {
           %8 = tribute_rt.box_int %7 : tribute_rt.anyref
           scf.yield %8
       } {
-          %9 = arith.const {value = 1} : core.i1
-          %10 = arith.const {value = unit} : core.nil
-          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-          scf.yield %11
+          %9 = arith.const {value = unit} : core.nil
+          %10 = core.unrealized_conversion_cast %9 : tribute_rt.anyref
+          scf.yield %10
       }
       func.return %6
   }

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -5,9 +5,9 @@ expression: ir_text
 core.module @mixed_nested_native {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
   !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !t2 = closure.closure(!t1)
   !t3 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
 
@@ -60,33 +60,32 @@ core.module @mixed_nested_native {
   }
 
   func.func @main() -> core.nil {
-      %0 = arith.const {value = 0} : core.i32
+      %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
-      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = func.constant {func_ref = @"mixed_nested_native::__lambda_10"} : !t1
-      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
-      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %12 = func.constant {func_ref = @"run_all::__clam_1"} : !t3
-      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-      %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = arith.const {value = 1361557906} : core.i32
-      %19 = core.unrealized_conversion_cast %16 : core.ptr
-      %20 = core.unrealized_conversion_cast %13 : core.ptr
-      %21 = func.call %1, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
-      %22 = func.call_indirect %9, %21, %10, %8 : tribute_rt.anyref
-      %23 = tribute_rt.unbox_int %22 : core.i32
-      %24 = tribute_rt.unbox_int %22 : core.i32
-      %25 = arith.const {value = unit} : core.nil
-      func.return %25
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = func.constant {func_ref = @"mixed_nested_native::__lambda_10"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_all::__clam_1"} : !t3
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = func.call {callee = @__tribute_next_tag} : core.i32
+      %17 = arith.const {value = 1361557906} : core.i32
+      %18 = core.unrealized_conversion_cast %15 : core.ptr
+      %19 = core.unrealized_conversion_cast %12 : core.ptr
+      %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
+      %21 = func.call_indirect %8, %20, %9, %7 : tribute_rt.anyref
+      %22 = tribute_rt.unbox_int %21 : core.i32
+      %23 = tribute_rt.unbox_int %21 : core.i32
+      %24 = arith.const {value = unit} : core.nil
+      func.return %24
   }
 
   func.func @"step::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -134,28 +133,21 @@ core.module @mixed_nested_native {
       %5 = arith.const {value = 1972422014} : core.i32
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
-          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"mixed_nested_native::__lambda_8"} : !t1
-          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-          %11 = arith.const {value = 7} : core.i32
-          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
-          %13 = core.unrealized_conversion_cast %2 : !t2
-          %14 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-          %15 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %12 : tribute_rt.anyref
-          scf.yield %16
+          %8 = arith.const {value = 7} : core.i32
+          %9 = tribute_rt.box_int %8 : tribute_rt.anyref
+          %10 = core.unrealized_conversion_cast %2 : !t2
+          %11 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
+          %13 = func.call_indirect %11, %0, %12, %9 : tribute_rt.anyref
+          scf.yield %13
       } {
-          %17 = arith.const {value = 1} : core.i1
-          %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %19 = func.constant {func_ref = @"mixed_nested_native::__lambda_9"} : !t1
-          %20 = adt.struct_new %19, %18 {type = !_closure} : !_closure
-          %21 = arith.const {value = unit} : core.nil
-          %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
-          %23 = core.unrealized_conversion_cast %2 : !t2
-          %24 = adt.struct_get %23 {field = 0, type = !_closure} : core.i32
-          %25 = adt.struct_get %23 {field = 1, type = !_closure} : tribute_rt.anyref
-          %26 = func.call_indirect %24, %0, %25, %22 : tribute_rt.anyref
-          scf.yield %26
+          %14 = arith.const {value = unit} : core.nil
+          %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
+          %16 = core.unrealized_conversion_cast %2 : !t2
+          %17 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
+          %18 = adt.struct_get %16 {field = 1, type = !_closure} : tribute_rt.anyref
+          %19 = func.call_indirect %17, %0, %18, %15 : tribute_rt.anyref
+          scf.yield %19
       }
       func.return %7
   }
@@ -193,20 +185,13 @@ core.module @mixed_nested_native {
       %5 = arith.const {value = 664197438} : core.i32
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
-          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"mixed_nested_native::__lambda_13"} : !t1
-          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-          %11 = arith.const {value = 3} : core.i32
-          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
-          scf.yield %12
+          %8 = arith.const {value = 3} : core.i32
+          %9 = tribute_rt.box_int %8 : tribute_rt.anyref
+          scf.yield %9
       } {
-          %13 = arith.const {value = 1} : core.i1
-          %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %15 = func.constant {func_ref = @"mixed_nested_native::__lambda_14"} : !t1
-          %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-          %17 = arith.const {value = unit} : core.nil
-          %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
-          scf.yield %18
+          %10 = arith.const {value = unit} : core.nil
+          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+          scf.yield %11
       }
       func.return %7
   }
@@ -219,10 +204,9 @@ core.module @mixed_nested_native {
           %8 = tribute_rt.box_int %7 : tribute_rt.anyref
           scf.yield %8
       } {
-          %9 = arith.const {value = 1} : core.i1
-          %10 = arith.const {value = unit} : core.nil
-          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-          scf.yield %11
+          %9 = arith.const {value = unit} : core.nil
+          %10 = core.unrealized_conversion_cast %9 : tribute_rt.anyref
+          scf.yield %10
       }
       func.return %6
   }

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -6,8 +6,8 @@ core.module @resumptive_op_native {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
-  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !t2 = closure.closure(!t1)
 
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
@@ -47,31 +47,30 @@ core.module @resumptive_op_native {
   }
 
   func.func @main() -> core.nil {
-      %0 = arith.const {value = 0} : core.i32
+      %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
-      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = func.constant {func_ref = @"resumptive_op_native::__lambda_5"} : !t1
-      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
-      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %12 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
-      %14 = arith.const {value = 0} : tribute_rt.anyref
-      %15 = func.call {callee = @__tribute_next_tag} : core.i32
-      %16 = arith.const {value = 3214451656} : core.i32
-      %17 = core.unrealized_conversion_cast %14 : core.ptr
-      %18 = core.unrealized_conversion_cast %13 : core.ptr
-      %19 = func.call %1, %16, %15, %17, %18 {callee = @__tribute_evidence_extend} : core.ptr
-      %20 = func.call_indirect %9, %19, %10, %8 : tribute_rt.anyref
-      %21 = tribute_rt.unbox_int %20 : core.i32
-      %22 = tribute_rt.unbox_int %20 : core.i32
-      %23 = arith.const {value = unit} : core.nil
-      func.return %23
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = func.constant {func_ref = @"resumptive_op_native::__lambda_5"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = arith.const {value = 0} : tribute_rt.anyref
+      %14 = func.call {callee = @__tribute_next_tag} : core.i32
+      %15 = arith.const {value = 3214451656} : core.i32
+      %16 = core.unrealized_conversion_cast %13 : core.ptr
+      %17 = core.unrealized_conversion_cast %12 : core.ptr
+      %18 = func.call %0, %15, %14, %16, %17 {callee = @__tribute_evidence_extend} : core.ptr
+      %19 = func.call_indirect %8, %18, %9, %7 : tribute_rt.anyref
+      %20 = tribute_rt.unbox_int %19 : core.i32
+      %21 = tribute_rt.unbox_int %19 : core.i32
+      %22 = arith.const {value = unit} : core.nil
+      func.return %22
   }
 
   func.func @"bump::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -112,28 +111,21 @@ core.module @resumptive_op_native {
       %5 = arith.const {value = 1972422014} : core.i32
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
-          %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"resumptive_op_native::__lambda_8"} : !t1
-          %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-          %11 = arith.const {value = 10} : core.i32
-          %12 = tribute_rt.box_int %11 : tribute_rt.anyref
-          %13 = core.unrealized_conversion_cast %2 : !t2
-          %14 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-          %15 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %12 : tribute_rt.anyref
-          scf.yield %16
+          %8 = arith.const {value = 10} : core.i32
+          %9 = tribute_rt.box_int %8 : tribute_rt.anyref
+          %10 = core.unrealized_conversion_cast %2 : !t2
+          %11 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
+          %13 = func.call_indirect %11, %0, %12, %9 : tribute_rt.anyref
+          scf.yield %13
       } {
-          %17 = arith.const {value = 1} : core.i1
-          %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %19 = func.constant {func_ref = @"resumptive_op_native::__lambda_9"} : !t1
-          %20 = adt.struct_new %19, %18 {type = !_closure} : !_closure
-          %21 = arith.const {value = unit} : core.nil
-          %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
-          %23 = core.unrealized_conversion_cast %2 : !t2
-          %24 = adt.struct_get %23 {field = 0, type = !_closure} : core.i32
-          %25 = adt.struct_get %23 {field = 1, type = !_closure} : tribute_rt.anyref
-          %26 = func.call_indirect %24, %0, %25, %22 : tribute_rt.anyref
-          scf.yield %26
+          %14 = arith.const {value = unit} : core.nil
+          %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
+          %16 = core.unrealized_conversion_cast %2 : !t2
+          %17 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
+          %18 = adt.struct_get %16 {field = 1, type = !_closure} : tribute_rt.anyref
+          %19 = func.call_indirect %17, %0, %18, %15 : tribute_rt.anyref
+          scf.yield %19
       }
       func.return %7
   }


### PR DESCRIPTION
## Summary
- make local DCE usable on any RewriteScope and expose a function-anchored dce_pass()
- add function-anchored scf_to_cf_pass() while keeping module entry points for compatibility
- schedule cleanup DCE and native SCF lowering through nested func.func pass managers
- update lowering docs and active native pipeline snapshots for the cleaner DCE output

## Tests
- cargo nextest run -p trunk-ir transforms::dce transforms::scf_to_cf pass::
- cargo nextest run -p tribute
- cargo nextest run -p trunk-ir
- cargo nextest run --workspace

Follow-up for #728 after #749.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cleanup and lowering now run in a more targeted, function-level way for better pass isolation.
  * Added function-scoped structured-control-flow lowering and dead-code elimination passes.

* **Bug Fixes**
  * Improved handling when cleanup or lowering passes fail, with clearer warnings and error reporting.
  * Updated dead-code elimination to avoid affecting unrelated functions.

* **Documentation**
  * Clarified pass scheduling guidance and updated examples to reflect the new function-focused flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->