### PR TITLE
Lower dynamic Wasm I/O through a scratch buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,12 @@ itertools.workspace = true
 salsa-test-macros = { path = "crates/salsa-test-macros" }
 serde.workspace = true
 
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"
+
 # Profile for building tribute-runtime as a lean no_std staticlib.
 # Usage: cargo build -p tribute-runtime --profile runtime
 [profile.runtime]

--- a/crates/tribute-passes/src/wasm/const_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/const_to_wasm.rs
@@ -151,6 +151,11 @@ pub fn analyze_consts(ctx: &IrContext, module: Module) -> ConstAnalysis {
         });
     }
 
+    let string_segment_count = collector.string_allocations.len() as u32;
+    for (_, data_idx, _) in &mut collector.bytes_allocations {
+        *data_idx += string_segment_count;
+    }
+
     ConstAnalysis {
         string_allocations: collector.string_allocations,
         bytes_allocations: collector.bytes_allocations,
@@ -205,7 +210,7 @@ impl RewritePattern for StringConstPattern {
         let value_str = string_const.value(ctx);
         let content = value_str.into_bytes();
 
-        let Some((offset, _len)) = lookup_offset(&self.allocations, &content) else {
+        let Some((offset, len)) = lookup_offset(&self.allocations, &content) else {
             return false;
         };
 
@@ -214,9 +219,11 @@ impl RewritePattern for StringConstPattern {
             .types
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
 
-        // Use typed helper to create wasm.i32_const with just the offset.
-        // Length information is available in ConstAnalysis and will be used by emit.rs.
+        // Preserve the literal length for legacy print intrinsic analysis.
         let new_op = wasm_dialect::i32_const(ctx, location, i32_ty, offset as i32);
+        ctx.op_mut(new_op.op_ref())
+            .attributes
+            .insert(Symbol::new("literal_len"), Attribute::Int(len.into()));
 
         rewriter.replace_op(new_op.op_ref());
         true

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -94,6 +94,7 @@ fn rewrite_evidence_ops_in_scope<S: RewriteScope>(ctx: &mut IrContext, scope: S)
 
 /// Replace evidence runtime function stubs with real implementations.
 fn replace_evidence_function_stubs(ctx: &mut IrContext, module: Module) {
+    let (needs_lookup, needs_extend) = evidence_helper_requirements(ctx, module);
     let ops = module.ops(ctx);
     let mut has_lookup = false;
     let mut has_extend = false;
@@ -129,15 +130,39 @@ fn replace_evidence_function_stubs(ctx: &mut IrContext, module: Module) {
         }
     }
 
-    if !has_lookup {
+    if needs_lookup && !has_lookup {
         let new_op = generate_evidence_lookup_function(ctx, location);
         prepend_module_op(ctx, module, new_op);
     }
 
-    if !has_extend {
+    if needs_extend && !has_extend {
         let new_op = generate_evidence_extend_function(ctx, location);
         prepend_module_op(ctx, module, new_op);
     }
+}
+
+fn evidence_helper_requirements(ctx: &IrContext, module: Module) -> (bool, bool) {
+    fn visit(ctx: &IrContext, region: RegionRef, lookup: &mut bool, extend: &mut bool) {
+        for &block in &ctx.region(region).blocks {
+            for &op in &ctx.block(block).ops {
+                *lookup |= ability::EvidenceLookup::from_op(ctx, op).is_ok()
+                    || effect::DispatchTail::from_op(ctx, op).is_ok()
+                    || effect::DispatchCps::from_op(ctx, op).is_ok();
+                *extend |= ability::EvidenceExtend::from_op(ctx, op).is_ok()
+                    || effect::Extend::from_op(ctx, op).is_ok();
+                for &nested in &ctx.op(op).regions {
+                    visit(ctx, nested, lookup, extend);
+                }
+            }
+        }
+    }
+
+    let mut lookup = false;
+    let mut extend = false;
+    if let Some(body) = module.body(ctx) {
+        visit(ctx, body, &mut lookup, &mut extend);
+    }
+    (lookup, extend)
 }
 
 /// Replace a top-level module operation with a new one.

--- a/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
@@ -321,6 +321,26 @@ impl RewritePattern for PrintLinePattern {
 
         let fd_const = wasm_dialect::i32_const(ctx, location, i32_ty, 1); // stdout
         let iovec_const = wasm_dialect::i32_const(ctx, location, i32_ty, iovec_offset as i32);
+        let ptr_const = wasm_dialect::i32_const(ctx, location, i32_ty, ptr as i32);
+        let len_const = wasm_dialect::i32_const(ctx, location, i32_ty, len as i32);
+        let store_ptr = wasm_dialect::i32_store(
+            ctx,
+            location,
+            iovec_const.result(ctx),
+            ptr_const.result(ctx),
+            0,
+            2,
+            0,
+        );
+        let store_len = wasm_dialect::i32_store(
+            ctx,
+            location,
+            iovec_const.result(ctx),
+            len_const.result(ctx),
+            4,
+            2,
+            0,
+        );
         let iovec_len_const = wasm_dialect::i32_const(ctx, location, i32_ty, 1); // one iovec entry
         let nwritten_const = wasm_dialect::i32_const(ctx, location, i32_ty, nwritten_offset as i32);
 
@@ -346,6 +366,10 @@ impl RewritePattern for PrintLinePattern {
             // Void: emit operations and drop the fd_write result
             rewriter.insert_op(fd_const.op_ref());
             rewriter.insert_op(iovec_const.op_ref());
+            rewriter.insert_op(ptr_const.op_ref());
+            rewriter.insert_op(len_const.op_ref());
+            rewriter.insert_op(store_ptr.op_ref());
+            rewriter.insert_op(store_len.op_ref());
             rewriter.insert_op(iovec_len_const.op_ref());
             rewriter.insert_op(nwritten_const.op_ref());
             rewriter.insert_op(call.op_ref());
@@ -354,6 +378,10 @@ impl RewritePattern for PrintLinePattern {
             // Non-void: emit operations, call result becomes the replacement value
             rewriter.insert_op(fd_const.op_ref());
             rewriter.insert_op(iovec_const.op_ref());
+            rewriter.insert_op(ptr_const.op_ref());
+            rewriter.insert_op(len_const.op_ref());
+            rewriter.insert_op(store_ptr.op_ref());
+            rewriter.insert_op(store_len.op_ref());
             rewriter.insert_op(iovec_len_const.op_ref());
             rewriter.insert_op(nwritten_const.op_ref());
             rewriter.replace_op(call.op_ref());

--- a/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 use tribute_ir::ModulePathExt;
 use trunk_ir::Symbol;
-use trunk_ir::context::IrContext;
+use trunk_ir::context::{BlockData, IrContext, RegionData};
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
@@ -20,6 +20,7 @@ use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
+use trunk_ir::smallvec::smallvec;
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 use trunk_ir_wasm_backend::gc_types::{BYTES_ARRAY_IDX, BYTES_STRUCT_IDX};
@@ -362,8 +363,8 @@ impl RewritePattern for PrintLinePattern {
         // Emit all operations
         let result_types = ctx.op_result_types(op).to_vec();
         let nil_ty = core::nil(ctx).as_type_ref();
-        if result_types.is_empty() || (result_types.len() == 1 && result_types[0] == nil_ty) {
-            // Void: emit operations and drop the fd_write result
+        if result_types.is_empty() {
+            // Void: emit operations and drop the fd_write result.
             rewriter.insert_op(fd_const.op_ref());
             rewriter.insert_op(iovec_const.op_ref());
             rewriter.insert_op(ptr_const.op_ref());
@@ -374,6 +375,35 @@ impl RewritePattern for PrintLinePattern {
             rewriter.insert_op(nwritten_const.op_ref());
             rewriter.insert_op(call.op_ref());
             rewriter.replace_op(drop_op.op_ref());
+        } else if result_types.len() == 1 && result_types[0] == nil_ty {
+            // Keep the IR-level nil result while emitting no Wasm value.
+            let block = ctx.create_block(BlockData {
+                location,
+                args: vec![],
+                ops: smallvec![],
+                parent_region: None,
+            });
+            for op in [
+                fd_const.op_ref(),
+                iovec_const.op_ref(),
+                ptr_const.op_ref(),
+                len_const.op_ref(),
+                store_ptr.op_ref(),
+                store_len.op_ref(),
+                iovec_len_const.op_ref(),
+                nwritten_const.op_ref(),
+                call.op_ref(),
+                drop_op.op_ref(),
+            ] {
+                ctx.push_op(block, op);
+            }
+            let region = ctx.create_region(RegionData {
+                location,
+                blocks: smallvec![block],
+                parent_op: None,
+            });
+            let block_op = wasm_dialect::block(ctx, location, nil_ty, region);
+            rewriter.replace_op(block_op.op_ref());
         } else {
             // Non-void: emit operations, call result becomes the replacement value
             rewriter.insert_op(fd_const.op_ref());

--- a/crates/tribute-passes/src/wasm/io.rs
+++ b/crates/tribute-passes/src/wasm/io.rs
@@ -1,0 +1,497 @@
+//! Lower target-independent output to WASI preview1.
+
+use std::collections::BTreeMap;
+
+use tribute_ir::dialect::tribute_io;
+use trunk_ir::Symbol;
+use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
+use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::dialect::{core, func};
+use trunk_ir::ops::DialectOp;
+use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
+use trunk_ir::rewrite::{
+    ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
+    TypeConverter,
+};
+use trunk_ir::smallvec::smallvec;
+use trunk_ir::types::{Location, TypeDataBuilder};
+use trunk_ir_wasm_backend::gc_types::{BYTES_ARRAY_IDX, BYTES_STRUCT_IDX};
+
+const WRITE_HELPER: &str = "__tribute_wasi_write";
+// WASI preview1 `errno::intr`.
+const WASI_ERRNO_INTR: i32 = 27;
+const PAGE_SIZE: i32 = 65_536;
+
+const BYTES_DATA_FIELD: u32 = 0;
+const BYTES_OFFSET_FIELD: u32 = 1;
+const BYTES_LEN_FIELD: u32 = 2;
+
+/// Linear-memory cells reserved for dynamic output.
+pub struct IoAnalysis {
+    pub needs_fd_write: bool,
+    pub iovec_offset: u32,
+    pub nwritten_offset: u32,
+    pub scratch_offset: u32,
+    pub total_size: u32,
+}
+
+impl IoAnalysis {
+    pub fn analyze(ctx: &IrContext, module: Module, base_offset: u32) -> Self {
+        let needs_fd_write = module.body(ctx).is_some_and(|body| {
+            let mut found = false;
+            walk_ops(ctx, body, &mut |ctx, op| {
+                found |= tribute_io::Write::from_op(ctx, op).is_ok();
+            });
+            found
+        });
+
+        if !needs_fd_write {
+            return Self {
+                needs_fd_write: false,
+                iovec_offset: base_offset,
+                nwritten_offset: base_offset,
+                scratch_offset: base_offset,
+                total_size: 0,
+            };
+        }
+
+        let iovec_offset = base_offset.div_ceil(4) * 4;
+        let nwritten_offset = iovec_offset + 8;
+        let scratch_offset = nwritten_offset + 4;
+        Self {
+            needs_fd_write: true,
+            iovec_offset,
+            nwritten_offset,
+            scratch_offset,
+            total_size: scratch_offset - base_offset,
+        }
+    }
+}
+
+fn walk_ops(ctx: &IrContext, region: RegionRef, callback: &mut impl FnMut(&IrContext, OpRef)) {
+    for &block in &ctx.region(region).blocks {
+        for &op in &ctx.block(block).ops {
+            callback(ctx, op);
+            for &nested in &ctx.op(op).regions {
+                walk_ops(ctx, nested, callback);
+            }
+        }
+    }
+}
+
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    analysis: &IoAnalysis,
+) -> Result<(), ConversionError> {
+    if analysis.needs_fd_write {
+        let helper = build_write_helper(ctx, ctx.op(module.op()).location, analysis);
+        let block = module
+            .first_block(ctx)
+            .expect("module should have a body block");
+        ctx.push_op(block, helper);
+    }
+
+    PatternApplicator::new(TypeConverter::new())
+        .add_pattern(WritePattern)
+        .with_target(ConversionTarget::new().illegal_dialect("tribute_io"))
+        .apply_partial_conversion(ctx, module, "io-to-wasm")?;
+    Ok(())
+}
+
+struct WritePattern;
+
+impl RewritePattern for WritePattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(write) = tribute_io::Write::from_op(ctx, op) else {
+            return false;
+        };
+        let call = func::call(
+            ctx,
+            ctx.op(op).location,
+            [write.bytes(ctx), write.newline(ctx)],
+            ctx.op_result_types(op)[0],
+            Symbol::new(WRITE_HELPER),
+        );
+        rewriter.replace_op(call.op_ref());
+        true
+    }
+}
+
+fn build_write_helper(ctx: &mut IrContext, loc: Location, analysis: &IoAnalysis) -> OpRef {
+    let i32_ty = simple_type(ctx, "core", "i32");
+    let bytes_ty = core::bytes(ctx).as_type_ref();
+    let nil_ty = core::nil(ctx).as_type_ref();
+    let body = ctx.create_block(BlockData {
+        location: loc,
+        args: vec![block_arg(bytes_ty), block_arg(i32_ty)],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    let bytes = ctx.block_arg(body, 0);
+    let newline = ctx.block_arg(body, 1);
+
+    let i8_ty = simple_type(ctx, "core", "i8");
+    let array_ty = core::array(ctx, i8_ty).as_type_ref();
+    let array_ref_ty = core::r#ref(ctx, array_ty, false).as_type_ref();
+    let data = wasm_dialect::struct_get(
+        ctx,
+        loc,
+        bytes,
+        array_ref_ty,
+        BYTES_STRUCT_IDX,
+        BYTES_DATA_FIELD,
+    );
+    let offset = wasm_dialect::struct_get(
+        ctx,
+        loc,
+        bytes,
+        i32_ty,
+        BYTES_STRUCT_IDX,
+        BYTES_OFFSET_FIELD,
+    );
+    let len = wasm_dialect::struct_get(ctx, loc, bytes, i32_ty, BYTES_STRUCT_IDX, BYTES_LEN_FIELD);
+    for op in [data.op_ref(), offset.op_ref(), len.op_ref()] {
+        ctx.push_op(body, op);
+    }
+
+    let total = wasm_dialect::i32_add(ctx, loc, len.result(ctx), newline, i32_ty);
+    ctx.push_op(body, total.op_ref());
+    trap_if_less(ctx, body, loc, total.result(ctx), len.result(ctx), i32_ty);
+
+    let scratch = i32_const(ctx, body, loc, i32_ty, analysis.scratch_offset as i32);
+    let end = wasm_dialect::i32_add(ctx, loc, scratch, total.result(ctx), i32_ty);
+    ctx.push_op(body, end.op_ref());
+    trap_if_less(ctx, body, loc, end.result(ctx), total.result(ctx), i32_ty);
+    ensure_memory(ctx, body, loc, end.result(ctx), i32_ty, nil_ty);
+
+    let zero = i32_const(ctx, body, loc, i32_ty, 0);
+    let copy = copy_loop(
+        ctx,
+        CopyLoopInput {
+            loc,
+            init: zero,
+            data: data.result(ctx),
+            offset: offset.result(ctx),
+            len: len.result(ctx),
+            scratch,
+            i32_ty,
+            nil_ty,
+        },
+    );
+    ctx.push_op(body, copy);
+
+    let newline_addr = wasm_dialect::i32_add(ctx, loc, scratch, len.result(ctx), i32_ty);
+    ctx.push_op(body, newline_addr.op_ref());
+    let newline_region = region(ctx, loc, |ctx, block| {
+        let lf = i32_const(ctx, block, loc, i32_ty, 10);
+        let store = wasm_dialect::i32_store8(ctx, loc, newline_addr.result(ctx), lf, 0, 0, 0);
+        ctx.push_op(block, store.op_ref());
+    });
+    let empty_region = region(ctx, loc, |_, _| {});
+    let append_newline =
+        wasm_dialect::r#if(ctx, loc, newline, nil_ty, newline_region, empty_region);
+    ctx.push_op(body, append_newline.op_ref());
+
+    let writes = write_loop(ctx, loc, zero, total.result(ctx), analysis, i32_ty, nil_ty);
+    ctx.push_op(body, writes);
+    let ret = func::r#return(ctx, loc, []);
+    ctx.push_op(body, ret.op_ref());
+
+    let body = ctx.create_region(RegionData {
+        location: loc,
+        blocks: smallvec![body],
+        parent_op: None,
+    });
+    let fn_ty = core::func(ctx, nil_ty, [bytes_ty, i32_ty]).as_type_ref();
+    func::func(ctx, loc, Symbol::new(WRITE_HELPER), fn_ty, body).op_ref()
+}
+
+fn ensure_memory(
+    ctx: &mut IrContext,
+    body: trunk_ir::BlockRef,
+    loc: Location,
+    end: ValueRef,
+    i32_ty: TypeRef,
+    nil_ty: TypeRef,
+) {
+    let one = i32_const(ctx, body, loc, i32_ty, 1);
+    let end_minus_one = wasm_dialect::i32_sub(ctx, loc, end, one, i32_ty);
+    ctx.push_op(body, end_minus_one.op_ref());
+    let page_size = i32_const(ctx, body, loc, i32_ty, PAGE_SIZE);
+    let quotient = wasm_dialect::i32_div_u(ctx, loc, end_minus_one.result(ctx), page_size, i32_ty);
+    ctx.push_op(body, quotient.op_ref());
+    let required = wasm_dialect::i32_add(ctx, loc, quotient.result(ctx), one, i32_ty);
+    ctx.push_op(body, required.op_ref());
+    let current = wasm_dialect::memory_size(ctx, loc, i32_ty, 0);
+    ctx.push_op(body, current.op_ref());
+    let needs_grow =
+        wasm_dialect::i32_gt_u(ctx, loc, required.result(ctx), current.result(ctx), i32_ty);
+    ctx.push_op(body, needs_grow.op_ref());
+
+    let grow_region = region(ctx, loc, |ctx, block| {
+        let delta =
+            wasm_dialect::i32_sub(ctx, loc, required.result(ctx), current.result(ctx), i32_ty);
+        ctx.push_op(block, delta.op_ref());
+        let grown = wasm_dialect::memory_grow(ctx, loc, delta.result(ctx), i32_ty, 0);
+        ctx.push_op(block, grown.op_ref());
+        let failed = wasm_dialect::i32_const(ctx, loc, i32_ty, -1);
+        ctx.push_op(block, failed.op_ref());
+        let is_failed =
+            wasm_dialect::i32_eq(ctx, loc, grown.result(ctx), failed.result(ctx), i32_ty);
+        ctx.push_op(block, is_failed.op_ref());
+        trap_if(ctx, block, loc, is_failed.result(ctx), nil_ty);
+    });
+    let no_grow = region(ctx, loc, |_, _| {});
+    let grow_if = wasm_dialect::r#if(
+        ctx,
+        loc,
+        needs_grow.result(ctx),
+        nil_ty,
+        grow_region,
+        no_grow,
+    );
+    ctx.push_op(body, grow_if.op_ref());
+}
+
+struct CopyLoopInput {
+    loc: Location,
+    init: ValueRef,
+    data: ValueRef,
+    offset: ValueRef,
+    len: ValueRef,
+    scratch: ValueRef,
+    i32_ty: TypeRef,
+    nil_ty: TypeRef,
+}
+
+fn copy_loop(ctx: &mut IrContext, input: CopyLoopInput) -> OpRef {
+    let CopyLoopInput {
+        loc,
+        init,
+        data,
+        offset,
+        len,
+        scratch,
+        i32_ty,
+        nil_ty,
+    } = input;
+    let loop_block = ctx.create_block(BlockData {
+        location: loc,
+        args: vec![block_arg(i32_ty)],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    let index = ctx.block_arg(loop_block, 0);
+    let done = wasm_dialect::i32_ge_u(ctx, loc, index, len, i32_ty);
+    ctx.push_op(loop_block, done.op_ref());
+    let break_if_done = wasm_dialect::br_if(ctx, loc, done.result(ctx), 1);
+    ctx.push_op(loop_block, break_if_done.op_ref());
+    let source = wasm_dialect::i32_add(ctx, loc, offset, index, i32_ty);
+    ctx.push_op(loop_block, source.op_ref());
+    let byte =
+        wasm_dialect::array_get_u(ctx, loc, data, source.result(ctx), i32_ty, BYTES_ARRAY_IDX);
+    ctx.push_op(loop_block, byte.op_ref());
+    let destination = wasm_dialect::i32_add(ctx, loc, scratch, index, i32_ty);
+    ctx.push_op(loop_block, destination.op_ref());
+    let store =
+        wasm_dialect::i32_store8(ctx, loc, destination.result(ctx), byte.result(ctx), 0, 0, 0);
+    ctx.push_op(loop_block, store.op_ref());
+    let one = i32_const(ctx, loop_block, loc, i32_ty, 1);
+    let next = wasm_dialect::i32_add(ctx, loc, index, one, i32_ty);
+    ctx.push_op(loop_block, next.op_ref());
+    let yield_next = wasm_dialect::r#yield(ctx, loc, next.result(ctx));
+    ctx.push_op(loop_block, yield_next.op_ref());
+    let continue_loop = wasm_dialect::br(ctx, loc, 0);
+    ctx.push_op(loop_block, continue_loop.op_ref());
+    loop_in_block(ctx, loc, init, loop_block, nil_ty)
+}
+
+fn write_loop(
+    ctx: &mut IrContext,
+    loc: Location,
+    init: ValueRef,
+    total: ValueRef,
+    analysis: &IoAnalysis,
+    i32_ty: TypeRef,
+    nil_ty: TypeRef,
+) -> OpRef {
+    let loop_block = ctx.create_block(BlockData {
+        location: loc,
+        args: vec![block_arg(i32_ty)],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    let written = ctx.block_arg(loop_block, 0);
+    let done = wasm_dialect::i32_ge_u(ctx, loc, written, total, i32_ty);
+    ctx.push_op(loop_block, done.op_ref());
+    let break_if_done = wasm_dialect::br_if(ctx, loc, done.result(ctx), 1);
+    ctx.push_op(loop_block, break_if_done.op_ref());
+
+    let scratch = i32_const(ctx, loop_block, loc, i32_ty, analysis.scratch_offset as i32);
+    let ptr = wasm_dialect::i32_add(ctx, loc, scratch, written, i32_ty);
+    ctx.push_op(loop_block, ptr.op_ref());
+    let remaining = wasm_dialect::i32_sub(ctx, loc, total, written, i32_ty);
+    ctx.push_op(loop_block, remaining.op_ref());
+    let iovec = i32_const(ctx, loop_block, loc, i32_ty, analysis.iovec_offset as i32);
+    let store_ptr = wasm_dialect::i32_store(ctx, loc, iovec, ptr.result(ctx), 0, 2, 0);
+    ctx.push_op(loop_block, store_ptr.op_ref());
+    let store_len = wasm_dialect::i32_store(ctx, loc, iovec, remaining.result(ctx), 4, 2, 0);
+    ctx.push_op(loop_block, store_len.op_ref());
+
+    let stdout = i32_const(ctx, loop_block, loc, i32_ty, 1);
+    let one_iovec = i32_const(ctx, loop_block, loc, i32_ty, 1);
+    let nwritten = i32_const(
+        ctx,
+        loop_block,
+        loc,
+        i32_ty,
+        analysis.nwritten_offset as i32,
+    );
+    let call = wasm_dialect::call(
+        ctx,
+        loc,
+        [stdout, iovec, one_iovec, nwritten],
+        [i32_ty],
+        Symbol::new("fd_write"),
+    );
+    ctx.push_op(loop_block, call.op_ref());
+    let zero = i32_const(ctx, loop_block, loc, i32_ty, 0);
+    let succeeded = wasm_dialect::i32_eq(ctx, loc, call.results(ctx)[0], zero, i32_ty);
+    ctx.push_op(loop_block, succeeded.op_ref());
+
+    let success = region(ctx, loc, |ctx, block| {
+        let count = wasm_dialect::i32_load(ctx, loc, nwritten, i32_ty, 0, 2, 0);
+        ctx.push_op(block, count.op_ref());
+        let no_progress = wasm_dialect::i32_eq(ctx, loc, count.result(ctx), zero, i32_ty);
+        ctx.push_op(block, no_progress.op_ref());
+        let break_if_stalled = wasm_dialect::br_if(ctx, loc, no_progress.result(ctx), 2);
+        ctx.push_op(block, break_if_stalled.op_ref());
+        let next = wasm_dialect::i32_add(ctx, loc, written, count.result(ctx), i32_ty);
+        ctx.push_op(block, next.op_ref());
+        let yield_next = wasm_dialect::r#yield(ctx, loc, next.result(ctx));
+        ctx.push_op(block, yield_next.op_ref());
+        let continue_loop = wasm_dialect::br(ctx, loc, 1);
+        ctx.push_op(block, continue_loop.op_ref());
+    });
+    let failure = region(ctx, loc, |ctx, block| {
+        let intr = i32_const(ctx, block, loc, i32_ty, WASI_ERRNO_INTR);
+        let interrupted = wasm_dialect::i32_eq(ctx, loc, call.results(ctx)[0], intr, i32_ty);
+        ctx.push_op(block, interrupted.op_ref());
+        let retry_if_interrupted = wasm_dialect::br_if(ctx, loc, interrupted.result(ctx), 1);
+        ctx.push_op(block, retry_if_interrupted.op_ref());
+        let stop = wasm_dialect::br(ctx, loc, 2);
+        ctx.push_op(block, stop.op_ref());
+    });
+    let handle_result =
+        wasm_dialect::r#if(ctx, loc, succeeded.result(ctx), nil_ty, success, failure);
+    ctx.push_op(loop_block, handle_result.op_ref());
+    loop_in_block(ctx, loc, init, loop_block, nil_ty)
+}
+
+fn loop_in_block(
+    ctx: &mut IrContext,
+    loc: Location,
+    init: ValueRef,
+    loop_block: trunk_ir::BlockRef,
+    nil_ty: TypeRef,
+) -> OpRef {
+    let loop_region = ctx.create_region(RegionData {
+        location: loc,
+        blocks: smallvec![loop_block],
+        parent_op: None,
+    });
+    let loop_op = wasm_dialect::r#loop(ctx, loc, [init], nil_ty, loop_region);
+    let block = ctx.create_block(BlockData {
+        location: loc,
+        args: vec![],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    ctx.push_op(block, loop_op.op_ref());
+    let region = ctx.create_region(RegionData {
+        location: loc,
+        blocks: smallvec![block],
+        parent_op: None,
+    });
+    wasm_dialect::block(ctx, loc, nil_ty, region).op_ref()
+}
+
+fn trap_if_less(
+    ctx: &mut IrContext,
+    body: trunk_ir::BlockRef,
+    loc: Location,
+    lhs: ValueRef,
+    rhs: ValueRef,
+    i32_ty: TypeRef,
+) {
+    let overflow = wasm_dialect::i32_lt_u(ctx, loc, lhs, rhs, i32_ty);
+    ctx.push_op(body, overflow.op_ref());
+    let nil_ty = core::nil(ctx).as_type_ref();
+    trap_if(ctx, body, loc, overflow.result(ctx), nil_ty);
+}
+
+fn trap_if(
+    ctx: &mut IrContext,
+    body: trunk_ir::BlockRef,
+    loc: Location,
+    condition: ValueRef,
+    nil_ty: TypeRef,
+) {
+    let trap = region(ctx, loc, |ctx, block| {
+        let unreachable = wasm_dialect::unreachable(ctx, loc);
+        ctx.push_op(block, unreachable.op_ref());
+    });
+    let ok = region(ctx, loc, |_, _| {});
+    let if_op = wasm_dialect::r#if(ctx, loc, condition, nil_ty, trap, ok);
+    ctx.push_op(body, if_op.op_ref());
+}
+
+fn region(
+    ctx: &mut IrContext,
+    loc: Location,
+    build: impl FnOnce(&mut IrContext, trunk_ir::BlockRef),
+) -> RegionRef {
+    let block = ctx.create_block(BlockData {
+        location: loc,
+        args: vec![],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    build(ctx, block);
+    ctx.create_region(RegionData {
+        location: loc,
+        blocks: smallvec![block],
+        parent_op: None,
+    })
+}
+
+fn i32_const(
+    ctx: &mut IrContext,
+    block: trunk_ir::BlockRef,
+    loc: Location,
+    ty: TypeRef,
+    value: i32,
+) -> ValueRef {
+    let op = wasm_dialect::i32_const(ctx, loc, ty, value);
+    let result = op.result(ctx);
+    ctx.push_op(block, op.op_ref());
+    result
+}
+
+fn simple_type(ctx: &mut IrContext, dialect: &'static str, name: &'static str) -> TypeRef {
+    ctx.types
+        .intern(TypeDataBuilder::new(Symbol::new(dialect), Symbol::new(name)).build())
+}
+
+fn block_arg(ty: TypeRef) -> BlockArgData {
+    BlockArgData {
+        ty,
+        attrs: BTreeMap::new(),
+    }
+}

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -26,6 +26,7 @@ use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 
 use super::const_to_wasm::ConstAnalysis;
 use super::intrinsic_to_wasm::IntrinsicAnalysis;
+use super::io::IoAnalysis;
 use super::type_converter::{self, wasm_type_converter};
 use trunk_ir_wasm_backend::gc_types::{EVIDENCE_IDX, STEP_IDX, STEP_TAG_DONE};
 
@@ -77,6 +78,13 @@ pub fn wasm_backend_ready_target() -> ConversionTarget {
 
 /// Run the full WASM lowering pipeline on arena IR.
 pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowerError> {
+    let const_analysis = super::const_to_wasm::analyze_consts(ctx, module);
+    let io_analysis = IoAnalysis::analyze(ctx, module, const_analysis.total_size());
+    {
+        let _span = tracing::info_span!("io_to_wasm").entered();
+        super::io::lower(ctx, module, &io_analysis)?;
+    }
+
     // Phase 1: Pattern-based lowering passes (using trunk-ir-wasm-backend)
     {
         let _span = tracing::info_span!("arith_to_wasm").entered();
@@ -147,16 +155,17 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowe
     }
 
     // Const analysis and lowering (string/bytes constants to data segments)
-    let const_analysis = {
+    {
         let _span = tracing::info_span!("const_to_wasm").entered();
-        let const_analysis = super::const_to_wasm::analyze_consts(ctx, module);
         super::const_to_wasm::lower(ctx, module, &const_analysis);
-        const_analysis
-    };
+    }
 
     // Intrinsic analysis and lowering (print_line -> fd_write)
-    let intrinsic_analysis =
-        super::intrinsic_to_wasm::analyze_intrinsics(ctx, module, const_analysis.total_size());
+    let intrinsic_analysis = super::intrinsic_to_wasm::analyze_intrinsics(
+        ctx,
+        module,
+        const_analysis.total_size() + io_analysis.total_size,
+    );
     {
         let _span = tracing::info_span!("intrinsic_to_wasm").entered();
         super::intrinsic_to_wasm::lower(ctx, module, &intrinsic_analysis);
@@ -165,7 +174,7 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowe
     // Phase 2: Module-level operations via WasmLowerer (in-place)
     {
         let _span = tracing::info_span!("wasm_lowerer").entered();
-        let mut lowerer = WasmLowerer::new(&const_analysis, &intrinsic_analysis);
+        let mut lowerer = WasmLowerer::new(&const_analysis, &io_analysis, &intrinsic_analysis);
         lowerer.lower_module(ctx, module);
     }
 
@@ -368,6 +377,7 @@ impl ArenaMemoryPlan {
 /// 3. Appends data segment ops and module-level extras (exports, _start function)
 struct WasmLowerer<'a> {
     const_analysis: &'a ConstAnalysis,
+    io_analysis: &'a IoAnalysis,
     intrinsic_analysis: &'a IntrinsicAnalysis,
     memory_plan: ArenaMemoryPlan,
     main_exports: MainExports,
@@ -375,9 +385,14 @@ struct WasmLowerer<'a> {
 }
 
 impl<'a> WasmLowerer<'a> {
-    fn new(const_analysis: &'a ConstAnalysis, intrinsic_analysis: &'a IntrinsicAnalysis) -> Self {
+    fn new(
+        const_analysis: &'a ConstAnalysis,
+        io_analysis: &'a IoAnalysis,
+        intrinsic_analysis: &'a IntrinsicAnalysis,
+    ) -> Self {
         Self {
             const_analysis,
+            io_analysis,
             intrinsic_analysis,
             memory_plan: ArenaMemoryPlan::new(),
             main_exports: MainExports::new(),
@@ -484,7 +499,7 @@ impl<'a> WasmLowerer<'a> {
         let mut preamble_ops: Vec<OpRef> = Vec::new();
 
         // Emit fd_write only when an explicit intrinsic needs it.
-        if self.intrinsic_analysis.needs_fd_write {
+        if self.io_analysis.needs_fd_write || self.intrinsic_analysis.needs_fd_write {
             let i32_ty = intern_type(ctx, "core", "i32");
             let import_ty = intern_func_type(ctx, vec![i32_ty, i32_ty, i32_ty, i32_ty], i32_ty);
             let op = wasm_dialect::import_func(
@@ -500,13 +515,14 @@ impl<'a> WasmLowerer<'a> {
 
         // Check if memory is needed
         let const_size = self.const_analysis.total_size();
+        let io_size = self.io_analysis.total_size;
         let intrinsic_size = self.intrinsic_analysis.total_size;
-        if const_size > 0 || intrinsic_size > 0 {
+        if const_size > 0 || io_size > 0 || intrinsic_size > 0 {
             self.memory_plan.needs_memory = true;
         }
 
         if self.memory_plan.needs_memory && !self.memory_plan.has_memory {
-            let total_data_size = const_size + intrinsic_size;
+            let total_data_size = const_size + io_size + intrinsic_size;
             let required_pages = self.memory_plan.required_pages(total_data_size);
             let op = wasm_dialect::memory(ctx, location, required_pages, 0, false, false);
             preamble_ops.push(op.op_ref());
@@ -842,7 +858,14 @@ mod tests {
             nwritten_offset: None,
             total_size: 0,
         };
-        let mut lowerer = WasmLowerer::new(&const_analysis, &intrinsic_analysis);
+        let io_analysis = IoAnalysis {
+            needs_fd_write: false,
+            iovec_offset: 0,
+            nwritten_offset: 0,
+            scratch_offset: 0,
+            total_size: 0,
+        };
+        let mut lowerer = WasmLowerer::new(&const_analysis, &io_analysis, &intrinsic_analysis);
         lowerer.main_exports.saw_main = true;
         lowerer.main_exports.main_result_type = Some(nil_ty);
         lowerer.main_exports.main_param_types = vec![evidence_ty];
@@ -893,7 +916,14 @@ mod tests {
             nwritten_offset: Some(16),
             total_size: 20,
         };
-        let mut lowerer = WasmLowerer::new(&const_analysis, &intrinsic_analysis);
+        let io_analysis = IoAnalysis {
+            needs_fd_write: false,
+            iovec_offset: 4,
+            nwritten_offset: 4,
+            scratch_offset: 4,
+            total_size: 0,
+        };
+        let mut lowerer = WasmLowerer::new(&const_analysis, &io_analysis, &intrinsic_analysis);
         let module_block = module.first_block(&ctx).expect("module body block");
         let placeholder = ctx.block(module_block).ops[0];
 

--- a/crates/tribute-passes/src/wasm/mod.rs
+++ b/crates/tribute-passes/src/wasm/mod.rs
@@ -17,6 +17,7 @@
 pub mod const_to_wasm;
 pub mod evidence_to_wasm;
 pub mod intrinsic_to_wasm;
+pub mod io;
 pub mod lower;
 pub mod normalize_primitive_types;
 pub mod tribute_rt_to_wasm;

--- a/crates/tribute-passes/src/wasm/type_converter.rs
+++ b/crates/tribute-passes/src/wasm/type_converter.rs
@@ -200,6 +200,10 @@ fn is_variant_instance_type(ctx: &IrContext, ty: TypeRef) -> bool {
 /// This includes `wasm.structref`, `wasm.anyref`, ADT struct/typeref types,
 /// variant instance types, and trampoline types that get lowered to ADT structs.
 fn is_struct_like(ctx: &IrContext, ty: TypeRef) -> bool {
+    if is_type(ctx, ty, Symbol::new("core"), Symbol::new("bytes")) {
+        return true;
+    }
+
     // wasm.structref or wasm.anyref
     if is_type(ctx, ty, Symbol::new("wasm"), Symbol::new("structref"))
         || is_type(ctx, ty, Symbol::new("wasm"), Symbol::new("anyref"))

--- a/crates/tribute-passes/src/wasm/wasm_gc_type_assign.rs
+++ b/crates/tribute-passes/src/wasm/wasm_gc_type_assign.rs
@@ -316,6 +316,21 @@ impl RewritePattern for UpdateStructGetPattern {
             return false;
         }
 
+        // Builtin GC layouts have canonical indices and must not be
+        // re-inferred from a value flowing through generic IR bookkeeping.
+        if ctx
+            .op(op)
+            .attributes
+            .get(&Symbol::new(ATTR_TYPE_IDX))
+            .and_then(|attr| match attr {
+                Attribute::Int(idx) => u32::try_from(*idx).ok(),
+                _ => None,
+            })
+            .is_some_and(|idx| idx < FIRST_USER_TYPE_IDX)
+        {
+            return false;
+        }
+
         // Get the struct operand and trace to find its type_idx
         let operands = ctx.op_operands(op).to_vec();
         let Some(&struct_val) = operands.first() else {

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -1206,7 +1206,7 @@ fn set_result_local(
     function: &mut Function,
 ) -> CompilationResult<()> {
     let results = ctx.op_result_types(op);
-    if results.is_empty() {
+    if results.is_empty() || helpers::is_nil_type(ctx, results[0]) {
         return Ok(());
     }
     let local = emit_ctx

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -22,8 +22,9 @@ use super::helpers;
 
 /// Intern a core.func type from params and result type.
 fn intern_func_type(ctx: &mut IrContext, params: &[TypeRef], result_ty: TypeRef) -> TypeRef {
-    let mut all_params: SmallVec<[TypeRef; 4]> = params.into();
-    all_params.push(result_ty); // last param is the return type
+    let mut all_params = SmallVec::with_capacity(params.len() + 1);
+    all_params.push(result_ty);
+    all_params.extend_from_slice(params);
     ctx.types.intern(TypeData {
         dialect: Symbol::new("core"),
         name: Symbol::new("func"),
@@ -350,4 +351,24 @@ pub(crate) fn has_call_indirect(ctx: &IrContext, module: Module) -> bool {
 
     let body = module.body(ctx).unwrap();
     check_region(ctx, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indirect_function_type_uses_result_first_layout() {
+        let mut ctx = IrContext::new();
+        let result = intern_simple_wasm_type(&mut ctx, "i32");
+        let first = intern_simple_wasm_type(&mut ctx, "i64");
+        let second = intern_simple_wasm_type(&mut ctx, "f32");
+
+        let func_ty = intern_func_type(&mut ctx, &[first, second], result);
+
+        assert_eq!(
+            helpers::func_type_parts(&ctx, func_ty),
+            Some((&[first, second][..], result))
+        );
+    }
 }

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -272,8 +272,8 @@ use super::super::helpers::attr_u32;
 /// Find a core.func type in the `type_idx_by_type` / `func_types` registries by
 /// matching params and result.
 ///
-/// core.func types encode parameters followed by a single result in `TypeData.params`:
-/// `[param1, .., paramN, result]`.
+/// core.func types encode a single result followed by parameters in `TypeData.params`:
+/// `[result, param1, .., paramN]`.
 ///
 /// This performs a linear O(n) scan over the registries to avoid requiring
 /// `&mut IrContext` for interning a new type. The trade-off is O(n) per
@@ -286,36 +286,19 @@ fn find_func_type_in_registry(
     result: TypeRef,
     module_info: &ModuleInfo,
 ) -> CompilationResult<TypeRef> {
-    let core_sym = Symbol::new("core");
-    let func_sym = Symbol::new("func");
-    let expected_len = params.len() + 1;
-
     // Search through registered func types (from imports, funcs, and call_indirect collection)
     for &ty_ref in module_info.type_idx_by_type.keys() {
-        let data = ctx.types.get(ty_ref);
-        if data.dialect != core_sym || data.name != func_sym {
-            continue;
-        }
-        if data.params.len() != expected_len {
-            continue;
-        }
-        // Check params match (all but last)
-        let (ty_params, ty_result) = data.params.split_at(data.params.len() - 1);
-        if ty_params == params && ty_result[0] == result {
+        if helpers::func_type_parts(ctx, ty_ref)
+            .is_some_and(|(ty_params, ty_result)| ty_result == result && ty_params == params)
+        {
             return Ok(ty_ref);
         }
     }
     // Also check func_types map
     for &ty_ref in module_info.func_types.values() {
-        let data = ctx.types.get(ty_ref);
-        if data.dialect != core_sym || data.name != func_sym {
-            continue;
-        }
-        if data.params.len() != expected_len {
-            continue;
-        }
-        let (ty_params, ty_result) = data.params.split_at(data.params.len() - 1);
-        if ty_params == params && ty_result[0] == result {
+        if helpers::func_type_parts(ctx, ty_ref)
+            .is_some_and(|(ty_params, ty_result)| ty_result == result && ty_params == params)
+        {
             return Ok(ty_ref);
         }
     }

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/struct_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/struct_handlers.rs
@@ -14,7 +14,8 @@ use trunk_ir::types::Attribute;
 use wasm_encoder::{Function, HeapType, Instruction, StorageType, ValType};
 
 use crate::gc_types::{
-    ATTR_FIELD_COUNT, ATTR_TYPE, ATTR_TYPE_IDX, CLOSURE_STRUCT_IDX, GcTypeDef, STEP_IDX,
+    ATTR_FIELD_COUNT, ATTR_TYPE, ATTR_TYPE_IDX, CLOSURE_STRUCT_IDX, FIRST_USER_TYPE_IDX, GcTypeDef,
+    STEP_IDX,
 };
 use crate::{CompilationError, CompilationResult};
 
@@ -209,6 +210,13 @@ fn resolve_struct_get_type_idx(
     attrs: &BTreeMap<Symbol, Attribute>,
     module_info: &ModuleInfo,
 ) -> CompilationResult<u32> {
+    if let Some(Attribute::Int(idx)) = attrs.get(&ATTR_TYPE_IDX())
+        && let Ok(idx) = u32::try_from(*idx)
+        && idx < FIRST_USER_TYPE_IDX
+    {
+        return Ok(idx);
+    }
+
     let Some(op_val) = operand else {
         debug!("struct_get: no operand, using fallback");
         return get_type_idx_from_attrs(ctx, attrs, None, &module_info.type_idx_by_type)

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -12,7 +12,7 @@ use trunk_ir::types::Attribute;
 use wasm_encoder::{AbstractHeapType, HeapType, RefType, ValType};
 
 use crate::errors::CompilationErrorKind;
-use crate::gc_types::{BYTES_STRUCT_IDX, CLOSURE_STRUCT_IDX, STEP_IDX};
+use crate::gc_types::{BYTES_ARRAY_IDX, BYTES_STRUCT_IDX, CLOSURE_STRUCT_IDX, STEP_IDX};
 use crate::{CompilationError, CompilationResult};
 
 // ============================================================================
@@ -99,8 +99,8 @@ pub(crate) fn func_type_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef
     if data.params.is_empty() {
         return None;
     }
-    let (params, ret) = data.params.split_at(data.params.len() - 1);
-    Some((params, ret[0]))
+    let (ret, params) = data.params.split_first()?;
+    Some((params, *ret))
 }
 
 /// Convert an IR type to a WebAssembly value type.
@@ -119,8 +119,17 @@ pub(crate) fn type_to_valtype(
         Ok(ValType::F64)
     } else if is_type(ctx, ty, "core", "bytes") {
         Ok(ValType::Ref(RefType {
-            nullable: true,
+            nullable: false,
             heap_type: HeapType::Concrete(BYTES_STRUCT_IDX),
+        }))
+    } else if is_bytes_array_ref(ctx, ty) {
+        let nullable = matches!(
+            ctx.types.get(ty).attrs.get(&Symbol::new("nullable")),
+            Some(Attribute::Bool(true))
+        );
+        Ok(ValType::Ref(RefType {
+            nullable,
+            heap_type: HeapType::Concrete(BYTES_ARRAY_IDX),
         }))
     } else if is_type(ctx, ty, "core", "string") || is_type(ctx, ty, "core", "ptr") {
         Ok(ValType::I32)
@@ -197,6 +206,21 @@ pub(crate) fn type_to_valtype(
             data.dialect, data.name
         )))
     }
+}
+
+fn is_bytes_array_ref(ctx: &IrContext, ty: TypeRef) -> bool {
+    let reference = ctx.types.get(ty);
+    if reference.dialect != Symbol::new("core")
+        || reference.name != Symbol::new("ref")
+        || reference.params.len() != 1
+    {
+        return false;
+    }
+    let array = ctx.types.get(reference.params[0]);
+    array.dialect == Symbol::new("core")
+        && array.name == Symbol::new("array")
+        && array.params.len() == 1
+        && is_type(ctx, array.params[0], "core", "i8")
 }
 
 /// Convert an IR return type to WebAssembly result types.

--- a/new-plans/io.md
+++ b/new-plans/io.md
@@ -186,6 +186,30 @@ Wasm lowering은 각각 #772와 #771이 담당한다.
 - WASI preview2/component model 전환은 이 source API와 독립적인 후속 backend
   작업이다.
 
+### Wasm Runtime Boundary
+
+현재 Wasm backend의 `Bytes`는 WasmGC `array i8`와 slice offset/length를 가진
+struct다. WASI preview1 `fd_write`의 iovec은 linear memory에 있어야 하므로 GC array
+reference를 직접 전달할 수 없다. 첫 구현은 instance-local linear scratch buffer를
+사용한다.
+
+- 출력할 `Bytes` slice를 GC array에서 scratch buffer로 복사한다.
+- `print_line`은 payload 끝에 `\n` 하나를 붙여 하나의 연속 구간으로 쓴다.
+- iovec과 `nwritten` cell도 compiler가 예약한 linear memory에 둔다.
+- payload가 현재 scratch capacity보다 크면 checked arithmetic으로 필요한 page 수를
+  계산해 memory를 grow한다. 실패는 현재 trap으로 처리한다.
+- `fd_write`가 partial write를 반환하면 iovec의 pointer/length를 갱신하여 남은 구간을
+  다시 쓴다. interrupt는 재시도하고 다른 host failure는 source-level `Throw`로
+  노출하지 않는다.
+- scratch pointer는 동기 host call 동안만 유효하며 host가 보관해서는 안 된다.
+- buffer는 instance 안에서 재사용한다. 현재 실행 모델은 single-threaded이며 threads나
+  reentrant host callback은 별도 정책이 필요하다.
+
+이 선택은 `tribute_io.write`의 target lowering 내부에만 존재한다. 이후 WASI
+preview2/component model이나 custom host import로 교체해도 source API와 shared IR
+boundary는 바뀌지 않는다. #771은 동적 출력만 다루며 Wasm `read_line`은 별도 후속
+범위다.
+
 ### Native Runtime ABI
 
 Native lowering은 다음 private C ABI를 사용한다. 이 ABI는 source API가 아니며

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -99,6 +99,19 @@ Printing program results belongs in explicit standard I/O calls such as
 `std::io::print_line`, which shared lowering maps to the target-independent I/O
 boundary described in [io.md](io.md), not in backend entrypoint lowering.
 
+### Dynamic basic output
+
+WASI preview1 `fd_write` cannot read a WasmGC `Bytes` array directly because its
+iovec points into linear memory. The initial `tribute_io.write` lowering copies
+the dynamic `Bytes` slice into an instance-local linear scratch buffer, appends
+the optional newline there, and invokes `fd_write` with compiler-owned iovec and
+`nwritten` cells. The lowering grows memory when required and retries partial or
+interrupted writes. See [io.md](io.md#wasm-runtime-boundary) for lifetime and
+failure rules.
+
+The old `__print_line` literal analysis is a compatibility path to remove. New
+source programs must reach Wasm output only through `tribute_io.write`.
+
 ---
 
 ## WasmGC 타입 처리

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -18,6 +18,8 @@
 
 mod common;
 
+use std::process::Command;
+
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::compile_to_wasm_binary;
 use tribute_front::SourceCst;
@@ -115,19 +117,57 @@ fn main() {
     expect_wasm_compilation_success(db, source, "Should compile function with params");
 }
 
-// Note: String literals work as intrinsic arguments (e.g., __print_line)
-// but require additional lowering for case branch return values.
-// This test calls the intrinsic directly (not through prelude's print_line,
-// which now depends on native-only extern "C" functions).
 #[salsa_test]
 fn test_compile_print_line(db: &salsa::DatabaseImpl) {
     let code = r#"
-extern "intrinsic" fn __print_line(message: String) -> Nil
-fn my_print(message: String) -> Nil { __print_line(message) }
-fn main() { my_print("Hello, World!") }
+fn main() ->{std::io::Io} Nil {
+    let left = b"Hello, "
+    let right = b"World!"
+    std::io::print_line(String::from_bytes(left <> right))
+}
 "#;
     let source = SourceCst::from_source_str(db, "hello.trb", code);
-    expect_wasm_compilation_success(db, source, "Should compile print_line");
+    expect_wasm_compilation_success(db, source, "Should compile dynamic print_line");
+}
+
+#[test]
+fn test_execute_dynamic_bytes_write_boundary() {
+    let mut ctx = trunk_ir::IrContext::new();
+    let left = "x".repeat(35_000);
+    let right = "y".repeat(35_000);
+    let ir = format!(
+        r#"core.module @test {{
+  func.func @main() -> core.nil {{
+    %left = adt.bytes_const {{value = b"{left}"}} : core.bytes
+    %right = adt.bytes_const {{value = b"{right}"}} : core.bytes
+    %joined = func.call %left, %right {{callee = @__bytes_concat}} : core.bytes
+    %newline = arith.const {{value = 1}} : core.i1
+    %result = tribute_io.write %joined, %newline : core.nil
+    func.return
+  }}
+}}"#
+    );
+    let module = trunk_ir::parser::parse_test_module(&mut ctx, &ir);
+    tribute_passes::wasm::lower::lower_to_wasm(&mut ctx, module)
+        .expect("lower dynamic output to Wasm");
+    let binary = trunk_ir_wasm_backend::emit_module_to_wasm(&mut ctx, module)
+        .expect("emit dynamic output Wasm");
+    let wasm = tempfile::NamedTempFile::new().expect("temporary Wasm file");
+    std::fs::write(wasm.path(), &binary.bytes).expect("write Wasm module");
+    let output = Command::new("wasmtime")
+        .arg("-Wgc=y,function-references=y")
+        .arg(wasm.path())
+        .output()
+        .expect("run Wasm module with wasmtime");
+    assert!(
+        output.status.success(),
+        "wasmtime failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut expected = left.into_bytes();
+    expected.extend_from_slice(right.as_bytes());
+    expected.push(b'\n');
+    assert_eq!(output.stdout, expected);
 }
 
 #[salsa_test]

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -18,6 +18,7 @@
 
 mod common;
 
+use std::io::Write as _;
 use std::process::Command;
 
 use salsa_test_macros::salsa_test;
@@ -138,11 +139,15 @@ fn test_execute_dynamic_bytes_write_boundary() {
     let ir = format!(
         r#"core.module @test {{
   func.func @main() -> core.nil {{
+    %before = adt.string_const {{value = "before|"}} : core.string
+    wasm.call %before {{callee = @__print_line}}
     %left = adt.bytes_const {{value = b"{left}"}} : core.bytes
     %right = adt.bytes_const {{value = b"{right}"}} : core.bytes
     %joined = func.call %left, %right {{callee = @__bytes_concat}} : core.bytes
     %newline = arith.const {{value = 1}} : core.i1
     %result = tribute_io.write %joined, %newline : core.nil
+    %after = adt.string_const {{value = "|after"}} : core.string
+    wasm.call %after {{callee = @__print_line}}
     func.return
   }}
 }}"#
@@ -152,8 +157,8 @@ fn test_execute_dynamic_bytes_write_boundary() {
         .expect("lower dynamic output to Wasm");
     let binary = trunk_ir_wasm_backend::emit_module_to_wasm(&mut ctx, module)
         .expect("emit dynamic output Wasm");
-    let wasm = tempfile::NamedTempFile::new().expect("temporary Wasm file");
-    std::fs::write(wasm.path(), &binary.bytes).expect("write Wasm module");
+    let mut wasm = tempfile::NamedTempFile::new().expect("temporary Wasm file");
+    wasm.write_all(&binary.bytes).expect("write Wasm module");
     let output = Command::new("wasmtime")
         .arg("-Wgc=y,function-references=y")
         .arg(wasm.path())
@@ -164,9 +169,11 @@ fn test_execute_dynamic_bytes_write_boundary() {
         "wasmtime failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let mut expected = left.into_bytes();
+    let mut expected = b"before|".to_vec();
+    expected.extend_from_slice(left.as_bytes());
     expected.extend_from_slice(right.as_bytes());
     expected.push(b'\n');
+    expected.extend_from_slice(b"|after");
     assert_eq!(output.stdout, expected);
 }
 


### PR DESCRIPTION
## Summary

- lower target-independent `tribute_io.write` operations to WASI preview1 `fd_write`
- copy dynamic WasmGC `Bytes` slices into an instance-local linear-memory scratch buffer
- grow memory for large payloads, append optional newlines, and retry interrupted or partial writes
- preserve builtin WasmGC layouts and correct emitter handling needed by the executable output path
- document the runtime boundary and keep the legacy literal path safe when mixed with scratch output
- reduce development and test debug information to line tables

## Why

WASI preview1 iovecs point into linear memory, while Tribute represents `Bytes` as a WasmGC struct backed by an `array i8`. The previous lowering only handled literal pointers and could not print dynamically produced strings or byte slices. The new lowering bridges those memory models without changing the source API or shared I/O dialect.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo nextest run --workspace` — 1,539 passed, 10 skipped
- `cargo nextest run -p tribute-passes` — 100 passed
- `cargo nextest run --test wasm_compilation` — 11 passed
- Wasmtime execution test writes a 70 KB dynamically concatenated payload, exercising `memory.grow` and newline output

Closes #771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WASI output support for dynamically sized byte content, including newline appending and resilient handling of partial/interrupted writes.
* **Bug Fixes**
  * Corrected WebAssembly `fd_write` emission for pointer/length ordering and proper handling of void vs nil results.
  * Avoided unnecessary evidence helper emission and improved `struct.get`/type resolution for built-in layouts and bytes/reference representations.
* **Tests**
  * Updated end-to-end WebAssembly tests to validate dynamic byte stdout via `wasmtime`, and adjusted `print_line` coverage to use the public printing path.
* **Documentation**
  * Added WASM runtime boundary documentation for dynamic bytes and output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->