### PR TITLE
Add optimization conformance gate for done continuation deduplication

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -19,6 +19,8 @@ use crate::ast::{
     AbilityId, CallingConvention, CtorId, LocalId, NodeId, SpanMap, TypeKind, TypeScheme,
 };
 
+use super::{AstToIrOptions, DoneContinuationPolicy};
+
 /// Information about a captured variable.
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
@@ -33,10 +35,18 @@ pub struct CaptureInfo {
     pub value: ValueRef,
 }
 
+/// Mutable reuse state for helper functions synthesized during lowering.
+#[derive(Default)]
+struct GeneratedFunctionCache {
+    identity_done_k: Option<Symbol>,
+}
+
 /// Context for lowering AST to arena TrunkIR.
 pub struct IrLoweringCtx<'db> {
     pub db: &'db dyn salsa::Database,
     pub path: PathRef,
+    /// Immutable policies selected for this lowering invocation.
+    options: AstToIrOptions,
     /// Span map for looking up source locations.
     span_map: SpanMap,
     /// Stack of scopes, each mapping LocalId to (name, SSA value).
@@ -55,11 +65,8 @@ pub struct IrLoweringCtx<'db> {
     module_path: SymbolVec,
     /// Counter for generating unique lambda names.
     lambda_counter: u64,
-    /// Shared identity `done_k` function for this compilation unit.
-    ///
-    /// The function definition is emitted once in the compilation root, while
-    /// each SSA region still creates its own closure value referencing it.
-    identity_done_k_func: Option<Symbol>,
+    /// Compiler-generated helper functions available for reuse.
+    generated_functions: GeneratedFunctionCache,
     /// Counter for generating unique local IDs (for synthetic bindings like continuations).
     local_id_counter: u32,
     /// Module's top-level block, used for in-place insertion of lifted lambdas.
@@ -109,6 +116,7 @@ impl<'db> IrLoweringCtx<'db> {
         Self {
             db,
             path,
+            options: AstToIrOptions::production(),
             span_map,
             scopes: vec![HashMap::new()],
             function_types,
@@ -116,7 +124,7 @@ impl<'db> IrLoweringCtx<'db> {
             definition_conventions: HashMap::new(),
             module_path,
             lambda_counter: 0,
-            identity_done_k_func: None,
+            generated_functions: GeneratedFunctionCache::default(),
             local_id_counter: 0x8000_0000, // Start high to avoid collisions with parsed LocalIds
             module_block: None,
             struct_fields: HashMap::new(),
@@ -129,6 +137,13 @@ impl<'db> IrLoweringCtx<'db> {
             done_k: None,
             evidence: None,
         }
+    }
+
+    /// Select immutable policies before lowering begins.
+    pub(crate) fn with_options(mut self, options: AstToIrOptions) -> Self {
+        debug_assert!(self.generated_functions.identity_done_k.is_none());
+        self.options = options;
+        self
     }
 
     /// Get the current module path.
@@ -345,17 +360,26 @@ impl<'db> IrLoweringCtx<'db> {
         )
     }
 
-    /// Return the shared identity `done_k` function, initializing it if needed.
+    /// Return the identity `done_k` function selected by the optimization profile.
     ///
     /// The symbol is cached only after `init` completes successfully.
     pub(crate) fn identity_done_k_func(&mut self, init: impl FnOnce(Symbol)) -> Symbol {
-        if let Some(name) = self.identity_done_k_func {
+        match self.options.done_continuation {
+            DoneContinuationPolicy::PerUse => {
+                let name = self.gen_lambda_name();
+                init(name);
+                return name;
+            }
+            DoneContinuationPolicy::PerCompilationUnit => {}
+        }
+
+        if let Some(name) = self.generated_functions.identity_done_k {
             return name;
         }
 
         let name = self.gen_compilation_unit_lambda_name();
         init(name);
-        self.identity_done_k_func = Some(name);
+        self.generated_functions.identity_done_k = Some(name);
         name
     }
 

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -135,6 +135,7 @@ impl<'db> TypedModule<'db> {
         db: &'db dyn salsa::Database,
         ir: &mut IrContext,
         path: PathRef,
+        options: super::super::AstToIrOptions,
     ) -> IrModule {
         let Self {
             ast,
@@ -156,7 +157,8 @@ impl<'db> TypedModule<'db> {
             ability_conventions,
             module_path,
             node_types,
-        );
+        )
+        .with_options(options);
 
         prescan_definition_conventions(&mut ctx, &ast.decls, &mut String::new());
 

--- a/crates/tribute-front/src/ast_to_ir/lower/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/mod.rs
@@ -328,7 +328,7 @@ pub(super) fn is_irrefutable_pattern<R: salsa::Update>(pattern: &Pattern<R>) -> 
 
 /// Create an identity `done_k` closure: `fn(result: anyref) -> anyref { return result }`.
 ///
-/// The direct `func.func` definition is shared by the entire compilation unit.
+/// The direct `func.func` definition may be shared by the compilation unit.
 /// Each call still creates a region-local `closure.new`, so SSA values do not
 /// cross region boundaries. This bypasses `lower_closure_lambda` and has a
 /// fixed, known signature:
@@ -385,7 +385,6 @@ pub(super) fn create_identity_done_k(
             blocks: trunk_ir::smallvec::smallvec![dk_block],
             parent_op: None,
         });
-
         let dk_func_op = func::func(builder.ir, location, name, dk_func_ty, dk_region);
 
         builder.ir.push_op(module_block, dk_func_op.op_ref());

--- a/crates/tribute-front/src/ast_to_ir/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/mod.rs
@@ -41,6 +41,41 @@ use crate::ast::{
 
 pub use context::IrLoweringCtx;
 
+/// Policy for compiler-generated identity done continuations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub enum DoneContinuationPolicy {
+    /// Emit a separate helper function at every use site.
+    PerUse,
+    /// Share one helper function across the compilation unit.
+    PerCompilationUnit,
+}
+
+/// Independently selectable AST-to-IR policies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub struct AstToIrOptions {
+    pub done_continuation: DoneContinuationPolicy,
+}
+
+impl AstToIrOptions {
+    pub const fn production() -> Self {
+        Self {
+            done_continuation: DoneContinuationPolicy::PerCompilationUnit,
+        }
+    }
+
+    pub const fn baseline() -> Self {
+        Self {
+            done_continuation: DoneContinuationPolicy::PerUse,
+        }
+    }
+}
+
+impl Default for AstToIrOptions {
+    fn default() -> Self {
+        Self::production()
+    }
+}
+
 /// A type-checked module and the metadata required to lower it to TrunkIR.
 ///
 /// This models the boundary between the typed frontend and IR lowering as one
@@ -63,8 +98,19 @@ impl<'db> TypedModule<'db> {
         ir: &mut IrContext,
         source_uri: &str,
     ) -> IrModule {
+        self.lower_to_ir_with_options(db, ir, source_uri, AstToIrOptions::production())
+    }
+
+    /// Lower this typed module with explicit optimization selection.
+    pub fn lower_to_ir_with_options(
+        self,
+        db: &'db dyn salsa::Database,
+        ir: &mut IrContext,
+        source_uri: &str,
+        options: AstToIrOptions,
+    ) -> IrModule {
         let path = ir.paths.intern(source_uri.to_owned());
-        self.lower_module(db, ir, path)
+        self.lower_module(db, ir, path, options)
     }
 }
 

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -19,6 +19,8 @@ root에 한 번만 만들고 모든 사용 지점에서 같은 함수 심볼을 
 지점의 null environment와 `closure.new`는 SSA 영역 가시성을 지키기 위해 해당 영역에
 각각 생성한다. 독립적으로 codegen되는 compilation unit은 자체 정의를 가지며, 향후
 separate compilation이 도입되면 backend의 link-once 정책으로 합칠 수 있다.
+이 deduplication은 독립적으로 끌 수 있어야 하며, 동일한 frontend IR
+경계에서 enabled/disabled snapshot과 native 실행 결과를 비교한다.
 
 ## 핵심 설계
 
@@ -220,6 +222,9 @@ ast_to_ir
 → effect ABI verification
 → backend-specific lowering
 ```
+
+Future effect specialization and handler inlining use the same validation
+contract defined in `optimizations.md`.
 
 `ast_to_ir` 단계에서 effectful function과 closure는 evidence parameter와
 현재 compatibility CPS representation을 반영한 IR로 생성된다. Shared lowering removes

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -63,7 +63,7 @@ flowchart TB
 
     subgraph native_passes["tribute-passes/src/native/"]
         cont["CPS effect lowering\nlower_ability_perform + lower_handle_dispatch"]
-        rc_pass["rc 삽입 (future)\nretain/release 삽입"]
+        rc_pass["RC insertion\nretain/release 삽입"]
     end
 
     subgraph clif_passes["trunk-ir-cranelift-backend/passes/"]

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -687,7 +687,7 @@ flowchart TB
     subgraph ability["Ability Processing"]
         evidence["evidence_insert"]
         resolve_ev["resolve_evidence"]
-        tail_opt["tail_resumptive_optimize (TODO)"]
+        tail_opt["convert_tail_resumptive"]
     end
 
     subgraph lowering["Final Lowering"]

--- a/new-plans/optimizations.md
+++ b/new-plans/optimizations.md
@@ -13,6 +13,40 @@
 | Tail-resumptive optimization    | 지원       | shift/reset 제거          |
 | Handler inlining                | 지원       | 간접 호출 제거            |
 
+### Optimization validation contract
+
+Every optimization must be independently selectable in the compiler pipeline.
+The production profile enables the optimizations that are ready for general
+use, while tests may disable one optimization without changing the rest of the
+pipeline.
+
+An optimization is not ready to be enabled broadly until all of the following
+gates exist:
+
+1. The same source fixture is compiled and executed with the optimization
+   disabled and enabled, and both executions have the same observable result.
+2. Named pipeline boundaries expose focused before/after IR snapshots. A
+   lowering-time optimization compares disabled and enabled output at the same
+   boundary; an IR-to-IR pass captures its immediate input and output.
+3. Structural assertions count the operations expected to disappear and the
+   semantically required operations expected to remain.
+4. Negative fixtures cover cases where the proof is incomplete and the
+   optimization must leave the IR unchanged.
+5. Ability and RC optimizations share fixtures and test helpers rather than
+   defining pass-specific execution models.
+
+The comparison toggles only the optimization under test. Other optimization
+settings, target selection, and sanitizer settings remain identical so that a
+failure is attributable to one transformation.
+
+Lowering-time choices are represented by immutable, stage-specific option
+objects rather than individual boolean fields on the lowering context. When a
+choice controls reuse of compiler-generated helpers, the context keeps that
+mutable reuse state in a dedicated generated-function cache. Policies with
+meaningful modes use named enums—for example, identity done continuations are
+either generated `PerUse` or shared `PerCompilationUnit`—so production and
+conformance profiles remain explicit as more optimizations are added.
+
 ---
 
 ## Optimization Pipeline

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -478,6 +478,16 @@ field_offsets[2] = 8   // c at byte 8
 
 - E2E: Tribute source → native binary with RC
 - Memory safety: Valgrind/AddressSanitizer (no leaks, no double-frees)
+- Optimization conformance: compile and execute the same fixture with one RC
+  optimization disabled and enabled, preserving exit status and output
+- Before/after IR: snapshot the named boundary after RC insertion and before RC
+  lowering, and assert the exact retain/release operations removed
+- Conservative negatives: calls, stores, branch arguments, aliases, closure
+  captures, handler captures, and continuation captures must block elision
+
+RC optimization tests follow the shared validation contract in
+`optimizations.md`. AddressSanitizer runs use the same sanitizer configuration
+for both sides of the optimization comparison.
 
 ### Test Scenarios
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,11 @@ fn compile_file(
             "native" => {
                 println!("Compiling {} to native executable...", input_path.display());
 
-                let config = CompilationConfig::new(db, sanitize_address);
+                let config = CompilationConfig::new(
+                    db,
+                    sanitize_address,
+                    tribute::pipeline::OptimizationOptions::production(),
+                );
                 if let Some(object_bytes) = compile_to_native_binary(db, source, config) {
                     let output = output_path.unwrap_or_else(|| input_path.with_extension(""));
                     if let Err(e) = link_native_binary(&object_bytes, &output) {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -101,6 +101,41 @@ impl From<PassError> for DumpIrError {
 pub struct CompilationConfig {
     /// Enable AddressSanitizer instrumentation.
     pub sanitize_address: bool,
+    /// Stage-specific optimization policies.
+    pub optimizations: OptimizationOptions,
+}
+
+/// Independently selectable optimization stages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub struct OptimizationOptions {
+    pub ast_to_ir: ast_to_ir::AstToIrOptions,
+}
+
+impl OptimizationOptions {
+    pub const fn production() -> Self {
+        Self {
+            ast_to_ir: ast_to_ir::AstToIrOptions::production(),
+        }
+    }
+
+    pub const fn baseline() -> Self {
+        Self {
+            ast_to_ir: ast_to_ir::AstToIrOptions::baseline(),
+        }
+    }
+}
+
+impl Default for OptimizationOptions {
+    fn default() -> Self {
+        Self::production()
+    }
+}
+
+/// Stable shared-pipeline boundaries available to optimization tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub enum SharedPipelineStage {
+    /// Immediately after AST-to-IR lowering, before shared middle-end passes.
+    AfterFrontend,
 }
 
 // AST-based pipeline imports
@@ -244,6 +279,7 @@ fn merge_and_lower_to_ir<'db>(
     db: &'db dyn salsa::Database,
     typed: &ast_typeck::TypeCheckOutput<'db>,
     source: SourceCst,
+    options: OptimizationOptions,
 ) -> (IrContext, Module) {
     use tribute_front::ast::TypedRef;
 
@@ -332,7 +368,7 @@ fn merge_and_lower_to_ir<'db>(
         node_types: merged_node_types,
         ability_conventions: merged_ability_conventions,
     }
-    .lower_to_ir(db, &mut ir, source_uri);
+    .lower_to_ir_with_options(db, &mut ir, source_uri, options.ast_to_ir);
 
     (ir, module)
 }
@@ -345,6 +381,14 @@ pub fn compile_frontend(
     db: &dyn salsa::Database,
     source: SourceCst,
 ) -> Option<(IrContext, Module)> {
+    compile_frontend_with_options(db, source, OptimizationOptions::production())
+}
+
+fn compile_frontend_with_options(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+    options: OptimizationOptions,
+) -> Option<(IrContext, Module)> {
     let typed = parse_and_lower_ast(db, source)?;
     let has_frontend_errors = parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
         .iter()
@@ -352,7 +396,7 @@ pub fn compile_frontend(
     if has_frontend_errors {
         return None;
     }
-    Some(merge_and_lower_to_ir(db, &typed, source))
+    Some(merge_and_lower_to_ir(db, &typed, source, options))
 }
 
 /// Result of the full compilation pipeline.
@@ -481,9 +525,22 @@ fn run_shared_pipeline(
     db: &dyn salsa::Database,
     source: SourceCst,
 ) -> PassResult<Option<(IrContext, Module)>> {
-    let Some((mut ctx, m)) = compile_frontend(db, source) else {
+    run_shared_pipeline_with_options(db, source, OptimizationOptions::production(), None)
+}
+
+fn run_shared_pipeline_with_options(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+    options: OptimizationOptions,
+    stop_after: Option<SharedPipelineStage>,
+) -> PassResult<Option<(IrContext, Module)>> {
+    let Some((mut ctx, m)) = compile_frontend_with_options(db, source, options) else {
         return Ok(None);
     };
+
+    if stop_after == Some(SharedPipelineStage::AfterFrontend) {
+        return Ok(Some((ctx, m)));
+    }
 
     // Middle-end passes, sequenced through the PassManager (#268).
     // Registration order == execution order.
@@ -527,6 +584,24 @@ fn run_shared_pipeline(
     ability_boundary_pm.run(&mut ctx, core_module)?;
 
     Ok(Some((ctx, m)))
+}
+
+/// Dump shared IR at a named optimization boundary.
+///
+/// This entry point exists for conformance gates. Production compilation still
+/// runs the complete shared pipeline.
+#[salsa::tracked]
+pub fn dump_shared_ir_at_stage(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+    stage: SharedPipelineStage,
+    options: OptimizationOptions,
+) -> Result<String, DumpIrError> {
+    let Some((ctx, module)) = run_shared_pipeline_with_options(db, source, options, Some(stage))?
+    else {
+        return Ok(String::new());
+    };
+    Ok(trunk_ir::printer::print_module(&ctx, module.op()))
 }
 
 fn install_debug_use_chain_verifier(pm: &mut PassManager) {
@@ -928,7 +1003,8 @@ pub fn compile_to_native_binary<'db>(
     source: SourceCst,
     config: CompilationConfig,
 ) -> Option<Vec<u8>> {
-    let (mut ctx, m) = match run_shared_pipeline(db, source) {
+    let options = config.optimizations(db);
+    let (mut ctx, m) = match run_shared_pipeline_with_options(db, source, options, None) {
         Ok(Some(result)) => result,
         Ok(None) => return None,
         Err(error) => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,8 +5,11 @@ use std::process::{Command, Output};
 use ropey::Rope;
 use salsa::Database;
 use tribute::TributeDatabaseImpl;
-use tribute::pipeline::{CompilationConfig, compile_to_native_binary, link_native_binary};
+use tribute::pipeline::{
+    CompilationConfig, OptimizationOptions, compile_to_native_binary, link_native_binary,
+};
 use tribute_front::SourceCst;
+use tribute_front::ast_to_ir::{AstToIrOptions, DoneContinuationPolicy};
 use tribute_passes::Diagnostic;
 
 /// Compile source to a native object file, panicking with diagnostics on failure.
@@ -22,7 +25,23 @@ pub fn compile_native_or_panic_with(
     source_file: SourceCst,
     sanitize_address: bool,
 ) -> Vec<u8> {
-    let config = CompilationConfig::new(db, sanitize_address);
+    compile_native_or_panic_with_options(
+        db,
+        source_file,
+        sanitize_address,
+        OptimizationOptions::production(),
+    )
+}
+
+/// Compile source with explicit optimization selection.
+#[allow(dead_code)]
+pub fn compile_native_or_panic_with_options(
+    db: &dyn salsa::Database,
+    source_file: SourceCst,
+    sanitize_address: bool,
+    optimizations: OptimizationOptions,
+) -> Vec<u8> {
+    let config = CompilationConfig::new(db, sanitize_address, optimizations);
     compile_to_native_binary(db, source_file, config).unwrap_or_else(|| {
         let diagnostics: Vec<_> =
             compile_to_native_binary::accumulated::<Diagnostic>(db, source_file, config);
@@ -42,7 +61,22 @@ pub fn compile_native_or_panic_with(
 /// Panics if compilation, linking, or execution fails.
 #[allow(dead_code)]
 pub fn compile_and_run_native(source_name: &str, source_code: &str) -> Output {
-    compile_and_run_native_impl(source_name, source_code, false)
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        false,
+        DoneContinuationPolicy::PerCompilationUnit,
+    )
+}
+
+/// Compile and run with explicit done-continuation deduplication selection.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_done_continuation_dedup(
+    source_name: &str,
+    source_code: &str,
+    policy: DoneContinuationPolicy,
+) -> Output {
+    compile_and_run_native_impl(source_name, source_code, false, policy)
 }
 
 /// Extern declarations for print intrinsics, prepended to test source code.
@@ -82,13 +116,19 @@ pub fn assert_native_output(source_name: &str, source_code: &str, expected_stdou
 /// Panics if compilation, linking, or execution fails.
 #[allow(dead_code)]
 pub fn compile_and_run_native_asan(source_name: &str, source_code: &str) -> Output {
-    compile_and_run_native_impl(source_name, source_code, true)
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        true,
+        DoneContinuationPolicy::PerCompilationUnit,
+    )
 }
 
 fn compile_and_run_native_impl(
     source_name: &str,
     source_code: &str,
     sanitize_address: bool,
+    done_continuation: DoneContinuationPolicy,
 ) -> Output {
     use tribute::database::parse_with_thread_local;
 
@@ -98,7 +138,11 @@ fn compile_and_run_native_impl(
         let tree = parse_with_thread_local(&source_rope, None);
         let source_file = SourceCst::from_path(db, source_name, source_rope.clone(), tree);
 
-        let object_bytes = compile_native_or_panic_with(db, source_file, sanitize_address);
+        let optimizations = OptimizationOptions {
+            ast_to_ir: AstToIrOptions { done_continuation },
+        };
+        let object_bytes =
+            compile_native_or_panic_with_options(db, source_file, sanitize_address, optimizations);
 
         // Link into executable
         let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");

--- a/tests/e2e_ability_core.rs
+++ b/tests/e2e_ability_core.rs
@@ -22,7 +22,7 @@ use ropey::Rope;
 use salsa::Database;
 use tribute::TributeDatabaseImpl;
 use tribute::database::parse_with_thread_local;
-use tribute::pipeline::{CompilationConfig, compile_to_native_binary};
+use tribute::pipeline::{CompilationConfig, OptimizationOptions, compile_to_native_binary};
 use tribute_front::SourceCst;
 
 /// Helper to compile code and collect diagnostics using CLI pipeline.
@@ -35,7 +35,7 @@ fn compile_and_check(code: &str, name: &str) -> Vec<tribute_passes::diagnostic::
         let tree = parse_with_thread_local(&source_code, None);
         let source_file = SourceCst::from_path(db, name, source_code.clone(), tree);
 
-        let config = CompilationConfig::new(db, false);
+        let config = CompilationConfig::new(db, false, OptimizationOptions::production());
         compile_to_native_binary::accumulated::<Diagnostic>(db, source_file, config)
             .into_iter()
             .cloned()

--- a/tests/fixtures/optimizations/done_continuation_dedup_state.trb
+++ b/tests/fixtures/optimizations/done_continuation_dedup_state.trb
@@ -1,0 +1,24 @@
+extern "C" fn __tribute_print_int(value: Int) -> Nil
+
+ability State(s) {
+    op get() -> s
+    op set(value: s) -> Nil
+}
+
+fn bump() ->{State(Int)} Int {
+    let n = State::get()
+    State::set(n + +1)
+    n
+}
+
+fn run_state() -> Int {
+    handle bump() {
+        do result { result }
+        op State::get() { resume +10 }
+        op State::set(value) { resume Nil }
+    }
+}
+
+fn main() {
+    __tribute_print_int(run_state())
+}

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -1,0 +1,133 @@
+//! Semantic and structural gates for independently selectable optimizations.
+
+mod common;
+
+use common::compile_and_run_native_with_done_continuation_dedup;
+use insta::assert_snapshot;
+use salsa_test_macros::salsa_test;
+use tribute::pipeline::{OptimizationOptions, SharedPipelineStage, dump_shared_ir_at_stage};
+use tribute_front::SourceCst;
+use tribute_front::ast_to_ir::DoneContinuationPolicy;
+
+const DONE_CONTINUATION_DEDUP_STATE: &str =
+    include_str!("fixtures/optimizations/done_continuation_dedup_state.trb");
+
+fn identity_done_symbols(ir: &str) -> Vec<&str> {
+    let lines: Vec<_> = ir.lines().collect();
+    lines
+        .windows(2)
+        .filter_map(|pair| {
+            let header = pair[0].trim_start();
+            (header.starts_with("func.func ")
+                && header.contains("%2: tribute_rt.anyref) -> tribute_rt.anyref")
+                && pair[1].trim() == "func.return %2")
+                .then(|| {
+                    header
+                        .strip_prefix("func.func ")
+                        .expect("checked prefix")
+                        .split('(')
+                        .next()
+                        .expect("function header has parameters")
+                })
+        })
+        .collect()
+}
+
+fn focused_identity_done_ir(ir: &str) -> String {
+    let symbols = identity_done_symbols(ir);
+    ir.lines()
+        .filter(|line| symbols.iter().any(|symbol| line.contains(symbol)))
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn lambda_function_count(ir: &str) -> usize {
+    ir.lines()
+        .filter(|line| {
+            let line = line.trim_start();
+            line.starts_with("func.func ") && line.contains("::__lambda_")
+        })
+        .count()
+}
+
+#[test]
+fn done_continuation_dedup_preserves_native_execution() {
+    let disabled = compile_and_run_native_with_done_continuation_dedup(
+        "done_continuation_dedup_disabled.trb",
+        DONE_CONTINUATION_DEDUP_STATE,
+        DoneContinuationPolicy::PerUse,
+    );
+    let enabled = compile_and_run_native_with_done_continuation_dedup(
+        "done_continuation_dedup_enabled.trb",
+        DONE_CONTINUATION_DEDUP_STATE,
+        DoneContinuationPolicy::PerCompilationUnit,
+    );
+
+    assert!(
+        disabled.status.success(),
+        "disabled pipeline failed: {}",
+        String::from_utf8_lossy(&disabled.stderr)
+    );
+    assert!(
+        enabled.status.success(),
+        "enabled pipeline failed: {}",
+        String::from_utf8_lossy(&enabled.stderr)
+    );
+    assert_eq!(disabled.stdout, enabled.stdout);
+    assert_eq!(String::from_utf8_lossy(&enabled.stdout).trim(), "10");
+}
+
+#[salsa_test]
+fn done_continuation_dedup_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "done_continuation_dedup_snapshot.trb",
+        DONE_CONTINUATION_DEDUP_STATE,
+    );
+    let before = dump_shared_ir_at_stage(
+        db,
+        source,
+        SharedPipelineStage::AfterFrontend,
+        OptimizationOptions::baseline(),
+    )
+    .expect("unoptimized frontend IR should be available");
+    let after = dump_shared_ir_at_stage(
+        db,
+        source,
+        SharedPipelineStage::AfterFrontend,
+        OptimizationOptions::production(),
+    )
+    .expect("optimized frontend IR should be available");
+
+    let before_symbols = identity_done_symbols(&before);
+    let after_symbols = identity_done_symbols(&after);
+    assert!(
+        before_symbols.len() > 1,
+        "fixture must generate duplicate identity done continuations"
+    );
+    assert_eq!(after_symbols.len(), 1);
+    assert_eq!(
+        lambda_function_count(&before) - before_symbols.len(),
+        lambda_function_count(&after) - after_symbols.len(),
+        "capturing and user-authored lambdas must remain distinct"
+    );
+
+    let before_references: usize = before_symbols
+        .iter()
+        .map(|symbol| before.matches(&format!("func_ref = {symbol}")).count())
+        .sum();
+    let after_references = after
+        .matches(&format!("func_ref = {}", after_symbols[0]))
+        .count();
+    assert_eq!(before_references, after_references);
+
+    assert_snapshot!(
+        "done_continuation_dedup_before",
+        focused_identity_done_ir(&before)
+    );
+    assert_snapshot!(
+        "done_continuation_dedup_after",
+        focused_identity_done_ir(&after)
+    );
+}

--- a/tests/snapshots/optimization_conformance__done_continuation_dedup_after.snap
+++ b/tests/snapshots/optimization_conformance__done_continuation_dedup_after.snap
@@ -1,0 +1,18 @@
+---
+source: tests/optimization_conformance.rs
+expression: focused_identity_done_ir(&after)
+---
+func.func @"done_continuation_dedup_snapshot::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%11 = closure.new %10 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%13 = closure.new %12 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%20 = closure.new %19 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%27 = closure.new %26 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%5 = closure.new %4 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%15 = closure.new %14 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%23 = closure.new %22 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%35 = closure.new %34 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0
+%43 = closure.new %42 {func_ref = @"done_continuation_dedup_snapshot::__lambda_0"} : !t0

--- a/tests/snapshots/optimization_conformance__done_continuation_dedup_before.snap
+++ b/tests/snapshots/optimization_conformance__done_continuation_dedup_before.snap
@@ -1,0 +1,30 @@
+---
+source: tests/optimization_conformance.rs
+expression: focused_identity_done_ir(&before)
+---
+func.func @"done_continuation_dedup_snapshot::Option::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::Option::__lambda_0"} : !t1
+func.func @"done_continuation_dedup_snapshot::Option::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::Option::__lambda_1"} : !t1
+func.func @"done_continuation_dedup_snapshot::Result::__lambda_2"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::Result::__lambda_2"} : !t1
+func.func @"done_continuation_dedup_snapshot::Result::__lambda_3"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%11 = closure.new %10 {func_ref = @"done_continuation_dedup_snapshot::Result::__lambda_3"} : !t1
+func.func @"done_continuation_dedup_snapshot::Result::__lambda_4"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%8 = closure.new %7 {func_ref = @"done_continuation_dedup_snapshot::Result::__lambda_4"} : !t1
+func.func @"done_continuation_dedup_snapshot::std::io::__lambda_5"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+func.func @"done_continuation_dedup_snapshot::std::io::__lambda_6"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+func.func @"done_continuation_dedup_snapshot::std::io::__lambda_7"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%13 = closure.new %12 {func_ref = @"done_continuation_dedup_snapshot::std::io::__lambda_5"} : !t1
+%20 = closure.new %19 {func_ref = @"done_continuation_dedup_snapshot::std::io::__lambda_6"} : !t1
+%27 = closure.new %26 {func_ref = @"done_continuation_dedup_snapshot::std::io::__lambda_7"} : !t1
+func.func @"done_continuation_dedup_snapshot::__lambda_8"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+func.func @"done_continuation_dedup_snapshot::__lambda_9"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+func.func @"done_continuation_dedup_snapshot::__lambda_10"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+func.func @"done_continuation_dedup_snapshot::__lambda_11"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+func.func @"done_continuation_dedup_snapshot::__lambda_12"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+%5 = closure.new %4 {func_ref = @"done_continuation_dedup_snapshot::__lambda_8"} : !t1
+%15 = closure.new %14 {func_ref = @"done_continuation_dedup_snapshot::__lambda_11"} : !t1
+%23 = closure.new %22 {func_ref = @"done_continuation_dedup_snapshot::__lambda_12"} : !t1
+%35 = closure.new %34 {func_ref = @"done_continuation_dedup_snapshot::__lambda_9"} : !t1
+%43 = closure.new %42 {func_ref = @"done_continuation_dedup_snapshot::__lambda_10"} : !t1


### PR DESCRIPTION
## Summary

- Group optimization selection into stage-specific `OptimizationOptions` and `AstToIrOptions` values.
- Represent identity done-continuation generation with the named `PerUse` and `PerCompilationUnit` policies.
- Keep immutable lowering policies and mutable generated-helper reuse state separate inside `IrLoweringCtx`.
- Add a reusable frontend IR dump boundary for before/after optimization comparisons.
- Gate done-continuation sharing with the same native fixture in both policy modes.
- Add focused IR snapshots and structural assertions that preserve required continuation references and non-identity lambdas.
- Document the conformance and lowering-policy contracts for future ability and reference-counting optimizations.

## Scope

This is the first concrete gate for #723, applied to the done-continuation deduplication implemented for #647. The remaining handler-inlining, effect-specialization, and RC optimization gates stay in #723 and their related issues.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cargo nextest run --workspace` — 1,513 passed, 10 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable optimization settings for compilation, including identity continuation deduplication.
  - Added baseline and production optimization profiles.
  - Added an option to inspect shared IR after frontend processing.
  - Native compilation now consistently applies the selected optimization configuration.

- **Documentation**
  - Expanded optimization and validation guidance, including enabled/disabled comparisons and conservative fallback cases.
  - Updated pipeline and backend diagrams to reflect current terminology.

- **Tests**
  - Added conformance coverage confirming optimized and unoptimized builds produce identical results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->