### PR TITLE
Add duplicate effect annotation diagnostic

### DIFF
--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -16,6 +16,7 @@ use crate::ast::{
 };
 
 use super::super::constraint::ConstraintSet;
+use super::super::effect_row::find_conflicting_effects;
 use super::super::func_context::FunctionInferenceContext;
 use super::super::solver::{RowSubst, TypeSolver, TypeSubst};
 use super::{Mode, TypeChecker};
@@ -173,6 +174,20 @@ impl<'db> TypeChecker<'db> {
             && let Some(declared) = declared_effect
         {
             let resolved_declared = row_subst.apply(self.db(), declared);
+            if let Some((_, effects)) = find_conflicting_effects(self.db(), resolved_declared) {
+                Diagnostic::new(
+                    format!(
+                        "function '{}' declares duplicate effect: {}",
+                        func.name,
+                        effects.iter().format(", "),
+                    ),
+                    self.get_span(func.id),
+                    DiagnosticSeverity::Error,
+                    CompilationPhase::TypeChecking,
+                )
+                .accumulate(self.db());
+            }
+
             // Only check if the declared row is closed (no rest variable)
             if resolved_declared.rest(self.db()).is_none() {
                 let resolved_body = row_subst.apply(self.db(), body_effect_row);

--- a/tests/diagnostic_snapshots.rs
+++ b/tests/diagnostic_snapshots.rs
@@ -245,6 +245,26 @@ fn test() ->{Foo} Nat {
 }
 
 #[salsa_test]
+fn diag_duplicate_effect_in_annotation(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+fn test() ->{State(Int), State(Int)} Nil {
+    Nil
+}
+"#,
+    );
+    let result = compile_with_diagnostics(db, source);
+    assert!(!result.diagnostics.is_empty());
+    insta::assert_yaml_snapshot!(result.diagnostics);
+}
+
+#[salsa_test]
 fn diag_missing_handler_arm(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,

--- a/tests/snapshots/diagnostic_snapshots__diag_duplicate_effect_in_annotation.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_duplicate_effect_in_annotation.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostic_snapshots.rs
+expression: result.diagnostics
+---
+- message: "function 'test' declares duplicate effect: State(Int), State(Int)"
+  span:
+    start: 41
+    end: 93
+  severity: Error
+  phase: TypeChecking


### PR DESCRIPTION
## Summary
- detect duplicate effects in explicit function effect annotations
- add a diagnostic snapshot for duplicate State(Int) entries

## Notes
- This covers one #721 failure mode with a minimal change.
- Other #721 cases, such as parameterized ability ambiguity and row-unification message cleanup, remain follow-up work.

## Validation
- cargo nextest run --test diagnostic_snapshots
- cargo nextest run -p tribute-front typeck::checker::func_check::tests::collect_deferred_resolution_univars_includes_callee_type
- pre-commit hook: clippy, markdownlint, and 1460 nextest tests passed

Refs #721


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The compiler now detects and reports duplicate or conflicting effect annotations in function signatures.
  * Improved diagnostics when an effect list contains the same effect more than once.

* **Tests**
  * Added coverage to verify the new duplicate-effect diagnostic output matches the expected snapshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->