### PR TITLE
Anchor wasm evidence lowering to functions

### DIFF
--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -54,11 +54,19 @@ pub fn prepare_wasm_evidence_runtime(ctx: &mut IrContext, module: Module) {
 }
 
 /// Lower evidence operations in one WASM function body.
+///
+/// Precondition: [`prepare_wasm_evidence_runtime`] must already have run for
+/// the containing module so the `__tribute_evidence_lookup` and
+/// `__tribute_evidence_extend` stubs exist as WASM runtime helpers.
 pub fn lower_evidence_to_wasm_func(ctx: &mut IrContext, func_op: wasm_dialect::Func) {
     rewrite_evidence_ops_in_scope(ctx, func_op);
 }
 
 /// PassManager-friendly WASM evidence lowering pass.
+///
+/// This pass is function-scoped and does not prepare module-scope runtime
+/// helpers. Run [`prepare_wasm_evidence_runtime`] on the module before adding
+/// this pass to a `wasm.func` pipeline.
 pub struct LowerEvidenceToWasm;
 
 impl Pass for LowerEvidenceToWasm {

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -28,9 +28,10 @@ use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    Module, PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter,
 };
 use trunk_ir::smallvec::smallvec;
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
@@ -43,17 +44,44 @@ use trunk_ir_wasm_backend::gc_types::{CLOSURE_STRUCT_IDX, EVIDENCE_IDX, MARKER_I
 /// 2. Lowers `effect.extend` and remaining legacy `ability.evidence_lookup` /
 ///    `ability.evidence_extend` operations to calls to the generated functions.
 pub fn lower_evidence_to_wasm(ctx: &mut IrContext, module: Module) {
-    // Phase 1: Replace stubs with real implementations
-    replace_evidence_function_stubs(ctx, module);
+    prepare_wasm_evidence_runtime(ctx, module);
+    rewrite_evidence_ops_in_scope(ctx, module);
+}
 
-    // Phase 2: Pattern-based lowering for remaining ability ops
+/// Prepare module-scope WASM evidence runtime helper functions.
+pub fn prepare_wasm_evidence_runtime(ctx: &mut IrContext, module: Module) {
+    replace_evidence_function_stubs(ctx, module);
+}
+
+/// Lower evidence operations in one WASM function body.
+pub fn lower_evidence_to_wasm_func(ctx: &mut IrContext, func_op: wasm_dialect::Func) {
+    rewrite_evidence_ops_in_scope(ctx, func_op);
+}
+
+/// PassManager-friendly WASM evidence lowering pass.
+pub struct LowerEvidenceToWasm;
+
+impl Pass for LowerEvidenceToWasm {
+    type Target = wasm_dialect::Func;
+
+    fn name(&self) -> &'static str {
+        "lower-evidence-to-wasm"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: wasm_dialect::Func) -> PassRunResult {
+        lower_evidence_to_wasm_func(ctx, target);
+        Ok(())
+    }
+}
+
+fn rewrite_evidence_ops_in_scope<S: RewriteScope>(ctx: &mut IrContext, scope: S) {
     let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern(EffectExtendPattern)
         .add_pattern(EffectDispatchTailPattern)
         .add_pattern(EffectDispatchCpsPattern)
         .add_pattern(EvidenceLookupPattern)
         .add_pattern(EvidenceExtendPattern);
-    applicator.apply_partial(ctx, module);
+    applicator.apply_partial(ctx, scope);
 }
 
 /// Replace evidence runtime function stubs with real implementations.
@@ -1232,6 +1260,24 @@ mod tests {
         print_module(&ctx, module.op())
     }
 
+    fn dispatch_module() -> &'static str {
+        r#"core.module @test {
+  func.func @selected(%ev: wasm.arrayref, %payload: wasm.anyref) -> wasm.anyref {
+    %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : wasm.anyref
+    func.return %result
+  }
+  func.func @untouched(%ev: wasm.arrayref, %payload: wasm.anyref) -> wasm.anyref {
+    %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : wasm.anyref
+    func.return %result
+  }
+}"#
+    }
+
+    fn lower_funcs_to_wasm(ctx: &mut IrContext, module: Module) {
+        let tc = super::super::type_converter::wasm_type_converter(ctx);
+        trunk_ir_wasm_backend::passes::func_to_wasm::lower(ctx, module, tc);
+    }
+
     #[test]
     fn textual_dispatch_tail_lowers_to_wasm_indirect_call() {
         let output = lower_text(
@@ -1280,5 +1326,48 @@ mod tests {
         assert!(!output.contains("effect.extend"), "{output}");
         assert!(output.contains("wasm.struct_new"), "{output}");
         assert!(output.contains("__tribute_evidence_extend"), "{output}");
+    }
+
+    #[test]
+    fn wasm_function_scope_rewrites_only_selected_function() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, dispatch_module());
+        lower_funcs_to_wasm(&mut ctx, module);
+        let selected = module
+            .ops(&ctx)
+            .into_iter()
+            .filter_map(|op| wasm_dialect::Func::from_op(&ctx, op).ok())
+            .next()
+            .expect("test module should contain a selected wasm function");
+
+        lower_evidence_to_wasm_func(&mut ctx, selected);
+
+        let output = print_module(&ctx, module.op());
+        assert_eq!(output.matches("effect.dispatch_tail").count(), 1);
+        assert!(output.contains("sym_name = @selected"), "{output}");
+        assert!(output.contains("sym_name = @untouched"), "{output}");
+        assert!(output.contains("op_name = @print"), "{output}");
+        assert!(output.contains("wasm.call_indirect"), "{output}");
+    }
+
+    #[test]
+    fn pass_adapter_runs_wasm_function_lowering() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, dispatch_module());
+        lower_funcs_to_wasm(&mut ctx, module);
+        let selected = module
+            .ops(&ctx)
+            .into_iter()
+            .filter_map(|op| wasm_dialect::Func::from_op(&ctx, op).ok())
+            .next()
+            .expect("test module should contain a selected wasm function");
+        let mut pass = LowerEvidenceToWasm;
+
+        assert_eq!(pass.name(), "lower-evidence-to-wasm");
+        pass.run(&mut ctx, selected).unwrap();
+
+        let output = print_module(&ctx, module.op());
+        assert_eq!(output.matches("effect.dispatch_tail").count(), 1);
+        assert!(output.contains("__tribute_evidence_lookup"), "{output}");
     }
 }

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -4,6 +4,8 @@
 //! wasm dialect operations. Uses arena IR for in-place mutation within a
 //! single arena session.
 
+use std::fmt;
+
 use tracing::{error, warn};
 use tribute_ir::ModulePathExt;
 use trunk_ir::Symbol;
@@ -11,6 +13,8 @@ use trunk_ir::context::{BlockData, IrContext, RegionData};
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::{PassError, PassManager};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, Module, PatternApplicator, TypeConverter,
@@ -26,6 +30,42 @@ use trunk_ir_wasm_backend::gc_types::{STEP_IDX, STEP_TAG_DONE};
 
 const WASM_BACKEND_READY_BOUNDARY: &str = "wasm-backend-ready";
 
+#[derive(Debug)]
+pub enum WasmLowerError {
+    Conversion(ConversionError),
+    Pass(PassError),
+}
+
+impl fmt::Display for WasmLowerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Conversion(error) => error.fmt(f),
+            Self::Pass(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for WasmLowerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Conversion(error) => Some(error),
+            Self::Pass(error) => Some(error),
+        }
+    }
+}
+
+impl From<ConversionError> for WasmLowerError {
+    fn from(error: ConversionError) -> Self {
+        Self::Conversion(error)
+    }
+}
+
+impl From<PassError> for WasmLowerError {
+    fn from(error: PassError) -> Self {
+        Self::Pass(error)
+    }
+}
+
 /// Conversion target for IR after Wasm-specific lowering has removed shared
 /// ability/effect ABI operations.
 pub fn wasm_backend_ready_target() -> ConversionTarget {
@@ -35,7 +75,7 @@ pub fn wasm_backend_ready_target() -> ConversionTarget {
 }
 
 /// Run the full WASM lowering pipeline on arena IR.
-pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError> {
+pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowerError> {
     // Phase 1: Pattern-based lowering passes (using trunk-ir-wasm-backend)
     {
         let _span = tracing::info_span!("arith_to_wasm").entered();
@@ -94,7 +134,15 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), Conversi
     // Lower evidence runtime function stubs (prepare for inline WASM operations)
     {
         let _span = tracing::info_span!("evidence_to_wasm").entered();
-        super::evidence_to_wasm::lower_evidence_to_wasm(ctx, module);
+        if let Ok(core_module) = core::Module::from_op(ctx, module.op()) {
+            super::evidence_to_wasm::prepare_wasm_evidence_runtime(ctx, module);
+            let mut pm = PassManager::new();
+            pm.nest::<wasm_dialect::Func>()
+                .add_pass(super::evidence_to_wasm::LowerEvidenceToWasm);
+            pm.run(ctx, core_module)?;
+        } else {
+            super::evidence_to_wasm::lower_evidence_to_wasm(ctx, module);
+        }
     }
 
     // Const analysis and lowering (string/bytes constants to data segments)
@@ -131,7 +179,8 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), Conversi
         super::wasm_gc_type_assign::assign_gc_type_indices(ctx, module);
     }
 
-    verify_wasm_backend_ready(ctx, module)
+    verify_wasm_backend_ready(ctx, module)?;
+    Ok(())
 }
 
 /// Verify the partial Wasm backend boundary.

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -1200,7 +1200,15 @@ fn is_step_adt(ctx: &IrContext, ty: TypeRef) -> bool {
 mod tests {
     use super::*;
     use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
     use trunk_ir::rewrite::LegalityCheck;
+
+    fn lower_text(ir: &str) -> String {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        lower_to_wasm(&mut ctx, module).expect("test module should lower to wasm");
+        print_module(&ctx, module.op())
+    }
 
     #[test]
     fn wasm_backend_ready_rejects_residual_effect_ops() {
@@ -1240,5 +1248,30 @@ mod tests {
 
         verify_wasm_backend_ready(&mut ctx, module)
             .expect("partial wasm backend boundary should allow unknown later-stage ops");
+    }
+
+    #[test]
+    fn lower_to_wasm_removes_effect_dispatch_tail() {
+        let output = lower_text(
+            r#"core.module @test {
+  func.func @run(%ev: wasm.arrayref, %payload: wasm.anyref) -> wasm.anyref {
+    %result = effect.dispatch_tail %ev, %payload {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : wasm.anyref
+    func.return %result
+  }
+}"#,
+        );
+
+        assert!(!output.contains("effect.dispatch_tail"), "{output}");
+        assert!(output.contains("__tribute_evidence_lookup"), "{output}");
+        assert!(output.contains("wasm.call_indirect"), "{output}");
+    }
+
+    #[test]
+    fn wasm_lower_error_wraps_conversion_error() {
+        let conversion = ConversionError::new(WASM_BACKEND_READY_BOUNDARY, vec![]);
+        let error = WasmLowerError::from(conversion);
+
+        assert!(error.to_string().contains(WASM_BACKEND_READY_BOUNDARY));
+        assert!(std::error::Error::source(&error).is_some());
     }
 }

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -1,5 +1,7 @@
 //! Arena-based wasm dialect.
 
+crate::register_isolated_op!(wasm.func);
+
 #[trunk_ir::dialect]
 mod wasm {
     // Types (abstract heap types)

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -12,7 +12,7 @@ use super::pattern::RewritePattern;
 use super::rewriter::{self, PatternRewriter};
 use super::type_converter::TypeConverter;
 use crate::context::IrContext;
-use crate::dialect::{core, func};
+use crate::dialect::{core, func, wasm};
 use crate::ops::DialectOp;
 use crate::refs::{BlockRef, OpRef, RegionRef};
 
@@ -42,6 +42,18 @@ impl RewriteScope for Module {
 }
 
 impl RewriteScope for func::Func {
+    type Regions = std::iter::Once<RegionRef>;
+
+    fn regions(self, ctx: &IrContext) -> Self::Regions {
+        std::iter::once(self.body(ctx))
+    }
+
+    fn module_first_block(self, _ctx: &IrContext) -> Option<BlockRef> {
+        None
+    }
+}
+
+impl RewriteScope for wasm::Func {
     type Regions = std::iter::Once<RegionRef>;
 
     fn regions(self, ctx: &IrContext) -> Self::Regions {

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -590,7 +590,8 @@ flowchart TB
 | | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |
 | **Backend effect ABI** | `native/evidence runtime decls` | evidence runtime stubs | native extern declarations | module-wide |
 | | `native/evidence` | effect.* | native runtime calls + call_indirect | function-anchored |
-| | `wasm/evidence_to_wasm` | effect.* | wasm evidence helpers + wasm.call_indirect | |
+| | `wasm/evidence runtime funcs` | evidence runtime stubs | wasm evidence helpers | module-wide |
+| | `wasm/evidence_to_wasm` | effect.* | wasm.call + wasm.call_indirect | function-anchored |
 | **Lowering** | `lower_case` | tribute.case | scf.if | |
 | | `canonicalize`, local `dce`, `scf_to_cf` | func.func body | canonical body / cf blocks | function-anchored |
 | | `global_dce` | module symbols | reachable funcs | module-wide |

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -362,7 +362,7 @@ fn compile_to_wasm(ctx: &mut IrContext, module: Module) -> WasmCompilationResult
     // Phase 1 - Lower to wasm dialect (Tribute-specific)
     {
         let _span = tracing::info_span!("lower_to_wasm").entered();
-        tribute_passes::wasm::lower::lower_to_wasm(ctx, module).map_err(wasm_conversion_failure)?;
+        tribute_passes::wasm::lower::lower_to_wasm(ctx, module).map_err(wasm_lowering_failure)?;
     }
 
     // Phase 2 - Resolve unrealized_conversion_cast operations (WASM type converter)
@@ -874,7 +874,7 @@ fn native_pass_failure(error: PassError) -> trunk_ir_cranelift_backend::Compilat
     trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string())
 }
 
-fn wasm_conversion_failure(error: ConversionError) -> CompilationError {
+fn wasm_lowering_failure(error: tribute_passes::wasm::lower::WasmLowerError) -> CompilationError {
     CompilationError::ir_validation(error.to_string())
 }
 


### PR DESCRIPTION
## Summary
- add wasm.func as an isolated rewrite/pass anchor and expose it through RewriteScope
- split wasm evidence lowering into module-scope runtime helper preparation and function-scoped rewriting
- run wasm evidence rewriting through a nested wasm.func PassManager in the WASM lowering pipeline
- update the implementation pass table to show WASM evidence runtime prep and function-anchored lowering separately

## Validation
- cargo fmt --all
- cargo nextest run -p tribute-passes
- cargo nextest run -p tribute test_compile_cps_dispatch_ability test_compile_tail_dispatch_ability
- cargo nextest run -p tribute
- pre-commit: clippy, markdownlint, cargo nextest run --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WASM lowering can now run on an individual WASM function or across the whole module.
  * Evidence-related WASM generation is split into separate helper-stub generation and function-level rewriting.

* **Bug Fixes**
  * Improved WASM lowering error reporting with clearer, more specific failure details.
  * Tightened rewriting behavior so only the intended function body is modified (leaving other functions unchanged).

* **Documentation**
  * Updated the implementation plan to reflect the new two-stage WASM evidence lowering flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->