### PR TITLE
Cover pass-manager use-chain verification

### DIFF
--- a/crates/trunk-ir/src/context.rs
+++ b/crates/trunk-ir/src/context.rs
@@ -335,6 +335,37 @@ impl IrContext {
         });
     }
 
+    /// Remove the i-th operand from an operation, updating use-chains.
+    pub fn remove_op_operand(&mut self, op: OpRef, index: u32) {
+        let old_operands: SmallVec<[ValueRef; 8]> =
+            self.ops[op].operands.as_slice(&self.value_pool).into();
+        let index_usize = index as usize;
+        assert!(
+            index_usize < old_operands.len(),
+            "remove_op_operand: operand index {index} out of bounds for operation {op}",
+        );
+
+        let removed = old_operands[index_usize];
+        self.uses[removed].retain(|u| !(u.user == op && u.operand_index == index));
+
+        for (old_idx, &val) in old_operands.iter().enumerate().skip(index_usize + 1) {
+            for use_entry in &mut self.uses[val] {
+                if use_entry.user == op && use_entry.operand_index == old_idx as u32 {
+                    use_entry.operand_index -= 1;
+                    break;
+                }
+            }
+        }
+
+        let mut operands = EntityList::new();
+        for (idx, &val) in old_operands.iter().enumerate() {
+            if idx != index_usize {
+                operands.push(val, &mut self.value_pool);
+            }
+        }
+        self.ops[op].operands = operands;
+    }
+
     /// Get the i-th result value of an operation.
     pub fn op_result(&self, op: OpRef, index: u32) -> ValueRef {
         self.result_values[op].as_slice(&self.value_pool)[index as usize]
@@ -1560,6 +1591,50 @@ mod tests {
         ctx.set_op_operand(op_user, 0, v_new);
         assert_eq!(ctx.uses(v_new).len(), 1); // unchanged
         assert!(!ctx.has_uses(v_old)); // still no uses
+    }
+
+    #[test]
+    fn remove_op_operand_updates_use_chains() {
+        let mut ctx = IrContext::new();
+        let loc = test_location(&mut ctx);
+        let i32_ty = i32_type(&mut ctx);
+
+        let v0_data = OperationDataBuilder::new(loc, Symbol::new("arith"), Symbol::new("const"))
+            .result(i32_ty)
+            .build(&mut ctx);
+        let v0_op = ctx.create_op(v0_data);
+        let v0 = ctx.op_result(v0_op, 0);
+        let v1_data = OperationDataBuilder::new(loc, Symbol::new("arith"), Symbol::new("const"))
+            .result(i32_ty)
+            .build(&mut ctx);
+        let v1_op = ctx.create_op(v1_data);
+        let v1 = ctx.op_result(v1_op, 0);
+
+        let user_data = OperationDataBuilder::new(loc, Symbol::new("arith"), Symbol::new("addi"))
+            .operand(v0)
+            .operand(v1)
+            .operand(v1)
+            .result(i32_ty)
+            .build(&mut ctx);
+        let user = ctx.create_op(user_data);
+
+        ctx.remove_op_operand(user, 1);
+
+        assert_eq!(ctx.op_operands(user), &[v0, v1]);
+        assert_eq!(
+            ctx.uses(v0),
+            &[Use {
+                user,
+                operand_index: 0
+            }]
+        );
+        assert_eq!(
+            ctx.uses(v1),
+            &[Use {
+                user,
+                operand_index: 1
+            }]
+        );
     }
 
     #[test]

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -29,6 +29,7 @@
 //!   %2 = op_after(%1)
 //! ```
 
+use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
 use smallvec::SmallVec;
@@ -37,7 +38,7 @@ use crate::context::{BlockArgData, BlockData, IrContext};
 use crate::dialect::{arith, cf, core, func, scf};
 use crate::ops::{DialectOp, DialectType};
 use crate::pass::{Pass, pass_fn};
-use crate::refs::{BlockRef, OpRef, RegionRef};
+use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use crate::rewrite::Module;
 use crate::rewrite::helpers::{inline_region_blocks, split_block};
 use crate::symbol::Symbol;
@@ -128,6 +129,24 @@ fn is_scf_control_flow(ctx: &IrContext, op: OpRef) -> bool {
     n == Symbol::new("if") || n == Symbol::new("loop") || n == Symbol::new("switch")
 }
 
+fn drop_nil_result_terminator_uses(ctx: &mut IrContext, value: ValueRef) {
+    let mut uses = ctx.uses(value).to_vec();
+    uses.sort_by_key(|use_entry| Reverse(use_entry.operand_index));
+
+    for use_entry in uses {
+        let data = ctx.op(use_entry.user);
+        let is_void_terminator = (data.dialect == Symbol::new("func")
+            && data.name == Symbol::new("return"))
+            || (data.dialect == Symbol::new("scf") && data.name == Symbol::new("yield"));
+        assert!(
+            is_void_terminator,
+            "nil scf result {value} is used by non-terminator operation {}.{} ({})",
+            data.dialect, data.name, use_entry.user,
+        );
+        ctx.remove_op_operand(use_entry.user, use_entry.operand_index);
+    }
+}
+
 /// Lower `scf.if` to cf.cond_br + then/else/merge blocks.
 fn lower_scf_if(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Location) {
     let if_op = scf::If::from_op(ctx, scf_op).unwrap();
@@ -141,8 +160,8 @@ fn lower_scf_if(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Locati
         None
     } else {
         let ty = ctx.value_ty(results[0]);
-        // Skip nil type (void)
         if core::Nil::matches(ctx, ty) {
+            drop_nil_result_terminator_uses(ctx, results[0]);
             None
         } else {
             Some(ty)
@@ -173,6 +192,7 @@ fn lower_scf_if(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Locati
     let parent_region = ctx.block(block).parent_region.unwrap();
     let then_blocks = inline_region_blocks(ctx, then_region, parent_region, Some(merge_block));
     let else_blocks = inline_region_blocks(ctx, else_region, parent_region, Some(merge_block));
+    ctx.remove_op(scf_op);
 
     let then_entry = then_blocks[0];
     let else_entry = else_blocks[0];
@@ -205,7 +225,13 @@ fn lower_scf_loop(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Loca
     let result_ty = if results.is_empty() {
         None
     } else {
-        Some(ctx.value_ty(results[0]))
+        let ty = ctx.value_ty(results[0]);
+        if core::Nil::matches(ctx, ty) {
+            drop_nil_result_terminator_uses(ctx, results[0]);
+            None
+        } else {
+            Some(ty)
+        }
     };
 
     // Split block at scf op: ops after go to exit block
@@ -230,6 +256,7 @@ fn lower_scf_loop(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Loca
     // Inline body region blocks into parent region (before exit block)
     let parent_region = ctx.block(block).parent_region.unwrap();
     let body_blocks = inline_region_blocks(ctx, body_region, parent_region, Some(exit_block));
+    ctx.remove_op(scf_op);
 
     // The first body block is the header (loop entry point)
     let header_block = body_blocks[0];
@@ -276,12 +303,7 @@ fn lower_scf_switch(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Lo
     let result_ty = if results.is_empty() {
         None
     } else {
-        let ty = ctx.value_ty(results[0]);
-        if core::Nil::matches(ctx, ty) {
-            None
-        } else {
-            Some(ty)
-        }
+        Some(ctx.value_ty(results[0]))
     };
 
     // Split block at scf op: ops after go to merge block
@@ -353,6 +375,7 @@ fn lower_scf_switch(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Lo
         ctx.block_mut(default_block).parent_region = Some(parent_region);
         default_block
     };
+    ctx.remove_op(scf_op);
 
     // Get the discriminant type for comparisons
     let disc_ty = ctx.value_ty(discriminant);
@@ -511,7 +534,7 @@ fn replace_continue_break(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dialect::{arith, func, scf};
+    use crate::dialect::{arith, core, func, scf};
     use crate::location::Span;
     use crate::symbol::Symbol;
     use crate::*;
@@ -723,6 +746,11 @@ mod tests {
 
         // Lower scf to cf
         lower_scf_to_cf(&mut ctx, module);
+        let use_chains = crate::validation::validate_use_chains(&ctx, module);
+        assert!(
+            use_chains.is_ok(),
+            "lowering must preserve use-chain consistency: {use_chains}"
+        );
 
         // Verify: no scf ops remain
         let func_body = func_op.body(&ctx);
@@ -834,11 +862,16 @@ mod tests {
         let module = build_module(&mut ctx, loc, vec![func_op.op_ref()]);
 
         lower_scf_to_cf(&mut ctx, module);
+        let use_chains = crate::validation::validate_use_chains(&ctx, module);
+        assert!(
+            use_chains.is_ok(),
+            "void lowering must preserve use-chain consistency: {use_chains}"
+        );
 
         let func_body = func_op.body(&ctx);
         let names = collect_op_names(&ctx, func_body);
         assert!(!names.iter().any(|n| n.starts_with("scf.")));
-        // Merge block should have no args (void if)
+        // Nil-typed scf.if results are not materialized as CFG values.
         let blocks = ctx.region(func_body).blocks.to_vec();
         let merge = blocks.last().unwrap();
         assert_eq!(ctx.block_args(*merge).len(), 0);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -592,6 +592,7 @@ fn run_cleanup_passes(ctx: &mut IrContext, m: Module) {
             .add_pass(trunk_ir::transforms::dce_pass(
                 trunk_ir::transforms::DceConfig::default(),
             ));
+        install_debug_use_chain_verifier(&mut pm);
         if let Err(error) = pm.run(ctx, core_module) {
             tracing::warn!("cleanup function passes failed: {error}");
         }
@@ -633,6 +634,7 @@ fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Dump
         let mut pm = PassManager::new();
         pm.nest::<func_dialect::Func>()
             .add_pass(tribute_passes::native::evidence::LowerEvidenceToNative);
+        install_debug_use_chain_verifier(&mut pm);
         pm.run(ctx, core_module)?;
     } else {
         tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
@@ -759,6 +761,7 @@ fn compile_module_to_native(
         let mut pm = PassManager::new();
         pm.nest::<func_dialect::Func>()
             .add_pass(trunk_ir::transforms::scf_to_cf_pass());
+        install_debug_use_chain_verifier(&mut pm);
         pm.run(ctx, core_module).map_err(native_pass_failure)?;
     } else {
         trunk_ir::transforms::scf_to_cf::lower_scf_to_cf(ctx, module);
@@ -1122,6 +1125,63 @@ mod tests {
     fn source_from_str(path: &str, text: &str) -> SourceCst {
         salsa::with_attached_database(|db| SourceCst::from_source_str(db, path, text))
             .expect("attached db")
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn debug_use_chain_verifier_reports_offending_pass() {
+        let input = r#"core.module @test {
+  func.func @f(%x: core.i32) -> core.i32 {
+    %y = arith.addi %x, %x : core.i32
+    func.return %y
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(&mut ctx, input);
+        let core_module = core_dialect::Module::from_op(&ctx, module.op())
+            .expect("test input must parse a core.module");
+
+        let mut pm = PassManager::new();
+        pm.add_pass(trunk_ir::pass::pass_fn(
+            "break-use-chain",
+            |ctx: &mut IrContext, module: core_dialect::Module| {
+                let module_block = ctx.region(module.body(ctx)).blocks[0];
+                let func_op = ctx.block(module_block).ops[0];
+                let func_region = ctx.op(func_op).regions[0];
+                let func_block = ctx.region(func_region).blocks[0];
+                let add_op = ctx
+                    .block(func_block)
+                    .ops
+                    .iter()
+                    .copied()
+                    .find(|&op| {
+                        let data = ctx.op(op);
+                        data.dialect == trunk_ir::Symbol::new("arith")
+                            && data.name == trunk_ir::Symbol::new("addi")
+                    })
+                    .expect("test input must contain arith.addi");
+
+                // Deliberately mutate operands without updating use-chains to
+                // exercise the graph-wide pass-manager verifier.
+                let _old_operands = std::mem::take(&mut ctx.op_mut(add_op).operands);
+                Ok(())
+            },
+        ));
+        install_debug_use_chain_verifier(&mut pm);
+
+        let error = pm.run(&mut ctx, core_module).unwrap_err();
+
+        assert_eq!(error.pass_name(), "break-use-chain");
+        assert!(
+            error
+                .to_string()
+                .contains("pass `break-use-chain` broke an IR invariant: use-chain regression"),
+            "{error}"
+        );
+        assert!(
+            error.to_string().contains("no such operand exists"),
+            "{error}"
+        );
     }
 
     #[salsa_test]


### PR DESCRIPTION
## Summary
- install the debug use-chain verifier on target-specific PassManagers for cleanup, native evidence lowering, and native scf-to-cf lowering
- fix scf-to-cf detached control-flow ops so their own operand use-chain entries are cleared
- add a pipeline test proving the debug verifier reports the offending pass name for a use-chain regression

Refs #729

## Tests
- cargo nextest run -p tribute pipeline::tests::debug_use_chain_verifier_reports_offending_pass
- cargo nextest run -p tribute pipeline::tests::
- cargo nextest run -p trunk-ir scf_to_cf
- cargo nextest run -p tribute --test e2e_ability_handler
- pre-commit: cargo fmt, clippy, markdownlint, cargo nextest run --workspace (1458 passed, 11 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug-only verifier that checks value use-chains after each compilation pass and reports the offending pass on failure.
* **Bug Fixes**
  * Fixed operand removal to keep remaining operand ordering and value use relationships correct.
  * Improved SCF-to-CF lowering for `core.nil` result cases to avoid incorrect materialization of merge inputs.
* **Tests**
  * Expanded unit coverage for operand removal correctness, nil-result lowering behavior, and verifier regression/error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->