### PR TITLE
Anchor native evidence lowering to functions

### DIFF
--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -32,6 +32,7 @@ use trunk_ir::context::IrContext;
 use trunk_ir::dialect::func;
 use trunk_ir::dialect::{adt, arith, core};
 use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::Module;
 use trunk_ir::rewrite::helpers::erase_op;
@@ -41,8 +42,37 @@ use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 ///
 /// Must run AFTER effect lowering passes and BEFORE DCE.
 pub fn lower_evidence_to_native(ctx: &mut IrContext, module: Module) {
-    replace_stubs_and_add_empty(ctx, module);
+    prepare_native_evidence_runtime(ctx, module);
     rewrite_evidence_ops_in_module(ctx, module);
+}
+
+/// Prepare native evidence runtime declarations at module scope.
+pub fn prepare_native_evidence_runtime(ctx: &mut IrContext, module: Module) {
+    replace_stubs_and_add_empty(ctx, module);
+}
+
+/// Lower evidence operations inside one function for the native backend.
+pub fn lower_evidence_to_native_func(ctx: &mut IrContext, func_op: func::Func) {
+    if is_evidence_runtime_fn(func_op.sym_name(ctx)) {
+        return;
+    }
+    rewrite_evidence_ops_in_region(ctx, func_op.body(ctx));
+}
+
+/// PassManager-friendly native evidence lowering pass.
+pub struct LowerEvidenceToNative;
+
+impl Pass for LowerEvidenceToNative {
+    type Target = func::Func;
+
+    fn name(&self) -> &'static str {
+        "lower-evidence-to-native"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        lower_evidence_to_native_func(ctx, target);
+        Ok(())
+    }
 }
 
 // =============================================================================
@@ -219,12 +249,7 @@ fn rewrite_evidence_ops_in_module(ctx: &mut IrContext, module: Module) {
 
     for op in ops {
         if let Ok(func_op) = func::Func::from_op(ctx, op) {
-            let name = func_op.sym_name(ctx);
-            if is_evidence_runtime_fn(name) {
-                continue;
-            }
-            let body = func_op.body(ctx);
-            rewrite_evidence_ops_in_region(ctx, body);
+            lower_evidence_to_native_func(ctx, func_op);
         }
     }
 }
@@ -601,5 +626,44 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) {
     // Erase dead ops (in reverse to handle dependencies)
     for op in ops_to_erase.into_iter().rev() {
         erase_op(ctx, op);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    #[test]
+    fn function_scope_rewrites_only_selected_function() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @selected(%ev: core.ptr, %payload: tribute_rt.anyref) -> core.ptr {
+    %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : core.ptr
+    func.return %result
+  }
+  func.func @untouched(%ev: core.ptr, %payload: tribute_rt.anyref) -> core.ptr {
+    %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : core.ptr
+    func.return %result
+  }
+}"#,
+        );
+        let selected = module
+            .ops(&ctx)
+            .into_iter()
+            .filter_map(|op| func::Func::from_op(&ctx, op).ok())
+            .next()
+            .expect("test module should contain a selected function");
+
+        lower_evidence_to_native_func(&mut ctx, selected);
+
+        let ir_text = print_module(&ctx, module.op());
+        assert_eq!(ir_text.matches("effect.dispatch_tail").count(), 1);
+        assert!(ir_text.contains("func.func @untouched"));
+        assert!(ir_text.contains("op_name = @print"));
+        assert!(ir_text.contains("__tribute_evidence_lookup_tr"));
     }
 }

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -635,12 +635,8 @@ mod tests {
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
 
-    #[test]
-    fn function_scope_rewrites_only_selected_function() {
-        let mut ctx = IrContext::new();
-        let module = parse_test_module(
-            &mut ctx,
-            r#"core.module @test {
+    fn dispatch_module() -> &'static str {
+        r#"core.module @test {
   func.func @selected(%ev: core.ptr, %payload: tribute_rt.anyref) -> core.ptr {
     %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : core.ptr
     func.return %result
@@ -649,8 +645,13 @@ mod tests {
     %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : core.ptr
     func.return %result
   }
-}"#,
-        );
+}"#
+    }
+
+    #[test]
+    fn function_scope_rewrites_only_selected_function() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, dispatch_module());
         let selected = module
             .ops(&ctx)
             .into_iter()
@@ -665,5 +666,65 @@ mod tests {
         assert!(ir_text.contains("func.func @untouched"));
         assert!(ir_text.contains("op_name = @print"));
         assert!(ir_text.contains("__tribute_evidence_lookup_tr"));
+    }
+
+    #[test]
+    fn module_entrypoint_prepares_runtime_and_rewrites_all_functions() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, dispatch_module());
+
+        lower_evidence_to_native(&mut ctx, module);
+
+        let ir_text = print_module(&ctx, module.op());
+        assert!(!ir_text.contains("effect.dispatch_tail"));
+        assert!(ir_text.contains("__tribute_evidence_empty"));
+        assert!(ir_text.contains("__tribute_evidence_lookup_tr"));
+        assert!(ir_text.contains("__tribute_evidence_lookup_handler"));
+    }
+
+    #[test]
+    fn pass_adapter_runs_function_lowering() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, dispatch_module());
+        let selected = module
+            .ops(&ctx)
+            .into_iter()
+            .filter_map(|op| func::Func::from_op(&ctx, op).ok())
+            .next()
+            .expect("test module should contain a selected function");
+        let mut pass = LowerEvidenceToNative;
+
+        assert_eq!(pass.name(), "lower-evidence-to-native");
+        pass.run(&mut ctx, selected).unwrap();
+
+        let ir_text = print_module(&ctx, module.op());
+        assert_eq!(ir_text.matches("effect.dispatch_tail").count(), 1);
+        assert!(ir_text.contains("__tribute_evidence_lookup"));
+    }
+
+    #[test]
+    fn function_scope_skips_evidence_runtime_functions() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @__tribute_evidence_empty(%ev: core.ptr, %payload: tribute_rt.anyref) -> core.ptr {
+    %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : core.ptr
+    func.return %result
+  }
+}"#,
+        );
+        let runtime_func = module
+            .ops(&ctx)
+            .into_iter()
+            .filter_map(|op| func::Func::from_op(&ctx, op).ok())
+            .next()
+            .expect("test module should contain a runtime function");
+
+        lower_evidence_to_native_func(&mut ctx, runtime_func);
+
+        let ir_text = print_module(&ctx, module.op());
+        assert!(ir_text.contains("func.func @__tribute_evidence_empty"));
+        assert!(ir_text.contains("effect.dispatch_tail"));
     }
 }

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -588,7 +588,8 @@ flowchart TB
 | | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | |
 | | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |
-| **Backend effect ABI** | `native/evidence` | effect.* | native runtime calls + call_indirect | |
+| **Backend effect ABI** | `native/evidence runtime decls` | evidence runtime stubs | native extern declarations | module-wide |
+| | `native/evidence` | effect.* | native runtime calls + call_indirect | function-anchored |
 | | `wasm/evidence_to_wasm` | effect.* | wasm evidence helpers + wasm.call_indirect | |
 | **Lowering** | `lower_case` | tribute.case | scf.if | |
 | | `canonicalize`, local `dce`, `scf_to_cf` | func.func body | canonical body / cf blocks | function-anchored |

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -626,7 +626,15 @@ fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Dump
         trunk_ir::transforms::inline::inline_functions(ctx, m, analyses);
     });
 
-    tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
+    if let Ok(core_module) = core_dialect::Module::from_op(ctx, m.op()) {
+        tribute_passes::native::evidence::prepare_native_evidence_runtime(ctx, m);
+        let mut pm = PassManager::new();
+        pm.nest::<func_dialect::Func>()
+            .add_pass(tribute_passes::native::evidence::LowerEvidenceToNative);
+        pm.run(ctx, core_module)?;
+    } else {
+        tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
+    }
     if cfg!(debug_assertions) {
         let result = trunk_ir::validation::validate_value_integrity(ctx, m);
         if !result.is_ok() {


### PR DESCRIPTION
## Summary
- split native evidence lowering into module-scope runtime declaration prep and function-scope rewriting
- run native evidence rewriting through a nested func.func PassManager in the native dump pipeline
- update the implementation pass table to mark native evidence rewriting as function-anchored

## Notes
- skipped wasm/evidence_to_wasm for this step because it runs after func_to_wasm, where bodies are anchored under wasm.func rather than func.func

## Validation
- cargo fmt --all
- cargo nextest run -p tribute-passes
- cargo nextest run -p tribute
- pre-commit: clippy, markdownlint, cargo nextest run --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native evidence processing now runs in a more targeted way, improving how modules are handled during the native pipeline.
  * Added clearer documentation for how native evidence-related steps fit into the pipeline.

* **Bug Fixes**
  * The runtime setup for native evidence is now prepared consistently before lowering, reducing issues with missing declarations.
  * Evidence rewriting now skips runtime-related functions and only updates the intended function scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->