### PR TITLE
Include deferred callee types when collecting unification variables

### DIFF
--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -114,6 +114,12 @@ impl<'db> TypeChecker<'db> {
             &mut all_univars,
         );
         self.collect_univars_from_body(&body, type_subst, row_subst, &mut all_univars);
+        self.collect_univars_from_deferred_resolutions(
+            &deferred_resolutions,
+            type_subst,
+            row_subst,
+            &mut all_univars,
+        );
 
         // Create a comprehensive mapping from all UniVars to BoundVars
         let var_to_index: HashMap<UniVarId<'db>, u32> = all_univars
@@ -935,6 +941,18 @@ impl<'db> TypeChecker<'db> {
         self.collect_univars_from_expr_kind(&body.kind, type_subst, row_subst, out);
     }
 
+    fn collect_univars_from_deferred_resolutions(
+        &self,
+        deferred_resolutions: &HashMap<crate::ast::NodeId, (FuncDefId<'db>, Type<'db>)>,
+        type_subst: &TypeSubst<'db>,
+        row_subst: &RowSubst<'db>,
+        out: &mut Vec<UniVarId<'db>>,
+    ) {
+        for (_, callee_ty) in deferred_resolutions.values() {
+            type_subst.collect_univars_from_type(self.db(), *callee_ty, row_subst, out);
+        }
+    }
+
     fn collect_univars_from_expr_kind(
         &self,
         kind: &ExprKind<TypedRef<'db>>,
@@ -1110,5 +1128,53 @@ impl<'db> TypeChecker<'db> {
                 self.collect_univars_from_pattern(pattern, type_subst, row_subst, out);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use salsa_test_macros::salsa_test;
+    use trunk_ir::Symbol;
+
+    use crate::ast::{EffectRow, NodeId, SpanMap, Type, TypeKind};
+    use crate::typeck::{TypeChecker, TypeSolver};
+
+    #[salsa_test]
+    fn collect_deferred_resolution_univars_includes_callee_type(db: &salsa::DatabaseImpl) {
+        let mut solver = TypeSolver::new(db);
+        let solver_var = solver.fresh_type_var(db);
+        let callee_ty = Type::new(
+            db,
+            TypeKind::Func {
+                params: vec![Type::new(db, TypeKind::Nat)],
+                result: solver_var,
+                effect: EffectRow::pure(db),
+            },
+        );
+
+        let mut deferred_resolutions = HashMap::new();
+        deferred_resolutions.insert(
+            NodeId::from_raw(1),
+            (
+                crate::ast::FuncDefId::new(db, Symbol::new("Box::map")),
+                callee_ty,
+            ),
+        );
+
+        let checker = TypeChecker::new(db, SpanMap::default());
+        let mut collected = Vec::new();
+        checker.collect_univars_from_deferred_resolutions(
+            &deferred_resolutions,
+            solver.type_subst(),
+            solver.row_subst(),
+            &mut collected,
+        );
+
+        let TypeKind::UniVar { id } = solver_var.kind(db) else {
+            panic!("fresh solver variable should be a UniVar");
+        };
+        assert_eq!(collected, vec![*id]);
     }
 }

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -103,9 +103,9 @@ impl<'db> TypeChecker<'db> {
         let type_subst = solver.type_subst();
         let row_subst = solver.row_subst();
 
-        // First, collect ALL unresolved UniVars from both the function type AND the body.
-        // This ensures that UniVars created during body type checking (e.g., from builtin calls)
-        // are also included in the generalization mapping.
+        // First, collect ALL unresolved UniVars from the function type, body, and deferred
+        // method callee types. This ensures that UniVars created during body type checking
+        // or post-solve deferred method resolution are included in the generalization mapping.
         let mut all_univars = Vec::new();
         type_subst.collect_univars_from_type(
             self.db(),

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -948,8 +948,11 @@ impl<'db> TypeChecker<'db> {
         row_subst: &RowSubst<'db>,
         out: &mut Vec<UniVarId<'db>>,
     ) {
-        for (_, callee_ty) in deferred_resolutions.values() {
-            type_subst.collect_univars_from_type(self.db(), *callee_ty, row_subst, out);
+        let mut node_ids: Vec<_> = deferred_resolutions.keys().copied().collect();
+        node_ids.sort();
+        for node_id in node_ids {
+            let (_, callee_ty) = deferred_resolutions[&node_id];
+            type_subst.collect_univars_from_type(self.db(), callee_ty, row_subst, out);
         }
     }
 
@@ -1144,22 +1147,38 @@ mod tests {
     #[salsa_test]
     fn collect_deferred_resolution_univars_includes_callee_type(db: &salsa::DatabaseImpl) {
         let mut solver = TypeSolver::new(db);
-        let solver_var = solver.fresh_type_var(db);
-        let callee_ty = Type::new(
+        let first_solver_var = solver.fresh_type_var(db);
+        let second_solver_var = solver.fresh_type_var(db);
+        let first_callee_ty = Type::new(
             db,
             TypeKind::Func {
                 params: vec![Type::new(db, TypeKind::Nat)],
-                result: solver_var,
+                result: first_solver_var,
+                effect: EffectRow::pure(db),
+            },
+        );
+        let second_callee_ty = Type::new(
+            db,
+            TypeKind::Func {
+                params: vec![Type::new(db, TypeKind::Nat)],
+                result: second_solver_var,
                 effect: EffectRow::pure(db),
             },
         );
 
         let mut deferred_resolutions = HashMap::new();
         deferred_resolutions.insert(
+            NodeId::from_raw(2),
+            (
+                crate::ast::FuncDefId::new(db, Symbol::new("Box::flat_map")),
+                second_callee_ty,
+            ),
+        );
+        deferred_resolutions.insert(
             NodeId::from_raw(1),
             (
                 crate::ast::FuncDefId::new(db, Symbol::new("Box::map")),
-                callee_ty,
+                first_callee_ty,
             ),
         );
 
@@ -1172,9 +1191,18 @@ mod tests {
             &mut collected,
         );
 
-        let TypeKind::UniVar { id } = solver_var.kind(db) else {
+        let TypeKind::UniVar {
+            id: first_solver_id,
+        } = first_solver_var.kind(db)
+        else {
             panic!("fresh solver variable should be a UniVar");
         };
-        assert_eq!(collected, vec![*id]);
+        let TypeKind::UniVar {
+            id: second_solver_id,
+        } = second_solver_var.kind(db)
+        else {
+            panic!("fresh solver variable should be a UniVar");
+        };
+        assert_eq!(collected, vec![*first_solver_id, *second_solver_id]);
     }
 }

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -582,7 +582,7 @@ flowchart TB
 | -------- | ---- | ---- | ---- | ---- |
 | **Frontend** | `resolve` | tribute.* ops | func.*, adt.* | ✓ |
 | | `inline_constants` | const refs | inlined values | |
-| | `typecheck` | type.var | concrete types | ✓ |
+| | `typecheck` | type.var | solved or generalized typed AST | ✓ |
 | **Closure** | `lambda_lift` | lambdas | top-level funcs | |
 | | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
 | | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
@@ -603,6 +603,12 @@ flowchart TB
 it is part of frontend IR construction rather than a standalone pass. The
 function-anchored lowering point after case construction is `scf_to_cf_pass()`,
 which runs under `PassManager::nest::<func.func>()`.
+
+`typecheck` solves function-local unification variables where constraints make
+them concrete and generalizes remaining polymorphic variables into stable
+`BoundVar` indices. Generalization covers the function signature, checked body,
+and post-solve deferred UFCS callee types so later TDNR and monomorphization do
+not see raw solver variables in typed references.
 
 ### 점진적 개선 방향: Fine-Grained Queries
 


### PR DESCRIPTION
## Summary
- collect UniVars from deferred resolution callee types before building the bound-variable mapping
- ensure deferred calls contribute their type variables to the function-level solver state
- add a focused test covering UniVar collection from a deferred callee type

## Testing
- Added a unit test for `collect_univars_from_deferred_resolutions`
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function type-checking for code paths involving deferred method calls, so polymorphic variables generalize correctly and no longer leave unresolved solver variables in typed references.
* **Tests**
  * Added unit test coverage to ensure UniVar collection from deferred method resolutions is reflected during generalization.
* **Documentation**
  * Updated the typecheck pipeline description to clarify it now produces solved or generalized typed AST (not just concrete types) and explains the scope of generalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->