### PR TITLE
Define std::io API and shared I/O boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,8 +1452,8 @@ checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
 name = "tree-sitter-tribute"
-version = "0.7.0"
-source = "git+https://github.com/Kroisse/tree-sitter-tribute?tag=v0.7.0#8d9b29b9868f2dac07effe820d6254a67ada79d6"
+version = "0.8.0"
+source = "git+https://github.com/Kroisse/tree-sitter-tribute?tag=v0.8.0#ceed5bca3c5d9f399f919614abf3af0fb022544e"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3.27"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tree-sitter = "0.26.8"
-tree-sitter-tribute = { git = "https://github.com/Kroisse/tree-sitter-tribute", tag = "v0.7.0" }
+tree-sitter-tribute = { git = "https://github.com/Kroisse/tree-sitter-tribute", tag = "v0.8.0" }
 tribute-core = { path = "crates/tribute-core" }
 tribute-rc = { path = "crates/tribute-rc" }
 tribute-front = { path = "crates/tribute-front" }

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -456,7 +456,6 @@ fn lower_struct_decl<'db>(
 ) {
     let location = ctx.location(decl.id);
     let name = decl.name;
-    let struct_ty = ctx.adt_typeref(ir, name);
 
     // Generate accessor module with getter functions
     let fields: Vec<(Symbol, TypeRef)> = decl
@@ -487,6 +486,7 @@ fn lower_struct_decl<'db>(
             qualified_key
         )
     });
+    let struct_ty = ctx.adt_typeref(ir, qualified_key);
 
     let module_path = ctx.module_path().clone();
 

--- a/crates/tribute-front/src/ast_to_ir/lower/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/mod.rs
@@ -183,7 +183,7 @@ pub(super) fn extract_type_name<'db>(
     resolved: &ResolvedRef<'db>,
 ) -> Symbol {
     match resolved {
-        ResolvedRef::Constructor { id, .. } => id.name(db),
+        ResolvedRef::Constructor { id, .. } => id.qualified(db),
         _ => unreachable!("Record type must be a constructor: {:?}", resolved),
     }
 }

--- a/crates/tribute-front/src/astgen/declarations.rs
+++ b/crates/tribute-front/src/astgen/declarations.rs
@@ -245,7 +245,7 @@ fn lower_type_node(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAnnot
                 kind: TypeAnnotationKind::Named(name),
             })
         }
-        "type_path" => Some(lower_ability_path(ctx, node)),
+        "type_path" => Some(lower_type_path(ctx, node)),
         "generic_type" => {
             // Generic type like List(a) or Map(k, v)
             let id = ctx.fresh_id_with_span(&node);
@@ -383,7 +383,7 @@ fn lower_ability_item(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAn
         .first()
         .filter(|n| n.kind() == "ability_path" || n.kind() == "type_identifier")?;
     let id = ctx.fresh_id_with_span(&node);
-    let name_ann = lower_ability_path(ctx, *path_node);
+    let name_ann = lower_type_path(ctx, *path_node);
 
     // Check for type_arguments (e.g. State(Int))
     let type_args_node = children.iter().find(|n| n.kind() == "type_arguments");
@@ -405,13 +405,13 @@ fn lower_ability_item(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAn
     }
 }
 
-/// Lower an ability_path into a TypeAnnotation.
+/// Lower a type path into a TypeAnnotation.
 ///
 /// Single segment (`Abort`) → `Named`, multi-segment (`abilities::Throw`) → `Path`.
-fn lower_ability_path(ctx: &mut AstLoweringCtx<'_>, node: Node) -> TypeAnnotation {
+fn lower_type_path(ctx: &mut AstLoweringCtx<'_>, node: Node) -> TypeAnnotation {
     let id = ctx.fresh_id_with_span(&node);
 
-    // Single segment: ability_path is just a type_identifier
+    // A single-segment path is represented as a type_identifier.
     if node.kind() == "type_identifier" {
         let name = ctx.node_symbol(&node);
         return TypeAnnotation {
@@ -420,7 +420,7 @@ fn lower_ability_path(ctx: &mut AstLoweringCtx<'_>, node: Node) -> TypeAnnotatio
         };
     }
 
-    // Multi-segment or single-segment ability_path
+    // Collect the segments of a qualified type or ability path.
     let mut segments = Vec::new();
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {

--- a/crates/tribute-front/src/astgen/declarations.rs
+++ b/crates/tribute-front/src/astgen/declarations.rs
@@ -207,7 +207,12 @@ pub(super) fn lower_type_annotation(
     // Check if the node itself is already a type node
     if matches!(
         node.kind(),
-        "type_identifier" | "type_variable" | "generic_type" | "function_type" | "tuple_type"
+        "type_identifier"
+            | "type_path"
+            | "type_variable"
+            | "generic_type"
+            | "function_type"
+            | "tuple_type"
     ) {
         return lower_type_node(ctx, node);
     }
@@ -216,8 +221,8 @@ pub(super) fn lower_type_annotation(
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         match child.kind() {
-            "type_identifier" | "type_variable" | "generic_type" | "function_type"
-            | "tuple_type" => {
+            "type_identifier" | "type_path" | "type_variable" | "generic_type"
+            | "function_type" | "tuple_type" => {
                 return lower_type_node(ctx, child);
             }
             _ => {}
@@ -240,6 +245,7 @@ fn lower_type_node(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAnnot
                 kind: TypeAnnotationKind::Named(name),
             })
         }
+        "type_path" => Some(lower_ability_path(ctx, node)),
         "generic_type" => {
             // Generic type like List(a) or Map(k, v)
             let id = ctx.fresh_id_with_span(&node);
@@ -248,11 +254,11 @@ fn lower_type_node(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Option<TypeAnnot
             let mut cursor = node.walk();
             let children: Vec<_> = node.named_children(&mut cursor).collect();
 
-            if let Some(name_node) = children.first().filter(|n| n.kind() == "type_identifier") {
-                let ctor = Box::new(TypeAnnotation {
-                    id: ctx.fresh_id_with_span(name_node),
-                    kind: TypeAnnotationKind::Named(ctx.node_symbol(name_node)),
-                });
+            if let Some(name_node) = children
+                .first()
+                .filter(|n| matches!(n.kind(), "type_identifier" | "type_path"))
+            {
+                let ctor = Box::new(lower_type_node(ctx, *name_node)?);
 
                 // Collect type arguments (remaining children)
                 let args: Vec<TypeAnnotation> = children

--- a/crates/tribute-front/src/astgen/expressions.rs
+++ b/crates/tribute-front/src/astgen/expressions.rs
@@ -148,8 +148,8 @@ pub fn lower_expr(ctx: &mut AstLoweringCtx<'_>, node: Node) -> Expr<UnresolvedNa
             ExprKind::Error
         }
 
-        // === Path expression ===
-        "path_expression" | "qualified_identifier" => {
+        // === Value path ===
+        "value_path" => {
             let sym = ctx.node_symbol(&node);
             let name_id = ctx.fresh_id_with_span(&node);
             ExprKind::Var(UnresolvedName::new(sym, name_id))

--- a/crates/tribute-front/src/astgen/mod.rs
+++ b/crates/tribute-front/src/astgen/mod.rs
@@ -847,6 +847,34 @@ mod tests {
     }
 
     #[test]
+    fn test_qualified_method_path_for_field_update() {
+        let source = "fn main() { user.name::set(\"Jane\") }";
+        let module = parse_and_lower(source);
+
+        let Decl::Function(func) = &module.decls[0] else {
+            panic!("Expected function");
+        };
+        let ExprKind::Block { value, .. } = func.body.kind.as_ref() else {
+            panic!("Expected block");
+        };
+        let ExprKind::MethodCall {
+            receiver,
+            method,
+            args,
+        } = value.kind.as_ref()
+        else {
+            panic!("Expected method call, got {:?}", value.kind);
+        };
+        let ExprKind::Var(name) = receiver.kind.as_ref() else {
+            panic!("Expected var receiver");
+        };
+
+        assert_eq!(name.name().to_string(), "user");
+        assert_eq!(method.to_string(), "name::set");
+        assert_eq!(args.len(), 1);
+    }
+
+    #[test]
     fn test_method_call_with_multiple_args() {
         let source = "fn main() { bytes.slice(0, 5) }";
         let module = parse_and_lower(source);
@@ -948,6 +976,23 @@ mod tests {
     }
 
     #[test]
+    fn test_qualified_constructor_expression() {
+        let source = "fn main() { std::io::Error::EndOfFile }";
+        let module = parse_and_lower(source);
+
+        let Decl::Function(func) = &module.decls[0] else {
+            panic!("Expected function");
+        };
+        let ExprKind::Block { value, .. } = func.body.kind.as_ref() else {
+            panic!("Expected block");
+        };
+        let ExprKind::Cons { ctor, .. } = value.kind.as_ref() else {
+            panic!("Expected constructor, got {:?}", value.kind);
+        };
+        assert_eq!(ctor.qualified.to_string(), "std::io::Error::EndOfFile");
+    }
+
+    #[test]
     fn test_constructor_no_args() {
         let source = "fn main() { None() }";
         let module = parse_and_lower(source);
@@ -982,6 +1027,39 @@ mod tests {
             panic!("Expected record, got {:?}", value.kind);
         };
         assert_eq!(type_name.name().to_string(), "Point");
+    }
+
+    #[test]
+    fn test_qualified_record_expression() {
+        let source = "fn main() { std::io::SystemError { code: 1 } }";
+        let module = parse_and_lower(source);
+
+        let Decl::Function(func) = &module.decls[0] else {
+            panic!("Expected function");
+        };
+        let ExprKind::Block { value, .. } = func.body.kind.as_ref() else {
+            panic!("Expected block");
+        };
+        let ExprKind::Record { type_name, .. } = value.kind.as_ref() else {
+            panic!("Expected record, got {:?}", value.kind);
+        };
+        assert_eq!(type_name.qualified.to_string(), "std::io::SystemError");
+    }
+
+    #[test]
+    fn test_qualified_type_annotation() {
+        let source = "fn identity(error: std::io::Error) -> std::io::Error { error }";
+        let module = parse_and_lower(source);
+
+        let Decl::Function(func) = &module.decls[0] else {
+            panic!("Expected function");
+        };
+        assert!(matches!(
+            func.params[0].ty.as_ref().map(|ty| &ty.kind),
+            Some(TypeAnnotationKind::Path(path))
+                if path.iter().map(ToString::to_string).collect::<Vec<_>>()
+                    == ["std", "io", "Error"]
+        ));
     }
 
     // =============================================================================

--- a/crates/tribute-front/src/astgen/patterns.rs
+++ b/crates/tribute-front/src/astgen/patterns.rs
@@ -104,7 +104,7 @@ fn lower_constructor_pattern(
     ctx: &mut AstLoweringCtx<'_>,
     node: Node,
 ) -> PatternKind<UnresolvedName> {
-    // grammar.js: field("name", $.type_identifier)
+    // grammar.js: field("name", $.type_path)
     //   + optional choice of:
     //     - Tuple-style: field("args", $.pattern_list)
     //     - Struct-style: field("fields", $.pattern_fields)
@@ -700,6 +700,24 @@ mod tests {
             panic!("Expected bind pattern in variant");
         };
         assert_eq!(name.to_string(), "y");
+    }
+
+    #[test]
+    fn test_qualified_constructor_pattern() {
+        let source = r#"
+            fn main() {
+                case x {
+                    std::io::ReadLine(bytes) -> bytes
+                    _ -> b""
+                }
+            }
+        "#;
+        let pattern = get_case_pattern(source, 0);
+        let PatternKind::Variant { ctor, fields } = pattern else {
+            panic!("Expected variant pattern, got {:?}", pattern);
+        };
+        assert_eq!(ctor.qualified.to_string(), "std::io::ReadLine");
+        assert_eq!(fields.len(), 1);
     }
 
     #[test]

--- a/crates/tribute-front/src/lib.rs
+++ b/crates/tribute-front/src/lib.rs
@@ -48,6 +48,16 @@ pub fn qualified_symbol(prefix: &mut String, name: Symbol) -> Symbol {
     }
 }
 
+/// Build a qualified symbol from parsed path segments.
+pub fn qualified_path_symbol(path: &[Symbol]) -> Option<Symbol> {
+    let (&name, prefix) = path.split_last()?;
+    let mut buf = String::new();
+    for &segment in prefix {
+        push_prefix(&mut buf, segment);
+    }
+    Some(qualified_symbol(&mut buf, name))
+}
+
 /// Push a segment onto a prefix buffer. Returns the length before push (for truncate).
 pub fn push_prefix(prefix: &mut String, name: Symbol) -> usize {
     let len = prefix.len();

--- a/crates/tribute-front/src/resolve/mod.rs
+++ b/crates/tribute-front/src/resolve/mod.rs
@@ -276,7 +276,10 @@ fn collect_definition<'db>(
                     }
                     // Also add the inner namespace itself under the module
                     // so Foo::Bar resolves to the Bar namespace
-                    env.add_to_namespace(
+                    // A type definition and its member namespace share a name
+                    // (`Point` and `Point::x`, `Error` and `Error::Variant`).
+                    // Preserve the type binding already transferred above.
+                    env.add_to_namespace_if_absent(
                         m.name,
                         inner_ns,
                         Binding::Module {
@@ -652,6 +655,29 @@ mod tests {
 
         let input = TestModuleInput::new(db, module);
         verify_nested_module_enum_namespace(db, input);
+    }
+
+    #[salsa_test]
+    fn test_nested_module_preserves_type_bindings(db: &dyn salsa::Database) {
+        // A type's member namespace must not replace the type/constructor
+        // binding when nested module namespaces are flattened.
+        let module = Module::new(
+            fresh_node_id(),
+            Some(Symbol::new("test")),
+            vec![Decl::Module(inline_module(
+                "std",
+                vec![Decl::Module(inline_module(
+                    "io",
+                    vec![Decl::Struct(simple_struct("SystemError"))],
+                ))],
+            ))],
+        );
+
+        let env = build_env(db, &module);
+        assert!(matches!(
+            env.lookup_qualified(Symbol::new("std::io"), Symbol::new("SystemError")),
+            Some(Binding::Constructor { .. })
+        ));
     }
 
     #[salsa_test]

--- a/crates/tribute-front/src/tdnr/resolver.rs
+++ b/crates/tribute-front/src/tdnr/resolver.rs
@@ -295,7 +295,7 @@ impl<'db> TdnrResolver<'db> {
                 }
             }
             TypeAnnotationKind::Path(path) if !path.is_empty() => {
-                let name = path.last().copied().unwrap();
+                let name = crate::qualified_path_symbol(path).unwrap();
                 Type::new(self.db, TypeKind::Named { name, args: vec![] })
             }
             TypeAnnotationKind::App { ctor, args } => {
@@ -329,7 +329,9 @@ impl<'db> TdnrResolver<'db> {
         let ann = annotation.as_ref()?;
         match &ann.kind {
             TypeAnnotationKind::Named(name) => Some(*name),
-            TypeAnnotationKind::Path(path) if !path.is_empty() => path.last().copied(),
+            TypeAnnotationKind::Path(path) if !path.is_empty() => {
+                crate::qualified_path_symbol(path)
+            }
             TypeAnnotationKind::App { ctor, .. } => {
                 self.extract_receiver_type_from_annotation(&Some((**ctor).clone()))
             }

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -235,10 +235,7 @@ impl<'db> TypeChecker<'db> {
         };
 
         let ctor_scheme = TypeScheme::new(self.db(), type_params.clone(), ctor_ty);
-        let ctor_id = CtorId::new(
-            self.db(),
-            crate::qualified_symbol(&mut self.current_prefix().to_owned(), name),
-        );
+        let ctor_id = CtorId::new(self.db(), qualified_name);
         self.env.register_constructor(ctor_id, ctor_scheme);
 
         // Register struct field information for accessor resolution

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -193,6 +193,7 @@ impl<'db> TypeChecker<'db> {
     /// Collect a struct definition.
     fn collect_struct_def(&mut self, s: &StructDecl) {
         let name = s.name;
+        let qualified_name = crate::qualified_symbol(&mut self.current_prefix().to_owned(), name);
         let type_params: Vec<TypeParam> = s
             .type_params
             .iter()
@@ -211,10 +212,10 @@ impl<'db> TypeChecker<'db> {
         let args: Vec<Type<'db>> = (0..type_params.len() as u32)
             .map(|i| Type::new(self.db(), TypeKind::BoundVar { index: i }))
             .collect();
-        let struct_ty = self.env.named_type(name, args);
+        let struct_ty = self.env.named_type(qualified_name, args);
 
         let scheme = TypeScheme::new(self.db(), type_params.clone(), struct_ty);
-        self.env.register_type_def(name, scheme);
+        self.env.register_type_def(qualified_name, scheme);
 
         // Register struct constructor
         // Constructor type is: fn(field_types...) -> StructType
@@ -250,12 +251,14 @@ impl<'db> TypeChecker<'db> {
                 Some((field_name, field_ty))
             })
             .collect();
-        self.env.register_struct_fields(name, type_params, fields);
+        self.env
+            .register_struct_fields(qualified_name, type_params, fields);
     }
 
     /// Collect an enum definition.
     fn collect_enum_def(&mut self, e: &EnumDecl) {
         let name = e.name;
+        let qualified_name = crate::qualified_symbol(&mut self.current_prefix().to_owned(), name);
         let type_params: Vec<TypeParam> = e
             .type_params
             .iter()
@@ -266,14 +269,15 @@ impl<'db> TypeChecker<'db> {
         let args: Vec<Type<'db>> = (0..type_params.len() as u32)
             .map(|i| Type::new(self.db(), TypeKind::BoundVar { index: i }))
             .collect();
-        let enum_ty = self.env.named_type(name, args);
+        let enum_ty = self.env.named_type(qualified_name, args);
 
         let scheme = TypeScheme::new(self.db(), type_params.clone(), enum_ty);
-        self.env.register_type_def(name, scheme);
+        self.env.register_type_def(qualified_name, scheme);
 
         // Register enum variant names for exhaustiveness checking
         let variant_names: Vec<Symbol> = e.variants.iter().map(|v| v.name).collect();
-        self.env.register_enum_variants(name, variant_names);
+        self.env
+            .register_enum_variants(qualified_name, variant_names);
 
         // Register constructors for each variant
         // Build name → BoundVar index lookup for type parameter resolution
@@ -399,7 +403,7 @@ impl<'db> TypeChecker<'db> {
             }
             TypeAnnotationKind::Named(name) => self.primitive_or_named_type(*name),
             TypeAnnotationKind::Path(parts) if !parts.is_empty() => {
-                if let Some(&name) = parts.last() {
+                if let Some(name) = crate::qualified_path_symbol(parts) {
                     self.env.named_type(name, vec![])
                 } else {
                     self.env.error_type()
@@ -509,7 +513,7 @@ impl<'db> TypeChecker<'db> {
                 self.env.tuple_type(elem_types)
             }
             TypeAnnotationKind::Path(parts) if !parts.is_empty() => {
-                if let Some(&name) = parts.last() {
+                if let Some(name) = crate::qualified_path_symbol(parts) {
                     self.env.named_type(name, vec![])
                 } else {
                     self.env.error_type()

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1923,7 +1923,7 @@ impl<'db> TypeChecker<'db> {
                 }
             }
             TypeAnnotationKind::Path(parts) if !parts.is_empty() => {
-                if let Some(&name) = parts.last() {
+                if let Some(name) = crate::qualified_path_symbol(parts) {
                     ctx.named_type(name, vec![])
                 } else {
                     ctx.error_type()
@@ -2307,9 +2307,9 @@ mod tests {
         ]));
         let ty = checker.annotation_to_type_with_ctx(&mut ctx, &ann);
 
-        // Should use last segment as name
+        // Qualified type identity preserves the complete path.
         if let TypeKind::Named { name, args } = ty.kind(db) {
-            assert_eq!(*name, Symbol::new("Option"));
+            assert_eq!(*name, Symbol::new("std::Option"));
             assert!(args.is_empty());
         } else {
             panic!("Path type should be Named");

--- a/crates/tribute-ir/src/dialect/mod.rs
+++ b/crates/tribute-ir/src/dialect/mod.rs
@@ -3,4 +3,5 @@
 pub mod ability;
 pub mod closure;
 pub mod effect;
+pub mod tribute_io;
 pub mod tribute_rt;

--- a/crates/tribute-ir/src/dialect/tribute_io.rs
+++ b/crates/tribute-ir/src/dialect/tribute_io.rs
@@ -1,0 +1,47 @@
+//! Target-independent standard I/O boundary.
+//!
+//! These operations carry flattened bytes and target-neutral result values.
+//! Native and Wasm pipelines lower them to their respective host interfaces.
+
+#[trunk_ir::dialect]
+mod tribute_io {
+    fn write(bytes: (), newline: ()) -> result {}
+    fn read_line() -> result {}
+}
+
+#[cfg(test)]
+mod tests {
+    use trunk_ir::ops::DialectOp;
+    use trunk_ir::refs::PathRef;
+    use trunk_ir::types::Location;
+    use trunk_ir::{Attribute, IrContext, Span, Symbol, TypeDataBuilder};
+
+    fn location() -> Location {
+        Location::new(PathRef::from_u32(0), Span::default())
+    }
+
+    #[test]
+    fn io_ops_round_trip() {
+        let mut ctx = IrContext::new();
+        let loc = location();
+        let ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("ptr")).build());
+        let bool_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i1")).build());
+        let bytes =
+            trunk_ir::dialect::arith::r#const(&mut ctx, loc, ty, Attribute::Int(0)).result(&ctx);
+        let newline = trunk_ir::dialect::arith::r#const(&mut ctx, loc, bool_ty, Attribute::Int(1))
+            .result(&ctx);
+
+        let write = super::write(&mut ctx, loc, bytes, newline, ty);
+        let parsed = super::Write::from_op(&ctx, write.op_ref()).expect("tribute_io.write");
+        assert_eq!(parsed.bytes(&ctx), bytes);
+        assert_eq!(parsed.newline(&ctx), newline);
+
+        let read = super::read_line(&mut ctx, loc, ty);
+        assert!(super::ReadLine::from_op(&ctx, read.op_ref()).is_ok());
+        assert_eq!(ctx.value_ty(read.result(&ctx)), ty);
+    }
+}

--- a/crates/tribute-passes/src/io_lowering.rs
+++ b/crates/tribute-passes/src/io_lowering.rs
@@ -1,0 +1,135 @@
+//! Lower embedded standard-library I/O intrinsics to the shared I/O dialect.
+
+use trunk_ir::context::IrContext;
+use trunk_ir::dialect::{core, func};
+use trunk_ir::ops::DialectOp;
+use trunk_ir::pass::{Pass, PassRunResult};
+use trunk_ir::refs::OpRef;
+use trunk_ir::rewrite::{
+    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+};
+
+use tribute_ir::dialect::tribute_io;
+
+const WRITE_INTRINSIC: &str = "std::io::__tribute_io_write";
+const READ_LINE_INTRINSIC: &str = "std::io::__tribute_io_read_line";
+
+pub struct LowerIoIntrinsics;
+
+impl Pass for LowerIoIntrinsics {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "lower-io-intrinsics"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
+        let applicator = PatternApplicator::new(TypeConverter::new())
+            .add_pattern(IoCallPattern)
+            .add_pattern(IoDeclarationPattern);
+        applicator.apply_partial(ctx, Module::from(target));
+        Ok(())
+    }
+}
+
+struct IoCallPattern;
+
+impl RewritePattern for IoCallPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(call) = func::Call::from_op(ctx, op) else {
+            return false;
+        };
+        let callee = call.callee(ctx);
+        let loc = ctx.op(op).location;
+        let result_ty = ctx.op_result_types(op).first().copied();
+        let operands = ctx.op_operands(op).to_vec();
+
+        let replacement = if callee == WRITE_INTRINSIC {
+            let (Some(result_ty), [bytes, newline]) = (result_ty, operands.as_slice()) else {
+                return false;
+            };
+            tribute_io::write(ctx, loc, *bytes, *newline, result_ty).op_ref()
+        } else if callee == READ_LINE_INTRINSIC {
+            let (Some(result_ty), []) = (result_ty, operands.as_slice()) else {
+                return false;
+            };
+            tribute_io::read_line(ctx, loc, result_ty).op_ref()
+        } else {
+            return false;
+        };
+
+        rewriter.replace_op(replacement);
+        true
+    }
+}
+
+struct IoDeclarationPattern;
+
+impl RewritePattern for IoDeclarationPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            return false;
+        };
+        let name = function.sym_name(ctx);
+        if name != WRITE_INTRINSIC && name != READ_LINE_INTRINSIC {
+            return false;
+        }
+
+        rewriter.erase_op(vec![]);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::pass::Pass;
+    use trunk_ir::printer::print_module;
+
+    #[test]
+    fn lowers_calls_and_removes_private_declarations() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"
+            core.module @test {
+                func.func @"std::io::__tribute_io_write"(%0: core.ptr, %1: core.i1) -> core.ptr
+                    attributes {abi = "intrinsic"} {
+                ^bb0:
+                    func.unreachable
+                }
+                func.func @"std::io::__tribute_io_read_line"() -> core.ptr
+                    attributes {abi = "intrinsic"} {
+                ^bb0:
+                    func.unreachable
+                }
+                func.func @caller(%0: core.ptr, %1: core.i1) -> core.ptr {
+                ^bb0:
+                    %2 = func.call %0, %1 {callee = @"std::io::__tribute_io_write"} : core.ptr
+                    %3 = func.call {callee = @"std::io::__tribute_io_read_line"} : core.ptr
+                    func.return %3
+                }
+            }
+            "#,
+        );
+        let core = core::Module::from_op(&ctx, module.op()).expect("core.module");
+
+        LowerIoIntrinsics.run(&mut ctx, core).unwrap();
+
+        let output = print_module(&ctx, module.op());
+        assert!(output.contains("tribute_io.write"), "{output}");
+        assert!(output.contains("tribute_io.read_line"), "{output}");
+        assert!(!output.contains("__tribute_io_"), "{output}");
+    }
+}

--- a/crates/tribute-passes/src/io_lowering.rs
+++ b/crates/tribute-passes/src/io_lowering.rs
@@ -132,4 +132,39 @@ mod tests {
         assert!(output.contains("tribute_io.read_line"), "{output}");
         assert!(!output.contains("__tribute_io_"), "{output}");
     }
+
+    #[test]
+    fn leaves_malformed_and_unrelated_calls_unchanged() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"
+            core.module @test {
+                func.func @other(%0: core.ptr) -> core.ptr {
+                ^bb0:
+                    func.return %0
+                }
+                func.func @caller(%0: core.ptr) -> core.ptr {
+                ^bb0:
+                    %1 = func.call %0 {callee = @"std::io::__tribute_io_write"} : core.ptr
+                    %2 = func.call %0 {callee = @"std::io::__tribute_io_read_line"} : core.ptr
+                    %3 = func.call %0 {callee = @other} : core.ptr
+                    func.return %3
+                }
+            }
+            "#,
+        );
+        let core = core::Module::from_op(&ctx, module.op()).expect("core.module");
+
+        LowerIoIntrinsics.run(&mut ctx, core).unwrap();
+
+        let output = print_module(&ctx, module.op());
+        assert!(!output.contains("tribute_io."), "{output}");
+        assert!(output.contains("std::io::__tribute_io_write"), "{output}");
+        assert!(
+            output.contains("std::io::__tribute_io_read_line"),
+            "{output}"
+        );
+        assert!(output.contains("func.func @other"), "{output}");
+    }
 }

--- a/crates/tribute-passes/src/io_lowering.rs
+++ b/crates/tribute-passes/src/io_lowering.rs
@@ -47,15 +47,15 @@ impl RewritePattern for IoCallPattern {
         let callee = call.callee(ctx);
         let loc = ctx.op(op).location;
         let result_ty = ctx.op_result_types(op).first().copied();
-        let operands = ctx.op_operands(op).to_vec();
 
         let replacement = if callee == WRITE_INTRINSIC {
-            let (Some(result_ty), [bytes, newline]) = (result_ty, operands.as_slice()) else {
+            let (Some(result_ty), [bytes, newline]) = (result_ty, ctx.op_operands(op)) else {
                 return false;
             };
-            tribute_io::write(ctx, loc, *bytes, *newline, result_ty).op_ref()
+            let (bytes, newline) = (*bytes, *newline);
+            tribute_io::write(ctx, loc, bytes, newline, result_ty).op_ref()
         } else if callee == READ_LINE_INTRINSIC {
-            let (Some(result_ty), []) = (result_ty, operands.as_slice()) else {
+            let (Some(result_ty), []) = (result_ty, ctx.op_operands(op)) else {
                 return false;
             };
             tribute_io::read_line(ctx, loc, result_ty).op_ref()

--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -16,6 +16,7 @@ pub mod boxing;
 pub mod closure_lower;
 pub mod evidence;
 pub mod intrinsic_to_arith;
+pub mod io_lowering;
 pub mod lower_ability_perform;
 pub mod lower_closure_lambda;
 pub mod lower_handle_dispatch;

--- a/lib/std/prelude.trb
+++ b/lib/std/prelude.trb
@@ -306,8 +306,66 @@ pub mod abilities {
 }
 
 // =============================================================================
-// I/O functions
+// Standard I/O
 // =============================================================================
+
+pub mod std {
+    pub mod io {
+        /// Platform error details reported by an I/O operation.
+        pub struct SystemError { code: Int, message: String }
+
+        /// Errors that may be raised by standard I/O operations.
+        pub enum Error {
+            EndOfFile,
+            InvalidEncoding,
+            System(std::io::SystemError),
+        }
+
+        // Private transport value used only between the embedded wrapper and
+        // the compiler-owned, target-independent I/O boundary.
+        enum ReadLineResult {
+            ReadLine(Bytes),
+            ReadEndOfFile,
+            ReadInvalidEncoding,
+            ReadSystem(Int, Bytes),
+        }
+
+        extern "intrinsic" fn __tribute_io_write(bytes: Bytes, newline: Bool) -> Nil
+        extern "intrinsic" fn __tribute_io_read_line() -> std::io::ReadLineResult
+
+        /// Print a string to standard output (no trailing newline).
+        pub fn print(message: String) ->{std::io::Io} Nil {
+            std::io::__tribute_io_write(String::to_bytes(message), False)
+        }
+
+        /// Print a line to standard output.
+        pub fn print_line(message: String) ->{std::io::Io} Nil {
+            std::io::__tribute_io_write(String::to_bytes(message), True)
+        }
+
+        /// Read one UTF-8 line from standard input.
+        pub fn read_line() ->{std::io::Io, abilities::Throw(std::io::Error)} String {
+            case std::io::__tribute_io_read_line() {
+                std::io::ReadLineResult::ReadLine(bytes) -> String::from_bytes(bytes)
+                std::io::ReadLineResult::ReadEndOfFile -> abilities::Throw::throw(
+                    std::io::Error::EndOfFile
+                )
+                std::io::ReadLineResult::ReadInvalidEncoding -> abilities::Throw::throw(
+                    std::io::Error::InvalidEncoding
+                )
+                std::io::ReadLineResult::ReadSystem(code, message) -> abilities::Throw::throw(
+                    std::io::Error::System(std::io::SystemError {
+                        code: code,
+                        message: String::from_bytes(message),
+                    })
+                )
+            }
+        }
+    }
+}
+
+// Legacy target-specific helpers remain available until the native and Wasm
+// backends lower the shared I/O boundary.
 
 /// Print a string to standard output (no trailing newline).
 fn print(message: String) -> Nil {

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -233,6 +233,12 @@ Compiler-owned ambient ability `std::io::Io`만 요구하는 함수는 현재
 `Io`와 `Throw(std::io::Error)`가 함께 있으면 `Throw` 때문에 `Cps`로 승격된다.
 자세한 표준 I/O 계약은 [io.md](io.md)를 따른다.
 
+기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
+Frontend shared lowering은 private intrinsic stub을 `tribute_io.write`와
+`tribute_io.read_line` operation으로 바꾼다. 이 boundary는 rope 표현 대신 `Bytes`와
+target-independent `ReadLineResult`를 사용한다. Native와 Wasm pipeline은 이후 각자의
+runtime ABI 또는 host import로 operation을 완전히 lower해야 한다.
+
 논리적인 CPS ABI에서 함수와 `done_k`의 control result는 `Never`다:
 
 ```text

--- a/new-plans/io.md
+++ b/new-plans/io.md
@@ -75,9 +75,11 @@ builtin discriminator를 가진다. Resolver는 `std::io::Io`를 virtual builtin
 사용자가 선언한 `ability Io {}`는 이름이 같아도 builtin metadata를 얻지 않는다.
 
 이 virtual binding은 아직 file-based module loader를 요구하지 않는다. 이후 기본 I/O
-함수와 오류 타입은 embedded standard-library source로 제공할 수 있지만, `Io`의 ambient
-성질은 source declaration이 아니라 builtin identity에 연결한다. Builtin identity는
-frontend 판정용이며 runtime ability ID나 Evidence marker를 암시하지 않는다.
+함수와 오류 타입은 embedded standard-library source의 `std::io` module로 제공하지만,
+`Io`의 ambient 성질은 source declaration이 아니라 builtin identity에 연결한다. Source
+module export와 virtual `Io` binding은 resolver의 동일한 `std::io` namespace에서
+결합된다. Builtin identity는 frontend 판정용이며 runtime ability ID나 Evidence marker를
+암시하지 않는다.
 
 ## Calling Convention
 
@@ -157,6 +159,27 @@ EOF는 runtime failure와 같은 `Throw(Error)` 채널을 사용하므로 반환
 Public API는 `extern "C"`, WASI import, `__print_line` 같은 target detail을
 노출하지 않는다. Shared lowering은 동적 `Bytes`를 읽고 쓸 수 있는
 target-independent I/O boundary를 생성한다.
+
+```text
+tribute_io.write(bytes: Bytes, newline: Bool) -> Nil
+tribute_io.read_line() -> ReadLineResult
+
+ReadLineResult =
+    Line(valid_utf8: Bytes)
+  | EndOfFile
+  | InvalidEncoding
+  | System(code: Int, message_utf8: Bytes)
+```
+
+Embedded `std::io` source는 `String::to_bytes`로 rope를 flatten한 뒤 `write`를
+호출한다. `read_line`의 `Line` payload와 `System` message는 boundary가 유효한 UTF-8임을
+보장하므로 source wrapper가 `String::from_bytes`로 감싼다. 나머지 status는
+`std::io::Error`로 변환하여 `Throw(Error)` operation을 호출한다.
+
+`tribute_io.*`는 shared IR operation이며 public source symbol이 아니다. Embedded source가
+사용하는 private intrinsic stub은 frontend lowering에서 이 operation으로 즉시 바뀌고,
+target pipeline 이전에는 제거된다. #770은 이 shared contract까지 구현하고, 실제 native와
+Wasm lowering은 각각 #772와 #771이 담당한다.
 
 - Native lowering은 `tribute-runtime`의 stdin/stdout ABI로 변환한다.
 - Wasm lowering은 현재 backend가 지원하는 WASI 또는 custom host import로 변환한다.

--- a/new-plans/syntax.md
+++ b/new-plans/syntax.md
@@ -284,12 +284,19 @@ pub mod List {
 }
 ```
 
-### Path Expression
+### Item Paths
 
 ```ebnf
 Path ::= PathSegment ('::' PathSegment)*
 PathSegment ::= Identifier | TypeId
+ValuePath ::= (PathSegment '::')* Identifier
+TypePath ::= (PathSegment '::')* TypeId
 ```
+
+선언 이름은 단일 `Identifier` 또는 `TypeId`지만, 참조 위치의 CST는 단일
+이름도 각각 `value_path` 또는 `type_path`로 감싼다. 따라서 `print`와
+`std::io::print`, `String`과 `std::io::Error`는 세그먼트 수와 무관하게 같은
+종류의 path node로 처리된다.
 
 **예시:**
 
@@ -307,7 +314,7 @@ std::io::print_line("hello")
 ConstDecl ::= 'pub'? 'const' Identifier (':' Type)? '=' ConstExpr
 
 ConstExpr ::= Literal                        // -1은 Int 리터럴로 처리
-            | Path                           // 다른 상수 참조
+            | ValuePath                      // 다른 상수 참조
             | ConstExpr BinOp ConstExpr      // 상수 폴딩
             | '{' ConstExpr '}'              // 그룹화
 ```
@@ -491,8 +498,8 @@ HandleExpr ::= 'handle' Expression '{' HandlerArm+ '}'
 HandlerArm ::= CompletionArm | FnHandlerArm | OpHandlerArm
 
 CompletionArm  ::= 'do' Identifier Block                        // do result { body }
-FnHandlerArm   ::= 'fn' Path '(' PatternList? ')' Block        // fn Op(args) { body }
-OpHandlerArm   ::= 'op' Path '(' PatternList? ')' Block        // op Op(args) { body }
+FnHandlerArm   ::= 'fn' ValuePath '(' PatternList? ')' Block   // fn Op(args) { body }
+OpHandlerArm   ::= 'op' ValuePath '(' PatternList? ')' Block   // op Op(args) { body }
 ```
 
 `handle expr { arms }`는 computation을 실행하고 handler arm으로 결과를 처리한다.
@@ -624,8 +631,7 @@ fn(x) {
 
 ```ebnf
 PrimaryExpr ::= Literal
-              | Identifier
-              | Path
+              | ValuePath
               | Block                             // { expr } 로 그룹화
               | ListExpr
               | TupleExpr
@@ -675,7 +681,7 @@ x * { y + z }           // x * (y + z) 와 동일
 ### Record Expression
 
 ```ebnf
-RecordExpr ::= TypeId '{' RecordFields? '}'
+RecordExpr ::= TypePath '{' RecordFields? '}'
 RecordFields ::= RecordField (',' RecordField)* ','?
 RecordField ::= '..' Expression                    // spread
               | Identifier ':' Expression          // field: value
@@ -694,9 +700,9 @@ Point { x: 10, y: 20 }
 ### Variant Construction
 
 ```ebnf
-VariantExpr ::= TypeId '(' ExprList? ')'     // positional
-              | TypeId '{' RecordFields '}'   // named
-              | TypeId                         // unit variant
+VariantExpr ::= TypePath '(' ExprList? ')'     // positional
+              | TypePath '{' RecordFields '}'   // named
+              | TypePath                         // unit variant
 ```
 
 **예시:**
@@ -713,7 +719,7 @@ Error { error: "failed" }
 
 ```ebnf
 CallExpr ::= Expression '(' ExprList? ')'
-UFCSExpr ::= Expression '.' Path CallArgs?
+UFCSExpr ::= Expression '.' ValuePath CallArgs?
 CallArgs ::= '(' ExprList? ')'
            | /* empty - 인자 없으면 괄호 생략 가능 */
 
@@ -857,8 +863,8 @@ AsPattern ::= Pattern 'as' Identifier        // 전체를 바인딩
 LiteralPattern ::= Number | StringLit | Rune | 'True' | 'False' | 'Nil'
 WildcardPattern ::= '_'
 IdentifierPattern ::= Identifier
-VariantPattern ::= TypeId ('(' PatternList ')' | '{' RecordPatternFields '}')?
-RecordPattern ::= TypeId '{' RecordPatternFields '}'
+VariantPattern ::= TypePath ('(' PatternList ')' | '{' RecordPatternFields '}')?
+RecordPattern ::= TypePath '{' RecordPatternFields '}'
 ListPattern ::= '[' PatternList? ']'
               | '[' PatternList ',' '..' Identifier? ']'    // [head, ..tail] or [head, ..]
 TuplePattern ::= '#(' PatternList? ')'
@@ -891,6 +897,8 @@ None
 Cons(head, tail)
 Ok { value }
 Error { error: e }
+std::io::Error::EndOfFile
+std::io::ReadLineResult::Line(bytes)
 
 // Record destructuring
 User { name, age }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -493,6 +493,7 @@ fn run_shared_pipeline(
     structural_pm
         .add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
         .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
+        .add_pass(tribute_passes::io_lowering::LowerIoIntrinsics)
         // Evidence params are now inserted directly during ast_to_ir lowering.
         .add_pass(tribute_passes::closure_lower::PrepareClosureLowering);
     structural_pm
@@ -1376,6 +1377,34 @@ mod tests {
         assert!(result.is_some(), "Should compile successfully");
         let (ctx, m) = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
+    }
+
+    #[salsa_test]
+    fn test_std_io_lowers_to_shared_dialect(db: &salsa::DatabaseImpl) {
+        let source = source_from_str(
+            "io.trb",
+            r#"
+use std::io::print_line
+use std::io::read_line
+
+fn input() ->{std::io::Io, abilities::Throw(std::io::Error)} String {
+    read_line()
+}
+
+fn main() ->{std::io::Io} Nil {
+    print_line("hello")
+}
+"#,
+        );
+
+        let (ctx, module) = compile_ast(db, source)
+            .expect("pipeline should not fail")
+            .expect("pipeline should produce a module");
+        let output = trunk_ir::printer::print_module(&ctx, module.op());
+
+        assert!(output.contains("tribute_io.write"), "{output}");
+        assert!(output.contains("tribute_io.read_line"), "{output}");
+        assert!(!output.contains("__tribute_io_"), "{output}");
     }
 
     #[salsa_test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1384,6 +1384,7 @@ mod tests {
         let source = source_from_str(
             "io.trb",
             r#"
+use std::io::print
 use std::io::print_line
 use std::io::read_line
 
@@ -1392,6 +1393,7 @@ fn input() ->{std::io::Io, abilities::Throw(std::io::Error)} String {
 }
 
 fn main() ->{std::io::Io} Nil {
+    print("hello")
     print_line("hello")
 }
 "#,
@@ -1405,6 +1407,21 @@ fn main() ->{std::io::Io} Nil {
         assert!(output.contains("tribute_io.write"), "{output}");
         assert!(output.contains("tribute_io.read_line"), "{output}");
         assert!(!output.contains("__tribute_io_"), "{output}");
+
+        let mut newline_values = Vec::new();
+        let _ = trunk_ir::walk::walk_op::<()>(&ctx, module.op(), &mut |op| {
+            if let Ok(write) = tribute_ir::dialect::tribute_io::Write::from_op(&ctx, op)
+                && let trunk_ir::refs::ValueDef::OpResult(producer, _) =
+                    ctx.value_def(write.newline(&ctx))
+                && let Ok(constant) = trunk_ir::dialect::arith::Const::from_op(&ctx, producer)
+                && let trunk_ir::Attribute::Bool(value) = constant.value(&ctx)
+            {
+                newline_values.push(value);
+            }
+            std::ops::ControlFlow::Continue(trunk_ir::walk::WalkAction::Advance)
+        });
+        newline_values.sort_unstable();
+        assert_eq!(newline_values, [false, true], "{output}");
     }
 
     #[salsa_test]

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -7,13 +7,17 @@ core.module @direct_fn {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
+  !t3 = core.ability_ref() {name = @"abilities::Throw"}
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
   !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, closure.closure(!t1), tribute_rt.anyref))
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -33,6 +37,7 @@ core.module @direct_fn {
   func.func @"direct_fn::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
+    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
 
   func.func @use_console(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
       %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
@@ -5,16 +5,20 @@ expression: ir_text
 core.module @float_comparisons {
   !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !t2 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
+  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
+  !t3 = core.ability_ref() {name = @"abilities::Throw"}
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t1 = closure.closure(core.func(tribute_rt.anyref, !t0, closure.closure(!t2), tribute_rt.anyref))
+  !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, closure.closure(!t1), tribute_rt.anyref))
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -31,6 +35,7 @@ core.module @float_comparisons {
   func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
       func.unreachable
   }
+    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
 
   func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
       %0 = arith.const {value = 1.0} : core.f64

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -8,16 +8,20 @@ core.module @mixed_nested {
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
   !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
   !t3 = closure.closure(!t1)
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
+  !t4 = core.ability_ref() {name = @"abilities::Throw"}
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !t4 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
+  !t5 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, tribute_rt.anyref)
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
   !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, !t3, tribute_rt.anyref))
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -37,6 +41,7 @@ core.module @mixed_nested {
   func.func @"mixed_nested::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
+    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
 
   func.func @step(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -61,7 +66,7 @@ core.module @mixed_nested {
       %7 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
       %8 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
       %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %10 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t4
+      %10 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t5
       %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
       %12 = arith.const {value = 0} : tribute_rt.anyref
       %13 = func.call {callee = @__tribute_next_tag} : core.i32
@@ -83,7 +88,7 @@ core.module @mixed_nested {
       %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
       %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
       %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %9 = func.constant {func_ref = @"run_all::__clam_1"} : !t4
+      %9 = func.constant {func_ref = @"run_all::__clam_1"} : !t5
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
       %11 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %12 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -3,20 +3,24 @@ source: tests/active_pipeline_goldens.rs
 expression: ir_text
 ---
 core.module @resumptive_op {
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
   !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
   !t3 = closure.closure(!t1)
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
+  !t4 = core.ability_ref() {name = @"abilities::Throw"}
   !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
   !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, !t3, tribute_rt.anyref))
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
   !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
@@ -36,6 +40,7 @@ core.module @resumptive_op {
   func.func @"resumptive_op::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
       func.return %2
   }
+    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
 
   func.func @bump(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = adt.struct_new %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"


### PR DESCRIPTION
## Summary
- define the source-level std::io API, ambient Io effects, and structured EOF/error behavior
- add a target-neutral tribute_io dialect and lower private prelude intrinsics into it
- preserve qualified type, constructor, pattern, record, and UFCS paths using tree-sitter-tribute v0.8.0
- document the shared boundary and keep target-specific ABI work in the native and Wasm follow-up issues

## Validation
- cargo nextest run --workspace (1510 passed, 10 skipped)
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all
- markdownlint via pre-commit hook

Closes #770
Part of #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cross-platform standard I/O with `print`, `print_line`, and `read_line`.
  - Introduced shared I/O operations and a target-independent IR boundary for consistent lowering.
  - Added structured I/O errors: `EndOfFile`, `InvalidEncoding`, and `SystemError`.
- **Bug Fixes**
  - Improved resolution and typing for qualified type, constructor, value, and pattern paths.
  - Prevented nested module flattening from overwriting existing type/constructor bindings.
- **Documentation**
  - Clarified `std::io` semantics, runtime integration, and updated syntax for value vs type paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->