### PR TITLE
Improve effect diagnostics across type checking and pipeline validation

### DIFF
--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -11,9 +11,11 @@ use trunk_ir::Symbol;
 
 use crate::ast::{
     AbilityId, Arm, BinOpKind, Effect, EffectRow, Expr, ExprKind, FieldPattern, HandlerArm,
-    HandlerKind, LiteralPattern, Pattern, PatternKind, ResolvedRef, Stmt, Type, TypeKind, TypedRef,
+    HandlerKind, LiteralPattern, NodeId, Pattern, PatternKind, ResolvedRef, Stmt, Type, TypeKind,
+    TypedRef,
 };
 
+use super::super::constraint::ConstraintOriginKind;
 use super::super::func_context::FunctionInferenceContext;
 use super::super::subst;
 use super::{Mode, TypeChecker};
@@ -103,7 +105,7 @@ impl<'db> TypeChecker<'db> {
                     .iter()
                     .map(|a| self.infer_expr_type_with_ctx(ctx, a))
                     .collect();
-                self.infer_call_with_ctx(ctx, callee_ty, &arg_types)
+                self.infer_call_with_ctx(ctx, callee_ty, &arg_types, expr.id)
             }
             ExprKind::Cons { ctor, args } => {
                 let ctor_ty = self.infer_var_with_ctx(ctx, ctor);
@@ -116,7 +118,7 @@ impl<'db> TypeChecker<'db> {
                         .iter()
                         .map(|a| self.infer_expr_type_with_ctx(ctx, a))
                         .collect();
-                    self.infer_call_with_ctx(ctx, ctor_ty, &arg_types)
+                    self.infer_call_with_ctx(ctx, ctor_ty, &arg_types, expr.id)
                 }
             }
             ExprKind::Record {
@@ -323,7 +325,12 @@ impl<'db> TypeChecker<'db> {
                     // Constrain the inferred effect (fresh_effect after body checking)
                     // to match the expected effect. This ensures UniVars in the body's
                     // types that reference fresh_effect get properly resolved.
-                    ctx.constrain_row_eq(inferred_effect, expected);
+                    ctx.constrain_row_eq_at(
+                        inferred_effect,
+                        expected,
+                        expr.id,
+                        ConstraintOriginKind::Lambda,
+                    );
                     expected
                 } else {
                     inferred_effect
@@ -388,7 +395,12 @@ impl<'db> TypeChecker<'db> {
                 // with the enclosing function's effect. Use constraint instead of
                 // merge to avoid creating spurious variable linkages that lead to
                 // RowMismatch when the solver chains substitutions.
-                ctx.constrain_row_eq(result_effect, effect_before_body);
+                ctx.constrain_row_eq_at(
+                    effect_before_body,
+                    result_effect,
+                    expr.id,
+                    ConstraintOriginKind::HandlerBoundary,
+                );
                 ctx.set_current_effect(effect_before_body);
 
                 body_ty
@@ -494,7 +506,7 @@ impl<'db> TypeChecker<'db> {
                     .iter()
                     .map(|a| self.infer_expr_type_with_ctx(ctx, a))
                     .collect();
-                self.infer_call_with_ctx(ctx, callee_ty, &arg_types)
+                self.infer_call_with_ctx(ctx, callee_ty, &arg_types, expr.id)
             }
             ExprKind::Cons { ctor, args } => {
                 let ctor_ty = self.infer_var_with_ctx(ctx, ctor);
@@ -507,7 +519,7 @@ impl<'db> TypeChecker<'db> {
                         .iter()
                         .map(|a| self.infer_expr_type_with_ctx(ctx, a))
                         .collect();
-                    self.infer_call_with_ctx(ctx, ctor_ty, &arg_types)
+                    self.infer_call_with_ctx(ctx, ctor_ty, &arg_types, expr.id)
                 }
             }
             ExprKind::Block { stmts, value } => {
@@ -705,6 +717,7 @@ impl<'db> TypeChecker<'db> {
         ctx: &mut FunctionInferenceContext<'_, 'db>,
         callee_ty: Type<'db>,
         arg_types: &[Type<'db>],
+        origin: NodeId,
     ) -> Type<'db> {
         // Create expected type - could be either a function or continuation type.
         // We create fresh type variables and let unification determine the actual type.
@@ -745,18 +758,33 @@ impl<'db> TypeChecker<'db> {
                 // effect row is already the handler body's effect row (assigned in
                 // convert_handler_arm_with_ctx), so it's already accounted for in the
                 // enclosing handle expression's effect propagation.
-                ctx.constrain_eq(callee_ty, expected_cont_ty);
-                ctx.constrain_eq(cont_arg_ty, arg_types[0]);
+                ctx.constrain_eq_at(
+                    callee_ty,
+                    expected_cont_ty,
+                    origin,
+                    ConstraintOriginKind::Call,
+                );
+                ctx.constrain_eq_at(
+                    cont_arg_ty,
+                    arg_types[0],
+                    origin,
+                    ConstraintOriginKind::Call,
+                );
                 return cont_result_ty;
             } else {
                 // Callee is a UniVar, concrete function type, or other - use function semantics
                 // This handles cases like higher-order functions with unknown callees
-                ctx.constrain_eq(callee_ty, expected_func_ty);
+                ctx.constrain_eq_at(
+                    callee_ty,
+                    expected_func_ty,
+                    origin,
+                    ConstraintOriginKind::Call,
+                );
                 for (param_ty, arg_ty) in param_types.iter().zip(arg_types.iter()) {
-                    ctx.constrain_eq(*param_ty, *arg_ty);
+                    ctx.constrain_eq_at(*param_ty, *arg_ty, origin, ConstraintOriginKind::Call);
                 }
 
-                ctx.merge_effect(self.resolve_callee_effect(callee_ty, callee_effect));
+                ctx.merge_effect_at(self.resolve_callee_effect(callee_ty, callee_effect), origin);
 
                 return result_ty;
             }
@@ -765,14 +793,19 @@ impl<'db> TypeChecker<'db> {
         // Multiple arguments (or zero): must be a function call
         let callee_effect = ctx.fresh_effect_row();
         let expected_func_ty = ctx.func_type(param_types.clone(), result_ty, callee_effect);
-        ctx.constrain_eq(callee_ty, expected_func_ty);
+        ctx.constrain_eq_at(
+            callee_ty,
+            expected_func_ty,
+            origin,
+            ConstraintOriginKind::Call,
+        );
 
         // Constrain argument types
         for (param_ty, arg_ty) in param_types.iter().zip(arg_types.iter()) {
-            ctx.constrain_eq(*param_ty, *arg_ty);
+            ctx.constrain_eq_at(*param_ty, *arg_ty, origin, ConstraintOriginKind::Call);
         }
 
-        ctx.merge_effect(self.resolve_callee_effect(callee_ty, callee_effect));
+        ctx.merge_effect_at(self.resolve_callee_effect(callee_ty, callee_effect), origin);
 
         result_ty
     }

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -15,10 +15,10 @@ use crate::ast::{
     PatternKind, ResolvedRef, Stmt, Type, TypeKind, TypeScheme, TypedRef, UniVarId,
 };
 
-use super::super::constraint::ConstraintSet;
+use super::super::constraint::{ConstraintOriginKind, ConstraintSet};
 use super::super::effect_row::find_conflicting_effects;
 use super::super::func_context::FunctionInferenceContext;
-use super::super::solver::{RowSubst, TypeSolver, TypeSubst};
+use super::super::solver::{LocatedSolveError, RowSubst, TypeSolver, TypeSubst};
 use super::{Mode, TypeChecker};
 
 impl<'db> TypeChecker<'db> {
@@ -45,6 +45,9 @@ impl<'db> TypeChecker<'db> {
         // Get the instantiated function type (with UniVars) for later generalization
         let (param_types, expected_return, instantiated_func_ty) =
             self.get_func_signature_with_type(&mut ctx, func_id, &func);
+        let diagnostic_func_id = func.id;
+        let diagnostic_func_name = func.name;
+        let diagnostic_effects = func.effects.clone();
 
         // Bind parameters: by LocalId when present, and also by name
         for (i, param) in func.params.iter().enumerate() {
@@ -83,15 +86,13 @@ impl<'db> TypeChecker<'db> {
 
         let mut solver = TypeSolver::new(self.db());
 
-        if let Err(error) = solver.solve(constraints) {
-            let span = self.get_span(func.id);
-            Diagnostic::new(
-                format!("type error in function '{}': {}", func.name, error),
-                span,
-                DiagnosticSeverity::Error,
-                CompilationPhase::TypeChecking,
-            )
-            .accumulate(self.db());
+        if let Err(error) = solver.solve_with_origin(constraints) {
+            self.report_solve_error(
+                diagnostic_func_id,
+                diagnostic_func_name,
+                diagnostic_effects.as_deref(),
+                error,
+            );
         }
 
         // 4b. Post-solve: resolve deferred method calls
@@ -256,6 +257,52 @@ impl<'db> TypeChecker<'db> {
             effects: func.effects,
             body,
         }
+    }
+
+    fn report_solve_error(
+        &self,
+        func_id: crate::ast::NodeId,
+        func_name: trunk_ir::Symbol,
+        effects: Option<&[crate::ast::TypeAnnotation]>,
+        failure: LocatedSolveError<'db>,
+    ) {
+        let primary_node = failure
+            .origin
+            .map(|origin| origin.node_id)
+            .unwrap_or(func_id);
+        let context = match failure.origin.map(|origin| origin.kind) {
+            Some(ConstraintOriginKind::Call) => " at call site",
+            Some(ConstraintOriginKind::Lambda) => " in lambda",
+            Some(ConstraintOriginKind::HandlerBoundary) => " at handler boundary",
+            Some(ConstraintOriginKind::Expression) | None => "",
+        };
+        let mut diagnostic = Diagnostic::builder(
+            format!(
+                "type error{context} in function '{}': {}",
+                func_name, failure.error
+            ),
+            self.get_span(primary_node),
+            DiagnosticSeverity::Error,
+            CompilationPhase::TypeChecking,
+        );
+
+        let is_effect_error = matches!(
+            &failure.error,
+            super::super::solver::SolveError::RowMismatch { .. }
+                | super::super::solver::SolveError::EffectArgArityMismatch { .. }
+        );
+        if is_effect_error && primary_node != func_id {
+            let related_node = effects
+                .and_then(|effects| effects.first())
+                .map(|annotation| annotation.id)
+                .unwrap_or(func_id);
+            diagnostic = diagnostic.label(
+                self.get_span(related_node),
+                "enclosing function effect contract is declared here",
+            );
+        }
+
+        diagnostic.build().accumulate(self.db());
     }
 
     /// Resolve deferred method calls after constraint solving.

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -379,16 +379,10 @@ impl<'db> TypeChecker<'db> {
             }
 
             if new_constraints.is_empty() {
-                // Emit diagnostics for methods that remain unresolved
-                for mc in &remaining {
-                    Diagnostic::new(
-                        format!("unresolved UFCS method '{}'", mc.method),
-                        self.get_span(mc.node_id),
-                        DiagnosticSeverity::Error,
-                        CompilationPhase::TypeChecking,
-                    )
-                    .accumulate(self.db());
-                }
+                // These calls may become resolvable after the surrounding
+                // function's types have propagated through TDNR. Keep them in
+                // the AST for that pass; any calls still unresolved afterward
+                // are diagnosed at the frontend boundary.
                 break;
             }
             if let Err(error) = solver.solve(new_constraints) {

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -21,6 +21,15 @@ use super::super::func_context::FunctionInferenceContext;
 use super::super::solver::{LocatedSolveError, RowSubst, TypeSolver, TypeSubst};
 use super::{Mode, TypeChecker};
 
+fn solve_error_context(kind: Option<ConstraintOriginKind>) -> &'static str {
+    match kind {
+        Some(ConstraintOriginKind::Call) => " at call site",
+        Some(ConstraintOriginKind::Lambda) => " in lambda",
+        Some(ConstraintOriginKind::HandlerBoundary) => " at handler boundary",
+        Some(ConstraintOriginKind::Expression) | None => "",
+    }
+}
+
 impl<'db> TypeChecker<'db> {
     /// Type check a function declaration with per-function inference.
     ///
@@ -270,12 +279,7 @@ impl<'db> TypeChecker<'db> {
             .origin
             .map(|origin| origin.node_id)
             .unwrap_or(func_id);
-        let context = match failure.origin.map(|origin| origin.kind) {
-            Some(ConstraintOriginKind::Call) => " at call site",
-            Some(ConstraintOriginKind::Lambda) => " in lambda",
-            Some(ConstraintOriginKind::HandlerBoundary) => " at handler boundary",
-            Some(ConstraintOriginKind::Expression) | None => "",
-        };
+        let context = solve_error_context(failure.origin.map(|origin| origin.kind));
         let mut diagnostic = Diagnostic::builder(
             format!(
                 "type error{context} in function '{}': {}",
@@ -1199,6 +1203,28 @@ mod tests {
 
     use crate::ast::{EffectRow, NodeId, SpanMap, Type, TypeKind};
     use crate::typeck::{TypeChecker, TypeSolver};
+
+    use super::{ConstraintOriginKind, solve_error_context};
+
+    #[test]
+    fn solve_error_context_describes_each_origin() {
+        assert_eq!(
+            [
+                solve_error_context(Some(ConstraintOriginKind::Call)),
+                solve_error_context(Some(ConstraintOriginKind::Lambda)),
+                solve_error_context(Some(ConstraintOriginKind::HandlerBoundary)),
+                solve_error_context(Some(ConstraintOriginKind::Expression)),
+                solve_error_context(None),
+            ],
+            [
+                " at call site",
+                " in lambda",
+                " at handler boundary",
+                "",
+                ""
+            ]
+        );
+    }
 
     #[salsa_test]
     fn collect_deferred_resolution_univars_includes_callee_type(db: &salsa::DatabaseImpl) {

--- a/crates/tribute-front/src/typeck/constraint.rs
+++ b/crates/tribute-front/src/typeck/constraint.rs
@@ -8,7 +8,28 @@
 //!     | C₁ ∧ C₂           -- conjunction
 //! ```
 
-use crate::ast::{EffectRow, Type};
+use crate::ast::{EffectRow, NodeId, Type};
+
+/// Source location and semantic role for a generated constraint.
+///
+/// The solver operates on normalized types and rows, so without this metadata
+/// it can only report an error against the enclosing function.  Keeping the
+/// originating AST node lets the diagnostic layer point back to the call,
+/// lambda, or handler boundary that introduced the failed constraint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConstraintOrigin {
+    pub node_id: NodeId,
+    pub kind: ConstraintOriginKind,
+}
+
+/// The source construct that introduced a constraint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConstraintOriginKind {
+    Expression,
+    Call,
+    Lambda,
+    HandlerBoundary,
+}
 
 /// A type inference constraint.
 #[derive(Clone, Debug)]
@@ -18,6 +39,12 @@ pub enum Constraint<'db> {
 
     /// Effect row equality: ρ₁ = ρ₂
     RowEq(EffectRow<'db>, EffectRow<'db>),
+
+    /// Type equality with a source origin.
+    TypeEqAt(Type<'db>, Type<'db>, ConstraintOrigin),
+
+    /// Effect row equality with a source origin.
+    RowEqAt(EffectRow<'db>, EffectRow<'db>, ConstraintOrigin),
 
     /// Conjunction of constraints.
     And(Vec<Constraint<'db>>),
@@ -32,6 +59,16 @@ impl<'db> Constraint<'db> {
     /// Create a row equality constraint.
     pub fn row_eq(r1: EffectRow<'db>, r2: EffectRow<'db>) -> Self {
         Self::RowEq(r1, r2)
+    }
+
+    /// Create a source-originated type equality constraint.
+    pub fn type_eq_at(t1: Type<'db>, t2: Type<'db>, origin: ConstraintOrigin) -> Self {
+        Self::TypeEqAt(t1, t2, origin)
+    }
+
+    /// Create a source-originated row equality constraint.
+    pub fn row_eq_at(r1: EffectRow<'db>, r2: EffectRow<'db>, origin: ConstraintOrigin) -> Self {
+        Self::RowEqAt(r1, r2, origin)
     }
 
     /// Create a conjunction of constraints.
@@ -75,6 +112,21 @@ impl<'db> ConstraintSet<'db> {
     /// Add a row equality constraint.
     pub fn add_row_eq(&mut self, r1: EffectRow<'db>, r2: EffectRow<'db>) {
         self.add(Constraint::row_eq(r1, r2));
+    }
+
+    /// Add a source-originated type equality constraint.
+    pub fn add_type_eq_at(&mut self, t1: Type<'db>, t2: Type<'db>, origin: ConstraintOrigin) {
+        self.add(Constraint::type_eq_at(t1, t2, origin));
+    }
+
+    /// Add a source-originated effect row equality constraint.
+    pub fn add_row_eq_at(
+        &mut self,
+        r1: EffectRow<'db>,
+        r2: EffectRow<'db>,
+        origin: ConstraintOrigin,
+    ) {
+        self.add(Constraint::row_eq_at(r1, r2, origin));
     }
 
     /// Extend with constraints from another set.

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -339,18 +339,129 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
 
     /// Instantiate a type scheme with fresh type variables.
     ///
-    /// Replaces each `BoundVar { index: i }` with a fresh `UniVar`.
+    /// Replaces each `BoundVar { index: i }` with a fresh `UniVar`, and each
+    /// free effect-row variable with a fresh row variable. Repeated occurrences
+    /// of the same row variable remain shared within one instantiation.
     pub fn instantiate_scheme(&mut self, scheme: TypeScheme<'db>) -> Type<'db> {
         let params = scheme.type_params(self.db);
-        if params.is_empty() {
-            return scheme.body(self.db);
+        let instantiated = if params.is_empty() {
+            scheme.body(self.db)
+        } else {
+            // Generate fresh variables for each parameter
+            let fresh_vars: Vec<Type<'db>> =
+                (0..params.len()).map(|_| self.fresh_type_var()).collect();
+
+            // Substitute bound variables with fresh variables
+            self.substitute_bound_vars(scheme.body(self.db), &fresh_vars)
+        };
+
+        let mut row_vars = HashMap::new();
+        self.freshen_effect_vars_in_type(instantiated, &mut row_vars)
+    }
+
+    fn freshen_effect_vars_in_type(
+        &mut self,
+        ty: Type<'db>,
+        row_vars: &mut HashMap<u64, EffectVar>,
+    ) -> Type<'db> {
+        let freshen_row =
+            |ctx: &mut Self, row: EffectRow<'db>, row_vars: &mut HashMap<u64, EffectVar>| {
+                let effects: Vec<Effect<'db>> = row
+                    .effects(ctx.db)
+                    .iter()
+                    .map(|effect| Effect {
+                        ability_id: effect.ability_id,
+                        args: effect
+                            .args
+                            .iter()
+                            .map(|arg| ctx.freshen_effect_vars_in_type(*arg, row_vars))
+                            .collect(),
+                    })
+                    .collect();
+                let rest = row.rest(ctx.db).map(|var| {
+                    if let Some(fresh) = row_vars.get(&var.id) {
+                        *fresh
+                    } else {
+                        let fresh = ctx.fresh_row_var();
+                        row_vars.insert(var.id, fresh);
+                        fresh
+                    }
+                });
+                EffectRow::new(ctx.db, effects, rest)
+            };
+
+        match ty.kind(self.db) {
+            TypeKind::Named { name, args } => {
+                let args = args
+                    .iter()
+                    .map(|arg| self.freshen_effect_vars_in_type(*arg, row_vars))
+                    .collect();
+                Type::new(self.db, TypeKind::Named { name: *name, args })
+            }
+            TypeKind::Func {
+                params,
+                result,
+                effect,
+            } => {
+                let params = params
+                    .iter()
+                    .map(|param| self.freshen_effect_vars_in_type(*param, row_vars))
+                    .collect();
+                let result = self.freshen_effect_vars_in_type(*result, row_vars);
+                let effect = freshen_row(self, *effect, row_vars);
+                Type::new(
+                    self.db,
+                    TypeKind::Func {
+                        params,
+                        result,
+                        effect,
+                    },
+                )
+            }
+            TypeKind::Tuple(elements) => {
+                let elements = elements
+                    .iter()
+                    .map(|element| self.freshen_effect_vars_in_type(*element, row_vars))
+                    .collect();
+                Type::new(self.db, TypeKind::Tuple(elements))
+            }
+            TypeKind::App { ctor, args } => {
+                let ctor = self.freshen_effect_vars_in_type(*ctor, row_vars);
+                let args = args
+                    .iter()
+                    .map(|arg| self.freshen_effect_vars_in_type(*arg, row_vars))
+                    .collect();
+                Type::new(self.db, TypeKind::App { ctor, args })
+            }
+            TypeKind::Continuation {
+                arg,
+                result,
+                effect,
+            } => {
+                let arg = self.freshen_effect_vars_in_type(*arg, row_vars);
+                let result = self.freshen_effect_vars_in_type(*result, row_vars);
+                let effect = freshen_row(self, *effect, row_vars);
+                Type::new(
+                    self.db,
+                    TypeKind::Continuation {
+                        arg,
+                        result,
+                        effect,
+                    },
+                )
+            }
+            TypeKind::BoundVar { .. }
+            | TypeKind::UniVar { .. }
+            | TypeKind::Int
+            | TypeKind::Nat
+            | TypeKind::Float
+            | TypeKind::Bool
+            | TypeKind::Bytes
+            | TypeKind::Rune
+            | TypeKind::Nil
+            | TypeKind::Never
+            | TypeKind::Error => ty,
         }
-
-        // Generate fresh variables for each parameter
-        let fresh_vars: Vec<Type<'db>> = (0..params.len()).map(|_| self.fresh_type_var()).collect();
-
-        // Substitute bound variables with fresh variables
-        self.substitute_bound_vars(scheme.body(self.db), &fresh_vars)
     }
 
     /// Substitute bound variables with given types.
@@ -708,6 +819,59 @@ mod tests {
             test_instantiate_scheme_inner(db),
             "Each instantiation should produce fresh type variables"
         );
+    }
+
+    #[salsa_test]
+    fn test_instantiate_scheme_freshens_shared_effect_row_vars(db: &dyn salsa::Database) {
+        fn extract_rows<'db>(
+            db: &'db dyn salsa::Database,
+            ty: Type<'db>,
+        ) -> (EffectRow<'db>, EffectRow<'db>) {
+            let TypeKind::Func { params, effect, .. } = ty.kind(db) else {
+                panic!("expected outer function type");
+            };
+            let TypeKind::Func {
+                effect: callback_effect,
+                ..
+            } = params[0].kind(db)
+            else {
+                panic!("expected callback function type");
+            };
+            (*effect, *callback_effect)
+        }
+
+        let env = ModuleTypeEnv::new(db);
+        let func_id = FuncDefId::new(db, Symbol::new("test_func"));
+        let mut ctx = FunctionInferenceContext::new(db, &env, func_id);
+
+        let shared = EffectRow::open(db, EffectVar { id: 0 });
+        let nil = Type::new(db, TypeKind::Nil);
+        let callback = Type::new(
+            db,
+            TypeKind::Func {
+                params: vec![],
+                result: nil,
+                effect: shared,
+            },
+        );
+        let outer = Type::new(
+            db,
+            TypeKind::Func {
+                params: vec![callback],
+                result: nil,
+                effect: shared,
+            },
+        );
+        let scheme = TypeScheme::new(db, vec![], outer);
+
+        let first = ctx.instantiate_scheme(scheme);
+        let second = ctx.instantiate_scheme(scheme);
+
+        let (first_outer, first_callback) = extract_rows(db, first);
+        let (second_outer, second_callback) = extract_rows(db, second);
+        assert_eq!(first_outer.rest(db), first_callback.rest(db));
+        assert_eq!(second_outer.rest(db), second_callback.rest(db));
+        assert_ne!(first_outer.rest(db), second_outer.rest(db));
     }
 
     #[salsa_test]

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -1100,6 +1100,7 @@ mod tests {
 mod merge_effect_tests {
     use super::*;
     use crate::ast::AbilityId;
+    use crate::typeck::constraint::Constraint;
     use crate::typeck::effect_row::simple_effect;
     use salsa_test_macros::salsa_test;
 
@@ -1208,6 +1209,54 @@ mod merge_effect_tests {
         let effects = result.effects(db);
         assert_eq!(effects.len(), 1);
         assert!(effects.contains(&console));
+    }
+
+    #[salsa_test]
+    fn merge_parameterized_effects_adds_unlocated_constraints(db: &dyn salsa::Database) {
+        let env = ModuleTypeEnv::new(db);
+        let func_id = FuncDefId::new(db, Symbol::new("test"));
+        let ability_id = test_ability_id(db, "State");
+
+        let mut ctx = FunctionInferenceContext::new(db, &env, func_id);
+        ctx.set_current_effect(EffectRow::single(
+            db,
+            Effect {
+                ability_id,
+                args: vec![ctx.int_type()],
+            },
+        ));
+        ctx.merge_effect(EffectRow::single(
+            db,
+            Effect {
+                ability_id,
+                args: vec![ctx.bool_type()],
+            },
+        ));
+        assert_eq!(ctx.current_effect().effects(db).len(), 1);
+        assert!(matches!(
+            ctx.take_constraints().into_constraints().as_slice(),
+            [Constraint::TypeEq(_, _)]
+        ));
+
+        let mut ctx = FunctionInferenceContext::new(db, &env, func_id);
+        ctx.set_current_effect(EffectRow::single(
+            db,
+            Effect {
+                ability_id,
+                args: vec![ctx.int_type()],
+            },
+        ));
+        ctx.merge_effect(EffectRow::single(
+            db,
+            Effect {
+                ability_id,
+                args: vec![],
+            },
+        ));
+        assert!(matches!(
+            ctx.take_constraints().into_constraints().as_slice(),
+            [Constraint::RowEq(_, _)]
+        ));
     }
 
     #[salsa_test]

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -18,7 +18,7 @@ use crate::ast::{
     UniVarId, UniVarSource,
 };
 
-use super::constraint::ConstraintSet;
+use super::constraint::{ConstraintOrigin, ConstraintOriginKind, ConstraintSet};
 use super::context::ModuleTypeEnv;
 use super::subst;
 
@@ -485,9 +485,33 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         self.constraints.add_type_eq(t1, t2);
     }
 
+    /// Add a type equality constraint tied to a source AST node.
+    pub fn constrain_eq_at(
+        &mut self,
+        t1: Type<'db>,
+        t2: Type<'db>,
+        node_id: NodeId,
+        kind: ConstraintOriginKind,
+    ) {
+        self.constraints
+            .add_type_eq_at(t1, t2, ConstraintOrigin { node_id, kind });
+    }
+
     /// Add an effect row equality constraint.
     pub fn constrain_row_eq(&mut self, r1: EffectRow<'db>, r2: EffectRow<'db>) {
         self.constraints.add_row_eq(r1, r2);
+    }
+
+    /// Add an effect row equality constraint tied to a source AST node.
+    pub fn constrain_row_eq_at(
+        &mut self,
+        r1: EffectRow<'db>,
+        r2: EffectRow<'db>,
+        node_id: NodeId,
+        kind: ConstraintOriginKind,
+    ) {
+        self.constraints
+            .add_row_eq_at(r1, r2, ConstraintOrigin { node_id, kind });
     }
 
     /// Constrain that inferred_effect is subsumed by expected_effect.
@@ -544,6 +568,15 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     ///   - `e1 = {B | e3}`
     ///   - `e2 = {A | e3}`
     pub fn merge_effect(&mut self, effect: EffectRow<'db>) {
+        self.merge_effect_with_origin(effect, None);
+    }
+
+    /// Merge an effect and tie any resulting type/arity constraint to a call.
+    pub fn merge_effect_at(&mut self, effect: EffectRow<'db>, node_id: NodeId) {
+        self.merge_effect_with_origin(effect, Some(node_id));
+    }
+
+    fn merge_effect_with_origin(&mut self, effect: EffectRow<'db>, origin: Option<NodeId>) {
         let db = self.db;
         let current = self.current_effect;
 
@@ -566,17 +599,33 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
                     // Check if there's already an effect with the same ability_id
                     if let Some(existing) = result.iter().find(|r| r.ability_id == e.ability_id) {
                         // Same ability: unify type args instead of adding duplicate
-                        debug_assert_eq!(
-                            existing.args.len(),
-                            e.args.len(),
-                            "ability {:?} arity mismatch: existing has {} args, incoming has {}",
-                            e.ability_id,
-                            existing.args.len(),
-                            e.args.len()
-                        );
+                        if existing.args.len() != e.args.len() {
+                            let existing_row = EffectRow::single(db, existing.clone());
+                            let incoming_row = EffectRow::single(db, e.clone());
+                            if let Some(node_id) = origin {
+                                ctx.constrain_row_eq_at(
+                                    incoming_row,
+                                    existing_row,
+                                    node_id,
+                                    ConstraintOriginKind::Call,
+                                );
+                            } else {
+                                ctx.constrain_row_eq(incoming_row, existing_row);
+                            }
+                            continue;
+                        }
                         for (existing_arg, incoming_arg) in existing.args.iter().zip(e.args.iter())
                         {
-                            ctx.constrain_eq(*existing_arg, *incoming_arg);
+                            if let Some(node_id) = origin {
+                                ctx.constrain_eq_at(
+                                    *existing_arg,
+                                    *incoming_arg,
+                                    node_id,
+                                    ConstraintOriginKind::Call,
+                                );
+                            } else {
+                                ctx.constrain_eq(*existing_arg, *incoming_arg);
+                            }
                         }
                         // Don't add the effect since it's already present (with unified args)
                     } else {

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -924,6 +924,49 @@ mod tests {
     }
 
     #[salsa_test]
+    fn test_instantiate_scheme_freshens_rows_in_app_and_continuation(db: &dyn salsa::Database) {
+        fn continuation_effect<'db>(db: &'db dyn salsa::Database, ty: Type<'db>) -> EffectRow<'db> {
+            let TypeKind::Continuation { effect, .. } = ty.kind(db) else {
+                panic!("expected continuation type");
+            };
+            *effect
+        }
+
+        let env = ModuleTypeEnv::new(db);
+        let func_id = FuncDefId::new(db, Symbol::new("test_func"));
+        let mut ctx = FunctionInferenceContext::new(db, &env, func_id);
+
+        let shared = EffectRow::open(db, EffectVar { id: 0 });
+        let nil = Type::new(db, TypeKind::Nil);
+        let continuation = Type::new(
+            db,
+            TypeKind::Continuation {
+                arg: nil,
+                result: nil,
+                effect: shared,
+            },
+        );
+        let app = Type::new(
+            db,
+            TypeKind::App {
+                ctor: continuation,
+                args: vec![continuation],
+            },
+        );
+        let scheme = TypeScheme::new(db, vec![], app);
+
+        let instantiated = ctx.instantiate_scheme(scheme);
+        let TypeKind::App { ctor, args } = instantiated.kind(db) else {
+            panic!("expected application type");
+        };
+        let ctor_effect = continuation_effect(db, *ctor);
+        let arg_effect = continuation_effect(db, args[0]);
+
+        assert_eq!(ctor_effect.rest(db), arg_effect.rest(db));
+        assert_ne!(ctor_effect.rest(db), shared.rest(db));
+    }
+
+    #[salsa_test]
     fn test_local_binding(db: &dyn salsa::Database) {
         let env = ModuleTypeEnv::new(db);
         let test_func_id = FuncDefId::new(db, Symbol::new("test_func"));

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -4,12 +4,11 @@
 
 use std::collections::HashMap;
 
-use itertools::Itertools;
 use trunk_ir::smallvec::SmallVec;
 
 use crate::ast::{Effect, EffectRow, EffectVar, Type, TypeKind, TypeParam, UniVarId, UniVarSource};
 
-use super::constraint::{Constraint, ConstraintSet};
+use super::constraint::{Constraint, ConstraintOrigin, ConstraintSet};
 
 /// Apply a type-transforming function to all effect type arguments in an effect row.
 ///
@@ -62,6 +61,28 @@ pub enum SolveError<'db> {
     },
 }
 
+/// A solver error together with the source construct that introduced the
+/// failing constraint, when one was recorded by the checker.
+#[derive(Clone, Debug)]
+pub struct LocatedSolveError<'db> {
+    pub error: SolveError<'db>,
+    pub origin: Option<ConstraintOrigin>,
+}
+
+/// Format an effect row using stable, source-oriented syntax.
+///
+/// Internal row-variable IDs are intentionally hidden.  Open rows use the
+/// generic source-level tail name `e`, and concrete effects are sorted so the
+/// message does not depend on insertion or hash-map iteration order.
+pub fn format_effect_row(db: &dyn salsa::Database, row: EffectRow<'_>) -> String {
+    let mut items: Vec<String> = row.effects(db).iter().map(ToString::to_string).collect();
+    items.sort();
+    if row.rest(db).is_some() {
+        items.push("e".to_string());
+    }
+    format!("{{{}}}", items.join(", "))
+}
+
 impl std::fmt::Display for SolveError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -76,19 +97,11 @@ impl std::fmt::Display for SolveError<'_> {
                 )
             }
             Self::RowMismatch { expected, actual } => salsa::with_attached_database(|db| {
-                let fmt_row = |row: &EffectRow<'_>| -> String {
-                    let effects = row.effects(db);
-                    if effects.is_empty() {
-                        "{{}}".to_string()
-                    } else {
-                        format!("{{{}}}", effects.iter().format(", "))
-                    }
-                };
                 write!(
                     f,
                     "effect mismatch: expected `{}`, found `{}`",
-                    fmt_row(expected),
-                    fmt_row(actual)
+                    format_effect_row(db, *expected),
+                    format_effect_row(db, *actual)
                 )
             })
             .unwrap_or(Err(std::fmt::Error)),
@@ -625,10 +638,19 @@ impl<'db> TypeSolver<'db> {
     /// variables as possible are resolved.  Returns the first error (if any)
     /// after all constraints have been attempted.
     pub fn solve(&mut self, constraints: ConstraintSet<'db>) -> Result<(), SolveError<'db>> {
+        self.solve_with_origin(constraints)
+            .map_err(|error| error.error)
+    }
+
+    /// Solve constraints while retaining the source origin of the first error.
+    pub fn solve_with_origin(
+        &mut self,
+        constraints: ConstraintSet<'db>,
+    ) -> Result<(), LocatedSolveError<'db>> {
         let constraints_vec = constraints.into_constraints();
-        let mut first_error: Option<SolveError<'db>> = None;
+        let mut first_error: Option<LocatedSolveError<'db>> = None;
         for constraint in constraints_vec.into_iter() {
-            if let Err(e) = self.solve_constraint(constraint) {
+            if let Err(e) = self.solve_constraint_with_origin(constraint) {
                 first_error.get_or_insert(e);
             }
         }
@@ -638,15 +660,40 @@ impl<'db> TypeSolver<'db> {
         }
     }
 
-    /// Solve a single constraint.
-    fn solve_constraint(&mut self, constraint: Constraint<'db>) -> Result<(), SolveError<'db>> {
+    /// Solve a single constraint while preserving any attached source origin.
+    fn solve_constraint_with_origin(
+        &mut self,
+        constraint: Constraint<'db>,
+    ) -> Result<(), LocatedSolveError<'db>> {
         match constraint {
-            Constraint::TypeEq(t1, t2) => self.unify_types(t1, t2),
-            Constraint::RowEq(r1, r2) => self.unify_rows(r1, r2),
+            Constraint::TypeEq(t1, t2) => {
+                self.unify_types(t1, t2).map_err(|error| LocatedSolveError {
+                    error,
+                    origin: None,
+                })
+            }
+            Constraint::RowEq(r1, r2) => {
+                self.unify_rows(r1, r2).map_err(|error| LocatedSolveError {
+                    error,
+                    origin: None,
+                })
+            }
+            Constraint::TypeEqAt(t1, t2, origin) => {
+                self.unify_types(t1, t2).map_err(|error| LocatedSolveError {
+                    error,
+                    origin: Some(origin),
+                })
+            }
+            Constraint::RowEqAt(r1, r2, origin) => {
+                self.unify_rows(r1, r2).map_err(|error| LocatedSolveError {
+                    error,
+                    origin: Some(origin),
+                })
+            }
             Constraint::And(cs) => {
-                let mut first_error: Option<SolveError<'db>> = None;
+                let mut first_error: Option<LocatedSolveError<'db>> = None;
                 for c in cs {
-                    if let Err(e) = self.solve_constraint(c) {
+                    if let Err(e) = self.solve_constraint_with_origin(c) {
                         first_error.get_or_insert(e);
                     }
                 }

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -15,7 +15,7 @@ use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{PassError, PassManager};
-use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
+use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, Module, PatternApplicator, TypeConverter,
     WasmFuncSignatureConversionPattern,
@@ -313,7 +313,6 @@ fn is_type(ctx: &IrContext, ty: TypeRef, dialect: &'static str, name: &'static s
 struct MainExports {
     saw_main: bool,
     main_result_type: Option<TypeRef>,
-    original_result_type: Option<TypeRef>,
     main_exported: bool,
 }
 
@@ -322,7 +321,6 @@ impl MainExports {
         Self {
             saw_main: false,
             main_result_type: None,
-            original_result_type: None,
             main_exported: false,
         }
     }
@@ -466,22 +464,6 @@ impl<'a> WasmLowerer<'a> {
                 self.main_exports.main_result_type = Some(result_ty);
             }
         }
-
-        // Read original_result_type attribute if present
-        if let Some(Attribute::Type(original_ty)) =
-            data.attributes.get(&Symbol::new("original_result_type"))
-        {
-            self.main_exports.original_result_type = Some(*original_ty);
-        }
-    }
-
-    /// Size of the runtime print buffer used by `_start` for itoa + fd_write.
-    const PRINT_BUF_TOTAL: u32 = 32;
-
-    /// Base offset for `_start`'s runtime print buffer in linear memory.
-    fn start_buf_base(&self) -> u32 {
-        let end = self.const_analysis.total_size() + self.intrinsic_analysis.total_size;
-        (end + 3) & !3
     }
 
     /// Insert preamble ops (imports, memory, globals) before existing module ops.
@@ -494,8 +476,8 @@ impl<'a> WasmLowerer<'a> {
     ) {
         let mut preamble_ops: Vec<OpRef> = Vec::new();
 
-        // Emit fd_write import if intrinsics need it OR if main exists (_start needs it)
-        if self.intrinsic_analysis.needs_fd_write || self.main_exports.saw_main {
+        // Emit fd_write only when an explicit intrinsic needs it.
+        if self.intrinsic_analysis.needs_fd_write {
             let i32_ty = intern_type(ctx, "core", "i32");
             let import_ty = intern_func_type(ctx, vec![i32_ty, i32_ty, i32_ty, i32_ty], i32_ty);
             let op = wasm_dialect::import_func(
@@ -512,17 +494,12 @@ impl<'a> WasmLowerer<'a> {
         // Check if memory is needed
         let const_size = self.const_analysis.total_size();
         let intrinsic_size = self.intrinsic_analysis.total_size;
-        let start_buf_size = if self.main_exports.saw_main {
-            Self::PRINT_BUF_TOTAL
-        } else {
-            0
-        };
-        if const_size > 0 || intrinsic_size > 0 || start_buf_size > 0 {
+        if const_size > 0 || intrinsic_size > 0 {
             self.memory_plan.needs_memory = true;
         }
 
         if self.memory_plan.needs_memory && !self.memory_plan.has_memory {
-            let total_data_size = const_size + intrinsic_size + start_buf_size;
+            let total_data_size = const_size + intrinsic_size;
             let required_pages = self.memory_plan.required_pages(total_data_size);
             let op = wasm_dialect::memory(ctx, location, required_pages, 0, false, false);
             preamble_ops.push(op.op_ref());
@@ -697,22 +674,6 @@ impl<'a> WasmLowerer<'a> {
         nil_ty: TypeRef,
     ) {
         let step_ty = type_converter::step_adt_type(ctx);
-        let anyref_ty = intern_type(ctx, "wasm", "anyref");
-
-        let orig_ty = self.main_exports.original_result_type;
-        let is_int_like = orig_ty
-            .map(|ty| {
-                is_type(ctx, ty, "tribute_rt", "int")
-                    || is_type(ctx, ty, "tribute_rt", "nat")
-                    || is_type(ctx, ty, "core", "i32")
-            })
-            .unwrap_or(false);
-        let is_nat = orig_ty
-            .map(|ty| is_type(ctx, ty, "tribute_rt", "nat"))
-            .unwrap_or(false);
-        let returns_nil = orig_ty
-            .map(|ty| is_type(ctx, ty, "core", "nil"))
-            .unwrap_or(false);
 
         // Call main — returns Step
         let call_main =
@@ -739,37 +700,6 @@ impl<'a> WasmLowerer<'a> {
             ops: smallvec![],
             parent_region: None,
         });
-
-        if !returns_nil {
-            // Extract value field (field 1) from Step
-            let get_value =
-                wasm_dialect::struct_get(ctx, location, step_result, anyref_ty, STEP_IDX, 1);
-            ctx.push_op(then_block, get_value.op_ref());
-            let value_val = get_value.result(ctx);
-
-            if is_int_like {
-                // Unbox to i32 and print
-                let i31ref_ty = intern_type(ctx, "wasm", "i31ref");
-                let cast =
-                    wasm_dialect::ref_cast(ctx, location, value_val, i31ref_ty, i31ref_ty, None);
-                ctx.push_op(then_block, cast.op_ref());
-
-                let unbox_val = if is_nat {
-                    let get_u = wasm_dialect::i31_get_u(ctx, location, cast.result(ctx), i32_ty);
-                    ctx.push_op(then_block, get_u.op_ref());
-                    get_u.result(ctx)
-                } else {
-                    let get_s = wasm_dialect::i31_get_s(ctx, location, cast.result(ctx), i32_ty);
-                    ctx.push_op(then_block, get_s.op_ref());
-                    get_s.result(ctx)
-                };
-                self.build_print_i32_body(ctx, then_block, location, unbox_val);
-            } else {
-                // Drop the anyref value
-                let drop_op = wasm_dialect::drop(ctx, location, value_val);
-                ctx.push_op(then_block, drop_op.op_ref());
-            }
-        }
 
         let ret_then = wasm_dialect::r#return(ctx, location, vec![]);
         ctx.push_op(then_block, ret_then.op_ref());
@@ -802,387 +732,20 @@ impl<'a> WasmLowerer<'a> {
         ctx.push_op(body_block, trap_end.op_ref());
     }
 
-    /// Build _start body for main NOT returning Step.
+    /// Build `_start` for a pure `main`, whose source-level result is always Nil.
     fn build_start_simple_body(
         &self,
         ctx: &mut IrContext,
         body_block: BlockRef,
         location: Location,
         _i32_ty: TypeRef,
-        nil_ty: TypeRef,
+        _nil_ty: TypeRef,
     ) {
-        let result_ty = self
-            .main_exports
-            .main_result_type
-            .filter(|&ty| ty != nil_ty);
-        let result_types: Vec<TypeRef> = result_ty.into_iter().collect();
-        let is_i32 = result_ty
-            .map(|ty| is_type(ctx, ty, "core", "i32"))
-            .unwrap_or(false);
-
-        let call = wasm_dialect::call(ctx, location, vec![], result_types, Symbol::new("main"));
+        let call = wasm_dialect::call(ctx, location, vec![], vec![], Symbol::new("main"));
         ctx.push_op(body_block, call.op_ref());
-
-        if is_i32 {
-            let result_val = call.results(ctx)[0];
-            self.build_print_i32_body(ctx, body_block, location, result_val);
-        } else if result_ty.is_some() {
-            let result_val = call.results(ctx)[0];
-            let drop_op = wasm_dialect::drop(ctx, location, result_val);
-            ctx.push_op(body_block, drop_op.op_ref());
-        }
 
         let ret = wasm_dialect::r#return(ctx, location, vec![]);
         ctx.push_op(body_block, ret.op_ref());
-    }
-
-    /// Build IR operations to print an i32 value as decimal to stdout via fd_write.
-    fn build_print_i32_body(
-        &self,
-        ctx: &mut IrContext,
-        block: BlockRef,
-        location: Location,
-        result_val: ValueRef,
-    ) {
-        let i32_ty = intern_type(ctx, "core", "i32");
-        let nil_ty = intern_type(ctx, "core", "nil");
-
-        // Memory layout offsets
-        let buf_base = self.start_buf_base();
-        let scratch_rem = buf_base;
-        let scratch_pos = buf_base + 4;
-        let buf_end = buf_base + 8 + 11;
-        let iovec_off = buf_base + 20;
-        let nwr_off = buf_base + 28;
-
-        let align_i32: u32 = 2;
-        let align_i8: u32 = 0;
-
-        // === Step 1: Handle sign — compute absolute value ===
-        let zero = wasm_dialect::i32_const(ctx, location, i32_ty, 0);
-        ctx.push_op(block, zero.op_ref());
-        let zero_val = zero.result(ctx);
-
-        let is_neg = wasm_dialect::i32_lt_s(ctx, location, result_val, zero_val, i32_ty);
-        ctx.push_op(block, is_neg.op_ref());
-        let is_neg_val = is_neg.result(ctx);
-
-        // if (result < 0) then (0 - result) else result → abs_value
-        let then_abs_block = ctx.create_block(BlockData {
-            location,
-            args: vec![],
-            ops: smallvec![],
-            parent_region: None,
-        });
-        let neg = wasm_dialect::i32_sub(ctx, location, zero_val, result_val, i32_ty);
-        ctx.push_op(then_abs_block, neg.op_ref());
-        let yield_neg = wasm_dialect::r#yield(ctx, location, neg.result(ctx));
-        ctx.push_op(then_abs_block, yield_neg.op_ref());
-
-        let else_abs_block = ctx.create_block(BlockData {
-            location,
-            args: vec![],
-            ops: smallvec![],
-            parent_region: None,
-        });
-        let yield_pos = wasm_dialect::r#yield(ctx, location, result_val);
-        ctx.push_op(else_abs_block, yield_pos.op_ref());
-
-        let then_abs_region = ctx.create_region(RegionData {
-            location,
-            blocks: smallvec![then_abs_block],
-            parent_op: None,
-        });
-        let else_abs_region = ctx.create_region(RegionData {
-            location,
-            blocks: smallvec![else_abs_block],
-            parent_op: None,
-        });
-        let if_abs = wasm_dialect::r#if(
-            ctx,
-            location,
-            is_neg_val,
-            i32_ty,
-            then_abs_region,
-            else_abs_region,
-        );
-        ctx.push_op(block, if_abs.op_ref());
-        let abs_value = if_abs.result(ctx);
-
-        // === Step 2: Initialize scratch memory ===
-        let rem_addr = wasm_dialect::i32_const(ctx, location, i32_ty, scratch_rem as i32);
-        ctx.push_op(block, rem_addr.op_ref());
-        let store_rem = wasm_dialect::i32_store(
-            ctx,
-            location,
-            rem_addr.result(ctx),
-            abs_value,
-            0,
-            align_i32,
-            0,
-        );
-        ctx.push_op(block, store_rem.op_ref());
-
-        let pos_addr_c = wasm_dialect::i32_const(ctx, location, i32_ty, scratch_pos as i32);
-        ctx.push_op(block, pos_addr_c.op_ref());
-        let buf_end_c = wasm_dialect::i32_const(ctx, location, i32_ty, buf_end as i32);
-        ctx.push_op(block, buf_end_c.op_ref());
-        let store_pos = wasm_dialect::i32_store(
-            ctx,
-            location,
-            pos_addr_c.result(ctx),
-            buf_end_c.result(ctx),
-            0,
-            align_i32,
-            0,
-        );
-        ctx.push_op(block, store_pos.op_ref());
-
-        // === Step 3: Do-while digit extraction loop ===
-        let loop_body_block = ctx.create_block(BlockData {
-            location,
-            args: vec![],
-            ops: smallvec![],
-            parent_region: None,
-        });
-        {
-            let b = loop_body_block;
-
-            let rem_addr_l = wasm_dialect::i32_const(ctx, location, i32_ty, scratch_rem as i32);
-            ctx.push_op(b, rem_addr_l.op_ref());
-            let rem = wasm_dialect::i32_load(
-                ctx,
-                location,
-                rem_addr_l.result(ctx),
-                i32_ty,
-                0,
-                align_i32,
-                0,
-            );
-            ctx.push_op(b, rem.op_ref());
-
-            let pos_addr_l = wasm_dialect::i32_const(ctx, location, i32_ty, scratch_pos as i32);
-            ctx.push_op(b, pos_addr_l.op_ref());
-            let pos = wasm_dialect::i32_load(
-                ctx,
-                location,
-                pos_addr_l.result(ctx),
-                i32_ty,
-                0,
-                align_i32,
-                0,
-            );
-            ctx.push_op(b, pos.op_ref());
-
-            let ten = wasm_dialect::i32_const(ctx, location, i32_ty, 10);
-            ctx.push_op(b, ten.op_ref());
-            let digit =
-                wasm_dialect::i32_rem_u(ctx, location, rem.result(ctx), ten.result(ctx), i32_ty);
-            ctx.push_op(b, digit.op_ref());
-            let next =
-                wasm_dialect::i32_div_u(ctx, location, rem.result(ctx), ten.result(ctx), i32_ty);
-            ctx.push_op(b, next.op_ref());
-
-            let ascii_0 = wasm_dialect::i32_const(ctx, location, i32_ty, 48);
-            ctx.push_op(b, ascii_0.op_ref());
-            let ascii = wasm_dialect::i32_add(
-                ctx,
-                location,
-                digit.result(ctx),
-                ascii_0.result(ctx),
-                i32_ty,
-            );
-            ctx.push_op(b, ascii.op_ref());
-            let store8 = wasm_dialect::i32_store8(
-                ctx,
-                location,
-                pos.result(ctx),
-                ascii.result(ctx),
-                0,
-                align_i8,
-                0,
-            );
-            ctx.push_op(b, store8.op_ref());
-
-            let rem_addr_s = wasm_dialect::i32_const(ctx, location, i32_ty, scratch_rem as i32);
-            ctx.push_op(b, rem_addr_s.op_ref());
-            let store_next = wasm_dialect::i32_store(
-                ctx,
-                location,
-                rem_addr_s.result(ctx),
-                next.result(ctx),
-                0,
-                align_i32,
-                0,
-            );
-            ctx.push_op(b, store_next.op_ref());
-
-            let one = wasm_dialect::i32_const(ctx, location, i32_ty, 1);
-            ctx.push_op(b, one.op_ref());
-            let new_pos =
-                wasm_dialect::i32_sub(ctx, location, pos.result(ctx), one.result(ctx), i32_ty);
-            ctx.push_op(b, new_pos.op_ref());
-            let pos_addr_s = wasm_dialect::i32_const(ctx, location, i32_ty, scratch_pos as i32);
-            ctx.push_op(b, pos_addr_s.op_ref());
-            let store_pos2 = wasm_dialect::i32_store(
-                ctx,
-                location,
-                pos_addr_s.result(ctx),
-                new_pos.result(ctx),
-                0,
-                align_i32,
-                0,
-            );
-            ctx.push_op(b, store_pos2.op_ref());
-
-            let br_if = wasm_dialect::br_if(ctx, location, next.result(ctx), 0);
-            ctx.push_op(b, br_if.op_ref());
-        }
-
-        let loop_body_region = ctx.create_region(RegionData {
-            location,
-            blocks: smallvec![loop_body_block],
-            parent_op: None,
-        });
-        let loop_op = wasm_dialect::r#loop(ctx, location, vec![], nil_ty, loop_body_region);
-        ctx.push_op(block, loop_op.op_ref());
-
-        // === Step 4: Read final position ===
-        let final_pos_addr = wasm_dialect::i32_const(ctx, location, i32_ty, scratch_pos as i32);
-        ctx.push_op(block, final_pos_addr.op_ref());
-        let final_pos = wasm_dialect::i32_load(
-            ctx,
-            location,
-            final_pos_addr.result(ctx),
-            i32_ty,
-            0,
-            align_i32,
-            0,
-        );
-        ctx.push_op(block, final_pos.op_ref());
-
-        // === Step 5: Handle negative sign prefix ===
-        let then_sign_block = ctx.create_block(BlockData {
-            location,
-            args: vec![],
-            ops: smallvec![],
-            parent_region: None,
-        });
-        {
-            let minus = wasm_dialect::i32_const(ctx, location, i32_ty, 45); // '-'
-            ctx.push_op(then_sign_block, minus.op_ref());
-            let store_sign = wasm_dialect::i32_store8(
-                ctx,
-                location,
-                final_pos.result(ctx),
-                minus.result(ctx),
-                0,
-                align_i8,
-                0,
-            );
-            ctx.push_op(then_sign_block, store_sign.op_ref());
-            let yield_sign = wasm_dialect::r#yield(ctx, location, final_pos.result(ctx));
-            ctx.push_op(then_sign_block, yield_sign.op_ref());
-        }
-
-        let else_sign_block = ctx.create_block(BlockData {
-            location,
-            args: vec![],
-            ops: smallvec![],
-            parent_region: None,
-        });
-        {
-            let one = wasm_dialect::i32_const(ctx, location, i32_ty, 1);
-            ctx.push_op(else_sign_block, one.op_ref());
-            let start = wasm_dialect::i32_add(
-                ctx,
-                location,
-                final_pos.result(ctx),
-                one.result(ctx),
-                i32_ty,
-            );
-            ctx.push_op(else_sign_block, start.op_ref());
-            let yield_start = wasm_dialect::r#yield(ctx, location, start.result(ctx));
-            ctx.push_op(else_sign_block, yield_start.op_ref());
-        }
-
-        let then_sign_region = ctx.create_region(RegionData {
-            location,
-            blocks: smallvec![then_sign_block],
-            parent_op: None,
-        });
-        let else_sign_region = ctx.create_region(RegionData {
-            location,
-            blocks: smallvec![else_sign_block],
-            parent_op: None,
-        });
-        let if_sign = wasm_dialect::r#if(
-            ctx,
-            location,
-            is_neg_val,
-            i32_ty,
-            then_sign_region,
-            else_sign_region,
-        );
-        ctx.push_op(block, if_sign.op_ref());
-        let start_ptr = if_sign.result(ctx);
-
-        // === Step 6: Calculate string length ===
-        let buf_end_plus1 = wasm_dialect::i32_const(ctx, location, i32_ty, (buf_end + 1) as i32);
-        ctx.push_op(block, buf_end_plus1.op_ref());
-        let len =
-            wasm_dialect::i32_sub(ctx, location, buf_end_plus1.result(ctx), start_ptr, i32_ty);
-        ctx.push_op(block, len.op_ref());
-
-        // === Step 7: Set up iovec and call fd_write ===
-        let iovec_addr = wasm_dialect::i32_const(ctx, location, i32_ty, iovec_off as i32);
-        ctx.push_op(block, iovec_addr.op_ref());
-        let store_iovec_ptr = wasm_dialect::i32_store(
-            ctx,
-            location,
-            iovec_addr.result(ctx),
-            start_ptr,
-            0,
-            align_i32,
-            0,
-        );
-        ctx.push_op(block, store_iovec_ptr.op_ref());
-
-        let iovec_len_addr = wasm_dialect::i32_const(ctx, location, i32_ty, (iovec_off + 4) as i32);
-        ctx.push_op(block, iovec_len_addr.op_ref());
-        let store_iovec_len = wasm_dialect::i32_store(
-            ctx,
-            location,
-            iovec_len_addr.result(ctx),
-            len.result(ctx),
-            0,
-            align_i32,
-            0,
-        );
-        ctx.push_op(block, store_iovec_len.op_ref());
-
-        let stdout = wasm_dialect::i32_const(ctx, location, i32_ty, 1);
-        ctx.push_op(block, stdout.op_ref());
-        let iovs_count = wasm_dialect::i32_const(ctx, location, i32_ty, 1);
-        ctx.push_op(block, iovs_count.op_ref());
-        let nwr_addr = wasm_dialect::i32_const(ctx, location, i32_ty, nwr_off as i32);
-        ctx.push_op(block, nwr_addr.op_ref());
-
-        let fd_result = wasm_dialect::call(
-            ctx,
-            location,
-            vec![
-                stdout.result(ctx),
-                iovec_addr.result(ctx),
-                iovs_count.result(ctx),
-                nwr_addr.result(ctx),
-            ],
-            vec![i32_ty],
-            Symbol::new("fd_write"),
-        );
-        ctx.push_op(block, fd_result.op_ref());
-        let drop_fd = wasm_dialect::drop(ctx, location, fd_result.results(ctx)[0]);
-        ctx.push_op(block, drop_fd.op_ref());
     }
 }
 
@@ -1199,8 +762,10 @@ fn is_step_adt(ctx: &IrContext, ty: TypeRef) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trunk_ir::Span;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
+    use trunk_ir::refs::PathRef;
     use trunk_ir::rewrite::LegalityCheck;
 
     fn lower_text(ir: &str) -> String {
@@ -1208,6 +773,93 @@ mod tests {
         let module = parse_test_module(&mut ctx, ir);
         lower_to_wasm(&mut ctx, module).expect("test module should lower to wasm");
         print_module(&ctx, module.op())
+    }
+
+    #[test]
+    fn module_lowerer_emits_explicit_intrinsic_and_data_requirements() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run() -> core.i32 {
+    %value = arith.const {value = 1} : core.i32
+    func.return %value
+  }
+}"#,
+        );
+        let const_analysis = ConstAnalysis {
+            string_allocations: vec![(b"text".to_vec(), 0, 4)],
+            bytes_allocations: vec![(vec![1, 2], 0, 2)],
+            string_total_size: 4,
+        };
+        let intrinsic_analysis = IntrinsicAnalysis {
+            needs_fd_write: true,
+            iovec_allocations: vec![(0, 4, 8)],
+            nwritten_offset: Some(16),
+            total_size: 20,
+        };
+        let mut lowerer = WasmLowerer::new(&const_analysis, &intrinsic_analysis);
+        let module_block = module.first_block(&ctx).expect("module body block");
+        let placeholder = ctx.block(module_block).ops[0];
+
+        lowerer.lower_module(&mut ctx, module);
+        trunk_ir::rewrite::erase_op(&mut ctx, placeholder);
+
+        let location = Location::new(PathRef::from_u32(0), Span::default());
+        let i32_ty = intern_type(&mut ctx, "core", "i32");
+        let i64_ty = intern_type(&mut ctx, "core", "i64");
+        let f32_ty = intern_type(&mut ctx, "core", "f32");
+        let f64_ty = intern_type(&mut ctx, "core", "f64");
+        let nil_ty = intern_type(&mut ctx, "core", "nil");
+        let body_block = ctx.create_block(BlockData {
+            location,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let address = wasm_dialect::i32_const(&mut ctx, location, i32_ty, 0);
+        let address_result = address.result(&ctx);
+        ctx.push_op(body_block, address.op_ref());
+        let i64_load = wasm_dialect::i64_load(&mut ctx, location, address_result, i64_ty, 0, 0, 0);
+        let f32_load = wasm_dialect::f32_load(&mut ctx, location, address_result, f32_ty, 0, 0, 0);
+        let f64_load = wasm_dialect::f64_load(&mut ctx, location, address_result, f64_ty, 0, 0, 0);
+        let i64_result = i64_load.result(&ctx);
+        let f32_result = f32_load.result(&ctx);
+        let f64_result = f64_load.result(&ctx);
+        for load in [i64_load.op_ref(), f32_load.op_ref(), f64_load.op_ref()] {
+            ctx.push_op(body_block, load);
+        }
+        for store in [
+            wasm_dialect::i64_store(&mut ctx, location, address_result, i64_result, 0, 0, 0)
+                .op_ref(),
+            wasm_dialect::f32_store(&mut ctx, location, address_result, f32_result, 0, 0, 0)
+                .op_ref(),
+            wasm_dialect::f64_store(&mut ctx, location, address_result, f64_result, 0, 0, 0)
+                .op_ref(),
+        ] {
+            ctx.push_op(body_block, store);
+        }
+        let ret = wasm_dialect::r#return(&mut ctx, location, vec![]);
+        ctx.push_op(body_block, ret.op_ref());
+        let body = ctx.create_region(RegionData {
+            location,
+            blocks: smallvec![body_block],
+            parent_op: None,
+        });
+        let func_ty = intern_func_type(&mut ctx, vec![], nil_ty);
+        let memory_func =
+            wasm_dialect::func(&mut ctx, location, Symbol::new("memory_ops"), func_ty, body);
+        ctx.push_op(module_block, memory_func.op_ref());
+
+        let output = print_module(&ctx, module.op());
+        assert!(output.contains("wasm.import_func"), "{output}");
+        assert!(output.contains("wasm.memory"), "{output}");
+        assert!(output.contains("wasm.export_memory"), "{output}");
+        assert_eq!(output.matches("wasm.data").count(), 4, "{output}");
+
+        let binary = trunk_ir_wasm_backend::emit_module_to_wasm(&mut ctx, module)
+            .expect("lowered module requirements should emit");
+        assert_eq!(&binary.bytes[..4], b"\0asm");
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/memory_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/memory_handlers.rs
@@ -546,3 +546,61 @@ pub(crate) fn handle_i64_store32(
     function.instruction(&Instruction::I64Store32(memarg));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use trunk_ir::Span;
+    use trunk_ir::Symbol;
+    use trunk_ir::refs::PathRef;
+    use trunk_ir::types::{Location, TypeDataBuilder};
+    use wasm_encoder::ValType;
+
+    use super::*;
+
+    #[test]
+    fn memarg_uses_natural_alignment_for_zero_and_clamps_explicit_alignment() {
+        let natural = make_memarg(4, 0, 1, 2);
+        assert_eq!(natural.offset, 4);
+        assert_eq!(natural.align, 2);
+        assert_eq!(natural.memory_index, 1);
+
+        let clamped = make_memarg(8, 7, 0, 2);
+        assert_eq!(clamped.align, 2);
+    }
+
+    #[test]
+    fn i32_memory_handlers_emit_with_mapped_operands_and_result() {
+        let mut ctx = IrContext::new();
+        let location = Location::new(PathRef::from_u32(0), Span::default());
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let address = wasm_dialect::i32_const(&mut ctx, location, i32_ty, 0);
+        let value = wasm_dialect::i32_const(&mut ctx, location, i32_ty, 42);
+        let address_result = address.result(&ctx);
+        let value_result = value.result(&ctx);
+        let load = wasm_dialect::i32_load(&mut ctx, location, address_result, i32_ty, 4, 7, 0);
+        let store =
+            wasm_dialect::i32_store(&mut ctx, location, address_result, value_result, 8, 7, 0);
+        let store8 =
+            wasm_dialect::i32_store8(&mut ctx, location, address_result, value_result, 12, 7, 0);
+        let emit_ctx = FunctionEmitContext {
+            value_locals: HashMap::from([
+                (address_result, 0),
+                (value_result, 1),
+                (load.result(&ctx), 2),
+            ]),
+            effective_types: HashMap::new(),
+            func_return_type: None,
+        };
+        let module_info = ModuleInfo::default();
+        let mut function = Function::new([(3, ValType::I32)]);
+
+        for op in [load.op_ref(), store.op_ref(), store8.op_ref()] {
+            crate::emit::emit_op_nested(&ctx, op, &emit_ctx, &module_info, &mut function, &[])
+                .expect("memory operation should emit through the dispatcher");
+        }
+    }
+}

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -630,7 +630,18 @@ which runs under `PassManager::nest::<func.func>()`.
 them concrete and generalizes remaining polymorphic variables into stable
 `BoundVar` indices. Generalization covers the function signature, checked body,
 and post-solve deferred UFCS callee types so later TDNR and monomorphization do
-not see raw solver variables in typed references.
+not see raw solver variables in typed references. Each type-scheme
+instantiation freshens both bound type variables and free effect-row variables,
+while preserving repeated references to the same row variable within that
+single instantiation.
+
+Constraints produced from calls, lambdas, and handler boundaries retain their
+source origin through solving. User-facing failures render effect rows in
+canonical source syntax, hide internal row-variable identities, and attach the
+primary diagnostic to the originating expression with the enclosing effect
+contract as secondary context. A frontend error stops the pipeline before AST
+to IR conversion and shared lowering so invalid source does not produce
+cascading diagnostics containing internal IR operation identities.
 
 ### 점진적 개선 방향: Fine-Grained Queries
 

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -87,6 +87,16 @@ layout. `wasm/evidence_to_wasm` is the Wasm boundary that removes those
 operations by generating evidence lookup/extend helpers, unpacking closure
 structs `(table_idx, env)`, and emitting `wasm.call_indirect`.
 
+### Entrypoint contract
+
+The frontend accepts `main` only when its declared result is `Nil`. A frontend
+error is terminal, so the Wasm backend never receives a valid program whose
+`main` returns an `Int`, `Nat`, or another user value. The generated `_start`
+function therefore calls a pure `main` for its side effects and ignores the
+`Done` payload of an effectful `main`; printing program results belongs in
+explicit I/O operations such as `__print_line`, not in backend entrypoint
+lowering.
+
 ---
 
 ## WasmGC 타입 처리

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -76,10 +76,12 @@ pub fn report_diagnostics(
     db: &dyn salsa::Database,
     source: SourceCst,
     file_path: &str,
-    accumulated_diags: Vec<&Diagnostic>,
+    mut accumulated_diags: Vec<&Diagnostic>,
 ) {
     let source_text = source.text(db);
     if !accumulated_diags.is_empty() {
+        accumulated_diags
+            .sort_by(|left, right| tribute::pipeline::compare_diagnostics(left, right));
         for diag in &accumulated_diags {
             print_diagnostic(diag, source_text, file_path);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,18 +153,19 @@ fn compile_file(
                         let output =
                             output_path.unwrap_or_else(|| input_path.with_extension("wasm"));
 
-                        match std::fs::write(&output, &wasm_bytes) {
-                            Ok(_) => {
-                                println!(
-                                    "Successfully wrote WebAssembly binary to {}",
-                                    output.display()
-                                );
-                            }
-                            Err(e) => {
-                                eprintln!("Error writing output file {}: {}", output.display(), e);
-                                std::process::exit(1);
-                            }
+                        if let Err(error) = std::fs::write(&output, &wasm_bytes) {
+                            eprintln!(
+                                "Error writing output file {}: {}",
+                                output.display(),
+                                error
+                            );
+                            std::process::exit(1);
                         }
+
+                        println!(
+                            "Successfully wrote WebAssembly binary to {}",
+                            output.display()
+                        );
                     }
                     Err(diagnostics) => {
                         let file_path = input_path.display().to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,26 +148,29 @@ fn compile_file(
             "wasm" => {
                 println!("Compiling {} to WebAssembly...", input_path.display());
 
-                if let Some(wasm_bytes) = compile_to_wasm_binary(db, source) {
-                    let output = output_path.unwrap_or_else(|| input_path.with_extension("wasm"));
+                match compile_to_wasm_binary(db, source) {
+                    Ok(wasm_bytes) => {
+                        let output =
+                            output_path.unwrap_or_else(|| input_path.with_extension("wasm"));
 
-                    match std::fs::write(&output, &wasm_bytes) {
-                        Ok(_) => {
-                            println!(
-                                "Successfully wrote WebAssembly binary to {}",
-                                output.display()
-                            );
-                        }
-                        Err(e) => {
-                            eprintln!("Error writing output file {}: {}", output.display(), e);
-                            std::process::exit(1);
+                        match std::fs::write(&output, &wasm_bytes) {
+                            Ok(_) => {
+                                println!(
+                                    "Successfully wrote WebAssembly binary to {}",
+                                    output.display()
+                                );
+                            }
+                            Err(e) => {
+                                eprintln!("Error writing output file {}: {}", output.display(), e);
+                                std::process::exit(1);
+                            }
                         }
                     }
-                } else {
-                    let file_path = input_path.display().to_string();
-                    let diags = compile_to_wasm_binary::accumulated::<Diagnostic>(db, source);
-                    report_diagnostics(db, source, &file_path, diags);
-                    std::process::exit(1);
+                    Err(diagnostics) => {
+                        let file_path = input_path.display().to_string();
+                        report_diagnostics(db, source, &file_path, diagnostics);
+                        std::process::exit(1);
+                    }
                 }
             }
             "none" => {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -104,8 +104,7 @@ pub struct CompilationConfig {
 }
 
 // AST-based pipeline imports
-use tribute_front::ast::ResolvedRef;
-use tribute_front::ast::SpanMap;
+use tribute_front::ast::{Decl, Expr, ExprKind, ResolvedRef, SpanMap, Stmt, TypedRef};
 use tribute_front::ast_to_ir;
 use tribute_front::astgen::ParsedAst;
 use tribute_front::query as ast_query;
@@ -328,6 +327,12 @@ pub fn compile_frontend(
     source: SourceCst,
 ) -> Option<(IrContext, Module)> {
     let typed = parse_and_lower_ast(db, source)?;
+    let has_frontend_errors = parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
+        .iter()
+        .any(|diagnostic| diagnostic.inner.severity == DiagnosticSeverity::Error);
+    if has_frontend_errors {
+        return None;
+    }
     Some(merge_and_lower_to_ir(db, &typed, source))
 }
 
@@ -1000,6 +1005,7 @@ pub fn parse_and_lower_ast<'db>(
         result.module,
         prelude_module(db).iter().map(|p| p.module(db)),
     );
+    report_unresolved_methods(db, &tdnr_ast, &span_map);
 
     Some(ast_typeck::TypeCheckOutput::new(
         db,
@@ -1008,6 +1014,130 @@ pub fn parse_and_lower_ast<'db>(
         result.node_types,
         span_map,
     ))
+}
+
+/// Report method calls that remain unresolved after TDNR has had the final
+/// opportunity to use types propagated through the enclosing function.
+fn report_unresolved_methods<'db>(
+    db: &'db dyn salsa::Database,
+    module: &tribute_front::ast::Module<TypedRef<'db>>,
+    span_map: &SpanMap,
+) {
+    fn visit_decl<'db>(
+        db: &'db dyn salsa::Database,
+        decl: &Decl<TypedRef<'db>>,
+        span_map: &SpanMap,
+    ) {
+        match decl {
+            Decl::Function(function) => visit_expr(db, &function.body, span_map),
+            Decl::Module(module) => {
+                if let Some(body) = &module.body {
+                    for decl in body {
+                        visit_decl(db, decl, span_map);
+                    }
+                }
+            }
+            Decl::ExternFunction(_)
+            | Decl::Struct(_)
+            | Decl::Enum(_)
+            | Decl::Ability(_)
+            | Decl::Use(_) => {}
+        }
+    }
+
+    fn visit_expr<'db>(
+        db: &'db dyn salsa::Database,
+        expr: &Expr<TypedRef<'db>>,
+        span_map: &SpanMap,
+    ) {
+        match expr.kind.as_ref() {
+            ExprKind::MethodCall {
+                receiver,
+                method,
+                args,
+            } => {
+                Diagnostic::new(
+                    format!("unresolved method '{}' for this receiver type", method),
+                    span_map.get_or_default(expr.id),
+                    DiagnosticSeverity::Error,
+                    CompilationPhase::TypeChecking,
+                )
+                .accumulate(db);
+                visit_expr(db, receiver, span_map);
+                for arg in args {
+                    visit_expr(db, arg, span_map);
+                }
+            }
+            ExprKind::Call { callee, args } => {
+                visit_expr(db, callee, span_map);
+                for arg in args {
+                    visit_expr(db, arg, span_map);
+                }
+            }
+            ExprKind::Cons { args, .. } => {
+                for arg in args {
+                    visit_expr(db, arg, span_map);
+                }
+            }
+            ExprKind::Record { fields, spread, .. } => {
+                for (_, value) in fields {
+                    visit_expr(db, value, span_map);
+                }
+                if let Some(spread) = spread {
+                    visit_expr(db, spread, span_map);
+                }
+            }
+            ExprKind::Block { stmts, value } => {
+                for statement in stmts {
+                    match statement {
+                        Stmt::Let { value, .. } => visit_expr(db, value, span_map),
+                        Stmt::Expr { expr, .. } => visit_expr(db, expr, span_map),
+                    }
+                }
+                visit_expr(db, value, span_map);
+            }
+            ExprKind::Case { scrutinee, arms } => {
+                visit_expr(db, scrutinee, span_map);
+                for arm in arms {
+                    if let Some(guard) = &arm.guard {
+                        visit_expr(db, guard, span_map);
+                    }
+                    visit_expr(db, &arm.body, span_map);
+                }
+            }
+            ExprKind::Lambda { body, .. } => visit_expr(db, body, span_map),
+            ExprKind::Handle { body, handlers } => {
+                visit_expr(db, body, span_map);
+                for handler in handlers {
+                    visit_expr(db, &handler.body, span_map);
+                }
+            }
+            ExprKind::Resume { arg, .. } => visit_expr(db, arg, span_map),
+            ExprKind::Tuple(elements) | ExprKind::List(elements) => {
+                for element in elements {
+                    visit_expr(db, element, span_map);
+                }
+            }
+            ExprKind::BinOp { lhs, rhs, .. } => {
+                visit_expr(db, lhs, span_map);
+                visit_expr(db, rhs, span_map);
+            }
+            ExprKind::Var(_)
+            | ExprKind::NatLit(_)
+            | ExprKind::IntLit(_)
+            | ExprKind::FloatLit(_)
+            | ExprKind::StringLit(_)
+            | ExprKind::BytesLit(_)
+            | ExprKind::BoolLit(_)
+            | ExprKind::Nil
+            | ExprKind::RuneLit(_)
+            | ExprKind::Error => {}
+        }
+    }
+
+    for decl in &module.decls {
+        visit_decl(db, decl, span_map);
+    }
 }
 
 /// Run the shared pipeline for diagnostic collection only.
@@ -1045,10 +1175,12 @@ pub fn compile_with_diagnostics(db: &dyn salsa::Database, source: SourceCst) -> 
     compile_ast_tracked(db, source);
 
     // Collect all accumulated diagnostics from the compilation
-    let diagnostics: Vec<Diagnostic> = compile_ast_tracked::accumulated::<Diagnostic>(db, source)
-        .into_iter()
-        .cloned()
-        .collect();
+    let mut diagnostics: Vec<Diagnostic> =
+        compile_ast_tracked::accumulated::<Diagnostic>(db, source)
+            .into_iter()
+            .cloned()
+            .collect();
+    diagnostics.sort_by(compare_diagnostics);
 
     // Run the pipeline again for the actual result (Salsa memoizes, so this is cheap)
     let module = run_shared_pipeline(db, source).ok().flatten();
@@ -1057,6 +1189,30 @@ pub fn compile_with_diagnostics(db: &dyn salsa::Database, source: SourceCst) -> 
         module,
         diagnostics,
     }
+}
+
+/// Compare diagnostics using a stable user-facing order.
+///
+/// Compilation phase is primary, followed by source location and message as
+/// deterministic tie-breakers. This is also used by the CLI for target-specific
+/// accumulator results.
+pub fn compare_diagnostics(left: &Diagnostic, right: &Diagnostic) -> std::cmp::Ordering {
+    fn phase_rank(phase: &CompilationPhase) -> u8 {
+        match phase {
+            CompilationPhase::Parsing => 0,
+            CompilationPhase::AstGeneration => 1,
+            CompilationPhase::TirGeneration => 2,
+            CompilationPhase::NameResolution => 3,
+            CompilationPhase::TypeChecking => 4,
+            CompilationPhase::Lowering => 5,
+            CompilationPhase::Optimization => 6,
+        }
+    }
+
+    phase_rank(&left.phase)
+        .cmp(&phase_rank(&right.phase))
+        .then_with(|| left.inner.span.cmp(&right.inner.span))
+        .then_with(|| left.inner.message.cmp(&right.inner.message))
 }
 
 // =============================================================================
@@ -1186,7 +1342,7 @@ mod tests {
 
     #[salsa_test]
     fn test_full_pipeline(db: &salsa::DatabaseImpl) {
-        let source = source_from_str("test.trb", "fn compute() -> Int { 42 }\nfn main() { }");
+        let source = source_from_str("test.trb", "fn compute() -> Int { +42 }\nfn main() { }");
 
         let result = compile_ast(db, source).expect("pipeline should not fail");
         assert!(result.is_some(), "Should compile successfully");
@@ -1423,7 +1579,7 @@ mod tests {
 
     #[salsa_test]
     fn test_ast_pipeline_simple_function(db: &salsa::DatabaseImpl) {
-        let source = source_from_str("test.trb", "fn compute() -> Int { 42 }\nfn main() { }");
+        let source = source_from_str("test.trb", "fn compute() -> Int { +42 }\nfn main() { }");
 
         let result = compile_frontend(db, source);
         assert!(result.is_some());
@@ -1446,16 +1602,20 @@ mod tests {
         let source = source_from_str(
             "test.trb",
             r#"
-            fn main() -> Int {
-                let x = 10;
-                let y = 20;
-                x + y
+            fn main() {
+                let x = 10
+                let y = 20
+                let _ = x + y
             }
             "#,
         );
 
         let result = compile_frontend(db, source);
-        assert!(result.is_some());
+        assert!(
+            result.is_some(),
+            "{:?}",
+            parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
+        );
         let (ctx, m) = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
     }
@@ -1470,7 +1630,7 @@ mod tests {
                 y: Int,
             }
 
-            fn main() -> Int { 0 }
+            fn main() { }
             "#,
         );
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -731,11 +731,8 @@ pub fn compile_to_wasm_binary(
     db: &dyn salsa::Database,
     source: SourceCst,
 ) -> Result<Vec<u8>, Vec<&Diagnostic>> {
-    compile_to_wasm_binary_tracked(db, source).ok_or_else(|| {
-        let mut diagnostics = compile_to_wasm_binary_tracked::accumulated::<Diagnostic>(db, source);
-        diagnostics.sort_by(|left, right| compare_diagnostics(left, right));
-        diagnostics
-    })
+    compile_to_wasm_binary_tracked(db, source)
+        .ok_or_else(|| compile_to_wasm_binary_tracked::accumulated::<Diagnostic>(db, source))
 }
 
 // =============================================================================

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -682,14 +682,8 @@ pub fn dump_ir(
     Ok(trunk_ir::printer::print_module(&ctx, m.op()))
 }
 
-/// Compile to WebAssembly binary bytes.
-///
-/// Runs the full pipeline (frontend → shared passes → WASM lowering → emit)
-/// in a single arena session, avoiding Salsa↔Arena round-trips after ast_to_ir.
-///
-/// Returns the raw WASM bytes on success, or `None` with diagnostics accumulated.
 #[salsa::tracked]
-pub fn compile_to_wasm_binary(db: &dyn salsa::Database, source: SourceCst) -> Option<Vec<u8>> {
+fn compile_to_wasm_binary_tracked(db: &dyn salsa::Database, source: SourceCst) -> Option<Vec<u8>> {
     let (mut ctx, m) = match run_shared_pipeline(db, source) {
         Ok(Some(result)) => result,
         Ok(None) => return None,
@@ -725,6 +719,23 @@ pub fn compile_to_wasm_binary(db: &dyn salsa::Database, source: SourceCst) -> Op
             None
         }
     }
+}
+
+/// Compile to WebAssembly binary bytes.
+///
+/// Runs the full pipeline (frontend → shared passes → WASM lowering → emit)
+/// in a single arena session, avoiding Salsa↔Arena round-trips after ast_to_ir.
+///
+/// Returns the raw WASM bytes on success, or the accumulated diagnostics on failure.
+pub fn compile_to_wasm_binary(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+) -> Result<Vec<u8>, Vec<&Diagnostic>> {
+    compile_to_wasm_binary_tracked(db, source).ok_or_else(|| {
+        let mut diagnostics = compile_to_wasm_binary_tracked::accumulated::<Diagnostic>(db, source);
+        diagnostics.sort_by(|left, right| compare_diagnostics(left, right));
+        diagnostics
+    })
 }
 
 // =============================================================================

--- a/tests/diagnostic_snapshots.rs
+++ b/tests/diagnostic_snapshots.rs
@@ -101,6 +101,25 @@ fn test() -> Int {
 }
 
 #[salsa_test]
+fn diag_unresolved_method_after_tdnr(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+struct Thing { value: Nat }
+
+fn test(thing: Thing) -> Nat {
+    thing.missing()
+}
+"#,
+    );
+    let result = compile_with_diagnostics(db, source);
+    assert!(!result.diagnostics.is_empty());
+    assert!(result.module.is_none());
+    insta::assert_yaml_snapshot!(result.diagnostics);
+}
+
+#[salsa_test]
 fn diag_main_must_return_nil(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(db, "test.trb", "fn main() -> Int { 42 }");
     let result = compile_with_diagnostics(db, source);

--- a/tests/diagnostic_snapshots.rs
+++ b/tests/diagnostic_snapshots.rs
@@ -7,6 +7,7 @@
 
 mod common;
 
+use salsa::Database;
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::compile_with_diagnostics;
 use tribute_front::SourceCst;
@@ -265,6 +266,138 @@ fn test() ->{State(Int), State(Int)} Nil {
 }
 
 #[salsa_test]
+fn diag_residual_effect_rejected_at_handler_boundary(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Foo {
+    op foo() -> Nil
+}
+
+ability Bar {
+    op bar() -> Nil
+}
+
+fn comp() ->{Foo, Bar} Nil {
+    Foo::foo()
+    Bar::bar()
+}
+
+fn test() ->{Foo} Nil {
+    handle comp() {
+        do result { result }
+        op Foo::foo() { resume Nil }
+    }
+}
+"#,
+    );
+    let result = compile_with_diagnostics(db, source);
+    assert!(!result.diagnostics.is_empty());
+    insta::assert_yaml_snapshot!(result.diagnostics);
+}
+
+#[salsa_test]
+fn diag_row_unification_mismatch_at_lambda(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Foo {
+    op foo() -> Nat
+}
+
+ability Bar {
+    op bar() -> Nat
+}
+
+fn accept_foo(comp: fn() ->{Foo} Nat) ->{Foo} Nat {
+    comp()
+}
+
+fn test() ->{Foo} Nat {
+    accept_foo(fn() { Bar::bar() })
+}
+"#,
+    );
+    let result = compile_with_diagnostics(db, source);
+    assert!(!result.diagnostics.is_empty());
+    insta::assert_yaml_snapshot!(result.diagnostics);
+}
+
+#[salsa_test]
+fn valid_distinct_parameterized_effect_annotations(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    fn get() -> s
+}
+
+fn valid() ->{State(Int), State(Bool)} Nil {
+    Nil
+}
+"#,
+    );
+    let result = compile_with_diagnostics(db, source);
+    assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+}
+
+#[salsa_test]
+fn valid_residual_effect_propagates_through_handler(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Foo {
+    op foo() -> Nil
+}
+
+ability Bar {
+    op bar() -> Nil
+}
+
+fn comp() ->{Foo, Bar} Nil {
+    Foo::foo()
+    Bar::bar()
+}
+
+fn valid() ->{Bar} Nil {
+    handle comp() {
+        do result { result }
+        op Foo::foo() { resume Nil }
+    }
+}
+"#,
+    );
+    let result = compile_with_diagnostics(db, source);
+    assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+}
+
+#[test]
+fn effect_diagnostics_are_deterministic_across_fresh_databases() {
+    const SOURCE: &str = r#"
+ability State(s) {
+    fn get() -> s
+}
+
+fn test() ->{State(Int), State(Int)} Nil {
+    Nil
+}
+"#;
+
+    let compile = || {
+        salsa::DatabaseImpl::default().attach(|db| {
+            let source = SourceCst::from_source_str(db, "test.trb", SOURCE);
+            compile_with_diagnostics(db, source).diagnostics
+        })
+    };
+
+    assert_eq!(compile(), compile());
+}
+
+#[salsa_test]
 fn diag_missing_handler_arm(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,
@@ -324,8 +457,6 @@ fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
     insta::assert_yaml_snapshot!(result.diagnostics);
 }
 
-/// Panics in func_context.rs debug_assert instead of producing a diagnostic.
-#[ignore = "arity mismatch panics in effect row merging"]
 #[salsa_test]
 fn diag_effect_arg_arity_mismatch(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -70,7 +70,7 @@ fn test_state_set_then_get() {
 }
 
 fn set_then_get() ->{State(Int)} Int {
-    State::set(100)
+    State::set(+100)
     State::get()
 }
 
@@ -83,7 +83,7 @@ fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
 }
 
 fn main() {
-    let _ = run_state(fn() { set_then_get() }, 0)
+    let _ = run_state(fn() { set_then_get() }, +0)
 }
 "#;
     let output = compile_and_run_native("state_set_then_get.trb", code);
@@ -190,7 +190,7 @@ fn test_handler_direct_result() {
 }
 
 fn no_effects() ->{State(Int)} Int {
-    42
+    +42
 }
 
 fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
@@ -202,7 +202,7 @@ fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
 }
 
 fn main() {
-    let _ = run_state(fn() { no_effects() }, 0)
+    let _ = run_state(fn() { no_effects() }, +0)
 }
 "#;
     let output = compile_and_run_native("handler_direct_result.trb", code);

--- a/tests/e2e_float.rs
+++ b/tests/e2e_float.rs
@@ -192,8 +192,8 @@ fn main() {
     let a = 1.5
     let b = 1.5
     case a == b {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
 }
 "#,
@@ -210,8 +210,8 @@ fn main() {
     let a = 1.0
     let b = 2.0
     case a < b {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
 }
 "#,
@@ -228,8 +228,8 @@ fn main() {
     let a = 1.0
     let b = 2.0
     case a != b {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
 }
 "#,
@@ -246,8 +246,8 @@ fn main() {
     let a = 2.0
     let b = 1.0
     case a > b {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
 }
 "#,
@@ -264,8 +264,8 @@ fn main() {
     let a = 1.0
     let b = 2.0
     case a <= b {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
 }
 "#,
@@ -282,8 +282,8 @@ fn main() {
     let a = 2.0
     let b = 2.0
     case a >= b {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
 }
 "#,
@@ -301,28 +301,28 @@ fn main() {
     let x = 1.0
 
     case nan == x {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
     case nan != x {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
     case nan < x {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
     case nan <= x {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
     case nan > x {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
     case nan >= x {
-        True -> __tribute_print_int(1)
-        False -> __tribute_print_int(0)
+        True -> __tribute_print_int(+1)
+        False -> __tribute_print_int(+0)
     }
 }
 "#,

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -58,7 +58,7 @@ fn test_pure_toplevel_function_no_evidence() {
 fn apply(f: fn(Int) -> Int, x: Int) -> Int { f(x) }
 
 fn run() -> Int {
-    apply(fn(n) { n + 1 }, 41)
+    apply(fn(n) { n + +1 }, +41)
 }
 
 fn main() { }
@@ -97,7 +97,7 @@ ability State(s) {
 fn run_with_state(f: fn() ->{State(Int)} Int) -> Int {
     handle f() {
         do result { result }
-        fn State::get() { 42 }
+        fn State::get() { +42 }
         fn State::set(v) { Nil }
     }
 }
@@ -138,14 +138,14 @@ ability State(s) {
 
 fn counter() ->{State(Int)} Int {
     let n = State::get()
-    State::set(n + 1)
+    State::set(n + +1)
     n
 }
 
 fn run_with_state(f: fn() ->{State(Int)} Int) -> Int {
     handle f() {
         do result { result }
-        fn State::get() { 0 }
+        fn State::get() { +0 }
         fn State::set(v) { Nil }
     }
 }
@@ -197,7 +197,7 @@ ability State(s) {
 fn run_with_state(f: fn() ->{State(Int)} Int) -> Int {
     handle f() {
         do result { result }
-        fn State::get() { 42 }
+        fn State::get() { +42 }
     }
 }
 

--- a/tests/salsa_integration.rs
+++ b/tests/salsa_integration.rs
@@ -4,6 +4,7 @@ use salsa::{Database as _, Setter as _};
 use salsa_test_macros::salsa_test;
 use tree_sitter::Parser;
 use tribute::{SourceCst, TributeDatabaseImpl, compile_frontend};
+use tribute_passes::diagnostic::Diagnostic;
 use trunk_ir::Symbol;
 use trunk_ir::{IrContext, Module};
 
@@ -36,19 +37,23 @@ fn test_salsa_database_examples(db: &salsa::DatabaseImpl) {
             r#"fn main() { print_line("Hello, World!") }"#,
             vec!["main"],
         ),
-        ("calc.trb", r#"fn main() { 1 + 2 + 3 }"#, vec!["main"]),
+        (
+            "calc.trb",
+            r#"fn main() { let _ = 1 + 2 + 3 }"#,
+            vec!["main"],
+        ),
         (
             "complex.trb",
             r#"
-fn factorial(n) {
+fn factorial(n: Nat) -> Nat {
   case n {
-    0 { 1 }
-    _ { n * factorial(n - 1) }
+    0 -> 1
+    _ -> n * factorial(n - 1)
   }
 }
 
 fn main() {
-  factorial(5)
+  let _ = factorial(5)
 }
 "#,
             vec!["factorial", "main"],
@@ -62,7 +67,11 @@ fn main() {
             .expect("Failed to set language");
         let tree = parser.parse(source_code, None).expect("tree");
         let source_file = SourceCst::from_path(db, filename, source_code.into(), Some(tree));
-        let (ctx, module) = compile_frontend(db, source_file).expect("compilation should succeed");
+        let Some((ctx, module)) = compile_frontend(db, source_file) else {
+            let diagnostics =
+                tribute::pipeline::parse_and_lower_ast::accumulated::<Diagnostic>(db, source_file);
+            panic!("compilation should succeed: {diagnostics:?}");
+        };
 
         // Verify that expected user functions exist
         for func_name in expected_funcs {
@@ -84,7 +93,7 @@ fn test_salsa_incremental_computation_detailed() {
     parser
         .set_language(&tree_sitter_tribute::LANGUAGE.into())
         .expect("Failed to set language");
-    let text = "fn main() { 1 + 2 }";
+    let text = "fn main() { let _ = 1 + 2 }";
     let tree = parser.parse(text, None).expect("tree");
     let source_file = SourceCst::from_path(&db, "incremental.trb", text.into(), Some(tree));
 
@@ -96,7 +105,7 @@ fn test_salsa_incremental_computation_detailed() {
     );
 
     // Modify the source file
-    let updated_text = "fn main() { 1 + 2 + 3 + 4 }";
+    let updated_text = "fn main() { let _ = 1 + 2 + 3 + 4 }";
     let updated_tree = parser.parse(updated_text, None).expect("tree");
     source_file.set_text(&mut db).to(updated_text.into());
     source_file.set_tree(&mut db).to(Some(updated_tree));
@@ -163,7 +172,7 @@ fn test_salsa_database_isolation() {
         parser
             .set_language(&tree_sitter_tribute::LANGUAGE.into())
             .expect("Failed to set language");
-        let text = "fn main() { 1 + 2 }";
+        let text = "fn main() { let _ = 1 + 2 }";
         let tree = parser.parse(text, None).expect("tree");
         let source1 = SourceCst::from_path(db, "test1.trb", text.into(), Some(tree));
         let (ctx, module) = compile_frontend(db, source1).expect("compilation should succeed");
@@ -175,7 +184,7 @@ fn test_salsa_database_isolation() {
         parser
             .set_language(&tree_sitter_tribute::LANGUAGE.into())
             .expect("Failed to set language");
-        let text = "fn main() { 3 * 4 }";
+        let text = "fn main() { let _ = 3 * 4 }";
         let tree = parser.parse(text, None).expect("tree");
         let source2 = SourceCst::from_path(db, "test2.trb", text.into(), Some(tree));
         let (ctx, module) = compile_frontend(db, source2).expect("compilation should succeed");
@@ -189,7 +198,7 @@ fn test_salsa_database_isolation() {
 
 #[salsa_test]
 fn test_function_lowering(db: &salsa::DatabaseImpl) {
-    let source = "fn main() { 1 + 2 }";
+    let source = "fn main() { let _ = 1 + 2 }";
     let mut parser = Parser::new();
     parser
         .set_language(&tree_sitter_tribute::LANGUAGE.into())

--- a/tests/salsa_integration.rs
+++ b/tests/salsa_integration.rs
@@ -40,6 +40,11 @@ fn compile_frontend_with_diagnostics(
     })
 }
 
+fn expect_compilation_success(db: &dyn salsa::Database, source: SourceCst) -> (IrContext, Module) {
+    compile_frontend_with_diagnostics(db, source)
+        .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"))
+}
+
 #[salsa_test]
 fn test_salsa_database_examples(db: &salsa::DatabaseImpl) {
     // Example source code
@@ -79,8 +84,7 @@ fn main() {
             .expect("Failed to set language");
         let tree = parser.parse(source_code, None).expect("tree");
         let source_file = SourceCst::from_path(db, filename, source_code.into(), Some(tree));
-        let (ctx, module) = compile_frontend_with_diagnostics(db, source_file)
-            .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
+        let (ctx, module) = expect_compilation_success(db, source_file);
 
         // Verify that expected user functions exist
         for func_name in expected_funcs {
@@ -118,8 +122,7 @@ fn test_salsa_incremental_computation_detailed() {
     let source_file = SourceCst::from_path(&db, "incremental.trb", text.into(), Some(tree));
 
     // Initial lowering
-    let (ctx1, module1) = compile_frontend_with_diagnostics(&db, source_file)
-        .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
+    let (ctx1, module1) = expect_compilation_success(&db, source_file);
     assert!(
         find_func_by_name(&ctx1, &module1, "main"),
         "Should have main function"
@@ -132,20 +135,14 @@ fn test_salsa_incremental_computation_detailed() {
     source_file.set_tree(&mut db).to(Some(updated_tree));
 
     // Lower again - should recompute with updated source
-    let (ctx2, module2) =
-        compile_frontend_with_diagnostics(&db, source_file).unwrap_or_else(|diagnostics| {
-            panic!("compilation should succeed after update: {diagnostics:?}")
-        });
+    let (ctx2, module2) = expect_compilation_success(&db, source_file);
     assert!(
         find_func_by_name(&ctx2, &module2, "main"),
         "Should have main function after update"
     );
 
     // Lower again without changes - pipeline still works
-    let (ctx3, module3) =
-        compile_frontend_with_diagnostics(&db, source_file).unwrap_or_else(|diagnostics| {
-            panic!("compilation should succeed on re-run: {diagnostics:?}")
-        });
+    let (ctx3, module3) = expect_compilation_success(&db, source_file);
     assert!(
         find_func_by_name(&ctx3, &module3, "main"),
         "Should have main function on cached run"
@@ -172,8 +169,7 @@ fn main() { print_line("test") }
 "#;
     let tree = parser.parse(text, None).expect("tree");
     let source = SourceCst::from_path(db, "multi.trb", text.into(), Some(tree));
-    let (ctx, module) = compile_frontend_with_diagnostics(db, source)
-        .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
+    let (ctx, module) = expect_compilation_success(db, source);
 
     // Verify all user functions exist
     assert!(
@@ -201,8 +197,7 @@ fn test_salsa_database_isolation() {
         let text = "fn main() { let _ = 1 + 2 }";
         let tree = parser.parse(text, None).expect("tree");
         let source1 = SourceCst::from_path(db, "test1.trb", text.into(), Some(tree));
-        let (ctx, module) = compile_frontend_with_diagnostics(db, source1)
-            .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
+        let (ctx, module) = expect_compilation_success(db, source1);
         module.name(&ctx).map(|s| s.to_string())
     });
 
@@ -214,8 +209,7 @@ fn test_salsa_database_isolation() {
         let text = "fn main() { let _ = 3 * 4 }";
         let tree = parser.parse(text, None).expect("tree");
         let source2 = SourceCst::from_path(db, "test2.trb", text.into(), Some(tree));
-        let (ctx, module) = compile_frontend_with_diagnostics(db, source2)
-            .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
+        let (ctx, module) = expect_compilation_success(db, source2);
         module.name(&ctx).map(|s| s.to_string())
     });
 
@@ -233,8 +227,7 @@ fn test_function_lowering(db: &salsa::DatabaseImpl) {
         .expect("Failed to set language");
     let tree = parser.parse(source, None).expect("tree");
     let source_file = SourceCst::from_path(db, "func_test.trb", source.into(), Some(tree));
-    let (ctx, module) = compile_frontend_with_diagnostics(db, source_file)
-        .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
+    let (ctx, module) = expect_compilation_success(db, source_file);
 
     // Verify the main function exists
     assert!(

--- a/tests/salsa_integration.rs
+++ b/tests/salsa_integration.rs
@@ -28,6 +28,18 @@ fn find_func_by_name(ctx: &IrContext, module: &Module, name: &str) -> bool {
     })
 }
 
+fn compile_frontend_with_diagnostics(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+) -> Result<(IrContext, Module), Vec<Diagnostic>> {
+    compile_frontend(db, source).ok_or_else(|| {
+        tribute::pipeline::parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
+            .into_iter()
+            .cloned()
+            .collect()
+    })
+}
+
 #[salsa_test]
 fn test_salsa_database_examples(db: &salsa::DatabaseImpl) {
     // Example source code
@@ -67,11 +79,8 @@ fn main() {
             .expect("Failed to set language");
         let tree = parser.parse(source_code, None).expect("tree");
         let source_file = SourceCst::from_path(db, filename, source_code.into(), Some(tree));
-        let Some((ctx, module)) = compile_frontend(db, source_file) else {
-            let diagnostics =
-                tribute::pipeline::parse_and_lower_ast::accumulated::<Diagnostic>(db, source_file);
-            panic!("compilation should succeed: {diagnostics:?}");
-        };
+        let (ctx, module) = compile_frontend_with_diagnostics(db, source_file)
+            .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
 
         // Verify that expected user functions exist
         for func_name in expected_funcs {
@@ -83,6 +92,17 @@ fn main() {
             );
         }
     }
+}
+
+#[salsa_test]
+fn test_compile_frontend_with_diagnostics_returns_errors(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(db, "invalid.trb", "fn main() -> Int { true }");
+
+    let Err(diagnostics) = compile_frontend_with_diagnostics(db, source) else {
+        panic!("invalid source should return diagnostics");
+    };
+
+    assert!(!diagnostics.is_empty());
 }
 
 #[test]
@@ -98,7 +118,8 @@ fn test_salsa_incremental_computation_detailed() {
     let source_file = SourceCst::from_path(&db, "incremental.trb", text.into(), Some(tree));
 
     // Initial lowering
-    let (ctx1, module1) = compile_frontend(&db, source_file).expect("compilation should succeed");
+    let (ctx1, module1) = compile_frontend_with_diagnostics(&db, source_file)
+        .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
     assert!(
         find_func_by_name(&ctx1, &module1, "main"),
         "Should have main function"
@@ -112,7 +133,9 @@ fn test_salsa_incremental_computation_detailed() {
 
     // Lower again - should recompute with updated source
     let (ctx2, module2) =
-        compile_frontend(&db, source_file).expect("compilation should succeed after update");
+        compile_frontend_with_diagnostics(&db, source_file).unwrap_or_else(|diagnostics| {
+            panic!("compilation should succeed after update: {diagnostics:?}")
+        });
     assert!(
         find_func_by_name(&ctx2, &module2, "main"),
         "Should have main function after update"
@@ -120,7 +143,9 @@ fn test_salsa_incremental_computation_detailed() {
 
     // Lower again without changes - pipeline still works
     let (ctx3, module3) =
-        compile_frontend(&db, source_file).expect("compilation should succeed on re-run");
+        compile_frontend_with_diagnostics(&db, source_file).unwrap_or_else(|diagnostics| {
+            panic!("compilation should succeed on re-run: {diagnostics:?}")
+        });
     assert!(
         find_func_by_name(&ctx3, &module3, "main"),
         "Should have main function on cached run"
@@ -147,7 +172,8 @@ fn main() { print_line("test") }
 "#;
     let tree = parser.parse(text, None).expect("tree");
     let source = SourceCst::from_path(db, "multi.trb", text.into(), Some(tree));
-    let (ctx, module) = compile_frontend(db, source).expect("compilation should succeed");
+    let (ctx, module) = compile_frontend_with_diagnostics(db, source)
+        .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
 
     // Verify all user functions exist
     assert!(
@@ -175,7 +201,8 @@ fn test_salsa_database_isolation() {
         let text = "fn main() { let _ = 1 + 2 }";
         let tree = parser.parse(text, None).expect("tree");
         let source1 = SourceCst::from_path(db, "test1.trb", text.into(), Some(tree));
-        let (ctx, module) = compile_frontend(db, source1).expect("compilation should succeed");
+        let (ctx, module) = compile_frontend_with_diagnostics(db, source1)
+            .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
         module.name(&ctx).map(|s| s.to_string())
     });
 
@@ -187,7 +214,8 @@ fn test_salsa_database_isolation() {
         let text = "fn main() { let _ = 3 * 4 }";
         let tree = parser.parse(text, None).expect("tree");
         let source2 = SourceCst::from_path(db, "test2.trb", text.into(), Some(tree));
-        let (ctx, module) = compile_frontend(db, source2).expect("compilation should succeed");
+        let (ctx, module) = compile_frontend_with_diagnostics(db, source2)
+            .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
         module.name(&ctx).map(|s| s.to_string())
     });
 
@@ -205,7 +233,8 @@ fn test_function_lowering(db: &salsa::DatabaseImpl) {
         .expect("Failed to set language");
     let tree = parser.parse(source, None).expect("tree");
     let source_file = SourceCst::from_path(db, "func_test.trb", source.into(), Some(tree));
-    let (ctx, module) = compile_frontend(db, source_file).expect("compilation should succeed");
+    let (ctx, module) = compile_frontend_with_diagnostics(db, source_file)
+        .unwrap_or_else(|diagnostics| panic!("compilation should succeed: {diagnostics:?}"));
 
     // Verify the main function exists
     assert!(

--- a/tests/salsa_integration.rs
+++ b/tests/salsa_integration.rs
@@ -31,12 +31,9 @@ fn find_func_by_name(ctx: &IrContext, module: &Module, name: &str) -> bool {
 fn compile_frontend_with_diagnostics(
     db: &dyn salsa::Database,
     source: SourceCst,
-) -> Result<(IrContext, Module), Vec<Diagnostic>> {
+) -> Result<(IrContext, Module), Vec<&Diagnostic>> {
     compile_frontend(db, source).ok_or_else(|| {
         tribute::pipeline::parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
-            .into_iter()
-            .cloned()
-            .collect()
     })
 }
 

--- a/tests/snapshots/diagnostic_snapshots__diag_effect_arg_arity_mismatch.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_effect_arg_arity_mismatch.snap
@@ -1,0 +1,15 @@
+---
+source: tests/diagnostic_snapshots.rs
+expression: result.diagnostics
+---
+- message: "type error at call site in function 'test': ability `State` expects 1 type argument, but 2 were given"
+  span:
+    start: 110
+    end: 122
+  severity: Error
+  labels:
+    - span:
+        start: 82
+        end: 98
+      message: enclosing function effect contract is declared here
+  phase: TypeChecking

--- a/tests/snapshots/diagnostic_snapshots__diag_main_must_return_nil.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_main_must_return_nil.snap
@@ -2,13 +2,13 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "type error in function 'main': expected `Nat`, found `Int`"
+- message: "function 'main' must return Nil, but returns `Int`"
   span:
     start: 0
     end: 23
   severity: Error
   phase: TypeChecking
-- message: "function 'main' must return Nil, but returns `Int`"
+- message: "type error in function 'main': expected `Nat`, found `Int`"
   span:
     start: 0
     end: 23

--- a/tests/snapshots/diagnostic_snapshots__diag_residual_effect_rejected_at_handler_boundary.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_residual_effect_rejected_at_handler_boundary.snap
@@ -1,0 +1,15 @@
+---
+source: tests/diagnostic_snapshots.rs
+expression: result.diagnostics
+---
+- message: "type error at handler boundary in function 'test': effect mismatch: expected `{Foo}`, found `{Bar, e}`"
+  span:
+    start: 165
+    end: 252
+  severity: Error
+  labels:
+    - span:
+        start: 150
+        end: 153
+      message: enclosing function effect contract is declared here
+  phase: TypeChecking

--- a/tests/snapshots/diagnostic_snapshots__diag_row_unification_mismatch_at_lambda.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_row_unification_mismatch_at_lambda.snap
@@ -1,0 +1,15 @@
+---
+source: tests/diagnostic_snapshots.rs
+expression: result.diagnostics
+---
+- message: "type error at call site in function 'test': effect mismatch: expected `{Foo}`, found `{Bar, e}`"
+  span:
+    start: 169
+    end: 200
+  severity: Error
+  labels:
+    - span:
+        start: 154
+        end: 157
+      message: enclosing function effect contract is declared here
+  phase: TypeChecking

--- a/tests/snapshots/diagnostic_snapshots__diag_type_mismatch_in_function.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_type_mismatch_in_function.snap
@@ -2,9 +2,9 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "type error in function 'test': expected `Int`, found `Nat`"
+- message: "type error at call site in function 'test': expected `Int`, found `Nat`"
   span:
-    start: 42
-    end: 82
+    start: 65
+    end: 80
   severity: Error
   phase: TypeChecking

--- a/tests/snapshots/diagnostic_snapshots__diag_unhandled_effect_in_main.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_unhandled_effect_in_main.snap
@@ -2,19 +2,13 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "Pipeline failed: pass `lower-handle-dispatch` failed: conversion boundary `ability-lowered` failed with 1 error(s):\n  - ability.call (op335, Illegal)\n"
-  span:
-    start: 0
-    end: 0
-  severity: Error
-  phase: Lowering
-- message: "function 'main' must return Nil, but returns `Int`"
+- message: "function 'main' has unhandled effects: MyEffect"
   span:
     start: 52
     end: 101
   severity: Error
   phase: TypeChecking
-- message: "function 'main' has unhandled effects: MyEffect"
+- message: "function 'main' must return Nil, but returns `Int`"
   span:
     start: 52
     end: 101

--- a/tests/snapshots/diagnostic_snapshots__diag_unresolved_method_after_tdnr.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_unresolved_method_after_tdnr.snap
@@ -2,9 +2,9 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "function 'main' has unhandled effects: Foo, Bar"
+- message: "unresolved method 'missing' for this receiver type"
   span:
-    start: 75
-    end: 125
+    start: 65
+    end: 80
   severity: Error
   phase: TypeChecking

--- a/tests/snapshots/diagnostic_snapshots__diag_unresolved_type.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_unresolved_type.snap
@@ -2,13 +2,13 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "type error in function 'main': expected `Nat`, found `Foo`"
+- message: "function 'main' must return Nil, but returns `Foo`"
   span:
     start: 0
     end: 23
   severity: Error
   phase: TypeChecking
-- message: "function 'main' must return Nil, but returns `Foo`"
+- message: "type error in function 'main': expected `Nat`, found `Foo`"
   span:
     start: 0
     end: 23

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -43,6 +43,11 @@ fn main() {
 "#,
     );
     let binary = compile_to_wasm_binary(db, source);
+    if binary.is_none() {
+        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
+            eprintln!("Diagnostic: {diagnostic:?}");
+        }
+    }
     assert!(binary.is_some(), "Should compile literal return");
 
     let bytes = binary.unwrap();
@@ -65,6 +70,11 @@ fn main() {
 "#,
     );
     let binary = compile_to_wasm_binary(db, source);
+    if binary.is_none() {
+        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
+            eprintln!("Diagnostic: {diagnostic:?}");
+        }
+    }
     assert!(binary.is_some(), "Should compile arithmetic expression");
 }
 
@@ -82,6 +92,11 @@ fn main() {
 "#;
     let source = SourceCst::from_source_str(db, "params.trb", code);
     let binary = compile_to_wasm_binary(db, source);
+    if binary.is_none() {
+        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
+            eprintln!("Diagnostic: {diagnostic:?}");
+        }
+    }
     assert!(binary.is_some(), "Should compile function with params");
 }
 
@@ -128,6 +143,11 @@ fn main() {
 "#;
     let source = SourceCst::from_source_str(db, "locals.trb", code);
     let binary = compile_to_wasm_binary(db, source);
+    if binary.is_none() {
+        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
+            eprintln!("Diagnostic: {diagnostic:?}");
+        }
+    }
     assert!(binary.is_some(), "Should compile local variables");
 }
 

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -21,7 +21,24 @@ mod common;
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::compile_to_wasm_binary;
 use tribute_front::SourceCst;
-use tribute_passes::diagnostic::Diagnostic;
+
+fn expect_wasm_compilation_success(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+    message: &str,
+) -> Vec<u8> {
+    compile_to_wasm_binary(db, source)
+        .unwrap_or_else(|diagnostics| panic!("{message}: {diagnostics:?}"))
+}
+
+#[salsa_test]
+fn test_compile_failure_returns_diagnostics(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(db, "invalid.trb", "fn main() -> Int { true }");
+    let Err(diagnostics) = compile_to_wasm_binary(db, source) else {
+        panic!("invalid source should fail WebAssembly compilation");
+    };
+    assert!(!diagnostics.is_empty());
+}
 
 // =============================================================================
 // Passing end-to-end tests
@@ -42,15 +59,7 @@ fn main() {
 }
 "#,
     );
-    let binary = compile_to_wasm_binary(db, source);
-    if binary.is_none() {
-        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
-            eprintln!("Diagnostic: {diagnostic:?}");
-        }
-    }
-    assert!(binary.is_some(), "Should compile literal return");
-
-    let bytes = binary.unwrap();
+    let bytes = expect_wasm_compilation_success(db, source, "Should compile literal return");
     assert_eq!(&bytes[0..4], b"\x00asm", "Should have wasm magic number");
 }
 
@@ -69,13 +78,7 @@ fn main() {
 }
 "#,
     );
-    let binary = compile_to_wasm_binary(db, source);
-    if binary.is_none() {
-        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
-            eprintln!("Diagnostic: {diagnostic:?}");
-        }
-    }
-    assert!(binary.is_some(), "Should compile arithmetic expression");
+    expect_wasm_compilation_success(db, source, "Should compile arithmetic expression");
 }
 
 #[salsa_test]
@@ -91,13 +94,7 @@ fn main() {
 }
 "#;
     let source = SourceCst::from_source_str(db, "params.trb", code);
-    let binary = compile_to_wasm_binary(db, source);
-    if binary.is_none() {
-        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
-            eprintln!("Diagnostic: {diagnostic:?}");
-        }
-    }
-    assert!(binary.is_some(), "Should compile function with params");
+    expect_wasm_compilation_success(db, source, "Should compile function with params");
 }
 
 // Note: String literals work as intrinsic arguments (e.g., __print_line)
@@ -112,17 +109,7 @@ fn my_print(message: String) -> Nil { __print_line(message) }
 fn main() { my_print("Hello, World!") }
 "#;
     let source = SourceCst::from_source_str(db, "hello.trb", code);
-    let binary = compile_to_wasm_binary(db, source);
-
-    if binary.is_none() {
-        // Collect and print diagnostics
-        let diagnostics = compile_to_wasm_binary::accumulated::<Diagnostic>(db, source);
-        for diag in &diagnostics {
-            eprintln!("Diagnostic: {:?}", diag);
-        }
-    }
-
-    assert!(binary.is_some(), "Should compile print_line");
+    expect_wasm_compilation_success(db, source, "Should compile print_line");
 }
 
 #[salsa_test]
@@ -142,13 +129,7 @@ fn main() {
 }
 "#;
     let source = SourceCst::from_source_str(db, "locals.trb", code);
-    let binary = compile_to_wasm_binary(db, source);
-    if binary.is_none() {
-        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
-            eprintln!("Diagnostic: {diagnostic:?}");
-        }
-    }
-    assert!(binary.is_some(), "Should compile local variables");
+    expect_wasm_compilation_success(db, source, "Should compile local variables");
 }
 
 // =============================================================================
@@ -172,13 +153,7 @@ extern "intrinsic" fn __print_line(message: String) -> Nil
 fn main() { __print_line(classify(1)) }
 "#;
     let source = SourceCst::from_source_str(db, "case_expr.trb", code);
-    let binary = compile_to_wasm_binary(db, source);
-    if binary.is_none() {
-        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
-            eprintln!("Diagnostic: {diagnostic:?}");
-        }
-    }
-    assert!(binary.is_some(), "Should compile case expression");
+    expect_wasm_compilation_success(db, source, "Should compile case expression");
 }
 
 #[salsa_test]
@@ -213,18 +188,10 @@ fn main() {
 }
 "#;
     let source = SourceCst::from_source_str(db, "tail_dispatch_ability.trb", code);
-    let binary = compile_to_wasm_binary(db, source);
-
-    if binary.is_none() {
-        let diagnostics = compile_to_wasm_binary::accumulated::<Diagnostic>(db, source);
-        for diag in &diagnostics {
-            eprintln!("Diagnostic: {:?}", diag);
-        }
-    }
-
-    assert!(
-        binary.is_some(),
-        "Should compile tail-dispatch ability through wasm effect ABI lowering"
+    expect_wasm_compilation_success(
+        db,
+        source,
+        "Should compile tail-dispatch ability through wasm effect ABI lowering",
     );
 }
 
@@ -260,17 +227,9 @@ fn main() {
 }
 "#;
     let source = SourceCst::from_source_str(db, "cps_dispatch_ability.trb", code);
-    let binary = compile_to_wasm_binary(db, source);
-
-    if binary.is_none() {
-        let diagnostics = compile_to_wasm_binary::accumulated::<Diagnostic>(db, source);
-        for diag in &diagnostics {
-            eprintln!("Diagnostic: {:?}", diag);
-        }
-    }
-
-    assert!(
-        binary.is_some(),
-        "Should compile CPS ability dispatch through wasm effect ABI lowering"
+    expect_wasm_compilation_success(
+        db,
+        source,
+        "Should compile CPS ability dispatch through wasm effect ABI lowering",
     );
 }

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -29,7 +29,19 @@ use tribute_passes::diagnostic::Diagnostic;
 
 #[salsa_test]
 fn test_compile_simple_literal(db: &salsa::DatabaseImpl) {
-    let source = SourceCst::from_source_str(db, "literal.trb", "fn main() { let _ = 42 }");
+    let source = SourceCst::from_source_str(
+        db,
+        "literal.trb",
+        r#"
+extern "intrinsic" fn __print_line(message: String) -> Nil
+fn main() {
+    case 42 {
+        42 -> __print_line("ok")
+        _ -> __print_line("unexpected")
+    }
+}
+"#,
+    );
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile literal return");
 
@@ -39,7 +51,19 @@ fn test_compile_simple_literal(db: &salsa::DatabaseImpl) {
 
 #[salsa_test]
 fn test_compile_arithmetic_expr(db: &salsa::DatabaseImpl) {
-    let source = SourceCst::from_source_str(db, "arith.trb", "fn main() { let _ = 1 + 2 * 3 }");
+    let source = SourceCst::from_source_str(
+        db,
+        "arith.trb",
+        r#"
+extern "intrinsic" fn __print_line(message: String) -> Nil
+fn main() {
+    case 1 + 2 * 3 {
+        7 -> __print_line("ok")
+        _ -> __print_line("unexpected")
+    }
+}
+"#,
+    );
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile arithmetic expression");
 }
@@ -47,8 +71,14 @@ fn test_compile_arithmetic_expr(db: &salsa::DatabaseImpl) {
 #[salsa_test]
 fn test_compile_function_with_params(db: &salsa::DatabaseImpl) {
     let code = r#"
+extern "intrinsic" fn __print_line(message: String) -> Nil
 fn add(a: Nat, b: Nat) -> Nat { a + b }
-fn main() { let _ = add(1, 2) }
+fn main() {
+    case add(1, 2) {
+        3 -> __print_line("ok")
+        _ -> __print_line("unexpected")
+    }
+}
 "#;
     let source = SourceCst::from_source_str(db, "params.trb", code);
     let binary = compile_to_wasm_binary(db, source);
@@ -88,7 +118,13 @@ fn test_ops() -> Nat {
     let b = 3
     a + b
 }
-fn main() { let _ = test_ops() }
+extern "intrinsic" fn __print_line(message: String) -> Nil
+fn main() {
+    case test_ops() {
+        13 -> __print_line("ok")
+        _ -> __print_line("unexpected")
+    }
+}
 "#;
     let source = SourceCst::from_source_str(db, "locals.trb", code);
     let binary = compile_to_wasm_binary(db, source);
@@ -112,7 +148,8 @@ fn classify(n: Nat) -> String {
         _ -> "other"
     }
 }
-fn main() { let _ = classify(1) }
+extern "intrinsic" fn __print_line(message: String) -> Nil
+fn main() { __print_line(classify(1)) }
 "#;
     let source = SourceCst::from_source_str(db, "case_expr.trb", code);
     let binary = compile_to_wasm_binary(db, source);
@@ -132,6 +169,8 @@ ability Console {
     fn print(value: Int) -> Nil
 }
 
+extern "intrinsic" fn __print_line(message: String) -> Nil
+
 fn use_console() ->{Console} Int {
     let n = Console::read()
     Console::print(n)
@@ -147,7 +186,10 @@ fn run() -> Int {
 }
 
 fn main() {
-    let _ = run()
+    case run() {
+        +41 -> __print_line("ok")
+        _ -> __print_line("unexpected")
+    }
 }
 "#;
     let source = SourceCst::from_source_str(db, "tail_dispatch_ability.trb", code);
@@ -174,6 +216,8 @@ ability State(s) {
     op set(value: s) -> Nil
 }
 
+extern "intrinsic" fn __print_line(message: String) -> Nil
+
 fn bump() ->{State(Int)} Int {
     let n = State::get()
     State::set(n + +1)
@@ -189,7 +233,10 @@ fn run_state() -> Int {
 }
 
 fn main() {
-    let _ = run_state()
+    case run_state() {
+        +41 -> __print_line("ok")
+        _ -> __print_line("unexpected")
+    }
 }
 "#;
     let source = SourceCst::from_source_str(db, "cps_dispatch_ability.trb", code);

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -29,7 +29,7 @@ use tribute_passes::diagnostic::Diagnostic;
 
 #[salsa_test]
 fn test_compile_simple_literal(db: &salsa::DatabaseImpl) {
-    let source = SourceCst::from_source_str(db, "literal.trb", "fn main() { 42 }");
+    let source = SourceCst::from_source_str(db, "literal.trb", "fn main() { let _ = 42 }");
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile literal return");
 
@@ -39,7 +39,7 @@ fn test_compile_simple_literal(db: &salsa::DatabaseImpl) {
 
 #[salsa_test]
 fn test_compile_arithmetic_expr(db: &salsa::DatabaseImpl) {
-    let source = SourceCst::from_source_str(db, "arith.trb", "fn main() { 1 + 2 * 3 }");
+    let source = SourceCst::from_source_str(db, "arith.trb", "fn main() { let _ = 1 + 2 * 3 }");
     let binary = compile_to_wasm_binary(db, source);
     assert!(binary.is_some(), "Should compile arithmetic expression");
 }
@@ -48,7 +48,7 @@ fn test_compile_arithmetic_expr(db: &salsa::DatabaseImpl) {
 fn test_compile_function_with_params(db: &salsa::DatabaseImpl) {
     let code = r#"
 fn add(a: Nat, b: Nat) -> Nat { a + b }
-fn main() { add(1, 2) }
+fn main() { let _ = add(1, 2) }
 "#;
     let source = SourceCst::from_source_str(db, "params.trb", code);
     let binary = compile_to_wasm_binary(db, source);
@@ -83,12 +83,12 @@ fn main() { my_print("Hello, World!") }
 #[salsa_test]
 fn test_compile_local_variables(db: &salsa::DatabaseImpl) {
     let code = r#"
-fn test_ops() {
-    let a = 10;
-    let b = 3;
+fn test_ops() -> Nat {
+    let a = 10
+    let b = 3
     a + b
 }
-fn main() { test_ops() }
+fn main() { let _ = test_ops() }
 "#;
     let source = SourceCst::from_source_str(db, "locals.trb", code);
     let binary = compile_to_wasm_binary(db, source);
@@ -105,17 +105,22 @@ fn main() { test_ops() }
 #[salsa_test]
 fn test_compile_case_expression(db: &salsa::DatabaseImpl) {
     let code = r#"
-fn classify(n) {
+fn classify(n: Nat) -> String {
     case n {
-        0 { "zero" }
-        1 { "one" }
-        _ { "other" }
+        0 -> "zero"
+        1 -> "one"
+        _ -> "other"
     }
 }
-fn main() { classify(1) }
+fn main() { let _ = classify(1) }
 "#;
     let source = SourceCst::from_source_str(db, "case_expr.trb", code);
     let binary = compile_to_wasm_binary(db, source);
+    if binary.is_none() {
+        for diagnostic in compile_to_wasm_binary::accumulated::<Diagnostic>(db, source) {
+            eprintln!("Diagnostic: {diagnostic:?}");
+        }
+    }
     assert!(binary.is_some(), "Should compile case expression");
 }
 
@@ -178,8 +183,8 @@ fn bump() ->{State(Int)} Int {
 fn run_state() -> Int {
     handle bump() {
         do result { result }
-        op State::get() -> k { resume k(+41) }
-        op State::set(value) -> k { resume k(Nil) }
+        op State::get() { resume +41 }
+        op State::set(value) { resume Nil }
     }
 }
 


### PR DESCRIPTION
## Summary
- Tighten type-checking and constraint handling for effects, lambdas, and function bodies
- Add and update diagnostics for duplicate effect annotations, arity mismatches, unhandled effects, and residual effects at handler boundaries
- Refresh pipeline and implementation docs to match the current effect-checking behavior
- Expand snapshot, e2e, salsa, float, evidence, and wasm coverage around the new diagnostics

## Testing
- Updated diagnostic snapshots and end-to-end tests to cover the new effect and type error paths
- Broadened integration coverage for type checking and compilation validation
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved type/effect error messages with clearer source context and more consistent constraint attribution.
  * Deterministic diagnostic ordering for repeatable compilation output.
  * Frontend now reports unresolved method calls as frontend errors and stops before further compilation.
  * WebAssembly startup now follows a clearer entrypoint contract, only emitting required runtime resources and simplifying result handling.

* **Bug Fixes**
  * Enhanced effect-row/type constraint inference and merging for more reliable diagnostics, including lambdas/handlers/calls.

* **Tests**
  * Expanded diagnostic snapshots and WASM/effect/memory coverage, including determinism checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->