### PR TITLE
Define layered TrunkIR validation responsibilities

### DIFF
--- a/crates/tribute-front/tests/expr_coverage.rs
+++ b/crates/tribute-front/tests/expr_coverage.rs
@@ -163,6 +163,22 @@ fn logic(a: Bool, b: Bool) -> Bool {
     assert_snapshot!(ir_text);
 }
 
+#[salsa_test]
+fn test_float_comparison_operators(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn comparisons(a: Float, b: Float) -> #(Bool, Bool, Bool, Bool, Bool, Bool) {
+    #(a == b, a != b, a < b, a <= b, a > b, a >= b)
+}
+"#,
+    );
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_snapshot!(ir_text);
+}
+
 // ========================================================================
 // Higher-Order Function Tests
 // ========================================================================

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
@@ -1,0 +1,21 @@
+---
+source: crates/tribute-front/tests/expr_coverage.rs
+assertion_line: 179
+expression: ir_text
+---
+core.module @test {
+  !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
+  !__tuple_i1_i1_i1_i1_i1_i1_1 = adt.typeref() {name = @__tuple_i1_i1_i1_i1_i1_i1}
+
+  func.func @comparisons(%0: core.f64, %1: core.f64) -> tribute_rt.anyref {
+      %2 = func.call %0, %1 {callee = @"Float::=="} : core.i1
+      %3 = func.call %0, %1 {callee = @"Float::!="} : core.i1
+      %4 = func.call %0, %1 {callee = @"Float::<"} : core.i1
+      %5 = func.call %0, %1 {callee = @"Float::<="} : core.i1
+      %6 = func.call %0, %1 {callee = @"Float::>"} : core.i1
+      %7 = func.call %0, %1 {callee = @"Float::>="} : core.i1
+      %8 = adt.struct_new %2, %3, %4, %5, %6, %7 {type = !__tuple_i1_i1_i1_i1_i1_i1} : !__tuple_i1_i1_i1_i1_i1_i1_1
+      %9 = core.unrealized_conversion_cast %8 : tribute_rt.anyref
+      func.return %9
+  }
+}

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -10,6 +10,9 @@
 //! 2. **Use-chain consistency**: Checks that the use-chain stored in `IrContext`
 //!    exactly matches the actual operands of all operations. This is unique to
 //!    arena IR.
+//!
+//! 3. **Operation verifiers**: Check local operation invariants that do not
+//!    require whole-IR analysis or conversion-boundary state.
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -47,7 +50,7 @@ pub enum ValidationError {
     /// A use-chain inconsistency was found.
     #[display("{message}")]
     UseChain { message: String },
-    /// An operation-level semantic validation error was found.
+    /// An operation-level verifier error was found.
     #[display("{message}")]
     Operation { message: String },
 }
@@ -303,12 +306,16 @@ pub fn validate_use_chains(ctx: &IrContext, module: Module) -> ValidationResult 
 }
 
 // ============================================================================
-// Operation semantic validation
+// Operation verifier validation
 // ============================================================================
 
-/// Validate operation-level semantic constraints that are independent of
-/// value scope/use-chain integrity.
-pub fn validate_operation_semantics(ctx: &IrContext, module: Module) -> ValidationResult {
+/// Validate local operation-level invariants.
+///
+/// Operation verifiers are for constraints that can be checked from one
+/// operation and its immediate shape: required attributes, supported attribute
+/// values, operand/result arity, region count, and terminator requirements.
+/// They must not encode conversion-boundary legality or graph-wide invariants.
+pub fn validate_operation_verifiers(ctx: &IrContext, module: Module) -> ValidationResult {
     let mut errors = Vec::new();
 
     let body = match module.body(ctx) {
@@ -326,6 +333,19 @@ pub fn validate_operation_semantics(ctx: &IrContext, module: Module) -> Validati
     ValidationResult { errors }
 }
 
+/// Validate operation-level semantic constraints that are independent of
+/// value scope/use-chain integrity.
+///
+/// Deprecated compatibility alias for callers that have not migrated to
+/// [`validate_operation_verifiers`].
+#[deprecated(
+    since = "0.1.0",
+    note = "use validate_operation_verifiers for local operation invariant checks"
+)]
+pub fn validate_operation_semantics(ctx: &IrContext, module: Module) -> ValidationResult {
+    validate_operation_verifiers(ctx, module)
+}
+
 fn validate_arith_cmpf_predicate(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
     let data = ctx.op(op);
     if data.dialect != Symbol::new("arith") || data.name != Symbol::new("cmpf") {
@@ -335,29 +355,57 @@ fn validate_arith_cmpf_predicate(ctx: &IrContext, op: OpRef, errors: &mut Vec<Va
     let Some(super::types::Attribute::Symbol(predicate)) =
         data.attributes.get(&Symbol::new("predicate"))
     else {
-        errors.push(ValidationError::Operation {
-            message: "arith.cmpf requires symbol predicate attribute".to_string(),
-        });
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "requires symbol predicate attribute",
+        ));
         return;
     };
 
     if !is_allowed_cmpf_predicate(*predicate) {
-        errors.push(ValidationError::Operation {
-            message: format!(
-                "arith.cmpf has unsupported predicate '{}'; supported predicates are oeq, une, olt, ole, ogt, oge",
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            format!(
+                "has unsupported predicate '{}'; supported predicates are {}",
                 predicate,
+                supported_cmpf_predicates_text(),
             ),
-        });
+        ));
     }
 }
 
+fn operation_verifier_error(
+    ctx: &IrContext,
+    op: OpRef,
+    detail: impl Into<String>,
+) -> ValidationError {
+    let data = ctx.op(op);
+    ValidationError::Operation {
+        message: format!(
+            "operation verifier failed for {}.{} ({}): {}",
+            data.dialect,
+            data.name,
+            op,
+            detail.into(),
+        ),
+    }
+}
+
+const SUPPORTED_CMPF_PREDICATES: [&str; 6] = ["oeq", "une", "olt", "ole", "ogt", "oge"];
+
+fn supported_cmpf_predicates_text() -> String {
+    SUPPORTED_CMPF_PREDICATES.join(", ")
+}
+
 fn is_allowed_cmpf_predicate(predicate: Symbol) -> bool {
-    predicate == Symbol::new("oeq")
-        || predicate == Symbol::new("une")
-        || predicate == Symbol::new("olt")
-        || predicate == Symbol::new("ole")
-        || predicate == Symbol::new("ogt")
-        || predicate == Symbol::new("oge")
+    predicate == Symbol::new(SUPPORTED_CMPF_PREDICATES[0])
+        || predicate == Symbol::new(SUPPORTED_CMPF_PREDICATES[1])
+        || predicate == Symbol::new(SUPPORTED_CMPF_PREDICATES[2])
+        || predicate == Symbol::new(SUPPORTED_CMPF_PREDICATES[3])
+        || predicate == Symbol::new(SUPPORTED_CMPF_PREDICATES[4])
+        || predicate == Symbol::new(SUPPORTED_CMPF_PREDICATES[5])
 }
 
 fn collect_block_values(ctx: &IrContext, block: BlockRef, values: &mut HashSet<ValueRef>) {
@@ -530,7 +578,7 @@ pub fn validate_call_arity(ctx: &IrContext, module: Module) {
 pub fn validate_all(ctx: &IrContext, module: Module) -> ValidationResult {
     let scope = validate_value_integrity(ctx, module);
     let uses = validate_use_chains(ctx, module);
-    let ops = validate_operation_semantics(ctx, module);
+    let ops = validate_operation_verifiers(ctx, module);
     let mut errors = scope.errors;
     errors.extend(uses.errors);
     errors.extend(ops.errors);
@@ -1430,7 +1478,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = crate::parser::parse_test_module(&mut ctx, input);
 
-        let result = validate_operation_semantics(&ctx, module);
+        let result = validate_operation_verifiers(&ctx, module);
         assert!(result.is_ok(), "{result}");
     }
 
@@ -1445,10 +1493,47 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = crate::parser::parse_test_module(&mut ctx, input);
 
+        let result = validate_operation_verifiers(&ctx, module);
+        let operation_errors = operation_error_messages(&result);
+        assert_eq!(operation_errors.len(), 1);
+        assert!(operation_errors[0].contains("operation verifier failed for arith.cmpf"));
+        assert!(operation_errors[0].contains("unsupported predicate 'ueq'"));
+    }
+
+    #[test]
+    fn cmpf_missing_predicate_is_rejected() {
+        let input = r#"core.module @test {
+  func.func @main(%0: core.f64, %1: core.f64) -> core.i1 {
+    %2 = arith.cmpf %0, %1 : core.i1
+    func.return %2
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        let operation_errors = operation_error_messages(&result);
+        assert_eq!(operation_errors.len(), 1);
+        assert!(operation_errors[0].contains("operation verifier failed for arith.cmpf"));
+        assert!(operation_errors[0].contains("requires symbol predicate attribute"));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_operation_semantics_alias_delegates_to_operation_verifiers() {
+        let input = r#"core.module @test {
+  func.func @main(%0: core.f64, %1: core.f64) -> core.i1 {
+    %2 = arith.cmpf %0, %1 {predicate = @ueq} : core.i1
+    func.return %2
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
         let result = validate_operation_semantics(&ctx, module);
         let operation_errors = operation_error_messages(&result);
         assert_eq!(operation_errors.len(), 1);
-        assert!(operation_errors[0].contains("unsupported predicate 'ueq'"));
+        assert!(operation_errors[0].contains("operation verifier failed for arith.cmpf"));
     }
 
     #[test]

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -18,6 +18,28 @@
 
 ---
 
+## TrunkIR Validation Responsibilities
+
+TrunkIR validation follows the layered model in `new-plans/ir.md`:
+
+- Local operation constraints belong in operation verifiers. They cover one
+  operation's operands, results, attributes, regions, and terminator shape
+  without relying on pipeline phase state.
+- Lowering boundaries belong in `ConversionTarget`. Use partial conversion for
+  intermediate rewrites that may leave unknown operations, and full conversion
+  for named backend-ready or stage-complete boundaries.
+- Whole-IR consistency belongs in pass-manager verifiers. Install these through
+  `PassManager::with_verifier` when a pass sequence should report the pass that
+  broke a graph-wide invariant such as SSA use-chain consistency.
+- Shared behavior belongs in operation interfaces such as `PureOps` and
+  `IsolatedFromAboveOps`. Add new interfaces only when there is an immediate
+  generic consumer, not as a speculative hierarchy.
+
+Do not add a separate semantic-contract DSL unless these existing mechanisms
+cannot express a required invariant.
+
+---
+
 ## Semantic Model
 
 ### 동적 의미론

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -45,6 +45,25 @@ Partial conversion may leave unknown operations for later passes. Full
 conversion boundaries, such as backend-ready native IR, must reject unknown
 operations.
 
+## Validation Layers
+
+TrunkIR validation is layered by responsibility. The compiler should use the
+smallest layer that can state an invariant precisely, and should not introduce a
+separate semantic-contract framework unless these layers leave a concrete gap.
+
+| Layer | Responsibility | Failure timing | Examples |
+| ---- | ---- | ---- | ---- |
+| Operation verifier | Local invariants of one operation: operand/result counts, required attributes, attribute domains, region shape, and terminator requirements that can be checked without global analysis. | During parsing/building when possible, or during explicit operation validation checkpoints. | `arith.cmpf` accepts only supported predicates; an op with regions requires the expected region count and terminator form. |
+| Conversion target | Dialect and type legality at a named lowering boundary. | Immediately after a pass or pass group claims a conversion boundary. Partial conversion rejects explicitly illegal operations; full conversion also rejects unknown operations. | Ability lowering leaves no `ability.perform`; backend-ready native IR contains only `clif.*` plus allowed infrastructure ops. |
+| Pass-manager verifier | Whole-IR consistency after transformations, with the offending pass identified. | After each pass registered in a `PassManager` when a verifier hook is installed. | SSA use-chain consistency, value visibility across isolated regions, or other graph-wide invariants. |
+| Operation interface | Shared behavior queried generically across dialects. | At the consumer that needs dialect-independent behavior. Interfaces should be introduced only for multiple concrete consumers or one generic transform. | `PureOps` for DCE removability; `IsolatedFromAboveOps` for nested pass-manager anchoring. |
+
+Local operation verifiers must not depend on conversion state or pass ordering.
+Conversion targets must not duplicate local semantic checks. Pass-manager
+verifiers should remain responsible for graph-wide invariants that require
+walking use-def chains, symbol tables, or nested region relationships. Operation
+interfaces describe behavior, not validation phases.
+
 ## Core Invariants
 
 - A `core.module` owns the top-level region for a compilation unit.

--- a/tests/active_pipeline_goldens.rs
+++ b/tests/active_pipeline_goldens.rs
@@ -221,6 +221,14 @@ fn main() {
 }
 "#;
 
+const FLOAT_COMPARISON_SOURCE: &str = r#"
+fn main() {
+    let a = 1.0
+    let b = 2.0
+    let _ = #(a == b, a != b, a < b, a <= b, a > b, a >= b)
+}
+"#;
+
 #[salsa_test]
 fn shared_pipeline_direct_fn_ability_call(db: &salsa::DatabaseImpl) {
     let ir_text = snapshot_shared_pipeline_ir(db, "direct_fn.trb", DIRECT_FN_SOURCE);
@@ -236,6 +244,12 @@ fn shared_pipeline_resumptive_op_continuation(db: &salsa::DatabaseImpl) {
 #[salsa_test]
 fn shared_pipeline_mixed_nested_handler_boundary(db: &salsa::DatabaseImpl) {
     let ir_text = snapshot_shared_pipeline_ir(db, "mixed_nested.trb", MIXED_NESTED_SOURCE);
+    assert_snapshot!(ir_text);
+}
+
+#[salsa_test]
+fn shared_pipeline_float_comparison_predicates(db: &salsa::DatabaseImpl) {
+    let ir_text = snapshot_shared_pipeline_ir(db, "float_comparisons.trb", FLOAT_COMPARISON_SOURCE);
     assert_snapshot!(ir_text);
 }
 

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
@@ -1,0 +1,49 @@
+---
+source: tests/active_pipeline_goldens.rs
+assertion_line: 253
+expression: ir_text
+---
+core.module @float_comparisons {
+  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
+  !t2 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
+  !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !t0 = core.array(!_Marker)
+  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !__tuple_i1_i1_i1_i1_i1_i1_1 = adt.typeref() {name = @__tuple_i1_i1_i1_i1_i1_i1}
+
+  func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
+      func.unreachable
+  }
+
+  func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
+      func.unreachable
+  }
+
+  func.func @main() -> core.nil {
+      %0 = arith.const {value = 1.0} : core.f64
+      %1 = arith.const {value = 2.0} : core.f64
+      %2 = arith.cmpf %0, %1 {predicate = @oeq} : core.i1
+      %3 = arith.cmpf %0, %1 {predicate = @une} : core.i1
+      %4 = arith.cmpf %0, %1 {predicate = @olt} : core.i1
+      %5 = arith.cmpf %0, %1 {predicate = @ole} : core.i1
+      %6 = arith.cmpf %0, %1 {predicate = @ogt} : core.i1
+      %7 = arith.cmpf %0, %1 {predicate = @oge} : core.i1
+      %8 = adt.struct_new %2, %3, %4, %5, %6, %7 {type = !__tuple_i1_i1_i1_i1_i1_i1} : !__tuple_i1_i1_i1_i1_i1_i1_1
+      %9 = arith.const {value = unit} : core.nil
+      func.return %9
+  }
+}


### PR DESCRIPTION
## Summary
- document TrunkIR validation layers in new-plans/ir.md
- add implementation guidance for operation verifiers, conversion targets, pass-manager verifiers, and operation interfaces
- introduce validate_operation_verifiers as the explicit operation-level validation entry point while keeping validate_operation_semantics as a compatibility alias
- improve arith.cmpf verifier diagnostics to identify the validation layer and operation

## Tests
- cargo fmt --all
- cargo nextest run -p trunk-ir validation::
- cargo nextest run -p trunk-ir pass::
- cargo nextest run -p trunk-ir rewrite::conversion_target::
- pre-commit: clippy, markdownlint, full cargo nextest (1448 passed, 11 skipped)

Closes #729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support and coverage for floating-point comparison operators, including equality, inequality, and ordering checks.
  * Expanded validation so operation-level checks now report clearer, standardized error messages.

* **Bug Fixes**
  * Improved validation behavior for invalid floating-point comparison predicates.
  * Updated the validation flow to use the latest verifier path consistently across checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->