### PR TITLE
Elide RC for proven-borrowed parameters

### DIFF
--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -843,16 +843,13 @@ fn insert_rc_in_block(
     for v in &dying_sorted {
         if let Some(&last_use_idx) = last_use_in_block.get(v) {
             let last_op = ops[last_use_idx];
-            if clif::Return::matches(ctx, last_op) {
+            if clif::Return::matches(ctx, last_op) || clif::Jump::matches(ctx, last_op) {
                 continue;
             }
             let alloc_size = infer_alloc_size(ctx, *v);
             let op_loc = ctx.op(last_op).location;
             let release_op = tribute_rt::release(ctx, op_loc, *v, alloc_size);
             if is_terminator_op(ctx, last_op) {
-                if clif::Jump::matches(ctx, last_op) {
-                    continue;
-                }
                 plan.before
                     .entry(last_use_idx)
                     .or_default()
@@ -935,6 +932,7 @@ mod tests {
     use trunk_ir::context::IrContext;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
+    use trunk_ir::validation::validate_use_chains;
 
     fn run_pass(ir: &str) -> String {
         run_pass_with_policy(ir, BorrowedParameterPolicy::Preserve)
@@ -943,8 +941,33 @@ mod tests {
     fn run_pass_with_policy(ir: &str, policy: BorrowedParameterPolicy) -> String {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
+        let validation = validate_use_chains(&ctx, module);
+        assert!(
+            validation.is_ok(),
+            "input fixture must have valid SSA use chains: {validation}"
+        );
         insert_rc_with_policy(&mut ctx, module, policy);
+        let validation = validate_use_chains(&ctx, module);
+        assert!(
+            validation.is_ok(),
+            "RC insertion must preserve SSA use chains: {validation}"
+        );
         print_module(&ctx, module.op())
+    }
+
+    fn focused_rc_ops(output: &str) -> String {
+        output
+            .lines()
+            .filter(|line| {
+                line.contains("tribute_rt.retain") || line.contains("tribute_rt.release")
+            })
+            .map(str::trim)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn assert_focused_rc(output: &str, expected: &str) {
+        assert_eq!(focused_rc_ops(output), expected, "full IR:\n{output}");
     }
 
     // =========================================================================
@@ -1191,8 +1214,7 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(!output.contains("tribute_rt.retain"));
-        assert!(!output.contains("tribute_rt.release"));
+        assert_focused_rc(&output, "");
     }
 
     #[test]
@@ -1209,8 +1231,7 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(!output.contains("tribute_rt.retain"));
-        assert!(!output.contains("tribute_rt.release"));
+        assert_focused_rc(&output, "");
     }
 
     #[test]
@@ -1225,8 +1246,7 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(!output.contains("tribute_rt.retain"));
-        assert!(!output.contains("tribute_rt.release"));
+        assert_focused_rc(&output, "");
     }
 
     #[test]
@@ -1239,7 +1259,7 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
+        assert_focused_rc(&output, "%1 = tribute_rt.retain %0 : core.ptr");
     }
 
     #[test]
@@ -1253,8 +1273,14 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
-        assert!(output.contains("tribute_rt.release"));
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%2 = tribute_rt.retain %0 : core.ptr\n",
+                "%3 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}"
+            ),
+        );
     }
 
     #[test]
@@ -1268,8 +1294,14 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
-        assert!(output.contains("tribute_rt.release"));
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%2 = tribute_rt.retain %0 : core.ptr\n",
+                "%3 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}"
+            ),
+        );
     }
 
     #[test]
@@ -1283,8 +1315,13 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
-        assert!(output.contains("tribute_rt.release"));
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%1 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}"
+            ),
+        );
     }
 
     #[test]
@@ -1301,7 +1338,13 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%1 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %2 {alloc_size = 0}"
+            ),
+        );
     }
 
     #[test]
@@ -1318,7 +1361,7 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
+        assert_focused_rc(&output, "%1 = tribute_rt.retain %0 : core.ptr");
     }
 
     #[test]
@@ -1335,8 +1378,13 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
-        assert!(output.contains("tribute_rt.release"));
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%1 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}"
+            ),
+        );
     }
 
     #[test]
@@ -1351,8 +1399,7 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(!output.contains("tribute_rt.retain"));
-        assert!(!output.contains("tribute_rt.release"));
+        assert_focused_rc(&output, "");
     }
 
     #[test]
@@ -1367,8 +1414,13 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
-        assert!(output.contains("tribute_rt.release"));
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%1 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}"
+            ),
+        );
     }
 
     #[test]
@@ -1385,9 +1437,14 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(
-            output.matches("tribute_rt.retain").count() >= 2,
-            "tail-call target and caller must preserve owned parameters:\n{output}"
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%1 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}\n",
+                "%1 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}"
+            ),
         );
     }
 
@@ -1406,7 +1463,12 @@ mod tests {
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,
         );
-        assert!(output.contains("tribute_rt.retain"));
-        assert!(output.contains("tribute_rt.release"));
+        assert_focused_rc(
+            &output,
+            concat!(
+                "%1 = tribute_rt.retain %0 : core.ptr\n",
+                "tribute_rt.release %0 {alloc_size = 0}"
+            ),
+        );
     }
 }

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -45,6 +45,15 @@ use trunk_ir::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 
 use tribute_ir::dialect::tribute_rt;
 
+/// Policy for eliding RC ownership of proven borrowed function parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BorrowedParameterPolicy {
+    /// Preserve the current owned-parameter convention for every parameter.
+    Preserve,
+    /// Omit parameter RC only when all uses are proven non-escaping.
+    ElideProvenBorrowed,
+}
+
 /// Check if a type is `tribute_rt.anyref` (RC-managed reference type).
 fn is_anyref_type(ctx: &IrContext, ty: TypeRef) -> bool {
     let data = ctx.types.get(ty);
@@ -368,10 +377,21 @@ struct InsertionPlan {
 /// Insert reference counting operations for all `tribute_rt.anyref`-typed values,
 /// then lower all remaining `tribute_rt.anyref` types to `core.ptr`.
 pub fn insert_rc(ctx: &mut IrContext, module: Module) {
+    insert_rc_with_policy(ctx, module, BorrowedParameterPolicy::Preserve);
+}
+
+/// Insert reference counting operations with an explicit borrowed-parameter
+/// policy, then lower all remaining `tribute_rt.anyref` types to `core.ptr`.
+pub fn insert_rc_with_policy(
+    ctx: &mut IrContext,
+    module: Module,
+    borrowed_parameters: BorrowedParameterPolicy,
+) {
     let Some(first_block) = module.first_block(ctx) else {
         return;
     };
     let module_ops: Vec<OpRef> = ctx.block(first_block).ops.to_vec();
+    let borrow_safe_functions = borrow_safe_functions(ctx, &module_ops);
 
     for op in &module_ops {
         if let Ok(func_op) = clif::Func::from_op(ctx, *op) {
@@ -380,13 +400,72 @@ pub fn insert_rc(ctx: &mut IrContext, module: Module) {
                 continue;
             }
             let body = func_op.body(ctx);
-            insert_rc_in_function(ctx, body);
+            let function_policy = if borrow_safe_functions.contains(&sym) {
+                borrowed_parameters
+            } else {
+                BorrowedParameterPolicy::Preserve
+            };
+            insert_rc_in_function(ctx, body, function_policy);
         }
     }
 
     // After RC insertion, lower all remaining `tribute_rt.anyref` types to `core.ptr`.
     // This ensures anyref doesn't survive past RC insertion into the Cranelift emit phase.
     lower_anyref_to_ptr(ctx, module);
+}
+
+/// Functions whose callers are guaranteed to keep an owning frame alive for
+/// the duration of an ordinary synchronous call.
+///
+/// A function is ineligible when it is externally callable, is the target of a
+/// direct tail call, or its address is materialized for an indirect/escaping
+/// call. These exclusions preserve the caller-lifetime premise of borrowed
+/// parameters without requiring inter-procedural ownership summaries.
+fn borrow_safe_functions(ctx: &IrContext, module_ops: &[OpRef]) -> HashSet<Symbol> {
+    let mut candidates = HashSet::new();
+    for &op in module_ops {
+        if let Ok(func_op) = clif::Func::from_op(ctx, op)
+            && !ctx.op(op).attributes.contains_key(&Symbol::new("abi"))
+        {
+            candidates.insert(func_op.sym_name(ctx));
+        }
+    }
+
+    let mut unsafe_callees = HashSet::new();
+    for &op in module_ops {
+        if let Ok(func_op) = clif::Func::from_op(ctx, op) {
+            collect_borrow_unsafe_callees(ctx, func_op.body(ctx), &candidates, &mut unsafe_callees);
+        }
+    }
+    candidates.retain(|symbol| !unsafe_callees.contains(symbol));
+    candidates
+}
+
+fn collect_borrow_unsafe_callees(
+    ctx: &IrContext,
+    region: RegionRef,
+    candidates: &HashSet<Symbol>,
+    unsafe_callees: &mut HashSet<Symbol>,
+) {
+    for &block in &ctx.region(region).blocks {
+        for &op in &ctx.block(block).ops {
+            if let Ok(return_call) = clif::ReturnCall::from_op(ctx, op) {
+                let callee = return_call.callee(ctx);
+                if candidates.contains(&callee) {
+                    unsafe_callees.insert(callee);
+                }
+            }
+            if let Ok(symbol_addr) = clif::SymbolAddr::from_op(ctx, op) {
+                let symbol = symbol_addr.sym(ctx);
+                if candidates.contains(&symbol) {
+                    unsafe_callees.insert(symbol);
+                }
+            }
+            for &nested in &ctx.op(op).regions {
+                collect_borrow_unsafe_callees(ctx, nested, candidates, unsafe_callees);
+            }
+        }
+    }
 }
 
 /// Rewrite all `tribute_rt.anyref` types to `core.ptr` in the module.
@@ -540,7 +619,11 @@ fn rewrite_type_anyref(
 }
 
 /// Insert RC in a function body.
-fn insert_rc_in_function(ctx: &mut IrContext, body: RegionRef) {
+fn insert_rc_in_function(
+    ctx: &mut IrContext,
+    body: RegionRef,
+    borrowed_parameter_policy: BorrowedParameterPolicy,
+) {
     let mut ptr_values = collect_ptr_values(ctx, body);
 
     if ptr_values.is_empty() {
@@ -549,6 +632,10 @@ fn insert_rc_in_function(ctx: &mut IrContext, body: RegionRef) {
 
     let ptr_alias_map = build_ptr_alias_map(ctx, body, &mut ptr_values);
     let liveness = compute_liveness(ctx, body, &ptr_values, &ptr_alias_map);
+    let borrowed_parameters = match borrowed_parameter_policy {
+        BorrowedParameterPolicy::Preserve => HashSet::new(),
+        BorrowedParameterPolicy::ElideProvenBorrowed => analyze_borrowed_parameters(ctx, body),
+    };
 
     let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
     for (block_idx, &block) in blocks.iter().enumerate() {
@@ -559,8 +646,53 @@ fn insert_rc_in_function(ctx: &mut IrContext, body: RegionRef) {
             &ptr_values,
             &liveness,
             &ptr_alias_map,
+            &borrowed_parameters,
         );
     }
+}
+
+/// Return entry parameters whose complete use set is proven not to escape the
+/// dynamic extent of the function call.
+fn analyze_borrowed_parameters(ctx: &IrContext, body: RegionRef) -> HashSet<ValueRef> {
+    let Some(&entry) = ctx.region(body).blocks.first() else {
+        return HashSet::new();
+    };
+
+    ctx.block_args(entry)
+        .iter()
+        .copied()
+        .filter(|&parameter| is_anyref_value(ctx, parameter))
+        .filter(|&parameter| parameter_is_proven_borrowed(ctx, body, parameter))
+        .collect()
+}
+
+fn parameter_is_proven_borrowed(ctx: &IrContext, body: RegionRef, parameter: ValueRef) -> bool {
+    ctx.uses(parameter).iter().all(|use_| {
+        let op = use_.user;
+        let Some(parent_block) = ctx.op(op).parent_block else {
+            return false;
+        };
+        if ctx.block(parent_block).parent_region != Some(body) {
+            return false;
+        }
+        is_proven_borrowed_parameter_use(ctx, op, use_.operand_index as usize)
+    })
+}
+
+fn is_proven_borrowed_parameter_use(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+    if clif::Load::matches(ctx, op) {
+        return operand_index == 0;
+    }
+
+    // `clif.store(value, addr)`: using the parameter as the address borrows it;
+    // storing the parameter as the value publishes an owned alias.
+    if clif::Store::matches(ctx, op) {
+        return operand_index == 1;
+    }
+
+    // Pointer equality/ordering observes the value without extending its
+    // lifetime. All other operations remain escape barriers by default.
+    clif::Icmp::matches(ctx, op)
 }
 
 /// Insert RC ops in a single block.
@@ -571,6 +703,7 @@ fn insert_rc_in_block(
     ptr_values: &HashSet<ValueRef>,
     liveness: &LivenessInfo,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    borrowed_parameters: &HashSet<ValueRef>,
 ) {
     let ops: Vec<OpRef> = ctx.block(block).ops.to_vec();
     let loc = ctx.block(block).location;
@@ -615,7 +748,8 @@ fn insert_rc_in_block(
     if is_entry {
         let args: Vec<ValueRef> = ctx.block_args(block).to_vec();
         for arg_val in args {
-            if is_anyref_type(ctx, ctx.value_ty(arg_val)) {
+            if is_anyref_type(ctx, ctx.value_ty(arg_val)) && !borrowed_parameters.contains(&arg_val)
+            {
                 let retain_op = tribute_rt::retain(ctx, loc, arg_val, ptr_ty);
                 plan.at_start.push(retain_op.op_ref());
             }
@@ -659,12 +793,16 @@ fn insert_rc_in_block(
     let mut dying_values: HashSet<ValueRef> = HashSet::new();
 
     for v in &live_in {
-        if !live_out.contains(v) && !returned_values.contains(v) {
+        if !live_out.contains(v) && !returned_values.contains(v) && !borrowed_parameters.contains(v)
+        {
             dying_values.insert(*v);
         }
     }
     for v in &defs_in_block {
-        if !live_out.contains(v) && !returned_values.contains(v) && !is_alloc_intermediate(ctx, *v)
+        if !live_out.contains(v)
+            && !returned_values.contains(v)
+            && !is_alloc_intermediate(ctx, *v)
+            && !borrowed_parameters.contains(v)
         {
             dying_values.insert(*v);
         }
@@ -776,9 +914,13 @@ mod tests {
     use trunk_ir::printer::print_module;
 
     fn run_pass(ir: &str) -> String {
+        run_pass_with_policy(ir, BorrowedParameterPolicy::Preserve)
+    }
+
+    fn run_pass_with_policy(ir: &str, policy: BorrowedParameterPolicy) -> String {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
-        insert_rc(&mut ctx, module);
+        insert_rc_with_policy(&mut ctx, module, policy);
         print_module(&ctx, module.op())
     }
 
@@ -1013,5 +1155,169 @@ mod tests {
             retain_count, 1,
             "should retain only anyref param, got {retain_count}"
         );
+    }
+
+    #[test]
+    fn borrowed_read_only_parameter_omits_entry_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = clif.load %0 {offset = 0} : core.i32
+    clif.return %1
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(!output.contains("tribute_rt.retain"));
+        assert!(!output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn borrowed_parameter_can_be_read_across_blocks() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+  ^bb0:
+    clif.jump [^bb1]
+  ^bb1:
+    %1 = clif.load %0 {offset = 0} : core.i32
+    clif.return %1
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(!output.contains("tribute_rt.retain"));
+        assert!(!output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn borrowed_parameter_allows_store_address_and_comparison() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref, %1: core.i32) -> core.i8 {
+    clif.store %1, %0 {offset = 0}
+    %2 = clif.icmp %0, %0 {cond = @eq} : core.i8
+    clif.return %2
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(!output.contains("tribute_rt.retain"));
+        assert!(!output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn returned_parameter_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> tribute_rt.anyref {
+    clif.return %0
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+    }
+
+    #[test]
+    fn stored_parameter_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref, %1: core.ptr) -> core.nil {
+    clif.store %0, %1 {offset = 0}
+    clif.return
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn opaque_call_parameter_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+    %1 = clif.call %0 {callee = @opaque} : core.nil
+    clif.return
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn branch_forwarded_parameter_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+  ^bb0:
+    clif.jump %0 [^bb1]
+  ^bb1(%1: tribute_rt.anyref):
+    %2 = clif.load %1 {offset = 0} : core.i32
+    clif.return %2
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+    }
+
+    #[test]
+    fn cast_alias_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = core.unrealized_conversion_cast %0 : core.ptr
+    %2 = clif.load %1 {offset = 0} : core.i32
+    clif.return %2
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn tail_call_target_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = clif.load %0 {offset = 0} : core.i32
+    clif.return %1
+  }
+  clif.func @caller(%0: tribute_rt.anyref) -> core.i32 {
+    clif.return_call %0 {callee = @f}
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(
+            output.matches("tribute_rt.retain").count() >= 2,
+            "tail-call target and caller must preserve owned parameters:\n{output}"
+        );
+    }
+
+    #[test]
+    fn address_taken_function_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = clif.load %0 {offset = 0} : core.i32
+    clif.return %1
+  }
+  clif.func @address() -> core.ptr {
+    %0 = clif.symbol_addr {sym = @f} : core.ptr
+    clif.return %0
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
     }
 }

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -667,7 +667,20 @@ fn analyze_borrowed_parameters(ctx: &IrContext, body: RegionRef) -> HashSet<Valu
 }
 
 fn parameter_is_proven_borrowed(ctx: &IrContext, body: RegionRef, parameter: ValueRef) -> bool {
-    ctx.uses(parameter).iter().all(|use_| {
+    value_is_proven_borrowed(ctx, body, parameter, &mut HashSet::new())
+}
+
+fn value_is_proven_borrowed(
+    ctx: &IrContext,
+    body: RegionRef,
+    value: ValueRef,
+    visited: &mut HashSet<ValueRef>,
+) -> bool {
+    if !visited.insert(value) {
+        return true;
+    }
+
+    ctx.uses(value).iter().all(|use_| {
         let op = use_.user;
         let Some(parent_block) = ctx.op(op).parent_block else {
             return false;
@@ -675,7 +688,17 @@ fn parameter_is_proven_borrowed(ctx: &IrContext, body: RegionRef, parameter: Val
         if ctx.block(parent_block).parent_region != Some(body) {
             return false;
         }
-        is_proven_borrowed_parameter_use(ctx, op, use_.operand_index as usize)
+
+        let operand_index = use_.operand_index as usize;
+        if is_proven_borrowed_parameter_use(ctx, op, operand_index) {
+            return true;
+        }
+
+        core::UnrealizedConversionCast::matches(ctx, op)
+            && operand_index == 0
+            && ctx.op_operands(op).len() == 1
+            && ctx.op_results(op).len() == 1
+            && value_is_proven_borrowed(ctx, body, ctx.op_results(op)[0], visited)
     })
 }
 
@@ -1235,6 +1258,21 @@ mod tests {
     }
 
     #[test]
+    fn continuation_frame_capture_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref, %1: core.ptr) -> core.nil {
+    clif.store %0, %1 {offset = 16}
+    clif.return
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
     fn opaque_call_parameter_preserves_owned_rc() {
         let output = run_pass_with_policy(
             r#"core.module @test {
@@ -1267,13 +1305,64 @@ mod tests {
     }
 
     #[test]
-    fn cast_alias_preserves_owned_rc() {
+    fn loop_block_argument_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+  ^entry:
+    clif.jump %0 [^loop]
+  ^loop(%1: tribute_rt.anyref):
+    %2 = clif.load %1 {offset = 0} : core.i32
+    clif.jump %1 [^loop]
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+    }
+
+    #[test]
+    fn nested_region_capture_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+    func.func @capturing_closure() -> core.i32 {
+      %1 = clif.load %0 {offset = 0} : core.i32
+      func.return %1
+    }
+    clif.return
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(output.contains("tribute_rt.retain"));
+        assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn transparent_cast_allows_borrowed_read() {
         let output = run_pass_with_policy(
             r#"core.module @test {
   clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
     %1 = core.unrealized_conversion_cast %0 : core.ptr
     %2 = clif.load %1 {offset = 0} : core.i32
     clif.return %2
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        assert!(!output.contains("tribute_rt.retain"));
+        assert!(!output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn escaping_cast_alias_preserves_owned_rc() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+    %1 = core.unrealized_conversion_cast %0 : core.ptr
+    %2 = clif.call %1 {callee = @opaque} : core.nil
+    clif.return
   }
 }"#,
             BorrowedParameterPolicy::ElideProvenBorrowed,

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -216,13 +216,28 @@ into control flow and atomic operations by RC lowering.
   is used, its uses are replaced with the original pointer before erasing the
   pair. This optimization does not cross basic-block boundaries or chase
   aliases.
-- **Borrow analysis (planned):** Identify temporary borrows that don't need RC
-  ops
+- **Borrowed parameter elision:** Before RC insertion, classify an `anyref`
+  function parameter as borrowed only when every use is proven to remain within
+  the dynamic extent of the call. Loads through the parameter, comparisons,
+  and stores that use it only as the destination address are borrowed uses.
+  Returning or storing the parameter as a value, passing it to a call or branch,
+  using it through an alias/cast or nested region, and every unknown operation
+  are escapes. Analysis failure preserves the existing owned-parameter RC.
+  The callee must also have the ordinary synchronous caller-lifetime guarantee:
+  C ABI entry points, direct tail-call targets, and functions whose address
+  escapes are ineligible because their caller may not retain an owning frame
+  for the full invocation.
+  For a proven borrowed parameter, RC insertion omits both the entry `retain`
+  and every parameter `release`; this keeps acquisition and release decisions
+  under one ownership proof instead of matching generated releases afterward.
+- **Temporary borrow analysis (planned):** Identify temporary values, including
+  field loads, that don't need RC ops
 - **Constant propagation (planned):** Elide RC for compile-time-known lifetimes
 
-The paired-elimination policy is selected by the native pipeline options, not
-stored in an IR lowering context. Production enables the proven optimization;
-the baseline profile disables it for conformance comparisons.
+The paired-elimination and borrowed-parameter policies are selected by the
+native pipeline options, not stored in an IR lowering context. Production
+enables proven optimizations; the baseline profile disables them for
+conformance comparisons.
 
 **Pipeline position:** Immediately after RC insertion and before unrealized
 cast resolution and RC lowering. Running before cast resolution keeps alias

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -220,9 +220,15 @@ into control flow and atomic operations by RC lowering.
   function parameter as borrowed only when every use is proven to remain within
   the dynamic extent of the call. Loads through the parameter, comparisons,
   and stores that use it only as the destination address are borrowed uses.
-  Returning or storing the parameter as a value, passing it to a call or branch,
-  using it through an alias/cast or nested region, and every unknown operation
-  are escapes. Analysis failure preserves the existing owned-parameter RC.
+  A chain of unrealized conversion casts is transparent only when every use of
+  its result is itself proven borrowed. Returning or storing the parameter as a
+  value, passing it to a call or branch, using it through any other alias or a
+  nested region, and every unknown operation are escapes. Closure, ability
+  handler, and continuation capture therefore preserve owned-parameter RC.
+  Analysis failure preserves the existing owned-parameter RC.
+  Calls are escape barriers even when the callee is direct: this pass does not
+  yet consume trusted ownership summaries, so it cannot prove that a forwarded
+  argument remains borrowed.
   The callee must also have the ordinary synchronous caller-lifetime guarantee:
   C ABI entry points, direct tail-call targets, and functions whose address
   escapes are ineligible because their caller may not retain an owning frame
@@ -239,10 +245,11 @@ native pipeline options, not stored in an IR lowering context. Production
 enables proven optimizations; the baseline profile disables them for
 conformance comparisons.
 
-**Pipeline position:** Immediately after RC insertion and before unrealized
-cast resolution and RC lowering. Running before cast resolution keeps alias
-handling conservative and makes the inserted and optimized RC boundaries
-directly observable in tests.
+**Pipeline position:** Borrowed-parameter analysis runs as part of RC insertion,
+before parameter RC operations are created. Paired elimination runs immediately
+after RC insertion. Both decisions occur before unrealized cast resolution and
+RC lowering, which keeps alias handling conservative and makes the inserted and
+optimized RC boundaries directly observable in tests.
 
 ### 3. RC Lowering Pass (PR 4)
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -132,18 +132,21 @@ impl OptimizationOptions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
 pub struct NativeOptimizationOptions {
     pub paired_rc_elimination: PairedRcEliminationPolicy,
+    pub borrowed_parameters: BorrowedParameterPolicy,
 }
 
 impl NativeOptimizationOptions {
     pub const fn production() -> Self {
         Self {
             paired_rc_elimination: PairedRcEliminationPolicy::Enabled,
+            borrowed_parameters: BorrowedParameterPolicy::ElideProvenBorrowed,
         }
     }
 
     pub const fn baseline() -> Self {
         Self {
             paired_rc_elimination: PairedRcEliminationPolicy::Disabled,
+            borrowed_parameters: BorrowedParameterPolicy::Preserve,
         }
     }
 }
@@ -153,6 +156,13 @@ impl NativeOptimizationOptions {
 pub enum PairedRcEliminationPolicy {
     Disabled,
     Enabled,
+}
+
+/// Policy for eliding ownership of proven borrowed native parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub enum BorrowedParameterPolicy {
+    Preserve,
+    ElideProvenBorrowed,
 }
 
 impl Default for OptimizationOptions {
@@ -173,6 +183,8 @@ pub enum SharedPipelineStage {
 pub enum NativePipelineStage {
     /// Immediately after reference-counting operations are inserted.
     AfterRcInsertion,
+    /// After borrowed-parameter-aware insertion, before paired elimination.
+    AfterBorrowedParameterOptimization,
     /// After optional local RC optimization, before cast resolution and lowering.
     AfterRcOptimization,
 }
@@ -999,10 +1011,31 @@ fn prepare_module_to_native(
             tribute_passes::native::type_converter::native_type_converter(ctx);
         tribute_passes::native::tribute_rt_to_clif::lower(ctx, module, type_converter)
             .map_err(native_conversion_failure)?;
-        tribute_passes::native::rc_insertion::insert_rc(ctx, module);
+        let borrowed_parameters = if stop_after == Some(NativePipelineStage::AfterRcInsertion) {
+            BorrowedParameterPolicy::Preserve
+        } else {
+            optimizations.borrowed_parameters
+        };
+        let borrowed_parameters = match borrowed_parameters {
+            BorrowedParameterPolicy::Preserve => {
+                tribute_passes::native::rc_insertion::BorrowedParameterPolicy::Preserve
+            }
+            BorrowedParameterPolicy::ElideProvenBorrowed => {
+                tribute_passes::native::rc_insertion::BorrowedParameterPolicy::ElideProvenBorrowed
+            }
+        };
+        tribute_passes::native::rc_insertion::insert_rc_with_policy(
+            ctx,
+            module,
+            borrowed_parameters,
+        );
     }
 
     if stop_after == Some(NativePipelineStage::AfterRcInsertion) {
+        return Ok(None);
+    }
+
+    if stop_after == Some(NativePipelineStage::AfterBorrowedParameterOptimization) {
         return Ok(None);
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,8 +7,8 @@ use ropey::Rope;
 use salsa::Database;
 use tribute::TributeDatabaseImpl;
 use tribute::pipeline::{
-    CompilationConfig, NativeOptimizationOptions, OptimizationOptions, PairedRcEliminationPolicy,
-    compile_to_native_binary, link_native_binary,
+    BorrowedParameterPolicy, CompilationConfig, NativeOptimizationOptions, OptimizationOptions,
+    PairedRcEliminationPolicy, compile_to_native_binary, link_native_binary,
 };
 use tribute_front::SourceCst;
 use tribute_front::ast_to_ir::{AstToIrOptions, DoneContinuationPolicy};
@@ -74,6 +74,7 @@ pub fn compile_and_run_native(source_name: &str, source_code: &str) -> Output {
         false,
         DoneContinuationPolicy::PerCompilationUnit,
         PairedRcEliminationPolicy::Enabled,
+        BorrowedParameterPolicy::ElideProvenBorrowed,
         NativeStdin::Null,
     )
 }
@@ -91,6 +92,7 @@ pub fn compile_and_run_native_with_done_continuation_dedup(
         false,
         policy,
         PairedRcEliminationPolicy::Enabled,
+        BorrowedParameterPolicy::ElideProvenBorrowed,
         NativeStdin::Null,
     )
 }
@@ -107,6 +109,26 @@ pub fn compile_and_run_native_with_paired_rc_elimination(
         source_code,
         false,
         DoneContinuationPolicy::PerCompilationUnit,
+        policy,
+        BorrowedParameterPolicy::Preserve,
+        NativeStdin::Null,
+    )
+}
+
+/// Compile and run with explicit borrowed-parameter RC selection.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_borrowed_parameters(
+    source_name: &str,
+    source_code: &str,
+    policy: BorrowedParameterPolicy,
+    sanitize_address: bool,
+) -> Output {
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        sanitize_address,
+        DoneContinuationPolicy::PerCompilationUnit,
+        PairedRcEliminationPolicy::Disabled,
         policy,
         NativeStdin::Null,
     )
@@ -125,6 +147,7 @@ pub fn compile_and_run_native_with_stdin(
         false,
         DoneContinuationPolicy::PerCompilationUnit,
         PairedRcEliminationPolicy::Enabled,
+        BorrowedParameterPolicy::ElideProvenBorrowed,
         NativeStdin::Bytes(stdin),
     )
 }
@@ -139,6 +162,7 @@ pub fn compile_and_run_native_with_closed_stdin(source_name: &str, source_code: 
         false,
         DoneContinuationPolicy::PerCompilationUnit,
         PairedRcEliminationPolicy::Enabled,
+        BorrowedParameterPolicy::ElideProvenBorrowed,
         NativeStdin::Closed,
     )
 }
@@ -186,6 +210,7 @@ pub fn compile_and_run_native_asan(source_name: &str, source_code: &str) -> Outp
         true,
         DoneContinuationPolicy::PerCompilationUnit,
         PairedRcEliminationPolicy::Enabled,
+        BorrowedParameterPolicy::ElideProvenBorrowed,
         NativeStdin::Null,
     )
 }
@@ -203,6 +228,7 @@ fn compile_and_run_native_impl(
     sanitize_address: bool,
     done_continuation: DoneContinuationPolicy,
     paired_rc_elimination: PairedRcEliminationPolicy,
+    borrowed_parameters: BorrowedParameterPolicy,
     stdin: NativeStdin<'_>,
 ) -> Output {
     use tribute::database::parse_with_thread_local;
@@ -217,6 +243,7 @@ fn compile_and_run_native_impl(
             ast_to_ir: AstToIrOptions { done_continuation },
             native: NativeOptimizationOptions {
                 paired_rc_elimination,
+                borrowed_parameters,
             },
         };
         let object_bytes =

--- a/tests/fixtures/optimizations/borrowed_parameters.trb
+++ b/tests/fixtures/optimizations/borrowed_parameters.trb
@@ -1,13 +1,18 @@
 extern "C" fn __tribute_print_nat(value: Nat) -> Nil
 
-fn choose_while_borrowing(value: fn(Nat) -> Nat, flag: Bool) -> Nat {
-    case flag {
-        True -> 10
-        False -> 20
+enum BoxedNat {
+    Boxed(Nat)
+    Wrapped(BoxedNat)
+}
+
+fn read_while_borrowing(boxed: BoxedNat) -> Nat {
+    case boxed {
+        Boxed(value) -> value
+        Wrapped(inner) -> read_while_borrowing(inner) + 0
     }
 }
 
 fn main() {
-    let increment = fn(value) { value + 1 }
-    __tribute_print_nat(choose_while_borrowing(increment, True))
+    let boxed = Boxed(10)
+    __tribute_print_nat(read_while_borrowing(boxed))
 }

--- a/tests/fixtures/optimizations/borrowed_parameters.trb
+++ b/tests/fixtures/optimizations/borrowed_parameters.trb
@@ -1,0 +1,13 @@
+extern "C" fn __tribute_print_nat(value: Nat) -> Nil
+
+fn choose_while_borrowing(value: fn(Nat) -> Nat, flag: Bool) -> Nat {
+    case flag {
+        True -> 10
+        False -> 20
+    }
+}
+
+fn main() {
+    let increment = fn(value) { value + 1 }
+    __tribute_print_nat(choose_while_borrowing(increment, True))
+}

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -267,7 +267,7 @@ fn borrowed_parameters_have_focused_before_after_ir(db: &salsa::DatabaseImpl) {
     assert!(before_retain > after_retain, "before RC ops:\n{before}");
     assert!(before_release > after_release, "before RC ops:\n{before}");
     assert_eq!(before_retain - after_retain, 1);
-    assert_eq!(before_release - after_release, 1);
+    assert_eq!(before_release - after_release, 2);
     assert!(
         after_retain > 0,
         "escaping parameters must retain ownership"

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -3,14 +3,16 @@
 mod common;
 
 use common::{
+    compile_and_run_native_with_borrowed_parameters,
     compile_and_run_native_with_done_continuation_dedup,
     compile_and_run_native_with_paired_rc_elimination,
 };
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::{
-    NativePipelineStage, OptimizationOptions, PairedRcEliminationPolicy, SharedPipelineStage,
-    dump_native_ir_at_stage, dump_shared_ir_at_stage,
+    BorrowedParameterPolicy, NativeOptimizationOptions, NativePipelineStage, OptimizationOptions,
+    PairedRcEliminationPolicy, SharedPipelineStage, dump_native_ir_at_stage,
+    dump_shared_ir_at_stage,
 };
 use tribute_front::SourceCst;
 use tribute_front::ast_to_ir::DoneContinuationPolicy;
@@ -19,6 +21,20 @@ const DONE_CONTINUATION_DEDUP_STATE: &str =
     include_str!("fixtures/optimizations/done_continuation_dedup_state.trb");
 const PAIRED_RC_ELIMINATION: &str =
     include_str!("fixtures/optimizations/paired_rc_elimination.trb");
+const BORROWED_PARAMETERS: &str = include_str!("fixtures/optimizations/borrowed_parameters.trb");
+
+fn native_optimization_options(
+    paired_rc_elimination: PairedRcEliminationPolicy,
+    borrowed_parameters: BorrowedParameterPolicy,
+) -> OptimizationOptions {
+    OptimizationOptions {
+        native: NativeOptimizationOptions {
+            paired_rc_elimination,
+            borrowed_parameters,
+        },
+        ..OptimizationOptions::production()
+    }
+}
 
 fn focused_rc_ops(ir: &str) -> String {
     ir.lines()
@@ -121,6 +137,37 @@ fn paired_rc_elimination_preserves_native_execution() {
     assert_eq!(String::from_utf8_lossy(&enabled.stdout).trim(), "10");
 }
 
+#[test]
+fn borrowed_parameters_preserve_native_execution() {
+    for sanitize_address in [false, true] {
+        let preserved = compile_and_run_native_with_borrowed_parameters(
+            "borrowed_parameters_preserved.trb",
+            BORROWED_PARAMETERS,
+            BorrowedParameterPolicy::Preserve,
+            sanitize_address,
+        );
+        let elided = compile_and_run_native_with_borrowed_parameters(
+            "borrowed_parameters_elided.trb",
+            BORROWED_PARAMETERS,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            sanitize_address,
+        );
+
+        assert!(
+            preserved.status.success(),
+            "preserved pipeline failed with sanitize_address={sanitize_address}: {}",
+            String::from_utf8_lossy(&preserved.stderr)
+        );
+        assert!(
+            elided.status.success(),
+            "elided pipeline failed with sanitize_address={sanitize_address}: {}",
+            String::from_utf8_lossy(&elided.stderr)
+        );
+        assert_eq!(preserved.stdout, elided.stdout);
+        assert_eq!(String::from_utf8_lossy(&elided.stdout).trim(), "10");
+    }
+}
+
 #[salsa_test]
 fn paired_rc_elimination_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -139,17 +186,20 @@ fn paired_rc_elimination_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
         db,
         source,
         NativePipelineStage::AfterRcOptimization,
-        OptimizationOptions::production(),
+        native_optimization_options(
+            PairedRcEliminationPolicy::Enabled,
+            BorrowedParameterPolicy::Preserve,
+        ),
     )
     .expect("RC optimization IR should be available");
     let disabled_after = dump_native_ir_at_stage(
         db,
         source,
         NativePipelineStage::AfterRcOptimization,
-        OptimizationOptions {
-            native: tribute::pipeline::NativeOptimizationOptions::baseline(),
-            ..OptimizationOptions::production()
-        },
+        native_optimization_options(
+            PairedRcEliminationPolicy::Disabled,
+            BorrowedParameterPolicy::Preserve,
+        ),
     )
     .expect("disabled RC optimization IR should be available");
 
@@ -168,6 +218,67 @@ fn paired_rc_elimination_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
 
     assert_snapshot!("paired_rc_elimination_before", before);
     assert_snapshot!("paired_rc_elimination_after", after);
+}
+
+#[salsa_test]
+fn borrowed_parameters_have_focused_before_after_ir(db: &salsa::DatabaseImpl) {
+    let source =
+        SourceCst::from_source_str(db, "borrowed_parameters_snapshot.trb", BORROWED_PARAMETERS);
+    let before = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterRcInsertion,
+        native_optimization_options(
+            PairedRcEliminationPolicy::Disabled,
+            BorrowedParameterPolicy::Preserve,
+        ),
+    )
+    .expect("owned-parameter RC insertion IR should be available");
+    let after = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterBorrowedParameterOptimization,
+        native_optimization_options(
+            PairedRcEliminationPolicy::Disabled,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        ),
+    )
+    .expect("borrowed-parameter IR should be available");
+    let preserved_after = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterBorrowedParameterOptimization,
+        native_optimization_options(
+            PairedRcEliminationPolicy::Disabled,
+            BorrowedParameterPolicy::Preserve,
+        ),
+    )
+    .expect("preserved parameter RC IR should be available");
+
+    let before = focused_rc_ops(&before);
+    let after = focused_rc_ops(&after);
+    let preserved_after = focused_rc_ops(&preserved_after);
+
+    assert_eq!(before, preserved_after);
+    let before_retain = before.matches("tribute_rt.retain").count();
+    let before_release = before.matches("tribute_rt.release").count();
+    let after_retain = after.matches("tribute_rt.retain").count();
+    let after_release = after.matches("tribute_rt.release").count();
+    assert!(before_retain > after_retain, "before RC ops:\n{before}");
+    assert!(before_release > after_release, "before RC ops:\n{before}");
+    assert_eq!(before_retain - after_retain, 1);
+    assert_eq!(before_release - after_release, 1);
+    assert!(
+        after_retain > 0,
+        "escaping parameters must retain ownership"
+    );
+    assert!(
+        after_release > 0,
+        "escaping parameters must still be released"
+    );
+
+    assert_snapshot!("borrowed_parameters_before", before);
+    assert_snapshot!("borrowed_parameters_after", after);
 }
 
 #[salsa_test]

--- a/tests/snapshots/optimization_conformance__borrowed_parameters_after.snap
+++ b/tests/snapshots/optimization_conformance__borrowed_parameters_after.snap
@@ -2,6 +2,5 @@
 source: tests/optimization_conformance.rs
 expression: after
 ---
-%4 = tribute_rt.retain %2 : core.ptr
-tribute_rt.release %2 {alloc_size = 0}
-tribute_rt.release %14 {alloc_size = 12}
+%9 = tribute_rt.retain %8 : core.ptr
+tribute_rt.release %8 {alloc_size = 0}

--- a/tests/snapshots/optimization_conformance__borrowed_parameters_after.snap
+++ b/tests/snapshots/optimization_conformance__borrowed_parameters_after.snap
@@ -1,0 +1,7 @@
+---
+source: tests/optimization_conformance.rs
+expression: after
+---
+%4 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %14 {alloc_size = 12}

--- a/tests/snapshots/optimization_conformance__borrowed_parameters_before.snap
+++ b/tests/snapshots/optimization_conformance__borrowed_parameters_before.snap
@@ -1,0 +1,9 @@
+---
+source: tests/optimization_conformance.rs
+expression: before
+---
+%4 = tribute_rt.retain %1 : core.ptr
+%5 = tribute_rt.retain %2 : core.ptr
+tribute_rt.release %1 {alloc_size = 0}
+tribute_rt.release %2 {alloc_size = 0}
+tribute_rt.release %15 {alloc_size = 12}

--- a/tests/snapshots/optimization_conformance__borrowed_parameters_before.snap
+++ b/tests/snapshots/optimization_conformance__borrowed_parameters_before.snap
@@ -2,8 +2,8 @@
 source: tests/optimization_conformance.rs
 expression: before
 ---
-%4 = tribute_rt.retain %1 : core.ptr
-%5 = tribute_rt.retain %2 : core.ptr
-tribute_rt.release %1 {alloc_size = 0}
-tribute_rt.release %2 {alloc_size = 0}
-tribute_rt.release %15 {alloc_size = 12}
+%1 = tribute_rt.retain %0 : core.ptr
+tribute_rt.release %0 {alloc_size = 0}
+%10 = tribute_rt.retain %9 : core.ptr
+tribute_rt.release %0 {alloc_size = 0}
+tribute_rt.release %9 {alloc_size = 0}


### PR DESCRIPTION
Closes #636.

## What changed

- add an independently selectable borrowed-parameter policy to the native optimization pipeline
- analyze parameter use chains before RC insertion and omit both entry retains and all corresponding releases only when every use is proven borrowed
- allow immutable loads, comparisons, store-address uses, and transparent unrealized-cast chains whose complete use sets remain borrowed
- conservatively preserve owned RC for returns, stored values, calls, branch forwarding, closure/handler/continuation capture, unknown operations, C ABI functions, tail-call targets, and address-taken functions
- avoid constructing an unattached release when a value's last use is a jump, preventing a dangling SSA use-chain entry
- document the ownership proof and pipeline position in `new-plans/rc.md`

## Correctness coverage

- focused unit tests cover safe reads, transparent casts, cross-block reads, stores, returns, unknown calls, escaping aliases, loops/block arguments, nested-region capture, continuation-frame capture, tail calls, and address-taken functions
- each focused unit test now compares the exact retain/release sequence, including operands and order, rather than checking only whether an RC operation exists
- RC insertion fixtures validate SSA use chains both before and after the pass
- the native conformance fixture performs real immutable tag/field reads through a recursive enum and snapshots the RC operations before and after the optimization
- disabled and enabled configurations execute identically with and without AddressSanitizer
- paired RC elimination remains independently gated

Trusted ownership summaries for forwarding borrowed arguments are intentionally deferred to #781.

## Validation

- `cargo nextest run -p tribute-passes` — 114 passed
- `cargo nextest run -p tribute --test optimization_conformance` — 6 passed
- `cargo clippy --workspace --all-targets`
- `cargo nextest run --workspace` — 1,554 passed, 10 skipped
- pre-commit checks repeated Clippy, formatting, and the full workspace suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable native reference-counting behavior for borrowed function parameters.
  - Production builds now omit unnecessary retain/release operations when parameters are proven safe to borrow, while baseline builds preserve existing behavior.
  - Added an option to select the borrowed-parameter policy and inspect the optimization pipeline after this stage.

- **Documentation**
  - Documented borrowed-parameter eligibility, escape conditions, and optimization ordering.

- **Tests**
  - Added coverage confirming equivalent program output and expected reference-counting changes across supported borrowing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->