### PR TITLE
Preserve effect annotation origins for duplicate diagnostics

### DIFF
--- a/crates/tribute-front/src/ast/types.rs
+++ b/crates/tribute-front/src/ast/types.rs
@@ -393,6 +393,68 @@ pub struct EffectVar {
 // Shared annotation → EffectRow conversion
 // =========================================================================
 
+/// Source origins for the concrete effects produced from an annotation list.
+///
+/// The IDs have the same order as the concrete effects in the converted row.
+/// Row-variable annotations are intentionally omitted. Keeping this metadata
+/// outside [`EffectRow`] preserves the row's semantic identity.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EffectAnnotationOrigins {
+    concrete: Vec<NodeId>,
+}
+
+impl EffectAnnotationOrigins {
+    /// Find the first duplicate in a resolved effect row and recover both
+    /// annotation origins associated with it.
+    pub fn find_duplicate<'db>(
+        &self,
+        db: &'db dyn salsa::Database,
+        row: EffectRow<'db>,
+    ) -> Option<DuplicateEffectAnnotations<'db>> {
+        use std::collections::HashMap;
+
+        let effects = row.effects(db);
+        // Solving an open row may append inferred effects after the concrete
+        // annotations. Only the prefix produced by the source conversion has
+        // annotation origins and can represent duplicate annotations.
+        let annotated_effects = &effects[..effects.len().min(self.concrete.len())];
+
+        let mut first_origins = HashMap::<Effect<'db>, NodeId>::new();
+        for (effect, &annotation_id) in annotated_effects.iter().zip(&self.concrete) {
+            if let Some(&first_annotation_id) = first_origins.get(effect) {
+                let duplicates = annotated_effects
+                    .iter()
+                    .filter(|candidate| *candidate == effect)
+                    .cloned()
+                    .collect();
+                return Some(DuplicateEffectAnnotations {
+                    effects: duplicates,
+                    first_annotation_id,
+                    duplicate_annotation_id: annotation_id,
+                });
+            }
+            first_origins.insert(effect.clone(), annotation_id);
+        }
+
+        None
+    }
+}
+
+/// A duplicate effect together with its first and repeated source annotations.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DuplicateEffectAnnotations<'db> {
+    pub effects: Vec<Effect<'db>>,
+    pub first_annotation_id: NodeId,
+    pub duplicate_annotation_id: NodeId,
+}
+
+/// Result of source-aware effect-annotation conversion.
+#[derive(Clone, Debug)]
+pub struct EffectRowConversion<'db> {
+    pub row: EffectRow<'db>,
+    pub origins: EffectAnnotationOrigins,
+}
+
 /// Check whether a symbol name looks like a type variable (starts with lowercase).
 pub fn is_type_variable(name: &Symbol) -> bool {
     name.with_str(|s| s.starts_with(|c: char| c.is_ascii_lowercase()))
@@ -483,7 +545,22 @@ pub fn abilities_to_effect_row<'db>(
     convert_type: &mut impl FnMut(&TypeAnnotation) -> Type<'db>,
     fresh_row_var: impl FnOnce() -> EffectVar,
 ) -> EffectRow<'db> {
+    abilities_to_effect_row_with_origins(db, abilities, prefix, convert_type, fresh_row_var).row
+}
+
+/// Convert ability annotations while preserving each concrete effect's origin.
+///
+/// Consumers that only need semantic effect identity should continue to use
+/// [`abilities_to_effect_row`].
+pub fn abilities_to_effect_row_with_origins<'db>(
+    db: &'db dyn salsa::Database,
+    abilities: &[TypeAnnotation],
+    prefix: &str,
+    convert_type: &mut impl FnMut(&TypeAnnotation) -> Type<'db>,
+    fresh_row_var: impl FnOnce() -> EffectVar,
+) -> EffectRowConversion<'db> {
     let mut effects = Vec::new();
+    let mut concrete_origins = Vec::new();
     let mut has_row_var = false;
 
     for ann in abilities {
@@ -497,6 +574,7 @@ pub fn abilities_to_effect_row<'db>(
             _ => {
                 if let Some(effect) = annotation_to_effect(db, ann, prefix, convert_type) {
                     effects.push(effect);
+                    concrete_origins.push(ann.id);
                 }
             }
         }
@@ -508,7 +586,12 @@ pub fn abilities_to_effect_row<'db>(
         None
     };
 
-    EffectRow::new(db, effects, rest)
+    EffectRowConversion {
+        row: EffectRow::new(db, effects, rest),
+        origins: EffectAnnotationOrigins {
+            concrete: concrete_origins,
+        },
+    }
 }
 
 /// Type annotation as written in source code.

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -103,10 +103,10 @@ impl<'db> TypeChecker<'db> {
             });
 
         // Build effect row from annotations (effects don't have BoundVars for now)
-        let effect = match &func.effects {
+        let (effect, effect_origins) = match &func.effects {
             Some(anns) => {
                 // For effects, we use a closed row during collection
-                crate::ast::abilities_to_effect_row(
+                let conversion = crate::ast::abilities_to_effect_row_with_origins(
                     self.db(),
                     anns,
                     self.current_prefix(),
@@ -114,11 +114,12 @@ impl<'db> TypeChecker<'db> {
                         self.annotation_to_type_for_sig(ann, &mut type_var_map, &mut next_bound_var)
                     },
                     || EffectVar { id: 0 }, // Placeholder, will be replaced during function check
-                )
+                );
+                (conversion.row, Some(conversion.origins))
             }
             // Omitting the annotation is effect-polymorphic (`->{e}`), not
             // an assertion that the row is closed and empty.
-            None => EffectRow::open(self.db(), EffectVar { id: 0 }),
+            None => (EffectRow::open(self.db(), EffectVar { id: 0 }), None),
         };
 
         let func_ty = self.env.func_type(param_types, return_ty, effect);
@@ -132,6 +133,9 @@ impl<'db> TypeChecker<'db> {
 
         // Register the function with its FuncDefId
         let func_id = self.func_def_id(func.name);
+        if let Some(origins) = effect_origins {
+            self.effect_annotation_origins.insert(func_id, origins);
+        }
         self.env.register_function(func_id, scheme);
 
         // Register as UFCS method candidate if function has parameters

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -16,7 +16,6 @@ use crate::ast::{
 };
 
 use super::super::constraint::{ConstraintOriginKind, ConstraintSet};
-use super::super::effect_row::find_conflicting_effects;
 use super::super::func_context::FunctionInferenceContext;
 use super::super::solver::{LocatedSolveError, RowSubst, TypeSolver, TypeSubst};
 use super::{Mode, TypeChecker};
@@ -233,17 +232,26 @@ impl<'db> TypeChecker<'db> {
             && let Some(declared) = declared_effect
         {
             let resolved_declared = row_subst.apply(self.db(), declared);
-            if let Some((_, effects)) = find_conflicting_effects(self.db(), resolved_declared) {
-                Diagnostic::new(
+            if let Some(duplicate) = self
+                .effect_annotation_origins
+                .get(&func_id)
+                .and_then(|origins| origins.find_duplicate(self.db(), resolved_declared))
+            {
+                Diagnostic::builder(
                     format!(
                         "function '{}' declares duplicate effect: {}",
                         func.name,
-                        effects.iter().format(", "),
+                        duplicate.effects.iter().format(", "),
                     ),
-                    self.get_span(func.id),
+                    self.get_span(duplicate.duplicate_annotation_id),
                     DiagnosticSeverity::Error,
                     CompilationPhase::TypeChecking,
                 )
+                .label(
+                    self.get_span(duplicate.first_annotation_id),
+                    "first matching effect annotation is here",
+                )
+                .build()
                 .accumulate(self.db());
             }
 

--- a/crates/tribute-front/src/typeck/checker/mod.rs
+++ b/crates/tribute-front/src/typeck/checker/mod.rs
@@ -72,6 +72,8 @@ pub struct TypeChecker<'db> {
     /// Accumulated node types from all functions.
     /// Collects NodeId → Type mappings during type checking.
     node_types: HashMap<NodeId, Type<'db>>,
+    /// Source origins for concrete effects in each collected function signature.
+    effect_annotation_origins: HashMap<FuncDefId<'db>, crate::ast::EffectAnnotationOrigins>,
 }
 
 impl<'db> TypeChecker<'db> {
@@ -82,6 +84,7 @@ impl<'db> TypeChecker<'db> {
             prefix: String::new(),
             span_map,
             node_types: HashMap::new(),
+            effect_annotation_origins: HashMap::new(),
         }
     }
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -770,6 +770,12 @@ contract as secondary context. A frontend error stops the pipeline before AST
 to IR conversion and shared lowering so invalid source does not produce
 cascading diagnostics containing internal IR operation identities.
 
+Effect-annotation conversion also preserves the source origin of each concrete
+effect separately from the semantic `EffectRow`. Duplicate annotations are
+diagnosed at the repeated annotation after solving, with the first matching
+annotation attached as secondary context; parameterized and qualified effects
+keep the origin recorded at their shared annotation-to-row conversion point.
+
 ### 점진적 개선 방향: Fine-Grained Queries
 
 현재 구조는 모듈 단위(coarse-grained) 처리를 한다. 장기적으로

--- a/tests/diagnostic_snapshots.rs
+++ b/tests/diagnostic_snapshots.rs
@@ -270,11 +270,7 @@ fn diag_duplicate_effect_in_annotation(db: &salsa::DatabaseImpl) {
         db,
         "test.trb",
         r#"
-ability State(s) {
-    op get() -> s
-}
-
-fn test() ->{State(Int), State(Int)} Nil {
+fn test() ->{abilities::Throw(Int), abilities::Throw(Int)} Nil {
     Nil
 }
 "#,

--- a/tests/snapshots/diagnostic_snapshots__diag_duplicate_effect_in_annotation.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_duplicate_effect_in_annotation.snap
@@ -2,9 +2,14 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
-- message: "function 'test' declares duplicate effect: State(Int), State(Int)"
+- message: "function 'test' declares duplicate effect: Throw(Int), Throw(Int)"
   span:
-    start: 41
-    end: 93
+    start: 37
+    end: 58
   severity: Error
+  labels:
+    - span:
+        start: 14
+        end: 35
+      message: first matching effect annotation is here
   phase: TypeChecking


### PR DESCRIPTION
## Summary

- preserve the source `NodeId` ordering for concrete effect annotations alongside, but outside, semantic `EffectRow` identity
- use the preserved origins after effect-row solving to anchor duplicate diagnostics at the repeated annotation and label the first occurrence
- strengthen the diagnostic snapshot with a qualified parameterized effect and document the source-origin contract in `new-plans/implementation.md`

## Root cause

The shared annotation-to-effect-row conversion discarded each annotation's source identity. Duplicate detection therefore knew which semantic effects conflicted, but could only anchor the diagnostic to the entire function declaration.

The new focused conversion result keeps source metadata separate from `EffectRow`, so existing type-checking and TDNR consumers retain the same semantic behavior without a second AST traversal.

## Validation

- pre-commit checks: clippy and formatting passed
- workspace nextest: 1,577 passed, 10 skipped
- `cargo nextest run -p tribute-front`: 516 passed, 1 skipped
- diagnostic snapshots: 21 passed, 2 ignored
- `cargo check --workspace`
- `cargo clippy -p tribute-front --all-targets -- -D warnings`

Closes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate effect annotation diagnostics.
  - Errors now identify the repeated annotation and reference the original matching annotation for clearer guidance.
  - Preserved accurate source locations for concrete effects, including parameterized and qualified effects.

- **Tests**
  - Updated diagnostic coverage for duplicate `Throw(Int)` effect annotations.

- **Documentation**
  - Clarified how effect annotation origins are preserved and reported during type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->