### PR TITLE
Anchor ability rewrites to function passes

### DIFF
--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -27,7 +27,7 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, erase_op,
+    PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter, erase_op,
 };
 
 use tribute_ir::dialect::ability;
@@ -52,26 +52,26 @@ impl CommonTypes {
 ///
 /// Residual ability operations are allowed here and rejected at the final
 /// `ability-lowered` boundary.
-pub(crate) fn lower_ability_perform(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_ability_perform<S: RewriteScope>(ctx: &mut IrContext, scope: S) {
     let types = CommonTypes::new(ctx);
     let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern(LowerPerformPattern { types })
         .add_pattern(LowerCallPattern { types });
-    applicator.apply_partial(ctx, module);
+    applicator.apply_partial(ctx, scope);
 }
 
 /// PassManager-friendly wrapper for [`lower_ability_perform`].
 pub struct LowerAbilityPerform;
 
 impl Pass for LowerAbilityPerform {
-    type Target = core::Module;
+    type Target = func::Func;
 
     fn name(&self) -> &'static str {
         "lower-ability-perform"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
-        lower_ability_perform(ctx, target.into());
+    fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        lower_ability_perform(ctx, target);
         Ok(())
     }
 }

--- a/crates/tribute-passes/src/lower_handle_dispatch.rs
+++ b/crates/tribute-passes/src/lower_handle_dispatch.rs
@@ -9,14 +9,14 @@
 //! Uses `PatternApplicator` for declarative op-level rewriting.
 
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{core, scf};
+use trunk_ir::dialect::{core, func, scf};
 use trunk_ir::ir_mapping::IrMapping;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
-    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
-    TypeConverter,
+    ConversionError, ConversionTarget, PatternApplicator, PatternRewriter, RewritePattern,
+    RewriteScope, TypeConverter,
 };
 use trunk_ir::types::Location;
 
@@ -35,12 +35,12 @@ pub fn ability_lowered_target() -> ConversionTarget {
 /// while allowing unknown operations owned by later lowering stages.
 pub(crate) fn lower_handle_dispatch(
     ctx: &mut IrContext,
-    module: Module,
+    scope: impl RewriteScope,
 ) -> Result<(), ConversionError> {
     let applicator = PatternApplicator::new(TypeConverter::new())
         .with_target(ability_lowered_target())
         .add_pattern(LowerHandleDispatchPattern);
-    applicator.apply_partial_conversion(ctx, module, ABILITY_LOWERED_BOUNDARY)?;
+    applicator.apply_partial_conversion(ctx, scope, ABILITY_LOWERED_BOUNDARY)?;
     Ok(())
 }
 
@@ -48,14 +48,14 @@ pub(crate) fn lower_handle_dispatch(
 pub struct LowerHandleDispatch;
 
 impl Pass for LowerHandleDispatch {
-    type Target = core::Module;
+    type Target = func::Func;
 
     fn name(&self) -> &'static str {
         "lower-handle-dispatch"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
-        lower_handle_dispatch(ctx, target.into()).map_err(Into::into)
+    fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        lower_handle_dispatch(ctx, target).map_err(Into::into)
     }
 }
 
@@ -282,6 +282,51 @@ mod tests {
         );
 
         lower_handle_dispatch(&mut ctx, module).unwrap();
+    }
+
+    #[test]
+    fn function_scope_converts_only_selected_function() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @selected() -> tribute_rt.anyref {
+    %body = arith.const {value = 42} : tribute_rt.anyref
+    %handler_fn = arith.const {value = 0} : tribute_rt.anyref
+    %result = ability.handle_dispatch %body, %handler_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
+      ability.done {
+        ^bb0(%v: tribute_rt.anyref):
+          scf.yield %v
+      }
+    }
+    func.return %result
+  }
+  func.func @untouched() -> tribute_rt.anyref {
+    %body = arith.const {value = 7} : tribute_rt.anyref
+    %handler_fn = arith.const {value = 0} : tribute_rt.anyref
+    %result = ability.handle_dispatch %body, %handler_fn {tag = 2, result_type = tribute_rt.anyref} : tribute_rt.anyref {
+      ability.done {
+        ^bb0(%v: tribute_rt.anyref):
+          scf.yield %v
+      }
+    }
+    func.return %result
+  }
+}"#,
+        );
+        let selected = module
+            .ops(&ctx)
+            .into_iter()
+            .filter_map(|op| func::Func::from_op(&ctx, op).ok())
+            .next()
+            .expect("test module should contain a selected function");
+
+        lower_handle_dispatch(&mut ctx, selected).unwrap();
+
+        let ir_text = print_module(&ctx, module.op());
+        assert_eq!(ir_text.matches("ability.handle_dispatch").count(), 1);
+        assert!(ir_text.contains("func.func @untouched"));
+        assert!(ir_text.contains("tag = 2"));
     }
 
     #[test]

--- a/crates/tribute-passes/src/tail_resumptive.rs
+++ b/crates/tribute-passes/src/tail_resumptive.rs
@@ -12,13 +12,13 @@
 //! 3. The result of `ability.resume` flows directly to `scf.yield` (tail position)
 
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::dialect::scf;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter,
 };
 
 use tribute_ir::dialect::ability;
@@ -138,24 +138,24 @@ impl RewritePattern for SuspendToYieldPattern {
 ///
 /// Uses `PatternApplicator` to walk all operations and replace eligible
 /// `ability.suspend` ops with `ability.yield`.
-pub(crate) fn convert_tail_resumptive(ctx: &mut IrContext, module: Module) {
+pub(crate) fn convert_tail_resumptive<S: RewriteScope>(ctx: &mut IrContext, scope: S) {
     let applicator =
         PatternApplicator::new(TypeConverter::new()).add_pattern(SuspendToYieldPattern);
-    applicator.apply_partial(ctx, module);
+    applicator.apply_partial(ctx, scope);
 }
 
 /// PassManager-friendly wrapper for [`convert_tail_resumptive`].
 pub struct ConvertTailResumptive;
 
 impl Pass for ConvertTailResumptive {
-    type Target = core::Module;
+    type Target = func::Func;
 
     fn name(&self) -> &'static str {
         "convert-tail-resumptive"
     }
 
-    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
-        convert_tail_resumptive(ctx, target.into());
+    fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        convert_tail_resumptive(ctx, target);
         Ok(())
     }
 }

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -68,35 +68,34 @@ impl ApplyResult {
     pub fn verify(
         &self,
         ctx: &IrContext,
-        module: Module,
+        scope: impl RewriteScope,
         target: &ConversionTarget,
     ) -> Result<(), Vec<IllegalOp>> {
-        self.verify_mode(ctx, module, target, ConversionMode::Partial)
+        self.verify_mode(ctx, scope, target, ConversionMode::Partial)
     }
 
     /// Verify that every operation is legal for the target.
     pub fn verify_full(
         &self,
         ctx: &IrContext,
-        module: Module,
+        scope: impl RewriteScope,
         target: &ConversionTarget,
     ) -> Result<(), Vec<IllegalOp>> {
-        self.verify_mode(ctx, module, target, ConversionMode::Full)
+        self.verify_mode(ctx, scope, target, ConversionMode::Full)
     }
 
     /// Verify the result under a specific conversion mode.
     pub fn verify_mode(
         &self,
         ctx: &IrContext,
-        module: Module,
+        scope: impl RewriteScope,
         target: &ConversionTarget,
         mode: ConversionMode,
     ) -> Result<(), Vec<IllegalOp>> {
-        let body = match module.body(ctx) {
-            Some(r) => r,
-            None => return Ok(()),
-        };
-        let illegal = target.verify_mode(ctx, body, mode);
+        let illegal: Vec<IllegalOp> = scope
+            .regions(ctx)
+            .flat_map(|region| target.verify_mode(ctx, region, mode))
+            .collect();
         if illegal.is_empty() {
             Ok(())
         } else {
@@ -214,12 +213,12 @@ impl PatternApplicator {
     pub fn apply_partial_conversion(
         &self,
         ctx: &mut IrContext,
-        module: Module,
+        scope: impl RewriteScope,
         boundary: &'static str,
     ) -> Result<ApplyResult, ConversionError> {
-        let result = self.apply_partial(ctx, module);
+        let result = self.apply_partial(ctx, scope);
         result
-            .verify(ctx, module, &self.target)
+            .verify(ctx, scope, &self.target)
             .map_err(|operations| ConversionError::new(boundary, operations))?;
         Ok(result)
     }
@@ -232,12 +231,12 @@ impl PatternApplicator {
     pub fn apply_full_conversion(
         &self,
         ctx: &mut IrContext,
-        module: Module,
+        scope: impl RewriteScope,
         boundary: &'static str,
     ) -> Result<ApplyResult, ConversionError> {
-        let result = self.apply_partial(ctx, module);
+        let result = self.apply_partial(ctx, scope);
         result
-            .verify_full(ctx, module, &self.target)
+            .verify_full(ctx, scope, &self.target)
             .map_err(|operations| ConversionError::new(boundary, operations))?;
         Ok(result)
     }

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -585,9 +585,9 @@ flowchart TB
 | | `closure_lower` | closure.new | func.call_indirect | |
 | | `tdnr` | x.method() | Type::method(x) | |
 | **Ability** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
-| | `lower_ability_perform` | ability.perform/call | effect.dispatch_* | |
+| | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | |
-| | `lower_handle_dispatch` | ability.handle_dispatch | done handler inline | |
+| | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |
 | **Backend effect ABI** | `native/evidence` | effect.* | native runtime calls + call_indirect | |
 | | `wasm/evidence_to_wasm` | effect.* | wasm evidence helpers + wasm.call_indirect | |
 | **Lowering** | `lower_case` | tribute.case | scf.if | |

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -466,19 +466,43 @@ fn run_shared_pipeline(
     // Registration order == execution order.
     let core_module =
         core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
-    let mut pm = PassManager::new();
-    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
+    let mut structural_pm = PassManager::new();
+    structural_pm
+        .add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
         .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
         // Evidence params are now inserted directly during ast_to_ir lowering.
-        .add_pass(tribute_passes::closure_lower::LowerClosures)
-        // CPS effect handling: lower_ability_perform produces
-        // ability.evidence_lookup ops that resolve_evidence needs to process.
-        // lower_handle_dispatch consumes handle_dispatch ops, so it must run
-        // AFTER resolve_evidence expands evidence.
+        .add_pass(tribute_passes::closure_lower::LowerClosures);
+    install_debug_use_chain_verifier(&mut structural_pm);
+    structural_pm.run(&mut ctx, core_module)?;
+
+    // CPS effect handling, function-local phase: lower_ability_perform produces
+    // ability.evidence_lookup ops that resolve_evidence needs to process.
+    let mut ability_pm = PassManager::new();
+    ability_pm
+        .nest::<func_dialect::Func>()
         .add_pass(tribute_passes::lower_ability_perform::LowerAbilityPerform)
-        .add_pass(tribute_passes::tail_resumptive::ConvertTailResumptive)
-        .add_pass(tribute_passes::resolve_evidence::ResolveEvidenceDispatch)
+        .add_pass(tribute_passes::tail_resumptive::ConvertTailResumptive);
+    install_debug_use_chain_verifier(&mut ability_pm);
+    ability_pm.run(&mut ctx, core_module)?;
+
+    let mut evidence_pm = PassManager::new();
+    evidence_pm.add_pass(tribute_passes::resolve_evidence::ResolveEvidenceDispatch);
+    install_debug_use_chain_verifier(&mut evidence_pm);
+    evidence_pm.run(&mut ctx, core_module)?;
+
+    // Final function-local ability conversion. This consumes handle_dispatch ops
+    // after resolve_evidence expands evidence setup.
+    let mut ability_boundary_pm = PassManager::new();
+    ability_boundary_pm
+        .nest::<func_dialect::Func>()
         .add_pass(tribute_passes::lower_handle_dispatch::LowerHandleDispatch);
+    install_debug_use_chain_verifier(&mut ability_boundary_pm);
+    ability_boundary_pm.run(&mut ctx, core_module)?;
+
+    Ok(Some((ctx, m)))
+}
+
+fn install_debug_use_chain_verifier(pm: &mut PassManager) {
     // Debug-only regression guard: re-check use-chain consistency after every
     // shared pass. step 1+2 (#710) made this invariant hold across the shared
     // middle-end; this catches any future pass that reintroduces a leak. The
@@ -486,7 +510,7 @@ fn run_shared_pipeline(
     // with the verification error. Compiled out in release.
     if cfg!(debug_assertions) {
         pm.with_verifier(|ctx, op| {
-            let Some(module) = Module::new(ctx, op) else {
+            let Some(module) = enclosing_module(ctx, op) else {
                 return Ok(());
             };
             let result = trunk_ir::validation::validate_use_chains(ctx, module);
@@ -506,9 +530,17 @@ fn run_shared_pipeline(
             })
         });
     }
-    pm.run(&mut ctx, core_module)?;
+}
 
-    Ok(Some((ctx, m)))
+fn enclosing_module(ctx: &IrContext, mut op: trunk_ir::OpRef) -> Option<Module> {
+    loop {
+        if let Some(module) = Module::new(ctx, op) {
+            return Some(module);
+        }
+        let block = ctx.op(op).parent_block?;
+        let region = ctx.block(block).parent_region?;
+        op = ctx.region(region).parent_op?;
+    }
 }
 
 /// Validate call arity and report mismatches as diagnostics.


### PR DESCRIPTION
## Summary
- make ability perform lowering, tail-resumptive conversion, and handle dispatch lowering run as func.func-targeted passes
- generalize PatternApplicator conversion verification to RewriteScope so function-scoped conversion boundaries can be checked directly
- split the shared pipeline into ordered module/function phases while keeping resolve_evidence module-wide
- add a function-scope regression test for handle dispatch lowering and update the implementation plan table

## Verification
- cargo nextest run -p tribute-passes
- cargo nextest run -p trunk-ir rewrite::applicator rewrite::conversion_target transforms::canonicalize transforms::dce
- cargo nextest run -p tribute
- cargo nextest run --workspace
- pre-commit hook: fmt, clippy, markdownlint, workspace tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ability-related lowering now runs at the function level, so only the selected function is transformed instead of the whole module.
  * Rewrite and conversion checks now work across arbitrary scopes, improving flexibility for partial transformations.

* **Bug Fixes**
  * Fixed dispatch lowering so changes stay isolated to the intended function.
  * Improved pipeline validation to better detect issues during staged lowering.

* **Documentation**
  * Updated implementation notes to reflect the new function-anchored pass flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->