### PR TITLE
Implement native basic I/O and read_line semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,6 +1558,7 @@ name = "tribute-runtime"
 version = "0.1.0"
 dependencies = [
  "itoa",
+ "libc",
  "smallvec",
  "tribute-rc",
  "zmij",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ itertools = "0.14"
 itoa = "1"
 inventory = "0.3"
 lasso = "0.7"
+libc = "0.2"
 lsp-server = "0.7"
 lsp-types = "0.97"
 object = { version = "0.38", features = ["write_core"] }

--- a/crates/tribute-passes/src/native/io.rs
+++ b/crates/tribute-passes/src/native/io.rs
@@ -1,0 +1,338 @@
+//! Lower target-independent I/O operations to the native runtime ABI.
+
+use trunk_ir::Symbol;
+use trunk_ir::context::{BlockData, IrContext, RegionData};
+use trunk_ir::dialect::{adt, arith, core, func, mem, scf};
+use trunk_ir::ops::DialectOp;
+use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
+use trunk_ir::rewrite::{
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
+};
+use trunk_ir::smallvec::smallvec;
+use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
+
+use tribute_ir::dialect::tribute_io;
+
+const WRITE_FN: &str = "__tribute_io_write";
+const READ_LINE_FN: &str = "__tribute_io_read_line";
+const DEALLOC_RESULT_FN: &str = "__tribute_io_read_line_result_dealloc";
+const READ_LINE_RESULT_TYPE: &str = "std::io::ReadLineResult";
+
+const TAG_LINE: i128 = 0;
+const TAG_END_OF_FILE: i128 = 1;
+const TAG_INVALID_ENCODING: i128 = 2;
+
+const TAG_OFFSET: u32 = 0;
+const CODE_OFFSET: u32 = 4;
+const BYTES_OFFSET: u32 = 8;
+const MESSAGE_OFFSET: u32 = 16;
+
+/// Lower every `tribute_io` operation and add the required runtime declarations.
+pub fn lower(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError> {
+    ensure_runtime_declarations(ctx, module);
+    let read_line_result_ty = find_read_line_result_type(ctx);
+
+    PatternApplicator::new(TypeConverter::new())
+        .add_pattern(NativeWritePattern)
+        .add_pattern(NativeReadLinePattern {
+            read_line_result_ty,
+        })
+        .with_target(ConversionTarget::new().illegal_dialect("tribute_io"))
+        .apply_partial_conversion(ctx, module, "io-to-native")?;
+    Ok(())
+}
+
+fn find_read_line_result_type(ctx: &IrContext) -> Option<TypeRef> {
+    let adt = Symbol::new("adt");
+    let enum_name = Symbol::new("enum");
+    let name_attr = Symbol::new("name");
+    let expected = Symbol::new(READ_LINE_RESULT_TYPE);
+    ctx.types.iter().find_map(|(ty, data)| {
+        (data.dialect == adt
+            && data.name == enum_name
+            && data.attrs.get(&name_attr) == Some(&Attribute::Symbol(expected)))
+        .then_some(ty)
+    })
+}
+
+fn ensure_runtime_declarations(ctx: &mut IrContext, module: Module) {
+    let Some(block) = module.first_block(ctx) else {
+        return;
+    };
+    let loc = ctx.op(module.op()).location;
+    let bytes_ty = core::bytes(ctx).as_type_ref();
+    let bool_ty = intern_type(ctx, "core", "i1");
+    let ptr_ty = core::ptr(ctx).as_type_ref();
+    let nil_ty = core::nil(ctx).as_type_ref();
+
+    for (name, params, result) in [
+        (WRITE_FN, vec![bytes_ty, bool_ty], nil_ty),
+        (READ_LINE_FN, vec![], ptr_ty),
+        (DEALLOC_RESULT_FN, vec![ptr_ty], nil_ty),
+    ] {
+        if has_function(ctx, block, name) {
+            continue;
+        }
+        let declaration = super::build_extern_func(ctx, loc, name, &params, result);
+        let first = ctx.block(block).ops.first().copied();
+        if let Some(first) = first {
+            ctx.insert_op_before(block, first, declaration);
+        } else {
+            ctx.push_op(block, declaration);
+        }
+    }
+}
+
+fn has_function(ctx: &IrContext, block: trunk_ir::BlockRef, name: &str) -> bool {
+    ctx.block(block)
+        .ops
+        .iter()
+        .copied()
+        .any(|op| func::Func::from_op(ctx, op).is_ok_and(|function| function.sym_name(ctx) == name))
+}
+
+fn intern_type(ctx: &mut IrContext, dialect: &'static str, name: &'static str) -> TypeRef {
+    ctx.types
+        .intern(TypeDataBuilder::new(Symbol::new(dialect), Symbol::new(name)).build())
+}
+
+struct NativeWritePattern;
+
+impl RewritePattern for NativeWritePattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(write) = tribute_io::Write::from_op(ctx, op) else {
+            return false;
+        };
+        let loc = ctx.op(op).location;
+        let result_ty = ctx.op_result_types(op)[0];
+        let call = func::call(
+            ctx,
+            loc,
+            [write.bytes(ctx), write.newline(ctx)],
+            result_ty,
+            Symbol::new(WRITE_FN),
+        );
+        rewriter.replace_op(call.op_ref());
+        true
+    }
+}
+
+struct NativeReadLinePattern {
+    read_line_result_ty: Option<TypeRef>,
+}
+
+impl RewritePattern for NativeReadLinePattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if tribute_io::ReadLine::from_op(ctx, op).is_err() {
+            return false;
+        }
+        let Some(enum_ty) = self.read_line_result_ty else {
+            return false;
+        };
+
+        let loc = ctx.op(op).location;
+        let result_ty = ctx.op_result_types(op)[0];
+        let ptr_ty = core::ptr(ctx).as_type_ref();
+        let bytes_ty = core::bytes(ctx).as_type_ref();
+        let i32_ty = intern_type(ctx, "core", "i32");
+        let i1_ty = intern_type(ctx, "core", "i1");
+        let nil_ty = core::nil(ctx).as_type_ref();
+
+        let descriptor = func::call(ctx, loc, [], ptr_ty, Symbol::new(READ_LINE_FN));
+        let descriptor_value = descriptor.result(ctx);
+        let tag = mem::load(ctx, loc, descriptor_value, i32_ty, TAG_OFFSET);
+        let code = mem::load(ctx, loc, descriptor_value, i32_ty, CODE_OFFSET);
+        let bytes = mem::load(ctx, loc, descriptor_value, bytes_ty, BYTES_OFFSET);
+        let message = mem::load(ctx, loc, descriptor_value, bytes_ty, MESSAGE_OFFSET);
+        let dealloc = func::call(
+            ctx,
+            loc,
+            [descriptor_value],
+            nil_ty,
+            Symbol::new(DEALLOC_RESULT_FN),
+        );
+
+        let (line_tag, line_cond) = tag_equals(ctx, loc, tag.result(ctx), TAG_LINE, i32_ty, i1_ty);
+        let (eof_tag, eof_cond) =
+            tag_equals(ctx, loc, tag.result(ctx), TAG_END_OF_FILE, i32_ty, i1_ty);
+        let (invalid_tag, invalid_cond) = tag_equals(
+            ctx,
+            loc,
+            tag.result(ctx),
+            TAG_INVALID_ENCODING,
+            i32_ty,
+            i1_ty,
+        );
+
+        let system_region = variant_region(
+            ctx,
+            loc,
+            enum_ty,
+            result_ty,
+            "ReadSystem",
+            [code.result(ctx), message.result(ctx)],
+        );
+        let invalid_region =
+            variant_region(ctx, loc, enum_ty, result_ty, "ReadInvalidEncoding", []);
+        let invalid_if = scf::r#if(
+            ctx,
+            loc,
+            invalid_cond.result(ctx),
+            result_ty,
+            invalid_region,
+            system_region,
+        );
+
+        let eof_region = variant_region(ctx, loc, enum_ty, result_ty, "ReadEndOfFile", []);
+        let eof_else = op_region(ctx, loc, invalid_if.op_ref(), invalid_if.result(ctx));
+        let eof_if = scf::r#if(
+            ctx,
+            loc,
+            eof_cond.result(ctx),
+            result_ty,
+            eof_region,
+            eof_else,
+        );
+
+        let line_region = variant_region(
+            ctx,
+            loc,
+            enum_ty,
+            result_ty,
+            "ReadLine",
+            [bytes.result(ctx)],
+        );
+        let line_else = op_region(ctx, loc, eof_if.op_ref(), eof_if.result(ctx));
+        let line_if = scf::r#if(
+            ctx,
+            loc,
+            line_cond.result(ctx),
+            result_ty,
+            line_region,
+            line_else,
+        );
+
+        for inserted in [
+            descriptor.op_ref(),
+            tag.op_ref(),
+            code.op_ref(),
+            bytes.op_ref(),
+            message.op_ref(),
+            dealloc.op_ref(),
+            line_tag.op_ref(),
+            line_cond.op_ref(),
+            eof_tag.op_ref(),
+            eof_cond.op_ref(),
+            invalid_tag.op_ref(),
+            invalid_cond.op_ref(),
+        ] {
+            rewriter.insert_op(inserted);
+        }
+        rewriter.replace_op(line_if.op_ref());
+        true
+    }
+}
+
+fn tag_equals(
+    ctx: &mut IrContext,
+    loc: Location,
+    tag: ValueRef,
+    expected: i128,
+    i32_ty: TypeRef,
+    i1_ty: TypeRef,
+) -> (arith::Const, arith::Cmpi) {
+    let constant = arith::r#const(ctx, loc, i32_ty, Attribute::Int(expected));
+    let comparison = arith::cmpi(
+        ctx,
+        loc,
+        tag,
+        constant.result(ctx),
+        i1_ty,
+        Symbol::new("eq"),
+    );
+    (constant, comparison)
+}
+
+fn variant_region<const N: usize>(
+    ctx: &mut IrContext,
+    loc: Location,
+    enum_ty: TypeRef,
+    result_ty: TypeRef,
+    tag: &'static str,
+    fields: [ValueRef; N],
+) -> RegionRef {
+    let variant = adt::variant_new(ctx, loc, fields, result_ty, enum_ty, Symbol::new(tag));
+    op_region(ctx, loc, variant.op_ref(), variant.result(ctx))
+}
+
+fn op_region(ctx: &mut IrContext, loc: Location, op: OpRef, result: ValueRef) -> RegionRef {
+    let yield_op = scf::r#yield(ctx, loc, [result]);
+    let block = ctx.create_block(BlockData {
+        location: loc,
+        args: vec![],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    ctx.push_op(block, op);
+    ctx.push_op(block, yield_op.op_ref());
+    ctx.create_region(RegionData {
+        location: loc,
+        blocks: smallvec![block],
+        parent_op: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    #[test]
+    fn lowers_native_io_and_builds_read_line_variants() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"
+            core.module @test {
+                !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
+
+                func.func @caller(%0: core.bytes, %1: core.i1) -> tribute_rt.anyref {
+                ^bb0:
+                    %2 = tribute_io.write %0, %1 : core.nil
+                    %3 = tribute_io.read_line : tribute_rt.anyref
+                    func.return %3
+                }
+            }
+            "#,
+        );
+
+        lower(&mut ctx, module).expect("native I/O lowering");
+
+        let output = print_module(&ctx, module.op());
+        assert!(!output.contains("tribute_io."), "{output}");
+        assert!(output.contains("callee = @__tribute_io_write"), "{output}");
+        assert!(
+            output.contains("callee = @__tribute_io_read_line"),
+            "{output}"
+        );
+        assert!(output.contains("tag = @ReadLine"), "{output}");
+        assert!(output.contains("tag = @ReadEndOfFile"), "{output}");
+        assert!(output.contains("tag = @ReadInvalidEncoding"), "{output}");
+        assert!(output.contains("tag = @ReadSystem"), "{output}");
+
+        let validation = trunk_ir::validation::validate_value_integrity(&ctx, module);
+        assert!(validation.is_ok(), "{:?}", validation.errors);
+    }
+}

--- a/crates/tribute-passes/src/native/mod.rs
+++ b/crates/tribute-passes/src/native/mod.rs
@@ -17,6 +17,7 @@ pub mod const_to_native;
 pub mod entrypoint;
 pub mod evidence;
 pub mod intrinsic_to_native;
+pub mod io;
 pub mod rc_insertion;
 pub mod rc_lowering;
 pub mod rtti;

--- a/crates/tribute-runtime/Cargo.toml
+++ b/crates/tribute-runtime/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["lib"]
 
 [dependencies]
 itoa.workspace = true
+libc.workspace = true
 smallvec.workspace = true
 tribute-rc.workspace = true
 zmij.workspace = true

--- a/crates/tribute-runtime/src/lib.rs
+++ b/crates/tribute-runtime/src/lib.rs
@@ -273,6 +273,51 @@ enum ReadByte {
     Error(i32),
 }
 
+enum ReadChunk {
+    Bytes(usize),
+    EndOfFile,
+    Interrupted,
+    Error(i32),
+}
+
+const STDIN_BUFFER_SIZE: usize = 8 * 1024;
+
+struct StdinBuffer {
+    bytes: [u8; STDIN_BUFFER_SIZE],
+    position: usize,
+    length: usize,
+}
+
+impl StdinBuffer {
+    const fn new() -> Self {
+        Self {
+            bytes: [0; STDIN_BUFFER_SIZE],
+            position: 0,
+            length: 0,
+        }
+    }
+
+    fn read_byte(&mut self, mut refill: impl FnMut(&mut [u8]) -> ReadChunk) -> ReadByte {
+        if self.position < self.length {
+            let byte = self.bytes[self.position];
+            self.position += 1;
+            return ReadByte::Byte(byte);
+        }
+
+        match refill(&mut self.bytes) {
+            ReadChunk::Bytes(length) => {
+                debug_assert!(length > 0 && length <= self.bytes.len());
+                self.position = 1;
+                self.length = length;
+                ReadByte::Byte(self.bytes[0])
+            }
+            ReadChunk::EndOfFile => ReadByte::EndOfFile,
+            ReadChunk::Interrupted => ReadByte::Interrupted,
+            ReadChunk::Error(code) => ReadByte::Error(code),
+        }
+    }
+}
+
 /// Write a flattened `Bytes` payload, optionally followed by one newline.
 ///
 /// # Safety
@@ -289,21 +334,26 @@ pub unsafe extern "C" fn __tribute_io_write(bytes: *const TributeBytes, newline:
 /// Read one line from native stdin and return a C-compatible result descriptor.
 #[unsafe(no_mangle)]
 pub extern "C" fn __tribute_io_read_line() -> *mut NativeReadLineResult {
+    let mut stdin = unsafe { thread_state() }.stdin_buffer();
     read_line_with(|| {
-        let mut byte = 0u8;
-        let read = unsafe { libc::read(libc::STDIN_FILENO, (&raw mut byte).cast(), 1) };
-        match read {
-            1 => ReadByte::Byte(byte),
-            0 => ReadByte::EndOfFile,
-            _ => {
-                let code = last_errno();
-                if code == libc::EINTR {
-                    ReadByte::Interrupted
-                } else {
-                    ReadByte::Error(code)
+        stdin.read_byte(|buffer| {
+            let read =
+                unsafe { libc::read(libc::STDIN_FILENO, buffer.as_mut_ptr().cast(), buffer.len()) };
+            if read > 0 {
+                return ReadChunk::Bytes(read as usize);
+            }
+            match read {
+                0 => ReadChunk::EndOfFile,
+                _ => {
+                    let code = last_errno();
+                    if code == libc::EINTR {
+                        ReadChunk::Interrupted
+                    } else {
+                        ReadChunk::Error(code)
+                    }
                 }
             }
-        }
+        })
     })
 }
 
@@ -797,6 +847,26 @@ mod tests {
         read_line_with(|| events.next().expect("read script exhausted"))
     }
 
+    fn buffered_scripted_read(
+        buffer: &mut StdinBuffer,
+        input: &[u8],
+        offset: &mut usize,
+        refill_count: &mut usize,
+    ) -> *mut NativeReadLineResult {
+        read_line_with(|| {
+            buffer.read_byte(|destination| {
+                *refill_count += 1;
+                if *offset == input.len() {
+                    return ReadChunk::EndOfFile;
+                }
+                let length = destination.len().min(input.len() - *offset);
+                destination[..length].copy_from_slice(&input[*offset..*offset + length]);
+                *offset += length;
+                ReadChunk::Bytes(length)
+            })
+        })
+    }
+
     unsafe fn bytes_contents(bytes: *const TributeBytes) -> Vec<u8> {
         if bytes.is_null() {
             return Vec::new();
@@ -892,6 +962,33 @@ mod tests {
             assert_eq!(unsafe { bytes_contents(result_ref.bytes) }, b"hello");
             unsafe { dealloc_test_read_result(result) };
         }
+    }
+
+    #[test]
+    fn test_stdin_buffer_preserves_bytes_between_lines() {
+        let mut buffer = StdinBuffer::new();
+        let mut offset = 0;
+        let mut refill_count = 0;
+
+        let first = buffered_scripted_read(
+            &mut buffer,
+            b"first\nsecond\n",
+            &mut offset,
+            &mut refill_count,
+        );
+        assert_eq!(unsafe { bytes_contents((*first).bytes) }, b"first");
+        unsafe { dealloc_test_read_result(first) };
+
+        let second = buffered_scripted_read(
+            &mut buffer,
+            b"first\nsecond\n",
+            &mut offset,
+            &mut refill_count,
+        );
+        assert_eq!(unsafe { bytes_contents((*second).bytes) }, b"second");
+        unsafe { dealloc_test_read_result(second) };
+
+        assert_eq!(refill_count, 1, "second line should use buffered bytes");
     }
 
     #[test]

--- a/crates/tribute-runtime/src/lib.rs
+++ b/crates/tribute-runtime/src/lib.rs
@@ -11,6 +11,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use smallvec::SmallVec;
 
@@ -242,6 +243,181 @@ pub unsafe extern "C" fn __tribute_bytes_print(bytes: *const TributeBytes) {
             write(1, b.ptr, b.len as usize);
         }
     }
+}
+
+// =============================================================================
+// Native basic I/O
+// =============================================================================
+
+pub const IO_READ_LINE: u32 = 0;
+pub const IO_READ_END_OF_FILE: u32 = 1;
+pub const IO_READ_INVALID_ENCODING: u32 = 2;
+pub const IO_READ_SYSTEM: u32 = 3;
+
+/// Target-neutral line-read result returned across the native runtime ABI.
+///
+/// The compiler copies the fields into `std::io::ReadLineResult` and then
+/// releases this descriptor with [`__tribute_io_read_line_result_dealloc`].
+#[repr(C)]
+pub struct NativeReadLineResult {
+    pub tag: u32,
+    pub code: i32,
+    pub bytes: *mut TributeBytes,
+    pub message: *mut TributeBytes,
+}
+
+enum ReadByte {
+    Byte(u8),
+    EndOfFile,
+    Interrupted,
+    Error(i32),
+}
+
+/// Write a flattened `Bytes` payload, optionally followed by one newline.
+///
+/// # Safety
+///
+/// `bytes` must point to a valid [`TributeBytes`] payload.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __tribute_io_write(bytes: *const TributeBytes, newline: u32) {
+    unsafe { __tribute_bytes_print(bytes) };
+    if newline == 1 {
+        __tribute_print_newline();
+    }
+}
+
+/// Read one line from native stdin and return a C-compatible result descriptor.
+#[unsafe(no_mangle)]
+pub extern "C" fn __tribute_io_read_line() -> *mut NativeReadLineResult {
+    read_line_with(|| {
+        let mut byte = 0u8;
+        let read = unsafe { libc::read(libc::STDIN_FILENO, (&raw mut byte).cast(), 1) };
+        match read {
+            1 => ReadByte::Byte(byte),
+            0 => ReadByte::EndOfFile,
+            _ => {
+                let code = last_errno();
+                if code == libc::EINTR {
+                    ReadByte::Interrupted
+                } else {
+                    ReadByte::Error(code)
+                }
+            }
+        }
+    })
+}
+
+/// Release a descriptor returned by [`__tribute_io_read_line`].
+///
+/// The RC-managed `bytes` and `message` payloads, if any, have already been
+/// transferred to the compiler-created result ADT and are not released here.
+///
+/// # Safety
+///
+/// `result` must be null or a pointer returned by [`__tribute_io_read_line`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __tribute_io_read_line_result_dealloc(result: *mut NativeReadLineResult) {
+    unsafe {
+        __tribute_dealloc(
+            result.cast(),
+            core::mem::size_of::<NativeReadLineResult>() as u64,
+        )
+    };
+}
+
+fn read_line_with(mut read_byte: impl FnMut() -> ReadByte) -> *mut NativeReadLineResult {
+    let mut bytes = Vec::new();
+    loop {
+        match read_byte() {
+            ReadByte::Byte(b'\n') => {
+                if bytes.last() == Some(&b'\r') {
+                    bytes.pop();
+                }
+                return line_result(bytes);
+            }
+            ReadByte::Byte(byte) => bytes.push(byte),
+            ReadByte::EndOfFile if bytes.is_empty() => {
+                return allocate_read_result(NativeReadLineResult {
+                    tag: IO_READ_END_OF_FILE,
+                    code: 0,
+                    bytes: core::ptr::null_mut(),
+                    message: core::ptr::null_mut(),
+                });
+            }
+            ReadByte::EndOfFile => return line_result(bytes),
+            ReadByte::Interrupted => {}
+            ReadByte::Error(code) => {
+                return allocate_read_result(NativeReadLineResult {
+                    tag: IO_READ_SYSTEM,
+                    code,
+                    bytes: core::ptr::null_mut(),
+                    message: allocate_bytes(b"stdin read failed"),
+                });
+            }
+        }
+    }
+}
+
+fn line_result(bytes: Vec<u8>) -> *mut NativeReadLineResult {
+    if core::str::from_utf8(&bytes).is_err() {
+        return allocate_read_result(NativeReadLineResult {
+            tag: IO_READ_INVALID_ENCODING,
+            code: 0,
+            bytes: core::ptr::null_mut(),
+            message: core::ptr::null_mut(),
+        });
+    }
+
+    allocate_read_result(NativeReadLineResult {
+        tag: IO_READ_LINE,
+        code: 0,
+        bytes: allocate_bytes(&bytes),
+        message: core::ptr::null_mut(),
+    })
+}
+
+fn allocate_read_result(result: NativeReadLineResult) -> *mut NativeReadLineResult {
+    let size = core::mem::size_of::<NativeReadLineResult>() as u64;
+    let raw = unsafe { __tribute_alloc(size) }.cast::<NativeReadLineResult>();
+    unsafe { raw.write(result) };
+    raw
+}
+
+fn allocate_bytes(bytes: &[u8]) -> *mut TributeBytes {
+    let len = bytes.len() as u64;
+    let data = if bytes.is_empty() {
+        core::ptr::null_mut()
+    } else {
+        let data = unsafe { __tribute_alloc(len) };
+        unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), data, bytes.len()) };
+        data
+    };
+
+    let size = core::mem::size_of::<tribute_rc::RcBox<TributeBytes>>() as u64;
+    let raw = unsafe { __tribute_alloc(size) };
+    let rc_box = unsafe { tribute_rc::RcBox::<TributeBytes>::init(raw, 0) };
+    unsafe {
+        (*rc_box).payload.ptr = data;
+        (*rc_box).payload.len = len;
+        &raw mut (*rc_box).payload
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn last_errno() -> i32 {
+    unsafe { *libc::__errno_location() }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+fn last_errno() -> i32 {
+    unsafe { *libc::__error() }
 }
 
 /// Return the byte length of a Bytes value.
@@ -616,6 +792,46 @@ pub unsafe extern "C" fn __tribute_evidence_lookup_handler(
 mod tests {
     use super::*;
 
+    fn scripted_read(events: impl IntoIterator<Item = ReadByte>) -> *mut NativeReadLineResult {
+        let mut events = events.into_iter();
+        read_line_with(|| events.next().expect("read script exhausted"))
+    }
+
+    unsafe fn bytes_contents(bytes: *const TributeBytes) -> Vec<u8> {
+        if bytes.is_null() {
+            return Vec::new();
+        }
+        let bytes = unsafe { &*bytes };
+        if bytes.len == 0 {
+            return Vec::new();
+        }
+        unsafe { core::slice::from_raw_parts(bytes.ptr, bytes.len as usize) }.to_vec()
+    }
+
+    unsafe fn dealloc_test_bytes(bytes: *mut TributeBytes) {
+        if bytes.is_null() {
+            return;
+        }
+        let payload = unsafe { &*bytes };
+        unsafe { __tribute_dealloc(payload.ptr.cast_mut(), payload.len) };
+        let raw = unsafe { tribute_rc::RcBox::from_payload_ptr_mut(bytes) }.cast();
+        unsafe {
+            __tribute_dealloc(
+                raw,
+                core::mem::size_of::<tribute_rc::RcBox<TributeBytes>>() as u64,
+            )
+        };
+    }
+
+    unsafe fn dealloc_test_read_result(result: *mut NativeReadLineResult) {
+        let result_ref = unsafe { &*result };
+        unsafe {
+            dealloc_test_bytes(result_ref.bytes);
+            dealloc_test_bytes(result_ref.message);
+            __tribute_io_read_line_result_dealloc(result);
+        }
+    }
+
     #[test]
     fn test_alloc_dealloc() {
         unsafe {
@@ -651,6 +867,83 @@ mod tests {
             __tribute_dealloc(core::ptr::null_mut(), 64);
             __tribute_dealloc(core::ptr::null_mut(), 0);
         }
+    }
+
+    #[test]
+    fn test_native_io_abi_layout() {
+        assert_eq!(core::mem::offset_of!(NativeReadLineResult, tag), 0);
+        assert_eq!(core::mem::offset_of!(NativeReadLineResult, code), 4);
+        assert_eq!(core::mem::offset_of!(NativeReadLineResult, bytes), 8);
+        assert_eq!(core::mem::offset_of!(NativeReadLineResult, message), 16);
+        assert_eq!(core::mem::size_of::<NativeReadLineResult>(), 24);
+
+        let _: unsafe extern "C" fn(*const TributeBytes, u32) = __tribute_io_write;
+        let _: extern "C" fn() -> *mut NativeReadLineResult = __tribute_io_read_line;
+        let _: unsafe extern "C" fn(*mut NativeReadLineResult) =
+            __tribute_io_read_line_result_dealloc;
+    }
+
+    #[test]
+    fn test_read_line_strips_lf_and_crlf() {
+        for input in [b"hello\n".as_slice(), b"hello\r\n".as_slice()] {
+            let result = scripted_read(input.iter().copied().map(ReadByte::Byte));
+            let result_ref = unsafe { &*result };
+            assert_eq!(result_ref.tag, IO_READ_LINE);
+            assert_eq!(unsafe { bytes_contents(result_ref.bytes) }, b"hello");
+            unsafe { dealloc_test_read_result(result) };
+        }
+    }
+
+    #[test]
+    fn test_read_line_preserves_empty_and_partial_lines() {
+        let empty = scripted_read([ReadByte::Byte(b'\n')]);
+        assert_eq!(unsafe { &*empty }.tag, IO_READ_LINE);
+        assert_eq!(unsafe { bytes_contents((*empty).bytes) }, b"");
+        unsafe { dealloc_test_read_result(empty) };
+
+        let partial = scripted_read(
+            b"partial"
+                .iter()
+                .copied()
+                .map(ReadByte::Byte)
+                .chain([ReadByte::EndOfFile]),
+        );
+        assert_eq!(unsafe { &*partial }.tag, IO_READ_LINE);
+        assert_eq!(unsafe { bytes_contents((*partial).bytes) }, b"partial");
+        unsafe { dealloc_test_read_result(partial) };
+    }
+
+    #[test]
+    fn test_read_line_distinguishes_eof_and_invalid_encoding() {
+        let eof = scripted_read([ReadByte::EndOfFile]);
+        assert_eq!(unsafe { &*eof }.tag, IO_READ_END_OF_FILE);
+        unsafe { dealloc_test_read_result(eof) };
+
+        let invalid = scripted_read([ReadByte::Byte(0xff), ReadByte::Byte(b'\n')]);
+        assert_eq!(unsafe { &*invalid }.tag, IO_READ_INVALID_ENCODING);
+        unsafe { dealloc_test_read_result(invalid) };
+    }
+
+    #[test]
+    fn test_read_line_retries_interrupt_and_reports_system_error() {
+        let line = scripted_read([
+            ReadByte::Interrupted,
+            ReadByte::Byte(b'x'),
+            ReadByte::EndOfFile,
+        ]);
+        assert_eq!(unsafe { &*line }.tag, IO_READ_LINE);
+        assert_eq!(unsafe { bytes_contents((*line).bytes) }, b"x");
+        unsafe { dealloc_test_read_result(line) };
+
+        let error = scripted_read([ReadByte::Error(5)]);
+        let error_ref = unsafe { &*error };
+        assert_eq!(error_ref.tag, IO_READ_SYSTEM);
+        assert_eq!(error_ref.code, 5);
+        assert_eq!(
+            unsafe { bytes_contents(error_ref.message) },
+            b"stdin read failed"
+        );
+        unsafe { dealloc_test_read_result(error) };
     }
 
     // =========================================================================

--- a/crates/tribute-runtime/src/lib.rs
+++ b/crates/tribute-runtime/src/lib.rs
@@ -209,9 +209,7 @@ pub unsafe extern "C" fn __tribute_print_bytes(ptr: *const u8, len: u64) {
 /// Signature: `() -> ()`
 #[unsafe(no_mangle)]
 pub extern "C" fn __tribute_print_newline() {
-    unsafe {
-        write(1, b"\n".as_ptr(), 1);
-    }
+    write_stdout_all(b"\n");
 }
 
 // =============================================================================
@@ -239,10 +237,36 @@ pub struct TributeBytes {
 pub unsafe extern "C" fn __tribute_bytes_print(bytes: *const TributeBytes) {
     let b = unsafe { &*bytes };
     if b.len > 0 && !b.ptr.is_null() {
-        unsafe {
-            write(1, b.ptr, b.len as usize);
+        let bytes = unsafe { core::slice::from_raw_parts(b.ptr, b.len as usize) };
+        write_stdout_all(bytes);
+    }
+}
+
+fn write_stdout_all(bytes: &[u8]) {
+    let _ = write_all_with(bytes, |remaining| {
+        let written = unsafe { write(1, remaining.as_ptr(), remaining.len()) };
+        if written >= 0 {
+            Ok(written as usize)
+        } else {
+            Err(last_errno())
+        }
+    });
+}
+
+fn write_all_with(
+    mut remaining: &[u8],
+    mut write_once: impl FnMut(&[u8]) -> Result<usize, i32>,
+) -> bool {
+    while !remaining.is_empty() {
+        match write_once(remaining) {
+            Ok(0) => return false,
+            Ok(written) if written <= remaining.len() => remaining = &remaining[written..],
+            Ok(_) => return false,
+            Err(code) if code == libc::EINTR => {}
+            Err(_) => return false,
         }
     }
+    true
 }
 
 // =============================================================================
@@ -951,6 +975,26 @@ mod tests {
         let _: extern "C" fn() -> *mut NativeReadLineResult = __tribute_io_read_line;
         let _: unsafe extern "C" fn(*mut NativeReadLineResult) =
             __tribute_io_read_line_result_dealloc;
+    }
+
+    #[test]
+    fn test_write_all_retries_short_writes_and_interrupts() {
+        let mut results = [Ok(2), Err(libc::EINTR), Ok(3)].into_iter();
+        let mut attempts = Vec::new();
+
+        let completed = write_all_with(b"hello", |remaining| {
+            attempts.push(remaining.to_vec());
+            results.next().expect("write script exhausted")
+        });
+
+        assert!(completed);
+        assert_eq!(attempts, [b"hello".as_slice(), b"llo", b"llo"]);
+    }
+
+    #[test]
+    fn test_write_all_stops_on_zero_or_other_error() {
+        assert!(!write_all_with(b"hello", |_| Ok(0)));
+        assert!(!write_all_with(b"hello", |_| Err(libc::EIO)));
     }
 
     #[test]

--- a/crates/tribute-runtime/src/tls.rs
+++ b/crates/tribute-runtime/src/tls.rs
@@ -7,8 +7,10 @@
 //! lazily allocated on first access via [`thread_state()`].
 
 use alloc::boxed::Box;
-use core::cell::Cell;
+use core::cell::{Cell, RefCell, RefMut};
 use core::ffi::c_void;
+
+use crate::StdinBuffer;
 
 // =============================================================================
 // Thread-local state
@@ -19,12 +21,14 @@ use core::ffi::c_void;
 
 pub(crate) struct ThreadState {
     tag_counter: Cell<i32>,
+    stdin: RefCell<StdinBuffer>,
 }
 
 impl ThreadState {
     fn new() -> Self {
         Self {
             tag_counter: Cell::new(0),
+            stdin: RefCell::new(StdinBuffer::new()),
         }
     }
 
@@ -32,6 +36,10 @@ impl ThreadState {
         let tag = self.tag_counter.get();
         self.tag_counter.set(tag.wrapping_add(1));
         tag
+    }
+
+    pub(crate) fn stdin_buffer(&self) -> RefMut<'_, StdinBuffer> {
+        self.stdin.borrow_mut()
     }
 }
 

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -178,6 +178,16 @@ Array:  [length: i64] [elements...]
 - `tribute compile --target native file.trb` → 실행 파일
 - E2E 테스트 (ability 포함)
 
+### Phase 6: Native Basic I/O
+
+- shared `tribute_io.write`와 `tribute_io.read_line`을
+  [io.md](io.md#native-runtime-abi)의 private runtime ABI로 낮춘다.
+- Runtime descriptor를 high-level `ReadLineResult` ADT로 바꾼 뒤 기존 SCF, ADT,
+  memory lowering을 적용한다.
+- Native runtime은 Tribute enum/RTTI layout에 의존하지 않는다.
+- E2E 테스트는 subprocess stdin에 raw bytes를 주입하여 빈 줄, partial EOF, EOF,
+  invalid UTF-8을 검증한다.
+
 ---
 
 ## References

--- a/new-plans/io.md
+++ b/new-plans/io.md
@@ -186,6 +186,32 @@ Wasm lowering은 각각 #772와 #771이 담당한다.
 - WASI preview2/component model 전환은 이 source API와 독립적인 후속 backend
   작업이다.
 
+### Native Runtime ABI
+
+Native lowering은 다음 private C ABI를 사용한다. 이 ABI는 source API가 아니며
+`tribute-runtime`과 native compiler pipeline 사이에서만 공유된다.
+
+```text
+__tribute_io_write(bytes: *const TributeBytes, newline: u32) -> void
+__tribute_io_read_line() -> *mut NativeReadLineResult
+__tribute_io_read_line_result_dealloc(result: *mut NativeReadLineResult) -> void
+
+NativeReadLineResult = repr(C) {
+    tag: u32,                  // 0 Line, 1 EOF, 2 InvalidEncoding, 3 System
+    code: i32,                // System에서만 사용
+    bytes: *mut TributeBytes, // Line에서만 사용
+    message: *mut TributeBytes, // System에서만 사용, valid UTF-8
+}
+```
+
+Runtime은 Tribute enum이나 RTTI layout을 직접 생성하지 않는다. Native lowering이
+descriptor의 필드를 읽어 `std::io::ReadLineResult` ADT를 만들고 descriptor를 즉시
+해제한다. `bytes`와 `message`는 RC-managed `Bytes` payload이며 해당 variant로 소유권이
+이전된다. 사용하지 않는 pointer field는 null이다.
+
+`newline`은 native ABI에서 `u32` 0/1로 전달한다. Runtime은 `bytes`를 먼저 모두 쓰고,
+값이 1일 때만 `\n` 하나를 추가한다.
+
 `String` 출력은 rope를 `Bytes` chunk로 순회하거나 flatten하여 처리할 수 있지만,
 source-level `Io` 계약과 target-independent boundary는 어느 표현을 선택하든
 동일해야 한다. Wasm도 문자열 literal뿐 아니라 동적으로 만든 `String`을 출력할

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -864,6 +864,9 @@ fn compile_module_to_native(
     tribute_passes::native::intrinsic_to_native::lower(ctx, module)
         .map_err(native_conversion_failure)?;
 
+    // Phase -0.2 - Lower target-independent I/O to the native runtime ABI.
+    tribute_passes::native::io::lower(ctx, module).map_err(native_conversion_failure)?;
+
     // Phase 0 - Lower structured control flow to CFG-based control flow
     if let Ok(core_module) = core_dialect::Module::from_op(ctx, module.op()) {
         let mut pm = PassManager::new();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,6 +13,11 @@ use tribute_front::SourceCst;
 use tribute_front::ast_to_ir::{AstToIrOptions, DoneContinuationPolicy};
 use tribute_passes::Diagnostic;
 
+#[cfg(unix)]
+unsafe extern "C" {
+    fn close(fd: i32) -> i32;
+}
+
 /// Compile source to a native object file, panicking with diagnostics on failure.
 #[allow(dead_code)]
 pub fn compile_native_or_panic(db: &dyn salsa::Database, source_file: SourceCst) -> Vec<u8> {
@@ -67,7 +72,7 @@ pub fn compile_and_run_native(source_name: &str, source_code: &str) -> Output {
         source_code,
         false,
         DoneContinuationPolicy::PerCompilationUnit,
-        None,
+        NativeStdin::Null,
     )
 }
 
@@ -78,7 +83,7 @@ pub fn compile_and_run_native_with_done_continuation_dedup(
     source_code: &str,
     policy: DoneContinuationPolicy,
 ) -> Output {
-    compile_and_run_native_impl(source_name, source_code, false, policy, None)
+    compile_and_run_native_impl(source_name, source_code, false, policy, NativeStdin::Null)
 }
 
 /// Compile and run Tribute source with raw bytes supplied to native stdin.
@@ -93,7 +98,20 @@ pub fn compile_and_run_native_with_stdin(
         source_code,
         false,
         DoneContinuationPolicy::PerCompilationUnit,
-        Some(stdin),
+        NativeStdin::Bytes(stdin),
+    )
+}
+
+/// Compile and run Tribute source after closing native stdin.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_closed_stdin(source_name: &str, source_code: &str) -> Output {
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        false,
+        DoneContinuationPolicy::PerCompilationUnit,
+        NativeStdin::Closed,
     )
 }
 
@@ -139,8 +157,15 @@ pub fn compile_and_run_native_asan(source_name: &str, source_code: &str) -> Outp
         source_code,
         true,
         DoneContinuationPolicy::PerCompilationUnit,
-        None,
+        NativeStdin::Null,
     )
+}
+
+enum NativeStdin<'a> {
+    Null,
+    Bytes(&'a [u8]),
+    #[cfg(unix)]
+    Closed,
 }
 
 fn compile_and_run_native_impl(
@@ -148,7 +173,7 @@ fn compile_and_run_native_impl(
     source_code: &str,
     sanitize_address: bool,
     done_continuation: DoneContinuationPolicy,
-    stdin: Option<&[u8]>,
+    stdin: NativeStdin<'_>,
 ) -> Output {
     use tribute::database::parse_with_thread_local;
 
@@ -182,24 +207,44 @@ fn compile_and_run_native_impl(
 
         // Run the executable
         let mut command = Command::new(&exec_path);
-        if let Some(input) = stdin {
-            let mut child = command
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"));
-            child
-                .stdin
-                .take()
-                .expect("piped stdin")
-                .write_all(input)
-                .expect("write native stdin");
-            child.wait_with_output().expect("wait for native binary")
-        } else {
-            command
+        match stdin {
+            NativeStdin::Bytes(input) => {
+                let mut child = command
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .spawn()
+                    .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"));
+                let mut child_stdin = child.stdin.take().expect("piped stdin");
+                let input = input.to_vec();
+                let writer = std::thread::spawn(move || child_stdin.write_all(&input));
+                let output = child.wait_with_output().expect("wait for native binary");
+                writer
+                    .join()
+                    .expect("native stdin writer panicked")
+                    .expect("write native stdin");
+                output
+            }
+            #[cfg(unix)]
+            NativeStdin::Closed => {
+                use std::os::unix::process::CommandExt;
+
+                unsafe {
+                    command.pre_exec(|| {
+                        if close(0) == 0 {
+                            Ok(())
+                        } else {
+                            Err(std::io::Error::last_os_error())
+                        }
+                    });
+                }
+                command
+                    .output()
+                    .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"))
+            }
+            NativeStdin::Null => command
                 .output()
-                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"))
+                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}")),
         }
     })
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,7 @@
 //! Common test utilities for e2e tests.
 
-use std::process::{Command, Output};
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
 
 use ropey::Rope;
 use salsa::Database;
@@ -66,6 +67,7 @@ pub fn compile_and_run_native(source_name: &str, source_code: &str) -> Output {
         source_code,
         false,
         DoneContinuationPolicy::PerCompilationUnit,
+        None,
     )
 }
 
@@ -76,7 +78,23 @@ pub fn compile_and_run_native_with_done_continuation_dedup(
     source_code: &str,
     policy: DoneContinuationPolicy,
 ) -> Output {
-    compile_and_run_native_impl(source_name, source_code, false, policy)
+    compile_and_run_native_impl(source_name, source_code, false, policy, None)
+}
+
+/// Compile and run Tribute source with raw bytes supplied to native stdin.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_stdin(
+    source_name: &str,
+    source_code: &str,
+    stdin: &[u8],
+) -> Output {
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        false,
+        DoneContinuationPolicy::PerCompilationUnit,
+        Some(stdin),
+    )
 }
 
 /// Extern declarations for print intrinsics, prepended to test source code.
@@ -121,6 +139,7 @@ pub fn compile_and_run_native_asan(source_name: &str, source_code: &str) -> Outp
         source_code,
         true,
         DoneContinuationPolicy::PerCompilationUnit,
+        None,
     )
 }
 
@@ -129,6 +148,7 @@ fn compile_and_run_native_impl(
     source_code: &str,
     sanitize_address: bool,
     done_continuation: DoneContinuationPolicy,
+    stdin: Option<&[u8]>,
 ) -> Output {
     use tribute::database::parse_with_thread_local;
 
@@ -161,8 +181,25 @@ fn compile_and_run_native_impl(
         }
 
         // Run the executable
-        Command::new(&exec_path)
-            .output()
-            .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"))
+        let mut command = Command::new(&exec_path);
+        if let Some(input) = stdin {
+            let mut child = command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"));
+            child
+                .stdin
+                .take()
+                .expect("piped stdin")
+                .write_all(input)
+                .expect("write native stdin");
+            child.wait_with_output().expect("wait for native binary")
+        } else {
+            command
+                .output()
+                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"))
+        }
     })
 }

--- a/tests/e2e_native.rs
+++ b/tests/e2e_native.rs
@@ -9,6 +9,8 @@
 
 mod common;
 
+#[cfg(unix)]
+use common::compile_and_run_native_with_closed_stdin;
 use common::{assert_native_output, compile_and_run_native, compile_and_run_native_with_stdin};
 
 fn std_io_read_line_program() -> &'static str {
@@ -590,6 +592,61 @@ fn test_native_std_io_read_line_contract() {
 }
 
 #[test]
+fn test_native_std_io_read_line_preserves_buffered_input() {
+    let output = compile_and_run_native_with_stdin(
+        "std_io_read_line_buffered.trb",
+        r#"
+use abilities::Throw
+use std::io::{Error, Io, print_line, read_line}
+
+fn read_or_error() ->{Io} String {
+    handle read_line() {
+        do line { line }
+        op Throw::throw(error) {
+            case error {
+                Error::EndOfFile -> "eof"
+                Error::InvalidEncoding -> "invalid"
+                Error::System(_) -> "system"
+            }
+        }
+    }
+}
+
+fn main() ->{Io} Nil {
+    print_line(read_or_error())
+    print_line(read_or_error())
+}
+"#,
+        b"first\nsecond\n",
+    );
+    assert!(
+        output.status.success(),
+        "exit={:?}, stderr='{}'",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "first\nsecond\n");
+}
+
+#[test]
+fn test_native_std_io_accepts_large_stdin() {
+    let mut stdin = vec![b'x'; 256 * 1024];
+    stdin.push(b'\n');
+    let output = compile_and_run_native_with_stdin(
+        "std_io_read_line_large.trb",
+        std_io_read_line_program(),
+        &stdin,
+    );
+    assert!(
+        output.status.success(),
+        "exit={:?}, stderr='{}'",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(output.stdout, stdin);
+}
+
+#[test]
 fn test_native_std_io_read_line_errors() {
     for (name, stdin, expected) in [
         ("eof", b"".as_slice(), "eof\n"),
@@ -608,6 +665,22 @@ fn test_native_std_io_read_line_errors() {
         );
         assert_eq!(String::from_utf8_lossy(&output.stdout), expected, "{name}");
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_native_std_io_read_line_system_error() {
+    let output = compile_and_run_native_with_closed_stdin(
+        "std_io_read_line_system.trb",
+        std_io_read_line_program(),
+    );
+    assert!(
+        output.status.success(),
+        "exit={:?}, stderr='{}'",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "system\n");
 }
 
 #[test]

--- a/tests/e2e_native.rs
+++ b/tests/e2e_native.rs
@@ -9,7 +9,31 @@
 
 mod common;
 
-use common::{assert_native_output, compile_and_run_native};
+use common::{assert_native_output, compile_and_run_native, compile_and_run_native_with_stdin};
+
+fn std_io_read_line_program() -> &'static str {
+    r#"
+use abilities::Throw
+use std::io::{Error, Io, print_line, read_line}
+
+fn read_or_error() ->{Io} String {
+    handle read_line() {
+        do line { line }
+        op Throw::throw(error) {
+            case error {
+                Error::EndOfFile -> "eof"
+                Error::InvalidEncoding -> "invalid"
+                Error::System(_) -> "system"
+            }
+        }
+    }
+}
+
+fn main() ->{Io} Nil {
+    print_line(read_or_error())
+}
+"#
+}
 
 #[test]
 fn test_native_simple_literal() {
@@ -512,6 +536,78 @@ fn main() {
         stderr,
     );
     assert_eq!(stdout, "Hello\nWorld\n");
+}
+
+#[test]
+fn test_native_std_io_prints_dynamic_strings() {
+    let output = compile_and_run_native(
+        "std_io_dynamic_print.trb",
+        r#"
+use std::io::{print, print_line}
+
+fn message() -> String {
+    "Hello" <> ", World"
+}
+
+fn main() ->{std::io::Io} Nil {
+    print(message())
+    print_line("!")
+}
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "exit={:?}, stdout='{}', stderr='{}'",
+        output.status,
+        stdout,
+        stderr,
+    );
+    assert_eq!(stdout, "Hello, World!\n");
+}
+
+#[test]
+fn test_native_std_io_read_line_contract() {
+    for (name, stdin, expected) in [
+        ("empty", b"\n".as_slice(), "\n"),
+        ("crlf", b"hello\r\n".as_slice(), "hello\n"),
+        ("partial", b"partial".as_slice(), "partial\n"),
+    ] {
+        let output = compile_and_run_native_with_stdin(
+            &format!("std_io_read_line_{name}.trb"),
+            std_io_read_line_program(),
+            stdin,
+        );
+        assert!(
+            output.status.success(),
+            "{name}: exit={:?}, stderr='{}'",
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), expected, "{name}");
+    }
+}
+
+#[test]
+fn test_native_std_io_read_line_errors() {
+    for (name, stdin, expected) in [
+        ("eof", b"".as_slice(), "eof\n"),
+        ("invalid", b"\xff\n".as_slice(), "invalid\n"),
+    ] {
+        let output = compile_and_run_native_with_stdin(
+            &format!("std_io_read_line_{name}.trb"),
+            std_io_read_line_program(),
+            stdin,
+        );
+        assert!(
+            output.status.success(),
+            "{name}: exit={:?}, stderr='{}'",
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), expected, "{name}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- define a private native runtime ABI for dynamic writes and structured read results
- implement UTF-8-aware `read_line` semantics, including CRLF stripping, partial EOF, and I/O error classification
- lower shared `tribute_io` operations to the runtime boundary and construct the public `std::io` result variants
- add runtime state-machine coverage and native end-to-end stdin tests

## Validation

- `cargo nextest run --workspace --all-targets` (1520 passed, 10 skipped)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build -p tribute-runtime --profile runtime`
- markdownlint and `git diff --check`

Closes #772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native standard I/O for byte writes and line-oriented `read_line`, powered by a private native ABI.
* **Bug Fixes**
  * Improved robustness for stdout writes (handles short writes and interrupted syscalls).
  * Enhanced `read_line` behavior: EOF vs invalid-encoding vs system errors, CRLF/newline handling, buffering across calls, and large input support.
* **Documentation**
  * Documented the Native Runtime ABI and how I/O is lowered to it.
* **Tests**
  * Expanded native end-to-end coverage, including deterministic stdin injection and closed-stdin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->