### PR TITLE
Add conservative native RC retain/release pair elimination

### DIFF
--- a/crates/tribute-passes/src/native/mod.rs
+++ b/crates/tribute-passes/src/native/mod.rs
@@ -10,6 +10,7 @@
 //! - `adt_rc_header`: Lower `adt.struct_new` to clif alloc + RC header init + field stores
 //! - `tribute_rt_to_clif`: Lower `tribute_rt.box_*`/`unbox_*` to clif alloc + load/store
 //! - `rc_insertion`: Insert `tribute_rt.retain`/`release` for reference counting
+//! - `rc_optimization`: Eliminate redundant local retain/release pairs
 //! - `rc_lowering`: Lower `tribute_rt.retain`/`release` to inline `clif.*` ops
 
 pub mod adt_rc_header;
@@ -20,6 +21,7 @@ pub mod intrinsic_to_native;
 pub mod io;
 pub mod rc_insertion;
 pub mod rc_lowering;
+pub mod rc_optimization;
 pub mod rtti;
 pub mod tribute_rt_to_clif;
 pub mod type_converter;

--- a/crates/tribute-passes/src/native/rc_optimization.rs
+++ b/crates/tribute-passes/src/native/rc_optimization.rs
@@ -1,0 +1,270 @@
+//! Local reference-counting optimizations for the native backend.
+//!
+//! This pass runs immediately after RC insertion. It removes a retain/release
+//! pair only when both operations are in the same block, refer to the same SSA
+//! value, and every intervening use is explicitly known not to let the value
+//! escape. Unknown uses are barriers by design; later RC optimization work can
+//! widen the safe-use set with dedicated borrow and alias analyses.
+
+use tribute_ir::dialect::tribute_rt;
+use trunk_ir::context::IrContext;
+use trunk_ir::dialect::clif;
+use trunk_ir::ops::DialectOp;
+use trunk_ir::rewrite::Module;
+use trunk_ir::rewrite::helpers::erase_op;
+use trunk_ir::{BlockRef, OpRef, RegionRef, ValueRef};
+
+/// Eliminate provably redundant retain/release pairs in `module`.
+pub fn eliminate_paired_rc(ctx: &mut IrContext, module: Module) {
+    let Some(body) = module.body(ctx) else {
+        return;
+    };
+    optimize_region(ctx, body);
+}
+
+fn optimize_region(ctx: &mut IrContext, region: RegionRef) {
+    let blocks = ctx.region(region).blocks.to_vec();
+    for block in blocks {
+        while eliminate_one_pair(ctx, block) {}
+
+        let ops = ctx.block(block).ops.to_vec();
+        for op in ops {
+            let nested_regions = ctx.op(op).regions.to_vec();
+            for nested in nested_regions {
+                optimize_region(ctx, nested);
+            }
+        }
+    }
+}
+
+fn eliminate_one_pair(ctx: &mut IrContext, block: BlockRef) -> bool {
+    let ops = ctx.block(block).ops.to_vec();
+
+    for (retain_index, &retain_ref) in ops.iter().enumerate() {
+        let Ok(retain) = tribute_rt::Retain::from_op(ctx, retain_ref) else {
+            continue;
+        };
+        let ptr = retain.ptr(ctx);
+        let retained = retain.result(ctx);
+
+        for &op in &ops[retain_index + 1..] {
+            if let Ok(release) = tribute_rt::Release::from_op(ctx, op) {
+                let released = release.ptr(ctx);
+                if released == ptr || released == retained {
+                    erase_op(ctx, op);
+                    ctx.replace_all_uses(retained, ptr);
+                    erase_op(ctx, retain_ref);
+                    return true;
+                }
+            }
+
+            if is_barrier_for(ctx, op, ptr, retained) {
+                break;
+            }
+        }
+    }
+
+    false
+}
+
+fn is_barrier_for(ctx: &IrContext, op: OpRef, ptr: ValueRef, retained: ValueRef) -> bool {
+    // Captures by nested regions are not represented as ordinary operands on
+    // the containing op, so do not move RC operations across region boundaries.
+    if !ctx.op(op).regions.is_empty() {
+        return true;
+    }
+
+    ctx.op_operands(op)
+        .iter()
+        .enumerate()
+        .any(|(operand_index, &operand)| {
+            (operand == ptr || operand == retained)
+                && !is_proven_non_escaping_use(ctx, op, operand_index)
+        })
+}
+
+fn is_proven_non_escaping_use(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+    // Reading through a reference does not transfer ownership.
+    if clif::Load::matches(ctx, op) {
+        return operand_index == 0;
+    }
+
+    // `clif.store(value, addr)`: the address is borrowed, while storing the
+    // reference as `value` lets it escape into memory.
+    if clif::Store::matches(ctx, op) {
+        return operand_index == 1;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+    use trunk_ir::validation::validate_use_chains;
+
+    fn run_pass(ir: &str) -> (IrContext, Module) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        eliminate_paired_rc(&mut ctx, module);
+        (ctx, module)
+    }
+
+    fn printed_after_pass(ir: &str) -> String {
+        let (ctx, module) = run_pass(ir);
+        print_module(&ctx, module.op())
+    }
+
+    #[test]
+    fn eliminates_adjacent_pair_and_rewrites_retain_result() {
+        let (ctx, module) = run_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr) -> core.i32 {
+    %1 = tribute_rt.retain %0 : core.ptr
+    %2 = clif.load %1 {offset = 0} : core.i32
+    tribute_rt.release %0 {alloc_size = 12}
+    clif.return %2
+  }
+}"#,
+        );
+        let output = print_module(&ctx, module.op());
+        assert!(!output.contains("tribute_rt.retain"));
+        assert!(!output.contains("tribute_rt.release"));
+        assert!(output.contains("clif.load %0"));
+        assert!(validate_use_chains(&ctx, module).is_ok());
+    }
+
+    #[test]
+    fn allows_borrowed_load_and_store_address_uses() {
+        let output = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr, %1: core.i32) -> core.i32 {
+    %2 = tribute_rt.retain %0 : core.ptr
+    %3 = clif.load %0 {offset = 0} : core.i32
+    clif.store %1, %2 {offset = 4}
+    tribute_rt.release %0 {alloc_size = 12}
+    clif.return %3
+  }
+}"#,
+        );
+        assert!(!output.contains("tribute_rt."));
+    }
+
+    #[test]
+    fn store_value_is_an_escape_barrier() {
+        let output = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr, %1: core.ptr) -> core.nil {
+    %2 = tribute_rt.retain %0 : core.ptr
+    clif.store %0, %1 {offset = 0}
+    tribute_rt.release %0 {alloc_size = 12}
+    clif.return
+  }
+}"#,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn call_argument_is_an_escape_barrier() {
+        let output = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr) -> core.nil {
+  ^bb0:
+    %1 = tribute_rt.retain %0 : core.ptr
+    %2 = clif.call %0 {callee = @consume} : core.nil
+    tribute_rt.release %0 {alloc_size = 12}
+    clif.return
+  }
+}"#,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn branch_argument_is_an_escape_barrier() {
+        let output = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr) -> core.nil {
+  ^bb0:
+    %1 = tribute_rt.retain %0 : core.ptr
+    clif.jump %0 [^bb1]
+  ^bb1(%2: core.ptr):
+    tribute_rt.release %2 {alloc_size = 12}
+    clif.return
+  }
+}"#,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn cast_alias_is_a_barrier() {
+        let output = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr) -> core.nil {
+    %1 = tribute_rt.retain %0 : core.ptr
+    %2 = core.unrealized_conversion_cast %0 : core.ptr
+    tribute_rt.release %0 {alloc_size = 12}
+    clif.return
+  }
+}"#,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn does_not_match_a_different_pointer_or_cross_blocks() {
+        let different = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr, %1: core.ptr) -> core.nil {
+    %2 = tribute_rt.retain %0 : core.ptr
+    tribute_rt.release %1 {alloc_size = 12}
+    clif.return
+  }
+}"#,
+        );
+        assert!(different.contains("tribute_rt.retain"));
+        assert!(different.contains("tribute_rt.release"));
+
+        let cross_block = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr) -> core.nil {
+  ^bb0:
+    %1 = tribute_rt.retain %0 : core.ptr
+    clif.jump [^bb1]
+  ^bb1:
+    tribute_rt.release %0 {alloc_size = 12}
+    clif.return
+  }
+}"#,
+        );
+        assert!(cross_block.contains("tribute_rt.retain"));
+        assert!(cross_block.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr) -> core.nil {
+    %1 = tribute_rt.retain %0 : core.ptr
+    tribute_rt.release %0 {alloc_size = 12}
+    clif.return
+  }
+}"#,
+        );
+        eliminate_paired_rc(&mut ctx, module);
+        let once = print_module(&ctx, module.op());
+        eliminate_paired_rc(&mut ctx, module);
+        assert_eq!(once, print_module(&ctx, module.op()));
+    }
+}

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -206,17 +206,19 @@ into control flow and atomic operations by RC lowering.
 **Optimizations:**
 
 - **Paired elimination:** Within one basic block, remove a `retain` followed by
-  a `release` of the same SSA value when every intervening use is proven not to
-  let the reference escape. The initial safe-use whitelist is deliberately
-  narrow: loads through the reference and stores that use it only as the
-  destination address. Storing the reference as a value, passing it to a call
-  or branch, crossing an unknown operation, entering a nested region, or
-  encountering an alias/cast prevents elimination. If the `retain` result is
-  used, its uses are replaced with the original pointer before erasing the
+  a matching `release` when every intervening use is proven not to let the
+  reference escape. The release operand may be either the original pointer
+  passed to `retain` or the `retain` result. The initial safe-use whitelist is
+  deliberately narrow: loads through the reference and stores that use it only
+  as the destination address. Storing the reference as a value, passing it to
+  a call or branch, crossing an unknown operation, entering a nested region,
+  or encountering an alias/cast prevents elimination. If the `retain` result
+  is used, its uses are replaced with the original pointer before erasing the
   pair. This optimization does not cross basic-block boundaries or chase
   aliases.
-- **Borrow analysis:** Identify temporary borrows that don't need RC ops
-- **Constant propagation:** Elide RC for compile-time-known lifetimes
+- **Borrow analysis (planned):** Identify temporary borrows that don't need RC
+  ops
+- **Constant propagation (planned):** Elide RC for compile-time-known lifetimes
 
 The paired-elimination policy is selected by the native pipeline options, not
 stored in an IR lowering context. Production enables the proven optimization;

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -196,18 +196,36 @@ based on SSA liveness analysis.
 
 **Pointer detection:** Use `core::Ptr::from_type()` to identify RC-managed values.
 
-### 2. RC Optimization Pass (Future)
+### 2. RC Optimization Pass
 
 **Location:** `tribute-passes/src/native/rc_optimization.rs`
 
-**Purpose:** Eliminate redundant retain/release pairs.
+**Purpose:** Eliminate redundant retain/release pairs before they are expanded
+into control flow and atomic operations by RC lowering.
 
 **Optimizations:**
 
-- **Paired elimination:** Remove adjacent `retain` followed by `release` on
-  same value
+- **Paired elimination:** Within one basic block, remove a `retain` followed by
+  a `release` of the same SSA value when every intervening use is proven not to
+  let the reference escape. The initial safe-use whitelist is deliberately
+  narrow: loads through the reference and stores that use it only as the
+  destination address. Storing the reference as a value, passing it to a call
+  or branch, crossing an unknown operation, entering a nested region, or
+  encountering an alias/cast prevents elimination. If the `retain` result is
+  used, its uses are replaced with the original pointer before erasing the
+  pair. This optimization does not cross basic-block boundaries or chase
+  aliases.
 - **Borrow analysis:** Identify temporary borrows that don't need RC ops
 - **Constant propagation:** Elide RC for compile-time-known lifetimes
+
+The paired-elimination policy is selected by the native pipeline options, not
+stored in an IR lowering context. Production enables the proven optimization;
+the baseline profile disables it for conformance comparisons.
+
+**Pipeline position:** Immediately after RC insertion and before unrealized
+cast resolution and RC lowering. Running before cast resolution keeps alias
+handling conservative and makes the inserted and optimized RC boundaries
+directly observable in tests.
 
 ### 3. RC Lowering Pass (PR 4)
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -109,20 +109,50 @@ pub struct CompilationConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
 pub struct OptimizationOptions {
     pub ast_to_ir: ast_to_ir::AstToIrOptions,
+    pub native: NativeOptimizationOptions,
 }
 
 impl OptimizationOptions {
     pub const fn production() -> Self {
         Self {
             ast_to_ir: ast_to_ir::AstToIrOptions::production(),
+            native: NativeOptimizationOptions::production(),
         }
     }
 
     pub const fn baseline() -> Self {
         Self {
             ast_to_ir: ast_to_ir::AstToIrOptions::baseline(),
+            native: NativeOptimizationOptions::baseline(),
         }
     }
+}
+
+/// Independently selectable native-backend optimizations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub struct NativeOptimizationOptions {
+    pub paired_rc_elimination: PairedRcEliminationPolicy,
+}
+
+impl NativeOptimizationOptions {
+    pub const fn production() -> Self {
+        Self {
+            paired_rc_elimination: PairedRcEliminationPolicy::Enabled,
+        }
+    }
+
+    pub const fn baseline() -> Self {
+        Self {
+            paired_rc_elimination: PairedRcEliminationPolicy::Disabled,
+        }
+    }
+}
+
+/// Policy for local retain/release pair elimination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub enum PairedRcEliminationPolicy {
+    Disabled,
+    Enabled,
 }
 
 impl Default for OptimizationOptions {
@@ -136,6 +166,15 @@ impl Default for OptimizationOptions {
 pub enum SharedPipelineStage {
     /// Immediately after AST-to-IR lowering, before shared middle-end passes.
     AfterFrontend,
+}
+
+/// Stable native-pipeline boundaries available to optimization tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub enum NativePipelineStage {
+    /// Immediately after reference-counting operations are inserted.
+    AfterRcInsertion,
+    /// After optional local RC optimization, before cast resolution and lowering.
+    AfterRcOptimization,
 }
 
 // AST-based pipeline imports
@@ -604,6 +643,31 @@ pub fn dump_shared_ir_at_stage(
     Ok(trunk_ir::printer::print_module(&ctx, module.op()))
 }
 
+/// Dump native IR at a named RC optimization boundary.
+///
+/// The same optimization options are used for the shared and native portions
+/// of the pipeline. Native emission is intentionally skipped.
+#[salsa::tracked]
+pub fn dump_native_ir_at_stage(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+    stage: NativePipelineStage,
+    options: OptimizationOptions,
+) -> Result<String, DumpIrError> {
+    let Some((mut ctx, module)) = run_shared_pipeline_with_options(db, source, options, None)?
+    else {
+        return Ok(String::new());
+    };
+    validate_and_report_arity(db, &ctx, module);
+    run_native_target_pipeline(&mut ctx, module)?;
+    prepare_module_to_native(&mut ctx, module, false, options.native, Some(stage)).map_err(
+        |error| DumpIrError {
+            message: error.to_string(),
+        },
+    )?;
+    Ok(trunk_ir::printer::print_module(&ctx, module.op()))
+}
+
 fn install_debug_use_chain_verifier(pm: &mut PassManager) {
     // Debug-only regression guard: re-check use-chain consistency after every
     // shared pass. step 1+2 (#710) made this invariant hold across the shared
@@ -842,12 +906,14 @@ pub fn compile_to_wasm_binary(
 /// 3. Runs RTTI, RC insertion, and RC lowering passes
 /// 4. Resolves unrealized conversion casts
 /// 5. Validates and emits the native object file via Cranelift
-fn compile_module_to_native(
+fn prepare_module_to_native(
     ctx: &mut IrContext,
     module: Module,
     sanitize: bool,
-) -> NativeCompilationResult<Vec<u8>> {
-    let _span = tracing::info_span!("compile_module_to_native").entered();
+    optimizations: NativeOptimizationOptions,
+    stop_after: Option<NativePipelineStage>,
+) -> NativeCompilationResult<Option<Vec<RodataEntry>>> {
+    let _span = tracing::info_span!("prepare_module_to_native").entered();
 
     // Phase -1 - Generate native entrypoint
     tribute_passes::native::entrypoint::generate_native_entrypoint(ctx, module, sanitize);
@@ -936,6 +1002,20 @@ fn compile_module_to_native(
         tribute_passes::native::rc_insertion::insert_rc(ctx, module);
     }
 
+    if stop_after == Some(NativePipelineStage::AfterRcInsertion) {
+        return Ok(None);
+    }
+
+    // Phase 2.9 - Eliminate local retain/release pairs while they are still
+    // directly observable tribute_rt operations.
+    if optimizations.paired_rc_elimination == PairedRcEliminationPolicy::Enabled {
+        tribute_passes::native::rc_optimization::eliminate_paired_rc(ctx, module);
+    }
+
+    if stop_after == Some(NativePipelineStage::AfterRcOptimization) {
+        return Ok(None);
+    }
+
     // Phase 3 - Resolve unrealized_conversion_cast operations
     {
         let (type_converter, _) =
@@ -977,6 +1057,17 @@ fn compile_module_to_native(
             data: data.clone(),
         })
         .collect();
+    Ok(Some(rodata))
+}
+
+fn compile_module_to_native(
+    ctx: &mut IrContext,
+    module: Module,
+    sanitize: bool,
+    optimizations: NativeOptimizationOptions,
+) -> NativeCompilationResult<Vec<u8>> {
+    let rodata = prepare_module_to_native(ctx, module, sanitize, optimizations, None)?
+        .expect("complete native preparation must produce rodata");
     emit_module_to_native(ctx, module, &rodata)
 }
 
@@ -1030,7 +1121,7 @@ pub fn compile_to_native_binary<'db>(
 
     // Native backend lowering + emit
     let sanitize = config.sanitize_address(db);
-    match compile_module_to_native(&mut ctx, m, sanitize) {
+    match compile_module_to_native(&mut ctx, m, sanitize, options.native) {
         Ok(bytes) => Some(bytes),
         Err(e) => {
             Diagnostic::new(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,8 @@ use ropey::Rope;
 use salsa::Database;
 use tribute::TributeDatabaseImpl;
 use tribute::pipeline::{
-    CompilationConfig, OptimizationOptions, compile_to_native_binary, link_native_binary,
+    CompilationConfig, NativeOptimizationOptions, OptimizationOptions, PairedRcEliminationPolicy,
+    compile_to_native_binary, link_native_binary,
 };
 use tribute_front::SourceCst;
 use tribute_front::ast_to_ir::{AstToIrOptions, DoneContinuationPolicy};
@@ -72,6 +73,7 @@ pub fn compile_and_run_native(source_name: &str, source_code: &str) -> Output {
         source_code,
         false,
         DoneContinuationPolicy::PerCompilationUnit,
+        PairedRcEliminationPolicy::Enabled,
         NativeStdin::Null,
     )
 }
@@ -83,7 +85,31 @@ pub fn compile_and_run_native_with_done_continuation_dedup(
     source_code: &str,
     policy: DoneContinuationPolicy,
 ) -> Output {
-    compile_and_run_native_impl(source_name, source_code, false, policy, NativeStdin::Null)
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        false,
+        policy,
+        PairedRcEliminationPolicy::Enabled,
+        NativeStdin::Null,
+    )
+}
+
+/// Compile and run with explicit paired RC elimination selection.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_paired_rc_elimination(
+    source_name: &str,
+    source_code: &str,
+    policy: PairedRcEliminationPolicy,
+) -> Output {
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        false,
+        DoneContinuationPolicy::PerCompilationUnit,
+        policy,
+        NativeStdin::Null,
+    )
 }
 
 /// Compile and run Tribute source with raw bytes supplied to native stdin.
@@ -98,6 +124,7 @@ pub fn compile_and_run_native_with_stdin(
         source_code,
         false,
         DoneContinuationPolicy::PerCompilationUnit,
+        PairedRcEliminationPolicy::Enabled,
         NativeStdin::Bytes(stdin),
     )
 }
@@ -111,6 +138,7 @@ pub fn compile_and_run_native_with_closed_stdin(source_name: &str, source_code: 
         source_code,
         false,
         DoneContinuationPolicy::PerCompilationUnit,
+        PairedRcEliminationPolicy::Enabled,
         NativeStdin::Closed,
     )
 }
@@ -157,6 +185,7 @@ pub fn compile_and_run_native_asan(source_name: &str, source_code: &str) -> Outp
         source_code,
         true,
         DoneContinuationPolicy::PerCompilationUnit,
+        PairedRcEliminationPolicy::Enabled,
         NativeStdin::Null,
     )
 }
@@ -173,6 +202,7 @@ fn compile_and_run_native_impl(
     source_code: &str,
     sanitize_address: bool,
     done_continuation: DoneContinuationPolicy,
+    paired_rc_elimination: PairedRcEliminationPolicy,
     stdin: NativeStdin<'_>,
 ) -> Output {
     use tribute::database::parse_with_thread_local;
@@ -185,6 +215,9 @@ fn compile_and_run_native_impl(
 
         let optimizations = OptimizationOptions {
             ast_to_ir: AstToIrOptions { done_continuation },
+            native: NativeOptimizationOptions {
+                paired_rc_elimination,
+            },
         };
         let object_bytes =
             compile_native_or_panic_with_options(db, source_file, sanitize_address, optimizations);

--- a/tests/fixtures/optimizations/paired_rc_elimination.trb
+++ b/tests/fixtures/optimizations/paired_rc_elimination.trb
@@ -1,0 +1,24 @@
+extern "C" fn __tribute_print_int(value: Int) -> Nil
+
+ability State(s) {
+    op get() -> s
+    op set(value: s) -> Nil
+}
+
+fn bump() ->{State(Int)} Int {
+    let n = State::get()
+    State::set(n + +1)
+    n
+}
+
+fn run_state() -> Int {
+    handle bump() {
+        do result { result }
+        op State::get() { resume +10 }
+        op State::set(value) { resume Nil }
+    }
+}
+
+fn main() {
+    __tribute_print_int(run_state())
+}

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -2,15 +2,31 @@
 
 mod common;
 
-use common::compile_and_run_native_with_done_continuation_dedup;
+use common::{
+    compile_and_run_native_with_done_continuation_dedup,
+    compile_and_run_native_with_paired_rc_elimination,
+};
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
-use tribute::pipeline::{OptimizationOptions, SharedPipelineStage, dump_shared_ir_at_stage};
+use tribute::pipeline::{
+    NativePipelineStage, OptimizationOptions, PairedRcEliminationPolicy, SharedPipelineStage,
+    dump_native_ir_at_stage, dump_shared_ir_at_stage,
+};
 use tribute_front::SourceCst;
 use tribute_front::ast_to_ir::DoneContinuationPolicy;
 
 const DONE_CONTINUATION_DEDUP_STATE: &str =
     include_str!("fixtures/optimizations/done_continuation_dedup_state.trb");
+const PAIRED_RC_ELIMINATION: &str =
+    include_str!("fixtures/optimizations/paired_rc_elimination.trb");
+
+fn focused_rc_ops(ir: &str) -> String {
+    ir.lines()
+        .filter(|line| line.contains("tribute_rt.retain") || line.contains("tribute_rt.release"))
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 fn identity_done_symbols(ir: &str) -> Vec<&str> {
     let lines: Vec<_> = ir.lines().collect();
@@ -76,6 +92,82 @@ fn done_continuation_dedup_preserves_native_execution() {
     );
     assert_eq!(disabled.stdout, enabled.stdout);
     assert_eq!(String::from_utf8_lossy(&enabled.stdout).trim(), "10");
+}
+
+#[test]
+fn paired_rc_elimination_preserves_native_execution() {
+    let disabled = compile_and_run_native_with_paired_rc_elimination(
+        "paired_rc_elimination_disabled.trb",
+        PAIRED_RC_ELIMINATION,
+        PairedRcEliminationPolicy::Disabled,
+    );
+    let enabled = compile_and_run_native_with_paired_rc_elimination(
+        "paired_rc_elimination_enabled.trb",
+        PAIRED_RC_ELIMINATION,
+        PairedRcEliminationPolicy::Enabled,
+    );
+
+    assert!(
+        disabled.status.success(),
+        "disabled pipeline failed: {}",
+        String::from_utf8_lossy(&disabled.stderr)
+    );
+    assert!(
+        enabled.status.success(),
+        "enabled pipeline failed: {}",
+        String::from_utf8_lossy(&enabled.stderr)
+    );
+    assert_eq!(disabled.stdout, enabled.stdout);
+    assert_eq!(String::from_utf8_lossy(&enabled.stdout).trim(), "10");
+}
+
+#[salsa_test]
+fn paired_rc_elimination_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "paired_rc_elimination_snapshot.trb",
+        PAIRED_RC_ELIMINATION,
+    );
+    let before = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterRcInsertion,
+        OptimizationOptions::production(),
+    )
+    .expect("RC insertion IR should be available");
+    let after = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterRcOptimization,
+        OptimizationOptions::production(),
+    )
+    .expect("RC optimization IR should be available");
+    let disabled_after = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterRcOptimization,
+        OptimizationOptions {
+            native: tribute::pipeline::NativeOptimizationOptions::baseline(),
+            ..OptimizationOptions::production()
+        },
+    )
+    .expect("disabled RC optimization IR should be available");
+
+    let before = focused_rc_ops(&before);
+    let after = focused_rc_ops(&after);
+    let disabled_after = focused_rc_ops(&disabled_after);
+
+    assert_eq!(before, disabled_after);
+    let before_retain = before.matches("tribute_rt.retain").count();
+    let before_release = before.matches("tribute_rt.release").count();
+    let after_retain = after.matches("tribute_rt.retain").count();
+    let after_release = after.matches("tribute_rt.release").count();
+    assert!(before_retain > after_retain, "before RC ops:\n{before}");
+    assert!(before_release > after_release, "before RC ops:\n{before}");
+    assert_eq!(before_retain - after_retain, before_release - after_release);
+
+    assert_snapshot!("paired_rc_elimination_before", before);
+    assert_snapshot!("paired_rc_elimination_after", after);
 }
 
 #[salsa_test]

--- a/tests/snapshots/optimization_conformance__paired_rc_elimination_after.snap
+++ b/tests/snapshots/optimization_conformance__paired_rc_elimination_after.snap
@@ -1,0 +1,28 @@
+---
+source: tests/optimization_conformance.rs
+expression: after
+---
+%3 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %43 {alloc_size = 0}
+%3 = tribute_rt.retain %1 : core.ptr
+%6 = tribute_rt.retain %5 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+%16 = tribute_rt.retain %5 : core.ptr
+tribute_rt.release %5 {alloc_size = 0}
+tribute_rt.release %36 {alloc_size = 12}
+%3 = tribute_rt.retain %2 : core.ptr
+%11 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %2 {alloc_size = 0}
+%5 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %18 {alloc_size = 12}
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %26 {alloc_size = 0}
+%3 = tribute_rt.retain %1 : core.ptr
+%4 = tribute_rt.retain %2 : core.ptr
+%9 = tribute_rt.retain %8 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %8 {alloc_size = 0}
+tribute_rt.release %18 {alloc_size = 12}
+tribute_rt.release %4 {alloc_size = 0}

--- a/tests/snapshots/optimization_conformance__paired_rc_elimination_before.snap
+++ b/tests/snapshots/optimization_conformance__paired_rc_elimination_before.snap
@@ -1,0 +1,38 @@
+---
+source: tests/optimization_conformance.rs
+expression: before
+---
+%3 = tribute_rt.retain %1 : core.ptr
+%4 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+tribute_rt.release %43 {alloc_size = 0}
+%3 = tribute_rt.retain %1 : core.ptr
+%4 = tribute_rt.retain %2 : core.ptr
+%7 = tribute_rt.retain %6 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+tribute_rt.release %2 {alloc_size = 0}
+%17 = tribute_rt.retain %6 : core.ptr
+tribute_rt.release %6 {alloc_size = 0}
+tribute_rt.release %37 {alloc_size = 12}
+%3 = tribute_rt.retain %1 : core.ptr
+%4 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+%12 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %2 {alloc_size = 0}
+%5 = tribute_rt.retain %1 : core.ptr
+%6 = tribute_rt.retain %2 : core.ptr
+%7 = tribute_rt.retain %4 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+tribute_rt.release %4 {alloc_size = 0}
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %20 {alloc_size = 12}
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %28 {alloc_size = 0}
+%3 = tribute_rt.retain %1 : core.ptr
+%4 = tribute_rt.retain %2 : core.ptr
+%9 = tribute_rt.retain %8 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %8 {alloc_size = 0}
+tribute_rt.release %18 {alloc_size = 12}
+tribute_rt.release %4 {alloc_size = 0}


### PR DESCRIPTION
## Summary

- Add a native RC optimization pass for safe same-block retain/release pairs.
- Add selectable baseline and production native optimization policies.
- Expose native IR stage dumps for before/after optimization comparisons.
- Add unit tests, execution conformance coverage, and IR snapshots.
- Document the optimization and pipeline position.

## Testing

- Added focused pass tests covering safe uses, escape barriers, block boundaries, aliases, and idempotence.
- Added disabled/enabled native execution comparison and before/after IR snapshot validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native backend optimization that safely removes redundant local `retain`/`release` pairs when proven non-escaping within the same block.
  * Introduced configuration to enable/disable the optimization, with stable native pipeline stage boundaries and IR-dump support.
* **Documentation**
  * Documented the paired-RC elimination pass, including when it runs and the safety conditions used to decide eligibility.
* **Tests**
  * Added fixture-based and conformance tests validating elimination, safety barriers, native IR before/after snapshots, and identical program output when toggled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->