### PR TITLE
Split closure lowering into a function pass

### DIFF
--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -19,8 +19,6 @@
 //!
 //! Uses `RewritePattern` + `PatternApplicator` for declarative transformation.
 
-use std::collections::HashSet;
-
 use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
@@ -32,7 +30,7 @@ use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, erase_op,
+    ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -61,82 +59,6 @@ fn is_closure_struct_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
         data.attrs.get(&Symbol::new("name")),
         Some(Attribute::Symbol(s)) if *s == Symbol::new("_closure")
     )
-}
-
-/// Check if an arena value is a closure value (for pre-lowering collection).
-fn is_any_closure_value(ctx: &IrContext, value: ValueRef) -> bool {
-    use trunk_ir::refs::ValueDef;
-
-    let ty = ctx.value_ty(value);
-
-    // Direct check for closure.new result
-    if let ValueDef::OpResult(op, _) = ctx.value_def(value)
-        && closure::New::from_op(ctx, op).is_ok()
-    {
-        return true;
-    }
-
-    // Check type
-    if closure::Closure::matches(ctx, ty) {
-        return true;
-    }
-    if core::Func::matches(ctx, ty) {
-        // core.func in func.call_indirect is always a closure value.
-        // Direct function calls use func.call; call_indirect operates on
-        // closure values (block args, env captures, etc.).
-        return true;
-    }
-    false
-}
-
-/// Collect ALL closure call_indirect operations as OpRefs.
-/// Collect all closure calls by location span (stable across Phase 1 rewrites).
-///
-/// We use `(span.start, span.end)` instead of `OpRef` because Phase 1 pattern
-/// application destroys original ops and creates new ones with different OpRefs.
-fn collect_all_closure_calls(ctx: &IrContext, module: Module) -> HashSet<(usize, usize)> {
-    let mut closure_calls = HashSet::new();
-    for op in module.ops(ctx) {
-        if let Ok(func_op) = func::Func::from_op(ctx, op) {
-            let body = func_op.body(ctx);
-            collect_closure_calls_in_region(ctx, body, &mut closure_calls);
-        }
-    }
-    closure_calls
-}
-
-fn collect_closure_calls_in_region(
-    ctx: &IrContext,
-    region: trunk_ir::refs::RegionRef,
-    closure_calls: &mut HashSet<(usize, usize)>,
-) {
-    for &block in ctx.region(region).blocks.iter() {
-        for &op in ctx.block(block).ops.iter() {
-            collect_closure_calls_in_op(ctx, op, closure_calls);
-        }
-    }
-}
-
-fn collect_closure_calls_in_op(
-    ctx: &IrContext,
-    op: OpRef,
-    closure_calls: &mut HashSet<(usize, usize)>,
-) {
-    // Check if this is a call_indirect with a closure callee
-    if func::CallIndirect::from_op(ctx, op).is_ok() {
-        let operands = ctx.op_operands(op);
-        if let Some(&callee) = operands.first()
-            && is_any_closure_value(ctx, callee)
-        {
-            let loc = ctx.op(op).location;
-            closure_calls.insert((loc.span.start, loc.span.end));
-        }
-    }
-
-    // Recurse into regions
-    for &region in ctx.op(op).regions.iter() {
-        collect_closure_calls_in_region(ctx, region, closure_calls);
-    }
 }
 
 // ============================================================================
@@ -198,6 +120,12 @@ impl RewritePattern for UpdateFuncSignatureArena {
         let func_name = func_op.sym_name(ctx);
         let body = func_op.body(ctx);
         let loc = ctx.op(op).location;
+        if let Some(entry) = ctx.region(body).blocks.first().copied() {
+            let arg_count = ctx.block_args(entry).len();
+            for (idx, &new_ty) in new_params[1..].iter().enumerate().take(arg_count) {
+                ctx.set_block_arg_type(entry, idx as u32, new_ty);
+            }
+        }
         ctx.detach_region(body);
         let new_op = func::func(ctx, loc, func_name, new_func_ty, body).op_ref();
         rewriter.replace_op(new_op);
@@ -252,7 +180,9 @@ impl RewritePattern for LowerClosureNewArena {
 }
 
 /// Lower `func.call_indirect` on closure values.
-struct LowerClosureCallArena;
+struct LowerClosureCallArena {
+    evidence_from_param: Option<ValueRef>,
+}
 
 impl RewritePattern for LowerClosureCallArena {
     fn match_and_rewrite(
@@ -319,8 +249,17 @@ impl RewritePattern for LowerClosureCallArena {
         let env_op = closure::env(ctx, loc, callee, anyref_ty);
         let env = ctx.op_result(env_op.op_ref(), 0);
 
-        // Generate: %result = func.call_indirect %table_idx, [%env, %args...]
-        let mut new_args = vec![env];
+        let evidence = if let Some(evidence) = self.evidence_from_param {
+            evidence
+        } else {
+            let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
+            let null_op = adt::ref_null(ctx, loc, evidence_ty, evidence_ty);
+            rewriter.insert_op(null_op.op_ref());
+            null_op.result(ctx)
+        };
+
+        // Generate: %result = func.call_indirect %table_idx, [%evidence, %env, %args...]
+        let mut new_args = vec![evidence, env];
         new_args.extend(args);
         let new_call = func::call_indirect(ctx, loc, table_idx, new_args, callee_return_ty);
 
@@ -405,10 +344,6 @@ impl RewritePattern for LowerClosureEnvArena {
     }
 }
 
-// ============================================================================
-// Phase 2: Evidence passing for closure calls
-// ============================================================================
-
 /// Extract the return type from a callee type (closure.closure or core.func).
 fn extract_return_type_from_callee(ctx: &IrContext, callee_ty: TypeRef) -> Option<TypeRef> {
     let data = ctx.types.get(callee_ty);
@@ -427,204 +362,65 @@ fn extract_return_type_from_callee(ctx: &IrContext, callee_ty: TypeRef) -> Optio
     None
 }
 
-/// Transform closure calls to pass evidence in arena IR.
-///
-/// After pattern application, closure calls have been expanded. Now we insert
-/// evidence as the first argument to all closure call_indirect operations.
-fn transform_closure_calls_with_evidence(
-    ctx: &mut IrContext,
-    module: Module,
-    closure_calls: &HashSet<(usize, usize)>,
-) {
-    if closure_calls.is_empty() {
-        return;
+fn evidence_param_for_func(ctx: &IrContext, func_op: func::Func) -> Option<ValueRef> {
+    let func_ty = func_op.r#type(ctx);
+    if !crate::evidence::has_evidence_first_param(ctx, func_ty) {
+        return None;
     }
 
-    let func_ops: Vec<OpRef> = module.ops(ctx);
-    for func_op_ref in func_ops {
-        let Ok(func_op) = func::Func::from_op(ctx, func_op_ref) else {
-            continue;
-        };
-
-        let func_ty = func_op.r#type(ctx);
-        let is_effectful = crate::evidence::has_evidence_first_param(ctx, func_ty);
-
-        let body = func_op.body(ctx);
-        let blocks: Vec<_> = ctx.region(body).blocks.to_vec();
-        if blocks.is_empty() {
-            continue;
-        }
-
-        // For effectful functions, get evidence from first block argument
-        let evidence_from_param = if is_effectful {
-            let entry = blocks[0];
-            let args = ctx.block_args(entry);
-            if !args.is_empty() {
-                let ev = args[0];
-                if tribute_ir::dialect::ability::is_evidence_type_ref(ctx, ctx.value_ty(ev)) {
-                    Some(ev)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        let loc = ctx.op(func_op_ref).location;
-        transform_closure_calls_in_region(ctx, body, evidence_from_param, closure_calls, loc);
-    }
-}
-
-/// Transform closure calls in a region, inserting evidence arguments.
-fn transform_closure_calls_in_region(
-    ctx: &mut IrContext,
-    region: trunk_ir::refs::RegionRef,
-    evidence_from_param: Option<ValueRef>,
-    closure_calls: &HashSet<(usize, usize)>,
-    func_location: trunk_ir::types::Location,
-) {
-    let blocks: Vec<_> = ctx.region(region).blocks.to_vec();
-    for block in blocks {
-        transform_closure_calls_in_block(
-            ctx,
-            block,
-            evidence_from_param,
-            closure_calls,
-            func_location,
-        );
-    }
-}
-
-/// Transform closure calls in a block, inserting evidence arguments.
-fn transform_closure_calls_in_block(
-    ctx: &mut IrContext,
-    block: trunk_ir::refs::BlockRef,
-    evidence_from_param: Option<ValueRef>,
-    closure_calls: &HashSet<(usize, usize)>,
-    func_location: trunk_ir::types::Location,
-) {
-    // We need to track null evidence creation (lazy)
-    let mut null_ev_value: Option<ValueRef> = None;
-
-    // Collect ops to process (snapshot since we'll mutate)
-    let ops: Vec<OpRef> = ctx.block(block).ops.to_vec();
-
-    for op in ops {
-        // Process nested regions first
-        let regions: Vec<_> = ctx.op(op).regions.to_vec();
-        for region in regions {
-            transform_closure_calls_in_region(
-                ctx,
-                region,
-                evidence_from_param,
-                closure_calls,
-                func_location,
-            );
-        }
-
-        // Check if this is a closure call_indirect that needs evidence
-        if func::CallIndirect::from_op(ctx, op).is_err() {
-            continue;
-        }
-
-        let loc_key = {
-            let loc = ctx.op(op).location;
-            (loc.span.start, loc.span.end)
-        };
-        if !closure_calls.contains(&loc_key) {
-            continue;
-        }
-
-        // Skip if evidence is already present as the first non-table-idx argument
-        {
-            let operands = ctx.op_operands(op);
-            if operands.len() > 1
-                && tribute_ir::dialect::ability::is_evidence_type_ref(
-                    ctx,
-                    ctx.value_ty(operands[1]),
-                )
-            {
-                continue;
-            }
-        }
-
-        let evidence = if let Some(ev) = evidence_from_param {
-            ev
-        } else {
-            // Create null evidence lazily
-            if null_ev_value.is_none() {
-                let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
-                let null_op = adt::ref_null(ctx, func_location, evidence_ty, evidence_ty);
-                let ev = ctx.op_result(null_op.op_ref(), 0);
-                // Insert null evidence at the beginning of the block
-                let first_op_in_block = ctx.block(block).ops.first().copied();
-                if let Some(first_op) = first_op_in_block {
-                    ctx.insert_op_before(block, first_op, null_op.op_ref());
-                } else {
-                    ctx.push_op(block, null_op.op_ref());
-                }
-                null_ev_value = Some(ev);
-            }
-            null_ev_value.unwrap()
-        };
-
-        // Transform: add evidence as first argument after table_idx
-        let operands = ctx.op_operands(op).to_vec();
-        let result_ty = ctx.op_result_types(op)[0];
-        let loc = ctx.op(op).location;
-
-        // operands[0] = table_idx, operands[1..] = env + args
-        let table_idx = operands[0];
-        let rest_args: Vec<ValueRef> = operands[1..].to_vec();
-
-        // Build new args: [evidence, env, args...]
-        let mut new_args = vec![evidence];
-        new_args.extend(rest_args);
-
-        let new_call = func::call_indirect(ctx, loc, table_idx, new_args, result_ty);
-
-        // Replace old result uses with new result
-        let old_result = ctx.op_result(op, 0);
-        let new_result = ctx.op_result(new_call.op_ref(), 0);
-        ctx.replace_all_uses(old_result, new_result);
-
-        // Insert new call and erase old one (clears its operand use-chain, #710)
-        ctx.insert_op_before(block, op, new_call.op_ref());
-        erase_op(ctx, op);
-    }
+    let body = func_op.body(ctx);
+    let entry = ctx.region(body).blocks.first().copied()?;
+    let evidence = *ctx.block_args(entry).first()?;
+    tribute_ir::dialect::ability::is_evidence_type_ref(ctx, ctx.value_ty(evidence))
+        .then_some(evidence)
 }
 
 /// Lower closures using arena IR.
 ///
-/// This pass has two phases:
-///
-/// Phase 1 (PatternApplicator):
-/// 1. UpdateFuncSignatureArena - updates function signatures: core.func params → closure.closure
-/// 2. LowerClosureCallArena - expands call_indirect to use closure.func/closure.env
-/// 3. LowerClosureNewArena - expands closure.new to func.constant + adt.struct_new
-/// 4. LowerClosureFuncArena - extracts i32 table index from struct (field 0)
-/// 5. LowerClosureEnvArena - extracts env from struct (field 1)
-///
-/// Phase 2 (Post-processing):
-/// - Transform ALL closure calls to pass evidence from the enclosing function
+/// This compatibility entry point prepares module-level function signatures,
+/// then lowers each function body independently.
 pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) {
-    // Collect ALL closure calls before pattern application
-    let all_closure_calls = collect_all_closure_calls(ctx, module);
+    prepare_closure_lowering(ctx, module);
 
-    // Phase 1: Pattern application
+    for op in module.ops(ctx) {
+        let Ok(func_op) = func::Func::from_op(ctx, op) else {
+            continue;
+        };
+        lower_closures_in_func(ctx, func_op);
+    }
+}
+
+/// Prepare module-level closure lowering state.
+///
+/// This updates function signatures (`core.func` params → `closure.closure`) and
+/// remains module-scoped because function signatures are interprocedural
+/// contracts.
+pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
+    let applicator =
+        PatternApplicator::new(TypeConverter::new()).add_pattern(UpdateFuncSignatureArena);
+    applicator.apply_partial(ctx, module);
+}
+
+/// Lower closure operations in one function body.
+///
+/// Closure calls receive the enclosing function's evidence parameter directly
+/// while the call is rewritten. Pure functions synthesize null evidence at the
+/// call site, avoiding a module-wide span-based post-processing pass.
+pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
+    let evidence_from_param = evidence_param_for_func(ctx, func_op);
     let applicator = PatternApplicator::new(TypeConverter::new())
-        .add_pattern(UpdateFuncSignatureArena)
-        .add_pattern(LowerClosureCallArena)
+        .with_target(
+            ConversionTarget::new()
+                .legal_op("func", "func")
+                .recursive_legal_op("func", "func"),
+        )
+        .add_pattern(LowerClosureCallArena {
+            evidence_from_param,
+        })
         .add_pattern(LowerClosureNewArena)
         .add_pattern(LowerClosureFuncArena)
         .add_pattern(LowerClosureEnvArena);
-    applicator.apply_partial(ctx, module);
-
-    // Phase 2: Evidence passing for closure calls
-    transform_closure_calls_with_evidence(ctx, module, &all_closure_calls);
+    applicator.apply_partial(ctx, func_op);
 }
 
 /// PassManager-friendly wrapper for [`lower_closures`].
@@ -640,5 +436,261 @@ impl Pass for LowerClosures {
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
         lower_closures(ctx, target.into());
         Ok(())
+    }
+}
+
+/// PassManager-friendly module preparation for closure lowering.
+pub struct PrepareClosureLowering;
+
+impl Pass for PrepareClosureLowering {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "prepare-closure-lowering"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
+        prepare_closure_lowering(ctx, target.into());
+        Ok(())
+    }
+}
+
+/// PassManager-friendly function-local closure lowering pass.
+pub struct LowerClosuresInFunc;
+
+impl Pass for LowerClosuresInFunc {
+    type Target = func::Func;
+
+    fn name(&self) -> &'static str {
+        "lower-closures-in-func"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        lower_closures_in_func(ctx, target);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ops::ControlFlow;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+    use trunk_ir::walk::{WalkAction, walk_op};
+
+    fn evidence_type_str() -> &'static str {
+        "core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})"
+    }
+
+    fn closure_test_module(ctx: &mut IrContext) -> Module {
+        let ev_ty = evidence_type_str();
+        parse_test_module(
+            ctx,
+            &format!(
+                r#"core.module @test {{
+  !closure = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+
+  func.func @callee(%ev: {ev_ty}, %env: tribute_rt.anyref, %arg: tribute_rt.anyref) -> tribute_rt.anyref {{
+      func.return %arg
+  }}
+
+  func.func @selected(%ev: {ev_ty}, %payload: tribute_rt.anyref) -> tribute_rt.anyref {{
+      %env = adt.ref_null {{type = tribute_rt.anyref}} : tribute_rt.anyref
+      %closure = closure.new %env {{func_ref = @callee}} : !closure
+      %result = func.call_indirect %closure, %payload : tribute_rt.anyref
+      func.return %result
+  }}
+
+  func.func @untouched(%ev: {ev_ty}, %payload: tribute_rt.anyref) -> tribute_rt.anyref {{
+      %env = adt.ref_null {{type = tribute_rt.anyref}} : tribute_rt.anyref
+      %closure = closure.new %env {{func_ref = @callee}} : !closure
+      %result = func.call_indirect %closure, %payload : tribute_rt.anyref
+      func.return %result
+  }}
+}}"#
+            ),
+        )
+    }
+
+    fn func_by_name(ctx: &IrContext, module: Module, name: &'static str) -> func::Func {
+        let name = Symbol::new(name);
+        module
+            .ops(ctx)
+            .into_iter()
+            .filter_map(|op| func::Func::from_op(ctx, op).ok())
+            .find(|func_op| func_op.sym_name(ctx) == name)
+            .expect("test function should exist")
+    }
+
+    fn func_by_name_recursive(ctx: &IrContext, module: Module, name: &'static str) -> func::Func {
+        let name = Symbol::new(name);
+        let mut found = None;
+        let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+            if let Ok(func_op) = func::Func::from_op(ctx, op)
+                && func_op.sym_name(ctx) == name
+            {
+                found = Some(func_op);
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        found.expect("test function should exist")
+    }
+
+    fn call_indirect_operands_in_func(ctx: &IrContext, func_op: func::Func) -> Vec<Vec<ValueRef>> {
+        let mut calls = Vec::new();
+        for &block in &ctx.region(func_op.body(ctx)).blocks {
+            for &op in &ctx.block(block).ops {
+                if func::CallIndirect::from_op(ctx, op).is_ok() {
+                    calls.push(ctx.op_operands(op).to_vec());
+                }
+            }
+        }
+        calls
+    }
+
+    fn entry_evidence_arg(ctx: &IrContext, func_op: func::Func) -> ValueRef {
+        let entry = ctx.region(func_op.body(ctx)).blocks[0];
+        ctx.block_args(entry)[0]
+    }
+
+    fn nested_closure_test_module(ctx: &mut IrContext) -> Module {
+        let ev_ty = evidence_type_str();
+        parse_test_module(
+            ctx,
+            &format!(
+                r#"core.module @test {{
+  !closure = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+
+  func.func @callee(%ev: {ev_ty}, %env: tribute_rt.anyref, %arg: tribute_rt.anyref) -> tribute_rt.anyref {{
+      func.return %arg
+  }}
+
+  func.func @outer(%outer_ev: {ev_ty}, %payload: tribute_rt.anyref) -> tribute_rt.anyref {{
+      func.func @inner(%inner_ev: {ev_ty}, %inner_payload: tribute_rt.anyref) -> tribute_rt.anyref {{
+          %env = adt.ref_null {{type = tribute_rt.anyref}} : tribute_rt.anyref
+          %closure = closure.new %env {{func_ref = @callee}} : !closure
+          %result = func.call_indirect %closure, %inner_payload : tribute_rt.anyref
+          func.return %result
+      }}
+      func.return %payload
+  }}
+}}"#
+            ),
+        )
+    }
+
+    #[test]
+    fn prepare_pass_adapter_updates_function_signatures() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @apply(%f: core.func(tribute_rt.anyref, tribute_rt.anyref), %arg: tribute_rt.anyref) -> tribute_rt.anyref {
+      %result = func.call_indirect %f, %arg : tribute_rt.anyref
+      func.return %result
+  }
+}"#,
+        );
+
+        let mut pass = PrepareClosureLowering;
+        let core_module = core::Module::from_op(&ctx, module.op()).unwrap();
+        pass.run(&mut ctx, core_module).unwrap();
+
+        let ir = print_module(&ctx, module.op());
+        assert!(
+            ir.contains("closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))"),
+            "function-typed params should be prepared as closure params:\n{ir}"
+        );
+    }
+
+    #[test]
+    fn function_pass_rewrites_only_selected_function_and_uses_evidence_param() {
+        let mut ctx = IrContext::new();
+        let module = closure_test_module(&mut ctx);
+        let selected = func_by_name(&ctx, module, "selected");
+
+        let mut pass = LowerClosuresInFunc;
+        pass.run(&mut ctx, selected).unwrap();
+
+        let selected_calls = call_indirect_operands_in_func(&ctx, selected);
+        assert_eq!(selected_calls.len(), 1);
+        let selected_operands = &selected_calls[0];
+        assert!(
+            selected_operands.len() >= 3,
+            "lowered closure call should have table index, evidence, and env operands"
+        );
+        assert_eq!(
+            selected_operands[1],
+            entry_evidence_arg(&ctx, selected),
+            "lowered closure call should pass the enclosing function's evidence argument immediately after table index"
+        );
+
+        let untouched = func_by_name(&ctx, module, "untouched");
+        let untouched_ir = print_module(&ctx, untouched.op_ref());
+        assert!(
+            untouched_ir.contains("closure.new") && untouched_ir.contains("func.call_indirect"),
+            "function-local pass should not rewrite other functions:\n{untouched_ir}"
+        );
+    }
+
+    #[test]
+    fn module_entrypoint_still_prepares_and_lowers_all_functions() {
+        let mut ctx = IrContext::new();
+        let module = closure_test_module(&mut ctx);
+
+        lower_closures(&mut ctx, module);
+
+        let ir = print_module(&ctx, module.op());
+        assert!(
+            !ir.contains("closure.new"),
+            "module entrypoint should lower closure.new:\n{ir}"
+        );
+        assert!(
+            !ir.contains("closure.func") && !ir.contains("closure.env"),
+            "module entrypoint should lower closure accessors:\n{ir}"
+        );
+
+        for name in ["selected", "untouched"] {
+            let func_op = func_by_name(&ctx, module, name);
+            let calls = call_indirect_operands_in_func(&ctx, func_op);
+            assert_eq!(
+                calls.len(),
+                1,
+                "{name} should have one lowered indirect call"
+            );
+            assert_eq!(
+                calls[0][1],
+                entry_evidence_arg(&ctx, func_op),
+                "{name} should pass the enclosing function's evidence argument immediately after table index"
+            );
+        }
+    }
+
+    #[test]
+    fn function_pass_leaves_nested_func_for_own_evidence_processing() {
+        let mut ctx = IrContext::new();
+        let module = nested_closure_test_module(&mut ctx);
+        let outer = func_by_name_recursive(&ctx, module, "outer");
+
+        lower_closures_in_func(&mut ctx, outer);
+
+        let inner = func_by_name_recursive(&ctx, module, "inner");
+        let inner_after_outer = print_module(&ctx, inner.op_ref());
+        assert!(
+            inner_after_outer.contains("closure.new"),
+            "outer function pass should not lower nested function body:\n{inner_after_outer}"
+        );
+
+        lower_closures_in_func(&mut ctx, inner);
+
+        let inner_calls = call_indirect_operands_in_func(&ctx, inner);
+        assert_eq!(inner_calls.len(), 1);
+        assert_eq!(
+            inner_calls[0][1],
+            entry_evidence_arg(&ctx, inner),
+            "nested function pass should use the nested function's own evidence argument"
+        );
     }
 }

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -431,7 +431,7 @@ native runtime call 또는 Wasm evidence helper와 indirect call로 제거한다
 
 ```text
 공통: parse → resolve → typecheck → tdnr → ast_to_ir
-      → evidence_params → closure_lower → evidence_calls
+      → evidence_params → prepare_closure_lowering → lower_closures_in_func
       → lower_ability_perform → resolve_evidence → lower_handle_dispatch
       → dce → resolve_casts
 
@@ -530,7 +530,8 @@ flowchart TB
 
     subgraph closure["Closure Processing"]
         lambda_lift["lambda_lift"]
-        closure_lower["closure_lower"]
+        closure_prep["prepare_closure_lowering"]
+        closure_func["lower_closures_in_func"]
         tdnr["tdnr"]
     end
 
@@ -562,8 +563,9 @@ flowchart TB
     resolve -->|"func.*, adt.*"| const_inline
     const_inline --> typecheck
     typecheck -->|"typed module"| lambda_lift
-    lambda_lift -->|"closure.new"| closure_lower
-    closure_lower -->|"call_indirect"| tdnr
+    lambda_lift -->|"closure signatures"| closure_prep
+    closure_prep -->|"closure.new"| closure_func
+    closure_func -->|"call_indirect + evidence"| tdnr
     tdnr --> evidence
     evidence -->|"+evidence param"| resolve_ev
     resolve_ev -->|"dispatch closures"| tail_opt
@@ -582,7 +584,8 @@ flowchart TB
 | | `inline_constants` | const refs | inlined values | |
 | | `typecheck` | type.var | concrete types | ✓ |
 | **Closure** | `lambda_lift` | lambdas | top-level funcs | |
-| | `closure_lower` | closure.new | func.call_indirect | module-wide: signatures + closure call evidence audit |
+| | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
+| | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
 | | `tdnr` | x.method() | Type::method(x) | |
 | **Ability** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
 | | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -36,11 +36,8 @@
 //!     ▼ evidence_params (Phase 1)
 //! Module (evidence params added to signatures)
 //!     │
-//!     ▼ closure_lower
-//! Module (closure.* lowered)
-//!     │
-//!     ▼ evidence_calls (Phase 2)
-//! Module (evidence passed through calls)
+//!     ▼ prepare_closure_lowering + lower_closures_in_func
+//! Module (closure.* lowered, evidence passed through closure calls)
 //!     │
 //!     ▼ lower_ability_perform (CPS tail-call)
 //! Module (ability.perform/call lowered to effect.dispatch_*)
@@ -438,7 +435,9 @@ pub fn run_through_closure_lower(
     let mut pm = PassManager::new();
     pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
         .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
-        .add_pass(tribute_passes::closure_lower::LowerClosures);
+        .add_pass(tribute_passes::closure_lower::PrepareClosureLowering);
+    pm.nest::<func_dialect::Func>()
+        .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
     pm.run(&mut ctx, core_module)?;
     Ok(Some((ctx, m)))
 }
@@ -471,7 +470,10 @@ fn run_shared_pipeline(
         .add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
         .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
         // Evidence params are now inserted directly during ast_to_ir lowering.
-        .add_pass(tribute_passes::closure_lower::LowerClosures);
+        .add_pass(tribute_passes::closure_lower::PrepareClosureLowering);
+    structural_pm
+        .nest::<func_dialect::Func>()
+        .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
     install_debug_use_chain_verifier(&mut structural_pm);
     structural_pm.run(&mut ctx, core_module)?;
 

--- a/tests/e2e_add.rs
+++ b/tests/e2e_add.rs
@@ -708,6 +708,10 @@ fn main() { }
             lowered_ops.has_struct_get,
             "Expected adt.struct_get after closure lowering (from closure.func/closure.env)"
         );
+        assert!(
+            lowered_ops.has_call_indirect_evidence_arg,
+            "Expected lowered func.call_indirect to pass evidence before closure env"
+        );
     });
 }
 
@@ -716,23 +720,35 @@ struct LoweredClosureOps {
     has_func_constant: bool,
     has_struct_new: bool,
     has_struct_get: bool,
+    has_call_indirect_evidence_arg: bool,
+}
+
+impl LoweredClosureOps {
+    fn empty() -> Self {
+        Self {
+            has_func_constant: false,
+            has_struct_new: false,
+            has_struct_get: false,
+            has_call_indirect_evidence_arg: false,
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.has_func_constant |= other.has_func_constant;
+        self.has_struct_new |= other.has_struct_new;
+        self.has_struct_get |= other.has_struct_get;
+        self.has_call_indirect_evidence_arg |= other.has_call_indirect_evidence_arg;
+    }
 }
 
 /// Helper to check for lowered closure operations in a module (arena version)
 fn check_for_lowered_closure_ops_in_module(ctx: &IrContext, m: Module) -> LoweredClosureOps {
-    let mut result = LoweredClosureOps {
-        has_func_constant: false,
-        has_struct_new: false,
-        has_struct_get: false,
-    };
+    let mut result = LoweredClosureOps::empty();
 
     for &op_ref in &m.ops(ctx) {
         let op_data = ctx.op(op_ref);
         for &region_ref in &op_data.regions {
-            let nested_result = check_for_lowered_closure_ops_in_region(ctx, region_ref);
-            result.has_func_constant = result.has_func_constant || nested_result.has_func_constant;
-            result.has_struct_new = result.has_struct_new || nested_result.has_struct_new;
-            result.has_struct_get = result.has_struct_get || nested_result.has_struct_get;
+            result.merge(check_for_lowered_closure_ops_in_region(ctx, region_ref));
         }
     }
 
@@ -746,15 +762,12 @@ fn check_for_lowered_closure_ops_in_region(
 ) -> LoweredClosureOps {
     let func_dialect = Symbol::new("func");
     let func_constant_name = Symbol::new("constant");
+    let func_call_indirect_name = Symbol::new("call_indirect");
     let adt_dialect = Symbol::new("adt");
     let adt_struct_new_name = Symbol::new("struct_new");
     let adt_struct_get_name = Symbol::new("struct_get");
 
-    let mut result = LoweredClosureOps {
-        has_func_constant: false,
-        has_struct_new: false,
-        has_struct_get: false,
-    };
+    let mut result = LoweredClosureOps::empty();
 
     let region = ctx.region(region_ref);
     for &block_ref in &region.blocks {
@@ -768,6 +781,17 @@ fn check_for_lowered_closure_ops_in_region(
             if dialect == func_dialect && op_name == func_constant_name {
                 result.has_func_constant = true;
             }
+            if dialect == func_dialect && op_name == func_call_indirect_name {
+                let operands = ctx.op_operands(op_ref);
+                if operands.len() > 1
+                    && tribute_ir::dialect::ability::is_evidence_type_ref(
+                        ctx,
+                        ctx.value_ty(operands[1]),
+                    )
+                {
+                    result.has_call_indirect_evidence_arg = true;
+                }
+            }
             // Check for adt.struct_new (from closure.new lowering)
             if dialect == adt_dialect && op_name == adt_struct_new_name {
                 result.has_struct_new = true;
@@ -779,11 +803,7 @@ fn check_for_lowered_closure_ops_in_region(
 
             // Recurse into nested regions
             for &nested_region in &op_data.regions {
-                let nested_result = check_for_lowered_closure_ops_in_region(ctx, nested_region);
-                result.has_func_constant =
-                    result.has_func_constant || nested_result.has_func_constant;
-                result.has_struct_new = result.has_struct_new || nested_result.has_struct_new;
-                result.has_struct_get = result.has_struct_get || nested_result.has_struct_get;
+                result.merge(check_for_lowered_closure_ops_in_region(ctx, nested_region));
             }
         }
     }

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -45,15 +45,15 @@ core.module @direct_fn_native {
 
   func.func @main() -> core.nil {
       %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"run::__clam_0"} : !t1
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"direct_fn_native::__lambda_5"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %2 = func.constant {func_ref = @"run::__clam_0"} : !t1
+      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = func.constant {func_ref = @"direct_fn_native::__lambda_5"} : !t1
+      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
+      %7 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %8 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
       %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %11 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
@@ -65,7 +65,7 @@ core.module @direct_fn_native {
       %18 = core.unrealized_conversion_cast %15 : core.ptr
       %19 = core.unrealized_conversion_cast %12 : core.ptr
       %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
-      %21 = func.call_indirect %8, %20, %9, %7 : tribute_rt.anyref
+      %21 = func.call_indirect %8, %20, %9, %6 : tribute_rt.anyref
       %22 = tribute_rt.unbox_int %21 : core.i32
       %23 = tribute_rt.unbox_int %21 : core.i32
       %24 = arith.const {value = unit} : core.nil

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -61,15 +61,15 @@ core.module @mixed_nested_native {
 
   func.func @main() -> core.nil {
       %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"mixed_nested_native::__lambda_10"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %2 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
+      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = func.constant {func_ref = @"mixed_nested_native::__lambda_10"} : !t1
+      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
+      %7 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %8 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
       %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %11 = func.constant {func_ref = @"run_all::__clam_1"} : !t3
       %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
@@ -81,7 +81,7 @@ core.module @mixed_nested_native {
       %18 = core.unrealized_conversion_cast %15 : core.ptr
       %19 = core.unrealized_conversion_cast %12 : core.ptr
       %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
-      %21 = func.call_indirect %8, %20, %9, %7 : tribute_rt.anyref
+      %21 = func.call_indirect %8, %20, %9, %6 : tribute_rt.anyref
       %22 = tribute_rt.unbox_int %21 : core.i32
       %23 = tribute_rt.unbox_int %21 : core.i32
       %24 = arith.const {value = unit} : core.nil

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -48,15 +48,15 @@ core.module @resumptive_op_native {
 
   func.func @main() -> core.nil {
       %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %1 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"resumptive_op_native::__lambda_5"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %2 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
+      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = func.constant {func_ref = @"resumptive_op_native::__lambda_5"} : !t1
+      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
+      %7 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %8 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
       %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %11 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
@@ -66,7 +66,7 @@ core.module @resumptive_op_native {
       %16 = core.unrealized_conversion_cast %13 : core.ptr
       %17 = core.unrealized_conversion_cast %12 : core.ptr
       %18 = func.call %0, %15, %14, %16, %17 {callee = @__tribute_evidence_extend} : core.ptr
-      %19 = func.call_indirect %8, %18, %9, %7 : tribute_rt.anyref
+      %19 = func.call_indirect %8, %18, %9, %6 : tribute_rt.anyref
       %20 = tribute_rt.unbox_int %19 : core.i32
       %21 = tribute_rt.unbox_int %19 : core.i32
       %22 = arith.const {value = unit} : core.nil

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -68,15 +68,15 @@ core.module @direct_fn {
   func.func @run() -> core.i32 {
       %0 = arith.const {value = 0} : core.i32
       %1 = adt.array_new %0 {type = !t0} : !t0
-      %2 = adt.ref_null {type = !t0} : !t0
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = func.constant {func_ref = @"run::__clam_0"} : !t1
-      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = func.constant {func_ref = @"direct_fn::__lambda_5"} : !t1
-      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
-      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = func.constant {func_ref = @"run::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = func.constant {func_ref = @"direct_fn::__lambda_5"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.ref_null {type = !t0} : !t0
+      %9 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
       %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %12 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
@@ -85,7 +85,7 @@ core.module @direct_fn {
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
       %18 = effect.extend %1, %17, %16, %13 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %19 = func.call_indirect %9, %18, %10, %8 : tribute_rt.anyref
+      %19 = func.call_indirect %9, %18, %10, %7 : tribute_rt.anyref
       %20 = core.unrealized_conversion_cast %19 : core.i32
       %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
       %22 = core.unrealized_conversion_cast %21 : core.i32

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -117,15 +117,15 @@ core.module @mixed_nested {
   func.func @run_all() -> core.i32 {
       %0 = arith.const {value = 0} : core.i32
       %1 = adt.array_new %0 {type = !t0} : !t0
-      %2 = adt.ref_null {type = !t0} : !t0
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
-      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = func.constant {func_ref = @"mixed_nested::__lambda_10"} : !t1
-      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
-      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = func.constant {func_ref = @"mixed_nested::__lambda_10"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.ref_null {type = !t0} : !t0
+      %9 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
       %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %12 = func.constant {func_ref = @"run_all::__clam_1"} : !t4
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
@@ -134,7 +134,7 @@ core.module @mixed_nested {
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
       %18 = effect.extend %1, %17, %16, %13 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %19 = func.call_indirect %9, %18, %10, %8 : tribute_rt.anyref
+      %19 = func.call_indirect %9, %18, %10, %7 : tribute_rt.anyref
       %20 = core.unrealized_conversion_cast %19 : core.i32
       %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
       %22 = core.unrealized_conversion_cast %21 : core.i32

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -66,22 +66,22 @@ core.module @resumptive_op {
   func.func @run_state() -> core.i32 {
       %0 = arith.const {value = 0} : core.i32
       %1 = adt.array_new %0 {type = !t0} : !t0
-      %2 = adt.ref_null {type = !t0} : !t0
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
-      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
-      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = func.constant {func_ref = @"resumptive_op::__lambda_5"} : !t1
-      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
-      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
+      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
+      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %6 = func.constant {func_ref = @"resumptive_op::__lambda_5"} : !t1
+      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
+      %8 = adt.ref_null {type = !t0} : !t0
+      %9 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
       %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %12 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
       %14 = arith.const {value = 0} : tribute_rt.anyref
       %15 = func.call {callee = @__tribute_next_tag} : core.i32
       %16 = effect.extend %1, %15, %14, %13 {ability_ref = core.ability_ref() {name = @State}} : !t0
-      %17 = func.call_indirect %9, %16, %10, %8 : tribute_rt.anyref
+      %17 = func.call_indirect %9, %16, %10, %7 : tribute_rt.anyref
       %18 = core.unrealized_conversion_cast %17 : core.i32
       %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
       %20 = core.unrealized_conversion_cast %19 : core.i32


### PR DESCRIPTION
## Summary
- split closure lowering into module-level signature preparation and function-local lowering
- inject closure call evidence during the function-local call rewrite instead of span-based module post-processing
- wire the shared pipeline through nested func passes and update active pipeline snapshots

## Validation
- cargo nextest run -p tribute-passes
- cargo nextest run -p tribute
- pre-commit hook: cargo fmt, clippy, markdownlint, 1441 nextest tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Closure call lowering now injects an explicit evidence operand into `func.call_indirect`, immediately after the closure table index (before closure environment/arguments).
  - Closure lowering has been split into a two-step process: preparation followed by per-function lowering.

- **Bug Fixes**
  - Evidence is now consistently provided during lowering, including synthesizing null evidence when required.
  - Return-type mismatches are handled with an automatic cast for consistency.

- **Tests**
  - End-to-end checks were updated to verify evidence presence and operand ordering.

- **Documentation**
  - Pipeline diagrams and stage descriptions were updated to reflect the new two-step flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->