### PR TITLE
Add calling convention support across frontend and lowering pipeline

### DIFF
--- a/crates/tribute-core/src/callable_abi.rs
+++ b/crates/tribute-core/src/callable_abi.rs
@@ -1,0 +1,129 @@
+//! Shared logical and lowered callable ABI layout.
+
+use crate::CallingConvention;
+
+/// A source callable paired with its selected calling convention.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallableAbi<T> {
+    pub convention: CallingConvention,
+    pub source_params: Vec<T>,
+    pub source_result: T,
+}
+
+impl<T: Copy> CallableAbi<T> {
+    pub fn new(
+        convention: CallingConvention,
+        source_params: impl IntoIterator<Item = T>,
+        source_result: T,
+    ) -> Self {
+        Self {
+            convention,
+            source_params: source_params.into_iter().collect(),
+            source_result,
+        }
+    }
+
+    /// Parameter types for the current compatibility representation.
+    pub fn lowered_params(&self, evidence: T, control_carrier: T) -> Vec<T> {
+        let mut params = Vec::with_capacity(
+            self.source_params.len()
+                + usize::from(self.convention.needs_evidence())
+                + usize::from(self.convention.needs_done_k()),
+        );
+        if self.convention.needs_evidence() {
+            params.push(evidence);
+        }
+        if self.convention.needs_done_k() {
+            params.push(control_carrier);
+        }
+        params.extend_from_slice(&self.source_params);
+        params
+    }
+
+    /// Result type for the current compatibility representation.
+    ///
+    /// Logical CPS does not directly return a source result. Until true
+    /// tail-call or trampoline lowering is selected, the IR uses the supplied
+    /// control carrier for the continuation chain.
+    pub fn lowered_result(&self, control_carrier: T) -> T {
+        if self.convention.needs_done_k() {
+            control_carrier
+        } else {
+            self.source_result
+        }
+    }
+
+    pub fn source_param_offset(&self) -> usize {
+        usize::from(self.convention.needs_evidence()) + usize::from(self.convention.needs_done_k())
+    }
+
+    /// Interpose the physical closure environment in convention order.
+    ///
+    /// Direct: `env, source...`
+    /// EvidenceDirect: `evidence, env, source...`
+    /// Cps: `evidence, env, done_k, source...`
+    pub fn interpose_environment(&self, logical_params: &[T], environment: T) -> Vec<T> {
+        debug_assert_eq!(
+            logical_params.len(),
+            self.lowered_params(environment, environment).len(),
+            "logical parameter count must match the selected convention",
+        );
+        let env_index = usize::from(self.convention.needs_evidence());
+        let mut physical = Vec::with_capacity(logical_params.len() + 1);
+        physical.extend_from_slice(&logical_params[..env_index]);
+        physical.push(environment);
+        physical.extend_from_slice(&logical_params[env_index..]);
+        physical
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn abi(convention: CallingConvention) -> CallableAbi<&'static str> {
+        CallableAbi::new(convention, ["arg"], "result")
+    }
+
+    #[test]
+    fn lowered_function_layouts_are_centralized() {
+        let direct = abi(CallingConvention::Direct);
+        assert_eq!(direct.lowered_params("ev", "control"), ["arg"]);
+        assert_eq!(direct.lowered_result("control"), "result");
+
+        let evidence_direct = abi(CallingConvention::EvidenceDirect);
+        assert_eq!(
+            evidence_direct.lowered_params("ev", "control"),
+            ["ev", "arg"]
+        );
+        assert_eq!(evidence_direct.lowered_result("control"), "result");
+
+        let cps = abi(CallingConvention::Cps);
+        assert_eq!(
+            cps.lowered_params("ev", "control"),
+            ["ev", "control", "arg"]
+        );
+        assert_eq!(cps.lowered_result("control"), "control");
+    }
+
+    #[test]
+    fn physical_closure_layout_only_interposes_environment() {
+        let direct = abi(CallingConvention::Direct);
+        assert_eq!(
+            direct.interpose_environment(&["arg"], "env"),
+            ["env", "arg"]
+        );
+
+        let evidence_direct = abi(CallingConvention::EvidenceDirect);
+        assert_eq!(
+            evidence_direct.interpose_environment(&["ev", "arg"], "env"),
+            ["ev", "env", "arg"]
+        );
+
+        let cps = abi(CallingConvention::Cps);
+        assert_eq!(
+            cps.interpose_environment(&["ev", "control", "arg"], "env"),
+            ["ev", "env", "control", "arg"]
+        );
+    }
+}

--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -12,15 +12,22 @@ pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
 /// Ordering is significant: composing requirements selects the stronger
 /// convention with [`CallingConvention::join`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, salsa::Update)]
+#[repr(u8)]
 pub enum CallingConvention {
     /// Pure function: source parameters and source result only.
     #[default]
-    Direct,
+    Direct = 0,
     /// Tail-resumptive effect: evidence parameter, direct source result.
-    EvidenceDirect,
+    EvidenceDirect = 1,
     /// General control effect: evidence and done continuation.
-    Cps,
+    Cps = 2,
 }
+
+const CALLING_CONVENTIONS_BY_CODE: &[CallingConvention] = &[
+    CallingConvention::Direct,
+    CallingConvention::EvidenceDirect,
+    CallingConvention::Cps,
+];
 
 impl CallingConvention {
     /// Compose two requirements by selecting the stronger convention.
@@ -37,22 +44,16 @@ impl CallingConvention {
     pub fn needs_done_k(self) -> bool {
         self == Self::Cps
     }
+}
 
-    fn code(self) -> i128 {
-        match self {
-            Self::Direct => 0,
-            Self::EvidenceDirect => 1,
-            Self::Cps => 2,
-        }
-    }
+impl TryFrom<u8> for CallingConvention {
+    type Error = u8;
 
-    fn from_code(code: i128) -> Option<Self> {
-        match code {
-            0 => Some(Self::Direct),
-            1 => Some(Self::EvidenceDirect),
-            2 => Some(Self::Cps),
-            _ => None,
-        }
+    fn try_from(code: u8) -> Result<Self, Self::Error> {
+        CALLING_CONVENTIONS_BY_CODE
+            .get(usize::from(code))
+            .copied()
+            .ok_or(code)
     }
 }
 
@@ -60,7 +61,7 @@ impl CallingConvention {
 pub fn set_calling_convention(ctx: &mut IrContext, op: OpRef, convention: CallingConvention) {
     ctx.op_mut(op).attributes.insert(
         Symbol::new(CALLING_CONVENTION_ATTR),
-        Attribute::Int(convention.code()),
+        Attribute::Int(convention as i128),
     );
 }
 
@@ -73,5 +74,21 @@ pub fn get_calling_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConve
     else {
         return None;
     };
-    CallingConvention::from_code(*code)
+    let code = u8::try_from(*code).ok()?;
+    code.try_into().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integer_codes_round_trip() {
+        for convention in CALLING_CONVENTIONS_BY_CODE {
+            let code = *convention as u8;
+            assert_eq!(CallingConvention::try_from(code), Ok(*convention));
+        }
+
+        assert_eq!(CallingConvention::try_from(3), Err(3));
+    }
 }

--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -1,0 +1,77 @@
+//! Compiler-wide calling-convention requirements.
+
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::refs::OpRef;
+use trunk_ir::types::Attribute;
+
+pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
+
+/// The ABI strength required to call a function.
+///
+/// Ordering is significant: composing requirements selects the stronger
+/// convention with [`CallingConvention::join`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, salsa::Update)]
+pub enum CallingConvention {
+    /// Pure function: source parameters and source result only.
+    #[default]
+    Direct,
+    /// Tail-resumptive effect: evidence parameter, direct source result.
+    EvidenceDirect,
+    /// General control effect: evidence and done continuation.
+    Cps,
+}
+
+impl CallingConvention {
+    /// Compose two requirements by selecting the stronger convention.
+    pub fn join(self, other: Self) -> Self {
+        self.max(other)
+    }
+
+    /// Whether the convention carries an evidence parameter.
+    pub fn needs_evidence(self) -> bool {
+        self >= Self::EvidenceDirect
+    }
+
+    /// Whether the convention carries a done continuation.
+    pub fn needs_done_k(self) -> bool {
+        self == Self::Cps
+    }
+
+    fn code(self) -> i128 {
+        match self {
+            Self::Direct => 0,
+            Self::EvidenceDirect => 1,
+            Self::Cps => 2,
+        }
+    }
+
+    fn from_code(code: i128) -> Option<Self> {
+        match code {
+            0 => Some(Self::Direct),
+            1 => Some(Self::EvidenceDirect),
+            2 => Some(Self::Cps),
+            _ => None,
+        }
+    }
+}
+
+/// Attach the logical calling convention to a high-level IR operation.
+pub fn set_calling_convention(ctx: &mut IrContext, op: OpRef, convention: CallingConvention) {
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(CALLING_CONVENTION_ATTR),
+        Attribute::Int(convention.code()),
+    );
+}
+
+/// Read explicitly attached calling-convention metadata.
+pub fn get_calling_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConvention> {
+    let Attribute::Int(code) = ctx
+        .op(op)
+        .attributes
+        .get(&Symbol::new(CALLING_CONVENTION_ATTR))?
+    else {
+        return None;
+    };
+    CallingConvention::from_code(*code)
+}

--- a/crates/tribute-core/src/lib.rs
+++ b/crates/tribute-core/src/lib.rs
@@ -1,7 +1,13 @@
 //! Tribute compiler utilities.
+pub mod callable_abi;
+pub mod calling_convention;
 pub mod diagnostic;
 pub mod fmt;
 pub mod target;
 
+pub use callable_abi::CallableAbi;
+pub use calling_convention::{
+    CALLING_CONVENTION_ATTR, CallingConvention, get_calling_convention, set_calling_convention,
+};
 pub use diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 pub use target::*;

--- a/crates/tribute-front/src/ast/calling_convention.rs
+++ b/crates/tribute-front/src/ast/calling_convention.rs
@@ -2,8 +2,26 @@
 
 use std::collections::HashMap;
 
-use super::{AbilityId, EffectRow, Type, TypeKind};
+use super::{AbilityId, EffectRow, Type, TypeAnnotation, TypeKind};
 pub use tribute_core::CallingConvention;
+
+/// ABI floor requested by a function declaration's effect annotation.
+pub fn function_declaration_abi_floor(effects: Option<&[TypeAnnotation]>) -> CallingConvention {
+    if effects.is_some() {
+        CallingConvention::EvidenceDirect
+    } else {
+        CallingConvention::Direct
+    }
+}
+
+/// ABI floor requested by an explicit function-type effect list.
+pub fn function_type_abi_floor(abilities: &[TypeAnnotation]) -> CallingConvention {
+    if abilities.is_empty() {
+        CallingConvention::EvidenceDirect
+    } else {
+        CallingConvention::Direct
+    }
+}
 
 /// Derive a convention from an effect row and ability-level requirements.
 ///

--- a/crates/tribute-front/src/ast/calling_convention.rs
+++ b/crates/tribute-front/src/ast/calling_convention.rs
@@ -2,26 +2,8 @@
 
 use std::collections::HashMap;
 
-use super::{AbilityId, EffectRow, Type, TypeAnnotation, TypeKind};
+use super::{AbilityId, EffectRow, Type, TypeKind};
 pub use tribute_core::CallingConvention;
-
-/// ABI floor requested by a function declaration's effect annotation.
-pub fn function_declaration_abi_floor(effects: Option<&[TypeAnnotation]>) -> CallingConvention {
-    if effects.is_some() {
-        CallingConvention::EvidenceDirect
-    } else {
-        CallingConvention::Direct
-    }
-}
-
-/// ABI floor requested by an explicit function-type effect list.
-pub fn function_type_abi_floor(abilities: &[TypeAnnotation]) -> CallingConvention {
-    if abilities.is_empty() {
-        CallingConvention::EvidenceDirect
-    } else {
-        CallingConvention::Direct
-    }
-}
 
 /// Derive a convention from an effect row and ability-level requirements.
 ///
@@ -99,6 +81,11 @@ mod tests {
         };
         let logger_only = EffectRow::new(&db, vec![logger_effect.clone()], None);
         let mixed = EffectRow::new(&db, vec![logger_effect, state_effect], None);
+
+        assert_eq!(
+            calling_convention_for_effect_row(&db, EffectRow::pure(&db), &abilities),
+            CallingConvention::Direct
+        );
 
         assert_eq!(
             calling_convention_for_effect_row(&db, logger_only, &abilities),

--- a/crates/tribute-front/src/ast/calling_convention.rs
+++ b/crates/tribute-front/src/ast/calling_convention.rs
@@ -1,0 +1,119 @@
+//! Calling-convention requirements derived from source effect rows.
+
+use std::collections::HashMap;
+
+use super::{AbilityId, EffectRow, Type, TypeKind};
+pub use tribute_core::CallingConvention;
+
+/// Derive a convention from an effect row and ability-level requirements.
+///
+/// Unknown abilities and open row tails conservatively require CPS.
+pub fn calling_convention_for_effect_row<'db>(
+    db: &'db dyn salsa::Database,
+    row: EffectRow<'db>,
+    abilities: &HashMap<AbilityId<'db>, CallingConvention>,
+) -> CallingConvention {
+    let mut convention = CallingConvention::Direct;
+    for effect in row.effects(db) {
+        let requirement = abilities
+            .get(&effect.ability_id)
+            .copied()
+            .unwrap_or(CallingConvention::Cps);
+        convention = convention.join(requirement);
+    }
+    if row.rest(db).is_some() {
+        convention = convention.join(CallingConvention::Cps);
+    }
+    convention
+}
+
+/// Derive a convention for a function type, including its explicit ABI lower bound.
+pub fn calling_convention_for_function_type<'db>(
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    abilities: &HashMap<AbilityId<'db>, CallingConvention>,
+) -> Option<CallingConvention> {
+    let TypeKind::Func {
+        effect,
+        minimum_convention,
+        ..
+    } = ty.kind(db)
+    else {
+        return None;
+    };
+    Some((*minimum_convention).join(calling_convention_for_effect_row(db, *effect, abilities)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{Effect, EffectVar};
+    use trunk_ir::Symbol;
+
+    #[test]
+    fn joins_to_the_strongest_requirement() {
+        assert_eq!(
+            CallingConvention::Direct.join(CallingConvention::EvidenceDirect),
+            CallingConvention::EvidenceDirect
+        );
+        assert_eq!(
+            CallingConvention::EvidenceDirect.join(CallingConvention::Cps),
+            CallingConvention::Cps
+        );
+    }
+
+    #[test]
+    fn effect_rows_use_ability_level_upper_bounds() {
+        let db = salsa::DatabaseImpl::new();
+        let logger = AbilityId::new(&db, Symbol::new("Logger"));
+        let state = AbilityId::new(&db, Symbol::new("State"));
+        let mut abilities = HashMap::new();
+        abilities.insert(logger, CallingConvention::EvidenceDirect);
+        abilities.insert(state, CallingConvention::Cps);
+
+        let logger_effect = Effect {
+            ability_id: logger,
+            args: vec![],
+        };
+        let state_effect = Effect {
+            ability_id: state,
+            args: vec![],
+        };
+        let logger_only = EffectRow::new(&db, vec![logger_effect.clone()], None);
+        let mixed = EffectRow::new(&db, vec![logger_effect, state_effect], None);
+
+        assert_eq!(
+            calling_convention_for_effect_row(&db, logger_only, &abilities),
+            CallingConvention::EvidenceDirect
+        );
+        assert_eq!(
+            calling_convention_for_effect_row(&db, mixed, &abilities),
+            CallingConvention::Cps
+        );
+    }
+
+    #[test]
+    fn open_and_unknown_rows_are_cps() {
+        let db = salsa::DatabaseImpl::new();
+        let unknown = AbilityId::new(&db, Symbol::new("Unknown"));
+        let unknown_row = EffectRow::new(
+            &db,
+            vec![Effect {
+                ability_id: unknown,
+                args: vec![],
+            }],
+            None,
+        );
+        let open_row = EffectRow::open(&db, EffectVar { id: 0 });
+        let abilities = HashMap::new();
+
+        assert_eq!(
+            calling_convention_for_effect_row(&db, unknown_row, &abilities),
+            CallingConvention::Cps
+        );
+        assert_eq!(
+            calling_convention_for_effect_row(&db, open_row, &abilities),
+            CallingConvention::Cps
+        );
+    }
+}

--- a/crates/tribute-front/src/ast/mod.rs
+++ b/crates/tribute-front/src/ast/mod.rs
@@ -48,6 +48,7 @@
 //! let typed: TypedModule<'db> = typecheck_module(db, resolved);
 //! ```
 
+mod calling_convention;
 mod decl;
 mod expr;
 pub mod lookup;
@@ -60,6 +61,7 @@ mod span_map;
 mod types;
 
 // Re-export core types
+pub use calling_convention::*;
 pub use decl::*;
 pub use expr::*;
 pub use node_id::*;

--- a/crates/tribute-front/src/ast/types.rs
+++ b/crates/tribute-front/src/ast/types.rs
@@ -107,6 +107,11 @@ pub enum TypeKind<'db> {
         params: Vec<Type<'db>>,
         result: Type<'db>,
         effect: EffectRow<'db>,
+        /// Calling-convention lower bound requested independently of the row.
+        ///
+        /// An explicit empty effect annotation (`->{}`) uses
+        /// `EvidenceDirect`, while an inferred pure function uses `Direct`.
+        minimum_convention: super::CallingConvention,
     },
 
     /// Tuple type.
@@ -530,7 +535,7 @@ pub enum TypeAnnotationKind {
     /// A function type: `fn(Int, Int) -> Int`
     ///
     /// The `abilities` field contains the ability row items:
-    /// - `vec![]`: pure function (`fn(a) ->{} b`)
+    /// - `vec![]`: explicit pure-effectful function (`fn(a) ->{} b`)
     /// - `vec![Infer]`: effect polymorphic (`fn(a) -> b` — no ability row written)
     /// - `vec![Named("State")]`: explicit effects (`fn(a) ->{State} b`)
     /// - `vec![Named("State"), Named("e")]`: mixed (`fn(a) ->{State, e} b`)

--- a/crates/tribute-front/src/ast/types.rs
+++ b/crates/tribute-front/src/ast/types.rs
@@ -109,8 +109,8 @@ pub enum TypeKind<'db> {
         effect: EffectRow<'db>,
         /// Calling-convention lower bound requested independently of the row.
         ///
-        /// An explicit empty effect annotation (`->{}`) uses
-        /// `EvidenceDirect`, while an inferred pure function uses `Direct`.
+        /// This is independent of the convention derived from the effect row.
+        /// Source function types currently use `Direct` as their floor.
         minimum_convention: super::CallingConvention,
     },
 
@@ -535,7 +535,7 @@ pub enum TypeAnnotationKind {
     /// A function type: `fn(Int, Int) -> Int`
     ///
     /// The `abilities` field contains the ability row items:
-    /// - `vec![]`: explicit pure-effectful function (`fn(a) ->{} b`)
+    /// - `vec![]`: explicit pure function (`fn(a) ->{} b`)
     /// - `vec![Infer]`: effect polymorphic (`fn(a) -> b` — no ability row written)
     /// - `vec![Named("State")]`: explicit effects (`fn(a) ->{State} b`)
     /// - `vec![Named("State"), Named("e")]`: mixed (`fn(a) ->{State, e} b`)

--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -15,7 +15,9 @@ use trunk_ir::dialect::core;
 use trunk_ir::refs::{BlockRef, PathRef, TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 
-use crate::ast::{CtorId, LocalId, NodeId, SpanMap, TypeKind, TypeScheme};
+use crate::ast::{
+    AbilityId, CallingConvention, CtorId, LocalId, NodeId, SpanMap, TypeKind, TypeScheme,
+};
 
 /// Information about a captured variable.
 #[derive(Clone, Debug)]
@@ -41,6 +43,14 @@ pub struct IrLoweringCtx<'db> {
     scopes: Vec<HashMap<LocalId, (Symbol, ValueRef)>>,
     /// Function type schemes from type checking, keyed by function name.
     function_types: HashMap<Symbol, TypeScheme<'db>>,
+    /// Ability-level calling-convention requirements.
+    ability_conventions: HashMap<AbilityId<'db>, CallingConvention>,
+    /// Physical worker conventions for named function definitions.
+    ///
+    /// These are intentionally separate from semantic function-type
+    /// conventions: an effect-polymorphic pure definition may have a Direct
+    /// worker while its first-class function type requires a CPS adapter.
+    definition_conventions: HashMap<Symbol, CallingConvention>,
     /// Module path as a vector of segments (e.g., ["std", "Option"]).
     module_path: SymbolVec,
     /// Counter for generating unique lambda names.
@@ -87,6 +97,7 @@ impl<'db> IrLoweringCtx<'db> {
         path: PathRef,
         span_map: SpanMap,
         function_types: HashMap<Symbol, TypeScheme<'db>>,
+        ability_conventions: HashMap<AbilityId<'db>, CallingConvention>,
         module_path: SymbolVec,
         node_types: HashMap<NodeId, crate::ast::Type<'db>>,
     ) -> Self {
@@ -96,6 +107,8 @@ impl<'db> IrLoweringCtx<'db> {
             span_map,
             scopes: vec![HashMap::new()],
             function_types,
+            ability_conventions,
+            definition_conventions: HashMap::new(),
             module_path,
             lambda_counter: 0,
             local_id_counter: 0x8000_0000, // Start high to avoid collisions with parsed LocalIds
@@ -174,6 +187,41 @@ impl<'db> IrLoweringCtx<'db> {
     /// Look up a function's type scheme by name.
     pub fn lookup_function_type(&self, name: Symbol) -> Option<&TypeScheme<'db>> {
         self.function_types.get(&name)
+    }
+
+    /// Derive a function convention from both its effect row and ABI lower bound.
+    pub(crate) fn calling_convention_for_type(
+        &self,
+        ty: crate::ast::Type<'db>,
+    ) -> Option<CallingConvention> {
+        crate::ast::calling_convention_for_function_type(self.db, ty, &self.ability_conventions)
+    }
+
+    /// Derive a convention from an effect row without a function-level ABI bound.
+    pub(crate) fn calling_convention_for_effect_row(
+        &self,
+        effect: crate::ast::EffectRow<'db>,
+    ) -> CallingConvention {
+        crate::ast::calling_convention_for_effect_row(self.db, effect, &self.ability_conventions)
+    }
+
+    /// Look up a function definition and derive its ABI convention.
+    pub(crate) fn function_calling_convention(&self, name: Symbol) -> Option<CallingConvention> {
+        if let Some(convention) = self.definition_conventions.get(&name) {
+            return Some(*convention);
+        }
+        let scheme = self.lookup_function_type(name)?;
+        let body = scheme.body(self.db);
+        self.calling_convention_for_type(body)
+    }
+
+    /// Register the physical worker convention for a named definition.
+    pub(crate) fn register_definition_convention(
+        &mut self,
+        name: Symbol,
+        convention: CallingConvention,
+    ) {
+        self.definition_conventions.insert(name, convention);
     }
 
     /// Look up a local variable.
@@ -690,6 +738,7 @@ mod tests {
             path,
             crate::ast::SpanMap::default(),
             HashMap::new(),
+            HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
         );
@@ -709,6 +758,7 @@ mod tests {
             &db,
             path,
             crate::ast::SpanMap::default(),
+            HashMap::new(),
             HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
@@ -737,6 +787,7 @@ mod tests {
             path,
             crate::ast::SpanMap::default(),
             HashMap::new(),
+            HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
         );
@@ -758,6 +809,7 @@ mod tests {
             &db,
             path,
             crate::ast::SpanMap::default(),
+            HashMap::new(),
             HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
@@ -788,6 +840,7 @@ mod tests {
             path,
             crate::ast::SpanMap::default(),
             HashMap::new(),
+            HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
         );
@@ -800,6 +853,7 @@ mod tests {
                 params: vec![bound_var],
                 result: bound_var,
                 effect,
+                minimum_convention: CallingConvention::Direct,
             },
         );
         let ir_ty = ctx.convert_type(&mut ir, ty);
@@ -819,6 +873,7 @@ mod tests {
             &db,
             path,
             crate::ast::SpanMap::default(),
+            HashMap::new(),
             HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
@@ -858,6 +913,7 @@ mod tests {
             path,
             crate::ast::SpanMap::default(),
             ft,
+            HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
         );

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -1,7 +1,6 @@
 //! Module-level and declaration lowering.
 
-use std::collections::HashMap;
-
+use tribute_core::{CallableAbi, set_calling_convention};
 use tribute_ir::dialect::ability;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
@@ -11,9 +10,10 @@ use trunk_ir::rewrite::Module as IrModule;
 use trunk_ir::types::{Attribute, Location};
 
 use crate::ast::{
-    CtorId, Decl, ExternFuncDecl, FuncDecl, Module, NodeId, SpanMap, TypeScheme, TypedRef,
+    CallingConvention, CtorId, Decl, EffectRow, ExternFuncDecl, FuncDecl, TypeKind, TypedRef,
 };
 
+use super::super::TypedModule;
 use super::super::context::IrLoweringCtx;
 use super::{FuncSignature, IrBuilder, convert_annotation_to_ir_type, expr, qualified_type_name};
 
@@ -82,58 +82,111 @@ fn prescan_struct_fields<'db>(
     }
 }
 
-/// Lower a module to arena TrunkIR.
+/// Record physical worker conventions separately from semantic function types.
 ///
-/// Returns an `Module` inside the given `IrContext`.
-pub fn lower_module<'db>(
-    db: &'db dyn salsa::Database,
-    ir: &mut IrContext,
-    path: PathRef,
-    span_map: SpanMap,
-    module: Module<TypedRef<'db>>,
-    function_types: HashMap<Symbol, TypeScheme<'db>>,
-    node_types: HashMap<NodeId, crate::ast::Type<'db>>,
-) -> IrModule {
-    let module_location = span_map.get_or_default(module.id);
-    let location = Location::new(path, module_location);
-    let module_name = module.name.unwrap_or_else(|| Symbol::new("main"));
-    let module_path = smallvec::smallvec![module_name];
+/// An omitted effect annotation denotes an open row, but its generalized tail
+/// does not by itself require the definition's worker to use CPS. Concrete
+/// residual effects still contribute their ability-level requirements. An
+/// explicit annotation, including `->{}`, requests its full semantic ABI.
+fn prescan_definition_conventions<'db>(
+    ctx: &mut IrLoweringCtx<'db>,
+    decls: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+) {
+    for decl in decls {
+        match decl {
+            Decl::Function(func_decl) => {
+                let qualified = crate::qualified_symbol(prefix, func_decl.name);
+                let scheme = ctx
+                    .lookup_function_type(qualified)
+                    .or_else(|| ctx.lookup_function_type(func_decl.name));
+                let Some(scheme) = scheme.copied() else {
+                    continue;
+                };
+                let body = scheme.body(ctx.db);
+                let Some(mut convention) = ctx.calling_convention_for_type(body) else {
+                    continue;
+                };
 
-    let mut ctx = IrLoweringCtx::new(
-        db,
-        path,
-        span_map.clone(),
-        function_types,
-        module_path,
-        node_types,
-    );
-
-    // Pre-scan: register all struct field orders before lowering any declarations.
-    prescan_struct_fields(&mut ctx, ir, &module.decls, &mut String::new());
-
-    // Create the module block (top-down: create block first, push ops into it)
-    let module_block = ir.create_block(BlockData {
-        location,
-        args: vec![],
-        ops: Default::default(),
-        parent_region: None,
-    });
-    ctx.set_module_block(module_block);
-
-    // Lower each declaration, pushing ops into the module block
-    for decl in module.decls {
-        lower_decl(&mut ctx, ir, module_block, decl);
+                if func_decl.effects.is_none()
+                    && let TypeKind::Func { effect, .. } = body.kind(ctx.db)
+                {
+                    let concrete = EffectRow::new(ctx.db, effect.effects(ctx.db).clone(), None);
+                    convention = ctx.calling_convention_for_effect_row(concrete);
+                }
+                ctx.register_definition_convention(qualified, convention);
+            }
+            Decl::Module(module) => {
+                if let Some(body) = &module.body {
+                    let saved = crate::push_prefix(prefix, module.name);
+                    prescan_definition_conventions(ctx, body, prefix);
+                    prefix.truncate(saved);
+                }
+            }
+            _ => {}
+        }
     }
+}
 
-    // Create region and module op
-    let module_region = ir.create_region(RegionData {
-        location,
-        blocks: trunk_ir::smallvec::smallvec![module_block],
-        parent_op: None,
-    });
+impl<'db> TypedModule<'db> {
+    /// Lower this module when its source path has already been interned.
+    pub(crate) fn lower_module(
+        self,
+        db: &'db dyn salsa::Database,
+        ir: &mut IrContext,
+        path: PathRef,
+    ) -> IrModule {
+        let Self {
+            ast,
+            span_map,
+            function_types,
+            node_types,
+            ability_conventions,
+        } = self;
+        let module_location = span_map.get_or_default(ast.id);
+        let location = Location::new(path, module_location);
+        let module_name = ast.name.unwrap_or_else(|| Symbol::new("main"));
+        let module_path = smallvec::smallvec![module_name];
 
-    let module_op = core::module(ir, location, module_name, module_region);
-    IrModule::new(ir, module_op.op_ref()).expect("valid core.module operation")
+        let mut ctx = IrLoweringCtx::new(
+            db,
+            path,
+            span_map.clone(),
+            function_types,
+            ability_conventions,
+            module_path,
+            node_types,
+        );
+
+        prescan_definition_conventions(&mut ctx, &ast.decls, &mut String::new());
+
+        // Pre-scan: register all struct field orders before lowering any declarations.
+        prescan_struct_fields(&mut ctx, ir, &ast.decls, &mut String::new());
+
+        // Create the module block (top-down: create block first, push ops into it)
+        let module_block = ir.create_block(BlockData {
+            location,
+            args: vec![],
+            ops: Default::default(),
+            parent_region: None,
+        });
+        ctx.set_module_block(module_block);
+
+        // Lower each declaration, pushing ops into the module block
+        for decl in ast.decls {
+            lower_decl(&mut ctx, ir, module_block, decl);
+        }
+
+        // Create region and module op
+        let module_region = ir.create_region(RegionData {
+            location,
+            blocks: trunk_ir::smallvec::smallvec![module_block],
+            parent_op: None,
+        });
+
+        let module_op = core::module(ir, location, module_name, module_region);
+        IrModule::new(ir, module_op.op_ref()).expect("valid core.module operation")
+    }
 }
 
 /// Lower a declaration to arena TrunkIR.
@@ -184,9 +237,15 @@ fn lower_function<'db>(
     let FuncSignature {
         param_types: param_ir_types,
         return_type: return_ty,
-        is_effectful,
+        convention: semantic_convention,
     } = sig;
+    let qualified_name = ctx.qualify_name(func_name);
+    let convention = ctx
+        .function_calling_convention(qualified_name)
+        .unwrap_or(semantic_convention);
     let anyref_ty = ctx.anyref_type(ir);
+    let evidence_ty = ability::evidence_adt_type_ref(ir);
+    let abi = CallableAbi::new(convention, param_ir_types.iter().copied(), return_ty);
 
     // Create entry block with parameter args
     let mut block_args: Vec<BlockArgData> = param_ir_types
@@ -203,11 +262,9 @@ fn lower_function<'db>(
         })
         .collect();
 
-    // Effectful functions receive evidence and done_k as the first two parameters.
-    // Evidence is threaded through to effectful callees.
-    // The function calls done_k(result) instead of func.return on normal completion.
-    let block_args = if is_effectful {
-        let evidence_ty = ability::evidence_adt_type_ref(ir);
+    // Effectful functions receive evidence. Only CPS functions also receive done_k
+    // and return through it on normal completion.
+    let block_args = if convention.needs_evidence() {
         let mut ev_arg = BlockArgData {
             ty: evidence_ty,
             attrs: Default::default(),
@@ -216,15 +273,18 @@ fn lower_function<'db>(
             Symbol::new("bind_name"),
             Attribute::Symbol(Symbol::new("__evidence")),
         );
-        let mut done_k_arg = BlockArgData {
-            ty: anyref_ty,
-            attrs: Default::default(),
-        };
-        done_k_arg.attrs.insert(
-            Symbol::new("bind_name"),
-            Attribute::Symbol(Symbol::new("__done_k")),
-        );
-        let mut args = vec![ev_arg, done_k_arg];
+        let mut args = vec![ev_arg];
+        if convention.needs_done_k() {
+            let mut done_k_arg = BlockArgData {
+                ty: anyref_ty,
+                attrs: Default::default(),
+            };
+            done_k_arg.attrs.insert(
+                Symbol::new("bind_name"),
+                Attribute::Symbol(Symbol::new("__done_k")),
+            );
+            args.push(done_k_arg);
+        }
         args.append(&mut block_args);
         args
     } else {
@@ -241,8 +301,7 @@ fn lower_function<'db>(
     // Bind parameters to their block argument values
     {
         let mut scope = ctx.scope();
-        // When effectful, evidence=0, done_k=1, params start at 2
-        let param_offset: u32 = if is_effectful { 2 } else { 0 };
+        let param_offset = abi.source_param_offset() as u32;
         for (i, param) in func_decl.params.iter().enumerate() {
             if let Some(local_id) = param.local_id {
                 let arg_val = ir.block_arg(entry_block, i as u32 + param_offset);
@@ -250,10 +309,10 @@ fn lower_function<'db>(
             }
         }
 
-        // For effectful functions: set done_k and use CPS body lowering.
+        // For CPS functions: set done_k and use CPS body lowering.
         // The done_k continuation is called at the end of the continuation chain
         // instead of func.return, handled by build_cps_continuation.
-        if is_effectful {
+        if convention.needs_done_k() {
             let prev_done_k = scope.done_k;
             let prev_evidence = scope.evidence;
             let evidence_val = ir.block_arg(entry_block, 0);
@@ -281,7 +340,12 @@ fn lower_function<'db>(
             scope.done_k = prev_done_k;
             scope.evidence = prev_evidence;
         } else {
-            // Pure function: lower body normally
+            // Direct and EvidenceDirect functions return their source result normally.
+            // EvidenceDirect still threads evidence through nested effectful calls.
+            let prev_evidence = scope.evidence;
+            if convention.needs_evidence() {
+                scope.evidence = Some(ir.block_arg(entry_block, 0));
+            }
             let mut builder = IrBuilder::new(&mut scope, ir, entry_block);
             if let Some(result) = expr::lower_expr(&mut builder, func_decl.body) {
                 let result = builder.cast_if_needed(location, result, return_ty);
@@ -292,19 +356,13 @@ fn lower_function<'db>(
                 let ret_op = func::r#return(builder.ir, location, [nil]);
                 builder.ir.push_op(builder.block, ret_op.op_ref());
             }
+            scope.evidence = prev_evidence;
         }
     }
 
     // Build function type
-    // Effectful functions: evidence + done_k are the first two params, return type is anyref
-    let (final_param_types, final_return_ty) = if is_effectful {
-        let evidence_ty = ability::evidence_adt_type_ref(ir);
-        let mut params = vec![evidence_ty, anyref_ty]; // evidence, done_k
-        params.extend_from_slice(&param_ir_types);
-        (params, anyref_ty)
-    } else {
-        (param_ir_types.clone(), return_ty)
-    };
+    let final_param_types = abi.lowered_params(evidence_ty, anyref_ty);
+    let final_return_ty = abi.lowered_result(anyref_ty);
     let func_type = ctx.func_type(ir, &final_param_types, final_return_ty);
 
     // Create body region and func op
@@ -316,6 +374,7 @@ fn lower_function<'db>(
 
     let qualified_name = ctx.qualify_name(func_name);
     let func_op = func::func(ir, location, qualified_name, func_type, body_region);
+    set_calling_convention(ir, func_op.op_ref(), convention);
     ir.push_op(top, func_op.op_ref());
 }
 
@@ -520,6 +579,6 @@ fn fallback_from_annotations<'db>(
     FuncSignature {
         param_types,
         return_type,
-        is_effectful: false,
+        convention: CallingConvention::Direct,
     }
 }

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -87,7 +87,7 @@ fn prescan_struct_fields<'db>(
 /// An omitted effect annotation denotes an open row, but its generalized tail
 /// does not by itself require the definition's worker to use CPS. Concrete
 /// residual effects still contribute their ability-level requirements. An
-/// explicit annotation, including `->{}`, requests its full semantic ABI.
+/// explicit annotations use the convention derived from their closed row.
 fn prescan_definition_conventions<'db>(
     ctx: &mut IrLoweringCtx<'db>,
     decls: &[Decl<TypedRef<'db>>],

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 use salsa::Accumulator;
 use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
+use tribute_core::set_calling_convention;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{adt, arith, core, func, scf};
@@ -24,6 +25,7 @@ use super::{
     IrBuilder, extract_ctor_id, extract_type_name, get_or_create_tuple_type, qualified_type_name,
     resolve_enum_type_attr,
 };
+use crate::ast::CallingConvention;
 
 /// Lower an expression to arena TrunkIR.
 pub(super) fn lower_expr<'db>(
@@ -137,6 +139,7 @@ pub(super) fn lower_expr<'db>(
                     func_name,
                     &param_ir_types,
                     result_ir_ty,
+                    None,
                 );
                 Some(result)
             }
@@ -149,8 +152,9 @@ pub(super) fn lower_expr<'db>(
                             .map(|t| builder.ctx.convert_type(builder.ir, *t))
                             .collect();
                         let r = builder.ctx.convert_type(builder.ir, *result);
-                        let result =
-                            super::lambda::wrap_func_as_closure(builder, location, *variant, &p, r);
+                        let result = super::lambda::wrap_func_as_closure(
+                            builder, location, *variant, &p, r, None,
+                        );
                         Some(result)
                     }
                     _ => {
@@ -230,7 +234,8 @@ pub(super) fn lower_expr<'db>(
         ExprKind::Block { stmts, value } => lower_block(builder, stmts, value),
 
         ExprKind::Call { callee, args } => {
-            let mut arg_values = builder.collect_args(args)?;
+            let arg_exprs = args;
+            let mut arg_values = builder.collect_args(arg_exprs.clone())?;
 
             match *callee.kind {
                 ExprKind::Var(ref typed_ref) => match &typed_ref.resolved {
@@ -238,34 +243,50 @@ pub(super) fn lower_expr<'db>(
                         let callee_name = id.qualified(builder.db());
 
                         // Insert casts for arguments if we have type scheme information
+                        adapt_named_function_args(
+                            builder,
+                            location,
+                            callee_name,
+                            &arg_exprs,
+                            &mut arg_values,
+                        );
                         cast_args_from_signature(builder, location, callee_name, &mut arg_values);
 
-                        // If callee is effectful and we have done_k, pass it as last arg.
-                        // This enables the CPS chain: the callee calls done_k(result)
-                        // instead of returning directly.
-                        let callee_is_effectful = matches!(
-                            typed_ref.ty.kind(builder.db()),
-                            TypeKind::Func { effect, .. } if !effect.is_pure(builder.db())
-                        );
-                        // If callee is effectful, pass done_k as first arg.
-                        // Use existing done_k if available, otherwise create identity.
-                        if callee_is_effectful {
-                            let evidence = super::get_or_create_evidence(builder, location);
-                            let done_k = builder.ctx.done_k.unwrap_or_else(|| {
-                                super::create_identity_done_k(builder, location)
-                            });
-                            let anyref_ty = builder.ctx.anyref_type(builder.ir);
-                            let mut cps_args = vec![evidence, done_k];
-                            cps_args.append(&mut arg_values);
-                            let op =
-                                func::call(builder.ir, location, cps_args, anyref_ty, callee_name);
-                            builder.ir.push_op(builder.block, op.op_ref());
-                            return Some(op.result(builder.ir));
-                        }
-
                         let result_ty = builder.call_result_type(&typed_ref.ty);
-                        let op =
-                            func::call(builder.ir, location, arg_values, result_ty, callee_name);
+                        let convention = builder
+                            .ctx
+                            .function_calling_convention(callee_name)
+                            .unwrap_or_else(|| {
+                                builder
+                                    .ctx
+                                    .calling_convention_for_type(typed_ref.ty)
+                                    .unwrap_or(CallingConvention::Direct)
+                            });
+                        let call_result_ty = match convention {
+                            CallingConvention::Direct => result_ty,
+                            CallingConvention::EvidenceDirect => {
+                                let evidence = super::get_or_create_evidence(builder, location);
+                                arg_values.insert(0, evidence);
+                                result_ty
+                            }
+                            CallingConvention::Cps => {
+                                let evidence = super::get_or_create_evidence(builder, location);
+                                let done_k = builder.ctx.done_k.unwrap_or_else(|| {
+                                    super::create_identity_done_k(builder, location)
+                                });
+                                arg_values.insert(0, done_k);
+                                arg_values.insert(0, evidence);
+                                builder.ctx.anyref_type(builder.ir)
+                            }
+                        };
+                        let op = func::call(
+                            builder.ir,
+                            location,
+                            arg_values,
+                            call_result_ty,
+                            callee_name,
+                        );
+                        set_calling_convention(builder.ir, op.op_ref(), convention);
                         builder.ir.push_op(builder.block, op.op_ref());
                         let result = op.result(builder.ir);
 
@@ -305,6 +326,11 @@ pub(super) fn lower_expr<'db>(
                                     vec![resume_anyref],
                                     anyref_ty,
                                 );
+                                set_calling_convention(
+                                    builder.ir,
+                                    op.op_ref(),
+                                    CallingConvention::Direct,
+                                );
                                 builder.ir.push_op(builder.block, op.op_ref());
                                 let result = op.result(builder.ir);
                                 Some(result)
@@ -337,35 +363,45 @@ pub(super) fn lower_expr<'db>(
                                 }
                             }
 
-                            // All closures use CPS calling convention: always pass done_k
-                            // as the first argument.
-                            let done_k = builder.ctx.done_k.unwrap_or_else(|| {
-                                super::create_identity_done_k(builder, location)
-                            });
-                            let anyref_ty = builder.ctx.anyref_type(builder.ir);
-
-                            // Cast callee to CPS closure type so closure_lower extracts
-                            // the correct return type (anyref, not the source-level type).
-                            let mut cps_param_types = vec![anyref_ty]; // done_k
-                            cps_param_types
-                                .extend(arg_values.iter().map(|v| builder.ir.value_ty(*v)));
-                            let cps_func_ty =
-                                builder
-                                    .ctx
-                                    .func_type(builder.ir, &cps_param_types, anyref_ty);
-                            let cps_closure_ty = builder.ctx.closure_type(builder.ir, cps_func_ty);
-                            let callee_cps =
-                                builder.cast_if_needed(location, callee_val, cps_closure_ty);
-
-                            let mut cps_args = vec![done_k];
-                            cps_args.append(&mut arg_values);
-                            let op = func::call_indirect(
-                                builder.ir, location, callee_cps, cps_args, anyref_ty,
+                            let convention = calling_convention_for_type(builder.ctx, typed_ref.ty);
+                            let expected_ty = builder.call_result_type(&typed_ref.ty);
+                            let call_result_ty = if convention.needs_done_k() {
+                                builder.ctx.anyref_type(builder.ir)
+                            } else {
+                                expected_ty
+                            };
+                            let mut hidden_args = Vec::new();
+                            if convention.needs_evidence() {
+                                hidden_args.push(super::get_or_create_evidence(builder, location));
+                            }
+                            if convention.needs_done_k() {
+                                let done_k = builder.ctx.done_k.unwrap_or_else(|| {
+                                    super::create_identity_done_k(builder, location)
+                                });
+                                hidden_args.push(done_k);
+                            }
+                            hidden_args.append(&mut arg_values);
+                            let closure_param_types: Vec<_> = hidden_args
+                                .iter()
+                                .map(|v| builder.ir.value_ty(*v))
+                                .collect();
+                            let closure_func_ty = builder.ctx.func_type(
+                                builder.ir,
+                                &closure_param_types,
+                                call_result_ty,
                             );
+                            let closure_ty = builder.ctx.closure_type(builder.ir, closure_func_ty);
+                            let callee = builder.cast_if_needed(location, callee_val, closure_ty);
+                            let op = func::call_indirect(
+                                builder.ir,
+                                location,
+                                callee,
+                                hidden_args,
+                                call_result_ty,
+                            );
+                            set_calling_convention(builder.ir, op.op_ref(), convention);
                             builder.ir.push_op(builder.block, op.op_ref());
                             let result = op.result(builder.ir);
-                            // Cast anyref result back to the expected type
-                            let expected_ty = builder.call_result_type(&typed_ref.ty);
                             let result = builder.cast_if_needed(location, result, expected_ty);
                             Some(result)
                         }
@@ -414,37 +450,56 @@ pub(super) fn lower_expr<'db>(
                 },
                 _ => {
                     // General expression callee -> indirect call
-                    // All closures use CPS calling convention: pass done_k as first arg.
+                    let callee_node_id = callee.id;
                     let callee_val = lower_expr(builder, callee)?;
-                    let done_k = builder
+                    let convention = builder
                         .ctx
-                        .done_k
-                        .unwrap_or_else(|| super::create_identity_done_k(builder, location));
-                    let anyref_ty = builder.ctx.anyref_type(builder.ir);
-
-                    // Cast callee to CPS closure type
-                    let mut cps_param_types = vec![anyref_ty]; // done_k
-                    cps_param_types.extend(arg_values.iter().map(|v| builder.ir.value_ty(*v)));
-                    let cps_func_ty =
-                        builder
-                            .ctx
-                            .func_type(builder.ir, &cps_param_types, anyref_ty);
-                    let cps_closure_ty = builder.ctx.closure_type(builder.ir, cps_func_ty);
-                    let callee_cps = builder.cast_if_needed(location, callee_val, cps_closure_ty);
-
-                    let mut cps_args = vec![done_k];
-                    cps_args.append(&mut arg_values);
-                    let op =
-                        func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty);
-                    builder.ir.push_op(builder.block, op.op_ref());
-                    let result = op.result(builder.ir);
-
-                    // Cast anyref result back to expected type
+                        .get_node_type(callee_node_id)
+                        .copied()
+                        .map(|ty| calling_convention_for_type(builder.ctx, ty))
+                        .unwrap_or(CallingConvention::Cps);
                     let expected_ty = builder
                         .ctx
                         .get_node_type(expr_node_id)
                         .map(|t| builder.ctx.convert_type(builder.ir, *t))
-                        .unwrap_or_else(|| anyref_ty);
+                        .unwrap_or_else(|| builder.ctx.anyref_type(builder.ir));
+                    let call_result_ty = if convention.needs_done_k() {
+                        builder.ctx.anyref_type(builder.ir)
+                    } else {
+                        expected_ty
+                    };
+                    let mut hidden_args = Vec::new();
+                    if convention.needs_evidence() {
+                        hidden_args.push(super::get_or_create_evidence(builder, location));
+                    }
+                    if convention.needs_done_k() {
+                        hidden_args.push(
+                            builder.ctx.done_k.unwrap_or_else(|| {
+                                super::create_identity_done_k(builder, location)
+                            }),
+                        );
+                    }
+                    hidden_args.append(&mut arg_values);
+                    let closure_param_types: Vec<_> = hidden_args
+                        .iter()
+                        .map(|v| builder.ir.value_ty(*v))
+                        .collect();
+                    let closure_func_ty =
+                        builder
+                            .ctx
+                            .func_type(builder.ir, &closure_param_types, call_result_ty);
+                    let closure_ty = builder.ctx.closure_type(builder.ir, closure_func_ty);
+                    let callee = builder.cast_if_needed(location, callee_val, closure_ty);
+                    let op = func::call_indirect(
+                        builder.ir,
+                        location,
+                        callee,
+                        hidden_args,
+                        call_result_ty,
+                    );
+                    set_calling_convention(builder.ir, op.op_ref(), convention);
+                    builder.ir.push_op(builder.block, op.op_ref());
+                    let result = op.result(builder.ir);
                     let result = builder.cast_if_needed(location, result, expected_ty);
 
                     Some(result)
@@ -619,35 +674,32 @@ pub(super) fn lower_expr<'db>(
                 node_ty.is_some(),
                 "lambda node type should be populated by typeck"
             );
-            let (param_ir_types, result_ir_ty) = match node_ty.map(|t| (t, t.kind(db))) {
+            let (param_ir_types, result_ir_ty, convention) = match node_ty.map(|t| (t, t.kind(db)))
+            {
                 Some((
-                    _,
+                    func_ty,
                     TypeKind::Func {
-                        params: p,
-                        result,
-                        effect,
+                        params: p, result, ..
                     },
                 )) => {
                     let pir: Vec<_> = p
                         .iter()
                         .map(|t| builder.ctx.convert_type(builder.ir, *t))
                         .collect();
-                    // Effectful lambdas with concrete abilities use anyref as
-                    // their return type. This ensures the CPS handler chain
-                    // (which passes boxed values) has consistent types.
-                    // Call sites using these closures via func.call_indirect
-                    // will get anyref and must cast to the expected type.
-                    let has_concrete_abilities = !effect.effects(db).is_empty();
-                    let rir = if has_concrete_abilities {
+                    let convention = builder
+                        .ctx
+                        .calling_convention_for_type(func_ty)
+                        .expect("lambda node type must be a function");
+                    let rir = if convention == CallingConvention::Cps {
                         builder.ctx.anyref_type(builder.ir)
                     } else {
                         builder.ctx.convert_type(builder.ir, *result)
                     };
-                    (pir, rir)
+                    (pir, rir, convention)
                 }
                 _ => {
                     let any = builder.ctx.anyref_type(builder.ir);
-                    (vec![any; params.len()], any)
+                    (vec![any; params.len()], any, CallingConvention::Cps)
                 }
             };
             super::lambda::lower_lambda(
@@ -657,6 +709,7 @@ pub(super) fn lower_expr<'db>(
                 &body,
                 &param_ir_types,
                 result_ir_ty,
+                convention,
             )
         }
 
@@ -863,7 +916,7 @@ fn lower_block_cps<'db>(
             return lower_cps_ability_op(builder, stmt, remaining, value).map(|r| (r, true));
         }
 
-        // CPS-transform effectful calls and closure calls when done_k is set.
+        // CPS-transform calls whose selected convention is Cps when done_k is set.
         // Skip in handler arm bodies (cps_handler_mode) — need scf.yield terminator.
         if can_lower_cps_call_in_current_context(builder.ctx) && is_cps_call_stmt(builder.ctx, stmt)
         {
@@ -881,7 +934,7 @@ fn lower_block_cps<'db>(
         return Some((result, true));
     }
 
-    // Check if the value expression is an effectful named function call with done_k.
+    // Check if the value expression is a named Cps function call with done_k.
     // If so, treat it as a CPS call: done_k is passed to the callee, which will
     // call it internally. The caller must NOT call done_k again (is_cps = true).
     // Skip in handler arm context (cps_handler_mode) — result flows to scf.yield.
@@ -889,17 +942,19 @@ fn lower_block_cps<'db>(
         && let ExprKind::Call { callee: c, .. } = &*value.kind
         && let ExprKind::Var(tr) = &*c.kind
         && !matches!(&tr.resolved, ResolvedRef::AbilityOp { .. })
-        && is_callee_effectful_by_definition(builder.ctx, tr)
+        && callee_requires_cps_by_definition(builder.ctx, tr)
         && let Some(result) = try_lower_value_effectful_call(builder, value.clone())
     {
         return Some((result, true));
     }
-    // All local closure calls are CPS (closures always have done_k)
+    // Local closure calls only participate in the CPS chain when their row
+    // requires the CPS convention.
     if can_lower_cps_call_in_current_context(builder.ctx)
         && let ExprKind::Call { callee: c, .. } = &*value.kind
         && let ExprKind::Var(tr) = &*c.kind
         && matches!(&tr.resolved, ResolvedRef::Local { .. })
         && !matches!(&tr.ty.kind(builder.db()), TypeKind::Continuation { .. })
+        && calling_convention_for_type(builder.ctx, tr.ty) == CallingConvention::Cps
     {
         let result = lower_expr(builder, value)?;
         return Some((result, true));
@@ -927,6 +982,14 @@ fn can_lower_cps_call_in_current_context(ctx: &super::super::context::IrLowering
     ctx.done_k.is_some() && !ctx.cps_handler_mode
 }
 
+fn calling_convention_for_type<'db>(
+    ctx: &super::super::context::IrLoweringCtx<'db>,
+    ty: crate::ast::Type<'db>,
+) -> CallingConvention {
+    ctx.calling_convention_for_type(ty)
+        .unwrap_or(CallingConvention::Cps)
+}
+
 fn is_cps_call_expr<'db>(
     ctx: &super::super::context::IrLoweringCtx<'db>,
     expr: &Expr<TypedRef<'db>>,
@@ -935,7 +998,10 @@ fn is_cps_call_expr<'db>(
         return false;
     };
     let ExprKind::Var(tr) = &*callee.kind else {
-        return true;
+        return ctx
+            .get_node_type(callee.id)
+            .copied()
+            .is_some_and(|ty| calling_convention_for_type(ctx, ty) == CallingConvention::Cps);
     };
     match &tr.resolved {
         ResolvedRef::AbilityOp {
@@ -943,8 +1009,11 @@ fn is_cps_call_expr<'db>(
             ..
         } => true,
         ResolvedRef::AbilityOp { .. } => false,
-        ResolvedRef::Local { .. } => !matches!(tr.ty.kind(ctx.db), TypeKind::Continuation { .. }),
-        _ => is_callee_effectful_by_definition(ctx, tr),
+        ResolvedRef::Local { .. } => {
+            !matches!(tr.ty.kind(ctx.db), TypeKind::Continuation { .. })
+                && calling_convention_for_type(ctx, tr.ty) == CallingConvention::Cps
+        }
+        _ => callee_requires_cps_by_definition(ctx, tr),
     }
 }
 
@@ -1214,6 +1283,7 @@ fn try_lower_value_effectful_call<'db>(
     cps_args.append(&mut arg_values);
 
     let call_op = func::call(builder.ir, location, cps_args, anyref_ty, callee_name);
+    set_calling_convention(builder.ir, call_op.op_ref(), CallingConvention::Cps);
     builder.ir.push_op(builder.block, call_op.op_ref());
     let call_result = call_op.result(builder.ir);
 
@@ -1243,17 +1313,11 @@ fn is_direct_ability_op_stmt<'db>(stmt: &Stmt<TypedRef<'db>>) -> bool {
     )
 }
 
-/// Check if a statement contains a call to an effectful function (non-pure).
-///
-/// This excludes direct ability op calls (handled by `is_direct_ability_op_stmt`)
-/// and targets regular function calls whose type has non-empty effects.
-/// Check if a statement contains a call to a function whose **definition** has effects.
-///
 /// Check if a statement contains a call that needs CPS transformation.
 ///
 /// This includes:
-/// - Effectful function calls (by definition TypeScheme, not call-site type)
-/// - All local closure calls (closures always have CPS calling convention)
+/// - Named functions whose definition selects Cps
+/// - Local and computed closures whose function type selects Cps
 ///
 /// Ability ops are excluded (handled separately by is_direct_ability_op_stmt).
 fn is_cps_call_stmt<'db>(
@@ -1267,30 +1331,20 @@ fn is_cps_call_stmt<'db>(
     is_cps_call_expr(ctx, call_expr) && !is_direct_ability_op_stmt(stmt)
 }
 
-/// Check if a callee is effectful based on its function **definition** (TypeScheme),
-/// not the call-site resolved type.
-fn is_callee_effectful_by_definition<'db>(
+/// Check whether a named callee's definition selects Cps.
+fn callee_requires_cps_by_definition<'db>(
     ctx: &super::super::context::IrLoweringCtx<'db>,
     tr: &TypedRef<'db>,
 ) -> bool {
     let callee_name = match &tr.resolved {
         ResolvedRef::Function { id } => id.qualified(ctx.db),
         _ => {
-            // For locals/closures, fall back to call-site type
-            return match tr.ty.kind(ctx.db) {
-                TypeKind::Func { effect, .. } => !effect.is_pure(ctx.db),
-                _ => false,
-            };
+            // For locals/closures, use the call-site function type.
+            return ctx.calling_convention_for_type(tr.ty) == Some(CallingConvention::Cps);
         }
     };
     // Look up the function's TypeScheme (definition type)
-    if let Some(scheme) = ctx.lookup_function_type(callee_name) {
-        let body = scheme.body(ctx.db);
-        if let TypeKind::Func { effect, .. } = body.kind(ctx.db) {
-            return !effect.is_pure(ctx.db);
-        }
-    }
-    false
+    ctx.function_calling_convention(callee_name) == Some(CallingConvention::Cps)
 }
 
 /// Lower a single non-CPS statement (let binding or expression statement).
@@ -1427,7 +1481,7 @@ fn lower_cps_ability_op<'db>(
     Some(perform_op.result(builder.ir))
 }
 
-/// CPS-transform a statement containing an effectful function call.
+/// CPS-transform a statement containing a Cps function call.
 ///
 /// Similar to `lower_cps_ability_op`, but for regular function calls to effectful
 /// functions. Builds a continuation for the remaining computation and passes it
@@ -1487,12 +1541,13 @@ fn lower_cps_call<'db>(
                 // Insert casts for arguments using type scheme information
                 cast_args_from_signature(builder, location, callee_name, &mut arg_values);
 
-                // Call effectful function with evidence + continuation as first args
+                // Call the Cps function with evidence + continuation as hidden args.
                 let evidence = super::get_or_create_evidence(builder, location);
                 let mut cps_args = vec![evidence, continuation];
                 cps_args.append(&mut arg_values);
 
                 let call_op = func::call(builder.ir, location, cps_args, anyref_ty, callee_name);
+                set_calling_convention(builder.ir, call_op.op_ref(), CallingConvention::Cps);
                 builder.ir.push_op(builder.block, call_op.op_ref());
                 Some(call_op.result(builder.ir))
             }
@@ -1512,7 +1567,8 @@ fn lower_cps_call<'db>(
 
                 // Cast callee to CPS closure type so closure_lower extracts
                 // the correct return type (anyref, not the source-level type).
-                let mut cps_param_types = vec![anyref_ty]; // done_k
+                let evidence = super::get_or_create_evidence(builder, location);
+                let mut cps_param_types = vec![builder.ir.value_ty(evidence), anyref_ty];
                 cps_param_types.extend(arg_values.iter().map(|v| builder.ir.value_ty(*v)));
                 let cps_func_ty = builder
                     .ctx
@@ -1521,11 +1577,12 @@ fn lower_cps_call<'db>(
                 let callee_cps = builder.cast_if_needed(location, callee_val, cps_closure_ty);
 
                 // Call closure with continuation as first arg (done_k)
-                let mut cps_args = vec![continuation];
+                let mut cps_args = vec![evidence, continuation];
                 cps_args.append(&mut arg_values);
 
                 let call_op =
                     func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty);
+                set_calling_convention(builder.ir, call_op.op_ref(), CallingConvention::Cps);
                 builder.ir.push_op(builder.block, call_op.op_ref());
                 Some(call_op.result(builder.ir))
             }
@@ -1534,7 +1591,8 @@ fn lower_cps_call<'db>(
         callee_kind => {
             let callee = Expr::new(callee_id, callee_kind);
             let callee_val = lower_expr(builder, callee)?;
-            let mut cps_param_types = vec![anyref_ty];
+            let evidence = super::get_or_create_evidence(builder, location);
+            let mut cps_param_types = vec![builder.ir.value_ty(evidence), anyref_ty];
             cps_param_types.extend(arg_values.iter().map(|v| builder.ir.value_ty(*v)));
             let cps_func_ty = builder
                 .ctx
@@ -1542,10 +1600,11 @@ fn lower_cps_call<'db>(
             let cps_closure_ty = builder.ctx.closure_type(builder.ir, cps_func_ty);
             let callee_cps = builder.cast_if_needed(location, callee_val, cps_closure_ty);
 
-            let mut cps_args = vec![continuation];
+            let mut cps_args = vec![evidence, continuation];
             cps_args.append(&mut arg_values);
             let call_op =
                 func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty);
+            set_calling_convention(builder.ir, call_op.op_ref(), CallingConvention::Cps);
             builder.ir.push_op(builder.block, call_op.op_ref());
             Some(call_op.result(builder.ir))
         }
@@ -1566,6 +1625,66 @@ fn lower_cps_call<'db>(
 ///
 /// Looks up the callee's TypeScheme and inserts `unrealized_conversion_cast`
 /// for any argument whose IR type doesn't match the declared parameter type.
+fn adapt_named_function_args<'db>(
+    builder: &mut IrBuilder<'_, 'db>,
+    location: Location,
+    callee_name: Symbol,
+    arg_exprs: &[Expr<TypedRef<'db>>],
+    arg_values: &mut [ValueRef],
+) {
+    let Some(scheme) = builder.ctx.lookup_function_type(callee_name) else {
+        return;
+    };
+    let TypeKind::Func {
+        params: expected_params,
+        ..
+    } = scheme.body(builder.ctx.db).kind(builder.ctx.db)
+    else {
+        return;
+    };
+    let expected_params = expected_params.clone();
+
+    for (i, (arg_expr, expected_ty)) in arg_exprs.iter().zip(expected_params.iter()).enumerate() {
+        let ExprKind::Var(typed_ref) = &*arg_expr.kind else {
+            continue;
+        };
+        let ResolvedRef::Function { id } = &typed_ref.resolved else {
+            continue;
+        };
+        let TypeKind::Func { params, result, .. } = typed_ref.ty.kind(builder.ctx.db) else {
+            continue;
+        };
+        if !matches!(expected_ty.kind(builder.ctx.db), TypeKind::Func { .. }) {
+            continue;
+        }
+        let func_name = id.qualified(builder.ctx.db);
+        let source_convention = builder
+            .ctx
+            .function_calling_convention(func_name)
+            .unwrap_or_default();
+        let target_convention = builder
+            .ctx
+            .calling_convention_for_type(*expected_ty)
+            .expect("expected parameter type must be a function");
+        if source_convention == target_convention {
+            continue;
+        }
+        let param_ir_types: Vec<_> = params
+            .iter()
+            .map(|ty| builder.ctx.convert_type(builder.ir, *ty))
+            .collect();
+        let result_ir_ty = builder.ctx.convert_type(builder.ir, *result);
+        arg_values[i] = super::lambda::wrap_func_as_closure(
+            builder,
+            location,
+            func_name,
+            &param_ir_types,
+            result_ir_ty,
+            Some(target_convention),
+        );
+    }
+}
+
 fn cast_args_from_signature(
     builder: &mut IrBuilder<'_, '_>,
     location: Location,

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -289,6 +289,7 @@ pub(super) fn lower_expr<'db>(
                         set_calling_convention(builder.ir, op.op_ref(), convention);
                         builder.ir.push_op(builder.block, op.op_ref());
                         let result = op.result(builder.ir);
+                        let result = builder.cast_if_needed(location, result, result_ty);
 
                         Some(result)
                     }
@@ -1001,7 +1002,7 @@ fn is_cps_call_expr<'db>(
         return ctx
             .get_node_type(callee.id)
             .copied()
-            .is_some_and(|ty| calling_convention_for_type(ctx, ty) == CallingConvention::Cps);
+            .is_none_or(|ty| calling_convention_for_type(ctx, ty) == CallingConvention::Cps);
     };
     match &tr.resolved {
         ResolvedRef::AbilityOp {
@@ -1269,9 +1270,11 @@ fn try_lower_value_effectful_call<'db>(
     };
 
     let location = builder.location(expr.id);
-    let mut arg_values = builder.collect_args(args)?;
+    let arg_exprs = args;
+    let mut arg_values = builder.collect_args(arg_exprs.clone())?;
 
     // Insert casts for arguments using type scheme information
+    adapt_named_function_args(builder, location, callee_name, &arg_exprs, &mut arg_values);
     cast_args_from_signature(builder, location, callee_name, &mut arg_values);
 
     let anyref_ty = builder.ctx.anyref_type(builder.ir);
@@ -1508,7 +1511,8 @@ fn lower_cps_call<'db>(
     let callee_kind = *callee.kind;
 
     // Lower arguments
-    let mut arg_values = builder.collect_args(args)?;
+    let arg_exprs = args;
+    let mut arg_values = builder.collect_args(arg_exprs.clone())?;
 
     // Determine the logical result type of the function call
     let logical_result_ty = builder
@@ -1539,6 +1543,13 @@ fn lower_cps_call<'db>(
                 let callee_name = id.qualified(builder.db());
 
                 // Insert casts for arguments using type scheme information
+                adapt_named_function_args(
+                    builder,
+                    location,
+                    callee_name,
+                    &arg_exprs,
+                    &mut arg_values,
+                );
                 cast_args_from_signature(builder, location, callee_name, &mut arg_values);
 
                 // Call the Cps function with evidence + continuation as hidden args.

--- a/crates/tribute-front/src/ast_to_ir/lower/lambda.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/lambda.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashSet;
 
+use tribute_core::{CallableAbi, set_calling_convention};
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, core, func};
@@ -20,6 +21,7 @@ use crate::ast::{Expr, ExprKind, LocalId, Param, ResolvedRef, Stmt, TypedRef};
 
 use super::super::context::{CaptureInfo, IrLoweringCtx};
 use super::IrBuilder;
+use crate::ast::CallingConvention;
 
 /// Collect all local variable references in an expression.
 pub(super) fn collect_free_vars<'db>(expr: &Expr<TypedRef<'db>>, free_vars: &mut HashSet<LocalId>) {
@@ -192,15 +194,19 @@ pub(super) fn lower_lambda<'db>(
     params: &[Param],
     body: &Expr<TypedRef<'db>>,
     param_ir_types: &[TypeRef],
-    _result_ir_ty: TypeRef,
+    result_ir_ty: TypeRef,
+    convention: CallingConvention,
 ) -> Option<ValueRef> {
+    let any_ty = builder.ctx.anyref_type(builder.ir);
+    let evidence_ty = ability::evidence_adt_type_ref(builder.ir);
+    let abi = CallableAbi::new(convention, param_ir_types.iter().copied(), result_ir_ty);
+
     // Step 1: Analyze captures
     let captures = analyze_captures(builder.ctx, builder.ir, params, body);
 
     // Step 2: Build lambda body region.
     // Entry block has only the lambda's formal parameters — evidence/env are
     // added later by the lower_closure_lambda pass.
-    let any_ty = builder.ctx.anyref_type(builder.ir);
     let mut block_args = Vec::new();
     for (i, param) in params.iter().enumerate() {
         let ty = param_ir_types.get(i).copied().unwrap_or(any_ty);
@@ -213,21 +219,31 @@ pub(super) fn lower_lambda<'db>(
         block_args.push(arg);
     }
 
-    // All closures have CPS calling convention: done_k is always the first
-    // block arg (before user params). Evidence/env are added later by
-    // lower_closure_lambda.
-    let block_args = {
-        let mut done_k_arg = BlockArgData {
-            ty: any_ty,
+    let block_args = if convention.needs_evidence() {
+        let mut evidence_arg = BlockArgData {
+            ty: evidence_ty,
             attrs: Default::default(),
         };
-        done_k_arg.attrs.insert(
+        evidence_arg.attrs.insert(
             Symbol::new("bind_name"),
-            Attribute::Symbol(Symbol::new("__done_k")),
+            Attribute::Symbol(Symbol::new("__evidence")),
         );
-        let mut args = vec![done_k_arg];
+        let mut args = vec![evidence_arg];
+        if convention.needs_done_k() {
+            let mut done_k_arg = BlockArgData {
+                ty: any_ty,
+                attrs: Default::default(),
+            };
+            done_k_arg.attrs.insert(
+                Symbol::new("bind_name"),
+                Attribute::Symbol(Symbol::new("__done_k")),
+            );
+            args.push(done_k_arg);
+        }
         args.append(&mut block_args);
         args
+    } else {
+        block_args
     };
 
     let entry_block = builder.ir.create_block(BlockData {
@@ -241,10 +257,10 @@ pub(super) fn lower_lambda<'db>(
     {
         let mut scope = builder.ctx.scope();
 
-        // Bind lambda parameters (done_k is at index 0, params start at 1)
+        let param_offset = abi.source_param_offset();
         for (i, param) in params.iter().enumerate() {
             if let Some(local_id) = param.local_id {
-                let arg_val = builder.ir.block_arg(entry_block, (i + 1) as u32);
+                let arg_val = builder.ir.block_arg(entry_block, (i + param_offset) as u32);
                 scope.bind(local_id, param.name, arg_val);
             }
         }
@@ -253,12 +269,12 @@ pub(super) fn lower_lambda<'db>(
         // The closure.lambda body is NOT isolated from above, so parent-scope
         // ValueRefs are valid inside the body region.
 
-        // All closures use CPS body lowering (done_k is always at index 0).
-        // Save and restore the parent's done_k since ScopeGuard's DerefMut
-        // gives us direct access to IrLoweringCtx fields (not scoped).
-        {
+        if convention.needs_done_k() {
             let prev_done_k = scope.done_k;
-            let done_k_val = builder.ir.block_arg(entry_block, 0);
+            let prev_evidence = scope.evidence;
+            let evidence_val = builder.ir.block_arg(entry_block, 0);
+            let done_k_val = builder.ir.block_arg(entry_block, 1);
+            scope.evidence = Some(evidence_val);
             scope.done_k = Some(done_k_val);
 
             let mut inner_builder = IrBuilder::new(&mut scope, builder.ir, entry_block);
@@ -285,6 +301,21 @@ pub(super) fn lower_lambda<'db>(
                 }
             }
             scope.done_k = prev_done_k;
+            scope.evidence = prev_evidence;
+        } else {
+            let prev_evidence = scope.evidence;
+            if convention.needs_evidence() {
+                scope.evidence = Some(builder.ir.block_arg(entry_block, 0));
+            }
+            let mut inner_builder = IrBuilder::new(&mut scope, builder.ir, entry_block);
+            let result = super::expr::lower_expr(&mut inner_builder, body.clone())
+                .unwrap_or_else(|| inner_builder.emit_nil(location));
+            let result = inner_builder.cast_if_needed(location, result, result_ir_ty);
+            let ret_op = func::r#return(inner_builder.ir, location, [result]);
+            inner_builder
+                .ir
+                .push_op(inner_builder.block, ret_op.op_ref());
+            scope.evidence = prev_evidence;
         }
     }
 
@@ -297,15 +328,8 @@ pub(super) fn lower_lambda<'db>(
     // Step 3: Emit closure.lambda
     let capture_values: Vec<ValueRef> = captures.iter().map(|c| c.value).collect();
 
-    // All closures use CPS calling convention: done_k is the first param,
-    // return type is always anyref (results delivered via done_k).
-    let anyref_ty = builder.ctx.anyref_type(builder.ir);
-    let func_param_types = {
-        let mut pts = vec![anyref_ty]; // done_k first
-        pts.extend_from_slice(param_ir_types);
-        pts
-    };
-    let func_result_ty = anyref_ty;
+    let func_param_types = abi.lowered_params(evidence_ty, any_ty);
+    let func_result_ty = abi.lowered_result(any_ty);
     let closure_func_ty = builder
         .ctx
         .func_type(builder.ir, &func_param_types, func_result_ty);
@@ -318,6 +342,7 @@ pub(super) fn lower_lambda<'db>(
         closure_ty,
         body_region,
     );
+    set_calling_convention(builder.ir, lambda_op.op_ref(), convention);
     builder.ir.push_op(builder.block, lambda_op.op_ref());
     Some(lambda_op.result(builder.ir))
 }
@@ -334,67 +359,52 @@ pub(super) fn wrap_func_as_closure(
     func_name: Symbol,
     param_ir_types: &[TypeRef],
     result_ir_ty: TypeRef,
+    target_convention: Option<CallingConvention>,
 ) -> ValueRef {
     let any_ty = builder.ctx.anyref_type(builder.ir);
     let evidence_ty = ability::evidence_adt_type_ref(builder.ir);
-
-    // Check if the original function is effectful (has done_k parameter)
-    let callee_is_effectful = builder
+    let source_convention = builder
         .ctx
-        .lookup_function_type(func_name)
-        .map(|scheme| {
-            let body = scheme.body(builder.ctx.db);
-            matches!(body.kind(builder.ctx.db), TypeKind::Func { effect, .. } if !effect.is_pure(builder.ctx.db))
-        })
-        .unwrap_or(false);
+        .function_calling_convention(func_name)
+        .unwrap_or(CallingConvention::Direct);
+    let convention = target_convention.unwrap_or(source_convention);
+    assert!(
+        source_convention <= convention,
+        "cannot adapt {source_convention:?} function to weaker {convention:?} convention"
+    );
+    let abi = CallableAbi::new(convention, param_ir_types.iter().copied(), result_ir_ty);
+    let source_abi = CallableAbi::new(
+        source_convention,
+        param_ir_types.iter().copied(),
+        result_ir_ty,
+    );
+    let logical_param_types = abi.lowered_params(evidence_ty, any_ty);
+    let physical_param_types = abi.interpose_environment(&logical_param_types, any_ty);
+    let lowered_result_ty = abi.lowered_result(any_ty);
 
     // Generate unique wrapper name
     let wrapper_name = builder.ctx.gen_lambda_name();
 
-    // Block args: [evidence, env, done_k, param1, param2, ...]
-    let mut block_args = Vec::new();
-    {
-        let mut arg = BlockArgData {
-            ty: evidence_ty,
-            attrs: Default::default(),
+    let env_index = usize::from(convention.needs_evidence());
+    let done_k_index = convention.needs_done_k().then_some(env_index + 1);
+    let source_offset = abi.source_param_offset() + 1;
+    let mut block_args = Vec::with_capacity(physical_param_types.len());
+    for (i, &ty) in physical_param_types.iter().enumerate() {
+        let name = if convention.needs_evidence() && i == 0 {
+            Symbol::new("__evidence")
+        } else if i == env_index {
+            Symbol::new("__env")
+        } else if Some(i) == done_k_index {
+            Symbol::new("__done_k")
+        } else {
+            Symbol::from_dynamic(&format!("__arg_{}", i - source_offset))
         };
-        arg.attrs.insert(
-            Symbol::new("bind_name"),
-            Attribute::Symbol(Symbol::new("__evidence")),
-        );
-        block_args.push(arg);
-    }
-    {
-        let mut arg = BlockArgData {
-            ty: any_ty,
-            attrs: Default::default(),
-        };
-        arg.attrs.insert(
-            Symbol::new("bind_name"),
-            Attribute::Symbol(Symbol::new("__env")),
-        );
-        block_args.push(arg);
-    }
-    {
-        let mut arg = BlockArgData {
-            ty: any_ty,
-            attrs: Default::default(),
-        };
-        arg.attrs.insert(
-            Symbol::new("bind_name"),
-            Attribute::Symbol(Symbol::new("__done_k")),
-        );
-        block_args.push(arg);
-    }
-    for (i, &ty) in param_ir_types.iter().enumerate() {
         let mut arg = BlockArgData {
             ty,
             attrs: Default::default(),
         };
-        arg.attrs.insert(
-            Symbol::new("bind_name"),
-            Attribute::Symbol(Symbol::from_dynamic(&format!("__arg_{}", i))),
-        );
+        arg.attrs
+            .insert(Symbol::new("bind_name"), Attribute::Symbol(name));
         block_args.push(arg);
     }
 
@@ -410,9 +420,7 @@ pub(super) fn wrap_func_as_closure(
         .map(|i| builder.ir.block_arg(entry_block, i as u32))
         .collect();
 
-    // arg_values layout: [evidence, env, done_k, param1, param2, ...]
-    let done_k_val = arg_values[2];
-    let user_params = &arg_values[3..];
+    let user_params = &arg_values[source_offset..];
 
     // Coerce arguments to match callee's declared parameter types
     let mut call_args: Vec<ValueRef> = user_params.to_vec();
@@ -438,46 +446,50 @@ pub(super) fn wrap_func_as_closure(
         }
     }
 
-    if callee_is_effectful {
-        // Effectful original: forward done_k as first arg.
-        // Evidence is handled by closure_lower which extracts it from
-        // the wrapper's own evidence parameter.
-        let mut cps_args = vec![done_k_val];
-        cps_args.append(&mut call_args);
-        let call_op = func::call(builder.ir, location, cps_args, any_ty, func_name);
-        builder.ir.push_op(entry_block, call_op.op_ref());
+    let mut lowered_call_args =
+        Vec::with_capacity(source_abi.source_param_offset() + call_args.len());
+    if source_convention.needs_evidence() {
+        lowered_call_args.push(arg_values[0]);
+    }
+    if source_convention.needs_done_k()
+        && let Some(done_k_index) = done_k_index
+    {
+        lowered_call_args.push(arg_values[done_k_index]);
+    }
+    lowered_call_args.append(&mut call_args);
+    let source_result_ty = source_abi.lowered_result(any_ty);
+    let call_op = func::call(
+        builder.ir,
+        location,
+        lowered_call_args,
+        source_result_ty,
+        func_name,
+    );
+    set_calling_convention(builder.ir, call_op.op_ref(), source_convention);
+    builder.ir.push_op(entry_block, call_op.op_ref());
+    if convention.needs_done_k() && !source_convention.needs_done_k() {
         let call_result = call_op.result(builder.ir);
-        let ret_op = func::r#return(builder.ir, location, [call_result]);
-        builder.ir.push_op(entry_block, ret_op.op_ref());
-    } else {
-        // Pure original: call and return result via done_k.
-        let call_op = func::call(builder.ir, location, call_args, result_ir_ty, func_name);
-        builder.ir.push_op(entry_block, call_op.op_ref());
-        let call_result = call_op.result(builder.ir);
-        // Cast result to anyref, then call done_k(result)
-        let call_anyref = {
-            let cast = core::unrealized_conversion_cast(builder.ir, location, call_result, any_ty);
-            builder.ir.push_op(entry_block, cast.op_ref());
-            cast.result(builder.ir)
-        };
-        let closure_func_ty = builder.ctx.func_type(builder.ir, &[any_ty], any_ty);
-        let closure_ty = builder.ctx.closure_type(builder.ir, closure_func_ty);
-        let done_k_closure = {
-            let cast =
-                core::unrealized_conversion_cast(builder.ir, location, done_k_val, closure_ty);
-            builder.ir.push_op(entry_block, cast.op_ref());
-            cast.result(builder.ir)
-        };
-        let dk_call = func::call_indirect(
-            builder.ir,
+        let mut inner_builder = IrBuilder::new(builder.ctx, builder.ir, entry_block);
+        super::emit_done_k_call(
+            &mut inner_builder,
             location,
-            done_k_closure,
-            vec![call_anyref],
-            any_ty,
+            arg_values[done_k_index.expect("Cps adapter has done_k")],
+            call_result,
         );
-        builder.ir.push_op(entry_block, dk_call.op_ref());
-        let dk_result = dk_call.result(builder.ir);
-        let ret_op = func::r#return(builder.ir, location, [dk_result]);
+    } else {
+        let result = if source_result_ty == lowered_result_ty {
+            call_op.result(builder.ir)
+        } else {
+            let cast = core::unrealized_conversion_cast(
+                builder.ir,
+                location,
+                call_op.result(builder.ir),
+                lowered_result_ty,
+            );
+            builder.ir.push_op(entry_block, cast.op_ref());
+            cast.result(builder.ir)
+        };
+        let ret_op = func::r#return(builder.ir, location, [result]);
         builder.ir.push_op(entry_block, ret_op.op_ref());
     }
 
@@ -488,10 +500,10 @@ pub(super) fn wrap_func_as_closure(
         parent_op: None,
     });
 
-    // Wrapper func type: (evidence, env, done_k, params...) -> anyref
-    let mut all_param_types = vec![evidence_ty, any_ty, any_ty]; // ev, env, done_k
-    all_param_types.extend_from_slice(param_ir_types);
-    let wrapper_func_ty = builder.ctx.func_type(builder.ir, &all_param_types, any_ty);
+    let wrapper_func_ty =
+        builder
+            .ctx
+            .func_type(builder.ir, &physical_param_types, lowered_result_ty);
 
     let func_op = func::func(
         builder.ir,
@@ -500,6 +512,7 @@ pub(super) fn wrap_func_as_closure(
         wrapper_func_ty,
         body_region,
     );
+    set_calling_convention(builder.ir, func_op.op_ref(), convention);
 
     let module_block = builder
         .ctx
@@ -508,17 +521,16 @@ pub(super) fn wrap_func_as_closure(
     builder.ir.push_op(module_block, func_op.op_ref());
 
     // Emit closure.new @wrapper, null_env at the call site
-    // The closure type uses CPS calling convention: (done_k, params...) -> anyref
     let null_op = adt::ref_null(builder.ir, location, any_ty, any_ty);
     builder.ir.push_op(builder.block, null_op.op_ref());
     let null_env = null_op.result(builder.ir);
-    let mut closure_param_types = vec![any_ty]; // done_k first
-    closure_param_types.extend_from_slice(param_ir_types);
-    let closure_func_ty = builder
-        .ctx
-        .func_type(builder.ir, &closure_param_types, any_ty);
+    let closure_func_ty =
+        builder
+            .ctx
+            .func_type(builder.ir, &logical_param_types, lowered_result_ty);
     let closure_ty = builder.ctx.closure_type(builder.ir, closure_func_ty);
     let closure_op = closure::new(builder.ir, location, null_env, closure_ty, wrapper_name);
+    set_calling_convention(builder.ir, closure_op.op_ref(), convention);
     builder.ir.push_op(builder.block, closure_op.op_ref());
     closure_op.result(builder.ir)
 }

--- a/crates/tribute-front/src/ast_to_ir/lower/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/mod.rs
@@ -19,15 +19,15 @@ use trunk_ir::types::{Attribute, Location};
 use super::context::IrLoweringCtx;
 
 use crate::ast::{
-    CtorId, Expr, NodeId, Pattern, PatternKind, ResolvedRef, TypeAnnotation, TypeAnnotationKind,
-    TypeKind, TypedRef,
+    CallingConvention, CtorId, Expr, NodeId, Pattern, PatternKind, ResolvedRef, TypeAnnotation,
+    TypeAnnotationKind, TypeKind, TypedRef,
 };
 
 /// IR-level function signature extracted from a TypeScheme.
 pub(super) struct FuncSignature {
     pub param_types: Vec<TypeRef>,
     pub return_type: TypeRef,
-    pub is_effectful: bool,
+    pub convention: CallingConvention,
 }
 
 impl FuncSignature {
@@ -38,22 +38,15 @@ impl FuncSignature {
         let scheme = *ctx.lookup_function_type(name)?;
         let body = scheme.body(ctx.db);
         match body.kind(ctx.db) {
-            TypeKind::Func {
-                params,
-                result,
-                effect,
-            } => Some(Self {
+            TypeKind::Func { params, result, .. } => Some(Self {
                 param_types: params.iter().map(|t| ctx.convert_type(ir, *t)).collect(),
                 return_type: ctx.convert_type(ir, *result),
-                is_effectful: !effect.is_pure(ctx.db),
+                convention: ctx.calling_convention_for_type(body)?,
             }),
             _ => None,
         }
     }
 }
-
-// Re-export lower_module as the public entry point
-pub use self::decl::lower_module;
 
 // =============================================================================
 // IrBuilder

--- a/crates/tribute-front/src/ast_to_ir/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/mod.rs
@@ -35,35 +35,37 @@ use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::rewrite::Module as IrModule;
 
-use crate::ast::{Module, NodeId, SpanMap, Type, TypeScheme, TypedRef};
+use crate::ast::{
+    AbilityId, CallingConvention, Module as AstModule, NodeId, SpanMap, Type, TypeScheme, TypedRef,
+};
 
 pub use context::IrLoweringCtx;
-pub use lower::lower_module;
 
-/// Lower a typed AST module to arena TrunkIR.
+/// A type-checked module and the metadata required to lower it to TrunkIR.
 ///
-/// This is the main entry point for AST-to-IR transformation.
-/// Emits directly into the given `IrContext`, returning an `Module`.
-///
-/// # Parameters
-/// - `db`: Salsa database (for AST type access and diagnostics)
-/// - `ir`: Arena IR context to emit into
-/// - `module`: Type-checked AST module
-/// - `span_map`: SpanMap for looking up source locations
-/// - `source_uri`: URI of the source file
-/// - `function_types`: Function type schemes from type checking
-/// - `node_types`: Node types from type checking (NodeId → Type)
-pub fn lower_ast_to_ir<'db>(
-    db: &'db dyn salsa::Database,
-    ir: &mut IrContext,
-    module: Module<TypedRef<'db>>,
-    span_map: SpanMap,
-    source_uri: &str,
-    function_types: HashMap<Symbol, TypeScheme<'db>>,
-    node_types: HashMap<NodeId, Type<'db>>,
-) -> IrModule {
-    let path = ir.paths.intern(source_uri.to_owned());
-    lower::lower_module(db, ir, path, span_map, module, function_types, node_types)
+/// This models the boundary between the typed frontend and IR lowering as one
+/// value, instead of passing parallel metadata collections positionally.
+pub struct TypedModule<'db> {
+    pub ast: AstModule<TypedRef<'db>>,
+    pub span_map: SpanMap,
+    pub function_types: HashMap<Symbol, TypeScheme<'db>>,
+    pub node_types: HashMap<NodeId, Type<'db>>,
+    pub ability_conventions: HashMap<AbilityId<'db>, CallingConvention>,
+}
+
+impl<'db> TypedModule<'db> {
+    /// Lower this typed module to arena TrunkIR.
+    ///
+    /// This is the main entry point for AST-to-IR transformation.
+    pub fn lower_to_ir(
+        self,
+        db: &'db dyn salsa::Database,
+        ir: &mut IrContext,
+        source_uri: &str,
+    ) -> IrModule {
+        let path = ir.paths.intern(source_uri.to_owned());
+        self.lower_module(db, ir, path)
+    }
 }
 
 #[cfg(test)]
@@ -85,6 +87,7 @@ mod tests {
             &db,
             path,
             span_map,
+            HashMap::new(),
             HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
@@ -130,6 +133,7 @@ mod tests {
             path,
             SpanMap::default(),
             HashMap::new(),
+            HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
         );
@@ -160,6 +164,7 @@ mod tests {
             &db,
             path,
             SpanMap::default(),
+            HashMap::new(),
             HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
@@ -194,6 +199,7 @@ mod tests {
             path,
             SpanMap::default(),
             HashMap::new(),
+            HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),
         );
@@ -221,6 +227,7 @@ mod tests {
             &db,
             path,
             span_map,
+            HashMap::new(),
             HashMap::new(),
             smallvec::smallvec![Symbol::new("test")],
             HashMap::new(),

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -2247,7 +2247,7 @@ mod tests {
 
     #[test]
     fn test_type_annotation_function_pure() {
-        // fn(a) ->{} b → explicit pure-effectful function (empty abilities)
+        // fn(a) ->{} b → explicit pure function (empty abilities)
         let source = "fn run(f: fn(Int) ->{} Bool) -> Bool { f(0) }";
         let module = parse_and_lower(source);
 

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -2247,7 +2247,7 @@ mod tests {
 
     #[test]
     fn test_type_annotation_function_pure() {
-        // fn(a) ->{} b → pure function (empty abilities)
+        // fn(a) ->{} b → explicit pure-effectful function (empty abilities)
         let source = "fn run(f: fn(Int) ->{} Bool) -> Bool { f(0) }";
         let module = parse_and_lower(source);
 

--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -522,6 +522,7 @@ mod tests {
                 params: vec![bv0],
                 result: bv0,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = make_scheme(&db, 1, scheme_body);
@@ -533,6 +534,7 @@ mod tests {
                 params: vec![int],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -552,6 +554,7 @@ mod tests {
                 params: vec![bv0, bv1],
                 result: bv0,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = make_scheme(&db, 2, scheme_body);
@@ -564,6 +567,7 @@ mod tests {
                 params: vec![int, float],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -582,6 +586,7 @@ mod tests {
                 params: vec![bv0, bv0],
                 result: bv0,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = make_scheme(&db, 1, scheme_body);
@@ -593,6 +598,7 @@ mod tests {
                 params: vec![int, int],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -611,6 +617,7 @@ mod tests {
                 params: vec![bv0, bv0],
                 result: bv0,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = make_scheme(&db, 1, scheme_body);
@@ -629,6 +636,7 @@ mod tests {
                 params: vec![int, text],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -653,6 +661,7 @@ mod tests {
                 params: vec![option_bv],
                 result: bv0,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = make_scheme(&db, 1, scheme_body);
@@ -671,6 +680,7 @@ mod tests {
                 params: vec![option_int],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -688,6 +698,7 @@ mod tests {
                 params: vec![int],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = make_scheme(&db, 0, body);
@@ -769,6 +780,7 @@ mod tests {
                 params: vec![pair_int_int],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -818,6 +830,7 @@ mod tests {
                 params: vec![bv0],
                 result: bv1,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme_body = Type::new(
@@ -826,6 +839,7 @@ mod tests {
                 params: vec![fn_param, bv0],
                 result: bv1,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = make_scheme(&db, 2, scheme_body);
@@ -838,6 +852,7 @@ mod tests {
                 params: vec![int],
                 result: bool_ty,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let concrete = Type::new(
@@ -846,6 +861,7 @@ mod tests {
                 params: vec![fn_concrete, int],
                 result: bool_ty,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 

--- a/crates/tribute-front/src/monomorphize/mangle.rs
+++ b/crates/tribute-front/src/monomorphize/mangle.rs
@@ -203,6 +203,7 @@ mod tests {
                 params: vec![int_ty],
                 result: bool_ty,
                 effect: crate::ast::EffectRow::new(&db, vec![], None),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let result = mangle_name(&db, base, &[func_ty]);

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -347,6 +347,7 @@ pub fn rewrite_type<'db>(
             params,
             result,
             effect,
+            minimum_convention,
         } => {
             let new_params: Vec<_> = params.iter().map(|p| rewrite_type(db, *p, map)).collect();
             let new_result = rewrite_type(db, *result, map);
@@ -359,6 +360,7 @@ pub fn rewrite_type<'db>(
                     params: new_params,
                     result: new_result,
                     effect: *effect,
+                    minimum_convention: *minimum_convention,
                 },
             )
         }
@@ -827,6 +829,7 @@ mod tests {
                 params: vec![option_int],
                 result: int,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let map = make_type_rewrite_map(

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -305,6 +305,9 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
                 })
                 .collect();
             if effect.rest(db).is_some()
+                // Preserve omitted effect-polymorphic functions whose resolved
+                // ability set is empty as Direct when annotations round-trip,
+                // rather than reclassifying them as EvidenceDirect.
                 || (abilities.is_empty()
                     && *minimum_convention == crate::ast::CallingConvention::Direct)
             {

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -270,7 +270,7 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
             params,
             result,
             effect,
-            minimum_convention,
+            ..
         } => {
             // Preserve the effect row as ability annotations. Each Effect
             // becomes a Named (or App) annotation; a row variable (`rest`) is
@@ -304,13 +304,7 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
                     }
                 })
                 .collect();
-            if effect.rest(db).is_some()
-                // Preserve omitted effect-polymorphic functions whose resolved
-                // ability set is empty as Direct when annotations round-trip,
-                // rather than reclassifying them as EvidenceDirect.
-                || (abilities.is_empty()
-                    && *minimum_convention == crate::ast::CallingConvention::Direct)
-            {
+            if effect.rest(db).is_some() {
                 abilities.push(TypeAnnotation {
                     id,
                     kind: TypeAnnotationKind::Infer,
@@ -1087,6 +1081,27 @@ mod tests {
             }
             other => panic!("expected Func annotation, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_type_to_annotation_func_preserves_closed_empty_row() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let func_ty = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![int],
+                result: int,
+                effect: EffectRow::pure(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+
+        let ann = type_to_annotation(&db, func_ty, node_id(1));
+        let TypeAnnotationKind::Func { abilities, .. } = ann.kind else {
+            panic!("expected Func annotation");
+        };
+        assert!(abilities.is_empty());
     }
 
     // ========================================================================

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -270,6 +270,7 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
             params,
             result,
             effect,
+            minimum_convention,
         } => {
             // Preserve the effect row as ability annotations. Each Effect
             // becomes a Named (or App) annotation; a row variable (`rest`) is
@@ -303,7 +304,10 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
                     }
                 })
                 .collect();
-            if effect.rest(db).is_some() {
+            if effect.rest(db).is_some()
+                || (abilities.is_empty()
+                    && *minimum_convention == crate::ast::CallingConvention::Direct)
+            {
                 abilities.push(TypeAnnotation {
                     id,
                     kind: TypeAnnotationKind::Infer,
@@ -895,6 +899,7 @@ mod tests {
                 params: vec![bv0],
                 result: bv0,
                 effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = TypeScheme::new(&db, vec![TypeParam::anonymous()], scheme_body);
@@ -1019,6 +1024,7 @@ mod tests {
                 params: vec![int],
                 result: int,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let ann = type_to_annotation(&db, func_ty, node_id(1));
@@ -1067,6 +1073,7 @@ mod tests {
                 params: vec![int],
                 result: int,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let ann = type_to_annotation(&db, func_ty, node_id(1));

--- a/crates/tribute-front/src/query.rs
+++ b/crates/tribute-front/src/query.rs
@@ -431,6 +431,46 @@ mod tests {
     }
 
     #[test]
+    fn omitted_effect_annotation_is_open_but_explicit_empty_is_closed() {
+        let db = salsa::DatabaseImpl::default();
+        let source = make_source(
+            &db,
+            r#"
+fn omitted() { Nil }
+fn explicit() ->{} Nil { Nil }
+"#,
+        );
+
+        let schemes = function_schemes(&db, source).expect("type checking should succeed");
+        let effect_of = |name: &str| {
+            let (_, scheme) = schemes
+                .iter()
+                .find(|(symbol, _)| *symbol == Symbol::from_dynamic(name))
+                .expect("function scheme should exist");
+            let crate::ast::TypeKind::Func {
+                effect,
+                minimum_convention,
+                ..
+            } = scheme.body(&db).kind(&db)
+            else {
+                panic!("expected function type");
+            };
+            (*effect, *minimum_convention)
+        };
+
+        let (omitted, omitted_minimum) = effect_of("omitted");
+        assert!(omitted.rest(&db).is_some());
+        assert_eq!(omitted_minimum, crate::ast::CallingConvention::Direct);
+
+        let (explicit, explicit_minimum) = effect_of("explicit");
+        assert!(explicit.is_pure(&db));
+        assert_eq!(
+            explicit_minimum,
+            crate::ast::CallingConvention::EvidenceDirect
+        );
+    }
+
+    #[test]
     fn test_type_check_output_has_both_fields() {
         let db = salsa::DatabaseImpl::default();
         let source = make_source(&db, "fn main() { 42 }");
@@ -451,11 +491,9 @@ mod tests {
     fn contains_univar(db: &dyn salsa::Database, ty: crate::ast::Type) -> bool {
         match ty.kind(db) {
             crate::ast::TypeKind::UniVar { .. } => true,
-            crate::ast::TypeKind::Func {
-                params,
-                result,
-                effect: _,
-            } => params.iter().any(|p| contains_univar(db, *p)) || contains_univar(db, *result),
+            crate::ast::TypeKind::Func { params, result, .. } => {
+                params.iter().any(|p| contains_univar(db, *p)) || contains_univar(db, *result)
+            }
             crate::ast::TypeKind::Named { args, .. } => {
                 args.iter().any(|a| contains_univar(db, *a))
             }

--- a/crates/tribute-front/src/query.rs
+++ b/crates/tribute-front/src/query.rs
@@ -445,7 +445,7 @@ fn explicit() ->{} Nil { Nil }
         let effect_of = |name: &str| {
             let (_, scheme) = schemes
                 .iter()
-                .find(|(symbol, _)| *symbol == Symbol::from_dynamic(name))
+                .find(|(symbol, _)| *symbol == name)
                 .expect("function scheme should exist");
             let crate::ast::TypeKind::Func {
                 effect,
@@ -489,10 +489,27 @@ fn explicit() ->{} Nil { Nil }
 
     /// Recursively check if a type contains any unresolved UniVar.
     fn contains_univar(db: &dyn salsa::Database, ty: crate::ast::Type) -> bool {
+        fn effect_contains_univar(
+            db: &dyn salsa::Database,
+            effect: crate::ast::EffectRow<'_>,
+        ) -> bool {
+            effect
+                .effects(db)
+                .iter()
+                .any(|effect| effect.args.iter().any(|arg| contains_univar(db, *arg)))
+        }
+
         match ty.kind(db) {
             crate::ast::TypeKind::UniVar { .. } => true,
-            crate::ast::TypeKind::Func { params, result, .. } => {
-                params.iter().any(|p| contains_univar(db, *p)) || contains_univar(db, *result)
+            crate::ast::TypeKind::Func {
+                params,
+                result,
+                effect,
+                ..
+            } => {
+                params.iter().any(|p| contains_univar(db, *p))
+                    || contains_univar(db, *result)
+                    || effect_contains_univar(db, *effect)
             }
             crate::ast::TypeKind::Named { args, .. } => {
                 args.iter().any(|a| contains_univar(db, *a))
@@ -503,6 +520,32 @@ fn explicit() ->{} Nil { Nil }
             }
             _ => false,
         }
+    }
+
+    #[test]
+    fn contains_univar_checks_function_effect_arguments() {
+        let db = salsa::DatabaseImpl::default();
+        let id = crate::ast::UniVarId::new(&db, crate::ast::UniVarSource::Anonymous(0), 0);
+        let var = crate::ast::Type::new(&db, crate::ast::TypeKind::UniVar { id });
+        let effect = crate::ast::EffectRow::new(
+            &db,
+            vec![crate::ast::Effect {
+                ability_id: crate::ast::AbilityId::new(&db, Symbol::new("State")),
+                args: vec![var],
+            }],
+            None,
+        );
+        let ty = crate::ast::Type::new(
+            &db,
+            crate::ast::TypeKind::Func {
+                params: vec![],
+                result: crate::ast::Type::new(&db, crate::ast::TypeKind::Nil),
+                effect,
+                minimum_convention: crate::ast::CallingConvention::Cps,
+            },
+        );
+
+        assert!(contains_univar(&db, ty));
     }
 
     #[test]

--- a/crates/tribute-front/src/query.rs
+++ b/crates/tribute-front/src/query.rs
@@ -518,12 +518,21 @@ fn explicit() ->{} Nil { Nil }
             crate::ast::TypeKind::App { ctor, args } => {
                 contains_univar(db, *ctor) || args.iter().any(|a| contains_univar(db, *a))
             }
+            crate::ast::TypeKind::Continuation {
+                arg,
+                result,
+                effect,
+            } => {
+                contains_univar(db, *arg)
+                    || contains_univar(db, *result)
+                    || effect_contains_univar(db, *effect)
+            }
             _ => false,
         }
     }
 
     #[test]
-    fn contains_univar_checks_function_effect_arguments() {
+    fn contains_univar_checks_effect_arguments() {
         let db = salsa::DatabaseImpl::default();
         let id = crate::ast::UniVarId::new(&db, crate::ast::UniVarSource::Anonymous(0), 0);
         let var = crate::ast::Type::new(&db, crate::ast::TypeKind::UniVar { id });
@@ -546,6 +555,16 @@ fn explicit() ->{} Nil { Nil }
         );
 
         assert!(contains_univar(&db, ty));
+
+        let continuation = crate::ast::Type::new(
+            &db,
+            crate::ast::TypeKind::Continuation {
+                arg: crate::ast::Type::new(&db, crate::ast::TypeKind::Nil),
+                result: crate::ast::Type::new(&db, crate::ast::TypeKind::Nil),
+                effect,
+            },
+        );
+        assert!(contains_univar(&db, continuation));
     }
 
     #[test]

--- a/crates/tribute-front/src/query.rs
+++ b/crates/tribute-front/src/query.rs
@@ -464,10 +464,7 @@ fn explicit() ->{} Nil { Nil }
 
         let (explicit, explicit_minimum) = effect_of("explicit");
         assert!(explicit.is_pure(&db));
-        assert_eq!(
-            explicit_minimum,
-            crate::ast::CallingConvention::EvidenceDirect
-        );
+        assert_eq!(explicit_minimum, crate::ast::CallingConvention::Direct);
     }
 
     #[test]

--- a/crates/tribute-front/src/tdnr/resolver.rs
+++ b/crates/tribute-front/src/tdnr/resolver.rs
@@ -238,11 +238,9 @@ impl<'db> TdnrResolver<'db> {
                 params,
                 result,
                 effect,
-                minimum_convention: if func.effects.is_some() {
-                    crate::ast::CallingConvention::EvidenceDirect
-                } else {
-                    crate::ast::CallingConvention::Direct
-                },
+                minimum_convention: crate::ast::function_declaration_abi_floor(
+                    func.effects.as_deref(),
+                ),
             },
         )
     }

--- a/crates/tribute-front/src/tdnr/resolver.rs
+++ b/crates/tribute-front/src/tdnr/resolver.rs
@@ -238,9 +238,7 @@ impl<'db> TdnrResolver<'db> {
                 params,
                 result,
                 effect,
-                minimum_convention: crate::ast::function_declaration_abi_floor(
-                    func.effects.as_deref(),
-                ),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         )
     }

--- a/crates/tribute-front/src/tdnr/resolver.rs
+++ b/crates/tribute-front/src/tdnr/resolver.rs
@@ -181,6 +181,7 @@ impl<'db> TdnrResolver<'db> {
                                 params: vec![self_ty],
                                 result: field_ty,
                                 effect,
+                                minimum_convention: crate::ast::CallingConvention::Direct,
                             },
                         );
 
@@ -237,6 +238,11 @@ impl<'db> TdnrResolver<'db> {
                 params,
                 result,
                 effect,
+                minimum_convention: if func.effects.is_some() {
+                    crate::ast::CallingConvention::EvidenceDirect
+                } else {
+                    crate::ast::CallingConvention::Direct
+                },
             },
         )
     }
@@ -249,7 +255,7 @@ impl<'db> TdnrResolver<'db> {
         use crate::ast::EffectRow;
 
         let Some(anns) = annotations else {
-            return EffectRow::pure(self.db);
+            return EffectRow::open(self.db, crate::ast::EffectVar { id: 0 });
         };
 
         if anns.is_empty() {
@@ -916,6 +922,7 @@ mod tests {
                 params: vec![int_ty],
                 result: option_int,
                 effect: EffectRow::pure(db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1139,6 +1146,7 @@ mod tests {
                 params: vec![foo_ty],
                 result: Type::new(db, TypeKind::Int),
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1191,6 +1199,7 @@ mod tests {
                     params: vec![foo_ty],
                     result: result_ty,
                     effect,
+                    minimum_convention: crate::ast::CallingConvention::Direct,
                 },
             )
         };
@@ -1276,6 +1285,7 @@ mod tests {
                 params: vec![list_named],
                 result: Type::new(db, TypeKind::Int),
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -122,11 +122,8 @@ impl<'db> TypeChecker<'db> {
         };
 
         // Create function type
-        let minimum_convention = if func.effects.is_some() {
-            crate::ast::CallingConvention::EvidenceDirect
-        } else {
-            crate::ast::CallingConvention::Direct
-        };
+        let minimum_convention =
+            crate::ast::function_declaration_abi_floor(func.effects.as_deref());
         let func_ty =
             self.env
                 .func_type_with_convention(param_types, return_ty, effect, minimum_convention);
@@ -443,11 +440,7 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_for_sig(a, type_var_map, next_bound_var),
                     || EffectVar { id: 0 },
                 );
-                let minimum_convention = if abilities.is_empty() {
-                    crate::ast::CallingConvention::EvidenceDirect
-                } else {
-                    crate::ast::CallingConvention::Direct
-                };
+                let minimum_convention = crate::ast::function_type_abi_floor(abilities);
                 self.env.func_type_with_convention(
                     param_types,
                     result_ty,
@@ -517,11 +510,7 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_for_ctor(a, type_param_indices),
                     || EffectVar { id: 0 },
                 );
-                let minimum_convention = if abilities.is_empty() {
-                    crate::ast::CallingConvention::EvidenceDirect
-                } else {
-                    crate::ast::CallingConvention::Direct
-                };
+                let minimum_convention = crate::ast::function_type_abi_floor(abilities);
                 self.env.func_type_with_convention(
                     param_types,
                     result_ty,

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -121,12 +121,7 @@ impl<'db> TypeChecker<'db> {
             None => EffectRow::open(self.db(), EffectVar { id: 0 }),
         };
 
-        // Create function type
-        let minimum_convention =
-            crate::ast::function_declaration_abi_floor(func.effects.as_deref());
-        let func_ty =
-            self.env
-                .func_type_with_convention(param_types, return_ty, effect, minimum_convention);
+        let func_ty = self.env.func_type(param_types, return_ty, effect);
 
         // Build type params from the collected BoundVars
         let type_params: Vec<TypeParam> = (0..next_bound_var)
@@ -440,13 +435,7 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_for_sig(a, type_var_map, next_bound_var),
                     || EffectVar { id: 0 },
                 );
-                let minimum_convention = crate::ast::function_type_abi_floor(abilities);
-                self.env.func_type_with_convention(
-                    param_types,
-                    result_ty,
-                    effect,
-                    minimum_convention,
-                )
+                self.env.func_type(param_types, result_ty, effect)
             }
             TypeAnnotationKind::Tuple(elems) => {
                 let elem_types: Vec<Type<'db>> = elems
@@ -510,13 +499,7 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_for_ctor(a, type_param_indices),
                     || EffectVar { id: 0 },
                 );
-                let minimum_convention = crate::ast::function_type_abi_floor(abilities);
-                self.env.func_type_with_convention(
-                    param_types,
-                    result_ty,
-                    effect,
-                    minimum_convention,
-                )
+                self.env.func_type(param_types, result_ty, effect)
             }
             TypeAnnotationKind::Tuple(elems) => {
                 let elem_types: Vec<Type<'db>> = elems

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -116,11 +116,20 @@ impl<'db> TypeChecker<'db> {
                     || EffectVar { id: 0 }, // Placeholder, will be replaced during function check
                 )
             }
-            None => EffectRow::pure(self.db()),
+            // Omitting the annotation is effect-polymorphic (`->{e}`), not
+            // an assertion that the row is closed and empty.
+            None => EffectRow::open(self.db(), EffectVar { id: 0 }),
         };
 
         // Create function type
-        let func_ty = self.env.func_type(param_types, return_ty, effect);
+        let minimum_convention = if func.effects.is_some() {
+            crate::ast::CallingConvention::EvidenceDirect
+        } else {
+            crate::ast::CallingConvention::Direct
+        };
+        let func_ty =
+            self.env
+                .func_type_with_convention(param_types, return_ty, effect, minimum_convention);
 
         // Build type params from the collected BoundVars
         let type_params: Vec<TypeParam> = (0..next_bound_var)
@@ -434,7 +443,17 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_for_sig(a, type_var_map, next_bound_var),
                     || EffectVar { id: 0 },
                 );
-                self.env.func_type(param_types, result_ty, effect)
+                let minimum_convention = if abilities.is_empty() {
+                    crate::ast::CallingConvention::EvidenceDirect
+                } else {
+                    crate::ast::CallingConvention::Direct
+                };
+                self.env.func_type_with_convention(
+                    param_types,
+                    result_ty,
+                    effect,
+                    minimum_convention,
+                )
             }
             TypeAnnotationKind::Tuple(elems) => {
                 let elem_types: Vec<Type<'db>> = elems
@@ -498,7 +517,17 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_for_ctor(a, type_param_indices),
                     || EffectVar { id: 0 },
                 );
-                self.env.func_type(param_types, result_ty, effect)
+                let minimum_convention = if abilities.is_empty() {
+                    crate::ast::CallingConvention::EvidenceDirect
+                } else {
+                    crate::ast::CallingConvention::Direct
+                };
+                self.env.func_type_with_convention(
+                    param_types,
+                    result_ty,
+                    effect,
+                    minimum_convention,
+                )
             }
             TypeAnnotationKind::Tuple(elems) => {
                 let elem_types: Vec<Type<'db>> = elems

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -33,6 +33,7 @@ fn type_contains_univar<'db>(db: &'db dyn salsa::Database, ty: Type<'db>) -> boo
             params,
             result,
             effect,
+            ..
         } => {
             params.iter().any(|p| type_contains_univar(db, *p))
                 || type_contains_univar(db, *result)
@@ -266,14 +267,20 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Lambda { params, body } => {
                 // Extract expected effect from mode if checking against a function type.
                 // This is crucial for lambdas passed to higher-order functions with effects.
-                let expected_effect = if let Mode::Check(expected_ty) = &mode {
-                    if let TypeKind::Func { effect, .. } = expected_ty.kind(self.db()) {
-                        Some(*effect)
+                let (expected_effect, minimum_convention) = if let Mode::Check(expected_ty) = &mode
+                {
+                    if let TypeKind::Func {
+                        effect,
+                        minimum_convention,
+                        ..
+                    } = expected_ty.kind(self.db())
+                    {
+                        (Some(*effect), *minimum_convention)
                     } else {
-                        None
+                        (None, crate::ast::CallingConvention::Direct)
                     }
                 } else {
-                    None
+                    (None, crate::ast::CallingConvention::Direct)
                 };
 
                 let param_types: Vec<Type<'db>> = params
@@ -338,7 +345,12 @@ impl<'db> TypeChecker<'db> {
 
                 let result_ty = ctx.fresh_type_var();
                 ctx.constrain_eq(result_ty, body_ty);
-                ctx.func_type(param_types, result_ty, lambda_effect)
+                ctx.func_type_with_convention(
+                    param_types,
+                    result_ty,
+                    lambda_effect,
+                    minimum_convention,
+                )
             }
             ExprKind::Handle { body, handlers } => {
                 // Handle expression:
@@ -1933,7 +1945,12 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_with_ctx(ctx, a),
                     || row_var,
                 );
-                ctx.func_type(param_types, result_ty, effect)
+                let minimum_convention = if abilities.is_empty() {
+                    crate::ast::CallingConvention::EvidenceDirect
+                } else {
+                    crate::ast::CallingConvention::Direct
+                };
+                ctx.func_type_with_convention(param_types, result_ty, effect, minimum_convention)
             }
             TypeAnnotationKind::Tuple(elems) => {
                 let elem_types: Vec<Type<'db>> = elems
@@ -2339,6 +2356,7 @@ mod tests {
             params,
             result,
             effect,
+            ..
         } = ty.kind(db)
         {
             assert_eq!(params.len(), 1);
@@ -2375,6 +2393,7 @@ mod tests {
             params,
             result,
             effect,
+            ..
         } = ty.kind(db)
         {
             assert_eq!(params.len(), 1);
@@ -2482,6 +2501,7 @@ mod tests {
                 params: vec![bound_var],
                 result: bound_var,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2495,6 +2515,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         assert_eq!(result, expected);

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1945,11 +1945,7 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_with_ctx(ctx, a),
                     || row_var,
                 );
-                let minimum_convention = if abilities.is_empty() {
-                    crate::ast::CallingConvention::EvidenceDirect
-                } else {
-                    crate::ast::CallingConvention::Direct
-                };
+                let minimum_convention = crate::ast::function_type_abi_floor(abilities);
                 ctx.func_type_with_convention(param_types, result_ty, effect, minimum_convention)
             }
             TypeAnnotationKind::Tuple(elems) => {

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1945,8 +1945,7 @@ impl<'db> TypeChecker<'db> {
                     &mut |a| self.annotation_to_type_with_ctx(ctx, a),
                     || row_var,
                 );
-                let minimum_convention = crate::ast::function_type_abi_floor(abilities);
-                ctx.func_type_with_convention(param_types, result_ty, effect, minimum_convention)
+                ctx.func_type(param_types, result_ty, effect)
             }
             TypeAnnotationKind::Tuple(elems) => {
                 let elem_types: Vec<Type<'db>> = elems

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -73,7 +73,15 @@ impl<'db> TypeChecker<'db> {
         // Set effect row from the function's declared type before checking body
         let declared_effect =
             if let TypeKind::Func { effect, .. } = instantiated_func_ty.kind(self.db()) {
-                ctx.set_current_effect(*effect);
+                // Omission is semantically `->{e}`, but the fresh generalized
+                // tail is not an effect performed by the body. Infer residual
+                // effects from a closed-empty accumulator and reattach the tail
+                // to the resulting function type after solving.
+                if func.effects.is_none() {
+                    ctx.set_current_effect(crate::ast::EffectRow::pure(self.db()));
+                } else {
+                    ctx.set_current_effect(*effect);
+                }
                 Some(*effect)
             } else {
                 None
@@ -139,8 +147,45 @@ impl<'db> TypeChecker<'db> {
             .map(|(i, id)| (id, i as u32))
             .collect();
 
-        // Apply substitution and generalization to the function type
-        let substituted_ty = type_subst.apply_with_rows(self.db(), instantiated_func_ty, row_subst);
+        // An omitted annotation denotes an open effect row. Preserve the
+        // concrete residual effects discovered while checking the body, then
+        // reattach the generalized tail supplied by the collected signature.
+        let inferred_func_ty = if func.effects.is_none() {
+            match instantiated_func_ty.kind(self.db()) {
+                TypeKind::Func {
+                    params,
+                    result,
+                    effect: declared_effect,
+                    minimum_convention,
+                    ..
+                } => {
+                    let inferred_effect = if body_effect_row.rest(self.db()).is_some() {
+                        body_effect_row
+                    } else {
+                        crate::ast::EffectRow::new(
+                            self.db(),
+                            body_effect_row.effects(self.db()).clone(),
+                            declared_effect.rest(self.db()),
+                        )
+                    };
+                    Type::new(
+                        self.db(),
+                        TypeKind::Func {
+                            params: params.clone(),
+                            result: *result,
+                            effect: inferred_effect,
+                            minimum_convention: *minimum_convention,
+                        },
+                    )
+                }
+                _ => instantiated_func_ty,
+            }
+        } else {
+            instantiated_func_ty
+        };
+
+        // Apply substitution and generalization to the function type.
+        let substituted_ty = type_subst.apply_with_rows(self.db(), inferred_func_ty, row_subst);
 
         // Validate that `main` returns Nil
         if func.name == "main"
@@ -346,6 +391,7 @@ impl<'db> TypeChecker<'db> {
                         params,
                         result,
                         effect,
+                        ..
                     } = func_ty.kind(self.db())
                     {
                         // Arity check
@@ -1237,6 +1283,7 @@ mod tests {
                 params: vec![Type::new(db, TypeKind::Nat)],
                 result: first_solver_var,
                 effect: EffectRow::pure(db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let second_callee_ty = Type::new(
@@ -1245,6 +1292,7 @@ mod tests {
                 params: vec![Type::new(db, TypeKind::Nat)],
                 result: second_solver_var,
                 effect: EffectRow::pure(db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 

--- a/crates/tribute-front/src/typeck/checker/mod.rs
+++ b/crates/tribute-front/src/typeck/checker/mod.rs
@@ -34,6 +34,7 @@ use crate::ast::{
 
 use super::PreludeExports;
 use super::context::ModuleTypeEnv;
+use crate::ast::CallingConvention;
 
 /// Result of module type checking.
 pub struct ModuleCheckResult<'db> {
@@ -43,6 +44,8 @@ pub struct ModuleCheckResult<'db> {
     pub function_types: Vec<(Symbol, TypeScheme<'db>)>,
     /// Node types for IR lowering (NodeId → monomorphic type).
     pub node_types: Vec<(NodeId, Type<'db>)>,
+    /// Ability-level calling-convention requirements.
+    pub ability_conventions: Vec<(crate::ast::AbilityId<'db>, CallingConvention)>,
 }
 
 /// Type checking mode.
@@ -153,6 +156,7 @@ impl<'db> TypeChecker<'db> {
 
         // Export the function types (already finalized during per-function checking)
         let function_types = self.env.export_function_types();
+        let ability_conventions = self.env.export_ability_conventions();
 
         // Convert node_types HashMap to Vec for Salsa compatibility
         // Sort by NodeId to ensure deterministic ordering for Salsa cache stability
@@ -167,6 +171,7 @@ impl<'db> TypeChecker<'db> {
             },
             function_types,
             node_types,
+            ability_conventions,
         }
     }
 
@@ -198,6 +203,7 @@ impl<'db> TypeChecker<'db> {
         let struct_fields = self.env.export_struct_fields();
         let enum_variants = self.env.export_enum_variants();
         let method_index = self.env.export_method_index();
+        let ability_conventions = self.env.export_ability_conventions();
 
         PreludeExports::new(
             self.db(),
@@ -207,6 +213,7 @@ impl<'db> TypeChecker<'db> {
             struct_fields,
             enum_variants,
             method_index,
+            ability_conventions,
         )
     }
 

--- a/crates/tribute-front/src/typeck/context.rs
+++ b/crates/tribute-front/src/typeck/context.rs
@@ -11,7 +11,8 @@ use std::collections::HashMap;
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    AbilityId, CtorId, EffectRow, FuncDefId, OpDeclKind, Type, TypeKind, TypeParam, TypeScheme,
+    AbilityId, CallingConvention, CtorId, EffectRow, FuncDefId, OpDeclKind, Type, TypeKind,
+    TypeParam, TypeScheme,
 };
 
 // =========================================================================
@@ -137,6 +138,9 @@ pub struct ModuleTypeEnv<'db> {
     /// Used for handler arm type checking.
     ability_defs: HashMap<AbilityId<'db>, AbilityInfo<'db>>,
 
+    /// Ability-level upper bounds used to derive function calling conventions.
+    ability_conventions: HashMap<AbilityId<'db>, CallingConvention>,
+
     /// Method index for UFCS resolution: method_name → candidates.
     /// Populated from function declarations (first param = receiver)
     /// and struct field accessors.
@@ -146,6 +150,12 @@ pub struct ModuleTypeEnv<'db> {
 impl<'db> ModuleTypeEnv<'db> {
     /// Create a new empty module type environment.
     pub fn new(db: &'db dyn salsa::Database) -> Self {
+        let mut ability_conventions = HashMap::new();
+        ability_conventions.insert(
+            AbilityId::new(db, Symbol::new("std::io::Io")),
+            CallingConvention::EvidenceDirect,
+        );
+
         Self {
             db,
             function_types: HashMap::new(),
@@ -154,6 +164,7 @@ impl<'db> ModuleTypeEnv<'db> {
             struct_fields: HashMap::new(),
             enum_variants: HashMap::new(),
             ability_defs: HashMap::new(),
+            ability_conventions,
             method_index: HashMap::new(),
         }
     }
@@ -228,6 +239,12 @@ impl<'db> ModuleTypeEnv<'db> {
 
     /// Register an ability definition.
     pub fn register_ability(&mut self, id: AbilityId<'db>, info: AbilityInfo<'db>) {
+        let convention = if info.operations.values().any(|op| op.kind == OpDeclKind::Op) {
+            CallingConvention::Cps
+        } else {
+            CallingConvention::EvidenceDirect
+        };
+        self.ability_conventions.insert(id, convention);
         self.ability_defs.insert(id, info);
     }
 
@@ -332,6 +349,9 @@ impl<'db> ModuleTypeEnv<'db> {
                 .entry(*name)
                 .or_default()
                 .extend(entries.iter().copied());
+        }
+        for (ability, convention) in exports.ability_conventions(self.db) {
+            self.ability_conventions.insert(*ability, *convention);
         }
     }
 
@@ -444,6 +464,20 @@ impl<'db> ModuleTypeEnv<'db> {
         result
     }
 
+    /// Export ability calling-convention requirements in deterministic order.
+    pub fn export_ability_conventions(&self) -> Vec<(AbilityId<'db>, CallingConvention)> {
+        let mut result: Vec<_> = self
+            .ability_conventions
+            .iter()
+            .map(|(ability, convention)| (*ability, *convention))
+            .collect();
+        result.sort_by(|(a, _), (b, _)| {
+            a.qualified(self.db)
+                .with_str(|a| b.qualified(self.db).with_str(|b| a.cmp(b)))
+        });
+        result
+    }
+
     // =========================================================================
     // Primitive types (convenience methods)
     // =========================================================================
@@ -510,12 +544,24 @@ impl<'db> ModuleTypeEnv<'db> {
         result: Type<'db>,
         effect: EffectRow<'db>,
     ) -> Type<'db> {
+        self.func_type_with_convention(params, result, effect, CallingConvention::Direct)
+    }
+
+    /// Create a function type with an explicit calling-convention lower bound.
+    pub fn func_type_with_convention(
+        &self,
+        params: Vec<Type<'db>>,
+        result: Type<'db>,
+        effect: EffectRow<'db>,
+        minimum_convention: CallingConvention,
+    ) -> Type<'db> {
         Type::new(
             self.db,
             TypeKind::Func {
                 params,
                 result,
                 effect,
+                minimum_convention,
             },
         )
     }
@@ -762,6 +808,7 @@ mod tests {
                     params: vec![receiver],
                     result: int_ty,
                     effect,
+                    minimum_convention: crate::ast::CallingConvention::Direct,
                 },
             );
             env.register_method(
@@ -819,6 +866,7 @@ mod tests {
                 params: params.to_vec(),
                 result,
                 effect: EffectRow::pure(db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         )
     }

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -402,6 +402,7 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
                 params,
                 result,
                 effect,
+                minimum_convention,
             } => {
                 let params = params
                     .iter()
@@ -415,6 +416,7 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
                         params,
                         result,
                         effect,
+                        minimum_convention: *minimum_convention,
                     },
                 )
             }
@@ -747,6 +749,18 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         self.env.func_type(params, result, effect)
     }
 
+    /// Create a function type with an explicit calling-convention lower bound.
+    pub fn func_type_with_convention(
+        &self,
+        params: Vec<Type<'db>>,
+        result: Type<'db>,
+        effect: EffectRow<'db>,
+        minimum_convention: crate::ast::CallingConvention,
+    ) -> Type<'db> {
+        self.env
+            .func_type_with_convention(params, result, effect, minimum_convention)
+    }
+
     /// Create a named type.
     pub fn named_type(&self, name: Symbol, args: Vec<Type<'db>>) -> Type<'db> {
         self.env.named_type(name, args)
@@ -821,6 +835,7 @@ mod tests {
                 params: vec![bound_var],
                 result: bound_var,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = TypeScheme::new(db, vec![type_param(Symbol::new("a"))], func_ty);
@@ -901,6 +916,7 @@ mod tests {
                 params: vec![],
                 result: nil,
                 effect: shared,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let outer = Type::new(
@@ -909,6 +925,7 @@ mod tests {
                 params: vec![callback],
                 result: nil,
                 effect: shared,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = TypeScheme::new(db, vec![], outer);
@@ -1029,6 +1046,7 @@ mod tests {
                 params: vec![bound_var],
                 result: result_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let scheme = TypeScheme::new(db, vec![type_param(Symbol::new("a"))], func_ty);

--- a/crates/tribute-front/src/typeck/mod.rs
+++ b/crates/tribute-front/src/typeck/mod.rs
@@ -37,7 +37,8 @@ pub use solver::{RowSubst, SolveError, TypeSolver, TypeSubst};
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    CtorId, FuncDefId, Module, NodeId, ResolvedRef, Type, TypeParam, TypeScheme, TypedRef,
+    AbilityId, CallingConvention, CtorId, FuncDefId, Module, NodeId, ResolvedRef, Type, TypeParam,
+    TypeScheme, TypedRef,
 };
 
 /// Salsa-tracked struct holding the complete type checking output.
@@ -61,6 +62,9 @@ pub struct TypeCheckOutput<'db> {
     /// Stored as Vec for Salsa compatibility (HashMap doesn't implement Hash).
     #[returns(ref)]
     pub node_types: Vec<(NodeId, Type<'db>)>,
+    /// Ability-level calling-convention requirements.
+    #[returns(ref)]
+    pub ability_conventions: Vec<(AbilityId<'db>, CallingConvention)>,
     /// Source span information for AST nodes.
     pub span_map: SpanMap,
 }
@@ -98,6 +102,9 @@ pub struct PreludeExports<'db> {
     /// Method index for UFCS resolution: method_name → candidates.
     #[returns(ref)]
     pub method_index: Vec<(Symbol, Vec<MethodEntry<'db>>)>,
+    /// Ability-level calling-convention requirements exported by the prelude.
+    #[returns(ref)]
+    pub ability_conventions: Vec<(AbilityId<'db>, CallingConvention)>,
 }
 
 /// Type check a module.
@@ -116,6 +123,7 @@ pub fn typecheck_module<'db>(
         result.module,
         result.function_types,
         result.node_types,
+        result.ability_conventions,
         span_map,
     )
 }

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -884,6 +884,7 @@ impl<'db> TypeSolver<'db> {
                 effect,
                 ..
             } => {
+                let effect = self.row_subst.apply(self.db, *effect);
                 params.iter().any(|p| self.occurs_in(var, *p))
                     || self.occurs_in(var, *result)
                     || effect
@@ -900,6 +901,7 @@ impl<'db> TypeSolver<'db> {
                 result,
                 effect,
             } => {
+                let effect = self.row_subst.apply(self.db, *effect);
                 self.occurs_in(var, *arg)
                     || self.occurs_in(var, *result)
                     || effect
@@ -942,26 +944,9 @@ impl<'db> TypeSolver<'db> {
                 effect,
                 ..
             } => {
-                let row = self.row_subst.apply(self.db, *effect);
-                if row.rest(self.db) == Some(var) {
-                    return true;
-                }
-                // Recursively check effect args
-                for e in row.effects(self.db) {
-                    for arg in &e.args {
-                        if self.row_occurs_in_type(var, *arg) {
-                            return true;
-                        }
-                    }
-                }
-                // Recursively check params and result
-                if params.iter().any(|p| self.row_occurs_in_type(var, *p)) {
-                    return true;
-                }
-                if self.row_occurs_in_type(var, *result) {
-                    return true;
-                }
-                false
+                self.row_occurs_in(var, *effect)
+                    || params.iter().any(|p| self.row_occurs_in_type(var, *p))
+                    || self.row_occurs_in_type(var, *result)
             }
             TypeKind::Named { args, .. } => args.iter().any(|a| self.row_occurs_in_type(var, *a)),
             TypeKind::Tuple(elems) => elems.iter().any(|e| self.row_occurs_in_type(var, *e)),
@@ -1523,6 +1508,50 @@ mod tests {
             matches!(result, Err(SolveError::OccursCheck { .. })),
             "Expected occurs check failure for ?a = fn() ->{{State(?a)}} Int"
         );
+    }
+
+    #[test]
+    fn test_occurs_check_applies_effect_row_substitution() {
+        let db = test_db();
+        let mut solver = TypeSolver::new(&db);
+
+        let var_ty = fresh_var(&db, 0);
+        let TypeKind::UniVar { id: var_id } = var_ty.kind(&db) else {
+            unreachable!("fresh_var must create a UniVar")
+        };
+        let row_var = EffectVar { id: 7 };
+        let substituted = EffectRow::new(
+            &db,
+            vec![Effect {
+                ability_id: test_ability_id(&db, "State"),
+                args: vec![var_ty],
+            }],
+            None,
+        );
+        solver.row_subst.insert(row_var.id, substituted);
+
+        let int_ty = Type::new(&db, TypeKind::Int);
+        let effect = EffectRow::open(&db, row_var);
+        let func_ty = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: int_ty,
+                effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+        let continuation_ty = Type::new(
+            &db,
+            TypeKind::Continuation {
+                arg: int_ty,
+                result: int_ty,
+                effect,
+            },
+        );
+
+        assert!(solver.occurs_in(*var_id, func_ty));
+        assert!(solver.occurs_in(*var_id, continuation_ty));
     }
 
     #[test]

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -186,6 +186,7 @@ impl<'db> TypeSubst<'db> {
                 params,
                 result,
                 effect,
+                minimum_convention,
             } => {
                 let params = params
                     .iter()
@@ -202,6 +203,7 @@ impl<'db> TypeSubst<'db> {
                         params,
                         result,
                         effect,
+                        minimum_convention: *minimum_convention,
                     },
                 )
             }
@@ -364,6 +366,7 @@ impl<'db> TypeSubst<'db> {
                 params,
                 result,
                 effect,
+                ..
             } => {
                 for p in params {
                     self.collect_unresolved_univars(db, *p, row_subst, out);
@@ -455,6 +458,7 @@ impl<'db> TypeSubst<'db> {
                 params,
                 result,
                 effect,
+                minimum_convention,
             } => {
                 let new_params: Vec<_> = params
                     .iter()
@@ -472,6 +476,7 @@ impl<'db> TypeSubst<'db> {
                         params: new_params,
                         result: new_result,
                         effect: new_effect,
+                        minimum_convention: *minimum_convention,
                     },
                 )
             }
@@ -773,11 +778,13 @@ impl<'db> TypeSolver<'db> {
                     params: ref p1,
                     result: r1,
                     effect: e1,
+                    ..
                 },
                 &TypeKind::Func {
                     params: ref p2,
                     result: r2,
                     effect: e2,
+                    ..
                 },
             ) => {
                 if p1.len() != p2.len() {
@@ -875,6 +882,7 @@ impl<'db> TypeSolver<'db> {
                 params,
                 result,
                 effect,
+                ..
             } => {
                 params.iter().any(|p| self.occurs_in(var, *p))
                     || self.occurs_in(var, *result)
@@ -932,6 +940,7 @@ impl<'db> TypeSolver<'db> {
                 params,
                 result,
                 effect,
+                ..
             } => {
                 let row = self.row_subst.apply(self.db, *effect);
                 if row.rest(self.db) == Some(var) {
@@ -1505,6 +1514,7 @@ mod tests {
                 params: vec![],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1541,6 +1551,7 @@ mod tests {
                 params: vec![],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1620,6 +1631,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect: empty_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let func2 = Type::new(
@@ -1628,6 +1640,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect: empty_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1650,6 +1663,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect: empty_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1662,6 +1676,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect: poly_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1936,6 +1951,7 @@ mod tests {
                 params: vec![var_ty],
                 result: var_ty,
                 effect: poly_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -1947,6 +1963,7 @@ mod tests {
             params,
             result,
             effect,
+            ..
         } = result.kind(&db)
         {
             assert_eq!(params.len(), 1);
@@ -1987,6 +2004,7 @@ mod tests {
                 params: vec![],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2031,6 +2049,7 @@ mod tests {
                 params: vec![],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2096,6 +2115,7 @@ mod tests {
                 params: vec![var_ty],
                 result: var_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2134,6 +2154,7 @@ mod tests {
                 params: vec![var_a],
                 result: var_b,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2178,6 +2199,7 @@ mod tests {
                 params: vec![var_ty],
                 result: var_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2621,6 +2643,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let func2 = Type::new(
@@ -2629,6 +2652,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         assert!(solver.types_unifiable(func1, func2));
@@ -2640,6 +2664,7 @@ mod tests {
                 params: vec![bool_ty],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         assert!(!solver.types_unifiable(func1, func3));
@@ -2651,6 +2676,7 @@ mod tests {
                 params: vec![int_ty],
                 result: bool_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         assert!(!solver.types_unifiable(func1, func4));
@@ -2663,6 +2689,7 @@ mod tests {
                 params: vec![var_ty],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         assert!(solver.types_unifiable(func1, func_with_var));
@@ -2760,6 +2787,7 @@ mod tests {
                 params: vec![],
                 result: int_ty,
                 effect: inner_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let outer_effect = EffectRow::new(&db, vec![], None);
@@ -2769,6 +2797,7 @@ mod tests {
                 params: vec![inner_func],
                 result: int_ty,
                 effect: outer_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2795,6 +2824,7 @@ mod tests {
                 params: vec![],
                 result: int_ty,
                 effect: inner_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         let outer_effect = EffectRow::new(&db, vec![], None);
@@ -2804,6 +2834,7 @@ mod tests {
                 params: vec![],
                 result: inner_func,
                 effect: outer_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -2831,6 +2862,7 @@ mod tests {
                 params: vec![],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -884,13 +884,9 @@ impl<'db> TypeSolver<'db> {
                 effect,
                 ..
             } => {
-                let effect = self.row_subst.apply(self.db, *effect);
                 params.iter().any(|p| self.occurs_in(var, *p))
                     || self.occurs_in(var, *result)
-                    || effect
-                        .effects(self.db)
-                        .iter()
-                        .any(|e| e.args.iter().any(|a| self.occurs_in(var, *a)))
+                    || self.occurs_in_effect_row(var, *effect)
             }
             TypeKind::Tuple(elements) => elements.iter().any(|e| self.occurs_in(var, *e)),
             TypeKind::App { ctor, args } => {
@@ -901,16 +897,21 @@ impl<'db> TypeSolver<'db> {
                 result,
                 effect,
             } => {
-                let effect = self.row_subst.apply(self.db, *effect);
                 self.occurs_in(var, *arg)
                     || self.occurs_in(var, *result)
-                    || effect
-                        .effects(self.db)
-                        .iter()
-                        .any(|e| e.args.iter().any(|a| self.occurs_in(var, *a)))
+                    || self.occurs_in_effect_row(var, *effect)
             }
             _ => false,
         }
+    }
+
+    /// Check a substituted effect row's type arguments for a type variable.
+    fn occurs_in_effect_row(&self, var: UniVarId<'db>, effect: EffectRow<'db>) -> bool {
+        self.row_subst
+            .apply(self.db, effect)
+            .effects(self.db)
+            .iter()
+            .any(|effect| effect.args.iter().any(|arg| self.occurs_in(var, *arg)))
     }
 
     /// Check if a row variable occurs in an effect row (for row occurs check).

--- a/crates/tribute-front/src/typeck/subst.rs
+++ b/crates/tribute-front/src/typeck/subst.rs
@@ -76,6 +76,7 @@ pub fn substitute_bound_vars<'db>(
             params,
             result,
             effect,
+            minimum_convention,
         } => {
             let mut new_params = Vec::with_capacity(params.len());
             for param in params {
@@ -95,6 +96,7 @@ pub fn substitute_bound_vars<'db>(
                     params: new_params,
                     result: new_result,
                     effect: new_effect,
+                    minimum_convention: *minimum_convention,
                 },
             ))
         }
@@ -302,6 +304,7 @@ mod tests {
                 params: vec![bound_var],
                 result: bound_var,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
 
@@ -315,6 +318,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
             },
         );
         assert_eq!(result, SubstResult::Ok(expected));

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -98,16 +98,17 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
     let function_types_map: std::collections::HashMap<_, _> =
         result.function_types.into_iter().collect();
     let node_types_map: std::collections::HashMap<_, _> = result.node_types.into_iter().collect();
+    let ability_conventions: std::collections::HashMap<_, _> =
+        result.ability_conventions.into_iter().collect();
     let mut ir = IrContext::new();
-    let module = tribute_front::ast_to_ir::lower_ast_to_ir(
-        db,
-        &mut ir,
-        tdnr_ast,
+    let module = tribute_front::ast_to_ir::TypedModule {
+        ast: tdnr_ast,
         span_map,
-        source.uri(db).as_str(),
-        function_types_map,
-        node_types_map,
-    );
+        function_types: function_types_map,
+        node_types: node_types_map,
+        ability_conventions,
+    }
+    .lower_to_ir(db, &mut ir, source.uri(db).as_str());
     print_module(&ir, module.op())
 }
 

--- a/crates/tribute-front/tests/snapshots/block_scope__block_let_binding_accessible_inside.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__block_let_binding_accessible_inside.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @example() -> core.i32 {
+  func.func @example() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 42} : core.i32
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/block_scope__block_with_case_pattern_binding.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__block_with_case_pattern_binding.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Option = adt.enum() {name = @Option, variants = [[@Some, [tribute_rt.anyref]], [@None, []]]}
 
-  func.func @example(%0: tribute_rt.anyref) -> core.i32 {
+  func.func @example(%0: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = adt.variant_is %0 {tag = @Some, type = !Option} : core.i1
       %2 = scf.if %1 : core.i32 {
           %3 = adt.variant_cast %0 {tag = @Some, type = !Option} : !Option

--- a/crates/tribute-front/tests/snapshots/block_scope__nested_blocks_separate_scopes.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__nested_blocks_separate_scopes.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @example() -> core.i32 {
+  func.func @example() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       func.return %1

--- a/crates/tribute-front/tests/snapshots/block_scope__outer_scope_accessible_in_inner_block.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__outer_scope_accessible_in_inner_block.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @example() -> core.i32 {
+  func.func @example() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 10} : core.i32
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/block_scope__sequential_blocks_independent_scopes.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__sequential_blocks_independent_scopes.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @example() -> core.i32 {
+  func.func @example() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       func.return %0

--- a/crates/tribute-front/tests/snapshots/case_type__case_bool_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_bool_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/case_type.rs
-assertion_line: 78
 expression: ir_text
 ---
 core.module @test {
-  func.func @invert(%0: core.i1) -> core.i1 {
+  func.func @invert(%0: core.i1) -> core.i1 attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = true} : core.i1
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i1 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_enum_variant.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_enum_variant.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Option = adt.enum() {name = @Option, variants = [[@Some, [tribute_rt.anyref]], [@None, []]]}
 
-  func.func @unwrap_or(%0: tribute_rt.anyref, %1: core.i32) -> core.i32 {
+  func.func @unwrap_or(%0: tribute_rt.anyref, %1: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
       %2 = adt.variant_is %0 {tag = @Some, type = !Option} : core.i1
       %3 = scf.if %2 : core.i32 {
           %4 = adt.variant_cast %0 {tag = @Some, type = !Option} : !Option

--- a/crates/tribute-front/tests/snapshots/case_type__case_int_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_int_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/case_type.rs
-assertion_line: 58
 expression: ir_text
 ---
 core.module @test {
-  func.func @sign(%0: core.i32) -> core.i32 {
+  func.func @sign(%0: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = -1} : core.i32
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_nat_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_nat_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/case_type.rs
-assertion_line: 36
 expression: ir_text
 ---
 core.module @test {
-  func.func @classify(%0: core.i32) -> core.i32 {
+  func.func @classify(%0: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = 0} : core.i32
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_nested.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_nested.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/case_type.rs
-assertion_line: 147
 expression: ir_text
 ---
 core.module @test {
-  func.func @nested(%0: core.i32, %1: core.i1) -> core.i32 {
+  func.func @nested(%0: core.i32, %1: core.i1) -> core.i32 attributes {tribute.calling_convention = 0} {
       %2 = arith.const {value = 0} : core.i32
       %3 = arith.cmpi %0, %2 {predicate = @eq} : core.i1
       %4 = scf.if %3 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_result_type_unification.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_result_type_unification.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/case_type.rs
-assertion_line: 124
 expression: ir_text
 ---
 core.module @test {
-  func.func @to_nat(%0: core.i1) -> core.i32 {
+  func.func @to_nat(%0: core.i1) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = true} : core.i1
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__ability_op_then_pure_expr.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__ability_op_then_pure_expr.snap
@@ -3,15 +3,12 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @get_value(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.i32
-      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
-      func.return %6
+  func.func @get_value(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = core.unrealized_conversion_cast %1 : core.i32
+      func.return %2
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
@@ -6,13 +6,10 @@ core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @get_state(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.i32
-      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %1 : !t0
-      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
-      func.return %6
+  func.func @get_state(%0: !t1) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = core.unrealized_conversion_cast %1 : core.i32
+      func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -26,78 +23,74 @@ core.module @test {
   func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @run() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
-          %2 = adt.ref_null {type = !t1} : !t1
-          %3 = func.call %2, %1 {callee = @get_state} : tribute_rt.anyref
+  func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda() -> tribute_rt.anyref {
+          %1 = adt.ref_null {type = !t1} : !t1
+          %2 = func.call %1 {callee = @get_state, tribute.calling_convention = 1} : core.i32
+          %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
           func.return %3
       }
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t0
-      %6 = func.call_indirect %0, %5 : tribute_rt.anyref
-      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref {
-          %11 = arith.const {value = 1972422014} : core.i32
-          %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
-          %13 = scf.if %12 : tribute_rt.anyref {
-              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %15 = closure.new %14 {func_ref = @"test::__lambda_3"} : !t0
-              %16 = arith.const {value = 42} : core.i32
-              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
-              %18 = core.unrealized_conversion_cast %8 : !t0
-              %19 = func.call_indirect %18, %17 : tribute_rt.anyref
-              scf.yield %19
+      %4 = func.call_indirect %0 : tribute_rt.anyref
+      %5 = closure.lambda(%6: tribute_rt.anyref, %7: core.i32, %8: tribute_rt.anyref) -> tribute_rt.anyref {
+          %9 = arith.const {value = 1972422014} : core.i32
+          %10 = arith.cmpi %7, %9 {predicate = @eq} : core.i1
+          %11 = scf.if %10 : tribute_rt.anyref {
+              %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %13 = closure.new %12 {func_ref = @"test::__lambda_2"} : !t0
+              %14 = arith.const {value = 42} : core.i32
+              %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
+              %16 = core.unrealized_conversion_cast %6 : !t0
+              %17 = func.call_indirect %16, %15 : tribute_rt.anyref
+              scf.yield %17
           } {
-              %20 = arith.const {value = 1} : core.i1
-              %21 = scf.if %20 : tribute_rt.anyref {
-                  %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %23 = closure.new %22 {func_ref = @"test::__lambda_4"} : !t0
-                  %24 = arith.const {value = unit} : core.nil
-                  %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
-                  %26 = core.unrealized_conversion_cast %8 : !t0
-                  %27 = func.call_indirect %26, %25 : tribute_rt.anyref
-                  scf.yield %27
+              %18 = arith.const {value = 1} : core.i1
+              %19 = scf.if %18 : tribute_rt.anyref {
+                  %20 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %21 = closure.new %20 {func_ref = @"test::__lambda_3"} : !t0
+                  %22 = arith.const {value = unit} : core.nil
+                  %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
+                  %24 = core.unrealized_conversion_cast %6 : !t0
+                  %25 = func.call_indirect %24, %23 : tribute_rt.anyref
+                  scf.yield %25
               } {
                   func.unreachable
               }
-              scf.yield %21
+              scf.yield %19
           }
-          func.return %13
+          func.return %11
       }
-      %28 = arith.const {value = 0} : tribute_rt.anyref
-      %29 = ability.handle_dispatch %6, %7, %28 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %26 = arith.const {value = 0} : tribute_rt.anyref
+      %27 = ability.handle_dispatch %4, %5, %26 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb8(%30: tribute_rt.anyref):
-              %31 = core.unrealized_conversion_cast %30 : core.i32
-              scf.yield %31
+            ^bb8(%28: tribute_rt.anyref):
+              %29 = core.unrealized_conversion_cast %28 : core.i32
+              scf.yield %29
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb9(%32: tribute_rt.anyref, %33: tribute_rt.anyref):
-              %34 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %35 = closure.new %34 {func_ref = @"test::__lambda_1"} : !t0
-              %36 = arith.const {value = 42} : core.i32
-              %37 = core.unrealized_conversion_cast %36 : tribute_rt.anyref
-              %38 = core.unrealized_conversion_cast %32 : !t0
-              %39 = func.call_indirect %38, %37 : tribute_rt.anyref
-              scf.yield %39
+            ^bb9(%30: tribute_rt.anyref, %31: tribute_rt.anyref):
+              %32 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %33 = closure.new %32 {func_ref = @"test::__lambda_0"} : !t0
+              %34 = arith.const {value = 42} : core.i32
+              %35 = core.unrealized_conversion_cast %34 : tribute_rt.anyref
+              %36 = core.unrealized_conversion_cast %30 : !t0
+              %37 = func.call_indirect %36, %35 : tribute_rt.anyref
+              scf.yield %37
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
-              %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %43 = closure.new %42 {func_ref = @"test::__lambda_2"} : !t0
-              %44 = arith.const {value = unit} : core.nil
-              %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
-              %46 = core.unrealized_conversion_cast %40 : !t0
-              %47 = func.call_indirect %46, %45 : tribute_rt.anyref
-              scf.yield %47
+            ^bb10(%38: tribute_rt.anyref, %39: tribute_rt.anyref):
+              %40 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %41 = closure.new %40 {func_ref = @"test::__lambda_1"} : !t0
+              %42 = arith.const {value = unit} : core.nil
+              %43 = core.unrealized_conversion_cast %42 : tribute_rt.anyref
+              %44 = core.unrealized_conversion_cast %38 : !t0
+              %45 = func.call_indirect %44, %43 : tribute_rt.anyref
+              scf.yield %45
           }
       }
-      %48 = core.unrealized_conversion_cast %29 : core.i32
-      func.return %48
+      %46 = core.unrealized_conversion_cast %27 : core.i32
+      func.return %46
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
@@ -6,13 +6,10 @@ core.module @test {
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @get_state(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.i32
-      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %1 : !t1
-      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
-      func.return %6
+  func.func @get_state(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = core.unrealized_conversion_cast %1 : core.i32
+      func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -26,89 +23,85 @@ core.module @test {
   func.func @"test::__lambda_3"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_4"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @run() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
-          %2 = adt.ref_null {type = !t0} : !t0
-          %3 = func.call %2, %1 {callee = @get_state} : tribute_rt.anyref
+  func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda() -> tribute_rt.anyref {
+          %1 = adt.ref_null {type = !t0} : !t0
+          %2 = func.call %1 {callee = @get_state, tribute.calling_convention = 1} : core.i32
+          %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
           func.return %3
       }
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t1
-      %6 = func.call_indirect %0, %5 : tribute_rt.anyref
-      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref {
-          %11 = arith.const {value = 1972422014} : core.i32
-          %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
-          %13 = scf.if %12 : tribute_rt.anyref {
-              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %15 = closure.new %14 {func_ref = @"test::__lambda_3"} : !t1
-              %16 = arith.const {value = 42} : core.i32
-              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+      %4 = func.call_indirect %0 : tribute_rt.anyref
+      %5 = closure.lambda(%6: tribute_rt.anyref, %7: core.i32, %8: tribute_rt.anyref) -> tribute_rt.anyref {
+          %9 = arith.const {value = 1972422014} : core.i32
+          %10 = arith.cmpi %7, %9 {predicate = @eq} : core.i1
+          %11 = scf.if %10 : tribute_rt.anyref {
+              %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %13 = closure.new %12 {func_ref = @"test::__lambda_2"} : !t1
+              %14 = arith.const {value = 42} : core.i32
+              %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
+              scf.yield %15
+          } {
+              %16 = arith.const {value = 1} : core.i1
+              %17 = scf.if %16 : tribute_rt.anyref {
+                  %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t1
+                  %20 = arith.const {value = unit} : core.nil
+                  %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
+                  scf.yield %21
+              } {
+                  func.unreachable
+              }
               scf.yield %17
+          }
+          func.return %11
+      }
+      %22 = closure.lambda(%23: core.i32, %24: tribute_rt.anyref) -> tribute_rt.anyref {
+          %25 = arith.const {value = 1972422014} : core.i32
+          %26 = arith.cmpi %23, %25 {predicate = @eq} : core.i1
+          %27 = scf.if %26 : tribute_rt.anyref {
+              %28 = arith.const {value = 42} : core.i32
+              %29 = core.unrealized_conversion_cast %28 : tribute_rt.anyref
+              scf.yield %29
           } {
-              %18 = arith.const {value = 1} : core.i1
-              %19 = scf.if %18 : tribute_rt.anyref {
-                  %20 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %21 = closure.new %20 {func_ref = @"test::__lambda_4"} : !t1
-                  %22 = arith.const {value = unit} : core.nil
-                  %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
-                  scf.yield %23
+              %30 = arith.const {value = 1} : core.i1
+              %31 = scf.if %30 : tribute_rt.anyref {
+                  %32 = arith.const {value = unit} : core.nil
+                  %33 = core.unrealized_conversion_cast %32 : tribute_rt.anyref
+                  scf.yield %33
               } {
                   func.unreachable
               }
-              scf.yield %19
-          }
-          func.return %13
-      }
-      %24 = closure.lambda(%25: core.i32, %26: tribute_rt.anyref) -> tribute_rt.anyref {
-          %27 = arith.const {value = 1972422014} : core.i32
-          %28 = arith.cmpi %25, %27 {predicate = @eq} : core.i1
-          %29 = scf.if %28 : tribute_rt.anyref {
-              %30 = arith.const {value = 42} : core.i32
-              %31 = core.unrealized_conversion_cast %30 : tribute_rt.anyref
               scf.yield %31
-          } {
-              %32 = arith.const {value = 1} : core.i1
-              %33 = scf.if %32 : tribute_rt.anyref {
-                  %34 = arith.const {value = unit} : core.nil
-                  %35 = core.unrealized_conversion_cast %34 : tribute_rt.anyref
-                  scf.yield %35
-              } {
-                  func.unreachable
-              }
-              scf.yield %33
           }
-          func.return %29
+          func.return %27
       }
-      %36 = ability.handle_dispatch %6, %7, %24 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %34 = ability.handle_dispatch %4, %5, %22 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb13(%37: tribute_rt.anyref):
-              %38 = core.unrealized_conversion_cast %37 : core.i32
-              scf.yield %38
+            ^bb13(%35: tribute_rt.anyref):
+              %36 = core.unrealized_conversion_cast %35 : core.i32
+              scf.yield %36
           }
           ability.yield {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb14(%39: tribute_rt.anyref, %40: tribute_rt.anyref):
-              %41 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %42 = closure.new %41 {func_ref = @"test::__lambda_1"} : !t1
-              %43 = arith.const {value = 42} : core.i32
-              %44 = core.unrealized_conversion_cast %43 : tribute_rt.anyref
-              scf.yield %44
+            ^bb14(%37: tribute_rt.anyref, %38: tribute_rt.anyref):
+              %39 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %40 = closure.new %39 {func_ref = @"test::__lambda_0"} : !t1
+              %41 = arith.const {value = 42} : core.i32
+              %42 = core.unrealized_conversion_cast %41 : tribute_rt.anyref
+              scf.yield %42
           }
           ability.yield {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb15(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
-              %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %48 = closure.new %47 {func_ref = @"test::__lambda_2"} : !t1
-              %49 = arith.const {value = unit} : core.nil
-              %50 = core.unrealized_conversion_cast %49 : tribute_rt.anyref
-              scf.yield %50
+            ^bb15(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
+              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t1
+              %47 = arith.const {value = unit} : core.nil
+              %48 = core.unrealized_conversion_cast %47 : tribute_rt.anyref
+              scf.yield %48
           }
       }
-      %51 = core.unrealized_conversion_cast %36 : core.i32
-      func.return %51
+      %49 = core.unrealized_conversion_cast %34 : core.i32
+      func.return %49
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
@@ -5,20 +5,17 @@ expression: ir_text
 core.module @test {
   !__ability_args_tuple = adt.struct() {fields = [[@_0, tribute_rt.anyref], [@_1, tribute_rt.anyref]], name = @__ability_args_tuple}
 
-  func.func @store(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = arith.const {value = 1} : core.i32
-      %3 = arith.const {value = 2} : core.i32
+  func.func @store(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> core.nil attributes {tribute.calling_convention = 1} {
+      %1 = arith.const {value = 1} : core.i32
+      %2 = arith.const {value = 2} : core.i32
+      %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
       %4 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %6 = adt.struct_new %4, %5 {type = !__ability_args_tuple} : tribute_rt.anyref
-      %7 = ability.call %6 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
-      %8 = core.unrealized_conversion_cast %7 : core.nil
-      %9 = core.unrealized_conversion_cast %8 : tribute_rt.anyref
-      %10 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %11 = func.call_indirect %10, %9 : tribute_rt.anyref
-      func.return %11
+      %5 = adt.struct_new %3, %4 {type = !__ability_args_tuple} : tribute_rt.anyref
+      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.nil
+      func.return %7
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_argument.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_argument.snap
@@ -6,28 +6,28 @@ core.module @test {
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
-  func.func @add_one(%0: core.i32) -> core.i32 {
+  func.func @add_one(%0: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = 1} : core.i32
-      %2 = func.call %0, %1 {callee = @"Int::+"} : core.i32
+      %2 = func.call %0, %1 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
       func.return %2
   }
-  func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
           %4 = core.unrealized_conversion_cast %3 : core.i32
-          %5 = func.call %4 {callee = @add_one} : core.i32
+          %5 = func.call %4 {callee = @add_one, tribute.calling_convention = 0} : core.i32
           %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
           %7 = core.unrealized_conversion_cast %1 : !t1
           %8 = func.call_indirect %7, %6 : tribute_rt.anyref
           func.return %8
       }
-      %9 = func.call %0, %2 {callee = @read} : tribute_rt.anyref
+      %9 = func.call %0, %2 {callee = @read, tribute.calling_convention = 2} : tribute_rt.anyref
       func.return %9
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_case_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_case_arm.snap
@@ -6,14 +6,14 @@ core.module @test {
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run(%0: !t0, %1: tribute_rt.anyref, %2: core.i1) -> tribute_rt.anyref {
+  func.func @run(%0: !t0, %1: tribute_rt.anyref, %2: core.i1) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %3 = arith.const {value = true} : core.i1
       %4 = arith.cmpi %2, %3 {predicate = @eq} : core.i1
       %5 = scf.if %4 : core.i32 {
@@ -22,12 +22,12 @@ core.module @test {
           %8 = closure.lambda(%9: tribute_rt.anyref) -> tribute_rt.anyref [%7] {
               %10 = core.unrealized_conversion_cast %9 : core.i32
               %11 = arith.const {value = 1} : core.i32
-              %12 = func.call %10, %11 {callee = @"Int::+"} : core.i32
+              %12 = func.call %10, %11 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
               %13 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
               %14 = func.call_indirect %7, %13 : tribute_rt.anyref
               func.return %14
           }
-          %15 = func.call %0, %8 {callee = @read} : tribute_rt.anyref
+          %15 = func.call %0, %8 {callee = @read, tribute.calling_convention = 2} : tribute_rt.anyref
           %16 = core.unrealized_conversion_cast %15 : core.i32
           scf.yield %16
       } {
@@ -39,7 +39,7 @@ core.module @test {
       %20 = func.call_indirect %19, %18 : tribute_rt.anyref
       func.return %20
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
@@ -6,7 +6,7 @@ core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
@@ -19,19 +19,19 @@ core.module @test {
   func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run() -> core.i32 {
+  func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
           %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
               %4 = core.unrealized_conversion_cast %3 : core.i32
               %5 = arith.const {value = 1} : core.i32
-              %6 = func.call %4, %5 {callee = @"Int::+"} : core.i32
+              %6 = func.call %4, %5 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
               %7 = core.unrealized_conversion_cast %6 : tribute_rt.anyref
               %8 = core.unrealized_conversion_cast %1 : !t0
               %9 = func.call_indirect %8, %7 : tribute_rt.anyref
               func.return %9
           }
           %10 = adt.ref_null {type = !t1} : !t1
-          %11 = func.call %10, %2 {callee = @read} : tribute_rt.anyref
+          %11 = func.call %10, %2 {callee = @read, tribute.calling_convention = 2} : tribute_rt.anyref
           func.return %11
       }
       %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -73,7 +73,7 @@ core.module @test {
       %39 = core.unrealized_conversion_cast %28 : core.i32
       func.return %39
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
@@ -6,7 +6,7 @@ core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @read_log(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @read_log(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Log}, op_name = @value} : tribute_rt.anyref
       func.return %2
   }
@@ -19,7 +19,7 @@ core.module @test {
   func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
           %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           func.return %4
@@ -32,10 +32,10 @@ core.module @test {
           %13 = scf.if %12 : tribute_rt.anyref {
               %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
-              %16 = func.call %0, %15 {callee = @read_log} : tribute_rt.anyref
+              %16 = func.call %0, %15 {callee = @read_log, tribute.calling_convention = 2} : tribute_rt.anyref
               %17 = arith.const {value = 1} : core.i32
               %18 = core.unrealized_conversion_cast %16 : core.i32
-              %19 = func.call %18, %17 {callee = @"Int::+"} : core.i32
+              %19 = func.call %18, %17 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
               %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
               %21 = core.unrealized_conversion_cast %9 : !t0
               %22 = func.call_indirect %21, %20 : tribute_rt.anyref
@@ -55,10 +55,10 @@ core.module @test {
             ^bb7(%26: tribute_rt.anyref, %27: tribute_rt.anyref):
               %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %29 = closure.new %28 {func_ref = @"test::__lambda_1"} : !t0
-              %30 = func.call %0, %29 {callee = @read_log} : tribute_rt.anyref
+              %30 = func.call %0, %29 {callee = @read_log, tribute.calling_convention = 2} : tribute_rt.anyref
               %31 = arith.const {value = 1} : core.i32
               %32 = core.unrealized_conversion_cast %30 : core.i32
-              %33 = func.call %32, %31 {callee = @"Int::+"} : core.i32
+              %33 = func.call %32, %31 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
               %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
               %35 = core.unrealized_conversion_cast %26 : !t0
               %36 = func.call_indirect %35, %34 : tribute_rt.anyref
@@ -69,7 +69,7 @@ core.module @test {
       %38 = func.call_indirect %37, %24 : tribute_rt.anyref
       func.return %38
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
@@ -33,9 +33,9 @@ core.module @test {
               %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
               %16 = func.call %0, %15 {callee = @read_log, tribute.calling_convention = 2} : tribute_rt.anyref
-              %17 = arith.const {value = 1} : core.i32
-              %18 = core.unrealized_conversion_cast %16 : core.i32
-              %19 = func.call %18, %17 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
+              %17 = core.unrealized_conversion_cast %16 : core.i32
+              %18 = arith.const {value = 1} : core.i32
+              %19 = func.call %17, %18 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
               %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
               %21 = core.unrealized_conversion_cast %9 : !t0
               %22 = func.call_indirect %21, %20 : tribute_rt.anyref
@@ -56,9 +56,9 @@ core.module @test {
               %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %29 = closure.new %28 {func_ref = @"test::__lambda_1"} : !t0
               %30 = func.call %0, %29 {callee = @read_log, tribute.calling_convention = 2} : tribute_rt.anyref
-              %31 = arith.const {value = 1} : core.i32
-              %32 = core.unrealized_conversion_cast %30 : core.i32
-              %33 = func.call %32, %31 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
+              %31 = core.unrealized_conversion_cast %30 : core.i32
+              %32 = arith.const {value = 1} : core.i32
+              %33 = func.call %31, %32 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
               %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
               %35 = core.unrealized_conversion_cast %26 : !t0
               %36 = func.call_indirect %35, %34 : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
@@ -6,19 +6,19 @@ core.module @test {
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = arith.const {value = false} : core.i1
       %3 = scf.if %2 : core.i1 {
           %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
           %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t1
-          %6 = func.call %0, %5 {callee = @read} : tribute_rt.anyref
+          %6 = func.call %0, %5 {callee = @read, tribute.calling_convention = 2} : tribute_rt.anyref
           %7 = core.unrealized_conversion_cast %6 : core.i1
           scf.yield %7
       } {
@@ -30,7 +30,7 @@ core.module @test {
       %11 = func.call_indirect %10, %9 : tribute_rt.anyref
       func.return %11
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_closure_call.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_closure_call.snap
@@ -3,26 +3,27 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @run(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
-          %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-          func.return %4
+  func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
+      %2 = closure.lambda(%3: !t0, %4: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
+          %5 = ability.perform %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          func.return %5
       }
-      %5 = closure.lambda(%6: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
-          %7 = core.unrealized_conversion_cast %6 : core.i32
-          %8 = arith.const {value = 1} : core.i32
-          %9 = func.call %7, %8 {callee = @"Int::+"} : core.i32
-          %10 = core.unrealized_conversion_cast %9 : tribute_rt.anyref
-          %11 = core.unrealized_conversion_cast %1 : !t0
-          %12 = func.call_indirect %11, %10 : tribute_rt.anyref
-          func.return %12
+      %6 = closure.lambda(%7: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
+          %8 = core.unrealized_conversion_cast %7 : core.i32
+          %9 = arith.const {value = 1} : core.i32
+          %10 = func.call %8, %9 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
+          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+          %12 = core.unrealized_conversion_cast %1 : !t1
+          %13 = func.call_indirect %12, %11 : tribute_rt.anyref
+          func.return %13
       }
-      %13 = func.call_indirect %2, %5 : tribute_rt.anyref
-      func.return %13
+      %14 = func.call_indirect %2, %0, %6 {tribute.calling_convention = 2} : tribute_rt.anyref
+      func.return %14
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__resume_in_op_handler.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__resume_in_op_handler.snap
@@ -18,7 +18,7 @@ core.module @test {
   func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run() -> core.i32 {
+  func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda() -> tribute_rt.anyref {
           %1 = arith.const {value = 42} : core.i32
           %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
@@ -84,7 +84,7 @@ core.module @test {
       %45 = core.unrealized_conversion_cast %26 : core.i32
       func.return %45
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__sequential_ability_ops.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__sequential_ability_ops.snap
@@ -3,18 +3,15 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @set_and_get(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = arith.const {value = 42} : core.i32
-      %3 = ability.call %2 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %3 : core.nil
-      %5 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.i32
-      %7 = core.unrealized_conversion_cast %6 : tribute_rt.anyref
-      %8 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %9 = func.call_indirect %8, %7 : tribute_rt.anyref
-      func.return %9
+  func.func @set_and_get(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = arith.const {value = 42} : core.i32
+      %2 = ability.call %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.nil
+      %4 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %5 = core.unrealized_conversion_cast %4 : core.i32
+      func.return %5
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__single_ability_op_in_block.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__single_ability_op_in_block.snap
@@ -3,15 +3,12 @@ source: crates/tribute-front/tests/cps_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @get_state(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.i32
-      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-      %6 = func.call_indirect %5, %4 : tribute_rt.anyref
-      func.return %6
+  func.func @get_state(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = core.unrealized_conversion_cast %1 : core.i32
+      func.return %2
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
@@ -6,28 +6,28 @@ core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @get_count(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @get_count(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Counter}, op_name = @inc} : tribute_rt.anyref
       func.return %2
   }
-  func.func @use_counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @use_counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
           %4 = core.unrealized_conversion_cast %3 : core.i32
           %5 = closure.lambda(%6: tribute_rt.anyref) -> tribute_rt.anyref [%4, %1] {
               %7 = core.unrealized_conversion_cast %6 : core.i32
-              %8 = func.call %4, %7 {callee = @"Nat::+"} : core.i32
+              %8 = func.call %4, %7 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
               %9 = core.unrealized_conversion_cast %8 : tribute_rt.anyref
               %10 = core.unrealized_conversion_cast %1 : !t0
               %11 = func.call_indirect %10, %9 : tribute_rt.anyref
               func.return %11
           }
-          %12 = func.call %0, %5 {callee = @get_count} : tribute_rt.anyref
+          %12 = func.call %0, %5 {callee = @get_count, tribute.calling_convention = 2} : tribute_rt.anyref
           func.return %12
       }
-      %13 = func.call %0, %2 {callee = @get_count} : tribute_rt.anyref
+      %13 = func.call %0, %2 {callee = @get_count, tribute.calling_convention = 2} : tribute_rt.anyref
       func.return %13
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
@@ -3,11 +3,11 @@ source: crates/tribute-front/tests/evidence_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  func.func @effectful(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @effectful(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Foo}, op_name = @bar} : tribute_rt.anyref
       func.return %2
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
@@ -6,7 +6,7 @@ core.module @test {
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @use_ask(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @use_ask(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask} : tribute_rt.anyref
       func.return %2
   }
@@ -19,10 +19,10 @@ core.module @test {
   func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
           %2 = adt.ref_null {type = !t0} : !t0
-          %3 = func.call %2, %1 {callee = @use_ask} : tribute_rt.anyref
+          %3 = func.call %2, %1 {callee = @use_ask, tribute.calling_convention = 2} : tribute_rt.anyref
           func.return %3
       }
       %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_false.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_false.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 111
 expression: ir_text
 ---
 core.module @test {
-  func.func @no() -> core.i1 {
+  func.func @no() -> core.i1 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = false} : core.i1
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_true.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_true.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 95
 expression: ir_text
 ---
 core.module @test {
-  func.func @yes() -> core.i1 {
+  func.func @yes() -> core.i1 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = true} : core.i1
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 163
 expression: ir_text
 ---
 core.module @test {
-  func.func @logic(%0: core.i1, %1: core.i1) -> core.i1 {
+  func.func @logic(%0: core.i1, %1: core.i1) -> core.i1 attributes {tribute.calling_convention = 0} {
       %2 = scf.if %0 : core.i1 {
           %3 = arith.const {value = true} : core.i1
           scf.yield %3

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bytes_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bytes_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 47
 expression: ir_text
 ---
 core.module @test {
-  func.func @data() -> core.bytes {
+  func.func @data() -> core.bytes attributes {tribute.calling_convention = 0} {
       %0 = adt.bytes_const {value = b"payload"} : core.bytes
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
@@ -1,19 +1,18 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 179
 expression: ir_text
 ---
 core.module @test {
   !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
   !__tuple_i1_i1_i1_i1_i1_i1_1 = adt.typeref() {name = @__tuple_i1_i1_i1_i1_i1_i1}
 
-  func.func @comparisons(%0: core.f64, %1: core.f64) -> tribute_rt.anyref {
-      %2 = func.call %0, %1 {callee = @"Float::=="} : core.i1
-      %3 = func.call %0, %1 {callee = @"Float::!="} : core.i1
-      %4 = func.call %0, %1 {callee = @"Float::<"} : core.i1
-      %5 = func.call %0, %1 {callee = @"Float::<="} : core.i1
-      %6 = func.call %0, %1 {callee = @"Float::>"} : core.i1
-      %7 = func.call %0, %1 {callee = @"Float::>="} : core.i1
+  func.func @comparisons(%0: core.f64, %1: core.f64) -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
+      %2 = func.call %0, %1 {callee = @"Float::==", tribute.calling_convention = 0} : core.i1
+      %3 = func.call %0, %1 {callee = @"Float::!=", tribute.calling_convention = 0} : core.i1
+      %4 = func.call %0, %1 {callee = @"Float::<", tribute.calling_convention = 0} : core.i1
+      %5 = func.call %0, %1 {callee = @"Float::<=", tribute.calling_convention = 0} : core.i1
+      %6 = func.call %0, %1 {callee = @"Float::>", tribute.calling_convention = 0} : core.i1
+      %7 = func.call %0, %1 {callee = @"Float::>=", tribute.calling_convention = 0} : core.i1
       %8 = adt.struct_new %2, %3, %4, %5, %6, %7 {type = !__tuple_i1_i1_i1_i1_i1_i1} : !__tuple_i1_i1_i1_i1_i1_i1_1
       %9 = core.unrealized_conversion_cast %8 : tribute_rt.anyref
       func.return %9

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 63
 expression: ir_text
 ---
 core.module @test {
-  func.func @pi() -> core.f64 {
+  func.func @pi() -> core.f64 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 3.14} : core.f64
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
@@ -1,33 +1,30 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 208
 expression: ir_text
 ---
 core.module @test {
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @id(%0: core.i32) -> core.i32 {
+  func.func @id(%0: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
       func.return %0
   }
-  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32) -> tribute_rt.anyref {
-      %4 = func.call %3 {callee = @id} : core.i32
-      %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %2 : !t1
-      %7 = func.call_indirect %6, %5 : tribute_rt.anyref
-      func.return %7
+  func.func @"test::__lambda_0"(%0: tribute_rt.anyref, %1: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %2 = func.call %1 {callee = @id, tribute.calling_convention = 0} : core.i32
+      func.return %2
   }
   func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @test_ref() -> core.i32 {
+  func.func @test_ref() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %1 = closure.new %0 {func_ref = @"test::__lambda_0"} : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32))
+      %1 = closure.new %0 {func_ref = @"test::__lambda_0", tribute.calling_convention = 0} : closure.closure(core.func(core.i32, core.i32))
       %2 = arith.const {value = 1} : core.i32
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %4 = closure.new %3 {func_ref = @"test::__lambda_1"} : !t1
-      %5 = func.call_indirect %1, %4, %2 : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.i32
-      func.return %6
+      %3 = adt.ref_null {type = !t0} : !t0
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = closure.new %4 {func_ref = @"test::__lambda_1"} : closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+      %6 = core.unrealized_conversion_cast %1 : closure.closure(core.func(tribute_rt.anyref, !t0, closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref)), core.i32))
+      %7 = func.call_indirect %6, %3, %5, %2 {tribute.calling_convention = 2} : tribute_rt.anyref
+      %8 = core.unrealized_conversion_cast %7 : core.i32
+      func.return %8
   }
 }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__lambda_as_argument.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__lambda_as_argument.snap
@@ -3,29 +3,30 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32))
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @"test::__lambda_0"(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @apply(%0: core.func(core.i32, core.i32), %1: core.i32) -> core.i32 {
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = closure.new %2 {func_ref = @"test::__lambda_0"} : !t1
-      %4 = core.unrealized_conversion_cast %0 : !t0
-      %5 = func.call_indirect %4, %3, %1 : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.i32
-      func.return %6
-  }
-  func.func @test_lambda() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref, %2: core.i32) -> tribute_rt.anyref {
-          %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-          %4 = core.unrealized_conversion_cast %1 : !t1
-          %5 = func.call_indirect %4, %3 : tribute_rt.anyref
-          func.return %5
-      }
-      %6 = arith.const {value = 1} : core.i32
-      %7 = func.call %0, %6 {callee = @apply} : core.i32
+  func.func @apply(%0: core.func(core.i32, core.i32), %1: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = closure.new %3 {func_ref = @"test::__lambda_0"} : !t1
+      %5 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, !t0, !t1, core.i32))
+      %6 = func.call_indirect %5, %2, %4, %1 {tribute.calling_convention = 2} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.i32
       func.return %7
+  }
+  func.func @test_lambda() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t0, %2: tribute_rt.anyref, %3: core.i32) -> tribute_rt.anyref {tribute.calling_convention = 2} {
+          %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+          %5 = core.unrealized_conversion_cast %2 : !t1
+          %6 = func.call_indirect %5, %4 : tribute_rt.anyref
+          func.return %6
+      }
+      %7 = arith.const {value = 1} : core.i32
+      %8 = func.call %0, %7 {callee = @apply, tribute.calling_convention = 0} : core.i32
+      func.return %8
   }
 }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__nil_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__nil_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 127
 expression: ir_text
 ---
 core.module @test {
-  func.func @nothing() -> core.nil {
+  func.func @nothing() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = unit} : core.nil
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__rune_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__rune_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 79
 expression: ir_text
 ---
 core.module @test {
-  func.func @letter() -> core.i32 {
+  func.func @letter() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 97} : core.i32
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__string_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__string_literal.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 31
 expression: ir_text
 ---
 core.module @test {
-  func.func @greeting() -> tribute_rt.anyref {
+  func.func @greeting() -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %0 = adt.string_const {value = "hello"} : tribute_rt.anyref
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__tuple_construction.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__tuple_construction.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/tribute-front/tests/expr_coverage.rs
-assertion_line: 147
 expression: ir_text
 ---
 core.module @test {
   !__tuple_i32_i1 = adt.struct() {fields = [[@0, core.i32], [@1, core.i1]], name = @__tuple_i32_i1}
 
-  func.func @pair() -> tribute_rt.anyref {
+  func.func @pair() -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 42} : core.i32
       %1 = arith.const {value = true} : core.i1
       %2 = adt.struct_new %0, %1 {type = !__tuple_i32_i1} : adt.typeref() {name = @__tuple_i32_i1}

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -5,18 +5,16 @@ expression: ir_text
 core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t2 = closure.closure(core.func(tribute_rt.anyref, !t1, tribute_rt.anyref))
 
-  func.func @counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.i32
-      %4 = arith.const {value = 1} : core.i32
-      %5 = func.call %3, %4 {callee = @"Int::+"} : core.i32
-      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %6 : core.nil
-      %8 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %9 = core.unrealized_conversion_cast %1 : !t0
-      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
-      func.return %10
+  func.func @counter(%0: !t1) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = core.unrealized_conversion_cast %1 : core.i32
+      %3 = arith.const {value = 1} : core.i32
+      %4 = func.call %2, %3 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
+      %5 = ability.call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %5 : core.nil
+      func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -33,10 +31,10 @@ core.module @test {
   func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref [%2] {
-          %6 = core.unrealized_conversion_cast %2 : !t0
-          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
+          %6 = core.unrealized_conversion_cast %2 : !t2
+          %7 = func.call_indirect %6, %0, %5 {tribute.calling_convention = 2} : tribute_rt.anyref
           func.return %7
       }
       %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -48,107 +46,99 @@ core.module @test {
           %17 = scf.if %16 : tribute_rt.anyref {
               %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
-              %20 = closure.lambda(%21: tribute_rt.anyref) -> tribute_rt.anyref [%12, %3] {
-                  %22 = core.unrealized_conversion_cast %12 : !t0
-                  %23 = func.call_indirect %22, %3 : tribute_rt.anyref
-                  %24 = core.unrealized_conversion_cast %21 : !t0
-                  %25 = func.call_indirect %24, %23 : tribute_rt.anyref
-                  func.return %25
+              %20 = closure.lambda(%21: !t1, %22: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12, %3] {
+                  %23 = core.unrealized_conversion_cast %12 : !t0
+                  %24 = func.call_indirect %23, %3 : tribute_rt.anyref
+                  %25 = core.unrealized_conversion_cast %22 : !t0
+                  %26 = func.call_indirect %25, %24 : tribute_rt.anyref
+                  func.return %26
               }
-              %26 = func.call %0, %19, %20, %3 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %26
+              %27 = func.call %0, %19, %20, %3 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %27
           } {
-              %27 = arith.const {value = 1} : core.i1
-              %28 = scf.if %27 : tribute_rt.anyref {
-                  %29 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %30 = closure.new %29 {func_ref = @"test::__lambda_4"} : !t0
-                  %31 = closure.lambda(%32: tribute_rt.anyref) -> tribute_rt.anyref [%12] {
-                      %33 = arith.const {value = unit} : core.nil
-                      %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
-                      %35 = core.unrealized_conversion_cast %12 : !t0
-                      %36 = func.call_indirect %35, %34 : tribute_rt.anyref
-                      %37 = core.unrealized_conversion_cast %32 : !t0
+              %28 = arith.const {value = 1} : core.i1
+              %29 = scf.if %28 : tribute_rt.anyref {
+                  %30 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %31 = closure.new %30 {func_ref = @"test::__lambda_4"} : !t0
+                  %32 = closure.lambda(%33: !t1, %34: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12] {
+                      %35 = arith.const {value = unit} : core.nil
+                      %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
+                      %37 = core.unrealized_conversion_cast %12 : !t0
                       %38 = func.call_indirect %37, %36 : tribute_rt.anyref
-                      func.return %38
+                      %39 = core.unrealized_conversion_cast %34 : !t0
+                      %40 = func.call_indirect %39, %38 : tribute_rt.anyref
+                      func.return %40
                   }
-                  %39 = func.call %0, %30, %31, %14 {callee = @run_state} : tribute_rt.anyref
-                  scf.yield %39
+                  %41 = func.call %0, %31, %32, %14 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+                  scf.yield %41
               } {
                   func.unreachable
               }
-              scf.yield %28
+              scf.yield %29
           }
           func.return %17
       }
-      %40 = arith.const {value = 0} : tribute_rt.anyref
-      %41 = ability.handle_dispatch %10, %11, %40 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %42 = arith.const {value = 0} : tribute_rt.anyref
+      %43 = ability.handle_dispatch %10, %11, %42 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb10(%42: tribute_rt.anyref):
-              scf.yield %42
+            ^bb10(%44: tribute_rt.anyref):
+              scf.yield %44
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb11(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
-              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t0
-              %47 = closure.lambda(%48: tribute_rt.anyref) -> tribute_rt.anyref [%43, %3] {
-                  %49 = core.unrealized_conversion_cast %43 : !t0
-                  %50 = func.call_indirect %49, %3 : tribute_rt.anyref
-                  %51 = core.unrealized_conversion_cast %48 : !t0
-                  %52 = func.call_indirect %51, %50 : tribute_rt.anyref
-                  func.return %52
+            ^bb11(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
+              %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %48 = closure.new %47 {func_ref = @"test::__lambda_1"} : !t0
+              %49 = closure.lambda(%50: !t1, %51: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%45, %3] {
+                  %52 = core.unrealized_conversion_cast %45 : !t0
+                  %53 = func.call_indirect %52, %3 : tribute_rt.anyref
+                  %54 = core.unrealized_conversion_cast %51 : !t0
+                  %55 = func.call_indirect %54, %53 : tribute_rt.anyref
+                  func.return %55
               }
-              %53 = func.call %0, %46, %47, %3 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %53
+              %56 = func.call %0, %48, %49, %3 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %56
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb13(%54: tribute_rt.anyref, %55: tribute_rt.anyref):
-              %56 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %57 = closure.new %56 {func_ref = @"test::__lambda_2"} : !t0
-              %58 = closure.lambda(%59: tribute_rt.anyref) -> tribute_rt.anyref [%54] {
-                  %60 = arith.const {value = unit} : core.nil
-                  %61 = core.unrealized_conversion_cast %60 : tribute_rt.anyref
-                  %62 = core.unrealized_conversion_cast %54 : !t0
-                  %63 = func.call_indirect %62, %61 : tribute_rt.anyref
-                  %64 = core.unrealized_conversion_cast %59 : !t0
-                  %65 = func.call_indirect %64, %63 : tribute_rt.anyref
-                  func.return %65
+            ^bb13(%57: tribute_rt.anyref, %58: tribute_rt.anyref):
+              %59 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %60 = closure.new %59 {func_ref = @"test::__lambda_2"} : !t0
+              %61 = closure.lambda(%62: !t1, %63: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%57] {
+                  %64 = arith.const {value = unit} : core.nil
+                  %65 = core.unrealized_conversion_cast %64 : tribute_rt.anyref
+                  %66 = core.unrealized_conversion_cast %57 : !t0
+                  %67 = func.call_indirect %66, %65 : tribute_rt.anyref
+                  %68 = core.unrealized_conversion_cast %63 : !t0
+                  %69 = func.call_indirect %68, %67 : tribute_rt.anyref
+                  func.return %69
               }
-              %66 = func.call %0, %57, %58, %55 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %66
+              %70 = func.call %0, %60, %61, %58 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %70
           }
       }
-      %67 = core.unrealized_conversion_cast %1 : !t0
-      %68 = func.call_indirect %67, %41 : tribute_rt.anyref
-      func.return %68
+      %71 = core.unrealized_conversion_cast %1 : !t0
+      %72 = func.call_indirect %71, %43 : tribute_rt.anyref
+      func.return %72
   }
   func.func @"test::__lambda_5"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @main() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
-          %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
-              %4 = core.unrealized_conversion_cast %3 : core.i32
-              %5 = closure.lambda(%6: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
-                  %7 = core.unrealized_conversion_cast %6 : core.i32
-                  %8 = adt.ref_null {type = !t1} : !t1
-                  %9 = func.call %8, %1 {callee = @counter} : tribute_rt.anyref
-                  func.return %9
-              }
-              %10 = adt.ref_null {type = !t1} : !t1
-              %11 = func.call %10, %5 {callee = @counter} : tribute_rt.anyref
-              func.return %11
-          }
-          %12 = adt.ref_null {type = !t1} : !t1
-          %13 = func.call %12, %2 {callee = @counter} : tribute_rt.anyref
-          func.return %13
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t1, %2: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
+          %3 = func.call %1 {callee = @counter, tribute.calling_convention = 1} : core.i32
+          %4 = func.call %1 {callee = @counter, tribute.calling_convention = 1} : core.i32
+          %5 = func.call %1 {callee = @counter, tribute.calling_convention = 1} : core.i32
+          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
+          %7 = core.unrealized_conversion_cast %2 : !t0
+          %8 = func.call_indirect %7, %6 : tribute_rt.anyref
+          func.return %8
       }
-      %14 = arith.const {value = 0} : core.i32
-      %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
-      %16 = adt.ref_null {type = !t1} : !t1
-      %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %18 = closure.new %17 {func_ref = @"test::__lambda_5"} : !t0
-      %19 = func.call %16, %18, %0, %15 {callee = @run_state} : tribute_rt.anyref
-      %20 = core.unrealized_conversion_cast %19 : core.i32
-      func.return %20
+      %9 = arith.const {value = 0} : core.i32
+      %10 = core.unrealized_conversion_cast %9 : tribute_rt.anyref
+      %11 = adt.ref_null {type = !t1} : !t1
+      %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %13 = closure.new %12 {func_ref = @"test::__lambda_5"} : !t0
+      %14 = func.call %11, %13, %0, %10 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+      %15 = core.unrealized_conversion_cast %14 : core.i32
+      func.return %15
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
@@ -5,6 +5,7 @@ expression: ir_text
 core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t2 = closure.closure(core.func(core.i32, !t1))
 
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -18,87 +19,81 @@ core.module @test {
   func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 {
-      %1 = closure.lambda(%2: tribute_rt.anyref) -> tribute_rt.anyref [%0] {
-          %3 = core.unrealized_conversion_cast %0 : !t0
-          %4 = func.call_indirect %3, %2 : tribute_rt.anyref
-          %5 = core.unrealized_conversion_cast %4 : core.i32
-          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-          func.return %6
+  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %1 = closure.lambda() -> tribute_rt.anyref [%0] {
+          %2 = adt.ref_null {type = !t1} : !t1
+          %3 = core.unrealized_conversion_cast %0 : !t2
+          %4 = func.call_indirect %3, %2 {tribute.calling_convention = 1} : core.i32
+          %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+          func.return %5
       }
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_0"} : !t0
-      %9 = func.call_indirect %1, %8 : tribute_rt.anyref
-      %10 = closure.lambda(%11: tribute_rt.anyref, %12: core.i32, %13: tribute_rt.anyref) -> tribute_rt.anyref {
-          %14 = arith.const {value = 1972422014} : core.i32
-          %15 = arith.cmpi %12, %14 {predicate = @eq} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = closure.new %17 {func_ref = @"test::__lambda_3"} : !t0
-              %19 = arith.const {value = 42} : core.i32
-              %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
-              %21 = core.unrealized_conversion_cast %11 : !t0
-              %22 = func.call_indirect %21, %20 : tribute_rt.anyref
-              scf.yield %22
+      %6 = func.call_indirect %1 : tribute_rt.anyref
+      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref {
+          %11 = arith.const {value = 1972422014} : core.i32
+          %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
+          %13 = scf.if %12 : tribute_rt.anyref {
+              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
+              %16 = arith.const {value = 42} : core.i32
+              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+              %18 = core.unrealized_conversion_cast %8 : !t0
+              %19 = func.call_indirect %18, %17 : tribute_rt.anyref
+              scf.yield %19
           } {
-              %23 = arith.const {value = 1} : core.i1
-              %24 = scf.if %23 : tribute_rt.anyref {
-                  %25 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %26 = closure.new %25 {func_ref = @"test::__lambda_4"} : !t0
-                  %27 = arith.const {value = unit} : core.nil
-                  %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
-                  %29 = core.unrealized_conversion_cast %11 : !t0
-                  %30 = func.call_indirect %29, %28 : tribute_rt.anyref
-                  scf.yield %30
+              %20 = arith.const {value = 1} : core.i1
+              %21 = scf.if %20 : tribute_rt.anyref {
+                  %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %23 = closure.new %22 {func_ref = @"test::__lambda_3"} : !t0
+                  %24 = arith.const {value = unit} : core.nil
+                  %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
+                  %26 = core.unrealized_conversion_cast %8 : !t0
+                  %27 = func.call_indirect %26, %25 : tribute_rt.anyref
+                  scf.yield %27
               } {
                   func.unreachable
               }
-              scf.yield %24
+              scf.yield %21
           }
-          func.return %16
+          func.return %13
       }
-      %31 = arith.const {value = 0} : tribute_rt.anyref
-      %32 = ability.handle_dispatch %9, %10, %31 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %28 = arith.const {value = 0} : tribute_rt.anyref
+      %29 = ability.handle_dispatch %6, %7, %28 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb8(%33: tribute_rt.anyref):
-              %34 = core.unrealized_conversion_cast %33 : core.i32
-              scf.yield %34
+            ^bb8(%30: tribute_rt.anyref):
+              %31 = core.unrealized_conversion_cast %30 : core.i32
+              scf.yield %31
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb9(%35: tribute_rt.anyref, %36: tribute_rt.anyref):
-              %37 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %38 = closure.new %37 {func_ref = @"test::__lambda_1"} : !t0
-              %39 = arith.const {value = 42} : core.i32
-              %40 = core.unrealized_conversion_cast %39 : tribute_rt.anyref
-              %41 = core.unrealized_conversion_cast %35 : !t0
-              %42 = func.call_indirect %41, %40 : tribute_rt.anyref
-              scf.yield %42
+            ^bb9(%32: tribute_rt.anyref, %33: tribute_rt.anyref):
+              %34 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %35 = closure.new %34 {func_ref = @"test::__lambda_0"} : !t0
+              %36 = arith.const {value = 42} : core.i32
+              %37 = core.unrealized_conversion_cast %36 : tribute_rt.anyref
+              %38 = core.unrealized_conversion_cast %32 : !t0
+              %39 = func.call_indirect %38, %37 : tribute_rt.anyref
+              scf.yield %39
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb10(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
-              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %46 = closure.new %45 {func_ref = @"test::__lambda_2"} : !t0
-              %47 = arith.const {value = unit} : core.nil
-              %48 = core.unrealized_conversion_cast %47 : tribute_rt.anyref
-              %49 = core.unrealized_conversion_cast %43 : !t0
-              %50 = func.call_indirect %49, %48 : tribute_rt.anyref
-              scf.yield %50
+            ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
+              %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %43 = closure.new %42 {func_ref = @"test::__lambda_1"} : !t0
+              %44 = arith.const {value = unit} : core.nil
+              %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
+              %46 = core.unrealized_conversion_cast %40 : !t0
+              %47 = func.call_indirect %46, %45 : tribute_rt.anyref
+              scf.yield %47
           }
       }
-      %51 = core.unrealized_conversion_cast %32 : core.i32
-      func.return %51
+      %48 = core.unrealized_conversion_cast %29 : core.i32
+      func.return %48
   }
-  func.func @main() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t1) -> core.i32 {tribute.calling_convention = 1} {
           %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-          %3 = core.unrealized_conversion_cast %1 : !t0
-          %4 = func.call_indirect %3, %2 : tribute_rt.anyref
-          func.return %4
+          %3 = core.unrealized_conversion_cast %2 : core.i32
+          func.return %3
       }
-      %5 = func.call %0 {callee = @run_with_state} : core.i32
-      func.return %5
+      %4 = func.call %0 {callee = @run_with_state, tribute.calling_convention = 0} : core.i32
+      func.return %4
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -3,113 +3,105 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t2 = closure.closure(core.func(core.i32, !t0))
 
-  func.func @counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.i32
-      %4 = arith.const {value = 1} : core.i32
-      %5 = func.call %3, %4 {callee = @"Int::+"} : core.i32
-      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %6 : core.nil
-      %8 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %9 = core.unrealized_conversion_cast %1 : !t0
-      %10 = func.call_indirect %9, %8 : tribute_rt.anyref
-      func.return %10
-  }
-  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @counter(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = core.unrealized_conversion_cast %1 : core.i32
+      %3 = arith.const {value = 1} : core.i32
+      %4 = func.call %2, %3 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
+      %5 = ability.call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %5 : core.nil
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_3"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 {
-      %1 = closure.lambda(%2: tribute_rt.anyref) -> tribute_rt.anyref [%0] {
-          %3 = core.unrealized_conversion_cast %0 : !t0
-          %4 = func.call_indirect %3, %2 : tribute_rt.anyref
-          %5 = core.unrealized_conversion_cast %4 : core.i32
-          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-          func.return %6
+  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %1 = closure.lambda() -> tribute_rt.anyref [%0] {
+          %2 = adt.ref_null {type = !t0} : !t0
+          %3 = core.unrealized_conversion_cast %0 : !t2
+          %4 = func.call_indirect %3, %2 {tribute.calling_convention = 1} : core.i32
+          %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+          func.return %5
       }
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_0"} : !t0
-      %9 = func.call_indirect %1, %8 : tribute_rt.anyref
-      %10 = closure.lambda(%11: tribute_rt.anyref, %12: core.i32, %13: tribute_rt.anyref) -> tribute_rt.anyref {
-          %14 = arith.const {value = 1972422014} : core.i32
-          %15 = arith.cmpi %12, %14 {predicate = @eq} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = closure.new %17 {func_ref = @"test::__lambda_3"} : !t0
-              %19 = arith.const {value = 0} : core.i32
-              %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
-              %21 = core.unrealized_conversion_cast %11 : !t0
-              %22 = func.call_indirect %21, %20 : tribute_rt.anyref
-              scf.yield %22
+      %6 = func.call_indirect %1 : tribute_rt.anyref
+      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref {
+          %11 = arith.const {value = 1972422014} : core.i32
+          %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
+          %13 = scf.if %12 : tribute_rt.anyref {
+              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t1
+              %16 = arith.const {value = 0} : core.i32
+              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+              %18 = core.unrealized_conversion_cast %8 : !t1
+              %19 = func.call_indirect %18, %17 : tribute_rt.anyref
+              scf.yield %19
           } {
-              %23 = arith.const {value = 1} : core.i1
-              %24 = scf.if %23 : tribute_rt.anyref {
-                  %25 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %26 = closure.new %25 {func_ref = @"test::__lambda_4"} : !t0
-                  %27 = arith.const {value = unit} : core.nil
-                  %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
-                  %29 = core.unrealized_conversion_cast %11 : !t0
-                  %30 = func.call_indirect %29, %28 : tribute_rt.anyref
-                  scf.yield %30
+              %20 = arith.const {value = 1} : core.i1
+              %21 = scf.if %20 : tribute_rt.anyref {
+                  %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %23 = closure.new %22 {func_ref = @"test::__lambda_3"} : !t1
+                  %24 = arith.const {value = unit} : core.nil
+                  %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
+                  %26 = core.unrealized_conversion_cast %8 : !t1
+                  %27 = func.call_indirect %26, %25 : tribute_rt.anyref
+                  scf.yield %27
               } {
                   func.unreachable
               }
-              scf.yield %24
+              scf.yield %21
           }
-          func.return %16
+          func.return %13
       }
-      %31 = arith.const {value = 0} : tribute_rt.anyref
-      %32 = ability.handle_dispatch %9, %10, %31 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %28 = arith.const {value = 0} : tribute_rt.anyref
+      %29 = ability.handle_dispatch %6, %7, %28 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb8(%33: tribute_rt.anyref):
-              %34 = core.unrealized_conversion_cast %33 : core.i32
-              scf.yield %34
+            ^bb8(%30: tribute_rt.anyref):
+              %31 = core.unrealized_conversion_cast %30 : core.i32
+              scf.yield %31
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb9(%35: tribute_rt.anyref, %36: tribute_rt.anyref):
-              %37 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %38 = closure.new %37 {func_ref = @"test::__lambda_1"} : !t0
-              %39 = arith.const {value = 0} : core.i32
-              %40 = core.unrealized_conversion_cast %39 : tribute_rt.anyref
-              %41 = core.unrealized_conversion_cast %35 : !t0
-              %42 = func.call_indirect %41, %40 : tribute_rt.anyref
-              scf.yield %42
+            ^bb9(%32: tribute_rt.anyref, %33: tribute_rt.anyref):
+              %34 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %35 = closure.new %34 {func_ref = @"test::__lambda_0"} : !t1
+              %36 = arith.const {value = 0} : core.i32
+              %37 = core.unrealized_conversion_cast %36 : tribute_rt.anyref
+              %38 = core.unrealized_conversion_cast %32 : !t1
+              %39 = func.call_indirect %38, %37 : tribute_rt.anyref
+              scf.yield %39
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb10(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
-              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %46 = closure.new %45 {func_ref = @"test::__lambda_2"} : !t0
-              %47 = arith.const {value = unit} : core.nil
-              %48 = core.unrealized_conversion_cast %47 : tribute_rt.anyref
-              %49 = core.unrealized_conversion_cast %43 : !t0
-              %50 = func.call_indirect %49, %48 : tribute_rt.anyref
-              scf.yield %50
+            ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
+              %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %43 = closure.new %42 {func_ref = @"test::__lambda_1"} : !t1
+              %44 = arith.const {value = unit} : core.nil
+              %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
+              %46 = core.unrealized_conversion_cast %40 : !t1
+              %47 = func.call_indirect %46, %45 : tribute_rt.anyref
+              scf.yield %47
           }
       }
-      %51 = core.unrealized_conversion_cast %32 : core.i32
-      func.return %51
+      %48 = core.unrealized_conversion_cast %29 : core.i32
+      func.return %48
   }
-  func.func @main() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
-          %2 = adt.ref_null {type = !t1} : !t1
-          %3 = func.call %2, %1 {callee = @counter} : tribute_rt.anyref
-          func.return %3
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t0) -> core.i32 {tribute.calling_convention = 1} {
+          %2 = func.call %1 {callee = @counter, tribute.calling_convention = 1} : core.i32
+          func.return %2
       }
-      %4 = func.call %0 {callee = @run_with_state} : core.i32
-      func.return %4
+      %3 = func.call %0 {callee = @run_with_state, tribute.calling_convention = 0} : core.i32
+      func.return %3
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
@@ -5,6 +5,7 @@ expression: ir_text
 core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t2 = closure.closure(core.func(core.i32, !t1))
 
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -18,93 +19,85 @@ core.module @test {
   func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 {
-      %1 = closure.lambda(%2: tribute_rt.anyref) -> tribute_rt.anyref [%0] {
-          %3 = core.unrealized_conversion_cast %0 : !t0
-          %4 = func.call_indirect %3, %2 : tribute_rt.anyref
-          %5 = core.unrealized_conversion_cast %4 : core.i32
-          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-          func.return %6
+  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %1 = closure.lambda() -> tribute_rt.anyref [%0] {
+          %2 = adt.ref_null {type = !t1} : !t1
+          %3 = core.unrealized_conversion_cast %0 : !t2
+          %4 = func.call_indirect %3, %2 {tribute.calling_convention = 1} : core.i32
+          %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+          func.return %5
       }
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_0"} : !t0
-      %9 = func.call_indirect %1, %8 : tribute_rt.anyref
-      %10 = closure.lambda(%11: tribute_rt.anyref, %12: core.i32, %13: tribute_rt.anyref) -> tribute_rt.anyref {
-          %14 = arith.const {value = 1972422014} : core.i32
-          %15 = arith.cmpi %12, %14 {predicate = @eq} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = closure.new %17 {func_ref = @"test::__lambda_3"} : !t0
-              %19 = arith.const {value = 0} : core.i32
-              %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
-              %21 = core.unrealized_conversion_cast %11 : !t0
-              %22 = func.call_indirect %21, %20 : tribute_rt.anyref
-              scf.yield %22
+      %6 = func.call_indirect %1 : tribute_rt.anyref
+      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref {
+          %11 = arith.const {value = 1972422014} : core.i32
+          %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
+          %13 = scf.if %12 : tribute_rt.anyref {
+              %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
+              %16 = arith.const {value = 0} : core.i32
+              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+              %18 = core.unrealized_conversion_cast %8 : !t0
+              %19 = func.call_indirect %18, %17 : tribute_rt.anyref
+              scf.yield %19
           } {
-              %23 = arith.const {value = 1} : core.i1
-              %24 = scf.if %23 : tribute_rt.anyref {
-                  %25 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %26 = closure.new %25 {func_ref = @"test::__lambda_4"} : !t0
-                  %27 = arith.const {value = unit} : core.nil
-                  %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
-                  %29 = core.unrealized_conversion_cast %11 : !t0
-                  %30 = func.call_indirect %29, %28 : tribute_rt.anyref
-                  scf.yield %30
+              %20 = arith.const {value = 1} : core.i1
+              %21 = scf.if %20 : tribute_rt.anyref {
+                  %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %23 = closure.new %22 {func_ref = @"test::__lambda_3"} : !t0
+                  %24 = arith.const {value = unit} : core.nil
+                  %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
+                  %26 = core.unrealized_conversion_cast %8 : !t0
+                  %27 = func.call_indirect %26, %25 : tribute_rt.anyref
+                  scf.yield %27
               } {
                   func.unreachable
               }
-              scf.yield %24
+              scf.yield %21
           }
-          func.return %16
+          func.return %13
       }
-      %31 = arith.const {value = 0} : tribute_rt.anyref
-      %32 = ability.handle_dispatch %9, %10, %31 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %28 = arith.const {value = 0} : tribute_rt.anyref
+      %29 = ability.handle_dispatch %6, %7, %28 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb8(%33: tribute_rt.anyref):
-              %34 = core.unrealized_conversion_cast %33 : core.i32
-              scf.yield %34
+            ^bb8(%30: tribute_rt.anyref):
+              %31 = core.unrealized_conversion_cast %30 : core.i32
+              scf.yield %31
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb9(%35: tribute_rt.anyref, %36: tribute_rt.anyref):
-              %37 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %38 = closure.new %37 {func_ref = @"test::__lambda_1"} : !t0
-              %39 = arith.const {value = 0} : core.i32
-              %40 = core.unrealized_conversion_cast %39 : tribute_rt.anyref
-              %41 = core.unrealized_conversion_cast %35 : !t0
-              %42 = func.call_indirect %41, %40 : tribute_rt.anyref
-              scf.yield %42
+            ^bb9(%32: tribute_rt.anyref, %33: tribute_rt.anyref):
+              %34 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %35 = closure.new %34 {func_ref = @"test::__lambda_0"} : !t0
+              %36 = arith.const {value = 0} : core.i32
+              %37 = core.unrealized_conversion_cast %36 : tribute_rt.anyref
+              %38 = core.unrealized_conversion_cast %32 : !t0
+              %39 = func.call_indirect %38, %37 : tribute_rt.anyref
+              scf.yield %39
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb10(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
-              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %46 = closure.new %45 {func_ref = @"test::__lambda_2"} : !t0
-              %47 = arith.const {value = unit} : core.nil
-              %48 = core.unrealized_conversion_cast %47 : tribute_rt.anyref
-              %49 = core.unrealized_conversion_cast %43 : !t0
-              %50 = func.call_indirect %49, %48 : tribute_rt.anyref
-              scf.yield %50
+            ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
+              %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %43 = closure.new %42 {func_ref = @"test::__lambda_1"} : !t0
+              %44 = arith.const {value = unit} : core.nil
+              %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
+              %46 = core.unrealized_conversion_cast %40 : !t0
+              %47 = func.call_indirect %46, %45 : tribute_rt.anyref
+              scf.yield %47
           }
       }
-      %51 = core.unrealized_conversion_cast %32 : core.i32
-      func.return %51
+      %48 = core.unrealized_conversion_cast %29 : core.i32
+      func.return %48
   }
-  func.func @main() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t1) -> core.i32 {tribute.calling_convention = 1} {
           %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           %3 = core.unrealized_conversion_cast %2 : core.i32
           %4 = arith.const {value = 1} : core.i32
-          %5 = func.call %3, %4 {callee = @"Nat::+"} : core.i32
+          %5 = func.call %3, %4 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
           %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
           %7 = core.unrealized_conversion_cast %6 : core.nil
-          %8 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-          %9 = core.unrealized_conversion_cast %1 : !t0
-          %10 = func.call_indirect %9, %8 : tribute_rt.anyref
-          func.return %10
+          func.return %3
       }
-      %11 = func.call %0 {callee = @run_with_state} : core.i32
-      func.return %11
+      %8 = func.call %0 {callee = @run_with_state, tribute.calling_convention = 0} : core.i32
+      func.return %8
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
@@ -5,6 +5,7 @@ expression: ir_text
 core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t2 = closure.closure(core.func(tribute_rt.anyref, !t1, tribute_rt.anyref))
 
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -21,10 +22,10 @@ core.module @test {
   func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref [%2] {
-          %6 = core.unrealized_conversion_cast %2 : !t0
-          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
+          %6 = core.unrealized_conversion_cast %2 : !t2
+          %7 = func.call_indirect %6, %0, %5 {tribute.calling_convention = 2} : tribute_rt.anyref
           func.return %7
       }
       %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -36,80 +37,80 @@ core.module @test {
           %17 = scf.if %16 : tribute_rt.anyref {
               %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
-              %20 = closure.lambda(%21: tribute_rt.anyref) -> tribute_rt.anyref [%12, %3] {
-                  %22 = core.unrealized_conversion_cast %12 : !t0
-                  %23 = func.call_indirect %22, %3 : tribute_rt.anyref
-                  %24 = core.unrealized_conversion_cast %21 : !t0
-                  %25 = func.call_indirect %24, %23 : tribute_rt.anyref
-                  func.return %25
+              %20 = closure.lambda(%21: !t1, %22: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12, %3] {
+                  %23 = core.unrealized_conversion_cast %12 : !t0
+                  %24 = func.call_indirect %23, %3 : tribute_rt.anyref
+                  %25 = core.unrealized_conversion_cast %22 : !t0
+                  %26 = func.call_indirect %25, %24 : tribute_rt.anyref
+                  func.return %26
               }
-              %26 = func.call %0, %19, %20, %3 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %26
+              %27 = func.call %0, %19, %20, %3 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %27
           } {
-              %27 = arith.const {value = 1} : core.i1
-              %28 = scf.if %27 : tribute_rt.anyref {
-                  %29 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %30 = closure.new %29 {func_ref = @"test::__lambda_4"} : !t0
-                  %31 = closure.lambda(%32: tribute_rt.anyref) -> tribute_rt.anyref [%12] {
-                      %33 = arith.const {value = unit} : core.nil
-                      %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
-                      %35 = core.unrealized_conversion_cast %12 : !t0
-                      %36 = func.call_indirect %35, %34 : tribute_rt.anyref
-                      %37 = core.unrealized_conversion_cast %32 : !t0
+              %28 = arith.const {value = 1} : core.i1
+              %29 = scf.if %28 : tribute_rt.anyref {
+                  %30 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %31 = closure.new %30 {func_ref = @"test::__lambda_4"} : !t0
+                  %32 = closure.lambda(%33: !t1, %34: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12] {
+                      %35 = arith.const {value = unit} : core.nil
+                      %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
+                      %37 = core.unrealized_conversion_cast %12 : !t0
                       %38 = func.call_indirect %37, %36 : tribute_rt.anyref
-                      func.return %38
+                      %39 = core.unrealized_conversion_cast %34 : !t0
+                      %40 = func.call_indirect %39, %38 : tribute_rt.anyref
+                      func.return %40
                   }
-                  %39 = func.call %0, %30, %31, %14 {callee = @run_state} : tribute_rt.anyref
-                  scf.yield %39
+                  %41 = func.call %0, %31, %32, %14 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+                  scf.yield %41
               } {
                   func.unreachable
               }
-              scf.yield %28
+              scf.yield %29
           }
           func.return %17
       }
-      %40 = arith.const {value = 0} : tribute_rt.anyref
-      %41 = ability.handle_dispatch %10, %11, %40 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %42 = arith.const {value = 0} : tribute_rt.anyref
+      %43 = ability.handle_dispatch %10, %11, %42 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb10(%42: tribute_rt.anyref):
-              scf.yield %42
+            ^bb10(%44: tribute_rt.anyref):
+              scf.yield %44
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb11(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
-              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t0
-              %47 = closure.lambda(%48: tribute_rt.anyref) -> tribute_rt.anyref [%43, %3] {
-                  %49 = core.unrealized_conversion_cast %43 : !t0
-                  %50 = func.call_indirect %49, %3 : tribute_rt.anyref
-                  %51 = core.unrealized_conversion_cast %48 : !t0
-                  %52 = func.call_indirect %51, %50 : tribute_rt.anyref
-                  func.return %52
+            ^bb11(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
+              %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %48 = closure.new %47 {func_ref = @"test::__lambda_1"} : !t0
+              %49 = closure.lambda(%50: !t1, %51: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%45, %3] {
+                  %52 = core.unrealized_conversion_cast %45 : !t0
+                  %53 = func.call_indirect %52, %3 : tribute_rt.anyref
+                  %54 = core.unrealized_conversion_cast %51 : !t0
+                  %55 = func.call_indirect %54, %53 : tribute_rt.anyref
+                  func.return %55
               }
-              %53 = func.call %0, %46, %47, %3 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %53
+              %56 = func.call %0, %48, %49, %3 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %56
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb13(%54: tribute_rt.anyref, %55: tribute_rt.anyref):
-              %56 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %57 = closure.new %56 {func_ref = @"test::__lambda_2"} : !t0
-              %58 = closure.lambda(%59: tribute_rt.anyref) -> tribute_rt.anyref [%54] {
-                  %60 = arith.const {value = unit} : core.nil
-                  %61 = core.unrealized_conversion_cast %60 : tribute_rt.anyref
-                  %62 = core.unrealized_conversion_cast %54 : !t0
-                  %63 = func.call_indirect %62, %61 : tribute_rt.anyref
-                  %64 = core.unrealized_conversion_cast %59 : !t0
-                  %65 = func.call_indirect %64, %63 : tribute_rt.anyref
-                  func.return %65
+            ^bb13(%57: tribute_rt.anyref, %58: tribute_rt.anyref):
+              %59 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %60 = closure.new %59 {func_ref = @"test::__lambda_2"} : !t0
+              %61 = closure.lambda(%62: !t1, %63: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%57] {
+                  %64 = arith.const {value = unit} : core.nil
+                  %65 = core.unrealized_conversion_cast %64 : tribute_rt.anyref
+                  %66 = core.unrealized_conversion_cast %57 : !t0
+                  %67 = func.call_indirect %66, %65 : tribute_rt.anyref
+                  %68 = core.unrealized_conversion_cast %63 : !t0
+                  %69 = func.call_indirect %68, %67 : tribute_rt.anyref
+                  func.return %69
               }
-              %66 = func.call %0, %57, %58, %55 {callee = @run_state} : tribute_rt.anyref
-              scf.yield %66
+              %70 = func.call %0, %60, %61, %58 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %70
           }
       }
-      %67 = core.unrealized_conversion_cast %1 : !t0
-      %68 = func.call_indirect %67, %41 : tribute_rt.anyref
-      func.return %68
+      %71 = core.unrealized_conversion_cast %1 : !t0
+      %72 = func.call_indirect %71, %43 : tribute_rt.anyref
+      func.return %72
   }
-  func.func @main() -> core.i32 {
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 0} : core.i32
       func.return %0
   }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -5,6 +5,7 @@ expression: ir_text
 core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t2 = closure.closure(core.func(tribute_rt.anyref, !t1, tribute_rt.anyref))
 
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
@@ -21,10 +22,10 @@ core.module @test {
   func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @with_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @with_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref [%2] {
-          %6 = core.unrealized_conversion_cast %2 : !t0
-          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
+          %6 = core.unrealized_conversion_cast %2 : !t2
+          %7 = func.call_indirect %6, %0, %5 {tribute.calling_convention = 2} : tribute_rt.anyref
           func.return %7
       }
       %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -36,96 +37,96 @@ core.module @test {
           %17 = scf.if %16 : tribute_rt.anyref {
               %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
               %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
-              %20 = closure.lambda(%21: tribute_rt.anyref) -> tribute_rt.anyref [%12, %3] {
-                  %22 = core.unrealized_conversion_cast %12 : !t0
-                  %23 = func.call_indirect %22, %3 : tribute_rt.anyref
-                  %24 = core.unrealized_conversion_cast %21 : !t0
-                  %25 = func.call_indirect %24, %23 : tribute_rt.anyref
-                  func.return %25
+              %20 = closure.lambda(%21: !t1, %22: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12, %3] {
+                  %23 = core.unrealized_conversion_cast %12 : !t0
+                  %24 = func.call_indirect %23, %3 : tribute_rt.anyref
+                  %25 = core.unrealized_conversion_cast %22 : !t0
+                  %26 = func.call_indirect %25, %24 : tribute_rt.anyref
+                  func.return %26
               }
-              %26 = func.call %0, %19, %20, %3 {callee = @with_state} : tribute_rt.anyref
-              scf.yield %26
+              %27 = func.call %0, %19, %20, %3 {callee = @with_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %27
           } {
-              %27 = arith.const {value = 1} : core.i1
-              %28 = scf.if %27 : tribute_rt.anyref {
-                  %29 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %30 = closure.new %29 {func_ref = @"test::__lambda_4"} : !t0
-                  %31 = closure.lambda(%32: tribute_rt.anyref) -> tribute_rt.anyref [%12] {
-                      %33 = arith.const {value = unit} : core.nil
-                      %34 = core.unrealized_conversion_cast %33 : tribute_rt.anyref
-                      %35 = core.unrealized_conversion_cast %12 : !t0
-                      %36 = func.call_indirect %35, %34 : tribute_rt.anyref
-                      %37 = core.unrealized_conversion_cast %32 : !t0
+              %28 = arith.const {value = 1} : core.i1
+              %29 = scf.if %28 : tribute_rt.anyref {
+                  %30 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+                  %31 = closure.new %30 {func_ref = @"test::__lambda_4"} : !t0
+                  %32 = closure.lambda(%33: !t1, %34: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12] {
+                      %35 = arith.const {value = unit} : core.nil
+                      %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
+                      %37 = core.unrealized_conversion_cast %12 : !t0
                       %38 = func.call_indirect %37, %36 : tribute_rt.anyref
-                      func.return %38
+                      %39 = core.unrealized_conversion_cast %34 : !t0
+                      %40 = func.call_indirect %39, %38 : tribute_rt.anyref
+                      func.return %40
                   }
-                  %39 = func.call %0, %30, %31, %14 {callee = @with_state} : tribute_rt.anyref
-                  scf.yield %39
+                  %41 = func.call %0, %31, %32, %14 {callee = @with_state, tribute.calling_convention = 2} : tribute_rt.anyref
+                  scf.yield %41
               } {
                   func.unreachable
               }
-              scf.yield %28
+              scf.yield %29
           }
           func.return %17
       }
-      %40 = arith.const {value = 0} : tribute_rt.anyref
-      %41 = ability.handle_dispatch %10, %11, %40 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %42 = arith.const {value = 0} : tribute_rt.anyref
+      %43 = ability.handle_dispatch %10, %11, %42 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb10(%42: tribute_rt.anyref):
-              scf.yield %42
+            ^bb10(%44: tribute_rt.anyref):
+              scf.yield %44
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb11(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
-              %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t0
-              %47 = closure.lambda(%48: tribute_rt.anyref) -> tribute_rt.anyref [%43, %3] {
-                  %49 = core.unrealized_conversion_cast %43 : !t0
-                  %50 = func.call_indirect %49, %3 : tribute_rt.anyref
-                  %51 = core.unrealized_conversion_cast %48 : !t0
-                  %52 = func.call_indirect %51, %50 : tribute_rt.anyref
-                  func.return %52
+            ^bb11(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
+              %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %48 = closure.new %47 {func_ref = @"test::__lambda_1"} : !t0
+              %49 = closure.lambda(%50: !t1, %51: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%45, %3] {
+                  %52 = core.unrealized_conversion_cast %45 : !t0
+                  %53 = func.call_indirect %52, %3 : tribute_rt.anyref
+                  %54 = core.unrealized_conversion_cast %51 : !t0
+                  %55 = func.call_indirect %54, %53 : tribute_rt.anyref
+                  func.return %55
               }
-              %53 = func.call %0, %46, %47, %3 {callee = @with_state} : tribute_rt.anyref
-              scf.yield %53
+              %56 = func.call %0, %48, %49, %3 {callee = @with_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %56
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
-            ^bb13(%54: tribute_rt.anyref, %55: tribute_rt.anyref):
-              %56 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %57 = closure.new %56 {func_ref = @"test::__lambda_2"} : !t0
-              %58 = closure.lambda(%59: tribute_rt.anyref) -> tribute_rt.anyref [%54] {
-                  %60 = arith.const {value = unit} : core.nil
-                  %61 = core.unrealized_conversion_cast %60 : tribute_rt.anyref
-                  %62 = core.unrealized_conversion_cast %54 : !t0
-                  %63 = func.call_indirect %62, %61 : tribute_rt.anyref
-                  %64 = core.unrealized_conversion_cast %59 : !t0
-                  %65 = func.call_indirect %64, %63 : tribute_rt.anyref
-                  func.return %65
+            ^bb13(%57: tribute_rt.anyref, %58: tribute_rt.anyref):
+              %59 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %60 = closure.new %59 {func_ref = @"test::__lambda_2"} : !t0
+              %61 = closure.lambda(%62: !t1, %63: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%57] {
+                  %64 = arith.const {value = unit} : core.nil
+                  %65 = core.unrealized_conversion_cast %64 : tribute_rt.anyref
+                  %66 = core.unrealized_conversion_cast %57 : !t0
+                  %67 = func.call_indirect %66, %65 : tribute_rt.anyref
+                  %68 = core.unrealized_conversion_cast %63 : !t0
+                  %69 = func.call_indirect %68, %67 : tribute_rt.anyref
+                  func.return %69
               }
-              %66 = func.call %0, %57, %58, %55 {callee = @with_state} : tribute_rt.anyref
-              scf.yield %66
+              %70 = func.call %0, %60, %61, %58 {callee = @with_state, tribute.calling_convention = 2} : tribute_rt.anyref
+              scf.yield %70
           }
       }
-      %67 = core.unrealized_conversion_cast %1 : !t0
-      %68 = func.call_indirect %67, %41 : tribute_rt.anyref
-      func.return %68
+      %71 = core.unrealized_conversion_cast %1 : !t0
+      %72 = func.call_indirect %71, %43 : tribute_rt.anyref
+      func.return %72
   }
   func.func @"test::__lambda_5"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @main() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
-          %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-          %3 = core.unrealized_conversion_cast %1 : !t0
-          %4 = func.call_indirect %3, %2 : tribute_rt.anyref
-          func.return %4
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t1, %2: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
+          %3 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %4 = core.unrealized_conversion_cast %2 : !t0
+          %5 = func.call_indirect %4, %3 : tribute_rt.anyref
+          func.return %5
       }
-      %5 = arith.const {value = 42} : core.i32
-      %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-      %7 = adt.ref_null {type = !t1} : !t1
-      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %9 = closure.new %8 {func_ref = @"test::__lambda_5"} : !t0
-      %10 = func.call %7, %9, %0, %6 {callee = @with_state} : tribute_rt.anyref
-      %11 = core.unrealized_conversion_cast %10 : core.i32
-      func.return %11
+      %6 = arith.const {value = 42} : core.i32
+      %7 = core.unrealized_conversion_cast %6 : tribute_rt.anyref
+      %8 = adt.ref_null {type = !t1} : !t1
+      %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %10 = closure.new %9 {func_ref = @"test::__lambda_5"} : !t0
+      %11 = func.call %8, %10, %0, %7 {callee = @with_state, tribute.calling_convention = 2} : tribute_rt.anyref
+      %12 = core.unrealized_conversion_cast %11 : core.i32
+      func.return %12
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
@@ -3,91 +3,87 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t2 = closure.closure(core.func(core.i32, !t0))
 
-  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 {
-      %1 = closure.lambda(%2: tribute_rt.anyref) -> tribute_rt.anyref [%0] {
-          %3 = core.unrealized_conversion_cast %0 : !t0
-          %4 = func.call_indirect %3, %2 : tribute_rt.anyref
-          %5 = core.unrealized_conversion_cast %4 : core.i32
-          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-          func.return %6
+  func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %1 = closure.lambda() -> tribute_rt.anyref [%0] {
+          %2 = adt.ref_null {type = !t0} : !t0
+          %3 = core.unrealized_conversion_cast %0 : !t2
+          %4 = func.call_indirect %3, %2 {tribute.calling_convention = 1} : core.i32
+          %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
+          func.return %5
       }
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = closure.new %7 {func_ref = @"test::__lambda_0"} : !t0
-      %9 = func.call_indirect %1, %8 : tribute_rt.anyref
-      %10 = closure.lambda(%11: tribute_rt.anyref, %12: core.i32, %13: tribute_rt.anyref) -> tribute_rt.anyref {
-          %14 = arith.const {value = 1} : core.i1
-          %15 = scf.if %14 : tribute_rt.anyref {
-              %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %17 = closure.new %16 {func_ref = @"test::__lambda_2"} : !t0
-              %18 = arith.const {value = 99} : core.i32
-              %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
-              %20 = core.unrealized_conversion_cast %11 : !t0
-              %21 = func.call_indirect %20, %19 : tribute_rt.anyref
-              scf.yield %21
+      %6 = func.call_indirect %1 : tribute_rt.anyref
+      %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref {
+          %11 = arith.const {value = 1} : core.i1
+          %12 = scf.if %11 : tribute_rt.anyref {
+              %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %14 = closure.new %13 {func_ref = @"test::__lambda_1"} : !t1
+              %15 = arith.const {value = 99} : core.i32
+              %16 = core.unrealized_conversion_cast %15 : tribute_rt.anyref
+              %17 = core.unrealized_conversion_cast %8 : !t1
+              %18 = func.call_indirect %17, %16 : tribute_rt.anyref
+              scf.yield %18
           } {
               func.unreachable
           }
-          func.return %15
+          func.return %12
       }
-      %22 = arith.const {value = 0} : tribute_rt.anyref
-      %23 = ability.handle_dispatch %9, %10, %22 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %19 = arith.const {value = 0} : tribute_rt.anyref
+      %20 = ability.handle_dispatch %6, %7, %19 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
-            ^bb6(%24: tribute_rt.anyref):
-              %25 = core.unrealized_conversion_cast %24 : core.i32
-              scf.yield %25
+            ^bb6(%21: tribute_rt.anyref):
+              %22 = core.unrealized_conversion_cast %21 : core.i32
+              scf.yield %22
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
-            ^bb7(%26: tribute_rt.anyref, %27: tribute_rt.anyref):
-              %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %29 = closure.new %28 {func_ref = @"test::__lambda_1"} : !t0
-              %30 = arith.const {value = 99} : core.i32
-              %31 = core.unrealized_conversion_cast %30 : tribute_rt.anyref
-              %32 = core.unrealized_conversion_cast %26 : !t0
-              %33 = func.call_indirect %32, %31 : tribute_rt.anyref
-              scf.yield %33
+            ^bb7(%23: tribute_rt.anyref, %24: tribute_rt.anyref):
+              %25 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+              %26 = closure.new %25 {func_ref = @"test::__lambda_0"} : !t1
+              %27 = arith.const {value = 99} : core.i32
+              %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
+              %29 = core.unrealized_conversion_cast %23 : !t1
+              %30 = func.call_indirect %29, %28 : tribute_rt.anyref
+              scf.yield %30
           }
       }
-      %34 = core.unrealized_conversion_cast %23 : core.i32
-      func.return %34
+      %31 = core.unrealized_conversion_cast %20 : core.i32
+      func.return %31
   }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @apply_thunk(%0: core.func(core.i32)) -> core.i32 {
-      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = closure.new %1 {func_ref = @"test::__lambda_3"} : !t0
-      %3 = core.unrealized_conversion_cast %0 : !t0
-      %4 = func.call_indirect %3, %2 : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %4 : core.i32
-      func.return %5
+  func.func @apply_thunk(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %1 = adt.ref_null {type = !t0} : !t0
+      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %3 = closure.new %2 {func_ref = @"test::__lambda_2"} : !t1
+      %4 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, !t0, !t1))
+      %5 = func.call_indirect %4, %1, %3 {tribute.calling_convention = 2} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %5 : core.i32
+      func.return %6
   }
-  func.func @main() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
-          %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
-              %4 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-              %5 = core.unrealized_conversion_cast %3 : !t0
-              %6 = func.call_indirect %5, %4 : tribute_rt.anyref
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t0, %2: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
+          %3 = closure.lambda(%4: !t0) -> core.i32 {tribute.calling_convention = 1} {
+              %5 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+              %6 = core.unrealized_conversion_cast %5 : core.i32
               func.return %6
           }
-          %7 = func.call %2 {callee = @run_with_state} : core.i32
+          %7 = func.call %3 {callee = @run_with_state, tribute.calling_convention = 0} : core.i32
           %8 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-          %9 = core.unrealized_conversion_cast %1 : !t0
+          %9 = core.unrealized_conversion_cast %2 : !t1
           %10 = func.call_indirect %9, %8 : tribute_rt.anyref
           func.return %10
       }
-      %11 = func.call %0 {callee = @apply_thunk} : core.i32
+      %11 = func.call %0 {callee = @apply_thunk, tribute.calling_convention = 0} : core.i32
       func.return %11
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
@@ -3,31 +3,32 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32))
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @"test::__lambda_0"(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @apply(%0: core.func(core.i32, core.i32), %1: core.i32) -> core.i32 {
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = closure.new %2 {func_ref = @"test::__lambda_0"} : !t1
-      %4 = core.unrealized_conversion_cast %0 : !t0
-      %5 = func.call_indirect %4, %3, %1 : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.i32
-      func.return %6
+  func.func @apply(%0: core.func(core.i32, core.i32), %1: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = closure.new %3 {func_ref = @"test::__lambda_0"} : !t1
+      %5 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, !t0, !t1, core.i32))
+      %6 = func.call_indirect %5, %2, %4, %1 {tribute.calling_convention = 2} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.i32
+      func.return %7
   }
-  func.func @main() -> core.i32 {
-      %0 = closure.lambda(%1: tribute_rt.anyref, %2: core.i32) -> tribute_rt.anyref {
-          %3 = arith.const {value = 1} : core.i32
-          %4 = func.call %2, %3 {callee = @"Nat::+"} : core.i32
-          %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-          %6 = core.unrealized_conversion_cast %1 : !t1
-          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
-          func.return %7
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+      %0 = closure.lambda(%1: !t0, %2: tribute_rt.anyref, %3: core.i32) -> tribute_rt.anyref {tribute.calling_convention = 2} {
+          %4 = arith.const {value = 1} : core.i32
+          %5 = func.call %3, %4 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
+          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
+          %7 = core.unrealized_conversion_cast %2 : !t1
+          %8 = func.call_indirect %7, %6 : tribute_rt.anyref
+          func.return %8
       }
-      %8 = arith.const {value = 41} : core.i32
-      %9 = func.call %0, %8 {callee = @apply} : core.i32
-      func.return %9
+      %9 = arith.const {value = 41} : core.i32
+      %10 = func.call %0, %9 {callee = @apply, tribute.calling_convention = 0} : core.i32
+      func.return %10
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
@@ -3,31 +3,32 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32))
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
-  func.func @"test::__lambda_0"(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @apply(%0: core.func(core.i32, core.i32), %1: core.i32) -> core.i32 {
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = closure.new %2 {func_ref = @"test::__lambda_0"} : !t1
-      %4 = core.unrealized_conversion_cast %0 : !t0
-      %5 = func.call_indirect %4, %3, %1 : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.i32
-      func.return %6
+  func.func @apply(%0: core.func(core.i32, core.i32), %1: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = closure.new %3 {func_ref = @"test::__lambda_0"} : !t1
+      %5 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, !t0, !t1, core.i32))
+      %6 = func.call_indirect %5, %2, %4, %1 {tribute.calling_convention = 2} : tribute_rt.anyref
+      %7 = core.unrealized_conversion_cast %6 : core.i32
+      func.return %7
   }
-  func.func @main() -> core.i32 {
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 10} : core.i32
-      %1 = closure.lambda(%2: tribute_rt.anyref, %3: core.i32) -> tribute_rt.anyref [%0] {
-          %4 = func.call %3, %0 {callee = @"Nat::+"} : core.i32
-          %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-          %6 = core.unrealized_conversion_cast %2 : !t1
-          %7 = func.call_indirect %6, %5 : tribute_rt.anyref
-          func.return %7
+      %1 = closure.lambda(%2: !t0, %3: tribute_rt.anyref, %4: core.i32) -> tribute_rt.anyref {tribute.calling_convention = 2} [%0] {
+          %5 = func.call %4, %0 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
+          %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
+          %7 = core.unrealized_conversion_cast %3 : !t1
+          %8 = func.call_indirect %7, %6 : tribute_rt.anyref
+          func.return %8
       }
-      %8 = arith.const {value = 32} : core.i32
-      %9 = func.call %1, %8 {callee = @apply} : core.i32
-      func.return %9
+      %9 = arith.const {value = 32} : core.i32
+      %10 = func.call %1, %9 {callee = @apply, tribute.calling_convention = 0} : core.i32
+      func.return %10
   }
 }

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 144
 expression: ir_text
 ---
 core.module @test {
@@ -18,7 +17,7 @@ core.module @test {
         func.return %1
     }
   }
-  func.func @make_point() -> tribute_rt.anyref {
+  func.func @make_point() -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 10} : core.i32
       %1 = arith.const {value = 20} : core.i32
       %2 = adt.struct_new %0, %1 {type = !Point} : adt.typeref() {name = @Point}

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 182
 expression: ir_text
 ---
 core.module @test {
@@ -18,7 +17,7 @@ core.module @test {
         func.return %1
     }
   }
-  func.func @make_pair() -> tribute_rt.anyref {
+  func.func @make_pair() -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 42} : core.i32
       %1 = arith.const {value = true} : core.i1
       %2 = adt.struct_new %0, %1 {type = !Pair} : adt.typeref() {name = @Pair}

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 163
 expression: ir_text
 ---
 core.module @test {
@@ -18,7 +17,7 @@ core.module @test {
         func.return %1
     }
   }
-  func.func @update_x(%0: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @update_x(%0: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = 100} : core.i32
       %2 = adt.struct_get %0 {field = 1, type = !Point} : tribute_rt.anyref
       %3 = adt.struct_new %1, %2 {type = !Point} : adt.typeref() {name = @Point}

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 222
 expression: ir_text
 ---
 core.module @test {
@@ -18,7 +17,7 @@ core.module @test {
         func.return %1
     }
   }
-  func.func @replace_all(%0: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @replace_all(%0: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = 1} : core.i32
       %2 = arith.const {value = 2} : core.i32
       %3 = adt.struct_new %1, %2 {type = !Point} : adt.typeref() {name = @Point}

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/record_field_type.rs
-assertion_line: 202
 expression: ir_text
 ---
 core.module @test {
@@ -18,7 +17,7 @@ core.module @test {
         func.return %1
     }
   }
-  func.func @copy_config(%0: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @copy_config(%0: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %1 = adt.struct_get %0 {field = 0, type = !Config} : tribute_rt.anyref
       %2 = adt.struct_get %0 {field = 1, type = !Config} : tribute_rt.anyref
       %3 = adt.struct_new %1, %2 {type = !Config} : adt.typeref() {name = @Config}

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
@@ -5,13 +5,13 @@ expression: ir_text
 core.module @test {
   !__tuple_i32_i32 = adt.struct() {fields = [[@0, core.i32], [@1, core.i32]], name = @__tuple_i32_i32}
 
-  func.func @test() -> core.i32 {
+  func.func @test() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = adt.struct_new %0, %1 {type = !__tuple_i32_i32} : adt.typeref() {name = @__tuple_i32_i32}
       %3 = adt.struct_get %2 {field = 0, type = !__tuple_i32_i32} : core.i32
       %4 = adt.struct_get %2 {field = 1, type = !__tuple_i32_i32} : core.i32
-      %5 = func.call %3, %4 {callee = @"Nat::+"} : core.i32
+      %5 = func.call %3, %4 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
       func.return %5
   }
 }

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
@@ -7,7 +7,7 @@ core.module @test {
   !__tuple_anyref_anyref = adt.struct() {fields = [[@0, tribute_rt.anyref], [@1, tribute_rt.anyref]], name = @__tuple_anyref_anyref}
   !__tuple_i32_i32 = adt.struct() {fields = [[@0, core.i32], [@1, core.i32]], name = @__tuple_i32_i32}
 
-  func.func @test() -> core.i32 {
+  func.func @test() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32
@@ -18,9 +18,9 @@ core.module @test {
       %7 = adt.struct_get %6 {field = 0, type = !__tuple_anyref_anyref} : tribute_rt.anyref
       %8 = adt.struct_get %6 {field = 1, type = !__tuple_anyref_anyref} : tribute_rt.anyref
       %9 = core.unrealized_conversion_cast %7 : core.i32
-      %10 = func.call %5, %9 {callee = @"Nat::+"} : core.i32
+      %10 = func.call %5, %9 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
       %11 = core.unrealized_conversion_cast %8 : core.i32
-      %12 = func.call %10, %11 {callee = @"Nat::+"} : core.i32
+      %12 = func.call %10, %11 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
       func.return %12
   }
 }

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !__tuple_i32_i32_i32 = adt.struct() {fields = [[@0, core.i32], [@1, core.i32], [@2, core.i32]], name = @__tuple_i32_i32_i32}
 
-  func.func @test() -> core.i32 {
+  func.func @test() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32
@@ -13,7 +13,7 @@ core.module @test {
       %4 = adt.struct_get %3 {field = 0, type = !__tuple_i32_i32_i32} : core.i32
       %5 = adt.struct_get %3 {field = 1, type = !__tuple_i32_i32_i32} : core.i32
       %6 = adt.struct_get %3 {field = 2, type = !__tuple_i32_i32_i32} : core.i32
-      %7 = func.call %4, %6 {callee = @"Nat::+"} : core.i32
+      %7 = func.call %4, %6 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
       func.return %7
   }
 }

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/ufcs_method_call.rs
-assertion_line: 169
 expression: ir_text
 ---
 core.module @test {
@@ -35,25 +34,25 @@ core.module @test {
         func.return %1
     }
   }
-  func.func @"Pair::extend"(%0: tribute_rt.anyref, %1: core.i32) -> tribute_rt.anyref {
-      %2 = func.call %0 {callee = @"Pair::x"} : core.i32
-      %3 = func.call %0 {callee = @"Pair::y"} : core.i32
+  func.func @"Pair::extend"(%0: tribute_rt.anyref, %1: core.i32) -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
+      %2 = func.call %0 {callee = @"Pair::x", tribute.calling_convention = 0} : core.i32
+      %3 = func.call %0 {callee = @"Pair::y", tribute.calling_convention = 0} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple} : adt.typeref() {name = @Triple}
       %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
       func.return %5
   }
-  func.func @"Triple::sum"(%0: tribute_rt.anyref) -> core.i32 {
-      %1 = func.call %0 {callee = @"Triple::x"} : core.i32
-      %2 = func.call %0 {callee = @"Triple::y"} : core.i32
-      %3 = func.call %1, %2 {callee = @"Nat::+"} : core.i32
-      %4 = func.call %0 {callee = @"Triple::z"} : core.i32
-      %5 = func.call %3, %4 {callee = @"Nat::+"} : core.i32
+  func.func @"Triple::sum"(%0: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 0} {
+      %1 = func.call %0 {callee = @"Triple::x", tribute.calling_convention = 0} : core.i32
+      %2 = func.call %0 {callee = @"Triple::y", tribute.calling_convention = 0} : core.i32
+      %3 = func.call %1, %2 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
+      %4 = func.call %0 {callee = @"Triple::z", tribute.calling_convention = 0} : core.i32
+      %5 = func.call %3, %4 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
       func.return %5
   }
-  func.func @test(%0: tribute_rt.anyref) -> core.i32 {
+  func.func @test(%0: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = 3} : core.i32
-      %2 = func.call %0, %1 {callee = @"Pair::extend"} : tribute_rt.anyref
-      %3 = func.call %2 {callee = @"Triple::sum"} : core.i32
+      %2 = func.call %0, %1 {callee = @"Pair::extend", tribute.calling_convention = 0} : tribute_rt.anyref
+      %3 = func.call %2 {callee = @"Triple::sum", tribute.calling_convention = 0} : core.i32
       func.return %3
   }
 }

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/tribute-front/tests/ufcs_method_call.rs
-assertion_line: 138
 expression: ir_text
 ---
 core.module @test {
@@ -35,16 +34,16 @@ core.module @test {
         func.return %1
     }
   }
-  func.func @"Pair::extend"(%0: tribute_rt.anyref, %1: core.i32) -> tribute_rt.anyref {
-      %2 = func.call %0 {callee = @"Pair::x"} : core.i32
-      %3 = func.call %0 {callee = @"Pair::y"} : core.i32
+  func.func @"Pair::extend"(%0: tribute_rt.anyref, %1: core.i32) -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
+      %2 = func.call %0 {callee = @"Pair::x", tribute.calling_convention = 0} : core.i32
+      %3 = func.call %0 {callee = @"Pair::y", tribute.calling_convention = 0} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple} : adt.typeref() {name = @Triple}
       %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
       func.return %5
   }
-  func.func @test(%0: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @test(%0: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 0} {
       %1 = arith.const {value = 3} : core.i32
-      %2 = func.call %0, %1 {callee = @"Pair::extend"} : tribute_rt.anyref
+      %2 = func.call %0, %1 {callee = @"Pair::extend", tribute.calling_convention = 0} : tribute_rt.anyref
       func.return %2
   }
 }

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -19,6 +19,7 @@
 //!
 //! Uses `RewritePattern` + `PatternApplicator` for declarative transformation.
 
+use tribute_core::{CallableAbi, get_calling_convention};
 use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
@@ -181,7 +182,7 @@ impl RewritePattern for LowerClosureNewArena {
 
 /// Lower `func.call_indirect` on closure values.
 struct LowerClosureCallArena {
-    evidence_from_param: Option<ValueRef>,
+    legacy_evidence: Option<ValueRef>,
 }
 
 impl RewritePattern for LowerClosureCallArena {
@@ -249,18 +250,25 @@ impl RewritePattern for LowerClosureCallArena {
         let env_op = closure::env(ctx, loc, callee, anyref_ty);
         let env = ctx.op_result(env_op.op_ref(), 0);
 
-        let evidence = if let Some(evidence) = self.evidence_from_param {
-            evidence
+        let new_args = if let Some(convention) = get_calling_convention(ctx, op) {
+            let hidden =
+                usize::from(convention.needs_evidence()) + usize::from(convention.needs_done_k());
+            let abi = CallableAbi::new(convention, args[hidden..].iter().copied(), env);
+            abi.interpose_environment(&args, env)
         } else {
-            let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
-            let null_op = adt::ref_null(ctx, loc, evidence_ty, evidence_ty);
-            rewriter.insert_op(null_op.op_ref());
-            null_op.result(ctx)
+            // Compatibility for hand-written legacy IR without metadata.
+            let evidence = if let Some(evidence) = self.legacy_evidence {
+                evidence
+            } else {
+                let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
+                let null_op = adt::ref_null(ctx, loc, evidence_ty, evidence_ty);
+                rewriter.insert_op(null_op.op_ref());
+                null_op.result(ctx)
+            };
+            let mut legacy = vec![evidence, env];
+            legacy.extend_from_slice(&args);
+            legacy
         };
-
-        // Generate: %result = func.call_indirect %table_idx, [%evidence, %env, %args...]
-        let mut new_args = vec![evidence, env];
-        new_args.extend(args);
         let new_call = func::call_indirect(ctx, loc, table_idx, new_args, callee_return_ty);
 
         rewriter.insert_op(table_idx_op.op_ref());
@@ -367,12 +375,9 @@ fn evidence_param_for_func(ctx: &IrContext, func_op: func::Func) -> Option<Value
     if !crate::evidence::has_evidence_first_param(ctx, func_ty) {
         return None;
     }
-
     let body = func_op.body(ctx);
     let entry = ctx.region(body).blocks.first().copied()?;
-    let evidence = *ctx.block_args(entry).first()?;
-    tribute_ir::dialect::ability::is_evidence_type_ref(ctx, ctx.value_ty(evidence))
-        .then_some(evidence)
+    ctx.block_args(entry).first().copied()
 }
 
 /// Lower closures using arena IR.
@@ -403,20 +408,17 @@ pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
 
 /// Lower closure operations in one function body.
 ///
-/// Closure calls receive the enclosing function's evidence parameter directly
-/// while the call is rewritten. Pure functions synthesize null evidence at the
-/// call site, avoiding a module-wide span-based post-processing pass.
+/// Closure calls already carry convention-specific hidden operands. This pass
+/// only interposes the physical closure environment.
 pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
-    let evidence_from_param = evidence_param_for_func(ctx, func_op);
+    let legacy_evidence = evidence_param_for_func(ctx, func_op);
     let applicator = PatternApplicator::new(TypeConverter::new())
         .with_target(
             ConversionTarget::new()
                 .legal_op("func", "func")
                 .recursive_legal_op("func", "func"),
         )
-        .add_pattern(LowerClosureCallArena {
-            evidence_from_param,
-        })
+        .add_pattern(LowerClosureCallArena { legacy_evidence })
         .add_pattern(LowerClosureNewArena)
         .add_pattern(LowerClosureFuncArena)
         .add_pattern(LowerClosureEnvArena);

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -24,6 +24,9 @@
 
 use std::collections::HashMap;
 
+use tribute_core::{
+    CallableAbi, CallingConvention, get_calling_convention, set_calling_convention,
+};
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, core, func};
@@ -144,9 +147,9 @@ fn lower_single_lambda(
 
     // Determine function return type and effect from the closure result type.
     let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+    let convention = get_calling_convention(ctx, lambda_ref);
     let func_result_ty = extract_return_type_from_closure(ctx, result_ty)
         .expect("closure.lambda result type must be closure.closure<core.func<...>>");
-    let evidence_ty = ability::evidence_adt_type_ref(ctx);
 
     // Build env struct type for captures.
     let env_struct_ty = if captures.is_empty() {
@@ -162,6 +165,7 @@ fn lower_single_lambda(
     };
 
     // === Build the lifted function ===
+    let evidence_ty = ability::evidence_adt_type_ref(ctx);
     let func_body_region = build_lifted_body(
         ctx,
         location,
@@ -171,17 +175,36 @@ fn lower_single_lambda(
             capture_types: &capture_types,
             env_struct_ty,
             orig_param_types: &orig_param_types,
+            convention,
             evidence_ty,
             anyref_ty,
         },
     );
 
-    // Function type: (evidence, env, params...) -> result.
-    let mut all_param_tys = vec![evidence_ty, anyref_ty];
-    all_param_tys.extend_from_slice(&orig_param_types);
+    // Source lambdas carry explicit convention metadata. Synthetic legacy
+    // continuations still use the compatibility ABI `(evidence, env, args...)`.
+    let all_param_tys = if let Some(convention) = convention {
+        let source_offset =
+            usize::from(convention.needs_evidence()) + usize::from(convention.needs_done_k());
+        let abi = CallableAbi::new(
+            convention,
+            orig_param_types[source_offset..].iter().copied(),
+            func_result_ty,
+        );
+        abi.interpose_environment(&orig_param_types, anyref_ty)
+    } else {
+        let mut params = Vec::with_capacity(orig_param_types.len() + 2);
+        params.push(ability::evidence_adt_type_ref(ctx));
+        params.push(anyref_ty);
+        params.extend_from_slice(&orig_param_types);
+        params
+    };
     let func_ty = core::func(ctx, func_result_ty, all_param_tys.iter().copied()).as_type_ref();
 
     let func_op = func::func(ctx, location, lifted_name, func_ty, func_body_region);
+    if let Some(convention) = convention {
+        set_calling_convention(ctx, func_op.op_ref(), convention);
+    }
     ctx.push_op(module_block, func_op.op_ref());
 
     // === Replace closure.lambda at the original site ===
@@ -207,6 +230,9 @@ fn lower_single_lambda(
         core::func(ctx, func_result_ty, orig_param_types.iter().copied()).as_type_ref();
     let closure_ty = closure::closure(ctx, closure_func_ty).as_type_ref();
     let closure_new_op = closure::new(ctx, location, closure_env, closure_ty, lifted_name);
+    if let Some(convention) = convention {
+        set_calling_convention(ctx, closure_new_op.op_ref(), convention);
+    }
     ctx.insert_op_before(parent_block, lambda_ref, closure_new_op.op_ref());
 
     // RAUW: lambda result → closure.new result.
@@ -230,6 +256,7 @@ struct LiftBodyParams<'a> {
     capture_types: &'a [TypeRef],
     env_struct_ty: Option<TypeRef>,
     orig_param_types: &'a [TypeRef],
+    convention: Option<CallingConvention>,
     evidence_ty: TypeRef,
     anyref_ty: TypeRef,
 }
@@ -246,6 +273,7 @@ fn build_lifted_body(
     let capture_types = params.capture_types;
     let env_struct_ty = params.env_struct_ty;
     let orig_param_types = params.orig_param_types;
+    let convention = params.convention;
     let evidence_ty = params.evidence_ty;
     let anyref_ty = params.anyref_ty;
     let orig_blocks: Vec<BlockRef> = ctx.region(orig_body).blocks.to_vec();
@@ -254,17 +282,29 @@ fn build_lifted_body(
 
     let mut mapping = IrMapping::new();
 
-    // --- Pass 1: Create new entry block with [evidence, env, params...] ---
+    // --- Pass 1: Create new entry block with the physical closure ABI. ---
     let mut new_entry_args = Vec::new();
-    new_entry_args.push(BlockArgData {
-        ty: evidence_ty,
-        attrs: make_bind_name_attrs("__evidence"),
-    });
+    match convention {
+        Some(convention) if convention.needs_evidence() => {
+            new_entry_args.push(BlockArgData {
+                ty: orig_param_types[0],
+                attrs: ctx.block(orig_entry).args[0].attrs.clone(),
+            });
+        }
+        None => {
+            new_entry_args.push(BlockArgData {
+                ty: evidence_ty,
+                attrs: make_bind_name_attrs("__evidence"),
+            });
+        }
+        Some(_) => {}
+    }
     new_entry_args.push(BlockArgData {
         ty: anyref_ty,
         attrs: make_bind_name_attrs("__env"),
     });
-    for (i, &param_ty) in orig_param_types.iter().enumerate() {
+    let source_start = usize::from(convention.is_some_and(CallingConvention::needs_evidence));
+    for (i, &param_ty) in orig_param_types.iter().enumerate().skip(source_start) {
         new_entry_args.push(BlockArgData {
             ty: param_ty,
             attrs: ctx.block(orig_entry).args[i].attrs.clone(),
@@ -280,15 +320,21 @@ fn build_lifted_body(
 
     mapping.map_block(orig_entry, new_entry);
 
-    // Map old param args → new param args (shifted by 2 for evidence + env).
+    // Map logical closure args around the inserted environment parameter.
     for i in 0..orig_param_count {
         let old_arg = ctx.block_arg(orig_entry, i as u32);
-        let new_arg = ctx.block_arg(new_entry, (i + 2) as u32);
+        let new_index = match convention {
+            Some(convention) if convention.needs_evidence() && i == 0 => 0,
+            Some(_) => i + 1,
+            None => i + 2,
+        };
+        let new_arg = ctx.block_arg(new_entry, new_index as u32);
         mapping.map_value(old_arg, new_arg);
     }
 
     // Insert env extraction ops at the start of the new entry block.
-    let raw_env_val = ctx.block_arg(new_entry, 1);
+    let env_index = u32::from(convention.is_none_or(CallingConvention::needs_evidence));
+    let raw_env_val = ctx.block_arg(new_entry, env_index);
     if let Some(env_ty) = env_struct_ty {
         let cast_op = adt::ref_cast(ctx, location, raw_env_val, env_ty, env_ty);
         ctx.push_op(new_entry, cast_op.op_ref());
@@ -538,6 +584,7 @@ mod tests {
             closure_ty,
             lambda_body_region,
         );
+        set_calling_convention(&mut ctx, lambda_op.op_ref(), CallingConvention::Direct);
 
         // Wrap in a func.func
         let outer_entry = ctx.create_block(BlockData {
@@ -592,11 +639,11 @@ mod tests {
             Symbol::from_dynamic("test_fn::__clam_0")
         );
 
-        // Lifted function should have 3 params: evidence, env, x
+        // Direct lifted function has only the physical environment and source arg.
         let lifted_ty = lifted.r#type(&ctx);
         let lifted_ty_data = ctx.types.get(lifted_ty);
         // params[0] = return, params[1..] = param types
-        assert_eq!(lifted_ty_data.params.len(), 4); // return + evidence + env + x
+        assert_eq!(lifted_ty_data.params.len(), 3); // return + env + x
     }
 
     #[test]
@@ -657,6 +704,7 @@ mod tests {
 
         // closure.lambda [%a] { ... }
         let lambda_op = closure::lambda(&mut ctx, loc, vec![a_val], closure_ty, lambda_body_region);
+        set_calling_convention(&mut ctx, lambda_op.op_ref(), CallingConvention::Direct);
         ctx.push_op(outer_entry, lambda_op.op_ref());
 
         let outer_body = ctx.create_region(RegionData {

--- a/crates/tribute-passes/src/native/entrypoint.rs
+++ b/crates/tribute-passes/src/native/entrypoint.rs
@@ -4,6 +4,8 @@
 //! The user's `main` is renamed to `_tribute_main`, and a new `main` is created
 //! that calls it and returns exit code 0.
 
+use tribute_core::{CallingConvention, get_calling_convention, set_calling_convention};
+use tribute_ir::dialect::ability::evidence_abi;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockData, IrContext, RegionData};
 use trunk_ir::dialect::arith;
@@ -39,6 +41,8 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
     let mut found_main = false;
     let mut has_tribute_main = false;
     let mut main_return_ty: Option<TypeRef> = None;
+    let mut main_param_types: Vec<TypeRef> = Vec::new();
+    let mut main_convention = CallingConvention::Direct;
     let mut has_tribute_init = false;
     let mut has_asan_init = false;
 
@@ -56,7 +60,9 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
                 // core.func layout: params[0] = result
                 if !type_data.params.is_empty() {
                     main_return_ty = Some(type_data.params[0]);
+                    main_param_types = type_data.params[1..].to_vec();
                 }
+                main_convention = get_calling_convention(ctx, op).unwrap_or_default();
             }
             if name == tribute_main_sym {
                 has_tribute_main = true;
@@ -84,9 +90,6 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
     }
 
     // Intern needed types
-    let i32_ty = ctx
-        .types
-        .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
     let nil_ty = core::nil(ctx).as_type_ref();
 
     let tribute_main_return_ty = main_return_ty.unwrap_or_else(|| {
@@ -125,8 +128,16 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
     }
 
     // Step 4: Build and append C ABI entrypoint wrapper
-    let entrypoint_op =
-        build_entrypoint(ctx, loc, tribute_main_return_ty, i32_ty, nil_ty, sanitize);
+    let entrypoint_op = build_entrypoint(
+        ctx,
+        loc,
+        TributeMainAbi {
+            return_type: tribute_main_return_ty,
+            parameter_types: &main_param_types,
+            convention: main_convention,
+        },
+        sanitize,
+    );
     ctx.push_op(first_block, entrypoint_op);
 }
 
@@ -185,19 +196,29 @@ fn rewrite_symbol_refs_in_region(
 /// func.func @main() -> i32 {
 ///     call @__asan_init()       // if sanitize
 ///     call @__tribute_init()
-///     call @_tribute_main()
+///     %ev = call @__tribute_evidence_empty() // EvidenceDirect only
+///     call @_tribute_main(%ev)
 ///     %zero = arith.const 0 : i32
 ///     return %zero
 /// }
 /// ```
+struct TributeMainAbi<'a> {
+    return_type: TypeRef,
+    parameter_types: &'a [TypeRef],
+    convention: CallingConvention,
+}
+
 fn build_entrypoint(
     ctx: &mut IrContext,
     loc: Location,
-    tribute_main_return_ty: TypeRef,
-    i32_ty: TypeRef,
-    nil_ty: TypeRef,
+    tribute_main: TributeMainAbi<'_>,
     sanitize: bool,
 ) -> OpRef {
+    let i32_ty = ctx
+        .types
+        .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+    let nil_ty = core::nil(ctx).as_type_ref();
+
     // Build func type: () -> i32
     let func_ty = core::func(ctx, i32_ty, []).as_type_ref();
 
@@ -219,14 +240,46 @@ fn build_entrypoint(
     let init_call = func::call(ctx, loc, [], nil_ty, Symbol::new("__tribute_init"));
     ctx.push_op(entry_block, init_call.op_ref());
 
-    // Call _tribute_main() — result is ignored
+    let main_args = match tribute_main.convention {
+        CallingConvention::Direct => {
+            assert!(
+                tribute_main.parameter_types.is_empty(),
+                "entrypoint: Direct `main` must not have hidden parameters"
+            );
+            Vec::new()
+        }
+        CallingConvention::EvidenceDirect => {
+            assert_eq!(
+                tribute_main.parameter_types.len(),
+                1,
+                "entrypoint: EvidenceDirect `main` must have exactly one evidence parameter"
+            );
+            let empty_evidence = func::call(
+                ctx,
+                loc,
+                [],
+                tribute_main.parameter_types[0],
+                Symbol::new(evidence_abi::EMPTY),
+            );
+            ctx.push_op(entry_block, empty_evidence.op_ref());
+            vec![empty_evidence.result(ctx)]
+        }
+        CallingConvention::Cps => {
+            panic!(
+                "entrypoint: Cps `main` is invalid; frontend must reject residual control effects"
+            )
+        }
+    };
+
+    // Call _tribute_main — its source-level result is ignored.
     let main_call = func::call(
         ctx,
         loc,
-        [],
-        tribute_main_return_ty,
+        main_args,
+        tribute_main.return_type,
         Symbol::new("_tribute_main"),
     );
+    set_calling_convention(ctx, main_call.op_ref(), tribute_main.convention);
     ctx.push_op(entry_block, main_call.op_ref());
 
     // Return exit code 0
@@ -248,6 +301,7 @@ fn build_entrypoint(
     // The Cranelift backend treats functions named "main" as Export linkage,
     // but functions with `abi` attribute are treated as Import and skipped.
     let main_func = func::func(ctx, loc, Symbol::new("main"), func_ty, body);
+    set_calling_convention(ctx, main_func.op_ref(), CallingConvention::Direct);
 
     main_func.op_ref()
 }
@@ -256,7 +310,7 @@ fn build_entrypoint(
 mod tests {
     use super::*;
     use trunk_ir::Span;
-    use trunk_ir::context::{BlockData, IrContext, RegionData};
+    use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
     use trunk_ir::dialect::arith;
     use trunk_ir::dialect::func;
     use trunk_ir::ops::DialectOp;
@@ -328,6 +382,53 @@ mod tests {
         .build(ctx);
         let module_op = ctx.create_op(module_data);
 
+        Module::new(ctx, module_op).expect("valid arena module")
+    }
+
+    fn make_evidence_main_module(ctx: &mut IrContext, loc: Location) -> Module {
+        let nil_ty = nil_type(ctx);
+        let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
+        let func_ty = core::func(ctx, nil_ty, [evidence_ty]).as_type_ref();
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![BlockArgData {
+                ty: evidence_ty,
+                attrs: Default::default(),
+            }],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let ret = func::r#return(ctx, loc, []);
+        ctx.push_op(entry, ret.op_ref());
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        let main_fn = func::func(ctx, loc, Symbol::new("main"), func_ty, body);
+        set_calling_convention(ctx, main_fn.op_ref(), CallingConvention::EvidenceDirect);
+
+        let module_block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        ctx.push_op(module_block, main_fn.op_ref());
+        let module_region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![module_block],
+            parent_op: None,
+        });
+        let module_data = trunk_ir::context::OperationDataBuilder::new(
+            loc,
+            Symbol::new("core"),
+            Symbol::new("module"),
+        )
+        .attr("sym_name", Attribute::Symbol(Symbol::new("test")))
+        .region(module_region)
+        .build(ctx);
+        let module_op = ctx.create_op(module_data);
         Module::new(ctx, module_op).expect("valid arena module")
     }
 
@@ -499,6 +600,57 @@ mod tests {
             }
         }
         panic!("main wrapper not found after entrypoint generation");
+    }
+
+    #[test]
+    fn evidence_direct_main_receives_initial_evidence() {
+        let (mut ctx, loc) = test_ctx();
+        let module = make_evidence_main_module(&mut ctx, loc);
+
+        generate_native_entrypoint(&mut ctx, module, false);
+
+        let wrapper = module
+            .ops(&ctx)
+            .into_iter()
+            .find_map(|op| {
+                let f = func::Func::from_op(&ctx, op).ok()?;
+                (f.sym_name(&ctx) == Symbol::new("main")).then_some(f)
+            })
+            .expect("generated main wrapper");
+        let entry = ctx.region(wrapper.body(&ctx)).blocks[0];
+        let calls: Vec<_> = ctx
+            .block(entry)
+            .ops
+            .iter()
+            .copied()
+            .filter(|op| {
+                let data = ctx.op(*op);
+                data.dialect == Symbol::new("func") && data.name == Symbol::new("call")
+            })
+            .collect();
+        let empty_call = calls
+            .iter()
+            .copied()
+            .find(|op| {
+                ctx.op(*op).attributes.get(&Symbol::new("callee"))
+                    == Some(&Attribute::Symbol(Symbol::new(evidence_abi::EMPTY)))
+            })
+            .expect("entrypoint should create empty evidence");
+        let user_main_call = calls
+            .iter()
+            .copied()
+            .find(|op| {
+                ctx.op(*op).attributes.get(&Symbol::new("callee"))
+                    == Some(&Attribute::Symbol(Symbol::new("_tribute_main")))
+            })
+            .expect("entrypoint should call renamed user main");
+
+        assert!(ctx.op_operands(empty_call).is_empty());
+        assert_eq!(ctx.op_operands(user_main_call).len(), 1);
+        assert_eq!(
+            get_calling_convention(&ctx, user_main_call),
+            Some(CallingConvention::EvidenceDirect)
+        );
     }
 
     #[test]

--- a/crates/tribute-passes/src/native/intrinsic_to_native.rs
+++ b/crates/tribute-passes/src/native/intrinsic_to_native.rs
@@ -26,7 +26,7 @@ use trunk_ir::types::{Attribute, TypeDataBuilder};
 /// Also removes `func.func` declarations for bytes intrinsics.
 pub fn lower(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError> {
     let intrinsic_names: Rc<HashSet<Symbol>> =
-        Rc::new([Symbol::from_dynamic("__bytes_get_or_panic")].into());
+        Rc::new([Symbol::new("__bytes_get_or_panic")].into());
 
     let mut applicator = PatternApplicator::new(TypeConverter::new());
     applicator =
@@ -93,7 +93,7 @@ impl RewritePattern for BytesGetOrPanicPattern {
         let Ok(call_op) = func::Call::from_op(ctx, op) else {
             return false;
         };
-        if call_op.callee(ctx) != Symbol::from_dynamic("__bytes_get_or_panic") {
+        if call_op.callee(ctx) != "__bytes_get_or_panic" {
             return false;
         }
 

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -7,6 +7,7 @@
 use std::fmt;
 
 use tracing::{error, warn};
+use tribute_core::{CallingConvention, get_calling_convention};
 use tribute_ir::ModulePathExt;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockData, IrContext, RegionData};
@@ -15,7 +16,7 @@ use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{PassError, PassManager};
-use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef};
+use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, Module, PatternApplicator, TypeConverter,
     WasmFuncSignatureConversionPattern,
@@ -26,7 +27,7 @@ use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 use super::const_to_wasm::ConstAnalysis;
 use super::intrinsic_to_wasm::IntrinsicAnalysis;
 use super::type_converter::{self, wasm_type_converter};
-use trunk_ir_wasm_backend::gc_types::{STEP_IDX, STEP_TAG_DONE};
+use trunk_ir_wasm_backend::gc_types::{EVIDENCE_IDX, STEP_IDX, STEP_TAG_DONE};
 
 const WASM_BACKEND_READY_BOUNDARY: &str = "wasm-backend-ready";
 
@@ -313,6 +314,8 @@ fn is_type(ctx: &IrContext, ty: TypeRef, dialect: &'static str, name: &'static s
 struct MainExports {
     saw_main: bool,
     main_result_type: Option<TypeRef>,
+    main_param_types: Vec<TypeRef>,
+    main_convention: CallingConvention,
     main_exported: bool,
 }
 
@@ -321,6 +324,8 @@ impl MainExports {
         Self {
             saw_main: false,
             main_result_type: None,
+            main_param_types: Vec::new(),
+            main_convention: CallingConvention::Direct,
             main_exported: false,
         }
     }
@@ -456,6 +461,7 @@ impl<'a> WasmLowerer<'a> {
         }
 
         self.main_exports.saw_main = true;
+        self.main_exports.main_convention = get_calling_convention(ctx, op).unwrap_or_default();
 
         if let Some(Attribute::Type(fn_ty)) = data.attributes.get(&Symbol::new("type")) {
             let fn_data = ctx.types.get(*fn_ty);
@@ -463,6 +469,7 @@ impl<'a> WasmLowerer<'a> {
             if let Some(&result_ty) = fn_data.params.first() {
                 self.main_exports.main_result_type = Some(result_ty);
             }
+            self.main_exports.main_param_types = fn_data.params[1..].to_vec();
         }
     }
 
@@ -676,8 +683,9 @@ impl<'a> WasmLowerer<'a> {
         let step_ty = type_converter::step_adt_type(ctx);
 
         // Call main — returns Step
+        let main_args = self.build_main_args(ctx, body_block, location, i32_ty);
         let call_main =
-            wasm_dialect::call(ctx, location, vec![], vec![step_ty], Symbol::new("main"));
+            wasm_dialect::call(ctx, location, main_args, vec![step_ty], Symbol::new("main"));
         ctx.push_op(body_block, call_main.op_ref());
         let step_result = call_main.results(ctx)[0];
 
@@ -738,14 +746,56 @@ impl<'a> WasmLowerer<'a> {
         ctx: &mut IrContext,
         body_block: BlockRef,
         location: Location,
-        _i32_ty: TypeRef,
+        i32_ty: TypeRef,
         _nil_ty: TypeRef,
     ) {
-        let call = wasm_dialect::call(ctx, location, vec![], vec![], Symbol::new("main"));
+        let main_args = self.build_main_args(ctx, body_block, location, i32_ty);
+        let call = wasm_dialect::call(ctx, location, main_args, vec![], Symbol::new("main"));
         ctx.push_op(body_block, call.op_ref());
 
         let ret = wasm_dialect::r#return(ctx, location, vec![]);
         ctx.push_op(body_block, ret.op_ref());
+    }
+
+    fn build_main_args(
+        &self,
+        ctx: &mut IrContext,
+        body_block: BlockRef,
+        location: Location,
+        i32_ty: TypeRef,
+    ) -> Vec<ValueRef> {
+        match self.main_exports.main_convention {
+            CallingConvention::Direct => {
+                assert!(
+                    self.main_exports.main_param_types.is_empty(),
+                    "Wasm entrypoint: Direct `main` must not have hidden parameters"
+                );
+                Vec::new()
+            }
+            CallingConvention::EvidenceDirect => {
+                assert_eq!(
+                    self.main_exports.main_param_types.len(),
+                    1,
+                    "Wasm entrypoint: EvidenceDirect `main` must have one evidence parameter"
+                );
+                let zero = wasm_dialect::i32_const(ctx, location, i32_ty, 0);
+                ctx.push_op(body_block, zero.op_ref());
+                let empty = wasm_dialect::array_new_default(
+                    ctx,
+                    location,
+                    zero.result(ctx),
+                    self.main_exports.main_param_types[0],
+                    EVIDENCE_IDX,
+                );
+                ctx.push_op(body_block, empty.op_ref());
+                vec![empty.result(ctx)]
+            }
+            CallingConvention::Cps => {
+                panic!(
+                    "Wasm entrypoint: Cps `main` is invalid; frontend must reject residual control effects"
+                )
+            }
+        }
     }
 }
 
@@ -773,6 +823,51 @@ mod tests {
         let module = parse_test_module(&mut ctx, ir);
         lower_to_wasm(&mut ctx, module).expect("test module should lower to wasm");
         print_module(&ctx, module.op())
+    }
+
+    #[test]
+    fn wasm_start_passes_empty_evidence_to_evidence_direct_main() {
+        let mut ctx = IrContext::new();
+        let location = Location::new(PathRef::from_u32(0), Span::default());
+        let evidence_ty = intern_type(&mut ctx, "wasm", "arrayref");
+        let nil_ty = intern_type(&mut ctx, "core", "nil");
+        let const_analysis = ConstAnalysis {
+            string_allocations: vec![],
+            bytes_allocations: vec![],
+            string_total_size: 0,
+        };
+        let intrinsic_analysis = IntrinsicAnalysis {
+            needs_fd_write: false,
+            iovec_allocations: vec![],
+            nwritten_offset: None,
+            total_size: 0,
+        };
+        let mut lowerer = WasmLowerer::new(&const_analysis, &intrinsic_analysis);
+        lowerer.main_exports.saw_main = true;
+        lowerer.main_exports.main_result_type = Some(nil_ty);
+        lowerer.main_exports.main_param_types = vec![evidence_ty];
+        lowerer.main_exports.main_convention = CallingConvention::EvidenceDirect;
+
+        let start = lowerer.build_start_function(&mut ctx, location);
+        let start = wasm_dialect::Func::from_op(&ctx, start).expect("wasm _start function");
+        let entry = ctx.region(start.body(&ctx)).blocks[0];
+        let ops = ctx.block(entry).ops.to_vec();
+        let empty = ops
+            .iter()
+            .copied()
+            .find(|op| ctx.op(*op).name == Symbol::new("array_new_default"))
+            .expect("_start should allocate empty evidence");
+        let call_main = ops
+            .iter()
+            .copied()
+            .find(|op| {
+                ctx.op(*op).name == Symbol::new("call")
+                    && ctx.op(*op).attributes.get(&Symbol::new("callee"))
+                        == Some(&Attribute::Symbol(Symbol::new("main")))
+            })
+            .expect("_start should call main");
+
+        assert_eq!(ctx.op_operands(call_main), &[ctx.op_result(empty, 0)]);
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -187,11 +187,21 @@ impl RewritePattern for FuncFuncPattern {
         let sym_name = func_op.sym_name(ctx);
         let func_type = func_op.r#type(ctx);
         let body = func_op.body(ctx);
+        let preserved_attrs: Vec<_> = ctx
+            .op(op)
+            .attributes
+            .iter()
+            .filter(|(name, _)| **name != Symbol::new("sym_name") && **name != Symbol::new("type"))
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
 
         // Detach body region so it can be reused in the new wasm.func
         ctx.detach_region(body);
 
         let new_op = wasm_dialect::func(ctx, loc, sym_name, func_type, body);
+        ctx.op_mut(new_op.op_ref())
+            .attributes
+            .extend(preserved_attrs);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -371,4 +381,37 @@ fn intern_i32_type(ctx: &mut IrContext) -> TypeRef {
 /// Intern a wasm.funcref type.
 fn intern_funcref_type(ctx: &mut IrContext) -> TypeRef {
     wasm_dialect::funcref(ctx).as_type_ref()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::types::Attribute;
+
+    #[test]
+    fn func_to_wasm_preserves_custom_function_attributes() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main() -> core.nil {
+    func.return
+  }
+}"#,
+        );
+        let original = module.ops(&ctx)[0];
+        ctx.op_mut(original)
+            .attributes
+            .insert(Symbol::new("custom"), Attribute::Int(7));
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let lowered = module.ops(&ctx)[0];
+        assert!(wasm_dialect::Func::from_op(&ctx, lowered).is_ok());
+        assert_eq!(
+            ctx.op(lowered).attributes.get(&Symbol::new("custom")),
+            Some(&Attribute::Int(7))
+        );
+    }
 }

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -23,7 +23,7 @@ use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, clone_attrs_except,
 };
 use trunk_ir::types::TypeDataBuilder;
 use trunk_ir::{BlockData, RegionData};
@@ -187,13 +187,7 @@ impl RewritePattern for FuncFuncPattern {
         let sym_name = func_op.sym_name(ctx);
         let func_type = func_op.r#type(ctx);
         let body = func_op.body(ctx);
-        let preserved_attrs: Vec<_> = ctx
-            .op(op)
-            .attributes
-            .iter()
-            .filter(|(name, _)| **name != Symbol::new("sym_name") && **name != Symbol::new("type"))
-            .map(|(name, value)| (*name, value.clone()))
-            .collect();
+        let attrs_to_preserve = clone_attrs_except(ctx, op, &["sym_name", "type"]);
 
         // Detach body region so it can be reused in the new wasm.func
         ctx.detach_region(body);
@@ -201,7 +195,7 @@ impl RewritePattern for FuncFuncPattern {
         let new_op = wasm_dialect::func(ctx, loc, sym_name, func_type, body);
         ctx.op_mut(new_op.op_ref())
             .attributes
-            .extend(preserved_attrs);
+            .extend(attrs_to_preserve);
         rewriter.replace_op(new_op.op_ref());
         true
     }

--- a/crates/trunk-ir/src/rewrite/helpers.rs
+++ b/crates/trunk-ir/src/rewrite/helpers.rs
@@ -5,8 +5,24 @@
 
 use smallvec::SmallVec;
 
+use crate::Symbol;
 use crate::context::{BlockData, IrContext};
 use crate::refs::{BlockRef, OpRef, RegionRef};
+use crate::types::Attribute;
+
+/// Clone an operation's attributes except for the named exclusions.
+pub fn clone_attrs_except(
+    ctx: &IrContext,
+    op: OpRef,
+    excluded_names: &[&str],
+) -> Vec<(Symbol, Attribute)> {
+    ctx.op(op)
+        .attributes
+        .iter()
+        .filter(|(name, _)| !excluded_names.iter().any(|excluded| **name == *excluded))
+        .map(|(name, value)| (*name, value.clone()))
+        .collect()
+}
 
 /// Split a block at `before_op`, moving `before_op` and all subsequent
 /// operations into a new block.

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -15,7 +15,7 @@ pub use applicator::{ApplyResult, PatternApplicator, RewriteScope};
 pub use conversion_target::{
     ConversionError, ConversionMode, ConversionTarget, IllegalOp, LegalityCheck, LegalityDecision,
 };
-pub use helpers::{erase_op, inline_region_blocks, split_block};
+pub use helpers::{clone_attrs_except, erase_op, inline_region_blocks, split_block};
 pub use pattern::RewritePattern;
 pub use rewriter::PatternRewriter;
 pub use signature_conversion::{

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -6,6 +6,7 @@
 //! - [`FuncSignatureConversionPattern`]: Converts `func.func` signatures
 //! - [`WasmFuncSignatureConversionPattern`]: Converts `wasm.func` signatures
 
+use crate::Symbol;
 use crate::context::IrContext;
 use crate::dialect::{core, func, wasm};
 use crate::ops::{DialectOp, DialectType};
@@ -110,6 +111,13 @@ fn rewrite_function_signature(
     make_op: impl FnOnce(&mut IrContext, TypeRef) -> OpRef,
 ) -> bool {
     let converter = rewriter.type_converter();
+    let preserved_attrs: Vec<_> = ctx
+        .op(op)
+        .attributes
+        .iter()
+        .filter(|(name, _)| **name != Symbol::new("sym_name") && **name != Symbol::new("type"))
+        .map(|(name, value)| (*name, value.clone()))
+        .collect();
 
     let Some(sig) = convert_func_signature(ctx, func_type, converter) else {
         return false;
@@ -128,6 +136,7 @@ fn rewrite_function_signature(
 
     // Create replacement op with new type
     let new_op = make_op(ctx, new_func_type);
+    ctx.op_mut(new_op).attributes.extend(preserved_attrs);
 
     rewriter.replace_op(new_op);
     true
@@ -402,6 +411,9 @@ mod tests {
 
         let func_ty = make_func_type(&mut ctx, &[i32_ty, i32_ty], i32_ty);
         let func_op = make_wasm_func_op(&mut ctx, loc, "wasm_fn", func_ty, &[i32_ty, i32_ty]);
+        ctx.op_mut(func_op)
+            .attributes
+            .insert(Symbol::new("custom"), Attribute::Int(7));
         let module = make_module(&mut ctx, loc, vec![func_op]);
 
         let tc = i32_to_i64_converter(i32_ty, i64_ty);
@@ -424,6 +436,11 @@ mod tests {
         assert_eq!(td.params[0], i64_ty, "return type should be i64");
         assert_eq!(td.params[1], i64_ty, "first param should be i64");
         assert_eq!(td.params[2], i64_ty, "second param should be i64");
+        assert_eq!(
+            ctx.op(ops[0]).attributes.get(&Symbol::new("custom")),
+            Some(&Attribute::Int(7)),
+            "signature conversion should preserve custom metadata"
+        );
 
         // Verify entry block args
         let body = new_func.body(&ctx);

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -6,11 +6,11 @@
 //! - [`FuncSignatureConversionPattern`]: Converts `func.func` signatures
 //! - [`WasmFuncSignatureConversionPattern`]: Converts `wasm.func` signatures
 
-use crate::Symbol;
 use crate::context::IrContext;
 use crate::dialect::{core, func, wasm};
 use crate::ops::{DialectOp, DialectType};
 use crate::refs::{OpRef, RegionRef, TypeRef};
+use crate::rewrite::clone_attrs_except;
 use crate::rewrite::pattern::RewritePattern;
 use crate::rewrite::rewriter::PatternRewriter;
 use crate::rewrite::type_converter::TypeConverter;
@@ -111,13 +111,7 @@ fn rewrite_function_signature(
     make_op: impl FnOnce(&mut IrContext, TypeRef) -> OpRef,
 ) -> bool {
     let converter = rewriter.type_converter();
-    let preserved_attrs: Vec<_> = ctx
-        .op(op)
-        .attributes
-        .iter()
-        .filter(|(name, _)| **name != Symbol::new("sym_name") && **name != Symbol::new("type"))
-        .map(|(name, value)| (*name, value.clone()))
-        .collect();
+    let attrs_to_preserve = clone_attrs_except(ctx, op, &["sym_name", "type"]);
 
     let Some(sig) = convert_func_signature(ctx, func_type, converter) else {
         return false;
@@ -136,7 +130,7 @@ fn rewrite_function_signature(
 
     // Create replacement op with new type
     let new_op = make_op(ctx, new_func_type);
-    ctx.op_mut(new_op).attributes.extend(preserved_attrs);
+    ctx.op_mut(new_op).attributes.extend(attrs_to_preserve);
 
     rewriter.replace_op(new_op);
     true

--- a/new-plans/abilities.md
+++ b/new-plans/abilities.md
@@ -37,7 +37,7 @@ fn fold(xs: List(a), init: b, f: fn(b, a) ->{e} b) ->{e} b
 ### 순수 함수 (Ability 없음)
 
 ```rust
-fn(a) ->{} b    // 빈 ability 집합 = 순수 함수
+fn(a) ->{} b    // 빈 ability 집합, 명시적 pure-effectful ABI
 ```
 
 순수 함수가 필요한 경우 명시적으로 `{}`를 표기한다:
@@ -483,7 +483,7 @@ fn main() ->{Io} Nil {
 | 문법 | 의미 |
 | ---- | ---- |
 | `fn(a) -> b` | `fn(a) ->{e} b` (fresh e) |
-| `fn(a) ->{} b` | 순수 함수 타입 |
+| `fn(a) ->{} b` | 빈 effect row를 명시한 pure-effectful 함수 타입 |
 | `fn(a) ->{E} b` | ability E를 수행하는 함수 타입 |
 | `fn(a) ->{e, E} b` | ability E + 나머지 e |
 | `Nil` | Unit 타입/값 |

--- a/new-plans/abilities.md
+++ b/new-plans/abilities.md
@@ -37,7 +37,7 @@ fn fold(xs: List(a), init: b, f: fn(b, a) ->{e} b) ->{e} b
 ### 순수 함수 (Ability 없음)
 
 ```rust
-fn(a) ->{} b    // 빈 ability 집합, 명시적 pure-effectful ABI
+fn(a) ->{} b    // 빈 ability 집합을 명시한 pure 함수
 ```
 
 순수 함수가 필요한 경우 명시적으로 `{}`를 표기한다:
@@ -483,7 +483,7 @@ fn main() ->{Io} Nil {
 | 문법 | 의미 |
 | ---- | ---- |
 | `fn(a) -> b` | `fn(a) ->{e} b` (fresh e) |
-| `fn(a) ->{} b` | 빈 effect row를 명시한 pure-effectful 함수 타입 |
+| `fn(a) ->{} b` | 빈 effect row를 명시한 pure 함수 타입 |
 | `fn(a) ->{E} b` | ability E를 수행하는 함수 타입 |
 | `fn(a) ->{e, E} b` | ability E + 나머지 e |
 | `Nil` | Unit 타입/값 |

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -6,6 +6,13 @@
 WasmGC yield bubbling, `YieldResult` 중심 trampoline, `cont.*` dialect 직접
 lowering은 현재 경로가 아니다.
 
+논리적 CPS 함수는 source result를 직접 반환하지 않는다. 완료 값은 `done_k`의
+인자로 전달되고 함수와 continuation의 control result는 `Never`다. 아래 예시의
+`anyref` result와 `func.return %result`는 현재 구현이 true tail call 대신
+continuation chain의 결과를 되돌려 보내기 위해 사용하는 compatibility carrier다.
+향후 control lowering은 이를 true tail call의 `Never` 또는 trampoline의 `Step`으로
+대체할 수 있다.
+
 ## 핵심 설계
 
 ### `fn` operation: direct dispatch
@@ -208,7 +215,7 @@ ast_to_ir
 ```
 
 `ast_to_ir` 단계에서 effectful function과 closure는 evidence parameter와
-CPS calling convention을 반영한 IR로 생성된다. Shared lowering removes
+현재 compatibility CPS representation을 반영한 IR로 생성된다. Shared lowering removes
 high-level dispatch operations and emits `effect.*` ABI operations. Backends
 then lower `effect.*` into evidence runtime calls, closure decomposition, and
 target-specific indirect calls.

--- a/new-plans/design.md
+++ b/new-plans/design.md
@@ -174,7 +174,7 @@ fn(a) ->{g} b    // 임의의 ability g에 대해 polymorphic
 **순수 함수는 빈 ability 집합으로 명시:**
 
 ```rust
-fn(a) ->{} b    // 순수 함수
+fn(a) ->{} b    // 빈 effect를 명시한 pure-effectful 함수
 ```
 
 ### Ability 추론

--- a/new-plans/design.md
+++ b/new-plans/design.md
@@ -174,7 +174,7 @@ fn(a) ->{g} b    // 임의의 ability g에 대해 polymorphic
 **순수 함수는 빈 ability 집합으로 명시:**
 
 ```rust
-fn(a) ->{} b    // 빈 effect를 명시한 pure-effectful 함수
+fn(a) ->{} b    // 빈 effect를 명시한 pure 함수
 ```
 
 ### Ability 추론

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -269,6 +269,67 @@ fn fetch_all(urls: List(Text), ev: Evidence) -> List(Response) {
 
 ## Selective Transformation
 
+### Effect Row Granularity and Convention Bound
+
+Source effect row는 operation 집합이 아니라 **ability identity의 집합**을
+기록한다. Calling convention은 row에 들어 있는 각 ability가 요구하는 convention의
+상한으로 결정한다.
+
+```text
+requirement({A₁, ..., Aₙ | e})
+  = requirement(A₁) ⊔ ... ⊔ requirement(Aₙ) ⊔ requirement(e)
+
+pure/closed empty row       → Direct
+fn-only or empty ability    → EvidenceDirect
+ability containing any op  → Cps
+open or otherwise unknown e → Cps
+```
+
+따라서 `fn`과 `op`를 함께 선언한 ability는 함수 ABI를 정할 때 `Cps`로
+분류한다. 이는 안전한 **ability 단위 상한**이다. 다만 CPS 함수 안에서도 개별
+`fn` operation 호출은 `tr_dispatch_fn`을 통한 evidence-direct fast path를
+사용할 수 있다. 함수 표현을 결정하는 상한과 operation call-site의 dispatch
+최적화는 서로 다른 결정이다.
+
+Operation 종류를 source effect row에 기록하는 대안은 채택하지 않는다. 예를 들어
+`{State::get}`과 `{State::get, State::set}`을 서로 다른 effect로 만들면 이 차이가
+함수 타입, effect polymorphism, subtyping, 간접 호출 및 별도 컴파일 단위의 ABI에
+모두 관여해야 한다. 내부 calling-convention 정보로만 operation 집합을 추적하면
+간접 호출에서 실제 callee가 더 강한 convention을 요구할 수 있으므로 sound하지 않다.
+
+#### 다른 언어와의 비교
+
+- **Koka**는 effect label 단위의 row를 사용하고, selective CPS 판정을 row의 각
+  label이 요구하는 변환의 join으로 계산한다. 열린 effect variable은 보수적으로
+  CPS가 필요하다고 판정한다. 최신 Koka의 `fun` operation과 linear effect는
+  tail-resumptive 호출을 evidence lookup 뒤 직접 실행하여 일반 control 변환을
+  피한다. Tribute의 ability 단위 상한과 `fn` fast path에 가장 가까운 선례다.
+  ([Type Directed Compilation of Row-Typed Algebraic Effects](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/algeff.pdf),
+  [Koka Language Book](https://koka-lang.github.io/koka/doc/book.html),
+  [Generalized Evidence Passing for Effect Handlers](https://xnning.github.io/papers/multip-tr.pdf))
+- **Eff**는 computation type의 dirt에 호출 가능한 operation 집합을 기록한다.
+  이 정밀도는 effect subtyping, 집합 포함 관계를 나타내는 coercion, elaboration과
+  함께 타입 시스템의 일부가 된다. 이는 operation 단위 설계가 가능함을 보여 주지만,
+  단순한 ABI 분석 속성으로 추가할 수 있는 기능은 아님을 보여 주는 대안이다.
+  ([Eff handlers tutorial](https://www.eff-lang.org/handlers-tutorial.pdf),
+  [Explicit Effect Subtyping](https://arxiv.org/abs/2005.13814))
+- **Unison**은 함수 타입에 ability 집합을 기록한다. Handler는 ability request의
+  operation별로 match하고 각 branch에서 continuation을 받으므로, ability-level
+  effect typing의 선례이지만 Tribute의 정적인 `fn`/`op` 구분에는 대응하지 않는다.
+  ([Abilities and ability handlers](https://www.unison-lang.org/docs/language-reference/abilities-and-ability-handlers/),
+  [Writing your own abilities](https://www.unison-lang.org/docs/fundamentals/abilities/writing-abilities/))
+- **Effekt**는 effect를 computation이 요구하는 capability로 해석하고 explicit
+  capability passing으로 내린다. Second-class block과 contextual effect
+  polymorphism을 사용하므로 Tribute의 first-class function ABI와 직접 같지는 않지만,
+  effect 정보를 capability-passing representation으로 lowering하는 비교 사례다.
+  ([Effects as Capabilities](https://ps.informatik.uni-tuebingen.de/publications/brachthaeuser20effekt/))
+
+이 비교에 따라 source effect row의 ability 단위 표현은 유지한다. Operation 단위
+정밀도가 실제로 필요해지면 숨은 최적화 메타데이터가 아니라 타입 시스템 기능으로
+별도 설계해야 한다. 열린 row의 보수적인 `Cps`가 성능 문제가 되면 source type을
+바꾸기보다 Koka와 같은 plain/CPS worker 분리나 specialization을 후속 최적화로
+검토한다.
+
 ### 변환 범위
 
 모든 코드를 CPS로 변환하지 않는다. Ability operation 지점에서만 continuation 캡처가 필요하다:
@@ -287,9 +348,13 @@ fn map(xs: List(a), f: fn(a) ->{e} b) ->{e} List(b)
 
 `f`가 순수인지 effectful인지 컴파일 타임에 모를 수 있다. 전략:
 
-1. **Evidence는 항상 전달**: 오버헤드 최소화 (포인터 하나)
-2. **Tail-resumptive 최적화**: 대부분의 handler가 즉시 resume하면 실제 shift 불필요
-3. **Inlining**: 구체적 타입이 알려지면 evidence 사용 여부 최적화
+1. **열린 row는 Cps**: 구체화 전에는 더 강한 convention을 요구할 가능성을
+   배제할 수 없으므로 `done_k`를 포함하는 ABI를 사용한다
+2. **Evidence는 항상 전달**: effectful polymorphic 호출은 동일한 evidence를 전달한다
+3. **Tail-resumptive 최적화**: 구체적인 `fn` operation call-site에서는 실제 shift가
+   필요 없다
+4. **Inlining/specialization**: row가 구체화되면 더 약한 convention의 worker로
+   최적화할 수 있다
 
 ### Tail-Resumptive Optimization
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -211,9 +211,10 @@ fn state_get(ev: Evidence) -> s {
 
 ### Evidence 전달 규칙
 
-1. **Direct worker**는 evidence를 전달받지 않는다. Effect annotation을 생략한
-   `fn(a) -> b`의 semantic type은 `fn(a) ->{e} b`이지만, 정의에서 발견된 concrete
-   residual effect가 없다면 worker 자체는 Direct일 수 있다
+1. **Direct 함수**는 evidence를 전달받지 않는다. 명시적인 닫힌 빈 row `->{}`는
+   Direct다. Effect annotation을 생략한 `fn(a) -> b`의 semantic type은
+   `fn(a) ->{e} b`이지만, 정의에서 발견된 concrete residual effect가 없다면
+   worker 자체도 Direct일 수 있다
 2. **EvidenceDirect 함수**는 evidence를 받지만 `done_k` 없이 source result를 직접 반환한다
 3. **CPS 함수**는 evidence와 `done_k`를 받고 source result를 직접 반환하지 않는다
 4. **Handler 설치** 시 새 evidence를 할당한다
@@ -293,7 +294,7 @@ ability가 요구하는 convention의 상한으로 결정한다.
 requirement({A₁, ..., Aₙ | e})
   = requirement(A₁) ⊔ ... ⊔ requirement(Aₙ) ⊔ requirement(e)
 
-explicit empty row `->{}`  → EvidenceDirect
+closed empty row `->{}`    → Direct
 fn-only or empty ability    → EvidenceDirect
 ability containing any op  → Cps
 open or otherwise unknown e → Cps
@@ -310,8 +311,8 @@ definition의 physical worker convention은 semantic function type과 별도로 
 생략된 annotation으로부터 생긴 generalized tail은 worker requirement에 포함하지
 않고, body에서 발견된 concrete residual abilities의 상한만 사용한다. 그러므로
 effect-polymorphic `add`는 Direct worker를 가질 수 있으며, first-class function
-boundary에서는 contextual convention에 맞는 adapter를 사용한다. 명시적인 `->{}`는
-이 예외를 적용하지 않고 `EvidenceDirect` worker를 요청한다.
+boundary에서는 contextual convention에 맞는 adapter를 사용한다. 명시적인 `->{}`도
+닫힌 빈 row이므로 Direct를 사용한다.
 
 여기서 `Cps`는 source result를 직접 반환하지 않고 `done_k`로 전달한다는
 논리적 convention이다. 실제 lowered result carrier는 control-lowering 전략이
@@ -369,7 +370,7 @@ plain/CPS worker 복제나 specialization은 후속 최적화로 검토한다.
 ```text
 생략 annotation의 semantic type       → open row, indirect call은 Cps
 concrete residual effect 없는 worker  → Direct
-명시적 빈 effect (fn(a) ->{} b)      → EvidenceDirect
+명시적 빈 effect (fn(a) ->{} b)      → Direct
 Ambient/fn effect                    → EvidenceDirect
 General op/Throw effect              → Cps, effect point만 continuation 처리
 ```

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -211,9 +211,11 @@ fn state_get(ev: Evidence) -> s {
 
 ### Evidence 전달 규칙
 
-1. **순수 함수** (`fn(a) ->{} b`)는 evidence를 전달받지 않는다
+1. **Direct worker**는 evidence를 전달받지 않는다. Effect annotation을 생략한
+   `fn(a) -> b`의 semantic type은 `fn(a) ->{e} b`이지만, 정의에서 발견된 concrete
+   residual effect가 없다면 worker 자체는 Direct일 수 있다
 2. **EvidenceDirect 함수**는 evidence를 받지만 `done_k` 없이 source result를 직접 반환한다
-3. **CPS 함수**는 evidence와 `done_k`를 받고 `anyref`를 반환한다
+3. **CPS 함수**는 evidence와 `done_k`를 받고 source result를 직접 반환하지 않는다
 4. **Handler 설치** 시 새 evidence를 할당한다
 5. **Handled ability operation** 시 evidence에서 marker를 조회한다
 
@@ -229,6 +231,18 @@ Compiler-owned ambient ability `std::io::Io`만 요구하는 함수는 현재
 구현 세부사항이다.
 `Io`와 `Throw(std::io::Error)`가 함께 있으면 `Throw` 때문에 `Cps`로 승격된다.
 자세한 표준 I/O 계약은 [io.md](io.md)를 따른다.
+
+논리적인 CPS ABI에서 함수와 `done_k`의 control result는 `Never`다:
+
+```text
+fn cps(ev: Evidence, done_k: fn(T) -> Never, args...) -> Never
+```
+
+현재 IR은 true tail call이 모든 경로에서 보장되지 않으므로 continuation chain의
+행정적 반환값을 `anyref`로 전달하는 compatibility representation을 사용한다.
+`anyref`는 source result가 아니며 `Cps` convention의 영구적인 의미도 아니다.
+Control lowering이 분리되면 true tail-call backend는 `Never`, trampoline
+backend는 `Step`, 기존 경로는 `anyref` carrier를 선택할 수 있다.
 
 ### 런타임 함수
 
@@ -272,18 +286,36 @@ fn fetch_all(urls: List(Text), ev: Evidence) -> List(Response) {
 ### Effect Row Granularity and Convention Bound
 
 Source effect row는 operation 집합이 아니라 **ability identity의 집합**을
-기록한다. Calling convention은 row에 들어 있는 각 ability가 요구하는 convention의
-상한으로 결정한다.
+기록한다. Semantic function type의 calling convention은 row에 들어 있는 각
+ability가 요구하는 convention의 상한으로 결정한다.
 
 ```text
 requirement({A₁, ..., Aₙ | e})
   = requirement(A₁) ⊔ ... ⊔ requirement(Aₙ) ⊔ requirement(e)
 
-pure/closed empty row       → Direct
+explicit empty row `->{}`  → EvidenceDirect
 fn-only or empty ability    → EvidenceDirect
 ability containing any op  → Cps
 open or otherwise unknown e → Cps
 ```
+
+Effect annotation 생략은 closed-empty 추론이 아니다.
+
+```text
+fn(a) -> b ≡ fn(a) ->{e} b
+```
+
+따라서 이 타입을 통한 **간접 호출**은 열린 `e` 때문에 `Cps`다. 반면 named
+definition의 physical worker convention은 semantic function type과 별도로 기록한다.
+생략된 annotation으로부터 생긴 generalized tail은 worker requirement에 포함하지
+않고, body에서 발견된 concrete residual abilities의 상한만 사용한다. 그러므로
+effect-polymorphic `add`는 Direct worker를 가질 수 있으며, first-class function
+boundary에서는 contextual convention에 맞는 adapter를 사용한다. 명시적인 `->{}`는
+이 예외를 적용하지 않고 `EvidenceDirect` worker를 요청한다.
+
+여기서 `Cps`는 source result를 직접 반환하지 않고 `done_k`로 전달한다는
+논리적 convention이다. 실제 lowered result carrier는 control-lowering 전략이
+`Never`, `Step`, 또는 compatibility `anyref` 중에서 결정한다.
 
 따라서 `fn`과 `op`를 함께 선언한 ability는 함수 ABI를 정할 때 `Cps`로
 분류한다. 이는 안전한 **ability 단위 상한**이다. 다만 CPS 함수 안에서도 개별
@@ -326,16 +358,18 @@ Operation 종류를 source effect row에 기록하는 대안은 채택하지 않
 
 이 비교에 따라 source effect row의 ability 단위 표현은 유지한다. Operation 단위
 정밀도가 실제로 필요해지면 숨은 최적화 메타데이터가 아니라 타입 시스템 기능으로
-별도 설계해야 한다. 열린 row의 보수적인 `Cps`가 성능 문제가 되면 source type을
-바꾸기보다 Koka와 같은 plain/CPS worker 분리나 specialization을 후속 최적화로
-검토한다.
+별도 설계해야 한다. 열린 row의 간접 호출은 보수적인 `Cps`를 유지하되, named
+definition에는 semantic type과 분리된 worker convention을 사용한다. 추가적인
+plain/CPS worker 복제나 specialization은 후속 최적화로 검토한다.
 
 ### 변환 범위
 
 모든 코드를 CPS로 변환하지 않는다. Ability operation 지점에서만 continuation 캡처가 필요하다:
 
 ```text
-순수 코드 (fn(a) ->{} b)            → Direct
+생략 annotation의 semantic type       → open row, indirect call은 Cps
+concrete residual effect 없는 worker  → Direct
+명시적 빈 effect (fn(a) ->{} b)      → EvidenceDirect
 Ambient/fn effect                    → EvidenceDirect
 General op/Throw effect              → Cps, effect point만 continuation 처리
 ```

--- a/new-plans/io.md
+++ b/new-plans/io.md
@@ -70,16 +70,16 @@ Compiler는 이름 문자열만 비교하지 않고 canonical builtin identity
 
 | Convention | Parameters | Result | Requirement |
 | ---------- | ---------- | ------ | ----------- |
-| `Direct` | source parameters | source result | pure named worker |
-| `EvidenceDirect` | evidence + source parameters | source result | explicit `->{}`, `Io`, or tail-resumptive `fn` effect |
+| `Direct` | source parameters | source result | closed empty effect row or pure named worker |
+| `EvidenceDirect` | evidence + source parameters | source result | `Io` or tail-resumptive `fn` effect |
 | `Cps` | evidence + `done_k` + source parameters | source result를 직접 반환하지 않음 | general `op`, `Throw`, or another CPS effect |
 
 규약을 합성할 때 `Direct < EvidenceDirect < Cps` 순서로 더 강한 규약이
 우선한다.
 
-명시적인 빈 effect annotation `->{}`는 effect row 자체는 비어 있지만
-effectful function ABI를 요청한다. 따라서 annotation을 생략해 얻은 pure worker와 달리
-`EvidenceDirect`를 사용한다.
+명시적인 빈 effect annotation `->{}`는 닫힌 빈 effect row를 뜻하므로
+`Direct`를 사용한다. Effect annotation을 생략한 함수와 달리 effect-polymorphic하지
+않지만, 빈 row 자체는 evidence parameter를 요구하지 않는다.
 
 Effect annotation을 생략한 `fn(...) -> T`의 semantic type은
 `fn(...) ->{e} T`다. 열린 row의 간접 호출은 `Cps`지만, 정의에서 concrete residual

--- a/new-plans/io.md
+++ b/new-plans/io.md
@@ -70,12 +70,21 @@ Compiler는 이름 문자열만 비교하지 않고 canonical builtin identity
 
 | Convention | Parameters | Result | Requirement |
 | ---------- | ---------- | ------ | ----------- |
-| `Direct` | source parameters | source result | pure function |
-| `EvidenceDirect` | evidence + source parameters | source result | `Io` 또는 tail-resumptive `fn` effect |
-| `Cps` | evidence + `done_k` + source parameters | `anyref` | general `op`, `Throw`, or another CPS effect |
+| `Direct` | source parameters | source result | pure named worker |
+| `EvidenceDirect` | evidence + source parameters | source result | explicit `->{}`, `Io`, or tail-resumptive `fn` effect |
+| `Cps` | evidence + `done_k` + source parameters | source result를 직접 반환하지 않음 | general `op`, `Throw`, or another CPS effect |
 
 규약을 합성할 때 `Direct < EvidenceDirect < Cps` 순서로 더 강한 규약이
 우선한다.
+
+명시적인 빈 effect annotation `->{}`는 effect row 자체는 비어 있지만
+effectful function ABI를 요청한다. 따라서 annotation을 생략해 얻은 pure worker와 달리
+`EvidenceDirect`를 사용한다.
+
+Effect annotation을 생략한 `fn(...) -> T`의 semantic type은
+`fn(...) ->{e} T`다. 열린 row의 간접 호출은 `Cps`지만, 정의에서 concrete residual
+effect가 발견되지 않으면 해당 named definition은 별도의 `Direct` worker를 가질 수
+있다.
 
 `Io`만 요구하는 함수는 현재 `EvidenceDirect`를 사용한다. Evidence는 전달되지만
 `Io` operation을 dispatch하기 위한 handler lookup은 수행하지 않는다. Evidence의
@@ -88,10 +97,12 @@ print_line(ev, message) -> Nil
 main(ev) -> Nil
 ```
 
-`read_line`은 실패 시 `Throw(Error)`를 수행하므로 CPS 규약을 사용한다.
+`read_line`은 실패 시 `Throw(Error)`를 수행하므로 CPS 규약을 사용한다. 논리적
+ABI에서 `done_k`와 함수의 control result는 `Never`이며, 현재 compatibility
+lowering만 이를 `anyref` carrier로 표현한다.
 
 ```text
-read_line(ev, done_k) -> anyref
+read_line(ev, done_k: fn(String) -> Never) -> Never
 ```
 
 ## Entrypoint

--- a/new-plans/syntax.md
+++ b/new-plans/syntax.md
@@ -1085,7 +1085,7 @@ fn main() ->{Io} Nil {
 | `List(a)`, `Option(Int)`           | 제네릭 타입                    |
 | `#(Int, Text)`                     | Tuple 타입                     |
 | `fn(a) -> b`                       | 함수 타입 (암묵적 polymorphic) |
-| `fn(a) ->{} b`                     | 순수 함수 타입                 |
+| `fn(a) ->{} b`                     | 명시적 빈 effect 함수 타입     |
 | `fn(a) ->{E} b`                    | Effect E를 수행하는 함수       |
 | `fn(a) ->{E, e} b`                 | E + row variable e             |
 

--- a/src/lsp/type_index.rs
+++ b/src/lsp/type_index.rs
@@ -66,6 +66,7 @@ pub fn print_ast_type(db: &dyn salsa::Database, ty: Type<'_>) -> String {
             params,
             result,
             effect,
+            ..
         } => {
             let params_str: Vec<String> = params.iter().map(|t| print_ast_type(db, *t)).collect();
             let result_str = print_ast_type(db, *result);
@@ -532,6 +533,7 @@ mod tests {
                 params: vec![int_ty, int_ty],
                 result: int_ty,
                 effect: pure_effect,
+                minimum_convention: tribute_front::ast::CallingConvention::Direct,
             },
         );
         assert_eq!(print_ast_type(&db, func_ty), "fn(Int, Int) -> Int");
@@ -688,6 +690,7 @@ mod tests {
                 params: vec![int_ty],
                 result: int_ty,
                 effect: effect_row,
+                minimum_convention: tribute_front::ast::CallingConvention::Direct,
             },
         );
         assert_eq!(print_ast_type(&db, func_ty), "fn(Int) ->{IO} Int");

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -186,6 +186,7 @@ fn prelude_module<'db>(db: &'db dyn salsa::Database) -> Option<ast_typeck::TypeC
         tdnr_ast,
         result.function_types,
         result.node_types,
+        result.ability_conventions,
         span_map,
     ))
 }
@@ -252,48 +253,67 @@ fn merge_and_lower_to_ir<'db>(
     let user_span_map = typed.span_map(db);
 
     // Merge prelude at AST level
-    let (merged_module, merged_fn_types, merged_node_types, merged_span_map) =
-        if let Some(prelude) = prelude_module(db) {
-            let prelude_module_ast = prelude.module(db);
-            let prelude_fn_types = prelude.function_types(db);
-            let prelude_node_types = prelude.node_types(db);
-            let prelude_span_map = prelude.span_map(db);
+    let user_ability_conventions = typed.ability_conventions(db);
+    let (
+        merged_module,
+        merged_fn_types,
+        merged_node_types,
+        merged_ability_conventions,
+        merged_span_map,
+    ) = if let Some(prelude) = prelude_module(db) {
+        let prelude_module_ast = prelude.module(db);
+        let prelude_fn_types = prelude.function_types(db);
+        let prelude_node_types = prelude.node_types(db);
+        let prelude_ability_conventions = prelude.ability_conventions(db);
+        let prelude_span_map = prelude.span_map(db);
 
-            // Prepend prelude decls before user decls
-            let mut merged_decls = prelude_module_ast.decls.clone();
-            merged_decls.extend(user_module.decls.iter().cloned());
+        // Prepend prelude decls before user decls
+        let mut merged_decls = prelude_module_ast.decls.clone();
+        merged_decls.extend(user_module.decls.iter().cloned());
 
-            let merged_ast = tribute_front::ast::Module::<TypedRef<'db>>::new(
-                user_module.id,
-                user_module.name,
-                merged_decls,
-            );
+        let merged_ast = tribute_front::ast::Module::<TypedRef<'db>>::new(
+            user_module.id,
+            user_module.name,
+            merged_decls,
+        );
 
-            // Merge function_types: prelude first, user overrides
-            let mut fn_types: std::collections::HashMap<_, _> =
-                prelude_fn_types.iter().cloned().collect();
-            fn_types.extend(user_fn_types.iter().cloned());
+        // Merge function_types: prelude first, user overrides
+        let mut fn_types: std::collections::HashMap<_, _> =
+            prelude_fn_types.iter().cloned().collect();
+        fn_types.extend(user_fn_types.iter().cloned());
 
-            // Merge node_types: prelude first, user overrides
-            let mut node_types: std::collections::HashMap<_, _> =
-                prelude_node_types.iter().cloned().collect();
-            node_types.extend(user_node_types.iter().cloned());
+        // Merge node_types: prelude first, user overrides
+        let mut node_types: std::collections::HashMap<_, _> =
+            prelude_node_types.iter().cloned().collect();
+        node_types.extend(user_node_types.iter().cloned());
 
-            // Merge span maps (user overrides prelude on conflict)
-            let merged_span_map = user_span_map.merge(&prelude_span_map);
+        let mut ability_conventions: std::collections::HashMap<_, _> =
+            prelude_ability_conventions.iter().cloned().collect();
+        ability_conventions.extend(user_ability_conventions.iter().cloned());
 
-            (merged_ast, fn_types, node_types, merged_span_map)
-        } else {
-            let fn_types: std::collections::HashMap<_, _> = user_fn_types.iter().cloned().collect();
-            let node_types: std::collections::HashMap<_, _> =
-                user_node_types.iter().cloned().collect();
-            (
-                user_module.clone(),
-                fn_types,
-                node_types,
-                user_span_map.clone(),
-            )
-        };
+        // Merge span maps (user overrides prelude on conflict)
+        let merged_span_map = user_span_map.merge(&prelude_span_map);
+
+        (
+            merged_ast,
+            fn_types,
+            node_types,
+            ability_conventions,
+            merged_span_map,
+        )
+    } else {
+        let fn_types: std::collections::HashMap<_, _> = user_fn_types.iter().cloned().collect();
+        let node_types: std::collections::HashMap<_, _> = user_node_types.iter().cloned().collect();
+        let ability_conventions: std::collections::HashMap<_, _> =
+            user_ability_conventions.iter().cloned().collect();
+        (
+            user_module.clone(),
+            fn_types,
+            node_types,
+            ability_conventions,
+            user_span_map.clone(),
+        )
+    };
 
     // Monomorphize generic functions
     let mono_result =
@@ -305,15 +325,14 @@ fn merge_and_lower_to_ir<'db>(
     // AST → TrunkIR (arena)
     let source_uri = source.uri(db).as_str();
     let mut ir = IrContext::new();
-    let module = ast_to_ir::lower_ast_to_ir(
-        db,
-        &mut ir,
-        merged_module,
-        merged_span_map,
-        source_uri,
-        merged_fn_types,
-        merged_node_types,
-    );
+    let module = ast_to_ir::TypedModule {
+        ast: merged_module,
+        span_map: merged_span_map,
+        function_types: merged_fn_types,
+        node_types: merged_node_types,
+        ability_conventions: merged_ability_conventions,
+    }
+    .lower_to_ir(db, &mut ir, source_uri);
 
     (ir, module)
 }
@@ -1020,6 +1039,7 @@ pub fn parse_and_lower_ast<'db>(
         tdnr_ast,
         result.function_types,
         result.node_types,
+        result.ability_conventions,
         span_map,
     ))
 }

--- a/tests/effect_var_collision.rs
+++ b/tests/effect_var_collision.rs
@@ -93,7 +93,7 @@ fn main() { }
 /// might get incorrectly typed as effectful, causing this to fail.
 ///
 /// This is the KEY test for the bug:
-/// - `apply_pure` requires `fn(Int) ->{} Int` (pure function)
+/// - `apply_pure` requires `fn(Int) ->{} Int` (explicit pure-effectful function)
 /// - `effectful_using_pure` is `->{State(Int)}`
 /// - The lambda `fn(x: Int) { x * 2 }` inside should be inferred as pure
 /// - If EffectVar { id: 0 } collision occurs, the lambda might get typed as effectful

--- a/tests/effect_var_collision.rs
+++ b/tests/effect_var_collision.rs
@@ -93,7 +93,7 @@ fn main() { }
 /// might get incorrectly typed as effectful, causing this to fail.
 ///
 /// This is the KEY test for the bug:
-/// - `apply_pure` requires `fn(Int) ->{} Int` (explicit pure-effectful function)
+/// - `apply_pure` requires `fn(Int) ->{} Int` (explicit pure function)
 /// - `effectful_using_pure` is `->{State(Int)}`
 /// - The lambda `fn(x: Int) { x * 2 }` inside should be inferred as pure
 /// - If EffectVar { id: 0 } collision occurs, the lambda might get typed as effectful

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -117,7 +117,7 @@ ability State {
 
 fn direct() -> Int { +1 }
 
-fn pure_effectful() ->{} Int { +1 }
+fn explicit_pure() ->{} Int { +1 }
 
 fn evidence_direct() ->{Logger} Int { +2 }
 
@@ -152,8 +152,8 @@ fn main() { }
             (0, true, false, false)
         );
         assert_eq!(
-            function_abi(&ctx, &module, "pure_effectful"),
-            (0, true, false, false)
+            function_abi(&ctx, &module, "explicit_pure"),
+            (0, false, false, false)
         );
         assert_eq!(
             function_abi(&ctx, &module, "call_evidence_direct"),
@@ -217,7 +217,7 @@ fn main() { }
 
         assert_eq!(
             function_param_names(&ctx, &module, "direct_closure::__clam_0"),
-            ["__evidence", "__env", "x"]
+            ["__env", "x"]
         );
         assert_eq!(
             function_param_names(&ctx, &module, "evidence_direct_closure::__clam_0"),

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -45,6 +45,191 @@ fn get_functions_with_evidence(ctx: &IrContext, module: &Module) -> Vec<(String,
     results
 }
 
+/// Return `(source parameter count, has evidence, has done_k, returns anyref)`.
+fn function_abi(ctx: &IrContext, module: &Module, target: &str) -> (usize, bool, bool, bool) {
+    let func_op = module
+        .ops(ctx)
+        .into_iter()
+        .find_map(|op| {
+            let func_op = func::Func::from_op(ctx, op).ok()?;
+            (func_op.sym_name(ctx) == target).then_some(func_op)
+        })
+        .unwrap_or_else(|| panic!("missing function '{target}'"));
+    let func_ty = func_op.r#type(ctx);
+    let data = ctx.types.get(func_ty);
+    let params = &data.params[1..];
+    let has_evidence = params
+        .first()
+        .is_some_and(|ty| tribute_ir::dialect::ability::is_evidence_type_ref(ctx, *ty));
+    let hidden_count = usize::from(has_evidence)
+        + usize::from(
+            has_evidence
+                && params.get(1).is_some_and(|ty| {
+                    let ty = ctx.types.get(*ty);
+                    ty.dialect == trunk_ir::Symbol::new("tribute_rt")
+                        && ty.name == trunk_ir::Symbol::new("anyref")
+                }),
+        );
+    let has_done_k = hidden_count == 2;
+    let result = ctx.types.get(data.params[0]);
+    let returns_anyref = result.dialect == trunk_ir::Symbol::new("tribute_rt")
+        && result.name == trunk_ir::Symbol::new("anyref");
+    (
+        params.len() - hidden_count,
+        has_evidence,
+        has_done_k,
+        returns_anyref,
+    )
+}
+
+fn function_param_names(ctx: &IrContext, module: &Module, target: &str) -> Vec<String> {
+    let func_op = module
+        .ops(ctx)
+        .into_iter()
+        .find_map(|op| {
+            let func_op = func::Func::from_op(ctx, op).ok()?;
+            (func_op.sym_name(ctx) == target).then_some(func_op)
+        })
+        .unwrap_or_else(|| panic!("missing function '{target}'"));
+    let entry = ctx.region(func_op.body(ctx)).blocks[0];
+    ctx.block(entry)
+        .args
+        .iter()
+        .map(
+            |arg| match arg.attrs.get(&trunk_ir::Symbol::new("bind_name")) {
+                Some(trunk_ir::Attribute::Symbol(name)) => name.to_string(),
+                _ => "_".to_owned(),
+            },
+        )
+        .collect()
+}
+
+#[test]
+fn test_toplevel_calling_conventions_follow_ability_upper_bound() {
+    let code = r#"
+ability Logger {
+    fn log(message: String) -> Nil
+}
+
+ability State {
+    op get() -> Int
+}
+
+fn direct() -> Int { +1 }
+
+fn pure_effectful() ->{} Int { +1 }
+
+fn evidence_direct() ->{Logger} Int { +2 }
+
+fn inferred_evidence_direct() {
+    Logger::log("inferred")
+}
+
+fn call_evidence_direct() ->{Logger} Int {
+    evidence_direct()
+}
+
+fn cps() ->{State} Int {
+    State::get()
+}
+
+fn inferred_cps() -> Int {
+    State::get()
+}
+
+fn main() { }
+"#;
+
+    TributeDatabaseImpl::default().attach(|db| {
+        let (ctx, module) = compile_to_ir(db, code, "calling_conventions.trb");
+
+        assert_eq!(
+            function_abi(&ctx, &module, "direct"),
+            (0, false, false, false)
+        );
+        assert_eq!(
+            function_abi(&ctx, &module, "evidence_direct"),
+            (0, true, false, false)
+        );
+        assert_eq!(
+            function_abi(&ctx, &module, "pure_effectful"),
+            (0, true, false, false)
+        );
+        assert_eq!(
+            function_abi(&ctx, &module, "call_evidence_direct"),
+            (0, true, false, false)
+        );
+        assert_eq!(
+            function_abi(&ctx, &module, "inferred_evidence_direct"),
+            (0, true, false, false)
+        );
+        assert_eq!(function_abi(&ctx, &module, "cps"), (0, true, true, true));
+        assert_eq!(
+            function_abi(&ctx, &module, "inferred_cps"),
+            (0, true, true, true)
+        );
+    });
+}
+
+#[test]
+fn test_lifted_closure_physical_abi_interposes_environment() {
+    let code = r#"
+ability Logger {
+    fn log(message: String) -> Nil
+}
+
+ability State {
+    op get() -> Int
+}
+
+fn call_direct(f: fn(Int) ->{} Int) -> Int {
+    f(+1)
+}
+
+fn call_logger(f: fn(Int) ->{Logger} Int) ->{Logger} Int {
+    f(+1)
+}
+
+fn call_state(f: fn() ->{State} Int) ->{State} Int {
+    f()
+}
+
+fn direct_closure() -> Int {
+    call_direct(fn(x: Int) { x })
+}
+
+fn evidence_direct_closure() ->{Logger} Int {
+    call_logger(fn(x: Int) {
+        Logger::log("called")
+        x
+    })
+}
+
+fn cps_closure() ->{State} Int {
+    call_state(fn() { State::get() })
+}
+
+fn main() { }
+"#;
+
+    TributeDatabaseImpl::default().attach(|db| {
+        let (ctx, module) = compile_to_ir(db, code, "closure_calling_conventions.trb");
+
+        assert_eq!(
+            function_param_names(&ctx, &module, "direct_closure::__clam_0"),
+            ["__evidence", "__env", "x"]
+        );
+        assert_eq!(
+            function_param_names(&ctx, &module, "evidence_direct_closure::__clam_0"),
+            ["__evidence", "__env", "x"]
+        );
+        assert_eq!(
+            function_param_names(&ctx, &module, "cps_closure::__clam_0"),
+            ["__evidence", "__env", "__done_k"]
+        );
+    });
+}
+
 // ========================================================================
 // Pure Lambda Tests
 // ========================================================================

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -5,7 +5,6 @@ expression: ir_text
 core.module @direct_fn_native {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
 
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
@@ -31,7 +30,7 @@ core.module @direct_fn_native {
       func.unreachable
   }
 
-  func.func @"direct_fn_native::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"direct_fn_native::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
 
@@ -39,61 +38,50 @@ core.module @direct_fn_native {
       func.return %2
   }
 
-  func.func @"direct_fn_native::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = func.constant {func_ref = @"run::__clam_0"} : !t1
+      %2 = func.constant {func_ref = @"run::__clam_0"} : core.func(tribute_rt.anyref)
       %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"direct_fn_native::__lambda_5"} : !t1
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %8 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      %4 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %5 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %8 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
       %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %11 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %11 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
-      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
-      %16 = func.call {callee = @__tribute_next_tag} : core.i32
-      %17 = arith.const {value = 1361557906} : core.i32
-      %18 = core.unrealized_conversion_cast %15 : core.ptr
-      %19 = core.unrealized_conversion_cast %12 : core.ptr
-      %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
-      %21 = func.call_indirect %8, %20, %9, %6 : tribute_rt.anyref
-      %22 = tribute_rt.unbox_int %21 : core.i32
-      %23 = tribute_rt.unbox_int %21 : core.i32
-      %24 = arith.const {value = unit} : core.nil
-      func.return %24
+      %13 = func.call {callee = @__tribute_next_tag} : core.i32
+      %14 = arith.const {value = 1361557906} : core.i32
+      %15 = core.unrealized_conversion_cast %12 : core.ptr
+      %16 = core.unrealized_conversion_cast %9 : core.ptr
+      %17 = func.call %0, %14, %13, %15, %16 {callee = @__tribute_evidence_extend} : core.ptr
+      %18 = func.call_indirect %5, %17, %6 : tribute_rt.anyref
+      %19 = tribute_rt.unbox_int %18 : core.i32
+      %20 = tribute_rt.unbox_int %18 : core.i32
+      %21 = arith.const {value = unit} : core.nil
+      func.return %21
   }
 
-  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = arith.const {value = 1361557906} : core.i32
-      %6 = func.call %0, %5 {callee = @__tribute_evidence_lookup_tr} : core.ptr
-      %7 = arith.const {value = 664197438} : core.i32
-      %8 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %10 = func.call_indirect %8, %0, %9, %7, %4 : tribute_rt.anyref
-      %11 = tribute_rt.unbox_int %10 : core.i32
-      %12 = arith.const {value = 1361557906} : core.i32
-      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_tr} : core.ptr
-      %14 = arith.const {value = 2110389019} : core.i32
-      %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %17 = func.call_indirect %15, %0, %16, %14, %10 : tribute_rt.anyref
-      %18 = core.unrealized_conversion_cast %17 : core.nil
-      %19 = core.unrealized_conversion_cast %2 : closure.closure(!t1)
-      %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-      %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-      %22 = func.call_indirect %20, %0, %21, %10 : tribute_rt.anyref
-      func.return %22
+  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = arith.const {value = 1361557906} : core.i32
+      %5 = func.call %0, %4 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %6 = arith.const {value = 664197438} : core.i32
+      %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %9 = func.call_indirect %7, %0, %8, %6, %3 : tribute_rt.anyref
+      %10 = tribute_rt.unbox_int %9 : core.i32
+      %11 = arith.const {value = 1361557906} : core.i32
+      %12 = func.call %0, %11 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %13 = arith.const {value = 2110389019} : core.i32
+      %14 = adt.struct_get %12 {field = 0, type = !_closure} : core.i32
+      %15 = adt.struct_get %12 {field = 1, type = !_closure} : tribute_rt.anyref
+      %16 = func.call_indirect %14, %0, %15, %13, %9 : tribute_rt.anyref
+      %17 = core.unrealized_conversion_cast %16 : core.nil
+      func.return %9
   }
 
   func.func @"run::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -47,7 +47,7 @@ core.module @mixed_nested_native {
       func.return %2
   }
 
-  func.func @"mixed_nested_native::__lambda_10"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"mixed_nested_native::__lambda_12"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
 
@@ -55,37 +55,30 @@ core.module @mixed_nested_native {
       func.return %2
   }
 
-  func.func @"mixed_nested_native::__lambda_14"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
+      %2 = func.constant {func_ref = @"run_all::__clam_0"} : core.func(tribute_rt.anyref)
       %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"mixed_nested_native::__lambda_10"} : !t1
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %8 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      %4 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %5 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %8 = func.constant {func_ref = @"run_all::__clam_1"} : !t3
+      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
       %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %11 = func.constant {func_ref = @"run_all::__clam_1"} : !t3
+      %11 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
-      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
-      %16 = func.call {callee = @__tribute_next_tag} : core.i32
-      %17 = arith.const {value = 1361557906} : core.i32
-      %18 = core.unrealized_conversion_cast %15 : core.ptr
-      %19 = core.unrealized_conversion_cast %12 : core.ptr
-      %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
-      %21 = func.call_indirect %8, %20, %9, %6 : tribute_rt.anyref
-      %22 = tribute_rt.unbox_int %21 : core.i32
-      %23 = tribute_rt.unbox_int %21 : core.i32
-      %24 = arith.const {value = unit} : core.nil
-      func.return %24
+      %13 = func.call {callee = @__tribute_next_tag} : core.i32
+      %14 = arith.const {value = 1361557906} : core.i32
+      %15 = core.unrealized_conversion_cast %12 : core.ptr
+      %16 = core.unrealized_conversion_cast %9 : core.ptr
+      %17 = func.call %0, %14, %13, %15, %16 {callee = @__tribute_evidence_extend} : core.ptr
+      %18 = func.call_indirect %5, %17, %6 : tribute_rt.anyref
+      %19 = tribute_rt.unbox_int %18 : core.i32
+      %20 = tribute_rt.unbox_int %18 : core.i32
+      %21 = arith.const {value = unit} : core.nil
+      func.return %21
   }
 
   func.func @"step::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -152,33 +145,29 @@ core.module @mixed_nested_native {
       func.return %7
   }
 
-  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = func.constant {func_ref = @"mixed_nested_native::__lambda_5"} : !t1
-      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-      %10 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %11 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %13 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t3
-      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
-      %15 = arith.const {value = 0} : tribute_rt.anyref
-      %16 = func.call {callee = @__tribute_next_tag} : core.i32
-      %17 = arith.const {value = 3214451656} : core.i32
-      %18 = core.unrealized_conversion_cast %15 : core.ptr
-      %19 = core.unrealized_conversion_cast %14 : core.ptr
-      %20 = func.call %0, %17, %16, %18, %19 {callee = @__tribute_evidence_extend} : core.ptr
-      %21 = func.call_indirect %10, %20, %11, %9 : tribute_rt.anyref
-      %22 = tribute_rt.unbox_int %21 : core.i32
-      %23 = tribute_rt.unbox_int %21 : core.i32
-      %24 = core.unrealized_conversion_cast %2 : !t2
-      %25 = adt.struct_get %24 {field = 0, type = !_closure} : core.i32
-      %26 = adt.struct_get %24 {field = 1, type = !_closure} : tribute_rt.anyref
-      %27 = func.call_indirect %25, %0, %26, %21 : tribute_rt.anyref
-      func.return %27
+  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %7 = func.constant {func_ref = @"mixed_nested_native::__lambda_5"} : !t1
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %12 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t3
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = arith.const {value = 0} : tribute_rt.anyref
+      %15 = func.call {callee = @__tribute_next_tag} : core.i32
+      %16 = arith.const {value = 3214451656} : core.i32
+      %17 = core.unrealized_conversion_cast %14 : core.ptr
+      %18 = core.unrealized_conversion_cast %13 : core.ptr
+      %19 = func.call %0, %16, %15, %17, %18 {callee = @__tribute_evidence_extend} : core.ptr
+      %20 = func.call_indirect %9, %19, %10, %8 : tribute_rt.anyref
+      %21 = tribute_rt.unbox_int %20 : core.i32
+      %22 = tribute_rt.unbox_int %20 : core.i32
+      func.return %20
   }
 
   func.func @"run_all::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: tribute_rt.anyref) -> tribute_rt.anyref {

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -46,7 +46,7 @@ core.module @resumptive_op_native {
       func.return %2
   }
 
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %2 = func.constant {func_ref = @"run_state::__clam_0"} : !t1

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -8,12 +8,12 @@ core.module @direct_fn {
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
+  !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, closure.closure(!t1), tribute_rt.anyref))
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -30,19 +30,14 @@ core.module @direct_fn {
       func.unreachable
   }
 
-  func.func @use_console(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %3 : core.i32
-      %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %6 = effect.dispatch_tail %0, %5 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %6 : core.nil
-      %8 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %9 = core.unrealized_conversion_cast %1 : closure.closure(!t1)
-      %10 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-      %11 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-      %12 = func.call_indirect %10, %0, %11, %8 : tribute_rt.anyref
-      func.return %12
+  func.func @use_console(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %2 = effect.dispatch_tail %0, %1 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
+      %3 = core.unrealized_conversion_cast %2 : core.i32
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %5 = effect.dispatch_tail %0, %4 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %5 : core.nil
+      func.return %3
   }
 
   func.func @"direct_fn::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -61,46 +56,40 @@ core.module @direct_fn {
       func.return %2
   }
 
-  func.func @"direct_fn::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @run() -> core.i32 {
+  func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 0} : core.i32
       %1 = adt.array_new %0 {type = !t0} : !t0
       %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"run::__clam_0"} : !t1
+      %3 = func.constant {func_ref = @"run::__clam_0"} : core.func(tribute_rt.anyref)
       %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"direct_fn::__lambda_5"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.ref_null {type = !t0} : !t0
-      %9 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %5 = adt.ref_null {type = !t0} : !t0
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
       %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %12 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+      %12 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-      %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = effect.extend %1, %17, %16, %13 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %19 = func.call_indirect %9, %18, %10, %7 : tribute_rt.anyref
-      %20 = core.unrealized_conversion_cast %19 : core.i32
-      %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
-      %22 = core.unrealized_conversion_cast %21 : core.i32
-      func.return %22
+      %14 = func.call {callee = @__tribute_next_tag} : core.i32
+      %15 = effect.extend %1, %14, %13, %10 {ability_ref = core.ability_ref() {name = @Console}} : !t0
+      %16 = func.call_indirect %6, %15, %7 : tribute_rt.anyref
+      %17 = core.unrealized_conversion_cast %16 : core.i32
+      %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %18 : core.i32
+      func.return %19
   }
 
-  func.func @main() -> core.nil {
-      %0 = func.call {callee = @run} : core.i32
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
+      %0 = func.call {callee = @run, tribute.calling_convention = 0} : core.i32
       %1 = arith.const {value = unit} : core.nil
       func.return %1
   }
 
-  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_null {type = !t0} : !t0
-      %4 = func.call %0, %2 {callee = @use_console} : tribute_rt.anyref
+  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = func.call %0 {callee = @use_console} : core.i32
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
       func.return %4
   }
 
@@ -109,7 +98,7 @@ core.module @direct_fn {
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
           %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"direct_fn::__lambda_8"} : !t1
+          %9 = func.constant {func_ref = @"direct_fn::__lambda_7"} : !t1
           %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
           %11 = arith.const {value = 41} : core.i32
           %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
@@ -118,7 +107,7 @@ core.module @direct_fn {
           %13 = arith.const {value = 1} : core.i1
           %14 = scf.if %13 : tribute_rt.anyref {
               %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %16 = func.constant {func_ref = @"direct_fn::__lambda_9"} : !t1
+              %16 = func.constant {func_ref = @"direct_fn::__lambda_8"} : !t1
               %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
               %18 = arith.const {value = unit} : core.nil
               %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/active_pipeline_goldens.rs
-assertion_line: 253
 expression: ir_text
 ---
 core.module @float_comparisons {
@@ -8,7 +7,6 @@ core.module @float_comparisons {
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
   !t2 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
@@ -16,6 +14,7 @@ core.module @float_comparisons {
   !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
+  !t1 = closure.closure(core.func(tribute_rt.anyref, !t0, closure.closure(!t2), tribute_rt.anyref))
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -33,7 +32,7 @@ core.module @float_comparisons {
       func.unreachable
   }
 
-  func.func @main() -> core.nil {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 1.0} : core.f64
       %1 = arith.const {value = 2.0} : core.f64
       %2 = arith.cmpf %0, %1 {predicate = @oeq} : core.i1

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -10,7 +10,6 @@ core.module @mixed_nested {
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
   !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
-  !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
   !t3 = closure.closure(!t1)
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
@@ -18,6 +17,7 @@ core.module @mixed_nested {
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
+  !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, !t3, tribute_rt.anyref))
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -34,7 +34,7 @@ core.module @mixed_nested {
       func.unreachable
   }
 
-  func.func @step(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @step(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
       %4 = core.unrealized_conversion_cast %3 : core.i32
@@ -67,31 +67,26 @@ core.module @mixed_nested {
       func.return %2
   }
 
-  func.func @run_state_with_console(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"mixed_nested::__lambda_5"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %11 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t4
-      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
-      %13 = arith.const {value = 0} : tribute_rt.anyref
-      %14 = func.call {callee = @__tribute_next_tag} : core.i32
-      %15 = effect.extend %0, %14, %13, %12 {ability_ref = core.ability_ref() {name = @State}} : !t0
-      %16 = func.call_indirect %8, %15, %9, %7 : tribute_rt.anyref
-      %17 = core.unrealized_conversion_cast %16 : core.i32
-      %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
-      %19 = core.unrealized_conversion_cast %18 : core.i32
-      %20 = core.unrealized_conversion_cast %19 : tribute_rt.anyref
-      %21 = core.unrealized_conversion_cast %1 : !t3
-      %22 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
-      %23 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
-      %24 = func.call_indirect %22, %0, %23, %20 : tribute_rt.anyref
-      func.return %24
+  func.func @run_state_with_console(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %2 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
+      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
+      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %5 = func.constant {func_ref = @"mixed_nested::__lambda_5"} : !t1
+      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
+      %7 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %10 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t4
+      %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
+      %12 = arith.const {value = 0} : tribute_rt.anyref
+      %13 = func.call {callee = @__tribute_next_tag} : core.i32
+      %14 = effect.extend %0, %13, %12, %11 {ability_ref = core.ability_ref() {name = @State}} : !t0
+      %15 = func.call_indirect %7, %14, %8, %6 : tribute_rt.anyref
+      %16 = core.unrealized_conversion_cast %15 : core.i32
+      %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+      %18 = core.unrealized_conversion_cast %17 : core.i32
+      func.return %18
   }
 
   func.func @"mixed_nested::__lambda_10"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -110,39 +105,32 @@ core.module @mixed_nested {
       func.return %2
   }
 
-  func.func @"mixed_nested::__lambda_14"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @run_all() -> core.i32 {
+  func.func @run_all() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 0} : core.i32
       %1 = adt.array_new %0 {type = !t0} : !t0
       %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
+      %3 = func.constant {func_ref = @"run_all::__clam_0"} : core.func(tribute_rt.anyref)
       %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"mixed_nested::__lambda_10"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.ref_null {type = !t0} : !t0
-      %9 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %5 = adt.ref_null {type = !t0} : !t0
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run_all::__clam_1"} : !t4
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
       %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %12 = func.constant {func_ref = @"run_all::__clam_1"} : !t4
+      %12 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-      %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = effect.extend %1, %17, %16, %13 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %19 = func.call_indirect %9, %18, %10, %7 : tribute_rt.anyref
-      %20 = core.unrealized_conversion_cast %19 : core.i32
-      %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
-      %22 = core.unrealized_conversion_cast %21 : core.i32
-      func.return %22
+      %14 = func.call {callee = @__tribute_next_tag} : core.i32
+      %15 = effect.extend %1, %14, %13, %10 {ability_ref = core.ability_ref() {name = @Console}} : !t0
+      %16 = func.call_indirect %6, %15, %7 : tribute_rt.anyref
+      %17 = core.unrealized_conversion_cast %16 : core.i32
+      %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
+      %19 = core.unrealized_conversion_cast %18 : core.i32
+      func.return %19
   }
 
-  func.func @main() -> core.nil {
-      %0 = func.call {callee = @run_all} : core.i32
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
+      %0 = func.call {callee = @run_all, tribute.calling_convention = 0} : core.i32
       %1 = arith.const {value = unit} : core.nil
       func.return %1
   }
@@ -202,9 +190,10 @@ core.module @mixed_nested {
       func.return %7
   }
 
-  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_null {type = !t0} : !t0
-      %4 = func.call %0, %2 {callee = @run_state_with_console} : tribute_rt.anyref
+  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+      %2 = adt.ref_null {type = !t0} : !t0
+      %3 = func.call %0 {callee = @run_state_with_console} : core.i32
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
       func.return %4
   }
 
@@ -213,7 +202,7 @@ core.module @mixed_nested {
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
           %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"mixed_nested::__lambda_13"} : !t1
+          %9 = func.constant {func_ref = @"mixed_nested::__lambda_12"} : !t1
           %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
           %11 = arith.const {value = 3} : core.i32
           %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
@@ -222,7 +211,7 @@ core.module @mixed_nested {
           %13 = arith.const {value = 1} : core.i1
           %14 = scf.if %13 : tribute_rt.anyref {
               %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %16 = func.constant {func_ref = @"mixed_nested::__lambda_14"} : !t1
+              %16 = func.constant {func_ref = @"mixed_nested::__lambda_13"} : !t1
               %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
               %18 = arith.const {value = unit} : core.nil
               %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -9,7 +9,6 @@ core.module @resumptive_op {
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
-  !t2 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref))
   !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
   !t3 = closure.closure(!t1)
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
@@ -17,6 +16,7 @@ core.module @resumptive_op {
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
+  !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, !t3, tribute_rt.anyref))
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -33,7 +33,7 @@ core.module @resumptive_op {
       func.unreachable
   }
 
-  func.func @bump(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @bump(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = adt.struct_new %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
       %3 = func.constant {func_ref = @"bump::__clam_0"} : !t1
       %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
@@ -63,7 +63,7 @@ core.module @resumptive_op {
       func.return %2
   }
 
-  func.func @run_state() -> core.i32 {
+  func.func @run_state() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 0} : core.i32
       %1 = adt.array_new %0 {type = !t0} : !t0
       %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -88,8 +88,8 @@ core.module @resumptive_op {
       func.return %20
   }
 
-  func.func @main() -> core.nil {
-      %0 = func.call {callee = @run_state} : core.i32
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
+      %0 = func.call {callee = @run_state, tribute.calling_convention = 0} : core.i32
       %1 = arith.const {value = unit} : core.nil
       func.return %1
   }


### PR DESCRIPTION
Closes #768.

## Summary
- Add first-class calling convention support to core ABI and frontend AST/type checking.
- Thread calling convention information through lowering, monomorphization, resolution, and signature conversion.
- Update closure, CPS, native entrypoint, and wasm lowering paths to preserve the selected convention.
- Refresh snapshots and coverage around lambdas, effects, tuples, records, patterns, and block scoping.

## Testing
- Updated snapshot coverage for the affected AST-to-IR and lowering cases.
- Validation passed across the touched compiler pipeline areas and related regression scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added calling-convention metadata and ABI-aware lowering across functions, lambdas, closures, and indirect calls (Direct, EvidenceDirect, CPS), including environment/evidence/done-k layout selection.
  * Exposed ability-level calling-convention information through type checking and drove entrypoint/WASM `_start` hidden-argument generation from it.
* **Bug Fixes**
  * Fixed convention-aware closure environment interposition and hidden-argument ordering for indirect calls.
  * Preserved custom operation attributes during IR signature conversion.
* **Documentation**
  * Clarified empty effect/ability syntax and refined evidence/done-k ABI semantics.
* **Tests**
  * Expanded ABI, entrypoint, closure, and attribute-preservation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->