### PR TITLE
Fix clippy failure propagation in pre-commit hook

### DIFF
--- a/.ci/lint.sh
+++ b/.ci/lint.sh
@@ -11,7 +11,16 @@ if ! cargo fmt --all --check; then
 fi
 
 echo "Running clippy..."
-if ! cargo clippy --workspace --all-targets --message-format=short -- -D warnings 2>&1 | head -n 40; then
+CLIPPY_OUTPUT="$(mktemp)"
+trap 'rm -f "$CLIPPY_OUTPUT"' EXIT HUP INT TERM
+if cargo clippy --workspace --all-targets --message-format=short -- -D warnings \
+    >"$CLIPPY_OUTPUT" 2>&1; then
+    rm -f "$CLIPPY_OUTPUT"
+    trap - EXIT HUP INT TERM
+else
+    tail -n 40 "$CLIPPY_OUTPUT" >&2
+    rm -f "$CLIPPY_OUTPUT"
+    trap - EXIT HUP INT TERM
     echo "" >&2
     echo "Clippy failed with warnings/errors. Fix the issues above and try again." >&2
     echo "Run 'cargo clippy --workspace --all-targets' to see all issues." >&2

--- a/.ci/lint.sh
+++ b/.ci/lint.sh
@@ -12,7 +12,10 @@ fi
 
 echo "Running clippy..."
 CLIPPY_OUTPUT="$(mktemp)"
-trap 'rm -f "$CLIPPY_OUTPUT"' EXIT HUP INT TERM
+trap 'rm -f "$CLIPPY_OUTPUT"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 if cargo clippy --workspace --all-targets --message-format=short -- -D warnings \
     >"$CLIPPY_OUTPUT" 2>&1; then
     rm -f "$CLIPPY_OUTPUT"

--- a/.ci/test-fixtures/lint/bin/cargo
+++ b/.ci/test-fixtures/lint/bin/cargo
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+case "$1" in
+    fmt)
+        exit 0
+        ;;
+    clippy)
+        line=1
+        while [ "$line" -le 100 ]; do
+            echo "clippy output $line"
+            line=$((line + 1))
+        done
+        echo "CLIPPY_FAILURE_MARKER"
+        exit 1
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/.ci/test-fixtures/lint/bin/npx
+++ b/.ci/test-fixtures/lint/bin/npx
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+: "${LINT_TEST_NPX_MARKER:?must be set by test-lint.sh}"
+touch "$LINT_TEST_NPX_MARKER"

--- a/.ci/test-lint.sh
+++ b/.ci/test-lint.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+
+mkdir "$TEMP_DIR/bin"
+
+cat >"$TEMP_DIR/bin/cargo" <<'EOF'
+#!/bin/sh
+
+case "$1" in
+    fmt)
+        exit 0
+        ;;
+    clippy)
+        line=1
+        while [ "$line" -le 100 ]; do
+            echo "clippy output $line"
+            line=$((line + 1))
+        done
+        echo "CLIPPY_FAILURE_MARKER"
+        exit 1
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+EOF
+
+cat >"$TEMP_DIR/bin/npx" <<EOF
+#!/bin/sh
+touch "$TEMP_DIR/npx-ran"
+exit 0
+EOF
+
+chmod +x "$TEMP_DIR/bin/cargo" "$TEMP_DIR/bin/npx"
+
+if PATH="$TEMP_DIR/bin:$PATH" "$SCRIPT_DIR/lint.sh" >"$TEMP_DIR/output" 2>&1; then
+    echo "lint.sh unexpectedly succeeded" >&2
+    exit 1
+else
+    status=$?
+fi
+
+if [ "$status" -ne 2 ]; then
+    echo "lint.sh returned $status instead of 2" >&2
+    exit 1
+fi
+
+if ! grep -q "CLIPPY_FAILURE_MARKER" "$TEMP_DIR/output"; then
+    echo "lint.sh did not print the tail of clippy output" >&2
+    exit 1
+fi
+
+if grep -q "clippy output 1$" "$TEMP_DIR/output"; then
+    echo "lint.sh printed unbounded clippy output" >&2
+    exit 1
+fi
+
+if [ -e "$TEMP_DIR/npx-ran" ]; then
+    echo "lint.sh continued after clippy failed" >&2
+    exit 1
+fi

--- a/.ci/test-lint.sh
+++ b/.ci/test-lint.sh
@@ -26,6 +26,16 @@ if ! grep -q "CLIPPY_FAILURE_MARKER" "$TEMP_DIR/output"; then
     exit 1
 fi
 
+if ! grep -q "clippy output 62$" "$TEMP_DIR/output"; then
+    echo "lint.sh did not print the complete 40-line clippy tail" >&2
+    exit 1
+fi
+
+if grep -q "clippy output 61$" "$TEMP_DIR/output"; then
+    echo "lint.sh printed more than the final 40 clippy lines" >&2
+    exit 1
+fi
+
 if grep -q "clippy output 1$" "$TEMP_DIR/output"; then
     echo "lint.sh printed unbounded clippy output" >&2
     exit 1

--- a/.ci/test-lint.sh
+++ b/.ci/test-lint.sh
@@ -6,39 +6,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
 
-mkdir "$TEMP_DIR/bin"
+FIXTURE_BIN="$SCRIPT_DIR/test-fixtures/lint/bin"
+export LINT_TEST_NPX_MARKER="$TEMP_DIR/npx-ran"
 
-cat >"$TEMP_DIR/bin/cargo" <<'EOF'
-#!/bin/sh
-
-case "$1" in
-    fmt)
-        exit 0
-        ;;
-    clippy)
-        line=1
-        while [ "$line" -le 100 ]; do
-            echo "clippy output $line"
-            line=$((line + 1))
-        done
-        echo "CLIPPY_FAILURE_MARKER"
-        exit 1
-        ;;
-    *)
-        exit 0
-        ;;
-esac
-EOF
-
-cat >"$TEMP_DIR/bin/npx" <<EOF
-#!/bin/sh
-touch "$TEMP_DIR/npx-ran"
-exit 0
-EOF
-
-chmod +x "$TEMP_DIR/bin/cargo" "$TEMP_DIR/bin/npx"
-
-if PATH="$TEMP_DIR/bin:$PATH" "$SCRIPT_DIR/lint.sh" >"$TEMP_DIR/output" 2>&1; then
+if PATH="$FIXTURE_BIN:$PATH" "$SCRIPT_DIR/lint.sh" >"$TEMP_DIR/output" 2>&1; then
     echo "lint.sh unexpectedly succeeded" >&2
     exit 1
 else
@@ -60,7 +31,7 @@ if grep -q "clippy output 1$" "$TEMP_DIR/output"; then
     exit 1
 fi
 
-if [ -e "$TEMP_DIR/npx-ran" ]; then
+if [ -e "$LINT_TEST_NPX_MARKER" ]; then
     echo "lint.sh continued after clippy failed" >&2
     exit 1
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Test lint failure propagation
+        run: .ci/test-lint.sh
+
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -814,7 +814,7 @@ impl<'a> WasmLowerer<'a> {
         let result_ty = self
             .main_exports
             .main_result_type
-            .and_then(|ty| if ty == nil_ty { None } else { Some(ty) });
+            .filter(|&ty| ty != nil_ty);
         let result_types: Vec<TypeRef> = result_ty.into_iter().collect();
         let is_i32 = result_ty
             .map(|ty| is_type(ctx, ty, "core", "i32"))

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -845,13 +845,10 @@ fn assign_locals_in_region(
                                 }
                             })
                             .or_else(|| {
-                                ctx.op_result_types(op).first().copied().and_then(|ty| {
-                                    if is_type(ctx, ty, "wasm", "structref") {
-                                        Some(ty)
-                                    } else {
-                                        None
-                                    }
-                                })
+                                ctx.op_result_types(op)
+                                    .first()
+                                    .copied()
+                                    .filter(|&ty| is_type(ctx, ty, "wasm", "structref"))
                             })
                     } else {
                         None

--- a/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
@@ -550,13 +550,7 @@ pub(crate) fn collect_gc_types(
                 }
             });
 
-            let placeholder_type_from_result = result_type.and_then(|ty| {
-                if is_structref(ctx, ty) {
-                    Some(ty)
-                } else {
-                    None
-                }
-            });
+            let placeholder_type_from_result = result_type.filter(|&ty| is_structref(ctx, ty));
 
             let placeholder_type = placeholder_type_from_attr.or(placeholder_type_from_result);
 


### PR DESCRIPTION
## Summary

- update Rust 1.97 `manual_filter` call sites so workspace clippy passes
- preserve clippy's real exit status in `.ci/lint.sh`
- buffer clippy output and print only the final 40 lines on failure
- add reusable fake command fixtures for a shell regression test and run it in CI

## Root cause

The lint script piped clippy through `head`. Under POSIX `sh`, the pipeline status came from `head`, so a clippy failure was reported as success and the pre-commit hook allowed the commit. Removing the pipeline outright would expose potentially unbounded output, so the script now captures output in a temporary file and emits a bounded tail only when clippy fails.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run -p tribute-passes -p trunk-ir-wasm-backend` (100 passed)
- `.ci/test-lint.sh`
- `.ci/lint.sh`
- pre-commit full suite (1,460 passed, 11 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI lint failure reporting by capturing and displaying only the most relevant Clippy output when linting fails.
  * Ensured the lint pipeline halts after a Clippy failure and doesn’t proceed to later formatting/lint steps.

* **Tests**
  * Added CI coverage to verify lint failure propagation, output truncation behavior, marker/cleanup handling, and prevention of subsequent steps.
  * Integrated the new lint-failure test into the CI workflow.

* **Refactor**
  * Simplified internal WebAssembly type filtering logic without changing observable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->