### PR TITLE
Introduce attribute maps across the IR and lowering pipelines

### DIFF
--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -67,10 +67,11 @@ pub fn set_calling_convention(ctx: &mut IrContext, op: OpRef, convention: Callin
 
 /// Read explicitly attached calling-convention metadata.
 pub fn get_calling_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConvention> {
-    let Attribute::Int(code) = ctx.op(op).attributes.get(CALLING_CONVENTION_ATTR)? else {
-        return None;
-    };
-    let code = u8::try_from(*code).ok()?;
+    let code = ctx
+        .op(op)
+        .attributes
+        .get_u8(CALLING_CONVENTION_ATTR)
+        .ok()??;
     code.try_into().ok()
 }
 

--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -67,11 +67,7 @@ pub fn set_calling_convention(ctx: &mut IrContext, op: OpRef, convention: Callin
 
 /// Read explicitly attached calling-convention metadata.
 pub fn get_calling_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConvention> {
-    let Attribute::Int(code) = ctx
-        .op(op)
-        .attributes
-        .get(&Symbol::new(CALLING_CONVENTION_ATTR))?
-    else {
+    let Attribute::Int(code) = ctx.op(op).attributes.get(CALLING_CONVENTION_ATTR)? else {
         return None;
     };
     let code = u8::try_from(*code).ok()?;

--- a/crates/tribute-front/src/ast_to_ir/lower/handle.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/handle.rs
@@ -866,7 +866,7 @@ fn build_tr_dispatch_chain<'db>(
 
     // Compute expected op_idx
     let ability_data = ir.types.get(ability_ref_ty);
-    let ability_name = match ability_data.attrs.get(&Symbol::new("name")) {
+    let ability_name = match ability_data.attrs.get("name") {
         Some(Attribute::Symbol(s)) => Some(*s),
         _ => None,
     };
@@ -1049,7 +1049,7 @@ fn build_handler_dispatch_chain<'db>(
 
     // Compute expected op_idx
     let ability_data = ir.types.get(ability_ref_ty);
-    let ability_name = match ability_data.attrs.get(&Symbol::new("name")) {
+    let ability_name = match ability_data.attrs.get("name") {
         Some(Attribute::Symbol(s)) => Some(*s),
         _ => None,
     };

--- a/crates/tribute-front/src/ast_to_ir/lower/handle.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/handle.rs
@@ -866,10 +866,7 @@ fn build_tr_dispatch_chain<'db>(
 
     // Compute expected op_idx
     let ability_data = ir.types.get(ability_ref_ty);
-    let ability_name = match ability_data.attrs.get("name") {
-        Some(Attribute::Symbol(s)) => Some(*s),
-        _ => None,
-    };
+    let ability_name = ability_data.attrs.get_symbol("name");
     let expected_idx = compute_op_idx(ability_name, Some(op_name));
 
     // Build handler arm body region (no k_val — fn handler doesn't use resume)
@@ -1049,10 +1046,7 @@ fn build_handler_dispatch_chain<'db>(
 
     // Compute expected op_idx
     let ability_data = ir.types.get(ability_ref_ty);
-    let ability_name = match ability_data.attrs.get("name") {
-        Some(Attribute::Symbol(s)) => Some(*s),
-        _ => None,
-    };
+    let ability_name = ability_data.attrs.get_symbol("name");
     let expected_idx = compute_op_idx(ability_name, Some(op_name));
 
     // Build handler arm body region

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -139,10 +139,7 @@ pub fn compute_ability_id(ctx: &IrContext, ability_ref: TypeRef) -> u32 {
 
 /// Return the source-level ability name attached to an ability reference type.
 pub fn ability_name(ctx: &IrContext, ability_ref: TypeRef) -> Option<Symbol> {
-    match ctx.types.get(ability_ref).attrs.get("name") {
-        Some(Attribute::Symbol(s)) => Some(*s),
-        _ => None,
-    }
+    ctx.types.get(ability_ref).attrs.get_symbol("name")
 }
 
 /// Build an `arith.const` for the stable runtime ability ID.
@@ -356,10 +353,7 @@ pub fn is_marker_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
     if data.dialect != Symbol::new("adt") || data.name != Symbol::new("struct") {
         return false;
     }
-    matches!(
-        data.attrs.get("name"),
-        Some(Attribute::Symbol(s)) if *s == Symbol::new("_Marker")
-    )
+    data.attrs.get_symbol("name") == Some(Symbol::new("_Marker"))
 }
 
 /// Check if a type is the evidence ADT type (`core.array(Marker)`).
@@ -391,10 +385,7 @@ mod tests {
         assert_eq!(data.name, Symbol::new("struct"));
 
         // Should have name "_Marker"
-        assert_eq!(
-            data.attrs.get("name"),
-            Some(&Attribute::Symbol(Symbol::new("_Marker")))
-        );
+        assert_eq!(data.attrs.get_symbol("name"), Some(Symbol::new("_Marker")));
 
         // Should have the canonical field layout.
         let fields = data.attrs.get("fields").unwrap();

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -139,7 +139,7 @@ pub fn compute_ability_id(ctx: &IrContext, ability_ref: TypeRef) -> u32 {
 
 /// Return the source-level ability name attached to an ability reference type.
 pub fn ability_name(ctx: &IrContext, ability_ref: TypeRef) -> Option<Symbol> {
-    match ctx.types.get(ability_ref).attrs.get(&Symbol::new("name")) {
+    match ctx.types.get(ability_ref).attrs.get("name") {
         Some(Attribute::Symbol(s)) => Some(*s),
         _ => None,
     }
@@ -357,7 +357,7 @@ pub fn is_marker_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
         return false;
     }
     matches!(
-        data.attrs.get(&Symbol::new("name")),
+        data.attrs.get("name"),
         Some(Attribute::Symbol(s)) if *s == Symbol::new("_Marker")
     )
 }
@@ -392,12 +392,12 @@ mod tests {
 
         // Should have name "_Marker"
         assert_eq!(
-            data.attrs.get(&Symbol::new("name")),
+            data.attrs.get("name"),
             Some(&Attribute::Symbol(Symbol::new("_Marker")))
         );
 
         // Should have the canonical field layout.
-        let fields = data.attrs.get(&Symbol::new("fields")).unwrap();
+        let fields = data.attrs.get("fields").unwrap();
         match fields {
             Attribute::List(list) => {
                 assert_eq!(list.len(), MARKER_FIELD_COUNT);

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -57,7 +57,7 @@ fn is_closure_struct_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
         return false;
     }
     matches!(
-        data.attrs.get(&Symbol::new("name")),
+        data.attrs.get("name"),
         Some(Attribute::Symbol(s)) if *s == Symbol::new("_closure")
     )
 }

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -56,10 +56,7 @@ fn is_closure_struct_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
     if data.dialect != Symbol::new("adt") || data.name != Symbol::new("struct") {
         return false;
     }
-    matches!(
-        data.attrs.get("name"),
-        Some(Attribute::Symbol(s)) if *s == Symbol::new("_closure")
-    )
+    data.attrs.get_symbol("name") == Some(Symbol::new("_closure"))
 }
 
 // ============================================================================

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -17,7 +17,7 @@ use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
-use trunk_ir::types::{Attribute, Location};
+use trunk_ir::types::Location;
 
 /// Lower intrinsic arithmetic/comparison calls to arith dialect operations.
 ///
@@ -237,10 +237,7 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
 
         // Check if this function has abi = "intrinsic"
         let attrs = &ctx.op(op).attributes;
-        let is_intrinsic = matches!(
-            attrs.get("abi"),
-            Some(Attribute::String(s)) if s == "intrinsic"
-        );
+        let is_intrinsic = attrs.get_str("abi") == Some("intrinsic");
         if !is_intrinsic {
             return false;
         }

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -238,7 +238,7 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
         // Check if this function has abi = "intrinsic"
         let attrs = &ctx.op(op).attributes;
         let is_intrinsic = matches!(
-            attrs.get(&Symbol::new("abi")),
+            attrs.get("abi"),
             Some(Attribute::String(s)) if s == "intrinsic"
         );
         if !is_intrinsic {

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -35,7 +35,7 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{Module, erase_op};
-use trunk_ir::types::{Attribute, TypeDataBuilder};
+use trunk_ir::types::{Attribute, AttributeMap, TypeDataBuilder};
 
 use tribute_ir::dialect::ability;
 use tribute_ir::dialect::closure;
@@ -484,8 +484,8 @@ fn make_adt_struct_type(
 }
 
 /// Create a `bind_name` attribute map for a block argument.
-fn make_bind_name_attrs(name: &str) -> std::collections::BTreeMap<Symbol, Attribute> {
-    let mut attrs = std::collections::BTreeMap::new();
+fn make_bind_name_attrs(name: &str) -> AttributeMap {
+    let mut attrs = AttributeMap::new();
     attrs.insert(
         Symbol::new("bind_name"),
         Attribute::Symbol(Symbol::from_dynamic(name)),

--- a/crates/tribute-passes/src/native/adt_rc_header.rs
+++ b/crates/tribute-passes/src/native/adt_rc_header.rs
@@ -340,7 +340,6 @@ impl RewritePattern for VariantNewPattern {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
     use trunk_ir::Span;
     use trunk_ir::context::{BlockArgData, BlockData, IrContext, OperationDataBuilder, RegionData};
     use trunk_ir::dialect::func;
@@ -378,7 +377,7 @@ mod tests {
             .iter()
             .map(|&ty| BlockArgData {
                 ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             })
             .collect();
 

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -63,7 +63,7 @@ fn find_string_enum_type(ctx: &IrContext) -> Option<TypeRef> {
         if td.dialect != Symbol::new("adt") {
             continue;
         }
-        if let Some(Attribute::Symbol(name)) = td.attrs.get(&Symbol::new("name")) {
+        if let Some(Attribute::Symbol(name)) = td.attrs.get("name") {
             if *name != Symbol::new("String") {
                 continue;
             }
@@ -71,7 +71,7 @@ fn find_string_enum_type(ctx: &IrContext) -> Option<TypeRef> {
             continue;
         }
         // Check it has "variants" attribute with Leaf and Branch
-        if let Some(Attribute::List(variants)) = td.attrs.get(&Symbol::new("variants")) {
+        if let Some(Attribute::List(variants)) = td.attrs.get("variants") {
             let has_leaf = variants.iter().any(|v| {
                 if let Attribute::List(items) = v {
                     items.first().is_some_and(
@@ -132,13 +132,13 @@ impl ConstCollector {
 
         if data.dialect == adt::DIALECT_NAME() {
             if data.name == Symbol::new("string_const") {
-                if let Some(Attribute::String(s)) = data.attributes.get(&Symbol::new("value")) {
+                if let Some(Attribute::String(s)) = data.attributes.get("value") {
                     let bytes = s.clone().into_bytes();
                     self.intern(bytes);
                     self.has_string_consts = true;
                 }
             } else if data.name == Symbol::new("bytes_const")
-                && let Some(Attribute::Bytes(b)) = data.attributes.get(&Symbol::new("value"))
+                && let Some(Attribute::Bytes(b)) = data.attributes.get("value")
             {
                 let bytes: Vec<u8> = b.to_vec();
                 self.intern(bytes);

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -63,11 +63,7 @@ fn find_string_enum_type(ctx: &IrContext) -> Option<TypeRef> {
         if td.dialect != Symbol::new("adt") {
             continue;
         }
-        if let Some(name) = td.attrs.get_symbol("name") {
-            if name != Symbol::new("String") {
-                continue;
-            }
-        } else {
+        if td.attrs.get_symbol("name") != Some(Symbol::new("String")) {
             continue;
         }
         // Check it has "variants" attribute with Leaf and Branch

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -63,8 +63,8 @@ fn find_string_enum_type(ctx: &IrContext) -> Option<TypeRef> {
         if td.dialect != Symbol::new("adt") {
             continue;
         }
-        if let Some(Attribute::Symbol(name)) = td.attrs.get("name") {
-            if *name != Symbol::new("String") {
+        if let Some(name) = td.attrs.get_symbol("name") {
+            if name != Symbol::new("String") {
                 continue;
             }
         } else {
@@ -132,8 +132,8 @@ impl ConstCollector {
 
         if data.dialect == adt::DIALECT_NAME() {
             if data.name == Symbol::new("string_const") {
-                if let Some(Attribute::String(s)) = data.attributes.get("value") {
-                    let bytes = s.clone().into_bytes();
+                if let Some(s) = data.attributes.get_str("value") {
+                    let bytes = s.as_bytes().to_vec();
                     self.intern(bytes);
                     self.has_string_consts = true;
                 }

--- a/crates/tribute-passes/src/native/entrypoint.rs
+++ b/crates/tribute-passes/src/native/entrypoint.rs
@@ -151,7 +151,7 @@ fn rewrite_symbol_refs(ctx: &mut IrContext, op: OpRef, old_sym: Symbol, new_sym:
     let callee_key = Symbol::new("callee");
     let func_ref_key = Symbol::new("func_ref");
 
-    if let Some(Attribute::Symbol(sym)) = ctx.op(op).attributes.get(callee_key).cloned()
+    if let Some(sym) = ctx.op(op).attributes.get_symbol(callee_key)
         && sym == old_sym
     {
         ctx.op_mut(op)
@@ -160,7 +160,7 @@ fn rewrite_symbol_refs(ctx: &mut IrContext, op: OpRef, old_sym: Symbol, new_sym:
     }
 
     // Rewrite func_ref attribute
-    if let Some(Attribute::Symbol(sym)) = ctx.op(op).attributes.get(func_ref_key).cloned()
+    if let Some(sym) = ctx.op(op).attributes.get_symbol(func_ref_key)
         && sym == old_sym
     {
         ctx.op_mut(op)
@@ -632,16 +632,15 @@ mod tests {
             .iter()
             .copied()
             .find(|op| {
-                ctx.op(*op).attributes.get("callee")
-                    == Some(&Attribute::Symbol(Symbol::new(evidence_abi::EMPTY)))
+                ctx.op(*op).attributes.get_symbol("callee")
+                    == Some(Symbol::new(evidence_abi::EMPTY))
             })
             .expect("entrypoint should create empty evidence");
         let user_main_call = calls
             .iter()
             .copied()
             .find(|op| {
-                ctx.op(*op).attributes.get("callee")
-                    == Some(&Attribute::Symbol(Symbol::new("_tribute_main")))
+                ctx.op(*op).attributes.get_symbol("callee") == Some(Symbol::new("_tribute_main"))
             })
             .expect("entrypoint should call renamed user main");
 

--- a/crates/tribute-passes/src/native/entrypoint.rs
+++ b/crates/tribute-passes/src/native/entrypoint.rs
@@ -151,7 +151,7 @@ fn rewrite_symbol_refs(ctx: &mut IrContext, op: OpRef, old_sym: Symbol, new_sym:
     let callee_key = Symbol::new("callee");
     let func_ref_key = Symbol::new("func_ref");
 
-    if let Some(Attribute::Symbol(sym)) = ctx.op(op).attributes.get(&callee_key).cloned()
+    if let Some(Attribute::Symbol(sym)) = ctx.op(op).attributes.get(callee_key).cloned()
         && sym == old_sym
     {
         ctx.op_mut(op)
@@ -160,7 +160,7 @@ fn rewrite_symbol_refs(ctx: &mut IrContext, op: OpRef, old_sym: Symbol, new_sym:
     }
 
     // Rewrite func_ref attribute
-    if let Some(Attribute::Symbol(sym)) = ctx.op(op).attributes.get(&func_ref_key).cloned()
+    if let Some(Attribute::Symbol(sym)) = ctx.op(op).attributes.get(func_ref_key).cloned()
         && sym == old_sym
     {
         ctx.op_mut(op)
@@ -632,7 +632,7 @@ mod tests {
             .iter()
             .copied()
             .find(|op| {
-                ctx.op(*op).attributes.get(&Symbol::new("callee"))
+                ctx.op(*op).attributes.get("callee")
                     == Some(&Attribute::Symbol(Symbol::new(evidence_abi::EMPTY)))
             })
             .expect("entrypoint should create empty evidence");
@@ -640,7 +640,7 @@ mod tests {
             .iter()
             .copied()
             .find(|op| {
-                ctx.op(*op).attributes.get(&Symbol::new("callee"))
+                ctx.op(*op).attributes.get("callee")
                     == Some(&Attribute::Symbol(Symbol::new("_tribute_main")))
             })
             .expect("entrypoint should call renamed user main");

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -705,7 +705,7 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) -> PassRu
             if !operands.is_empty() {
                 let base_val = operands[0];
                 if let Some(&(ev_val, ability_id_val)) = evidence_lookup_results.get(&base_val) {
-                    let field_attr = ctx.op(op).attributes.get(&Symbol::new("field"));
+                    let field_attr = ctx.op(op).attributes.get("field");
                     let field_idx = match field_attr {
                         Some(Attribute::Int(bits)) => *bits,
                         other => {

--- a/crates/tribute-passes/src/native/intrinsic_to_native.rs
+++ b/crates/tribute-passes/src/native/intrinsic_to_native.rs
@@ -19,7 +19,7 @@ use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, LegalityDecision, Module, PatternApplicator,
     PatternRewriter, RewritePattern, TypeConverter,
 };
-use trunk_ir::types::{Attribute, TypeDataBuilder};
+use trunk_ir::types::TypeDataBuilder;
 
 /// Lower bytes intrinsic calls to native mem operations.
 ///
@@ -51,10 +51,7 @@ pub fn lower(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError>
         .dynamic_op("func", "func", move |ctx, op| {
             if let Ok(func_op) = func::Func::from_op(ctx, op) {
                 let attrs = &ctx.op(op).attributes;
-                let is_intrinsic = matches!(
-                    attrs.get("abi"),
-                    Some(Attribute::String(s)) if s == "intrinsic"
-                );
+                let is_intrinsic = attrs.get_str("abi") == Some("intrinsic");
                 if is_intrinsic && func_intrinsic_names.contains(&func_op.sym_name(ctx)) {
                     return LegalityDecision::Illegal;
                 }
@@ -157,10 +154,7 @@ impl RewritePattern for BytesIntrinsicFuncDeclPattern {
         };
 
         let attrs = &ctx.op(op).attributes;
-        let is_intrinsic = matches!(
-            attrs.get("abi"),
-            Some(Attribute::String(s)) if s == "intrinsic"
-        );
+        let is_intrinsic = attrs.get_str("abi") == Some("intrinsic");
         if !is_intrinsic {
             return false;
         }

--- a/crates/tribute-passes/src/native/intrinsic_to_native.rs
+++ b/crates/tribute-passes/src/native/intrinsic_to_native.rs
@@ -52,7 +52,7 @@ pub fn lower(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError>
             if let Ok(func_op) = func::Func::from_op(ctx, op) {
                 let attrs = &ctx.op(op).attributes;
                 let is_intrinsic = matches!(
-                    attrs.get(&Symbol::new("abi")),
+                    attrs.get("abi"),
                     Some(Attribute::String(s)) if s == "intrinsic"
                 );
                 if is_intrinsic && func_intrinsic_names.contains(&func_op.sym_name(ctx)) {
@@ -158,7 +158,7 @@ impl RewritePattern for BytesIntrinsicFuncDeclPattern {
 
         let attrs = &ctx.op(op).attributes;
         let is_intrinsic = matches!(
-            attrs.get(&Symbol::new("abi")),
+            attrs.get("abi"),
             Some(Attribute::String(s)) if s == "intrinsic"
         );
         if !is_intrinsic {

--- a/crates/tribute-passes/src/native/io.rs
+++ b/crates/tribute-passes/src/native/io.rs
@@ -51,7 +51,7 @@ fn find_read_line_result_type(ctx: &IrContext) -> Option<TypeRef> {
     ctx.types.iter().find_map(|(ty, data)| {
         (data.dialect == adt
             && data.name == enum_name
-            && data.attrs.get(name_attr) == Some(&Attribute::Symbol(expected)))
+            && data.attrs.get_symbol(name_attr) == Some(expected))
         .then_some(ty)
     })
 }

--- a/crates/tribute-passes/src/native/io.rs
+++ b/crates/tribute-passes/src/native/io.rs
@@ -51,7 +51,7 @@ fn find_read_line_result_type(ctx: &IrContext) -> Option<TypeRef> {
     ctx.types.iter().find_map(|(ty, data)| {
         (data.dialect == adt
             && data.name == enum_name
-            && data.attrs.get(&name_attr) == Some(&Attribute::Symbol(expected)))
+            && data.attrs.get(name_attr) == Some(&Attribute::Symbol(expected)))
         .then_some(ty)
     })
 }

--- a/crates/tribute-passes/src/native/mod.rs
+++ b/crates/tribute-passes/src/native/mod.rs
@@ -26,7 +26,6 @@ pub mod rtti;
 pub mod tribute_rt_to_clif;
 pub mod type_converter;
 
-use std::collections::BTreeMap;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::core;
@@ -52,7 +51,7 @@ pub(crate) fn build_extern_func(
         .iter()
         .map(|&ty| BlockArgData {
             ty,
-            attrs: BTreeMap::new(),
+            attrs: Default::default(),
         })
         .collect();
 

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -425,7 +425,7 @@ fn borrow_safe_functions(ctx: &IrContext, module_ops: &[OpRef]) -> HashSet<Symbo
     let mut candidates = HashSet::new();
     for &op in module_ops {
         if let Ok(func_op) = clif::Func::from_op(ctx, op)
-            && !ctx.op(op).attributes.contains_key(&Symbol::new("abi"))
+            && !ctx.op(op).attributes.contains_key("abi")
         {
             candidates.insert(func_op.sym_name(ctx));
         }

--- a/crates/tribute-passes/src/native/rtti.rs
+++ b/crates/tribute-passes/src/native/rtti.rs
@@ -24,7 +24,7 @@
 //! Runs before `adt_to_clif` (Phase 1.9) so that `adt_to_clif` can use the
 //! `RttiMap` to store correct `rtti_idx` values in allocation headers.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use trunk_ir::Symbol;
 use trunk_ir::TypeDataBuilder;
@@ -241,7 +241,7 @@ fn generate_release_function_for_struct(
         location: loc,
         args: vec![BlockArgData {
             ty: ptr_ty,
-            attrs: BTreeMap::new(),
+            attrs: Default::default(),
         }],
         ops: smallvec![],
         parent_region: None,
@@ -431,7 +431,7 @@ fn generate_release_function_for_enum(
         location: loc,
         args: vec![BlockArgData {
             ty: ptr_ty,
-            attrs: BTreeMap::new(),
+            attrs: Default::default(),
         }],
         ops: smallvec![],
         parent_region: None,
@@ -668,7 +668,6 @@ fn generate_release_function_for_enum(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
     use trunk_ir::Span;
     use trunk_ir::context::{BlockArgData, BlockData, IrContext, OperationDataBuilder};
     use trunk_ir::dialect::func;
@@ -703,7 +702,7 @@ mod tests {
             .iter()
             .map(|&ty| BlockArgData {
                 ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             })
             .collect();
 
@@ -846,15 +845,15 @@ mod tests {
             args: vec![
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: Default::default(),
                 },
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: Default::default(),
                 },
                 BlockArgData {
                     ty: ptr_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: Default::default(),
                 },
             ],
             ops: smallvec![],

--- a/crates/tribute-passes/src/native/type_converter.rs
+++ b/crates/tribute-passes/src/native/type_converter.rs
@@ -392,7 +392,7 @@ pub fn is_ptr_like(ctx: &IrContext, ty: TypeRef, evidence_ty: TypeRef, ptr_ty: T
             return true;
         }
         // Check for variant instance (has is_variant=true)
-        if let Some(trunk_ir::types::Attribute::Bool(true)) = data.attrs.get("is_variant") {
+        if data.attrs.get_bool("is_variant") == Some(true) {
             return true;
         }
     }
@@ -436,10 +436,7 @@ fn is_adt_ptr_type(ctx: &IrContext, ty: TypeRef) -> bool {
     data.name == Symbol::new("typeref")
         || data.attrs.contains_key("fields")
         || data.attrs.contains_key("variants")
-        || matches!(
-            data.attrs.get("is_variant"),
-            Some(trunk_ir::types::Attribute::Bool(true))
-        )
+        || data.attrs.get_bool("is_variant") == Some(true)
 }
 
 /// Helper: Check if a type is closure.closure.

--- a/crates/tribute-passes/src/native/type_converter.rs
+++ b/crates/tribute-passes/src/native/type_converter.rs
@@ -385,10 +385,10 @@ pub fn is_ptr_like(ctx: &IrContext, ty: TypeRef, evidence_ty: TypeRef, ptr_ty: T
             return true;
         }
         // Check for struct or enum types (have "fields" or "variants" attrs)
-        if data.attrs.contains_key(&Symbol::new("fields")) {
+        if data.attrs.contains_key("fields") {
             return true;
         }
-        if data.attrs.contains_key(&Symbol::new("variants")) {
+        if data.attrs.contains_key("variants") {
             return true;
         }
         // Check for variant instance (has is_variant=true)
@@ -434,8 +434,8 @@ fn is_adt_ptr_type(ctx: &IrContext, ty: TypeRef) -> bool {
     }
     // struct, enum, typeref, variant instance
     data.name == Symbol::new("typeref")
-        || data.attrs.contains_key(&Symbol::new("fields"))
-        || data.attrs.contains_key(&Symbol::new("variants"))
+        || data.attrs.contains_key("fields")
+        || data.attrs.contains_key("variants")
         || matches!(
             data.attrs.get("is_variant"),
             Some(trunk_ir::types::Attribute::Bool(true))

--- a/crates/tribute-passes/src/native/type_converter.rs
+++ b/crates/tribute-passes/src/native/type_converter.rs
@@ -392,9 +392,7 @@ pub fn is_ptr_like(ctx: &IrContext, ty: TypeRef, evidence_ty: TypeRef, ptr_ty: T
             return true;
         }
         // Check for variant instance (has is_variant=true)
-        if let Some(trunk_ir::types::Attribute::Bool(true)) =
-            data.attrs.get(&Symbol::new("is_variant"))
-        {
+        if let Some(trunk_ir::types::Attribute::Bool(true)) = data.attrs.get("is_variant") {
             return true;
         }
     }
@@ -439,7 +437,7 @@ fn is_adt_ptr_type(ctx: &IrContext, ty: TypeRef) -> bool {
         || data.attrs.contains_key(&Symbol::new("fields"))
         || data.attrs.contains_key(&Symbol::new("variants"))
         || matches!(
-            data.attrs.get(&Symbol::new("is_variant")),
+            data.attrs.get("is_variant"),
             Some(trunk_ir::types::Attribute::Bool(true))
         )
 }

--- a/crates/tribute-passes/src/wasm/const_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/const_to_wasm.rs
@@ -75,12 +75,12 @@ impl ConstCollector {
 
         if data.dialect == adt::DIALECT_NAME() {
             if data.name == Symbol::new("string_const") {
-                if let Some(Attribute::String(s)) = data.attributes.get(&Symbol::new("value")) {
+                if let Some(Attribute::String(s)) = data.attributes.get("value") {
                     self.has_string_consts = true;
                     self.collect_content(s.clone().into_bytes());
                 }
             } else if data.name == Symbol::new("bytes_const")
-                && let Some(Attribute::Bytes(b)) = data.attributes.get(&Symbol::new("value"))
+                && let Some(Attribute::Bytes(b)) = data.attributes.get("value")
             {
                 self.collect_content(b.to_vec());
             }
@@ -95,7 +95,7 @@ fn find_string_enum_type(ctx: &IrContext) -> Option<trunk_ir::TypeRef> {
             return None;
         }
         if !matches!(
-            data.attrs.get(&Symbol::new("name")),
+            data.attrs.get("name"),
             Some(Attribute::Symbol(name)) if *name == Symbol::new("String")
         ) {
             return None;

--- a/crates/tribute-passes/src/wasm/const_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/const_to_wasm.rs
@@ -75,9 +75,9 @@ impl ConstCollector {
 
         if data.dialect == adt::DIALECT_NAME() {
             if data.name == Symbol::new("string_const") {
-                if let Some(Attribute::String(s)) = data.attributes.get("value") {
+                if let Some(s) = data.attributes.get_str("value") {
                     self.has_string_consts = true;
-                    self.collect_content(s.clone().into_bytes());
+                    self.collect_content(s.as_bytes().to_vec());
                 }
             } else if data.name == Symbol::new("bytes_const")
                 && let Some(Attribute::Bytes(b)) = data.attributes.get("value")
@@ -94,10 +94,7 @@ fn find_string_enum_type(ctx: &IrContext) -> Option<trunk_ir::TypeRef> {
         if data.dialect != Symbol::new("adt") || data.name != Symbol::new("enum") {
             return None;
         }
-        if !matches!(
-            data.attrs.get("name"),
-            Some(Attribute::Symbol(name)) if *name == Symbol::new("String")
-        ) {
+        if data.attrs.get_symbol("name") != Some(Symbol::new("String")) {
             return None;
         }
         let variants = get_enum_variants(ctx, ty_ref)?;

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -107,13 +107,7 @@ fn replace_evidence_function_stubs(ctx: &mut IrContext, module: Module) {
             continue;
         }
 
-        let sym_name = data.attributes.get("sym_name").and_then(|a| {
-            if let Attribute::Symbol(s) = a {
-                Some(*s)
-            } else {
-                None
-            }
-        });
+        let sym_name = data.attributes.get_symbol("sym_name");
 
         if sym_name == Some(Symbol::new(evidence_abi::LOOKUP)) {
             has_lookup = true;

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -20,8 +20,6 @@
 //! binary search (O(log n)) since the evidence array is maintained in sorted order
 //! by ability_id.
 
-use std::collections::BTreeMap;
-
 use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
@@ -109,7 +107,7 @@ fn replace_evidence_function_stubs(ctx: &mut IrContext, module: Module) {
             continue;
         }
 
-        let sym_name = data.attributes.get(&Symbol::new("sym_name")).and_then(|a| {
+        let sym_name = data.attributes.get("sym_name").and_then(|a| {
             if let Attribute::Symbol(s) = a {
                 Some(*s)
             } else {
@@ -617,11 +615,11 @@ fn generate_evidence_lookup_function(ctx: &mut IrContext, location: Location) ->
         args: vec![
             BlockArgData {
                 ty: evidence_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
             BlockArgData {
                 ty: i32_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
         ],
         ops: smallvec![],
@@ -892,11 +890,11 @@ fn generate_evidence_extend_function(ctx: &mut IrContext, location: Location) ->
         args: vec![
             BlockArgData {
                 ty: evidence_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
             BlockArgData {
                 ty: marker_sig_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
         ],
         ops: smallvec![],

--- a/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
@@ -21,7 +21,7 @@ use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::smallvec::smallvec;
-use trunk_ir::types::{Attribute, TypeDataBuilder};
+use trunk_ir::types::TypeDataBuilder;
 
 use trunk_ir_wasm_backend::gc_types::{BYTES_ARRAY_IDX, BYTES_STRUCT_IDX};
 
@@ -143,14 +143,8 @@ fn get_literal_info(ctx: &IrContext, value: ValueRef) -> Option<(u32, u32)> {
     if data.name != Symbol::new("i32_const") {
         return None;
     }
-    let Attribute::Int(ptr) = data.attributes.get("value")? else {
-        return None;
-    };
-    let Attribute::Int(len) = data.attributes.get("literal_len")? else {
-        return None;
-    };
-    let ptr_u32 = u32::try_from(*ptr).ok()?;
-    let len_u32 = u32::try_from(*len).ok()?;
+    let ptr_u32 = data.attributes.get_u32("value").ok()??;
+    let len_u32 = data.attributes.get_u32("literal_len").ok()??;
     Some((ptr_u32, len_u32))
 }
 

--- a/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
@@ -143,10 +143,10 @@ fn get_literal_info(ctx: &IrContext, value: ValueRef) -> Option<(u32, u32)> {
     if data.name != Symbol::new("i32_const") {
         return None;
     }
-    let Attribute::Int(ptr) = data.attributes.get(&Symbol::new("value"))? else {
+    let Attribute::Int(ptr) = data.attributes.get("value")? else {
         return None;
     };
-    let Attribute::Int(len) = data.attributes.get(&Symbol::new("literal_len"))? else {
+    let Attribute::Int(len) = data.attributes.get("literal_len")? else {
         return None;
     };
     let ptr_u32 = u32::try_from(*ptr).ok()?;

--- a/crates/tribute-passes/src/wasm/io.rs
+++ b/crates/tribute-passes/src/wasm/io.rs
@@ -1,7 +1,5 @@
 //! Lower target-independent output to WASI preview1.
 
-use std::collections::BTreeMap;
-
 use tribute_ir::dialect::tribute_io;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
@@ -492,6 +490,6 @@ fn simple_type(ctx: &mut IrContext, dialect: &'static str, name: &'static str) -
 fn block_arg(ty: TypeRef) -> BlockArgData {
     BlockArgData {
         ty,
-        attrs: BTreeMap::new(),
+        attrs: Default::default(),
     }
 }

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -1137,9 +1137,7 @@ mod tests {
         assert_eq!(lowerer.main_exports.main_result_type, Some(nil_ty));
         assert_eq!(lowerer.main_exports.main_param_types, vec![i32_ty]);
 
-        ctx.op_mut(main.op_ref())
-            .attributes
-            .remove(&Symbol::new("sym_name"));
+        ctx.op_mut(main.op_ref()).attributes.remove("sym_name");
         lowerer.main_exports.saw_main = false;
         lowerer.scan_wasm_func(&ctx, main.op_ref());
         assert!(!lowerer.main_exports.saw_main);

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -244,7 +244,7 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
             let data = ctx.op(op);
             // Check for func.func or wasm.func operations
             if data.dialect == func::DIALECT_NAME() && data.name == Symbol::new("func") {
-                if let Some(Attribute::Type(fn_ty)) = data.attributes.get(&Symbol::new("type")) {
+                if let Some(Attribute::Type(fn_ty)) = data.attributes.get("type") {
                     let fn_data = ctx.types.get(*fn_ty);
                     let params: Vec<_> = fn_data
                         .params
@@ -256,14 +256,14 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
                         .collect();
                     let sym_name = data
                         .attributes
-                        .get(&Symbol::new("sym_name"))
+                        .get("sym_name")
                         .map(|a| format!("{a:?}"))
                         .unwrap_or_default();
                     tracing::debug!("[{phase}] func.func {sym_name}: params={params:?}");
                 }
             } else if data.dialect == wasm_dialect::DIALECT_NAME()
                 && data.name == Symbol::new("func")
-                && let Some(Attribute::Type(fn_ty)) = data.attributes.get(&Symbol::new("type"))
+                && let Some(Attribute::Type(fn_ty)) = data.attributes.get("type")
             {
                 let fn_data = ctx.types.get(*fn_ty);
                 let params: Vec<_> = fn_data
@@ -276,7 +276,7 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
                     .collect();
                 let sym_name = data
                     .attributes
-                    .get(&Symbol::new("sym_name"))
+                    .get("sym_name")
                     .map(|a| format!("{a:?}"))
                     .unwrap_or_default();
                 tracing::debug!("[{phase}] wasm.func {sym_name}: params={params:?}");
@@ -443,8 +443,7 @@ impl<'a> WasmLowerer<'a> {
                     } else if data.name == Symbol::new("export_memory") {
                         self.memory_plan.has_exported_memory = true;
                     } else if data.name == Symbol::new("export_func")
-                        && let Some(Attribute::String(name)) =
-                            data.attributes.get(&Symbol::new("name"))
+                        && let Some(Attribute::String(name)) = data.attributes.get("name")
                     {
                         if name == "main" {
                             self.main_exports.main_exported = true;
@@ -472,8 +471,7 @@ impl<'a> WasmLowerer<'a> {
     /// Check if a wasm.func op is the main function and record its metadata.
     fn scan_wasm_func(&mut self, ctx: &IrContext, op: OpRef) {
         let data = ctx.op(op);
-        let Some(Attribute::Symbol(sym_name)) = data.attributes.get(&Symbol::new("sym_name"))
-        else {
+        let Some(Attribute::Symbol(sym_name)) = data.attributes.get("sym_name") else {
             return;
         };
 
@@ -485,7 +483,7 @@ impl<'a> WasmLowerer<'a> {
         self.main_exports.saw_main = true;
         self.main_exports.main_convention = get_calling_convention(ctx, op).unwrap_or_default();
 
-        if let Some(Attribute::Type(fn_ty)) = data.attributes.get(&Symbol::new("type")) {
+        if let Some(Attribute::Type(fn_ty)) = data.attributes.get("type") {
             let fn_data = ctx.types.get(*fn_ty);
             // In arena core.func type, params[0] is the return type
             if let Some(&result_ty) = fn_data.params.first() {
@@ -813,7 +811,7 @@ impl<'a> WasmLowerer<'a> {
 /// Check if a type is the Step ADT type.
 fn is_step_adt(ctx: &IrContext, ty: TypeRef) -> bool {
     let data = ctx.types.get(ty);
-    if let Some(Attribute::Symbol(name)) = data.attrs.get(&Symbol::new("name")) {
+    if let Some(Attribute::Symbol(name)) = data.attrs.get("name") {
         *name == Symbol::new("_Step")
     } else {
         false
@@ -893,7 +891,7 @@ mod tests {
             .copied()
             .find(|op| {
                 ctx.op(*op).name == Symbol::new("call")
-                    && ctx.op(*op).attributes.get(&Symbol::new("callee"))
+                    && ctx.op(*op).attributes.get("callee")
                         == Some(&Attribute::Symbol(Symbol::new("main")))
             })
             .expect("_start should call main");

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -244,8 +244,8 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
             let data = ctx.op(op);
             // Check for func.func or wasm.func operations
             if data.dialect == func::DIALECT_NAME() && data.name == Symbol::new("func") {
-                if let Some(Attribute::Type(fn_ty)) = data.attributes.get("type") {
-                    let fn_data = ctx.types.get(*fn_ty);
+                if let Some(fn_ty) = data.attributes.get_type("type") {
+                    let fn_data = ctx.types.get(fn_ty);
                     let params: Vec<_> = fn_data
                         .params
                         .iter()
@@ -256,16 +256,16 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
                         .collect();
                     let sym_name = data
                         .attributes
-                        .get("sym_name")
-                        .map(|a| format!("{a:?}"))
+                        .get_text("sym_name")
+                        .map(|text| text.to_string())
                         .unwrap_or_default();
                     tracing::debug!("[{phase}] func.func {sym_name}: params={params:?}");
                 }
             } else if data.dialect == wasm_dialect::DIALECT_NAME()
                 && data.name == Symbol::new("func")
-                && let Some(Attribute::Type(fn_ty)) = data.attributes.get("type")
+                && let Some(fn_ty) = data.attributes.get_type("type")
             {
-                let fn_data = ctx.types.get(*fn_ty);
+                let fn_data = ctx.types.get(fn_ty);
                 let params: Vec<_> = fn_data
                     .params
                     .iter()
@@ -276,8 +276,8 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
                     .collect();
                 let sym_name = data
                     .attributes
-                    .get("sym_name")
-                    .map(|a| format!("{a:?}"))
+                    .get_text("sym_name")
+                    .map(|text| text.to_string())
                     .unwrap_or_default();
                 tracing::debug!("[{phase}] wasm.func {sym_name}: params={params:?}");
             }
@@ -442,10 +442,8 @@ impl<'a> WasmLowerer<'a> {
                         self.memory_plan.has_memory = true;
                     } else if data.name == Symbol::new("export_memory") {
                         self.memory_plan.has_exported_memory = true;
-                    } else if data.name == Symbol::new("export_func")
-                        && let Some(Attribute::String(name)) = data.attributes.get("name")
-                    {
-                        if name == "main" {
+                    } else if data.name == Symbol::new("export_func") {
+                        if data.attributes.get_str("name") == Some("main") {
                             self.main_exports.main_exported = true;
                         }
                     } else if data.name == Symbol::new("func") {
@@ -471,7 +469,7 @@ impl<'a> WasmLowerer<'a> {
     /// Check if a wasm.func op is the main function and record its metadata.
     fn scan_wasm_func(&mut self, ctx: &IrContext, op: OpRef) {
         let data = ctx.op(op);
-        let Some(Attribute::Symbol(sym_name)) = data.attributes.get("sym_name") else {
+        let Some(sym_name) = data.attributes.get_symbol("sym_name") else {
             return;
         };
 
@@ -483,8 +481,8 @@ impl<'a> WasmLowerer<'a> {
         self.main_exports.saw_main = true;
         self.main_exports.main_convention = get_calling_convention(ctx, op).unwrap_or_default();
 
-        if let Some(Attribute::Type(fn_ty)) = data.attributes.get("type") {
-            let fn_data = ctx.types.get(*fn_ty);
+        if let Some(fn_ty) = data.attributes.get_type("type") {
+            let fn_data = ctx.types.get(fn_ty);
             // In arena core.func type, params[0] is the return type
             if let Some(&result_ty) = fn_data.params.first() {
                 self.main_exports.main_result_type = Some(result_ty);
@@ -811,11 +809,7 @@ impl<'a> WasmLowerer<'a> {
 /// Check if a type is the Step ADT type.
 fn is_step_adt(ctx: &IrContext, ty: TypeRef) -> bool {
     let data = ctx.types.get(ty);
-    if let Some(Attribute::Symbol(name)) = data.attrs.get("name") {
-        *name == Symbol::new("_Step")
-    } else {
-        false
-    }
+    data.attrs.get_symbol("name") == Some(Symbol::new("_Step"))
 }
 
 #[cfg(test)]
@@ -891,8 +885,7 @@ mod tests {
             .copied()
             .find(|op| {
                 ctx.op(*op).name == Symbol::new("call")
-                    && ctx.op(*op).attributes.get("callee")
-                        == Some(&Attribute::Symbol(Symbol::new("main")))
+                    && ctx.op(*op).attributes.get_symbol("callee") == Some(Symbol::new("main"))
             })
             .expect("_start should call main");
 

--- a/crates/tribute-passes/src/wasm/type_converter.rs
+++ b/crates/tribute-passes/src/wasm/type_converter.rs
@@ -190,10 +190,7 @@ fn is_adt_typeref(ctx: &IrContext, ty: TypeRef) -> bool {
 
 /// Check if a type has the `is_variant` attribute set to true.
 fn is_variant_instance_type(ctx: &IrContext, ty: TypeRef) -> bool {
-    matches!(
-        ctx.types.get(ty).attrs.get("is_variant"),
-        Some(Attribute::Bool(true))
-    )
+    ctx.types.get(ty).attrs.get_bool("is_variant") == Some(true)
 }
 
 /// Check if a type is a struct-like reference type.

--- a/crates/tribute-passes/src/wasm/type_converter.rs
+++ b/crates/tribute-passes/src/wasm/type_converter.rs
@@ -191,7 +191,7 @@ fn is_adt_typeref(ctx: &IrContext, ty: TypeRef) -> bool {
 /// Check if a type has the `is_variant` attribute set to true.
 fn is_variant_instance_type(ctx: &IrContext, ty: TypeRef) -> bool {
     matches!(
-        ctx.types.get(ty).attrs.get(&Symbol::new("is_variant")),
+        ctx.types.get(ty).attrs.get("is_variant"),
         Some(Attribute::Bool(true))
     )
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -62,11 +62,7 @@ const CLOSURE_STRUCT_NAME_STR: &str = "_closure";
 fn is_closure_struct(ctx: &IrContext, ty: TypeRef) -> bool {
     let data = ctx.types.get(ty);
     data.attrs
-        .get("name")
-        .and_then(|a| match a {
-            Attribute::Symbol(s) => Some(*s),
-            _ => None,
-        })
+        .get_symbol("name")
         .is_some_and(|name| name == Symbol::new(CLOSURE_STRUCT_NAME_STR))
 }
 
@@ -126,13 +122,7 @@ impl RewritePattern for FuncFuncPattern {
 
         // Convert parameter and return types in the function signature
         let data = ctx.op(op);
-        let func_type_attr = data.attributes.get("type").and_then(|a| {
-            if let Attribute::Type(t) = a {
-                Some(*t)
-            } else {
-                None
-            }
-        });
+        let func_type_attr = data.attributes.get_type("type");
 
         let mut new_attrs = data.attributes.clone();
         if let Some(func_ty) = func_type_attr {
@@ -142,16 +132,15 @@ impl RewritePattern for FuncFuncPattern {
                 // - Layout A: params = [ret, arg1, arg2, ...] (translate_signature format)
                 // - Layout B: params = [arg1, arg2, ...], attrs.result = ret
                 // We read both and output in Layout A for translate_signature.
-                let (arg_params, ret_ty) =
-                    if let Some(Attribute::Type(r)) = type_data.attrs.get("result") {
-                        // Layout B: return type in attrs
-                        (&type_data.params[..], Some(*r))
-                    } else if !type_data.params.is_empty() {
-                        // Layout A: params[0] = return type
-                        (&type_data.params[1..], Some(type_data.params[0]))
-                    } else {
-                        (&type_data.params[..], None)
-                    };
+                let (arg_params, ret_ty) = if let Some(r) = type_data.attrs.get_type("result") {
+                    // Layout B: return type in attrs
+                    (&type_data.params[..], Some(r))
+                } else if !type_data.params.is_empty() {
+                    // Layout A: params[0] = return type
+                    (&type_data.params[1..], Some(type_data.params[0]))
+                } else {
+                    (&type_data.params[..], None)
+                };
 
                 // Convert params and return type
                 let new_params: Vec<TypeRef> = arg_params

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -62,7 +62,7 @@ const CLOSURE_STRUCT_NAME_STR: &str = "_closure";
 fn is_closure_struct(ctx: &IrContext, ty: TypeRef) -> bool {
     let data = ctx.types.get(ty);
     data.attrs
-        .get(&Symbol::new("name"))
+        .get("name")
         .and_then(|a| match a {
             Attribute::Symbol(s) => Some(*s),
             _ => None,
@@ -126,7 +126,7 @@ impl RewritePattern for FuncFuncPattern {
 
         // Convert parameter and return types in the function signature
         let data = ctx.op(op);
-        let func_type_attr = data.attributes.get(&Symbol::new("type")).and_then(|a| {
+        let func_type_attr = data.attributes.get("type").and_then(|a| {
             if let Attribute::Type(t) = a {
                 Some(*t)
             } else {
@@ -143,7 +143,7 @@ impl RewritePattern for FuncFuncPattern {
                 // - Layout B: params = [arg1, arg2, ...], attrs.result = ret
                 // We read both and output in Layout A for translate_signature.
                 let (arg_params, ret_ty) =
-                    if let Some(Attribute::Type(r)) = type_data.attrs.get(&Symbol::new("result")) {
+                    if let Some(Attribute::Type(r)) = type_data.attrs.get("result") {
                         // Layout B: return type in attrs
                         (&type_data.params[..], Some(*r))
                     } else if !type_data.params.is_empty() {

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -375,7 +375,7 @@ fn emit_module_impl(
         let func_type_ref = func_wrapped.r#type(ctx);
 
         let op_data = ctx.op(func_op);
-        let has_abi = op_data.attributes.contains_key(&Symbol::new("abi"));
+        let has_abi = op_data.attributes.contains_key("abi");
         let linkage = if name_sym == "main" {
             Linkage::Export
         } else if has_abi {
@@ -437,7 +437,7 @@ fn emit_module_impl(
 
     for &func_op in &all_func_ops {
         let op_data = ctx.op(func_op);
-        let has_abi = op_data.attributes.contains_key(&Symbol::new("abi"));
+        let has_abi = op_data.attributes.contains_key("abi");
         if has_abi {
             continue;
         }

--- a/crates/trunk-ir-macros/src/codegen.rs
+++ b/crates/trunk-ir-macros/src/codegen.rs
@@ -725,25 +725,29 @@ fn attr_from_attr(crate_path: &TokenStream, ty: AttrType) -> TokenStream {
         },
         AttrType::I32 => quote! {
             match attr {
-                #crate_path::Attribute::Int(v) => *v as i32,
+                #crate_path::Attribute::Int(v) => i32::try_from(*v)
+                    .expect("Int attribute is out of range for i32"),
                 _ => panic!("expected Int attribute"),
             }
         },
         AttrType::I64 => quote! {
             match attr {
-                #crate_path::Attribute::Int(v) => *v as i64,
+                #crate_path::Attribute::Int(v) => i64::try_from(*v)
+                    .expect("Int attribute is out of range for i64"),
                 _ => panic!("expected Int attribute"),
             }
         },
         AttrType::U32 => quote! {
             match attr {
-                #crate_path::Attribute::Int(v) => *v as u32,
+                #crate_path::Attribute::Int(v) => u32::try_from(*v)
+                    .expect("Int attribute is out of range for u32"),
                 _ => panic!("expected Int attribute"),
             }
         },
         AttrType::U64 => quote! {
             match attr {
-                #crate_path::Attribute::Int(v) => *v as u64,
+                #crate_path::Attribute::Int(v) => u64::try_from(*v)
+                    .expect("Int attribute is out of range for u64"),
                 _ => panic!("expected Int attribute"),
             }
         },

--- a/crates/trunk-ir-macros/src/codegen.rs
+++ b/crates/trunk-ir-macros/src/codegen.rs
@@ -245,24 +245,48 @@ fn gen_attr_accessors(crate_path: &TokenStream, attrs: &[AttrDef]) -> TokenStrea
 }
 
 fn gen_attr_accessor(crate_path: &TokenStream, attr: &AttrDef) -> TokenStream {
+    gen_map_attr_accessor(crate_path, attr, quote!(ctx.op(self.0).attributes))
+}
+
+fn gen_map_attr_accessor(
+    crate_path: &TokenStream,
+    attr: &AttrDef,
+    attrs: TokenStream,
+) -> TokenStream {
     let name = &attr.raw_ident;
     let name_str = &attr.name;
     let rust_ty = attr_rust_type(crate_path, attr.ty);
-    let from_attr = attr_from_attr(crate_path, attr.ty);
 
+    if let Some(lookup) = typed_attr_lookup(attr.ty, &attrs, name_str) {
+        return if attr.optional {
+            quote! {
+                pub fn #name(&self, ctx: &#crate_path::IrContext) -> Option<#rust_ty> {
+                    #lookup
+                }
+            }
+        } else {
+            quote! {
+                pub fn #name(&self, ctx: &#crate_path::IrContext) -> #rust_ty {
+                    #lookup.expect(concat!("missing attribute: ", #name_str))
+                }
+            }
+        };
+    }
+
+    let from_attr = attr_from_attr(crate_path, attr.ty);
     if attr.optional {
         quote! {
             pub fn #name(&self, ctx: &#crate_path::IrContext) -> Option<#rust_ty> {
-                ctx.op(self.0).attributes
-                    .get(&#crate_path::Symbol::new(#name_str))
+                #attrs
+                    .get(#name_str)
                     .map(|attr| #from_attr)
             }
         }
     } else {
         quote! {
             pub fn #name(&self, ctx: &#crate_path::IrContext) -> #rust_ty {
-                let attr = ctx.op(self.0).attributes
-                    .get(&#crate_path::Symbol::new(#name_str))
+                let attr = #attrs
+                    .get(#name_str)
                     .expect(concat!("missing attribute: ", #name_str));
                 #from_attr
             }
@@ -570,29 +594,7 @@ fn gen_type_param_accessors(
 }
 
 fn gen_type_attr_accessor(crate_path: &TokenStream, attr: &AttrDef) -> TokenStream {
-    let name = &attr.raw_ident;
-    let name_str = &attr.name;
-    let rust_ty = attr_rust_type(crate_path, attr.ty);
-    let from_attr = attr_from_attr(crate_path, attr.ty);
-
-    if attr.optional {
-        quote! {
-            pub fn #name(&self, ctx: &#crate_path::IrContext) -> Option<#rust_ty> {
-                ctx.types.get(self.0).attrs
-                    .get(&#crate_path::Symbol::new(#name_str))
-                    .map(|attr| #from_attr)
-            }
-        }
-    } else {
-        quote! {
-            pub fn #name(&self, ctx: &#crate_path::IrContext) -> #rust_ty {
-                let attr = ctx.types.get(self.0).attrs
-                    .get(&#crate_path::Symbol::new(#name_str))
-                    .expect(concat!("missing attribute: ", #name_str));
-                #from_attr
-            }
-        }
-    }
+    gen_map_attr_accessor(crate_path, attr, quote!(ctx.types.get(self.0).attrs))
 }
 
 fn gen_type_constructor(
@@ -711,6 +713,38 @@ fn attr_to_attr(crate_path: &TokenStream, ty: AttrType, val: TokenStream) -> Tok
             quote!(#crate_path::Attribute::Symbol(#val))
         }
         AttrType::Bytes => quote!(#crate_path::Attribute::Bytes(#val)),
+    }
+}
+
+fn typed_attr_lookup(ty: AttrType, attrs: &TokenStream, name: &str) -> Option<TokenStream> {
+    match ty {
+        AttrType::Bool => Some(quote!(#attrs.get_bool(#name))),
+        AttrType::I32 => Some(quote!(
+            #attrs
+                .get_i32(#name)
+                .expect(concat!("attribute out of range: ", #name))
+        )),
+        AttrType::I64 => Some(quote!(
+            #attrs
+                .get_i64(#name)
+                .expect(concat!("attribute out of range: ", #name))
+        )),
+        AttrType::U32 => Some(quote!(
+            #attrs
+                .get_u32(#name)
+                .expect(concat!("attribute out of range: ", #name))
+        )),
+        AttrType::U64 => Some(quote!(
+            #attrs
+                .get_u64(#name)
+                .expect(concat!("attribute out of range: ", #name))
+        )),
+        AttrType::Type => Some(quote!(#attrs.get_type(#name))),
+        AttrType::String => Some(quote!(
+            #attrs.get_str(#name).map(::std::borrow::ToOwned::to_owned)
+        )),
+        AttrType::Symbol | AttrType::QualifiedName => Some(quote!(#attrs.get_symbol(#name))),
+        AttrType::Any | AttrType::F32 | AttrType::F64 | AttrType::Bytes => None,
     }
 }
 

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -42,7 +42,6 @@ use trunk_ir::Symbol;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
-use trunk_ir::types::Attribute;
 use wasm_encoder::{
     AbstractHeapType, ArrayType, CodeSection, CompositeInnerType, CompositeType, ConstExpr,
     DataCountSection, DataSection, ElementSection, Elements, EntityType, ExportKind, ExportSection,
@@ -1207,17 +1206,5 @@ fn intern_simple_type(ctx: &mut IrContext, dialect: &'static str, name: &'static
         name: Symbol::new(name),
         params: Default::default(),
         attrs: Default::default(),
-    })
-}
-
-/// Intern a named adt.struct type (e.g., _Step, _Continuation).
-fn intern_named_adt_struct(ctx: &mut IrContext, name: &'static str) -> TypeRef {
-    let mut attrs = trunk_ir::AttributeMap::new();
-    attrs.insert(Symbol::new("name"), Attribute::Symbol(Symbol::new(name)));
-    ctx.types.intern(trunk_ir::types::TypeData {
-        dialect: Symbol::new("adt"),
-        name: Symbol::new("struct"),
-        params: Default::default(),
-        attrs,
     })
 }

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -1212,7 +1212,7 @@ fn intern_simple_type(ctx: &mut IrContext, dialect: &'static str, name: &'static
 
 /// Intern a named adt.struct type (e.g., _Step, _Continuation).
 fn intern_named_adt_struct(ctx: &mut IrContext, name: &'static str) -> TypeRef {
-    let mut attrs = std::collections::BTreeMap::new();
+    let mut attrs = trunk_ir::AttributeMap::new();
     attrs.insert(Symbol::new("name"), Attribute::Symbol(Symbol::new(name)));
     ctx.types.intern(trunk_ir::types::TypeData {
         dialect: Symbol::new("adt"),

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -3,7 +3,7 @@
 //! This module handles the collection of function types used in call_indirect
 //! operations, ref_func declarations, and related type inference.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use tracing::debug;
 use trunk_ir::IrContext;
@@ -14,7 +14,7 @@ use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{RegionRef, TypeRef};
 use trunk_ir::smallvec::SmallVec;
-use trunk_ir::types::{Attribute, TypeData};
+use trunk_ir::types::{Attribute, AttributeMap, TypeData};
 
 use crate::errors::CompilationResult;
 
@@ -45,7 +45,7 @@ fn intern_simple_wasm_type(ctx: &mut IrContext, name: &str) -> TypeRef {
 
 /// Intern an adt.struct type with the given name attribute.
 fn intern_named_adt_struct(ctx: &mut IrContext, name: &'static str) -> TypeRef {
-    let mut attrs = BTreeMap::new();
+    let mut attrs = AttributeMap::new();
     attrs.insert(Symbol::new("name"), Attribute::Symbol(Symbol::new(name)));
     ctx.types.intern(TypeData {
         dialect: Symbol::new("adt"),

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -14,11 +14,11 @@ use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{RegionRef, TypeRef};
 use trunk_ir::smallvec::SmallVec;
-use trunk_ir::types::{Attribute, AttributeMap, TypeData};
+use trunk_ir::types::TypeData;
 
 use crate::errors::CompilationResult;
 
-use super::helpers;
+use super::helpers::{self, intern_named_adt_struct};
 
 /// Intern a core.func type from params and result type.
 fn intern_func_type(ctx: &mut IrContext, params: &[TypeRef], result_ty: TypeRef) -> TypeRef {
@@ -40,18 +40,6 @@ fn intern_simple_wasm_type(ctx: &mut IrContext, name: &str) -> TypeRef {
         name: Symbol::from_dynamic(name),
         params: Default::default(),
         attrs: Default::default(),
-    })
-}
-
-/// Intern an adt.struct type with the given name attribute.
-fn intern_named_adt_struct(ctx: &mut IrContext, name: &'static str) -> TypeRef {
-    let mut attrs = AttributeMap::new();
-    attrs.insert(Symbol::new("name"), Attribute::Symbol(Symbol::new(name)));
-    ctx.types.intern(TypeData {
-        dialect: Symbol::new("adt"),
-        name: Symbol::new("struct"),
-        params: Default::default(),
-        attrs,
     })
 }
 

--- a/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
@@ -204,7 +204,7 @@ pub(crate) fn extract_data_def(
     let offset = if passive { 0 } else { data_op.offset(ctx) };
     // bytes is typed as `any` in the dialect, so we access the raw attribute
     let op_data = ctx.op(data_op.op_ref());
-    let bytes = match op_data.attributes.get(&Symbol::new("bytes")) {
+    let bytes = match op_data.attributes.get("bytes") {
         Some(Attribute::Bytes(value)) => value.to_vec(),
         _ => {
             return Err(CompilationError::invalid_attribute(
@@ -289,7 +289,7 @@ pub(crate) fn extract_global_def(
     })?;
     let mutable = global_op.mutable(ctx);
     let op_data = ctx.op(global_op.op_ref());
-    let init = match op_data.attributes.get(&Symbol::new("init")) {
+    let init = match op_data.attributes.get("init") {
         Some(Attribute::Int(v)) => i64::try_from(*v).map_err(|_| {
             CompilationError::invalid_attribute(format!("global init value {} out of i64 range", v))
         })?,

--- a/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
@@ -93,28 +93,28 @@ fn get_canonical_type_name(ctx: &IrContext, ty: TypeRef) -> Option<Symbol> {
 
     // Check if this is a variant instance type (adt type with "base_enum" attr)
     if data.dialect == Symbol::new("adt")
-        && let Some(Attribute::Type(base_enum)) = data.attrs.get("base_enum")
+        && let Some(base_enum) = data.attrs.get_type("base_enum")
     {
-        let base_data = ctx.types.get(*base_enum);
-        if let Some(Attribute::Symbol(name_sym)) = base_data.attrs.get("name") {
-            return Some(*name_sym);
+        let base_data = ctx.types.get(base_enum);
+        if let Some(name_sym) = base_data.attrs.get_symbol("name") {
+            return Some(name_sym);
         }
     }
 
     // Check if this is an adt.enum type
     if data.dialect == Symbol::new("adt")
         && data.name == Symbol::new("enum")
-        && let Some(Attribute::Symbol(name_sym)) = data.attrs.get("name")
+        && let Some(name_sym) = data.attrs.get_symbol("name")
     {
-        return Some(*name_sym);
+        return Some(name_sym);
     }
 
     // Check if this is an adt.struct type
     if data.dialect == Symbol::new("adt")
         && data.name == Symbol::new("struct")
-        && let Some(Attribute::Symbol(name_sym)) = data.attrs.get("name")
+        && let Some(name_sym) = data.attrs.get_symbol("name")
     {
-        return Some(*name_sym);
+        return Some(name_sym);
     }
 
     None
@@ -128,9 +128,9 @@ fn normalize_type_for_gc(ctx: &IrContext, ty: TypeRef) -> TypeRef {
 
     // Normalize variant instance types to their base enum
     if data.dialect == Symbol::new("adt")
-        && let Some(Attribute::Type(base_enum)) = data.attrs.get("base_enum")
+        && let Some(base_enum) = data.attrs.get_type("base_enum")
     {
-        return *base_enum;
+        return base_enum;
     }
 
     // Note: tribute_rt types (int, nat, bool, float, any, intref) should be

--- a/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
@@ -13,7 +13,7 @@ use trunk_ir::Symbol;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
-use trunk_ir::types::{Attribute, TypeData};
+use trunk_ir::types::TypeData;
 use wasm_encoder::{FieldType, StorageType, ValType};
 
 use crate::gc_types::{
@@ -22,7 +22,7 @@ use crate::gc_types::{
 };
 use crate::{CompilationError, CompilationResult};
 
-use super::helpers;
+use super::helpers::{self, intern_named_adt_struct};
 
 /// Result type for GC type collection.
 pub(crate) type GcTypesResult = (Vec<GcTypeDef>, HashMap<TypeRef, u32>);
@@ -253,18 +253,6 @@ fn type_to_field_type(
     Ok(FieldType {
         element_type: StorageType::Val(val_type),
         mutable: true,
-    })
-}
-
-/// Create an adt.struct TypeRef with a given name attribute.
-fn intern_named_adt_struct(ctx: &mut IrContext, name: &'static str) -> TypeRef {
-    let mut attrs = trunk_ir::AttributeMap::new();
-    attrs.insert(Symbol::new("name"), Attribute::Symbol(Symbol::new(name)));
-    ctx.types.intern(TypeData {
-        dialect: Symbol::new("adt"),
-        name: Symbol::new("struct"),
-        params: Default::default(),
-        attrs,
     })
 }
 

--- a/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
@@ -93,10 +93,10 @@ fn get_canonical_type_name(ctx: &IrContext, ty: TypeRef) -> Option<Symbol> {
 
     // Check if this is a variant instance type (adt type with "base_enum" attr)
     if data.dialect == Symbol::new("adt")
-        && let Some(Attribute::Type(base_enum)) = data.attrs.get(&Symbol::new("base_enum"))
+        && let Some(Attribute::Type(base_enum)) = data.attrs.get("base_enum")
     {
         let base_data = ctx.types.get(*base_enum);
-        if let Some(Attribute::Symbol(name_sym)) = base_data.attrs.get(&Symbol::new("name")) {
+        if let Some(Attribute::Symbol(name_sym)) = base_data.attrs.get("name") {
             return Some(*name_sym);
         }
     }
@@ -104,7 +104,7 @@ fn get_canonical_type_name(ctx: &IrContext, ty: TypeRef) -> Option<Symbol> {
     // Check if this is an adt.enum type
     if data.dialect == Symbol::new("adt")
         && data.name == Symbol::new("enum")
-        && let Some(Attribute::Symbol(name_sym)) = data.attrs.get(&Symbol::new("name"))
+        && let Some(Attribute::Symbol(name_sym)) = data.attrs.get("name")
     {
         return Some(*name_sym);
     }
@@ -112,7 +112,7 @@ fn get_canonical_type_name(ctx: &IrContext, ty: TypeRef) -> Option<Symbol> {
     // Check if this is an adt.struct type
     if data.dialect == Symbol::new("adt")
         && data.name == Symbol::new("struct")
-        && let Some(Attribute::Symbol(name_sym)) = data.attrs.get(&Symbol::new("name"))
+        && let Some(Attribute::Symbol(name_sym)) = data.attrs.get("name")
     {
         return Some(*name_sym);
     }
@@ -128,7 +128,7 @@ fn normalize_type_for_gc(ctx: &IrContext, ty: TypeRef) -> TypeRef {
 
     // Normalize variant instance types to their base enum
     if data.dialect == Symbol::new("adt")
-        && let Some(Attribute::Type(base_enum)) = data.attrs.get(&Symbol::new("base_enum"))
+        && let Some(Attribute::Type(base_enum)) = data.attrs.get("base_enum")
     {
         return *base_enum;
     }
@@ -258,7 +258,7 @@ fn type_to_field_type(
 
 /// Create an adt.struct TypeRef with a given name attribute.
 fn intern_named_adt_struct(ctx: &mut IrContext, name: &'static str) -> TypeRef {
-    let mut attrs = std::collections::BTreeMap::new();
+    let mut attrs = trunk_ir::AttributeMap::new();
     attrs.insert(Symbol::new("name"), Attribute::Symbol(Symbol::new(name)));
     ctx.types.intern(TypeData {
         dialect: Symbol::new("adt"),
@@ -315,14 +315,11 @@ pub(crate) fn collect_gc_types(
     type_idx_by_type.insert(marker_ty, MARKER_IDX);
     // Evidence ADT type (core.array(Marker)) — use a core.array type with marker param
     let evidence_ty = {
-        let mut attrs = std::collections::BTreeMap::new();
-        // No additional attrs needed, params carry the element type
-        let _ = &mut attrs;
         ctx.types.intern(TypeData {
             dialect: Symbol::new("core"),
             name: Symbol::new("array"),
             params: trunk_ir::smallvec::smallvec![marker_ty],
-            attrs,
+            attrs: Default::default(),
         })
     };
     type_idx_by_type.insert(evidence_ty, EVIDENCE_IDX);

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -222,7 +222,7 @@ pub(crate) fn handle_call_indirect(
     // call_indirect with i32 table index
     // IR operand order: [table_idx, arg1, arg2, ...]
     // WebAssembly stack order: [arg1, arg2, ..., table_idx]
-    let table = match attrs.get(&Symbol::new("table")) {
+    let table = match attrs.get("table") {
         Some(_) => attr_u32(attrs, Symbol::new("table"))?,
         None => 0,
     };

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -59,10 +59,9 @@ fn is_named_adt_struct(ctx: &IrContext, ty: TypeRef, expected_name: &'static str
     if data.dialect != Symbol::new("adt") || data.name != Symbol::new("struct") {
         return false;
     }
-    match data.attrs.get("name") {
-        Some(Attribute::Symbol(name)) => name.with_str(|s| s == expected_name),
-        _ => false,
-    }
+    data.attrs
+        .get_symbol("name")
+        .is_some_and(|name| name == expected_name)
 }
 
 /// Check if a type is the Step type (for trampoline-based effect system).
@@ -113,10 +112,7 @@ pub(crate) fn type_to_valtype(
             heap_type: HeapType::Concrete(BYTES_STRUCT_IDX),
         }))
     } else if is_bytes_array_ref(ctx, ty) {
-        let nullable = matches!(
-            ctx.types.get(ty).attrs.get("nullable"),
-            Some(Attribute::Bool(true))
-        );
+        let nullable = ctx.types.get(ty).attrs.get_bool("nullable") == Some(true);
         Ok(ValType::Ref(RefType {
             nullable,
             heap_type: HeapType::Concrete(BYTES_ARRAY_IDX),

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -30,6 +30,18 @@ pub(crate) fn is_type(
     data.dialect == Symbol::new(dialect) && data.name == Symbol::new(name)
 }
 
+/// Intern an `adt.struct` type with the given name attribute.
+pub(crate) fn intern_named_adt_struct(ctx: &mut IrContext, name: &'static str) -> TypeRef {
+    let mut attrs = AttributeMap::new();
+    attrs.insert(Symbol::new("name"), Attribute::Symbol(Symbol::new(name)));
+    ctx.types.intern(trunk_ir::types::TypeData {
+        dialect: Symbol::new("adt"),
+        name: Symbol::new("struct"),
+        params: Default::default(),
+        attrs,
+    })
+}
+
 // ============================================================================
 // Value type helpers
 // ============================================================================

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -3,12 +3,12 @@
 //! This module contains type conversion and utility functions shared across
 //! the emit module.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
 use trunk_ir::refs::{TypeRef, ValueRef};
-use trunk_ir::types::Attribute;
+use trunk_ir::types::{Attribute, AttributeMap};
 use wasm_encoder::{AbstractHeapType, HeapType, RefType, ValType};
 
 use crate::errors::CompilationErrorKind;
@@ -59,7 +59,7 @@ fn is_named_adt_struct(ctx: &IrContext, ty: TypeRef, expected_name: &'static str
     if data.dialect != Symbol::new("adt") || data.name != Symbol::new("struct") {
         return false;
     }
-    match data.attrs.get(&Symbol::new("name")) {
+    match data.attrs.get("name") {
         Some(Attribute::Symbol(name)) => name.with_str(|s| s == expected_name),
         _ => false,
     }
@@ -114,7 +114,7 @@ pub(crate) fn type_to_valtype(
         }))
     } else if is_bytes_array_ref(ctx, ty) {
         let nullable = matches!(
-            ctx.types.get(ty).attrs.get(&Symbol::new("nullable")),
+            ctx.types.get(ty).attrs.get("nullable"),
             Some(Attribute::Bool(true))
         );
         Ok(ValType::Ref(RefType {
@@ -234,10 +234,10 @@ pub(crate) fn result_types(
 /// Extract a heap type from operation attributes.
 pub(crate) fn attr_heap_type(
     ctx: &IrContext,
-    attrs: &std::collections::BTreeMap<Symbol, Attribute>,
+    attrs: &AttributeMap,
     key: Symbol,
 ) -> CompilationResult<HeapType> {
-    match attrs.get(&key) {
+    match attrs.get(key) {
         Some(Attribute::Int(bits)) => {
             let idx = u32::try_from(*bits).map_err(|_| {
                 CompilationError::invalid_attribute(format!(
@@ -319,8 +319,8 @@ pub(crate) fn symbol_to_abstract_heap_type(name: &str) -> CompilationResult<Heap
 /// - Key absent → `missing_attribute` error
 /// - Key present but wrong variant → `invalid_attribute` error
 /// - Key present and Int → checked u32 conversion
-pub(crate) fn attr_u32(attrs: &BTreeMap<Symbol, Attribute>, key: Symbol) -> CompilationResult<u32> {
-    match attrs.get(&key) {
+pub(crate) fn attr_u32(attrs: &AttributeMap, key: Symbol) -> CompilationResult<u32> {
+    match attrs.get(key) {
         Some(Attribute::Int(bits)) => u32::try_from(*bits).map_err(|_| {
             CompilationError::invalid_attribute(format!(
                 "attribute '{}' value {} out of u32 range",

--- a/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
@@ -241,7 +241,7 @@ fn make_variant_type(ctx: &mut IrContext, base_type: TypeRef, tag: Symbol) -> Ty
         // Get the name attribute from the typeref type
         base_data
             .attrs
-            .get(&Symbol::new("name"))
+            .get("name")
             .and_then(|a| match a {
                 Attribute::Symbol(s) => Some(*s),
                 _ => None,
@@ -375,10 +375,7 @@ impl RewritePattern for VariantGetPattern {
             .unwrap_or_else(|| variant_get.result_ty(ctx));
         let operand_ty = ctx.value_ty(ref_val);
         let variant_type = if matches!(
-            ctx.types
-                .get(operand_ty)
-                .attrs
-                .get(&Symbol::new("is_variant")),
+            ctx.types.get(operand_ty).attrs.get("is_variant"),
             Some(Attribute::Bool(true))
         ) {
             operand_ty
@@ -688,13 +685,13 @@ mod tests {
             .copied()
             .find(|&op| {
                 let data = ctx.op(op);
-                let Some(Attribute::Type(ty)) = data.attributes.get(&Symbol::new("type")) else {
+                let Some(Attribute::Type(ty)) = data.attributes.get("type") else {
                     return false;
                 };
                 data.dialect == wasm_gc_dialect::DIALECT_NAME()
                     && data.name == "struct_get"
                     && matches!(
-                        ctx.types.get(*ty).attrs.get(&Symbol::new("is_variant")),
+                        ctx.types.get(*ty).attrs.get("is_variant"),
                         Some(Attribute::Bool(true))
                     )
             })

--- a/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
@@ -696,10 +696,12 @@ mod tests {
                     )
             })
             .expect("lowered variant_get");
-        let Attribute::Type(variant_ty) = ctx.op(variant_get).attributes[&Symbol::new("type")]
-        else {
-            unreachable!("struct_get type must be a Type attribute");
-        };
+        let variant_ty = ctx
+            .op(variant_get)
+            .attributes
+            .get("type")
+            .and_then(Attribute::as_type)
+            .expect("struct_get type must be a Type attribute");
         assert_eq!(variant_ty, ctx.value_ty(ctx.op_operands(variant_get)[0]));
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
@@ -239,14 +239,7 @@ fn make_variant_type(ctx: &mut IrContext, base_type: TypeRef, tag: Symbol) -> Ty
 
     let base_name = if is_typeref {
         // Get the name attribute from the typeref type
-        base_data
-            .attrs
-            .get("name")
-            .and_then(|a| match a {
-                Attribute::Symbol(s) => Some(*s),
-                _ => None,
-            })
-            .unwrap_or(base_data.name)
+        base_data.attrs.get_symbol("name").unwrap_or(base_data.name)
     } else {
         base_data.name
     };
@@ -374,10 +367,7 @@ impl RewritePattern for VariantGetPattern {
             })
             .unwrap_or_else(|| variant_get.result_ty(ctx));
         let operand_ty = ctx.value_ty(ref_val);
-        let variant_type = if matches!(
-            ctx.types.get(operand_ty).attrs.get("is_variant"),
-            Some(Attribute::Bool(true))
-        ) {
+        let variant_type = if ctx.types.get(operand_ty).attrs.get_bool("is_variant") == Some(true) {
             operand_ty
         } else {
             make_variant_type(ctx, variant_get.r#type(ctx), variant_get.tag(ctx))
@@ -685,22 +675,18 @@ mod tests {
             .copied()
             .find(|&op| {
                 let data = ctx.op(op);
-                let Some(Attribute::Type(ty)) = data.attributes.get("type") else {
+                let Some(ty) = data.attributes.get_type("type") else {
                     return false;
                 };
                 data.dialect == wasm_gc_dialect::DIALECT_NAME()
                     && data.name == "struct_get"
-                    && matches!(
-                        ctx.types.get(*ty).attrs.get("is_variant"),
-                        Some(Attribute::Bool(true))
-                    )
+                    && ctx.types.get(ty).attrs.get_bool("is_variant") == Some(true)
             })
             .expect("lowered variant_get");
         let variant_ty = ctx
             .op(variant_get)
             .attributes
-            .get("type")
-            .and_then(Attribute::as_type)
+            .get_type("type")
             .expect("struct_get type must be a Type attribute");
         assert_eq!(variant_ty, ctx.value_ty(ctx.op_operands(variant_get)[0]));
     }

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -404,7 +404,7 @@ mod tests {
         let lowered = module.ops(&ctx)[0];
         assert!(wasm_dialect::Func::from_op(&ctx, lowered).is_ok());
         assert_eq!(
-            ctx.op(lowered).attributes.get(&Symbol::new("custom")),
+            ctx.op(lowered).attributes.get("custom"),
             Some(&Attribute::Int(7))
         );
     }

--- a/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
@@ -10,7 +10,6 @@ use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
-use trunk_ir::types::Attribute;
 
 use crate::gc_types::{
     BOXED_F64_IDX, BYTES_ARRAY_IDX, BYTES_STRUCT_IDX, CLOSURE_STRUCT_IDX, CONTINUATION_IDX,
@@ -20,10 +19,7 @@ use crate::gc_types::{
 fn named_adt(ctx: &IrContext, ty: TypeRef, expected: &'static str) -> bool {
     let data = ctx.types.get(ty);
     data.dialect == Symbol::new("adt")
-        && matches!(
-            data.attrs.get("name"),
-            Some(Attribute::Symbol(name)) if *name == Symbol::new(expected)
-        )
+        && data.attrs.get_symbol("name") == Some(Symbol::new(expected))
 }
 
 fn is_bytes_array(ctx: &IrContext, ty: TypeRef) -> bool {

--- a/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
@@ -21,7 +21,7 @@ fn named_adt(ctx: &IrContext, ty: TypeRef, expected: &'static str) -> bool {
     let data = ctx.types.get(ty);
     data.dialect == Symbol::new("adt")
         && matches!(
-            data.attrs.get(&Symbol::new("name")),
+            data.attrs.get("name"),
             Some(Attribute::Symbol(name)) if *name == Symbol::new(expected)
         )
 }

--- a/crates/trunk-ir/src/adt_layout.rs
+++ b/crates/trunk-ir/src/adt_layout.rs
@@ -120,7 +120,7 @@ pub fn get_struct_fields(ctx: &IrContext, ty: TypeRef) -> Option<Vec<(Symbol, Ty
         return None;
     }
 
-    let fields_attr = data.attrs.get(&Symbol::new("fields"))?;
+    let fields_attr = data.attrs.get("fields")?;
     let Attribute::List(fields) = fields_attr else {
         return None;
     };
@@ -162,7 +162,7 @@ pub fn get_enum_variants(ctx: &IrContext, ty: TypeRef) -> Option<Vec<(Symbol, Ve
         return None;
     }
 
-    let variants_attr = data.attrs.get(&Symbol::new("variants"))?;
+    let variants_attr = data.attrs.get("variants")?;
     let Attribute::List(variants) = variants_attr else {
         return None;
     };

--- a/crates/trunk-ir/src/context.rs
+++ b/crates/trunk-ir/src/context.rs
@@ -5,7 +5,7 @@
 //! use `EntityList + ListPool` for compact 4-byte per-field storage.
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use cranelift_entity::{EntityList, ListPool, PrimaryMap, SecondaryMap};
 use smallvec::SmallVec;
@@ -39,7 +39,7 @@ pub struct OperationData {
     pub name: Symbol,
     pub operands: EntityList<ValueRef>,
     pub results: EntityList<TypeRef>,
-    pub attributes: BTreeMap<Symbol, Attribute>,
+    pub attributes: AttributeMap,
     pub regions: SmallVec<[RegionRef; 4]>,
     pub successors: SmallVec<[BlockRef; 4]>,
     pub parent_block: Option<BlockRef>,
@@ -59,7 +59,7 @@ pub struct ValueData {
 #[derive(Clone, Debug)]
 pub struct BlockArgData {
     pub ty: TypeRef,
-    pub attrs: BTreeMap<Symbol, Attribute>,
+    pub attrs: AttributeMap,
 }
 
 /// Data for a basic block.
@@ -871,7 +871,7 @@ impl OperationData {
             name,
             operands: EntityList::new(),
             results: EntityList::new(),
-            attributes: BTreeMap::new(),
+            attributes: AttributeMap::new(),
             regions: SmallVec::new(),
             successors: SmallVec::new(),
             parent_block: None,
@@ -889,7 +889,7 @@ pub struct OperationDataBuilder {
     name: Symbol,
     operands: Vec<ValueRef>,
     results: Vec<TypeRef>,
-    attributes: BTreeMap<Symbol, Attribute>,
+    attributes: AttributeMap,
     regions: SmallVec<[RegionRef; 4]>,
     successors: SmallVec<[BlockRef; 4]>,
 }
@@ -902,7 +902,7 @@ impl OperationDataBuilder {
             name,
             operands: Vec::new(),
             results: Vec::new(),
-            attributes: BTreeMap::new(),
+            attributes: AttributeMap::new(),
             regions: SmallVec::new(),
             successors: SmallVec::new(),
         }
@@ -1002,7 +1002,7 @@ mod tests {
         assert_eq!(ctx.op(op).name, Symbol::new("const"));
         assert_eq!(ctx.op_result_types(op), &[i32_ty]);
         assert_eq!(
-            ctx.op(op).attributes.get(&Symbol::new("value")),
+            ctx.op(op).attributes.get("value"),
             Some(&Attribute::Int(42))
         );
     }
@@ -1044,11 +1044,11 @@ mod tests {
             args: vec![
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: AttributeMap::new(),
                 },
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: AttributeMap::new(),
                 },
             ],
             ops: SmallVec::new(),
@@ -1255,11 +1255,11 @@ mod tests {
             args: vec![
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: AttributeMap::new(),
                 },
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: AttributeMap::new(),
                 },
             ],
             ops: SmallVec::new(),
@@ -1274,7 +1274,7 @@ mod tests {
             block,
             BlockArgData {
                 ty: f64_ty,
-                attrs: BTreeMap::new(),
+                attrs: AttributeMap::new(),
             },
         );
 
@@ -1317,7 +1317,7 @@ mod tests {
             block,
             BlockArgData {
                 ty: i32_ty,
-                attrs: BTreeMap::new(),
+                attrs: AttributeMap::new(),
             },
         );
 
@@ -1369,11 +1369,11 @@ mod tests {
             args: vec![
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: AttributeMap::new(),
                 },
                 BlockArgData {
                     ty: i32_ty,
-                    attrs: BTreeMap::new(),
+                    attrs: AttributeMap::new(),
                 },
             ],
             ops: SmallVec::new(),
@@ -1697,12 +1697,7 @@ mod tests {
         let cloned_region = ctx.clone_region(body_region, &mut mapping);
 
         // Build a new func.func with the cloned region
-        let func_ty = ctx
-            .op(func_op)
-            .attributes
-            .get(&Symbol::new("type"))
-            .cloned()
-            .unwrap();
+        let func_ty = ctx.op(func_op).attributes.get("type").cloned().unwrap();
         let new_func = OperationDataBuilder::new(
             ctx.op(func_op).location,
             Symbol::new("func"),

--- a/crates/trunk-ir/src/dialect/adt.rs
+++ b/crates/trunk-ir/src/dialect/adt.rs
@@ -7,7 +7,7 @@ inventory::submit!(crate::op_interface::TypeAliasHint {
         ctx.types
             .get(ty)
             .attrs
-            .get(&crate::Symbol::new("name"))
+            .get("name")
             .and_then(crate::Attribute::as_symbol)
     },
 });

--- a/crates/trunk-ir/src/dialect/adt.rs
+++ b/crates/trunk-ir/src/dialect/adt.rs
@@ -3,13 +3,7 @@
 // === Type alias hint registration ===
 inventory::submit!(crate::op_interface::TypeAliasHint {
     dialect: "adt",
-    suggest: |ctx, ty| {
-        ctx.types
-            .get(ty)
-            .attrs
-            .get("name")
-            .and_then(crate::Attribute::as_symbol)
-    },
+    suggest: |ctx, ty| { ctx.types.get(ty).attrs.get_symbol("name") },
 });
 
 // === Pure operation registrations ===

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -44,10 +44,7 @@ fn print_func(
     // Extract sym_name before mutable operations
     let sym_name = {
         let data = h.ctx().op(op);
-        data.attributes.get("sym_name").and_then(|a| match a {
-            crate::Attribute::Symbol(s) => Some(*s),
-            _ => None,
-        })
+        data.attributes.get_symbol("sym_name")
     };
 
     write!(h, "{indent_str}func.func")?;
@@ -85,8 +82,8 @@ fn print_func(
     // Extract type decomposition: return type from core.func type attribute
     let type_info = {
         let data = h.ctx().op(op);
-        if let Some(crate::Attribute::Type(func_ty)) = data.attributes.get("type") {
-            let ty_data = h.ctx().types.get(*func_ty);
+        if let Some(func_ty) = data.attributes.get_type("type") {
+            let ty_data = h.ctx().types.get(func_ty);
             let is_core_func = ty_data.dialect == crate::Symbol::new("core")
                 && ty_data.name == crate::Symbol::new("func");
             if is_core_func && !ty_data.params.is_empty() {

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -44,12 +44,10 @@ fn print_func(
     // Extract sym_name before mutable operations
     let sym_name = {
         let data = h.ctx().op(op);
-        data.attributes
-            .get(&crate::Symbol::new("sym_name"))
-            .and_then(|a| match a {
-                crate::Attribute::Symbol(s) => Some(*s),
-                _ => None,
-            })
+        data.attributes.get("sym_name").and_then(|a| match a {
+            crate::Attribute::Symbol(s) => Some(*s),
+            _ => None,
+        })
     };
 
     write!(h, "{indent_str}func.func")?;
@@ -87,9 +85,7 @@ fn print_func(
     // Extract type decomposition: return type from core.func type attribute
     let type_info = {
         let data = h.ctx().op(op);
-        if let Some(crate::Attribute::Type(func_ty)) =
-            data.attributes.get(&crate::Symbol::new("type"))
-        {
+        if let Some(crate::Attribute::Type(func_ty)) = data.attributes.get("type") {
             let ty_data = h.ctx().types.get(*func_ty);
             let is_core_func = ty_data.dialect == crate::Symbol::new("core")
                 && ty_data.name == crate::Symbol::new("func");

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -88,7 +88,8 @@ pub use ir_mapping::IrMapping;
 pub use refs::{BlockRef, OpRef, PathRef, RegionRef, TypeRef, ValueDef, ValueRef};
 pub use rewrite::Module;
 pub use types::{
-    Attribute, AttributeKey, AttributeMap, Location, PathInterner, TypeData, TypeDataBuilder,
-    TypeInterner,
+    Attribute, AttributeIntoIter, AttributeIter, AttributeIterMut, AttributeKey, AttributeKeys,
+    AttributeMap, AttributeValues, AttributeValuesMut, Location, PathInterner, TypeData,
+    TypeDataBuilder, TypeInterner,
 };
 pub use walk::WalkAction;

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -89,7 +89,7 @@ pub use refs::{BlockRef, OpRef, PathRef, RegionRef, TypeRef, ValueDef, ValueRef}
 pub use rewrite::Module;
 pub use types::{
     Attribute, AttributeIntoIter, AttributeIter, AttributeIterMut, AttributeKey, AttributeKeys,
-    AttributeMap, AttributeValues, AttributeValuesMut, Location, PathInterner, TypeData,
-    TypeDataBuilder, TypeInterner,
+    AttributeMap, AttributeText, AttributeValues, AttributeValuesMut, IntegerOutOfRange, Location,
+    PathInterner, TypeData, TypeDataBuilder, TypeInterner,
 };
 pub use walk::WalkAction;

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -87,5 +87,8 @@ pub use context::{
 pub use ir_mapping::IrMapping;
 pub use refs::{BlockRef, OpRef, PathRef, RegionRef, TypeRef, ValueDef, ValueRef};
 pub use rewrite::Module;
-pub use types::{Attribute, Location, PathInterner, TypeData, TypeDataBuilder, TypeInterner};
+pub use types::{
+    Attribute, AttributeKey, AttributeMap, Location, PathInterner, TypeData, TypeDataBuilder,
+    TypeInterner,
+};
 pub use walk::WalkAction;

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -10,7 +10,7 @@
 //! 2. **IR build**: `ArenaIrBuilder` converts `Raw*` → arena `OpRef`,
 //!    `BlockRef`, `RegionRef`, etc.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use smallvec::smallvec;
 use winnow::prelude::*;
@@ -82,7 +82,7 @@ impl<'a> ArenaIrBuilder<'a> {
                     .iter()
                     .map(|p| self.build_type(p))
                     .collect::<Result<_, _>>()?;
-                let attrs: BTreeMap<Symbol, Attribute> = attrs
+                let attrs: AttributeMap = attrs
                     .iter()
                     .map(|(k, v)| Ok((Symbol::from_dynamic(k), self.build_attribute(v)?)))
                     .collect::<Result<_, ParseError>>()?;
@@ -218,7 +218,7 @@ impl<'a> ArenaIrBuilder<'a> {
                     .and_then(|rest| rest.parse::<usize>().ok())
                     .is_some_and(|n| n == j);
 
-                let mut attrs = BTreeMap::new();
+                let mut attrs = AttributeMap::new();
                 if !is_default_name {
                     attrs.insert(
                         Symbol::new("bind_name"),
@@ -361,7 +361,7 @@ impl<'a> ArenaIrBuilder<'a> {
             .collect::<Result<_, _>>()?;
 
         // Build attributes from explicit attr dict
-        let mut attributes: BTreeMap<Symbol, Attribute> = raw
+        let mut attributes: AttributeMap = raw
             .attributes
             .iter()
             .map(|(k, v)| Ok((Symbol::from_dynamic(k), self.build_attribute(v)?)))

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -888,9 +888,9 @@ fn print_module_op(
     write!(f, "{indent_str}core.module")?;
 
     // Module name
-    if let Some(Attribute::Symbol(name)) = data.attributes.get("sym_name") {
+    if let Some(name) = data.attributes.get_symbol("sym_name") {
         f.write_char(' ')?;
-        write_symbol(f, *name)?;
+        write_symbol(f, name)?;
     }
 
     let regions = &data.regions;

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -888,7 +888,7 @@ fn print_module_op(
     write!(f, "{indent_str}core.module")?;
 
     // Module name
-    if let Some(Attribute::Symbol(name)) = data.attributes.get(&crate::Symbol::new("sym_name")) {
+    if let Some(Attribute::Symbol(name)) = data.attributes.get("sym_name") {
         f.write_char(' ')?;
         write_symbol(f, *name)?;
     }

--- a/crates/trunk-ir/src/rewrite/helpers.rs
+++ b/crates/trunk-ir/src/rewrite/helpers.rs
@@ -146,8 +146,6 @@ mod tests {
     use crate::symbol::Symbol;
     use crate::*;
     use smallvec::smallvec;
-    use std::collections::BTreeMap;
-
     fn test_ctx() -> (IrContext, Location) {
         let mut ctx = IrContext::new();
         let path = ctx.paths.intern("test.trb".to_owned());
@@ -406,14 +404,14 @@ mod tests {
             block,
             BlockArgData {
                 ty: i32_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
         );
         let v1 = ctx.add_block_arg(
             block,
             BlockArgData {
                 ty: i32_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
         );
 

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -72,7 +72,7 @@ impl Module {
     pub fn name(self, ctx: &IrContext) -> Option<crate::symbol::Symbol> {
         ctx.op(self.0)
             .attributes
-            .get(&crate::symbol::Symbol::new("sym_name"))
+            .get("sym_name")
             .and_then(|a| match a {
                 super::types::Attribute::Symbol(s) => Some(*s),
                 _ => None,

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -70,13 +70,7 @@ impl Module {
 
     /// Get the module name (from `sym_name` attribute).
     pub fn name(self, ctx: &IrContext) -> Option<crate::symbol::Symbol> {
-        ctx.op(self.0)
-            .attributes
-            .get("sym_name")
-            .and_then(|a| match a {
-                super::types::Attribute::Symbol(s) => Some(*s),
-                _ => None,
-            })
+        ctx.op(self.0).attributes.get_symbol("sym_name")
     }
 
     /// Get the first block of the module body.

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -211,8 +211,6 @@ mod tests {
     use crate::rewrite::{ConversionTarget, Module, PatternApplicator, TypeConverter};
     use crate::types::{Attribute, TypeDataBuilder};
     use smallvec::smallvec;
-    use std::collections::BTreeMap;
-
     fn test_ctx() -> (IrContext, crate::types::Location) {
         let mut ctx = IrContext::new();
         let path = ctx.paths.intern("test.trb".to_owned());
@@ -272,7 +270,7 @@ mod tests {
                 .iter()
                 .map(|&ty| BlockArgData {
                     ty,
-                    attrs: BTreeMap::new(),
+                    attrs: Default::default(),
                 })
                 .collect(),
             ops: smallvec![],
@@ -301,7 +299,7 @@ mod tests {
                 .iter()
                 .map(|&ty| BlockArgData {
                     ty,
-                    attrs: BTreeMap::new(),
+                    attrs: Default::default(),
                 })
                 .collect(),
             ops: smallvec![],
@@ -431,7 +429,7 @@ mod tests {
         assert_eq!(td.params[1], i64_ty, "first param should be i64");
         assert_eq!(td.params[2], i64_ty, "second param should be i64");
         assert_eq!(
-            ctx.op(ops[0]).attributes.get(&Symbol::new("custom")),
+            ctx.op(ops[0]).attributes.get("custom"),
             Some(&Attribute::Int(7)),
             "signature conversion should preserve custom metadata"
         );

--- a/crates/trunk-ir/src/symbol.rs
+++ b/crates/trunk-ir/src/symbol.rs
@@ -70,6 +70,11 @@ impl Symbol {
         Self::get_or_else(text, |rodeo| rodeo.get_or_intern(text))
     }
 
+    /// Look up an already-interned string without interning it when absent.
+    pub fn lookup(text: &str) -> Option<Self> {
+        INTERNER.read_recursive().get(text).map(Self)
+    }
+
     fn get_or_else(text: &str, f: impl for<'r> FnOnce(&'r mut Rodeo) -> Spur) -> Self {
         let mut lock = INTERNER.upgradable_read();
         Symbol(if let Some(spur) = lock.get(text) {
@@ -169,6 +174,21 @@ impl PartialEq<Symbol> for &str {
 impl std::fmt::Display for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.with_str(|s| write!(f, "{}", s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_does_not_intern_missing_text() {
+        let text = "__trunk_ir_symbol_lookup_missing_text__";
+        assert_eq!(Symbol::lookup(text), None);
+        assert_eq!(Symbol::lookup(text), None);
+
+        let symbol = Symbol::from_dynamic(text);
+        assert_eq!(Symbol::lookup(text), Some(symbol));
     }
 }
 

--- a/crates/trunk-ir/src/transforms/global_dce.rs
+++ b/crates/trunk-ir/src/transforms/global_dce.rs
@@ -183,7 +183,7 @@ impl GlobalDcePass {
 
                     // Treat abi functions as entry points so their callees
                     // are also considered reachable.
-                    if ctx.op(op).attributes.contains_key(&self.syms.abi) {
+                    if ctx.op(op).attributes.contains_key(self.syms.abi) {
                         self.reachability_roots.insert(func_name);
                     }
 

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -416,7 +416,7 @@ impl RewritePattern for InlineCallSite {
             return false;
         }
 
-        let callee = match ctx.op(op).attributes.get(&Symbol::new("callee")) {
+        let callee = match ctx.op(op).attributes.get("callee") {
             Some(Attribute::Symbol(s)) => *s,
             _ => return false,
         };
@@ -464,8 +464,6 @@ mod mechanics {
     use crate::location::Span;
     use crate::*;
     use smallvec::smallvec;
-    use std::collections::BTreeMap;
-
     fn test_ctx() -> (IrContext, Location) {
         let mut ctx = IrContext::new();
         let path = ctx.paths.intern("test.trb".to_owned());
@@ -505,7 +503,7 @@ mod mechanics {
                 .iter()
                 .map(|&ty| BlockArgData {
                     ty,
-                    attrs: BTreeMap::new(),
+                    attrs: Default::default(),
                 })
                 .collect(),
             ops: smallvec![],
@@ -835,8 +833,6 @@ mod pass {
     use crate::location::Span;
     use crate::*;
     use smallvec::smallvec;
-    use std::collections::BTreeMap;
-
     fn test_ctx() -> (IrContext, Location) {
         let mut ctx = IrContext::new();
         let path = ctx.paths.intern("test.trb".to_owned());
@@ -875,7 +871,7 @@ mod pass {
                 .iter()
                 .map(|&ty| BlockArgData {
                     ty,
-                    attrs: BTreeMap::new(),
+                    attrs: Default::default(),
                 })
                 .collect(),
             ops: smallvec![],
@@ -924,7 +920,7 @@ mod pass {
         let _ = walk_region::<()>(ctx, body, &mut |op| {
             if func::Call::matches(ctx, op)
                 && let Some(crate::types::Attribute::Symbol(s)) =
-                    ctx.op(op).attributes.get(&Symbol::new("callee"))
+                    ctx.op(op).attributes.get("callee")
                 && *s == target
             {
                 count += 1;
@@ -997,7 +993,7 @@ mod pass {
             let ret = func::r#return(ctx, loc, [c.result(ctx)]);
             ctx.push_op(entry, ret.op_ref());
         });
-        let fn_ty_helper = ctx.op(helper).attributes.get(&Symbol::new("type")).cloned();
+        let fn_ty_helper = ctx.op(helper).attributes.get("type").cloned();
         let helper_fn_ty = match fn_ty_helper {
             Some(Attribute::Type(t)) => t,
             _ => panic!("expected type attr"),

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -191,7 +191,6 @@ fn splice_callee_body_before(
 use super::call_graph::{CallGraph, recursive_functions};
 use crate::rewrite::{Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter};
 use crate::symbol::Symbol;
-use crate::types::Attribute;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -412,9 +411,8 @@ impl RewritePattern for InlineCallSite {
             return false;
         }
 
-        let callee = match ctx.op(op).attributes.get("callee") {
-            Some(Attribute::Symbol(s)) => *s,
-            _ => return false,
+        let Some(callee) = ctx.op(op).attributes.get_symbol("callee") else {
+            return false;
         };
 
         if !should_inline(&self.graph, &self.config, &self.recursive, ctx, callee) {
@@ -915,9 +913,7 @@ mod pass {
         let body = ctx.op(func_op).regions[0];
         let _ = walk_region::<()>(ctx, body, &mut |op| {
             if func::Call::matches(ctx, op)
-                && let Some(crate::types::Attribute::Symbol(s)) =
-                    ctx.op(op).attributes.get("callee")
-                && *s == target
+                && ctx.op(op).attributes.get_symbol("callee") == Some(target)
             {
                 count += 1;
             }
@@ -989,11 +985,11 @@ mod pass {
             let ret = func::r#return(ctx, loc, [c.result(ctx)]);
             ctx.push_op(entry, ret.op_ref());
         });
-        let fn_ty_helper = ctx.op(helper).attributes.get("type").cloned();
-        let helper_fn_ty = match fn_ty_helper {
-            Some(Attribute::Type(t)) => t,
-            _ => panic!("expected type attr"),
-        };
+        let helper_fn_ty = ctx
+            .op(helper)
+            .attributes
+            .get_type("type")
+            .expect("expected type attr");
 
         let other = build_func(&mut ctx, loc, "other", &[], i32_ty, |ctx, entry, _args| {
             let c = func::constant(ctx, loc, helper_fn_ty, Symbol::new("helper"));

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -258,11 +258,7 @@ fn should_inline(
     }
     // Skip extern/ABI functions: they are externally callable and the body
     // may be empty or have calling-convention constraints.
-    if ctx
-        .op(callee_op)
-        .attributes
-        .contains_key(&Symbol::new("abi"))
-    {
+    if ctx.op(callee_op).attributes.contains_key("abi") {
         return false;
     }
     // Skip recursive functions to avoid unbounded instantiation.

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -29,10 +29,8 @@
 //!   %2 = op_after(%1)
 //! ```
 
-use std::cmp::Reverse;
-use std::collections::BTreeMap;
-
 use smallvec::SmallVec;
+use std::cmp::Reverse;
 
 use crate::context::{BlockArgData, BlockData, IrContext};
 use crate::dialect::{arith, cf, core, func, scf};
@@ -177,7 +175,7 @@ fn lower_scf_if(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Locati
             merge_block,
             BlockArgData {
                 ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
         );
         // RAUW: replace all uses of scf.if result with merge block arg
@@ -246,7 +244,7 @@ fn lower_scf_loop(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Loca
             exit_block,
             BlockArgData {
                 ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
         );
         let loop_result = ctx.op_results(scf_op)[0];
@@ -318,7 +316,7 @@ fn lower_scf_switch(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Lo
             merge_block,
             BlockArgData {
                 ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             },
         );
         let results = ctx.op_results(scf_op);
@@ -899,7 +897,7 @@ mod tests {
             location: loc,
             args: vec![BlockArgData {
                 ty: i32_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             }],
             ops: smallvec![],
             parent_region: None,

--- a/crates/trunk-ir/src/types.rs
+++ b/crates/trunk-ir/src/types.rs
@@ -316,6 +316,10 @@ impl AttributeMap {
         self.get_integer(key, "u32", u32::try_from)
     }
 
+    pub fn get_u8(&self, key: impl AttributeKey) -> Result<Option<u8>, IntegerOutOfRange> {
+        self.get_integer(key, "u8", u8::try_from)
+    }
+
     pub fn get_str(&self, key: impl AttributeKey) -> Option<&str> {
         self.get(key).and_then(Attribute::as_str)
     }
@@ -640,9 +644,10 @@ mod tests {
     }
 
     #[test]
-    fn attribute_map_typed_getters_distinguish_absence_kind_and_range() {
+    fn attribute_map_typed_getters_handle_absence_and_integer_range() {
         let mut attrs = AttributeMap::new();
         attrs.insert(Symbol::new("count"), Attribute::Int(i64::MAX as i128));
+        attrs.insert(Symbol::new("byte"), Attribute::Int(u8::MAX as i128));
         attrs.insert(Symbol::new("enabled"), Attribute::Bool(true));
         attrs.insert(Symbol::new("name"), Attribute::String("tribute".to_owned()));
         attrs.insert(
@@ -652,6 +657,7 @@ mod tests {
 
         assert_eq!(attrs.get_i64("count"), Ok(Some(i64::MAX)));
         assert_eq!(attrs.get_i128("count"), Some(i64::MAX as i128));
+        assert_eq!(attrs.get_u8("byte"), Ok(Some(u8::MAX)));
         assert_eq!(attrs.get_bool("enabled"), Some(true));
         assert_eq!(attrs.get_str("name"), Some("tribute"));
         assert_eq!(attrs.get_i32("missing"), Ok(None));
@@ -660,6 +666,13 @@ mod tests {
             Err(IntegerOutOfRange {
                 value: i64::MAX as i128,
                 target: "i32",
+            })
+        );
+        assert_eq!(
+            attrs.get_u8("count"),
+            Err(IntegerOutOfRange {
+                value: i64::MAX as i128,
+                target: "u8",
             })
         );
         assert_eq!(attrs.get_u32("enabled"), Ok(None));

--- a/crates/trunk-ir/src/types.rs
+++ b/crates/trunk-ir/src/types.rs
@@ -1,6 +1,7 @@
 //! Type interning and path interning for arena-based IR.
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 
 use cranelift_entity::PrimaryMap;
 use smallvec::SmallVec;
@@ -51,6 +52,67 @@ pub enum Attribute {
     Location(Location),
 }
 
+/// An integer attribute that cannot be represented by the requested type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct IntegerOutOfRange {
+    pub value: i128,
+    pub target: &'static str,
+}
+
+impl fmt::Display for IntegerOutOfRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "integer attribute {} is out of range for {}",
+            self.value, self.target
+        )
+    }
+}
+
+impl std::error::Error for IntegerOutOfRange {}
+
+/// Text stored either directly or as an interned symbol attribute.
+#[derive(Clone, Copy, Debug)]
+pub enum AttributeText<'a> {
+    String(&'a str),
+    Symbol(Symbol),
+}
+
+impl AttributeText<'_> {
+    pub fn with_str<R>(&self, f: impl FnOnce(&str) -> R) -> R {
+        match self {
+            AttributeText::String(text) => f(text),
+            AttributeText::Symbol(symbol) => symbol.with_str(f),
+        }
+    }
+}
+
+impl PartialEq for AttributeText<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.with_str(|text| other.with_str(|other| text == other))
+    }
+}
+
+impl Eq for AttributeText<'_> {}
+
+impl PartialEq<str> for AttributeText<'_> {
+    fn eq(&self, other: &str) -> bool {
+        self.with_str(|text| text == other)
+    }
+}
+
+impl PartialEq<&str> for AttributeText<'_> {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+impl fmt::Display for AttributeText<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.with_str(|text| f.write_str(text))
+    }
+}
+
 impl Attribute {
     /// Extract the inner `Symbol` if this is `Attribute::Symbol`.
     pub fn as_symbol(&self) -> Option<Symbol> {
@@ -69,7 +131,7 @@ impl Attribute {
     }
 
     /// Extract the inner integer if this is `Attribute::Int`.
-    pub fn as_int(&self) -> Option<i128> {
+    pub fn as_i128(&self) -> Option<i128> {
         match self {
             Attribute::Int(v) => Some(*v),
             _ => None,
@@ -228,6 +290,64 @@ impl AttributeMap {
     pub fn get_mut(&mut self, key: impl AttributeKey) -> Option<&mut Attribute> {
         let symbol = key.lookup_symbol()?;
         self.0.get_mut(&symbol)
+    }
+
+    pub fn get_bool(&self, key: impl AttributeKey) -> Option<bool> {
+        self.get(key).and_then(Attribute::as_bool)
+    }
+
+    pub fn get_i128(&self, key: impl AttributeKey) -> Option<i128> {
+        self.get(key).and_then(Attribute::as_i128)
+    }
+
+    pub fn get_i64(&self, key: impl AttributeKey) -> Result<Option<i64>, IntegerOutOfRange> {
+        self.get_integer(key, "i64", i64::try_from)
+    }
+
+    pub fn get_i32(&self, key: impl AttributeKey) -> Result<Option<i32>, IntegerOutOfRange> {
+        self.get_integer(key, "i32", i32::try_from)
+    }
+
+    pub fn get_u64(&self, key: impl AttributeKey) -> Result<Option<u64>, IntegerOutOfRange> {
+        self.get_integer(key, "u64", u64::try_from)
+    }
+
+    pub fn get_u32(&self, key: impl AttributeKey) -> Result<Option<u32>, IntegerOutOfRange> {
+        self.get_integer(key, "u32", u32::try_from)
+    }
+
+    pub fn get_str(&self, key: impl AttributeKey) -> Option<&str> {
+        self.get(key).and_then(Attribute::as_str)
+    }
+
+    pub fn get_symbol(&self, key: impl AttributeKey) -> Option<Symbol> {
+        self.get(key).and_then(Attribute::as_symbol)
+    }
+
+    pub fn get_type(&self, key: impl AttributeKey) -> Option<TypeRef> {
+        self.get(key).and_then(Attribute::as_type)
+    }
+
+    pub fn get_text(&self, key: impl AttributeKey) -> Option<AttributeText<'_>> {
+        match self.get(key)? {
+            Attribute::String(text) => Some(AttributeText::String(text)),
+            Attribute::Symbol(symbol) => Some(AttributeText::Symbol(*symbol)),
+            _ => None,
+        }
+    }
+
+    fn get_integer<T>(
+        &self,
+        key: impl AttributeKey,
+        target: &'static str,
+        convert: impl FnOnce(i128) -> Result<T, std::num::TryFromIntError>,
+    ) -> Result<Option<T>, IntegerOutOfRange> {
+        let Some(value) = self.get_i128(key) else {
+            return Ok(None);
+        };
+        convert(value)
+            .map(Some)
+            .map_err(|_| IntegerOutOfRange { value, target })
     }
 
     pub fn contains_key(&self, key: impl AttributeKey) -> bool {
@@ -517,6 +637,39 @@ mod tests {
 
         assert_eq!(attrs.remove(answer), Some(Attribute::Int(42)));
         assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn attribute_map_typed_getters_distinguish_absence_kind_and_range() {
+        let mut attrs = AttributeMap::new();
+        attrs.insert(Symbol::new("count"), Attribute::Int(i64::MAX as i128));
+        attrs.insert(Symbol::new("enabled"), Attribute::Bool(true));
+        attrs.insert(Symbol::new("name"), Attribute::String("tribute".to_owned()));
+        attrs.insert(
+            Symbol::new("symbol_name"),
+            Attribute::Symbol(Symbol::new("tribute")),
+        );
+
+        assert_eq!(attrs.get_i64("count"), Ok(Some(i64::MAX)));
+        assert_eq!(attrs.get_i128("count"), Some(i64::MAX as i128));
+        assert_eq!(attrs.get_bool("enabled"), Some(true));
+        assert_eq!(attrs.get_str("name"), Some("tribute"));
+        assert_eq!(attrs.get_i32("missing"), Ok(None));
+        assert_eq!(
+            attrs.get_i32("count"),
+            Err(IntegerOutOfRange {
+                value: i64::MAX as i128,
+                target: "i32",
+            })
+        );
+        assert_eq!(attrs.get_u32("enabled"), Ok(None));
+
+        let string_text = attrs.get_text("name").expect("string text");
+        let symbol_text = attrs.get_text("symbol_name").expect("symbol text");
+        assert_eq!(string_text, "tribute");
+        assert_eq!(symbol_text, "tribute");
+        assert_eq!(string_text, symbol_text);
+        assert_eq!(attrs.get_text("enabled"), None);
     }
 
     #[test]

--- a/crates/trunk-ir/src/types.rs
+++ b/crates/trunk-ir/src/types.rs
@@ -1,10 +1,10 @@
 //! Type interning and path interning for arena-based IR.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::ops::{Deref, DerefMut};
 
 use cranelift_entity::PrimaryMap;
 use smallvec::SmallVec;
-use std::collections::HashMap;
 
 use super::refs::{PathRef, TypeRef};
 use crate::location::Span;
@@ -179,6 +179,107 @@ impl From<Location> for Attribute {
     }
 }
 
+/// A deterministic map of IR attributes with ergonomic symbol and string lookup.
+///
+/// Existing `BTreeMap` mutation and iteration APIs remain available through
+/// [`Deref`] and [`DerefMut`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct AttributeMap(BTreeMap<Symbol, Attribute>);
+
+/// A key accepted by [`AttributeMap::get`].
+pub enum AttributeKey<'a> {
+    Symbol(Symbol),
+    Text(&'a str),
+}
+
+impl From<Symbol> for AttributeKey<'_> {
+    fn from(value: Symbol) -> Self {
+        Self::Symbol(value)
+    }
+}
+
+impl From<&Symbol> for AttributeKey<'_> {
+    fn from(value: &Symbol) -> Self {
+        Self::Symbol(*value)
+    }
+}
+
+impl<'a> From<&'a str> for AttributeKey<'a> {
+    fn from(value: &'a str) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl AttributeMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the attribute associated with a symbol or already-interned string.
+    ///
+    /// A missing string key is not added to the global symbol interner.
+    pub fn get<'a>(&self, key: impl Into<AttributeKey<'a>>) -> Option<&Attribute> {
+        let symbol = match key.into() {
+            AttributeKey::Symbol(symbol) => symbol,
+            AttributeKey::Text(text) => Symbol::lookup(text)?,
+        };
+        self.0.get(&symbol)
+    }
+}
+
+impl Deref for AttributeMap {
+    type Target = BTreeMap<Symbol, Attribute>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AttributeMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl FromIterator<(Symbol, Attribute)> for AttributeMap {
+    fn from_iter<T: IntoIterator<Item = (Symbol, Attribute)>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl Extend<(Symbol, Attribute)> for AttributeMap {
+    fn extend<T: IntoIterator<Item = (Symbol, Attribute)>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+impl IntoIterator for AttributeMap {
+    type Item = (Symbol, Attribute);
+    type IntoIter = std::collections::btree_map::IntoIter<Symbol, Attribute>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a AttributeMap {
+    type Item = (&'a Symbol, &'a Attribute);
+    type IntoIter = std::collections::btree_map::Iter<'a, Symbol, Attribute>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut AttributeMap {
+    type Item = (&'a Symbol, &'a mut Attribute);
+    type IntoIter = std::collections::btree_map::IterMut<'a, Symbol, Attribute>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
 // ============================================================================
 // TypeData
 // ============================================================================
@@ -189,7 +290,7 @@ pub struct TypeData {
     pub dialect: Symbol,
     pub name: Symbol,
     pub params: SmallVec<[TypeRef; 4]>,
-    pub attrs: BTreeMap<Symbol, Attribute>,
+    pub attrs: AttributeMap,
 }
 
 /// Builder for constructing `TypeData` with a fluent API.
@@ -199,7 +300,7 @@ pub struct TypeDataBuilder {
     dialect: Symbol,
     name: Symbol,
     params: SmallVec<[TypeRef; 4]>,
-    attrs: BTreeMap<Symbol, Attribute>,
+    attrs: AttributeMap,
 }
 
 impl TypeDataBuilder {
@@ -208,7 +309,7 @@ impl TypeDataBuilder {
             dialect,
             name,
             params: SmallVec::new(),
-            attrs: BTreeMap::new(),
+            attrs: AttributeMap::new(),
         }
     }
 
@@ -353,6 +454,30 @@ mod tests {
     use super::*;
     use crate::IrContext;
     use crate::Symbol;
+
+    #[test]
+    fn attribute_map_accepts_string_and_symbol_keys_without_interning_misses() {
+        fn get_by_symbol<'a>(attrs: &'a AttributeMap, key: &Symbol) -> Option<&'a Attribute> {
+            attrs.get(key)
+        }
+
+        let mut attrs = AttributeMap::new();
+        let answer = Symbol::new("answer");
+        attrs.insert(answer, Attribute::Int(42));
+
+        assert_eq!(attrs.get("answer"), Some(&Attribute::Int(42)));
+        assert_eq!(attrs.get(answer), Some(&Attribute::Int(42)));
+        assert_eq!(get_by_symbol(&attrs, &answer), Some(&Attribute::Int(42)));
+        assert_eq!(attrs.keys().copied().collect::<Vec<_>>(), vec![answer]);
+
+        let missing = "__trunk_ir_attribute_map_missing_key__";
+        assert_eq!(Symbol::lookup(missing), None);
+        assert_eq!(attrs.get(missing), None);
+        assert_eq!(Symbol::lookup(missing), None);
+
+        assert_eq!(attrs.remove(&answer), Some(Attribute::Int(42)));
+        assert!(attrs.is_empty());
+    }
 
     #[test]
     fn type_interner_dedup() {

--- a/crates/trunk-ir/src/types.rs
+++ b/crates/trunk-ir/src/types.rs
@@ -1,7 +1,6 @@
 //! Type interning and path interning for arena-based IR.
 
 use std::collections::{BTreeMap, HashMap};
-use std::ops::{Deref, DerefMut};
 
 use cranelift_entity::PrimaryMap;
 use smallvec::SmallVec;
@@ -180,33 +179,36 @@ impl From<Location> for Attribute {
 }
 
 /// A deterministic map of IR attributes with ergonomic symbol and string lookup.
-///
-/// Existing `BTreeMap` mutation and iteration APIs remain available through
-/// [`Deref`] and [`DerefMut`].
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AttributeMap(BTreeMap<Symbol, Attribute>);
 
+pub type AttributeIter<'a> = std::collections::btree_map::Iter<'a, Symbol, Attribute>;
+pub type AttributeIterMut<'a> = std::collections::btree_map::IterMut<'a, Symbol, Attribute>;
+pub type AttributeKeys<'a> = std::collections::btree_map::Keys<'a, Symbol, Attribute>;
+pub type AttributeValues<'a> = std::collections::btree_map::Values<'a, Symbol, Attribute>;
+pub type AttributeValuesMut<'a> = std::collections::btree_map::ValuesMut<'a, Symbol, Attribute>;
+pub type AttributeIntoIter = std::collections::btree_map::IntoIter<Symbol, Attribute>;
+
 /// A key accepted by [`AttributeMap::get`].
-pub enum AttributeKey<'a> {
-    Symbol(Symbol),
-    Text(&'a str),
+pub trait AttributeKey {
+    fn lookup_symbol(self) -> Option<Symbol>;
 }
 
-impl From<Symbol> for AttributeKey<'_> {
-    fn from(value: Symbol) -> Self {
-        Self::Symbol(value)
+impl AttributeKey for Symbol {
+    fn lookup_symbol(self) -> Option<Symbol> {
+        Some(self)
     }
 }
 
-impl From<&Symbol> for AttributeKey<'_> {
-    fn from(value: &Symbol) -> Self {
-        Self::Symbol(*value)
+impl AttributeKey for &Symbol {
+    fn lookup_symbol(self) -> Option<Symbol> {
+        Some(*self)
     }
 }
 
-impl<'a> From<&'a str> for AttributeKey<'a> {
-    fn from(value: &'a str) -> Self {
-        Self::Text(value)
+impl AttributeKey for &str {
+    fn lookup_symbol(self) -> Option<Symbol> {
+        Symbol::lookup(self)
     }
 }
 
@@ -218,26 +220,62 @@ impl AttributeMap {
     /// Return the attribute associated with a symbol or already-interned string.
     ///
     /// A missing string key is not added to the global symbol interner.
-    pub fn get<'a>(&self, key: impl Into<AttributeKey<'a>>) -> Option<&Attribute> {
-        let symbol = match key.into() {
-            AttributeKey::Symbol(symbol) => symbol,
-            AttributeKey::Text(text) => Symbol::lookup(text)?,
-        };
+    pub fn get(&self, key: impl AttributeKey) -> Option<&Attribute> {
+        let symbol = key.lookup_symbol()?;
         self.0.get(&symbol)
     }
-}
 
-impl Deref for AttributeMap {
-    type Target = BTreeMap<Symbol, Attribute>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn get_mut(&mut self, key: impl AttributeKey) -> Option<&mut Attribute> {
+        let symbol = key.lookup_symbol()?;
+        self.0.get_mut(&symbol)
     }
-}
 
-impl DerefMut for AttributeMap {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    pub fn contains_key(&self, key: impl AttributeKey) -> bool {
+        let Some(symbol) = key.lookup_symbol() else {
+            return false;
+        };
+        self.0.contains_key(&symbol)
+    }
+
+    pub fn insert(&mut self, key: Symbol, value: Attribute) -> Option<Attribute> {
+        self.0.insert(key, value)
+    }
+
+    pub fn remove(&mut self, key: impl AttributeKey) -> Option<Attribute> {
+        let symbol = key.lookup_symbol()?;
+        self.0.remove(&symbol)
+    }
+
+    pub fn iter(&self) -> AttributeIter<'_> {
+        self.0.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> AttributeIterMut<'_> {
+        self.0.iter_mut()
+    }
+
+    pub fn keys(&self) -> AttributeKeys<'_> {
+        self.0.keys()
+    }
+
+    pub fn values(&self) -> AttributeValues<'_> {
+        self.0.values()
+    }
+
+    pub fn values_mut(&mut self) -> AttributeValuesMut<'_> {
+        self.0.values_mut()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
     }
 }
 
@@ -255,7 +293,7 @@ impl Extend<(Symbol, Attribute)> for AttributeMap {
 
 impl IntoIterator for AttributeMap {
     type Item = (Symbol, Attribute);
-    type IntoIter = std::collections::btree_map::IntoIter<Symbol, Attribute>;
+    type IntoIter = AttributeIntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -264,7 +302,7 @@ impl IntoIterator for AttributeMap {
 
 impl<'a> IntoIterator for &'a AttributeMap {
     type Item = (&'a Symbol, &'a Attribute);
-    type IntoIter = std::collections::btree_map::Iter<'a, Symbol, Attribute>;
+    type IntoIter = AttributeIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -273,7 +311,7 @@ impl<'a> IntoIterator for &'a AttributeMap {
 
 impl<'a> IntoIterator for &'a mut AttributeMap {
     type Item = (&'a Symbol, &'a mut Attribute);
-    type IntoIter = std::collections::btree_map::IterMut<'a, Symbol, Attribute>;
+    type IntoIter = AttributeIterMut<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter_mut()
@@ -468,14 +506,16 @@ mod tests {
         assert_eq!(attrs.get("answer"), Some(&Attribute::Int(42)));
         assert_eq!(attrs.get(answer), Some(&Attribute::Int(42)));
         assert_eq!(get_by_symbol(&attrs, &answer), Some(&Attribute::Int(42)));
+        assert!(attrs.contains_key("answer"));
         assert_eq!(attrs.keys().copied().collect::<Vec<_>>(), vec![answer]);
 
         let missing = "__trunk_ir_attribute_map_missing_key__";
         assert_eq!(Symbol::lookup(missing), None);
         assert_eq!(attrs.get(missing), None);
+        assert!(!attrs.contains_key(missing));
         assert_eq!(Symbol::lookup(missing), None);
 
-        assert_eq!(attrs.remove(&answer), Some(Attribute::Int(42)));
+        assert_eq!(attrs.remove(answer), Some(Attribute::Int(42)));
         assert!(attrs.is_empty());
     }
 

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -113,7 +113,7 @@ fn describe_value(ctx: &IrContext, v: ValueRef) -> String {
         ValueDef::OpResult(op, idx) => {
             let data = ctx.op(op);
             let full_name = format!("{}.{}", data.dialect, data.name);
-            match data.attributes.get(&Symbol::new("sym_name")) {
+            match data.attributes.get("sym_name") {
                 Some(super::types::Attribute::Symbol(s)) => {
                     format!("result #{} of {} (@{})", idx, full_name, s)
                 }
@@ -203,7 +203,7 @@ fn validate_functions_in_region(
                 // This is a func.func or wasm.func
                 let fn_name = data
                     .attributes
-                    .get(&Symbol::new("sym_name"))
+                    .get("sym_name")
                     .and_then(|a| match a {
                         super::types::Attribute::Symbol(s) => Some(s.to_string()),
                         _ => None,
@@ -353,9 +353,7 @@ fn validate_arith_cmpf_predicate(ctx: &IrContext, op: OpRef, errors: &mut Vec<Va
         return;
     }
 
-    let Some(super::types::Attribute::Symbol(predicate)) =
-        data.attributes.get(&Symbol::new("predicate"))
-    else {
+    let Some(super::types::Attribute::Symbol(predicate)) = data.attributes.get("predicate") else {
         errors.push(operation_verifier_error(
             ctx,
             op,
@@ -528,12 +526,12 @@ fn collect_function_signatures(ctx: &IrContext, module_body: RegionRef) -> HashM
             }
 
             let Some(&super::types::Attribute::Symbol(sym_name)) =
-                data.attributes.get(&sym_name_key)
+                data.attributes.get(sym_name_key)
             else {
                 continue;
             };
 
-            let Some(&super::types::Attribute::Type(func_ty)) = data.attributes.get(&type_key)
+            let Some(&super::types::Attribute::Type(func_ty)) = data.attributes.get(type_key)
             else {
                 continue;
             };
@@ -576,7 +574,7 @@ fn check_call_arity_in_region(
             return std::ops::ControlFlow::Continue(walk::WalkAction::Advance);
         }
 
-        let Some(&super::types::Attribute::Symbol(callee_sym)) = data.attributes.get(&callee_key)
+        let Some(&super::types::Attribute::Symbol(callee_sym)) = data.attributes.get(callee_key)
         else {
             return std::ops::ControlFlow::Continue(walk::WalkAction::Advance);
         };
@@ -629,7 +627,7 @@ pub fn validate_call_arity(ctx: &IrContext, module: Module) {
 
             let fn_name = data
                 .attributes
-                .get(&sym_name_key)
+                .get(sym_name_key)
                 .and_then(|a| match a {
                     super::types::Attribute::Symbol(s) => Some(s.to_string()),
                     _ => None,
@@ -688,8 +686,6 @@ mod tests {
     use crate::types::{Attribute, Location};
     use crate::{BlockArgData, BlockData, IrContext, RegionData, TypeDataBuilder};
     use smallvec::smallvec;
-    use std::collections::BTreeMap;
-
     fn test_location(ctx: &mut IrContext) -> Location {
         let path = ctx.paths.intern("test.trb".to_owned());
         Location::new(path, Span::new(0, 0))
@@ -951,7 +947,7 @@ mod tests {
             location: loc,
             args: vec![BlockArgData {
                 ty: i32_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             }],
             ops: smallvec![],
             parent_region: None,
@@ -1021,7 +1017,7 @@ mod tests {
             location: loc,
             args: vec![BlockArgData {
                 ty: i32_ty,
-                attrs: BTreeMap::new(),
+                attrs: Default::default(),
             }],
             ops: smallvec![],
             parent_region: None,

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -113,8 +113,8 @@ fn describe_value(ctx: &IrContext, v: ValueRef) -> String {
         ValueDef::OpResult(op, idx) => {
             let data = ctx.op(op);
             let full_name = format!("{}.{}", data.dialect, data.name);
-            match data.attributes.get("sym_name") {
-                Some(super::types::Attribute::Symbol(s)) => {
+            match data.attributes.get_symbol("sym_name") {
+                Some(s) => {
                     format!("result #{} of {} (@{})", idx, full_name, s)
                 }
                 _ => format!("result #{} of {}", idx, full_name),

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -203,11 +203,8 @@ fn validate_functions_in_region(
                 // This is a func.func or wasm.func
                 let fn_name = data
                     .attributes
-                    .get("sym_name")
-                    .and_then(|a| match a {
-                        super::types::Attribute::Symbol(s) => Some(s.to_string()),
-                        _ => None,
-                    })
+                    .get_symbol("sym_name")
+                    .map(|s| s.to_string())
                     .unwrap_or_else(|| "<unnamed>".to_string());
 
                 // Check operands with visibility-based scoping.
@@ -353,7 +350,7 @@ fn validate_arith_cmpf_predicate(ctx: &IrContext, op: OpRef, errors: &mut Vec<Va
         return;
     }
 
-    let Some(super::types::Attribute::Symbol(predicate)) = data.attributes.get("predicate") else {
+    let Some(predicate) = data.attributes.get_symbol("predicate") else {
         errors.push(operation_verifier_error(
             ctx,
             op,
@@ -362,7 +359,7 @@ fn validate_arith_cmpf_predicate(ctx: &IrContext, op: OpRef, errors: &mut Vec<Va
         return;
     };
 
-    if !is_allowed_cmpf_predicate(*predicate) {
+    if !is_allowed_cmpf_predicate(predicate) {
         errors.push(operation_verifier_error(
             ctx,
             op,
@@ -525,14 +522,11 @@ fn collect_function_signatures(ctx: &IrContext, module_body: RegionRef) -> HashM
                 continue;
             }
 
-            let Some(&super::types::Attribute::Symbol(sym_name)) =
-                data.attributes.get(sym_name_key)
-            else {
+            let Some(sym_name) = data.attributes.get_symbol(sym_name_key) else {
                 continue;
             };
 
-            let Some(&super::types::Attribute::Type(func_ty)) = data.attributes.get(type_key)
-            else {
+            let Some(func_ty) = data.attributes.get_type(type_key) else {
                 continue;
             };
 
@@ -574,8 +568,7 @@ fn check_call_arity_in_region(
             return std::ops::ControlFlow::Continue(walk::WalkAction::Advance);
         }
 
-        let Some(&super::types::Attribute::Symbol(callee_sym)) = data.attributes.get(callee_key)
-        else {
+        let Some(callee_sym) = data.attributes.get_symbol(callee_key) else {
             return std::ops::ControlFlow::Continue(walk::WalkAction::Advance);
         };
 
@@ -627,11 +620,8 @@ pub fn validate_call_arity(ctx: &IrContext, module: Module) {
 
             let fn_name = data
                 .attributes
-                .get(sym_name_key)
-                .and_then(|a| match a {
-                    super::types::Attribute::Symbol(s) => Some(s.to_string()),
-                    _ => None,
-                })
+                .get_symbol(sym_name_key)
+                .map(|s| s.to_string())
                 .unwrap_or_else(|| "<unnamed>".to_string());
 
             for &func_region in &data.regions {

--- a/examples/salsa_usage.rs
+++ b/examples/salsa_usage.rs
@@ -6,7 +6,6 @@
 use salsa::Setter;
 use tree_sitter::Parser;
 use tribute::{SourceCst, TributeDatabaseImpl, compile_frontend};
-use trunk_ir::Attribute;
 use trunk_ir::Symbol;
 
 fn main() {
@@ -57,7 +56,7 @@ fn basic_database_usage() {
     for (i, op_ref) in ops.iter().enumerate() {
         let op_data = ctx.op(*op_ref);
         if op_data.dialect == Symbol::new("func") && op_data.name == Symbol::new("func") {
-            if let Some(Attribute::Symbol(name)) = op_data.attributes.get("sym_name") {
+            if let Some(name) = op_data.attributes.get_symbol("sym_name") {
                 println!("  Operation {}: func.func \"{}\"", i + 1, name);
             }
         } else {

--- a/examples/salsa_usage.rs
+++ b/examples/salsa_usage.rs
@@ -57,8 +57,7 @@ fn basic_database_usage() {
     for (i, op_ref) in ops.iter().enumerate() {
         let op_data = ctx.op(*op_ref);
         if op_data.dialect == Symbol::new("func") && op_data.name == Symbol::new("func") {
-            if let Some(Attribute::Symbol(name)) = op_data.attributes.get(&Symbol::new("sym_name"))
-            {
+            if let Some(Attribute::Symbol(name)) = op_data.attributes.get("sym_name") {
                 println!("  Operation {}: func.func \"{}\"", i + 1, name);
             }
         } else {

--- a/tests/e2e_add.rs
+++ b/tests/e2e_add.rs
@@ -415,8 +415,7 @@ fn main() { }
         let has_lifted = m.ops(&ctx).iter().any(|&op_ref| {
             let op_data = ctx.op(op_ref);
             if op_data.dialect == func_dialect && op_data.name == func_name {
-                if let Some(trunk_ir::Attribute::Symbol(name)) =
-                    op_data.attributes.get(&Symbol::new("sym_name"))
+                if let Some(trunk_ir::Attribute::Symbol(name)) = op_data.attributes.get("sym_name")
                 {
                     name.last_segment()
                         .with_str(|s: &str| s.starts_with("__clam_"))

--- a/tests/e2e_add.rs
+++ b/tests/e2e_add.rs
@@ -414,17 +414,15 @@ fn main() { }
 
         let has_lifted = m.ops(&ctx).iter().any(|&op_ref| {
             let op_data = ctx.op(op_ref);
-            if op_data.dialect == func_dialect && op_data.name == func_name {
-                if let Some(trunk_ir::Attribute::Symbol(name)) = op_data.attributes.get("sym_name")
-                {
-                    name.last_segment()
-                        .with_str(|s: &str| s.starts_with("__clam_"))
-                } else {
-                    false
-                }
-            } else {
-                false
-            }
+            op_data.dialect == func_dialect
+                && op_data.name == func_name
+                && op_data
+                    .attributes
+                    .get_symbol("sym_name")
+                    .is_some_and(|name| {
+                        name.last_segment()
+                            .with_str(|s: &str| s.starts_with("__clam_"))
+                    })
         });
 
         assert!(

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -95,9 +95,11 @@ fn function_param_names(ctx: &IrContext, module: &Module, target: &str) -> Vec<S
     ctx.block(entry)
         .args
         .iter()
-        .map(|arg| match arg.attrs.get("bind_name") {
-            Some(trunk_ir::Attribute::Symbol(name)) => name.to_string(),
-            _ => "_".to_owned(),
+        .map(|arg| {
+            arg.attrs
+                .get_symbol("bind_name")
+                .map(|name| name.to_string())
+                .unwrap_or_else(|| "_".to_owned())
         })
         .collect()
 }

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -95,12 +95,10 @@ fn function_param_names(ctx: &IrContext, module: &Module, target: &str) -> Vec<S
     ctx.block(entry)
         .args
         .iter()
-        .map(
-            |arg| match arg.attrs.get(&trunk_ir::Symbol::new("bind_name")) {
-                Some(trunk_ir::Attribute::Symbol(name)) => name.to_string(),
-                _ => "_".to_owned(),
-            },
-        )
+        .map(|arg| match arg.attrs.get("bind_name") {
+            Some(trunk_ir::Attribute::Symbol(name)) => name.to_string(),
+            _ => "_".to_owned(),
+        })
         .collect()
 }
 

--- a/tests/salsa_integration.rs
+++ b/tests/salsa_integration.rs
@@ -19,9 +19,8 @@ fn find_func_by_name(ctx: &IrContext, module: &Module, name: &str) -> bool {
         if op_data.dialect == func_dialect && op_data.name == func_name {
             op_data
                 .attributes
-                .get(sym_name_key)
-                .map(|attr| matches!(attr, trunk_ir::types::Attribute::Symbol(s) if *s == name))
-                .unwrap_or(false)
+                .get_symbol(sym_name_key)
+                .is_some_and(|symbol| symbol == name)
         } else {
             false
         }

--- a/tests/salsa_integration.rs
+++ b/tests/salsa_integration.rs
@@ -19,7 +19,7 @@ fn find_func_by_name(ctx: &IrContext, module: &Module, name: &str) -> bool {
         if op_data.dialect == func_dialect && op_data.name == func_name {
             op_data
                 .attributes
-                .get(&sym_name_key)
+                .get(sym_name_key)
                 .map(|attr| matches!(attr, trunk_ir::types::Attribute::Symbol(s) if *s == name))
                 .unwrap_or(false)
         } else {


### PR DESCRIPTION
## Summary

- Add attribute-map support throughout Trunk IR, dialects, rewrites, validation, and backends
- Update Tribute lowering and native/Wasm passes to use the new attribute representation
- Adjust affected examples and end-to-end tests

## Testing

Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a richer, typed attribute system with convenient accessors for symbols, strings/text, types, booleans, and integers.
  * Added safe integer range validation and a non-interning symbol lookup helper.
  * Exposed an attribute-map abstraction and expanded public IR utilities for querying attributes.

* **Refactor**
  * Standardized metadata/attribute retrieval across compilation, native, and WebAssembly pipelines.
  * Simplified attribute handling while preserving existing lowering and code generation behavior.

* **Tests**
  * Updated unit and integration tests to use the new typed attribute access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->