### PR TITLE
Refine CPS effect lowering for shared identity handling

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -55,6 +55,11 @@ pub struct IrLoweringCtx<'db> {
     module_path: SymbolVec,
     /// Counter for generating unique lambda names.
     lambda_counter: u64,
+    /// Shared identity `done_k` function for this compilation unit.
+    ///
+    /// The function definition is emitted once in the compilation root, while
+    /// each SSA region still creates its own closure value referencing it.
+    identity_done_k_func: Option<Symbol>,
     /// Counter for generating unique local IDs (for synthetic bindings like continuations).
     local_id_counter: u32,
     /// Module's top-level block, used for in-place insertion of lifted lambdas.
@@ -111,6 +116,7 @@ impl<'db> IrLoweringCtx<'db> {
             definition_conventions: HashMap::new(),
             module_path,
             lambda_counter: 0,
+            identity_done_k_func: None,
             local_id_counter: 0x8000_0000, // Start high to avoid collisions with parsed LocalIds
             module_block: None,
             struct_fields: HashMap::new(),
@@ -326,6 +332,31 @@ impl<'db> IrLoweringCtx<'db> {
                 .join("::");
             Symbol::from_dynamic(&format!("{}::{}", path_str, lambda_name))
         }
+    }
+
+    /// Generate a unique lambda name owned by the compilation root.
+    pub(crate) fn gen_compilation_unit_lambda_name(&mut self) -> Symbol {
+        let lambda_name = format!("__lambda_{}", self.lambda_counter);
+        self.lambda_counter += 1;
+
+        self.module_path.first().map_or_else(
+            || Symbol::from_dynamic(&lambda_name),
+            |root| Symbol::from_dynamic(&format!("{root}::{lambda_name}")),
+        )
+    }
+
+    /// Return the shared identity `done_k` function, initializing it if needed.
+    ///
+    /// The symbol is cached only after `init` completes successfully.
+    pub(crate) fn identity_done_k_func(&mut self, init: impl FnOnce(Symbol)) -> Symbol {
+        if let Some(name) = self.identity_done_k_func {
+            return name;
+        }
+
+        let name = self.gen_compilation_unit_lambda_name();
+        init(name);
+        self.identity_done_k_func = Some(name);
+        name
     }
 
     /// Register struct field order for lowering Record expressions.

--- a/crates/tribute-front/src/ast_to_ir/lower/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/mod.rs
@@ -328,8 +328,10 @@ pub(super) fn is_irrefutable_pattern<R: salsa::Update>(pattern: &Pattern<R>) -> 
 
 /// Create an identity `done_k` closure: `fn(result: anyref) -> anyref { return result }`.
 ///
-/// Built as a direct `func.func` + `closure.new` (NOT `closure.lambda`), so it
-/// bypasses `lower_closure_lambda` and has a fixed, known signature:
+/// The direct `func.func` definition is shared by the entire compilation unit.
+/// Each call still creates a region-local `closure.new`, so SSA values do not
+/// cross region boundaries. This bypasses `lower_closure_lambda` and has a
+/// fixed, known signature:
 /// `(evidence, env, result) -> anyref`.
 ///
 /// This is an internal mechanism closure, not a user lambda.
@@ -344,51 +346,50 @@ pub(super) fn create_identity_done_k(
 
     let anyref_ty = builder.ctx.anyref_type(builder.ir);
     let evidence_ty = ability::evidence_adt_type_ref(builder.ir);
-
-    let dk_name = builder.ctx.gen_lambda_name();
-
-    // func.func @identity_dk(%evidence, %env, %result) -> anyref { return %result }
-    let dk_block = builder.ir.create_block(BlockData {
-        location,
-        args: vec![
-            BlockArgData {
-                ty: evidence_ty,
-                attrs: Default::default(),
-            },
-            BlockArgData {
-                ty: anyref_ty,
-                attrs: Default::default(),
-            },
-            BlockArgData {
-                ty: anyref_ty,
-                attrs: Default::default(),
-            },
-        ],
-        ops: Default::default(),
-        parent_region: None,
-    });
-    let result_param = builder.ir.block_arg(dk_block, 2); // result is 3rd arg
-    let ret = func::r#return(builder.ir, location, [result_param]);
-    builder.ir.push_op(dk_block, ret.op_ref());
-
-    let dk_region = builder.ir.create_region(RegionData {
-        location,
-        blocks: trunk_ir::smallvec::smallvec![dk_block],
-        parent_op: None,
-    });
-
     let all_param_types = vec![evidence_ty, anyref_ty, anyref_ty];
     let dk_func_ty = builder
         .ctx
         .func_type(builder.ir, &all_param_types, anyref_ty);
-    let dk_func_op = func::func(builder.ir, location, dk_name, dk_func_ty, dk_region);
-
-    // Push to module block
     let module_block = builder
         .ctx
         .module_block()
         .expect("module block should be set");
-    builder.ir.push_op(module_block, dk_func_op.op_ref());
+
+    let dk_name = builder.ctx.identity_done_k_func(|name| {
+        // func.func @identity_dk(%evidence, %env, %result) -> anyref { return %result }
+        let dk_block = builder.ir.create_block(BlockData {
+            location,
+            args: vec![
+                BlockArgData {
+                    ty: evidence_ty,
+                    attrs: Default::default(),
+                },
+                BlockArgData {
+                    ty: anyref_ty,
+                    attrs: Default::default(),
+                },
+                BlockArgData {
+                    ty: anyref_ty,
+                    attrs: Default::default(),
+                },
+            ],
+            ops: Default::default(),
+            parent_region: None,
+        });
+        let result_param = builder.ir.block_arg(dk_block, 2); // result is 3rd arg
+        let ret = func::r#return(builder.ir, location, [result_param]);
+        builder.ir.push_op(dk_block, ret.op_ref());
+
+        let dk_region = builder.ir.create_region(RegionData {
+            location,
+            blocks: trunk_ir::smallvec::smallvec![dk_block],
+            parent_op: None,
+        });
+
+        let dk_func_op = func::func(builder.ir, location, name, dk_func_ty, dk_region);
+
+        builder.ir.push_op(module_block, dk_func_op.op_ref());
+    });
 
     // closure.new @identity_dk, null_env
     let null_op = adt::ref_null(builder.ir, location, anyref_ty, anyref_ty);

--- a/crates/tribute-front/tests/lambda_effect_type.rs
+++ b/crates/tribute-front/tests/lambda_effect_type.rs
@@ -13,6 +13,38 @@ use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
 use tribute_front::SourceCst;
 
+fn assert_shared_identity_done_k(ir_text: &str, expected_references: usize) {
+    let lines: Vec<_> = ir_text.lines().collect();
+    let identity_done_k_headers: Vec<_> = lines
+        .windows(2)
+        .filter_map(|pair| {
+            let header = pair[0].trim_start();
+            (header.starts_with("func.func ")
+                && header.contains("%2: tribute_rt.anyref) -> tribute_rt.anyref")
+                && pair[1].trim() == "func.return %2")
+                .then_some(header)
+        })
+        .collect();
+    assert_eq!(
+        identity_done_k_headers.len(),
+        1,
+        "identity done_k should have one function definition per compilation unit"
+    );
+
+    let identity_done_k_symbol = identity_done_k_headers[0]
+        .strip_prefix("func.func ")
+        .expect("identity done_k header should start with func.func")
+        .split('(')
+        .next()
+        .expect("identity done_k header should contain a parameter list");
+    let identity_done_k_ref = format!("func_ref = {identity_done_k_symbol}");
+    assert_eq!(
+        ir_text.matches(&identity_done_k_ref).count(),
+        expected_references,
+        "all identity done_k closures should reference the shared function"
+    );
+}
+
 // ========================================================================
 // Pure Lambda Tests - No Effect Expected
 // ========================================================================
@@ -241,6 +273,7 @@ fn main() -> Int {
     );
 
     let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert_shared_identity_done_k(&ir_text, 6);
     assert_snapshot!(ir_text);
 }
 

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
@@ -14,15 +14,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda() -> tribute_rt.anyref {
           %1 = adt.ref_null {type = !t1} : !t1
@@ -36,7 +27,7 @@ core.module @test {
           %10 = arith.cmpi %7, %9 {predicate = @eq} : core.i1
           %11 = scf.if %10 : tribute_rt.anyref {
               %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %13 = closure.new %12 {func_ref = @"test::__lambda_2"} : !t0
+              %13 = closure.new %12 {func_ref = @"test::__lambda_0"} : !t0
               %14 = arith.const {value = 42} : core.i32
               %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
               %16 = core.unrealized_conversion_cast %6 : !t0
@@ -46,7 +37,7 @@ core.module @test {
               %18 = arith.const {value = 1} : core.i1
               %19 = scf.if %18 : tribute_rt.anyref {
                   %20 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %21 = closure.new %20 {func_ref = @"test::__lambda_3"} : !t0
+                  %21 = closure.new %20 {func_ref = @"test::__lambda_0"} : !t0
                   %22 = arith.const {value = unit} : core.nil
                   %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
                   %24 = core.unrealized_conversion_cast %6 : !t0
@@ -79,7 +70,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb10(%38: tribute_rt.anyref, %39: tribute_rt.anyref):
               %40 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %41 = closure.new %40 {func_ref = @"test::__lambda_1"} : !t0
+              %41 = closure.new %40 {func_ref = @"test::__lambda_0"} : !t0
               %42 = arith.const {value = unit} : core.nil
               %43 = core.unrealized_conversion_cast %42 : tribute_rt.anyref
               %44 = core.unrealized_conversion_cast %38 : !t0

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
@@ -14,15 +14,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda() -> tribute_rt.anyref {
           %1 = adt.ref_null {type = !t0} : !t0
@@ -36,7 +27,7 @@ core.module @test {
           %10 = arith.cmpi %7, %9 {predicate = @eq} : core.i1
           %11 = scf.if %10 : tribute_rt.anyref {
               %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %13 = closure.new %12 {func_ref = @"test::__lambda_2"} : !t1
+              %13 = closure.new %12 {func_ref = @"test::__lambda_0"} : !t1
               %14 = arith.const {value = 42} : core.i32
               %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
               scf.yield %15
@@ -44,7 +35,7 @@ core.module @test {
               %16 = arith.const {value = 1} : core.i1
               %17 = scf.if %16 : tribute_rt.anyref {
                   %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t1
+                  %19 = closure.new %18 {func_ref = @"test::__lambda_0"} : !t1
                   %20 = arith.const {value = unit} : core.nil
                   %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
                   scf.yield %21
@@ -92,7 +83,7 @@ core.module @test {
           ability.yield {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb15(%43: tribute_rt.anyref, %44: tribute_rt.anyref):
               %45 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %46 = closure.new %45 {func_ref = @"test::__lambda_1"} : !t1
+              %46 = closure.new %45 {func_ref = @"test::__lambda_0"} : !t1
               %47 = arith.const {value = unit} : core.nil
               %48 = core.unrealized_conversion_cast %47 : tribute_rt.anyref
               scf.yield %48

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
@@ -13,12 +13,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
           %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref [%1] {
@@ -41,7 +35,7 @@ core.module @test {
           %19 = arith.const {value = 1} : core.i1
           %20 = scf.if %19 : tribute_rt.anyref {
               %21 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %22 = closure.new %21 {func_ref = @"test::__lambda_2"} : !t0
+              %22 = closure.new %21 {func_ref = @"test::__lambda_0"} : !t0
               %23 = arith.const {value = 41} : core.i32
               %24 = core.unrealized_conversion_cast %23 : tribute_rt.anyref
               %25 = core.unrealized_conversion_cast %16 : !t0
@@ -62,7 +56,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
             ^bb8(%31: tribute_rt.anyref, %32: tribute_rt.anyref):
               %33 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %34 = closure.new %33 {func_ref = @"test::__lambda_1"} : !t0
+              %34 = closure.new %33 {func_ref = @"test::__lambda_0"} : !t0
               %35 = arith.const {value = 41} : core.i32
               %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
               %37 = core.unrealized_conversion_cast %31 : !t0

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
@@ -13,12 +13,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
           %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
@@ -31,7 +25,7 @@ core.module @test {
           %12 = arith.const {value = 1} : core.i1
           %13 = scf.if %12 : tribute_rt.anyref {
               %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
+              %15 = closure.new %14 {func_ref = @"test::__lambda_0"} : !t0
               %16 = func.call %0, %15 {callee = @read_log, tribute.calling_convention = 2} : tribute_rt.anyref
               %17 = core.unrealized_conversion_cast %16 : core.i32
               %18 = arith.const {value = 1} : core.i32
@@ -54,7 +48,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
             ^bb7(%26: tribute_rt.anyref, %27: tribute_rt.anyref):
               %28 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %29 = closure.new %28 {func_ref = @"test::__lambda_1"} : !t0
+              %29 = closure.new %28 {func_ref = @"test::__lambda_0"} : !t0
               %30 = func.call %0, %29 {callee = @read_log, tribute.calling_convention = 2} : tribute_rt.anyref
               %31 = core.unrealized_conversion_cast %30 : core.i32
               %32 = arith.const {value = 1} : core.i32

--- a/crates/tribute-front/tests/snapshots/cps_lowering__resume_in_op_handler.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__resume_in_op_handler.snap
@@ -4,18 +4,8 @@ expression: ir_text
 ---
 core.module @test {
   !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
   func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
@@ -30,7 +20,7 @@ core.module @test {
           %9 = arith.cmpi %6, %8 {predicate = @eq} : core.i1
           %10 = scf.if %9 : tribute_rt.anyref {
               %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %12 = closure.new %11 {func_ref = @"test::__lambda_2"} : !t0
+              %12 = closure.new %11 {func_ref = @"test::__lambda_0"} : !t0
               %13 = arith.const {value = 0} : core.i32
               %14 = core.unrealized_conversion_cast %13 : tribute_rt.anyref
               %15 = core.unrealized_conversion_cast %5 : !t0
@@ -40,7 +30,7 @@ core.module @test {
               %17 = arith.const {value = 1} : core.i1
               %18 = scf.if %17 : tribute_rt.anyref {
                   %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %20 = closure.new %19 {func_ref = @"test::__lambda_3"} : !t0
+                  %20 = closure.new %19 {func_ref = @"test::__lambda_0"} : !t0
                   %21 = arith.const {value = unit} : core.nil
                   %22 = core.unrealized_conversion_cast %21 : tribute_rt.anyref
                   %23 = core.unrealized_conversion_cast %5 : !t0
@@ -73,7 +63,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb10(%37: tribute_rt.anyref, %38: tribute_rt.anyref):
               %39 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %40 = closure.new %39 {func_ref = @"test::__lambda_1"} : !t0
+              %40 = closure.new %39 {func_ref = @"test::__lambda_0"} : !t0
               %41 = arith.const {value = unit} : core.nil
               %42 = core.unrealized_conversion_cast %41 : tribute_rt.anyref
               %43 = core.unrealized_conversion_cast %37 : !t0

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
@@ -3,39 +3,33 @@ source: crates/tribute-front/tests/evidence_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
-  func.func @use_ask(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
+  func.func @use_ask(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask} : tribute_rt.anyref
       func.return %2
   }
-  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
   func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: tribute_rt.anyref) -> tribute_rt.anyref {
-          %2 = adt.ref_null {type = !t0} : !t0
+          %2 = adt.ref_null {type = !t1} : !t1
           %3 = func.call %2, %1 {callee = @use_ask, tribute.calling_convention = 2} : tribute_rt.anyref
           func.return %3
       }
       %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t1
+      %5 = closure.new %4 {func_ref = @"test::__lambda_0"} : !t0
       %6 = func.call_indirect %0, %5 : tribute_rt.anyref
       %7 = closure.lambda(%8: tribute_rt.anyref, %9: core.i32, %10: tribute_rt.anyref) -> tribute_rt.anyref {
           %11 = arith.const {value = 1} : core.i1
           %12 = scf.if %11 : tribute_rt.anyref {
               %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %14 = closure.new %13 {func_ref = @"test::__lambda_2"} : !t1
+              %14 = closure.new %13 {func_ref = @"test::__lambda_0"} : !t0
               %15 = arith.const {value = 42} : core.i32
               %16 = core.unrealized_conversion_cast %15 : tribute_rt.anyref
-              %17 = core.unrealized_conversion_cast %8 : !t1
+              %17 = core.unrealized_conversion_cast %8 : !t0
               %18 = func.call_indirect %17, %16 : tribute_rt.anyref
               scf.yield %18
           } {
@@ -53,10 +47,10 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask} {
             ^bb7(%23: tribute_rt.anyref, %24: tribute_rt.anyref):
               %25 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %26 = closure.new %25 {func_ref = @"test::__lambda_1"} : !t1
+              %26 = closure.new %25 {func_ref = @"test::__lambda_0"} : !t0
               %27 = arith.const {value = 42} : core.i32
               %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
-              %29 = core.unrealized_conversion_cast %23 : !t1
+              %29 = core.unrealized_conversion_cast %23 : !t0
               %30 = func.call_indirect %29, %28 : tribute_rt.anyref
               scf.yield %30
           }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -19,18 +19,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref [%2] {
           %6 = core.unrealized_conversion_cast %2 : !t2
@@ -45,7 +33,7 @@ core.module @test {
           %16 = arith.cmpi %13, %15 {predicate = @eq} : core.i1
           %17 = scf.if %16 : tribute_rt.anyref {
               %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
+              %19 = closure.new %18 {func_ref = @"test::__lambda_0"} : !t0
               %20 = closure.lambda(%21: !t1, %22: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12, %3] {
                   %23 = core.unrealized_conversion_cast %12 : !t0
                   %24 = func.call_indirect %23, %3 : tribute_rt.anyref
@@ -59,7 +47,7 @@ core.module @test {
               %28 = arith.const {value = 1} : core.i1
               %29 = scf.if %28 : tribute_rt.anyref {
                   %30 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %31 = closure.new %30 {func_ref = @"test::__lambda_4"} : !t0
+                  %31 = closure.new %30 {func_ref = @"test::__lambda_0"} : !t0
                   %32 = closure.lambda(%33: !t1, %34: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12] {
                       %35 = arith.const {value = unit} : core.nil
                       %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
@@ -87,7 +75,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
             ^bb11(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
               %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %48 = closure.new %47 {func_ref = @"test::__lambda_1"} : !t0
+              %48 = closure.new %47 {func_ref = @"test::__lambda_0"} : !t0
               %49 = closure.lambda(%50: !t1, %51: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%45, %3] {
                   %52 = core.unrealized_conversion_cast %45 : !t0
                   %53 = func.call_indirect %52, %3 : tribute_rt.anyref
@@ -101,7 +89,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb13(%57: tribute_rt.anyref, %58: tribute_rt.anyref):
               %59 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %60 = closure.new %59 {func_ref = @"test::__lambda_2"} : !t0
+              %60 = closure.new %59 {func_ref = @"test::__lambda_0"} : !t0
               %61 = closure.lambda(%62: !t1, %63: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%57] {
                   %64 = arith.const {value = unit} : core.nil
                   %65 = core.unrealized_conversion_cast %64 : tribute_rt.anyref
@@ -119,9 +107,6 @@ core.module @test {
       %72 = func.call_indirect %71, %43 : tribute_rt.anyref
       func.return %72
   }
-  func.func @"test::__lambda_5"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: !t1, %2: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
           %3 = func.call %1 {callee = @counter, tribute.calling_convention = 1} : core.i32
@@ -136,7 +121,7 @@ core.module @test {
       %10 = core.unrealized_conversion_cast %9 : tribute_rt.anyref
       %11 = adt.ref_null {type = !t1} : !t1
       %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %13 = closure.new %12 {func_ref = @"test::__lambda_5"} : !t0
+      %13 = closure.new %12 {func_ref = @"test::__lambda_0"} : !t0
       %14 = func.call %11, %13, %0, %10 {callee = @run_state, tribute.calling_convention = 2} : tribute_rt.anyref
       %15 = core.unrealized_conversion_cast %14 : core.i32
       func.return %15

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
@@ -10,15 +10,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = closure.lambda() -> tribute_rt.anyref [%0] {
           %2 = adt.ref_null {type = !t1} : !t1
@@ -33,7 +24,7 @@ core.module @test {
           %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
           %13 = scf.if %12 : tribute_rt.anyref {
               %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
+              %15 = closure.new %14 {func_ref = @"test::__lambda_0"} : !t0
               %16 = arith.const {value = 42} : core.i32
               %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
               %18 = core.unrealized_conversion_cast %8 : !t0
@@ -43,7 +34,7 @@ core.module @test {
               %20 = arith.const {value = 1} : core.i1
               %21 = scf.if %20 : tribute_rt.anyref {
                   %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %23 = closure.new %22 {func_ref = @"test::__lambda_3"} : !t0
+                  %23 = closure.new %22 {func_ref = @"test::__lambda_0"} : !t0
                   %24 = arith.const {value = unit} : core.nil
                   %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
                   %26 = core.unrealized_conversion_cast %8 : !t0
@@ -76,7 +67,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
               %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %43 = closure.new %42 {func_ref = @"test::__lambda_1"} : !t0
+              %43 = closure.new %42 {func_ref = @"test::__lambda_0"} : !t0
               %44 = arith.const {value = unit} : core.nil
               %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
               %46 = core.unrealized_conversion_cast %40 : !t0

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -3,11 +3,11 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
-  !t2 = closure.closure(core.func(core.i32, !t0))
+  !t0 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !t2 = closure.closure(core.func(core.i32, !t1))
 
-  func.func @counter(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
+  func.func @counter(%0: !t1) -> core.i32 attributes {tribute.calling_convention = 1} {
       %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %2 = core.unrealized_conversion_cast %1 : core.i32
       %3 = arith.const {value = 1} : core.i32
@@ -16,21 +16,12 @@ core.module @test {
       %6 = core.unrealized_conversion_cast %5 : core.nil
       func.return %2
   }
-  func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
   func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = closure.lambda() -> tribute_rt.anyref [%0] {
-          %2 = adt.ref_null {type = !t0} : !t0
+          %2 = adt.ref_null {type = !t1} : !t1
           %3 = core.unrealized_conversion_cast %0 : !t2
           %4 = func.call_indirect %3, %2 {tribute.calling_convention = 1} : core.i32
           %5 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
@@ -42,20 +33,20 @@ core.module @test {
           %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
           %13 = scf.if %12 : tribute_rt.anyref {
               %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t1
+              %15 = closure.new %14 {func_ref = @"test::__lambda_0"} : !t0
               %16 = arith.const {value = 0} : core.i32
               %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
-              %18 = core.unrealized_conversion_cast %8 : !t1
+              %18 = core.unrealized_conversion_cast %8 : !t0
               %19 = func.call_indirect %18, %17 : tribute_rt.anyref
               scf.yield %19
           } {
               %20 = arith.const {value = 1} : core.i1
               %21 = scf.if %20 : tribute_rt.anyref {
                   %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %23 = closure.new %22 {func_ref = @"test::__lambda_3"} : !t1
+                  %23 = closure.new %22 {func_ref = @"test::__lambda_0"} : !t0
                   %24 = arith.const {value = unit} : core.nil
                   %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
-                  %26 = core.unrealized_conversion_cast %8 : !t1
+                  %26 = core.unrealized_conversion_cast %8 : !t0
                   %27 = func.call_indirect %26, %25 : tribute_rt.anyref
                   scf.yield %27
               } {
@@ -75,20 +66,20 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
             ^bb9(%32: tribute_rt.anyref, %33: tribute_rt.anyref):
               %34 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %35 = closure.new %34 {func_ref = @"test::__lambda_0"} : !t1
+              %35 = closure.new %34 {func_ref = @"test::__lambda_0"} : !t0
               %36 = arith.const {value = 0} : core.i32
               %37 = core.unrealized_conversion_cast %36 : tribute_rt.anyref
-              %38 = core.unrealized_conversion_cast %32 : !t1
+              %38 = core.unrealized_conversion_cast %32 : !t0
               %39 = func.call_indirect %38, %37 : tribute_rt.anyref
               scf.yield %39
           }
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
               %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %43 = closure.new %42 {func_ref = @"test::__lambda_1"} : !t1
+              %43 = closure.new %42 {func_ref = @"test::__lambda_0"} : !t0
               %44 = arith.const {value = unit} : core.nil
               %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
-              %46 = core.unrealized_conversion_cast %40 : !t1
+              %46 = core.unrealized_conversion_cast %40 : !t0
               %47 = func.call_indirect %46, %45 : tribute_rt.anyref
               scf.yield %47
           }
@@ -97,7 +88,7 @@ core.module @test {
       func.return %48
   }
   func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
-      %0 = closure.lambda(%1: !t0) -> core.i32 {tribute.calling_convention = 1} {
+      %0 = closure.lambda(%1: !t1) -> core.i32 {tribute.calling_convention = 1} {
           %2 = func.call %1 {callee = @counter, tribute.calling_convention = 1} : core.i32
           func.return %2
       }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
@@ -10,15 +10,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = closure.lambda() -> tribute_rt.anyref [%0] {
           %2 = adt.ref_null {type = !t1} : !t1
@@ -33,7 +24,7 @@ core.module @test {
           %12 = arith.cmpi %9, %11 {predicate = @eq} : core.i1
           %13 = scf.if %12 : tribute_rt.anyref {
               %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %15 = closure.new %14 {func_ref = @"test::__lambda_2"} : !t0
+              %15 = closure.new %14 {func_ref = @"test::__lambda_0"} : !t0
               %16 = arith.const {value = 0} : core.i32
               %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
               %18 = core.unrealized_conversion_cast %8 : !t0
@@ -43,7 +34,7 @@ core.module @test {
               %20 = arith.const {value = 1} : core.i1
               %21 = scf.if %20 : tribute_rt.anyref {
                   %22 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %23 = closure.new %22 {func_ref = @"test::__lambda_3"} : !t0
+                  %23 = closure.new %22 {func_ref = @"test::__lambda_0"} : !t0
                   %24 = arith.const {value = unit} : core.nil
                   %25 = core.unrealized_conversion_cast %24 : tribute_rt.anyref
                   %26 = core.unrealized_conversion_cast %8 : !t0
@@ -76,7 +67,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb10(%40: tribute_rt.anyref, %41: tribute_rt.anyref):
               %42 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %43 = closure.new %42 {func_ref = @"test::__lambda_1"} : !t0
+              %43 = closure.new %42 {func_ref = @"test::__lambda_0"} : !t0
               %44 = arith.const {value = unit} : core.nil
               %45 = core.unrealized_conversion_cast %44 : tribute_rt.anyref
               %46 = core.unrealized_conversion_cast %40 : !t0

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
@@ -10,18 +10,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref [%2] {
           %6 = core.unrealized_conversion_cast %2 : !t2
@@ -36,7 +24,7 @@ core.module @test {
           %16 = arith.cmpi %13, %15 {predicate = @eq} : core.i1
           %17 = scf.if %16 : tribute_rt.anyref {
               %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
+              %19 = closure.new %18 {func_ref = @"test::__lambda_0"} : !t0
               %20 = closure.lambda(%21: !t1, %22: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12, %3] {
                   %23 = core.unrealized_conversion_cast %12 : !t0
                   %24 = func.call_indirect %23, %3 : tribute_rt.anyref
@@ -50,7 +38,7 @@ core.module @test {
               %28 = arith.const {value = 1} : core.i1
               %29 = scf.if %28 : tribute_rt.anyref {
                   %30 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %31 = closure.new %30 {func_ref = @"test::__lambda_4"} : !t0
+                  %31 = closure.new %30 {func_ref = @"test::__lambda_0"} : !t0
                   %32 = closure.lambda(%33: !t1, %34: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12] {
                       %35 = arith.const {value = unit} : core.nil
                       %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
@@ -78,7 +66,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
             ^bb11(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
               %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %48 = closure.new %47 {func_ref = @"test::__lambda_1"} : !t0
+              %48 = closure.new %47 {func_ref = @"test::__lambda_0"} : !t0
               %49 = closure.lambda(%50: !t1, %51: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%45, %3] {
                   %52 = core.unrealized_conversion_cast %45 : !t0
                   %53 = func.call_indirect %52, %3 : tribute_rt.anyref
@@ -92,7 +80,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb13(%57: tribute_rt.anyref, %58: tribute_rt.anyref):
               %59 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %60 = closure.new %59 {func_ref = @"test::__lambda_2"} : !t0
+              %60 = closure.new %59 {func_ref = @"test::__lambda_0"} : !t0
               %61 = closure.lambda(%62: !t1, %63: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%57] {
                   %64 = arith.const {value = unit} : core.nil
                   %65 = core.unrealized_conversion_cast %64 : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -10,18 +10,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_2"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_3"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-  func.func @"test::__lambda_4"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @with_state(%0: !t1, %1: tribute_rt.anyref, %2: core.func(tribute_rt.anyref), %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %4 = closure.lambda(%5: tribute_rt.anyref) -> tribute_rt.anyref [%2] {
           %6 = core.unrealized_conversion_cast %2 : !t2
@@ -36,7 +24,7 @@ core.module @test {
           %16 = arith.cmpi %13, %15 {predicate = @eq} : core.i1
           %17 = scf.if %16 : tribute_rt.anyref {
               %18 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %19 = closure.new %18 {func_ref = @"test::__lambda_3"} : !t0
+              %19 = closure.new %18 {func_ref = @"test::__lambda_0"} : !t0
               %20 = closure.lambda(%21: !t1, %22: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12, %3] {
                   %23 = core.unrealized_conversion_cast %12 : !t0
                   %24 = func.call_indirect %23, %3 : tribute_rt.anyref
@@ -50,7 +38,7 @@ core.module @test {
               %28 = arith.const {value = 1} : core.i1
               %29 = scf.if %28 : tribute_rt.anyref {
                   %30 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-                  %31 = closure.new %30 {func_ref = @"test::__lambda_4"} : !t0
+                  %31 = closure.new %30 {func_ref = @"test::__lambda_0"} : !t0
                   %32 = closure.lambda(%33: !t1, %34: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%12] {
                       %35 = arith.const {value = unit} : core.nil
                       %36 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
@@ -78,7 +66,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
             ^bb11(%45: tribute_rt.anyref, %46: tribute_rt.anyref):
               %47 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %48 = closure.new %47 {func_ref = @"test::__lambda_1"} : !t0
+              %48 = closure.new %47 {func_ref = @"test::__lambda_0"} : !t0
               %49 = closure.lambda(%50: !t1, %51: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%45, %3] {
                   %52 = core.unrealized_conversion_cast %45 : !t0
                   %53 = func.call_indirect %52, %3 : tribute_rt.anyref
@@ -92,7 +80,7 @@ core.module @test {
           ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @set} {
             ^bb13(%57: tribute_rt.anyref, %58: tribute_rt.anyref):
               %59 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %60 = closure.new %59 {func_ref = @"test::__lambda_2"} : !t0
+              %60 = closure.new %59 {func_ref = @"test::__lambda_0"} : !t0
               %61 = closure.lambda(%62: !t1, %63: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} [%57] {
                   %64 = arith.const {value = unit} : core.nil
                   %65 = core.unrealized_conversion_cast %64 : tribute_rt.anyref
@@ -110,9 +98,6 @@ core.module @test {
       %72 = func.call_indirect %71, %43 : tribute_rt.anyref
       func.return %72
   }
-  func.func @"test::__lambda_5"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: !t1, %2: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
           %3 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
@@ -124,7 +109,7 @@ core.module @test {
       %7 = core.unrealized_conversion_cast %6 : tribute_rt.anyref
       %8 = adt.ref_null {type = !t1} : !t1
       %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %10 = closure.new %9 {func_ref = @"test::__lambda_5"} : !t0
+      %10 = closure.new %9 {func_ref = @"test::__lambda_0"} : !t0
       %11 = func.call %8, %10, %0, %7 {callee = @with_state, tribute.calling_convention = 2} : tribute_rt.anyref
       %12 = core.unrealized_conversion_cast %11 : core.i32
       func.return %12

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
@@ -10,9 +10,6 @@ core.module @test {
   func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
-  func.func @"test::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @run_with_state(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = closure.lambda() -> tribute_rt.anyref [%0] {
           %2 = adt.ref_null {type = !t0} : !t0
@@ -26,7 +23,7 @@ core.module @test {
           %11 = arith.const {value = 1} : core.i1
           %12 = scf.if %11 : tribute_rt.anyref {
               %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %14 = closure.new %13 {func_ref = @"test::__lambda_1"} : !t1
+              %14 = closure.new %13 {func_ref = @"test::__lambda_0"} : !t1
               %15 = arith.const {value = 99} : core.i32
               %16 = core.unrealized_conversion_cast %15 : tribute_rt.anyref
               %17 = core.unrealized_conversion_cast %8 : !t1
@@ -58,13 +55,10 @@ core.module @test {
       %31 = core.unrealized_conversion_cast %20 : core.i32
       func.return %31
   }
-  func.func @"test::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
   func.func @apply_thunk(%0: core.func(core.i32)) -> core.i32 attributes {tribute.calling_convention = 0} {
       %1 = adt.ref_null {type = !t0} : !t0
       %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = closure.new %2 {func_ref = @"test::__lambda_2"} : !t1
+      %3 = closure.new %2 {func_ref = @"test::__lambda_0"} : !t1
       %4 = core.unrealized_conversion_cast %0 : closure.closure(core.func(tribute_rt.anyref, !t0, !t1))
       %5 = func.call_indirect %4, %1, %3 {tribute.calling_convention = 2} : tribute_rt.anyref
       %6 = core.unrealized_conversion_cast %5 : core.i32

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -13,6 +13,13 @@ continuation chain의 결과를 되돌려 보내기 위해 사용하는 compatib
 향후 control lowering은 이를 true tail call의 `Never` 또는 trampoline의 `Step`으로
 대체할 수 있다.
 
+현재 compatibility representation에서 캡처 없는 identity `done_k`의 함수 본문은
+컴파일 단위 전체에서 동일하다. AST-to-IR lowering은 이 내부 함수 정의를 compilation
+root에 한 번만 만들고 모든 사용 지점에서 같은 함수 심볼을 참조한다. 다만 각 사용
+지점의 null environment와 `closure.new`는 SSA 영역 가시성을 지키기 위해 해당 영역에
+각각 생성한다. 독립적으로 codegen되는 compilation unit은 자체 정의를 가지며, 향후
+separate compilation이 도입되면 backend의 link-once 정책으로 합칠 수 있다.
+
 ## 핵심 설계
 
 ### `fn` operation: direct dispatch

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -30,11 +30,7 @@ core.module @direct_fn_native {
       func.unreachable
   }
 
-  func.func @"direct_fn_native::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"direct_fn_native::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"direct_fn_native::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
 

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -35,23 +35,7 @@ core.module @mixed_nested_native {
       func.unreachable
   }
 
-  func.func @"mixed_nested_native::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested_native::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested_native::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested_native::__lambda_12"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested_native::__lambda_13"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"mixed_nested_native::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
 
@@ -151,7 +135,7 @@ core.module @mixed_nested_native {
       %4 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
       %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
       %6 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %7 = func.constant {func_ref = @"mixed_nested_native::__lambda_5"} : !t1
+      %7 = func.constant {func_ref = @"mixed_nested_native::__lambda_0"} : !t1
       %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
       %9 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
       %10 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -4,8 +4,8 @@ expression: ir_text
 ---
 core.module @resumptive_op_native {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !t2 = closure.closure(!t1)
@@ -34,15 +34,7 @@ core.module @resumptive_op_native {
       func.unreachable
   }
 
-  func.func @"resumptive_op_native::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op_native::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op_native::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"resumptive_op_native::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
 
@@ -52,7 +44,7 @@ core.module @resumptive_op_native {
       %2 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
       %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
       %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"resumptive_op_native::__lambda_5"} : !t1
+      %5 = func.constant {func_ref = @"resumptive_op_native::__lambda_0"} : !t1
       %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
       %7 = func.call {callee = @__tribute_evidence_empty} : core.ptr
       %8 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -30,6 +30,10 @@ core.module @direct_fn {
       func.unreachable
   }
 
+  func.func @"direct_fn::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
   func.func @use_console(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
       %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %2 = effect.dispatch_tail %0, %1 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
@@ -38,22 +42,6 @@ core.module @direct_fn {
       %5 = effect.dispatch_tail %0, %4 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
       %6 = core.unrealized_conversion_cast %5 : core.nil
       func.return %3
-  }
-
-  func.func @"direct_fn::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"direct_fn::__lambda_6"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"direct_fn::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"direct_fn::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
   }
 
   func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
@@ -98,7 +86,7 @@ core.module @direct_fn {
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
           %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"direct_fn::__lambda_7"} : !t1
+          %9 = func.constant {func_ref = @"direct_fn::__lambda_0"} : !t1
           %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
           %11 = arith.const {value = 41} : core.i32
           %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
@@ -107,7 +95,7 @@ core.module @direct_fn {
           %13 = arith.const {value = 1} : core.i1
           %14 = scf.if %13 : tribute_rt.anyref {
               %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %16 = func.constant {func_ref = @"direct_fn::__lambda_8"} : !t1
+              %16 = func.constant {func_ref = @"direct_fn::__lambda_0"} : !t1
               %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
               %18 = arith.const {value = unit} : core.nil
               %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -34,6 +34,10 @@ core.module @mixed_nested {
       func.unreachable
   }
 
+  func.func @"mixed_nested::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
   func.func @step(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
@@ -47,32 +51,12 @@ core.module @mixed_nested {
       func.return %10
   }
 
-  func.func @"mixed_nested::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested::__lambda_6"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
   func.func @run_state_with_console(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
       %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %2 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
       %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
       %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"mixed_nested::__lambda_5"} : !t1
+      %5 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
       %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
       %7 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
       %8 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
@@ -87,22 +71,6 @@ core.module @mixed_nested {
       %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
       %18 = core.unrealized_conversion_cast %17 : core.i32
       func.return %18
-  }
-
-  func.func @"mixed_nested::__lambda_10"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested::__lambda_11"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested::__lambda_12"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested::__lambda_13"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
   }
 
   func.func @run_all() -> core.i32 attributes {tribute.calling_convention = 0} {
@@ -160,7 +128,7 @@ core.module @mixed_nested {
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
           %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"mixed_nested::__lambda_8"} : !t1
+          %9 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
           %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
           %11 = arith.const {value = 7} : core.i32
           %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
@@ -173,7 +141,7 @@ core.module @mixed_nested {
           %17 = arith.const {value = 1} : core.i1
           %18 = scf.if %17 : tribute_rt.anyref {
               %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %20 = func.constant {func_ref = @"mixed_nested::__lambda_9"} : !t1
+              %20 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
               %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
               %22 = arith.const {value = unit} : core.nil
               %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
@@ -202,7 +170,7 @@ core.module @mixed_nested {
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
           %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"mixed_nested::__lambda_12"} : !t1
+          %9 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
           %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
           %11 = arith.const {value = 3} : core.i32
           %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
@@ -211,7 +179,7 @@ core.module @mixed_nested {
           %13 = arith.const {value = 1} : core.i1
           %14 = scf.if %13 : tribute_rt.anyref {
               %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %16 = func.constant {func_ref = @"mixed_nested::__lambda_13"} : !t1
+              %16 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
               %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
               %18 = arith.const {value = unit} : core.nil
               %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -33,6 +33,10 @@ core.module @resumptive_op {
       func.unreachable
   }
 
+  func.func @"resumptive_op::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.return %2
+  }
+
   func.func @bump(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = adt.struct_new %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
       %3 = func.constant {func_ref = @"bump::__clam_0"} : !t1
@@ -43,26 +47,6 @@ core.module @resumptive_op {
       func.return %7
   }
 
-  func.func @"resumptive_op::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op::__lambda_6"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
   func.func @run_state() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 0} : core.i32
       %1 = adt.array_new %0 {type = !t0} : !t0
@@ -70,7 +54,7 @@ core.module @resumptive_op {
       %3 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
       %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
       %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"resumptive_op::__lambda_5"} : !t1
+      %6 = func.constant {func_ref = @"resumptive_op::__lambda_0"} : !t1
       %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
       %8 = adt.ref_null {type = !t0} : !t0
       %9 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
@@ -120,7 +104,7 @@ core.module @resumptive_op {
       %6 = arith.cmpi %3, %5 {predicate = @eq} : core.i1
       %7 = scf.if %6 : tribute_rt.anyref {
           %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %9 = func.constant {func_ref = @"resumptive_op::__lambda_8"} : !t1
+          %9 = func.constant {func_ref = @"resumptive_op::__lambda_0"} : !t1
           %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
           %11 = arith.const {value = 10} : core.i32
           %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
@@ -133,7 +117,7 @@ core.module @resumptive_op {
           %17 = arith.const {value = 1} : core.i1
           %18 = scf.if %17 : tribute_rt.anyref {
               %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %20 = func.constant {func_ref = @"resumptive_op::__lambda_9"} : !t1
+              %20 = func.constant {func_ref = @"resumptive_op::__lambda_0"} : !t1
               %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
               %22 = arith.const {value = unit} : core.nil
               %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref


### PR DESCRIPTION
## Summary
- Tighten AST-to-IR lowering for effectful lambdas and handler boundaries
- Add/adjust CPS lowering coverage for nested effectful calls, resumptions, and operation arms
- Update effect-type inference snapshots for lambda rows and ability/core patterns
- Document the CPS effects design in `new-plans/cps-effects.md`

## Testing
- Added and updated snapshot-based tests for lambda effect typing, evidence lowering, CPS lowering, and active pipeline goldens
- Validation covered both native and shared pipeline paths for direct calls, nested handler boundaries, and resumptive continuations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced duplicate generation of the shared identity `done_k` function during compilation.
  - Continued creating call-site closures as needed for correct IR behavior.

- **Tests**
  - Added coverage verifying that identity `done_k` references share a single function definition.

- **Documentation**
  - Clarified how shared identity functions and call-site closures are represented, including considerations for separate compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->