### PR TITLE
Propagate trusted RC ownership summaries

### DIFF
--- a/crates/tribute-passes/src/native/mod.rs
+++ b/crates/tribute-passes/src/native/mod.rs
@@ -19,6 +19,7 @@ pub mod entrypoint;
 pub mod evidence;
 pub mod intrinsic_to_native;
 pub mod io;
+pub mod ownership_summary;
 pub mod rc_insertion;
 pub mod rc_lowering;
 pub mod rc_optimization;

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -254,10 +254,21 @@ fn collect_escaping_function_symbols(
         let Ok(function) = func::Func::from_op(ctx, op) else {
             continue;
         };
-        visit_region_ops(ctx, function.body(ctx), &mut |nested| {
-            let symbol = if let Ok(constant) = func::Constant::from_op(ctx, nested) {
+        collect_escaping_function_symbols_in_region(ctx, function.body(ctx), functions, ineligible);
+    }
+}
+
+fn collect_escaping_function_symbols_in_region(
+    ctx: &IrContext,
+    region: RegionRef,
+    functions: &HashMap<Symbol, OpRef>,
+    ineligible: &mut HashSet<Symbol>,
+) {
+    for &block in &ctx.region(region).blocks {
+        for &op in &ctx.block(block).ops {
+            let symbol = if let Ok(constant) = func::Constant::from_op(ctx, op) {
                 Some(constant.func_ref(ctx))
-            } else if let Ok(tail_call) = func::TailCall::from_op(ctx, nested) {
+            } else if let Ok(tail_call) = func::TailCall::from_op(ctx, op) {
                 Some(tail_call.callee(ctx))
             } else {
                 None
@@ -267,7 +278,70 @@ fn collect_escaping_function_symbols(
             {
                 ineligible.insert(symbol);
             }
-        });
+
+            if let Ok(nested_function) = func::Func::from_op(ctx, op) {
+                collect_escaping_function_symbols_in_region(
+                    ctx,
+                    nested_function.body(ctx),
+                    functions,
+                    ineligible,
+                );
+            } else {
+                for &nested in &ctx.op(op).regions {
+                    collect_escaping_function_symbols_in_region(ctx, nested, functions, ineligible);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BorrowedUseKind {
+    LoadAddress,
+    StoreAddress { address_operand: usize },
+    Comparison,
+    TransparentAlias,
+    DirectCall,
+    Escaping,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BorrowedUse {
+    Safe,
+    TransparentAlias(ValueRef),
+    DirectCall,
+    Escaping,
+}
+
+pub(super) fn classify_borrowed_use(
+    ctx: &IrContext,
+    body: RegionRef,
+    op: OpRef,
+    operand_index: usize,
+    kind: BorrowedUseKind,
+) -> BorrowedUse {
+    let Some(parent_block) = ctx.op(op).parent_block else {
+        return BorrowedUse::Escaping;
+    };
+    if ctx.block(parent_block).parent_region != Some(body) {
+        return BorrowedUse::Escaping;
+    }
+
+    match kind {
+        BorrowedUseKind::LoadAddress if operand_index == 0 => BorrowedUse::Safe,
+        BorrowedUseKind::StoreAddress { address_operand } if operand_index == address_operand => {
+            BorrowedUse::Safe
+        }
+        BorrowedUseKind::Comparison => BorrowedUse::Safe,
+        BorrowedUseKind::TransparentAlias
+            if operand_index == 0
+                && ctx.op_operands(op).len() == 1
+                && ctx.op_results(op).len() == 1 =>
+        {
+            BorrowedUse::TransparentAlias(ctx.op_results(op)[0])
+        }
+        BorrowedUseKind::DirectCall => BorrowedUse::DirectCall,
+        _ => BorrowedUse::Escaping,
     }
 }
 
@@ -283,67 +357,56 @@ fn value_is_borrowed(
     }
     ctx.uses(value).iter().all(|use_| {
         let op = use_.user;
-        let Some(parent_block) = ctx.op(op).parent_block else {
-            return false;
-        };
-        if ctx.block(parent_block).parent_region != Some(body) {
-            return false;
-        }
         let operand_index = use_.operand_index as usize;
-        if let Ok(call) = func::Call::from_op(ctx, op) {
-            return summaries
-                .get(&call.callee(ctx))
-                .and_then(|summary| summary.get(operand_index))
-                == Some(&ParameterOwnership::Borrowed);
+        match classify_borrowed_use(ctx, body, op, operand_index, borrowed_use_kind(ctx, op)) {
+            BorrowedUse::Safe => true,
+            BorrowedUse::TransparentAlias(alias) => {
+                value_is_borrowed(ctx, body, alias, summaries, visited)
+            }
+            BorrowedUse::DirectCall => {
+                let call = func::Call::from_op(ctx, op).expect("classified func.call");
+                summaries
+                    .get(&call.callee(ctx))
+                    .and_then(|summary| summary.get(operand_index))
+                    == Some(&ParameterOwnership::Borrowed)
+            }
+            BorrowedUse::Escaping => false,
         }
-        if is_transparent_alias(ctx, op, operand_index) {
-            return ctx.op_results(op).len() == 1
-                && value_is_borrowed(ctx, body, ctx.op_results(op)[0], summaries, visited);
-        }
-        is_local_borrowed_use(ctx, op, operand_index)
     })
 }
 
-fn is_transparent_alias(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
-    operand_index == 0
-        && (core::UnrealizedConversionCast::matches(ctx, op)
-            || adt::VariantCast::matches(ctx, op)
-            || adt::RefCast::matches(ctx, op))
-}
-
-fn is_local_borrowed_use(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+fn borrowed_use_kind(ctx: &IrContext, op: OpRef) -> BorrowedUseKind {
+    if func::Call::matches(ctx, op) {
+        return BorrowedUseKind::DirectCall;
+    }
     if mem::Load::matches(ctx, op) || clif::Load::matches(ctx, op) {
-        return operand_index == 0;
+        return BorrowedUseKind::LoadAddress;
     }
     if mem::Store::matches(ctx, op) {
-        return operand_index == 0;
+        return BorrowedUseKind::StoreAddress { address_operand: 0 };
     }
     if clif::Store::matches(ctx, op) {
-        return operand_index == 1;
+        return BorrowedUseKind::StoreAddress { address_operand: 1 };
     }
     if arith::Cmpi::matches(ctx, op) || clif::Icmp::matches(ctx, op) {
-        return true;
+        return BorrowedUseKind::Comparison;
     }
-    operand_index == 0
-        && (adt::StructGet::matches(ctx, op)
-            || adt::VariantIs::matches(ctx, op)
-            || adt::VariantGet::matches(ctx, op)
-            || adt::ArrayGet::matches(ctx, op)
-            || adt::ArrayLen::matches(ctx, op)
-            || adt::RefIsNull::matches(ctx, op))
-}
-
-fn visit_region_ops(ctx: &IrContext, region: RegionRef, visitor: &mut impl FnMut(OpRef)) {
-    for &block in &ctx.region(region).blocks {
-        for &op in &ctx.block(block).ops {
-            visitor(op);
-            if !func::Func::matches(ctx, op) {
-                for &nested in &ctx.op(op).regions {
-                    visit_region_ops(ctx, nested, visitor);
-                }
-            }
-        }
+    if core::UnrealizedConversionCast::matches(ctx, op)
+        || adt::VariantCast::matches(ctx, op)
+        || adt::RefCast::matches(ctx, op)
+    {
+        return BorrowedUseKind::TransparentAlias;
     }
+    if adt::StructGet::matches(ctx, op)
+        || adt::VariantIs::matches(ctx, op)
+        || adt::VariantGet::matches(ctx, op)
+        || adt::ArrayGet::matches(ctx, op)
+        || adt::ArrayLen::matches(ctx, op)
+        || adt::RefIsNull::matches(ctx, op)
+    {
+        return BorrowedUseKind::LoadAddress;
+    }
+    BorrowedUseKind::Escaping
 }
 
 #[cfg(test)]
@@ -386,6 +449,40 @@ mod tests {
 }"#,
         );
         assert_snapshot!("trusted_direct_chain_summaries", summaries);
+    }
+
+    #[test]
+    fn nested_function_references_make_targets_ineligible() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @constant_target(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = mem.load %0 {offset = 0} : core.i32
+    func.return %1
+  }
+  func.func @tail_target(%0: tribute_rt.anyref) -> core.nil {
+    func.return
+  }
+  func.func @outer() -> core.nil {
+    func.func @nested() -> core.nil {
+      %0 = func.constant {func_ref = @constant_target} : core.ptr
+      func.tail_call {callee = @tail_target}
+    }
+    func.return
+  }
+}"#,
+        );
+        let summaries = compute_and_attach(&mut ctx, module, &TypeConverter::new());
+
+        assert_eq!(
+            summaries.summaries.get(&Symbol::new("constant_target")),
+            Some(&vec![ParameterOwnership::Owned])
+        );
+        assert_eq!(
+            summaries.summaries.get(&Symbol::new("tail_target")),
+            Some(&vec![ParameterOwnership::Owned])
+        );
     }
 
     #[test]

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -1,0 +1,494 @@
+use std::collections::{HashMap, HashSet};
+
+use trunk_ir::context::IrContext;
+use trunk_ir::dialect::{adt, arith, clif, core, func, mem};
+use trunk_ir::ops::DialectOp;
+use trunk_ir::rewrite::{Module, TypeConverter};
+use trunk_ir::transforms::call_graph::{build_call_graph, recursive_functions};
+use trunk_ir::{Attribute, OpRef, RegionRef, Symbol, ValueRef};
+
+pub const PARAMETER_OWNERSHIP_ATTR: &str = "tribute.rc.parameter_ownership_v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParameterOwnership {
+    Borrowed,
+    Owned,
+}
+
+impl ParameterOwnership {
+    fn as_attribute(self) -> Attribute {
+        Attribute::Symbol(Symbol::new(match self {
+            Self::Borrowed => "borrowed",
+            Self::Owned => "owned",
+        }))
+    }
+}
+
+pub struct TrustedOwnershipSummaries {
+    summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
+}
+
+pub fn compute_and_attach(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: &TypeConverter,
+) -> TrustedOwnershipSummaries {
+    let Some(module_block) = module.first_block(ctx) else {
+        return TrustedOwnershipSummaries {
+            summaries: HashMap::new(),
+        };
+    };
+    let module_ops = ctx.block(module_block).ops.to_vec();
+    let mut definitions: HashMap<Symbol, Vec<OpRef>> = HashMap::new();
+    for &op in &module_ops {
+        ctx.op_mut(op).attributes.remove(PARAMETER_OWNERSHIP_ATTR);
+        if let Ok(function) = func::Func::from_op(ctx, op) {
+            definitions
+                .entry(function.sym_name(ctx))
+                .or_default()
+                .push(op);
+        }
+    }
+
+    let unique_functions: HashMap<Symbol, OpRef> = definitions
+        .iter()
+        .filter_map(|(&symbol, ops)| (ops.len() == 1).then_some((symbol, ops[0])))
+        .collect();
+    let recursive = recursive_functions(&build_call_graph(ctx, module));
+    let mut ineligible = recursive;
+    for (&symbol, &op) in &unique_functions {
+        if ctx.op(op).attributes.contains_key("abi") {
+            ineligible.insert(symbol);
+        }
+    }
+    collect_escaping_function_symbols(ctx, &module_ops, &unique_functions, &mut ineligible);
+
+    let mut summaries = HashMap::new();
+    for (&symbol, &op) in &unique_functions {
+        let function = func::Func::from_op(ctx, op).expect("collected func.func");
+        let parameters = entry_parameters(ctx, function.body(ctx));
+        let initial: Vec<ParameterOwnership> = parameters
+            .iter()
+            .map(|&parameter| {
+                if !ineligible.contains(&symbol) && lowers_to_anyref(ctx, parameter, type_converter)
+                {
+                    ParameterOwnership::Borrowed
+                } else {
+                    ParameterOwnership::Owned
+                }
+            })
+            .collect();
+        summaries.insert(symbol, initial);
+    }
+
+    loop {
+        let mut changed = false;
+        for (&symbol, &op) in &unique_functions {
+            if ineligible.contains(&symbol) {
+                continue;
+            }
+            let function = func::Func::from_op(ctx, op).expect("collected func.func");
+            let body = function.body(ctx);
+            let parameters = entry_parameters(ctx, body);
+            for (index, &parameter) in parameters.iter().enumerate() {
+                if summaries[&symbol][index] == ParameterOwnership::Borrowed
+                    && !value_is_borrowed(ctx, body, parameter, &summaries, &mut HashSet::new())
+                {
+                    summaries.get_mut(&symbol).expect("summary exists")[index] =
+                        ParameterOwnership::Owned;
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    for (&symbol, &op) in &unique_functions {
+        let entries = summaries[&symbol]
+            .iter()
+            .copied()
+            .map(ParameterOwnership::as_attribute)
+            .collect();
+        ctx.op_mut(op).attributes.insert(
+            Symbol::new(PARAMETER_OWNERSHIP_ATTR),
+            Attribute::List(entries),
+        );
+    }
+
+    TrustedOwnershipSummaries { summaries }
+}
+
+impl TrustedOwnershipSummaries {
+    pub fn validated_for_clif(
+        &self,
+        ctx: &IrContext,
+        module_ops: &[OpRef],
+    ) -> HashMap<Symbol, Vec<ParameterOwnership>> {
+        let mut definitions: HashMap<Symbol, Vec<OpRef>> = HashMap::new();
+        for &op in module_ops {
+            if let Ok(function) = clif::Func::from_op(ctx, op) {
+                definitions
+                    .entry(function.sym_name(ctx))
+                    .or_default()
+                    .push(op);
+            }
+        }
+
+        self.summaries
+            .iter()
+            .filter_map(|(&symbol, expected)| {
+                let ops = definitions.get(&symbol)?;
+                if ops.len() != 1 {
+                    return None;
+                }
+                let function = clif::Func::from_op(ctx, ops[0]).ok()?;
+                let parameters = entry_parameters(ctx, function.body(ctx));
+                if parameters.len() != expected.len() {
+                    return None;
+                }
+                if expected
+                    .iter()
+                    .zip(&parameters)
+                    .any(|(ownership, &parameter)| {
+                        *ownership == ParameterOwnership::Borrowed
+                            && !is_anyref_value(ctx, parameter)
+                    })
+                {
+                    return None;
+                }
+                let Attribute::List(entries) =
+                    ctx.op(ops[0]).attributes.get(PARAMETER_OWNERSHIP_ATTR)?
+                else {
+                    return None;
+                };
+                let actual: Option<Vec<_>> = entries
+                    .iter()
+                    .map(|entry| match entry {
+                        Attribute::Symbol(value) if *value == Symbol::new("borrowed") => {
+                            Some(ParameterOwnership::Borrowed)
+                        }
+                        Attribute::Symbol(value) if *value == Symbol::new("owned") => {
+                            Some(ParameterOwnership::Owned)
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                let actual = actual?;
+                if actual != *expected {
+                    return None;
+                }
+                Some((symbol, actual))
+            })
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn attach_locally_borrowed_for_tests(ctx: &mut IrContext, module: Module) -> Self {
+        let Some(module_block) = module.first_block(ctx) else {
+            return Self {
+                summaries: HashMap::new(),
+            };
+        };
+        let mut summaries = HashMap::new();
+        let op_count = ctx.block(module_block).ops.len();
+        for index in 0..op_count {
+            let op = ctx.block(module_block).ops[index];
+            let Ok(function) = clif::Func::from_op(ctx, op) else {
+                continue;
+            };
+            let symbol = function.sym_name(ctx);
+            let summary: Vec<_> = entry_parameters(ctx, function.body(ctx))
+                .into_iter()
+                .map(|parameter| {
+                    if is_anyref_value(ctx, parameter) {
+                        ParameterOwnership::Borrowed
+                    } else {
+                        ParameterOwnership::Owned
+                    }
+                })
+                .collect();
+            let entries = summary
+                .iter()
+                .copied()
+                .map(ParameterOwnership::as_attribute)
+                .collect();
+            ctx.op_mut(op).attributes.insert(
+                Symbol::new(PARAMETER_OWNERSHIP_ATTR),
+                Attribute::List(entries),
+            );
+            summaries.insert(symbol, summary);
+        }
+        Self { summaries }
+    }
+}
+
+fn entry_parameters(ctx: &IrContext, body: RegionRef) -> Vec<ValueRef> {
+    ctx.region(body)
+        .blocks
+        .first()
+        .map(|&entry| ctx.block_args(entry).to_vec())
+        .unwrap_or_default()
+}
+
+fn is_anyref_value(ctx: &IrContext, value: ValueRef) -> bool {
+    let ty = ctx.types.get(ctx.value_ty(value));
+    ty.dialect == Symbol::new("tribute_rt") && ty.name == Symbol::new("anyref")
+}
+
+fn lowers_to_anyref(ctx: &mut IrContext, value: ValueRef, type_converter: &TypeConverter) -> bool {
+    let original = ctx.value_ty(value);
+    let converted = type_converter.convert_type_or_identity(ctx, original);
+    let ty = ctx.types.get(converted);
+    ty.dialect == Symbol::new("tribute_rt") && ty.name == Symbol::new("anyref")
+}
+
+fn collect_escaping_function_symbols(
+    ctx: &IrContext,
+    module_ops: &[OpRef],
+    functions: &HashMap<Symbol, OpRef>,
+    ineligible: &mut HashSet<Symbol>,
+) {
+    for &op in module_ops {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            continue;
+        };
+        visit_region_ops(ctx, function.body(ctx), &mut |nested| {
+            let symbol = if let Ok(constant) = func::Constant::from_op(ctx, nested) {
+                Some(constant.func_ref(ctx))
+            } else if let Ok(tail_call) = func::TailCall::from_op(ctx, nested) {
+                Some(tail_call.callee(ctx))
+            } else {
+                None
+            };
+            if let Some(symbol) = symbol
+                && functions.contains_key(&symbol)
+            {
+                ineligible.insert(symbol);
+            }
+        });
+    }
+}
+
+fn value_is_borrowed(
+    ctx: &IrContext,
+    body: RegionRef,
+    value: ValueRef,
+    summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
+    visited: &mut HashSet<ValueRef>,
+) -> bool {
+    if !visited.insert(value) {
+        return true;
+    }
+    ctx.uses(value).iter().all(|use_| {
+        let op = use_.user;
+        let Some(parent_block) = ctx.op(op).parent_block else {
+            return false;
+        };
+        if ctx.block(parent_block).parent_region != Some(body) {
+            return false;
+        }
+        let operand_index = use_.operand_index as usize;
+        if let Ok(call) = func::Call::from_op(ctx, op) {
+            return summaries
+                .get(&call.callee(ctx))
+                .and_then(|summary| summary.get(operand_index))
+                == Some(&ParameterOwnership::Borrowed);
+        }
+        if is_transparent_alias(ctx, op, operand_index) {
+            return ctx.op_results(op).len() == 1
+                && value_is_borrowed(ctx, body, ctx.op_results(op)[0], summaries, visited);
+        }
+        is_local_borrowed_use(ctx, op, operand_index)
+    })
+}
+
+fn is_transparent_alias(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+    operand_index == 0
+        && (core::UnrealizedConversionCast::matches(ctx, op)
+            || adt::VariantCast::matches(ctx, op)
+            || adt::RefCast::matches(ctx, op))
+}
+
+fn is_local_borrowed_use(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+    if mem::Load::matches(ctx, op) || clif::Load::matches(ctx, op) {
+        return operand_index == 0;
+    }
+    if mem::Store::matches(ctx, op) {
+        return operand_index == 0;
+    }
+    if clif::Store::matches(ctx, op) {
+        return operand_index == 1;
+    }
+    if arith::Cmpi::matches(ctx, op) || clif::Icmp::matches(ctx, op) {
+        return true;
+    }
+    operand_index == 0
+        && (adt::StructGet::matches(ctx, op)
+            || adt::VariantIs::matches(ctx, op)
+            || adt::VariantGet::matches(ctx, op)
+            || adt::ArrayGet::matches(ctx, op)
+            || adt::ArrayLen::matches(ctx, op)
+            || adt::RefIsNull::matches(ctx, op))
+}
+
+fn visit_region_ops(ctx: &IrContext, region: RegionRef, visitor: &mut impl FnMut(OpRef)) {
+    for &block in &ctx.region(region).blocks {
+        for &op in &ctx.block(block).ops {
+            visitor(op);
+            if !func::Func::matches(ctx, op) {
+                for &nested in &ctx.op(op).regions {
+                    visit_region_ops(ctx, nested, visitor);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::rc_insertion::{BorrowedParameterPolicy, insert_rc_with_trusted_summaries};
+    use insta::assert_snapshot;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    fn summarize(ir: &str) -> String {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        let type_converter = TypeConverter::new();
+        compute_and_attach(&mut ctx, module, &type_converter);
+        print_module(&ctx, module.op())
+            .lines()
+            .filter(|line| line.contains(PARAMETER_OWNERSHIP_ATTR))
+            .map(str::trim)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn direct_chain_reaches_borrowed_fixed_point() {
+        let summaries = summarize(
+            r#"core.module @test {
+  func.func @leaf(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = mem.load %0 {offset = 0} : core.i32
+    func.return %1
+  }
+  func.func @middle(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = func.call %0 {callee = @leaf} : core.i32
+    func.return %1
+  }
+  func.func @root(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = func.call %0 {callee = @middle} : core.i32
+    func.return %1
+  }
+}"#,
+        );
+        assert_snapshot!("trusted_direct_chain_summaries", summaries);
+    }
+
+    #[test]
+    fn cycles_unknown_indirect_and_external_are_owned() {
+        let summaries = summarize(
+            r#"core.module @test {
+  func.func @left(%0: tribute_rt.anyref) -> core.nil {
+    %1 = func.call %0 {callee = @right} : core.nil
+    func.return
+  }
+  func.func @right(%0: tribute_rt.anyref) -> core.nil {
+    %1 = func.call %0 {callee = @left} : core.nil
+    func.return
+  }
+  func.func @unknown(%0: tribute_rt.anyref) -> core.nil {
+    %1 = func.call %0 {callee = @missing} : core.nil
+    func.return
+  }
+  func.func @indirect(%0: tribute_rt.anyref, %1: core.ptr) -> core.nil {
+    %2 = func.call_indirect %1, %0 : core.nil
+    func.return
+  }
+  func.func @external(%0: tribute_rt.anyref) -> core.nil attributes {abi = "C"} {
+    func.unreachable
+  }
+}"#,
+        );
+        assert_snapshot!("untrusted_call_summaries", summaries);
+    }
+
+    fn lower_func_ops_to_clif(ctx: &mut IrContext, region: RegionRef) {
+        let blocks = ctx.region(region).blocks.to_vec();
+        for block in blocks {
+            let ops = ctx.block(block).ops.to_vec();
+            for op in ops {
+                let regions = ctx.op(op).regions.to_vec();
+                if func::Func::matches(ctx, op)
+                    || func::Call::matches(ctx, op)
+                    || func::Return::matches(ctx, op)
+                {
+                    ctx.op_mut(op).dialect = Symbol::new("clif");
+                }
+                for nested in regions {
+                    lower_func_ops_to_clif(ctx, nested);
+                }
+            }
+        }
+    }
+
+    fn rc_after_metadata_mutation(mutate: impl FnOnce(&mut IrContext, OpRef)) -> String {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @leaf(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = clif.load %0 {offset = 0} : core.i32
+    func.return %1
+  }
+  func.func @caller(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = func.call %0 {callee = @leaf} : core.i32
+    func.return %1
+  }
+}"#,
+        );
+        let type_converter = TypeConverter::new();
+        let trusted = compute_and_attach(&mut ctx, module, &type_converter);
+        let module_block = module.first_block(&ctx).expect("module body");
+        let caller = ctx.block(module_block).ops[1];
+        mutate(&mut ctx, caller);
+        let body = module.body(&ctx).expect("module region");
+        lower_func_ops_to_clif(&mut ctx, body);
+        insert_rc_with_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            &trusted,
+        );
+        print_module(&ctx, module.op())
+            .lines()
+            .filter(|line| line.contains("tribute_rt.retain"))
+            .map(str::trim)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn missing_metadata_fails_closed() {
+        let retains = rc_after_metadata_mutation(|ctx, caller| {
+            ctx.op_mut(caller)
+                .attributes
+                .remove(PARAMETER_OWNERSHIP_ATTR);
+        });
+        assert_eq!(retains.matches("tribute_rt.retain").count(), 1, "{retains}");
+    }
+
+    #[test]
+    fn inconsistent_metadata_fails_closed() {
+        let retains = rc_after_metadata_mutation(|ctx, caller| {
+            ctx.op_mut(caller).attributes.insert(
+                Symbol::new(PARAMETER_OWNERSHIP_ATTR),
+                Attribute::List(vec![Attribute::Symbol(Symbol::new("owned"))]),
+            );
+        });
+        assert_eq!(retains.matches("tribute_rt.retain").count(), 1, "{retains}");
+    }
+}

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -46,7 +46,10 @@ use trunk_ir::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 
 use tribute_ir::dialect::tribute_rt;
 
-use super::ownership_summary::{ParameterOwnership, TrustedOwnershipSummaries};
+use super::ownership_summary::{
+    BorrowedUse, BorrowedUseKind, ParameterOwnership, TrustedOwnershipSummaries,
+    classify_borrowed_use,
+};
 
 /// Policy for eliding RC ownership of proven borrowed function parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -447,6 +450,10 @@ pub fn insert_rc_with_trusted_summaries(
 
 /// Insert reference counting operations with independently selectable borrow
 /// policies, then lower all remaining `tribute_rt.anyref` types to `core.ptr`.
+///
+/// Without trusted ownership summaries, `ElideProvenBorrowed` falls back to
+/// preserving parameter ownership; this entrypoint does not perform local-only
+/// borrowed-parameter elision.
 pub fn insert_rc_with_policies(
     ctx: &mut IrContext,
     module: Module,
@@ -1071,52 +1078,41 @@ fn value_is_proven_borrowed(
 
     ctx.uses(value).iter().all(|use_| {
         let op = use_.user;
-        let Some(parent_block) = ctx.op(op).parent_block else {
-            return false;
-        };
-        if ctx.block(parent_block).parent_region != Some(body) {
-            return false;
-        }
-
         let operand_index = use_.operand_index as usize;
-        if let Ok(call) = clif::Call::from_op(ctx, op) {
-            return trusted_summaries
-                .get(&call.callee(ctx))
-                .and_then(|summary| summary.get(operand_index))
-                == Some(&ParameterOwnership::Borrowed);
+        match classify_borrowed_use(ctx, body, op, operand_index, borrowed_use_kind(ctx, op)) {
+            BorrowedUse::Safe => true,
+            BorrowedUse::TransparentAlias(alias) => {
+                value_is_proven_borrowed(ctx, body, alias, trusted_summaries, visited)
+            }
+            BorrowedUse::DirectCall => {
+                let call = clif::Call::from_op(ctx, op).expect("classified clif.call");
+                trusted_summaries
+                    .get(&call.callee(ctx))
+                    .and_then(|summary| summary.get(operand_index))
+                    == Some(&ParameterOwnership::Borrowed)
+            }
+            BorrowedUse::Escaping => false,
         }
-        if is_proven_borrowed_parameter_use(ctx, op, operand_index) {
-            return true;
-        }
-
-        core::UnrealizedConversionCast::matches(ctx, op)
-            && operand_index == 0
-            && ctx.op_operands(op).len() == 1
-            && ctx.op_results(op).len() == 1
-            && value_is_proven_borrowed(
-                ctx,
-                body,
-                ctx.op_results(op)[0],
-                trusted_summaries,
-                visited,
-            )
     })
 }
 
-fn is_proven_borrowed_parameter_use(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+fn borrowed_use_kind(ctx: &IrContext, op: OpRef) -> BorrowedUseKind {
+    if clif::Call::matches(ctx, op) {
+        return BorrowedUseKind::DirectCall;
+    }
     if clif::Load::matches(ctx, op) {
-        return operand_index == 0;
+        return BorrowedUseKind::LoadAddress;
     }
-
-    // `clif.store(value, addr)`: using the parameter as the address borrows it;
-    // storing the parameter as the value publishes an owned alias.
     if clif::Store::matches(ctx, op) {
-        return operand_index == 1;
+        return BorrowedUseKind::StoreAddress { address_operand: 1 };
     }
-
-    // Pointer equality/ordering observes the value without extending its
-    // lifetime. All other operations remain escape barriers by default.
-    clif::Icmp::matches(ctx, op)
+    if clif::Icmp::matches(ctx, op) {
+        return BorrowedUseKind::Comparison;
+    }
+    if core::UnrealizedConversionCast::matches(ctx, op) {
+        return BorrowedUseKind::TransparentAlias;
+    }
+    BorrowedUseKind::Escaping
 }
 
 /// Insert RC ops in a single block.

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -1354,6 +1354,13 @@ mod tests {
         run_pass_with_policies(ir, policy, TemporaryBorrowPolicy::Preserve)
     }
 
+    fn run_pass_with_legacy_policy(ir: &str, policy: BorrowedParameterPolicy) -> String {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        insert_rc_with_policy(&mut ctx, module, policy);
+        print_module(&ctx, module.op())
+    }
+
     fn run_pass_with_policies(
         ir: &str,
         parameter_policy: BorrowedParameterPolicy,
@@ -1421,6 +1428,45 @@ mod tests {
             output.matches("tribute_rt.retain").count(),
             output.matches("tribute_rt.release").count(),
         )
+    }
+
+    #[test]
+    fn parameter_and_temporary_borrow_policies_compose_independently() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    %2 = clif.load %1 {offset = 0} : core.i32
+    clif.return %2
+  }
+}"#;
+
+        let preserved = run_pass_with_policies(
+            ir,
+            BorrowedParameterPolicy::Preserve,
+            TemporaryBorrowPolicy::Preserve,
+        );
+        let parameter_only = run_pass_with_policies(
+            ir,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            TemporaryBorrowPolicy::Preserve,
+        );
+        let temporary_only = run_pass_with_policies(
+            ir,
+            BorrowedParameterPolicy::Preserve,
+            TemporaryBorrowPolicy::ElideProvenFieldBorrows,
+        );
+        let composed = run_pass_with_policies(
+            ir,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            TemporaryBorrowPolicy::ElideProvenFieldBorrows,
+        );
+        let legacy = run_pass_with_legacy_policy(ir, BorrowedParameterPolicy::ElideProvenBorrowed);
+
+        assert_eq!(rc_counts(&preserved), (2, 2));
+        assert_eq!(rc_counts(&parameter_only), (1, 1));
+        assert_eq!(rc_counts(&temporary_only), (1, 1));
+        assert_eq!(rc_counts(&composed), (0, 0));
+        assert_eq!(rc_counts(&legacy), (2, 2));
     }
 
     // =========================================================================

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -45,6 +45,8 @@ use trunk_ir::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 
 use tribute_ir::dialect::tribute_rt;
 
+use super::ownership_summary::{ParameterOwnership, TrustedOwnershipSummaries};
+
 /// Policy for eliding RC ownership of proven borrowed function parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BorrowedParameterPolicy {
@@ -387,10 +389,31 @@ pub fn insert_rc_with_policy(
     module: Module,
     borrowed_parameters: BorrowedParameterPolicy,
 ) {
+    insert_rc_impl(ctx, module, borrowed_parameters, None);
+}
+
+pub fn insert_rc_with_trusted_summaries(
+    ctx: &mut IrContext,
+    module: Module,
+    borrowed_parameters: BorrowedParameterPolicy,
+    trusted_summaries: &TrustedOwnershipSummaries,
+) {
+    insert_rc_impl(ctx, module, borrowed_parameters, Some(trusted_summaries));
+}
+
+fn insert_rc_impl(
+    ctx: &mut IrContext,
+    module: Module,
+    borrowed_parameters: BorrowedParameterPolicy,
+    trusted_summaries: Option<&TrustedOwnershipSummaries>,
+) {
     let Some(first_block) = module.first_block(ctx) else {
         return;
     };
     let module_ops: Vec<OpRef> = ctx.block(first_block).ops.to_vec();
+    let trusted_summaries = trusted_summaries
+        .map(|summaries| summaries.validated_for_clif(ctx, &module_ops))
+        .unwrap_or_default();
     let borrow_safe_functions = borrow_safe_functions(ctx, &module_ops);
 
     for op in &module_ops {
@@ -405,7 +428,7 @@ pub fn insert_rc_with_policy(
             } else {
                 BorrowedParameterPolicy::Preserve
             };
-            insert_rc_in_function(ctx, body, function_policy);
+            insert_rc_in_function(ctx, sym, body, function_policy, &trusted_summaries);
         }
     }
 
@@ -621,8 +644,10 @@ fn rewrite_type_anyref(
 /// Insert RC in a function body.
 fn insert_rc_in_function(
     ctx: &mut IrContext,
+    function: Symbol,
     body: RegionRef,
     borrowed_parameter_policy: BorrowedParameterPolicy,
+    trusted_summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
 ) {
     let mut ptr_values = collect_ptr_values(ctx, body);
 
@@ -634,7 +659,9 @@ fn insert_rc_in_function(
     let liveness = compute_liveness(ctx, body, &ptr_values, &ptr_alias_map);
     let borrowed_parameters = match borrowed_parameter_policy {
         BorrowedParameterPolicy::Preserve => HashSet::new(),
-        BorrowedParameterPolicy::ElideProvenBorrowed => analyze_borrowed_parameters(ctx, body),
+        BorrowedParameterPolicy::ElideProvenBorrowed => {
+            analyze_borrowed_parameters(ctx, function, body, trusted_summaries)
+        }
     };
 
     let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
@@ -653,27 +680,45 @@ fn insert_rc_in_function(
 
 /// Return entry parameters whose complete use set is proven not to escape the
 /// dynamic extent of the function call.
-fn analyze_borrowed_parameters(ctx: &IrContext, body: RegionRef) -> HashSet<ValueRef> {
+fn analyze_borrowed_parameters(
+    ctx: &IrContext,
+    function: Symbol,
+    body: RegionRef,
+    trusted_summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
+) -> HashSet<ValueRef> {
     let Some(&entry) = ctx.region(body).blocks.first() else {
+        return HashSet::new();
+    };
+
+    let Some(function_summary) = trusted_summaries.get(&function) else {
         return HashSet::new();
     };
 
     ctx.block_args(entry)
         .iter()
         .copied()
+        .enumerate()
+        .filter(|(index, _)| function_summary.get(*index) == Some(&ParameterOwnership::Borrowed))
+        .map(|(_, parameter)| parameter)
         .filter(|&parameter| is_anyref_value(ctx, parameter))
-        .filter(|&parameter| parameter_is_proven_borrowed(ctx, body, parameter))
+        .filter(|&parameter| parameter_is_proven_borrowed(ctx, body, parameter, trusted_summaries))
         .collect()
 }
 
-fn parameter_is_proven_borrowed(ctx: &IrContext, body: RegionRef, parameter: ValueRef) -> bool {
-    value_is_proven_borrowed(ctx, body, parameter, &mut HashSet::new())
+fn parameter_is_proven_borrowed(
+    ctx: &IrContext,
+    body: RegionRef,
+    parameter: ValueRef,
+    trusted_summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
+) -> bool {
+    value_is_proven_borrowed(ctx, body, parameter, trusted_summaries, &mut HashSet::new())
 }
 
 fn value_is_proven_borrowed(
     ctx: &IrContext,
     body: RegionRef,
     value: ValueRef,
+    trusted_summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
     visited: &mut HashSet<ValueRef>,
 ) -> bool {
     if !visited.insert(value) {
@@ -690,6 +735,12 @@ fn value_is_proven_borrowed(
         }
 
         let operand_index = use_.operand_index as usize;
+        if let Ok(call) = clif::Call::from_op(ctx, op) {
+            return trusted_summaries
+                .get(&call.callee(ctx))
+                .and_then(|summary| summary.get(operand_index))
+                == Some(&ParameterOwnership::Borrowed);
+        }
         if is_proven_borrowed_parameter_use(ctx, op, operand_index) {
             return true;
         }
@@ -698,7 +749,13 @@ fn value_is_proven_borrowed(
             && operand_index == 0
             && ctx.op_operands(op).len() == 1
             && ctx.op_results(op).len() == 1
-            && value_is_proven_borrowed(ctx, body, ctx.op_results(op)[0], visited)
+            && value_is_proven_borrowed(
+                ctx,
+                body,
+                ctx.op_results(op)[0],
+                trusted_summaries,
+                visited,
+            )
     })
 }
 
@@ -946,7 +1003,13 @@ mod tests {
             validation.is_ok(),
             "input fixture must have valid SSA use chains: {validation}"
         );
-        insert_rc_with_policy(&mut ctx, module, policy);
+        if policy == BorrowedParameterPolicy::ElideProvenBorrowed {
+            let trusted =
+                TrustedOwnershipSummaries::attach_locally_borrowed_for_tests(&mut ctx, module);
+            insert_rc_with_trusted_summaries(&mut ctx, module, policy, &trusted);
+        } else {
+            insert_rc_with_policy(&mut ctx, module, policy);
+        }
         let validation = validate_use_chains(&ctx, module);
         assert!(
             validation.is_ok(),

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__ownership_summary__tests__trusted_direct_chain_summaries.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__ownership_summary__tests__trusted_direct_chain_summaries.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tribute-passes/src/native/ownership_summary.rs
+expression: summaries
+---
+func.func @leaf(%0: tribute_rt.anyref) -> core.i32 attributes {tribute.rc.parameter_ownership_v1 = [@borrowed]} {
+func.func @middle(%0: tribute_rt.anyref) -> core.i32 attributes {tribute.rc.parameter_ownership_v1 = [@borrowed]} {
+func.func @root(%0: tribute_rt.anyref) -> core.i32 attributes {tribute.rc.parameter_ownership_v1 = [@borrowed]} {

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__ownership_summary__tests__untrusted_call_summaries.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__ownership_summary__tests__untrusted_call_summaries.snap
@@ -1,0 +1,9 @@
+---
+source: crates/tribute-passes/src/native/ownership_summary.rs
+expression: summaries
+---
+func.func @left(%0: tribute_rt.anyref) -> core.nil attributes {tribute.rc.parameter_ownership_v1 = [@owned]} {
+func.func @right(%0: tribute_rt.anyref) -> core.nil attributes {tribute.rc.parameter_ownership_v1 = [@owned]} {
+func.func @unknown(%0: tribute_rt.anyref) -> core.nil attributes {tribute.rc.parameter_ownership_v1 = [@owned]} {
+func.func @indirect(%0: tribute_rt.anyref, %1: core.ptr) -> core.nil attributes {tribute.rc.parameter_ownership_v1 = [@owned, @owned]} {
+func.func @external(%0: tribute_rt.anyref) -> core.nil attributes {abi = "C", tribute.rc.parameter_ownership_v1 = [@owned]} {

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -237,20 +237,51 @@ into control flow and atomic operations by RC lowering.
   For a proven borrowed parameter, RC insertion omits both the entry `retain`
   and every parameter `release`; this keeps acquisition and release decisions
   under one ownership proof instead of matching generated releases afterward.
-- **Temporary borrow analysis (planned):** Identify temporary values, including
-  field loads, that don't need RC ops
+- **Temporary field borrows:** RC insertion may omit ownership acquisition and
+  release for an `anyref` result of `clif.load` when the load is proven to be a
+  field-derived temporary borrow. The analysis runs on lowered Clif, where an
+  `adt.struct_get` is represented by `clif.load`; it does not match
+  `adt.struct_get` directly.
+
+  The load address must resolve directly to an RC-managed owner, optionally
+  through transparent unrealized pointer casts and address calculations. The
+  resolved owner must be an RC-managed value tracked by RC liveness; a raw
+  `core.ptr` derived from `__tribute_alloc` is not sufficient ownership proof.
+  The owner definition must dominate the field load, the field load must
+  dominate every use of its result, and every result use must remain in the
+  same function region. The only initially accepted uses are further field
+  loads through the temporary, pointer comparisons, and stores that use it
+  solely as the destination address. Unrealized pointer casts are transparent
+  only when every use of the cast result satisfies these same rules. Returning
+  or storing the temporary or an alias as a value, passing either to any call
+  or branch, forwarding either as a block argument, capture by a nested region,
+  or any unknown operation prevents elision.
+
+  The owner's lifetime must also be extended through every accepted use of the
+  temporary. RC liveness therefore treats those uses as uses of the owner before
+  insertion. A temporary is rejected when its uses occur in sibling dominator
+  subtrees, after a join not dominated by its load, on a loop-carried path, or
+  anywhere else that does not establish one dominated, non-escaping lifetime.
+  Nested field loads are considered independently and are eligible only when
+  each loaded owner's lifetime is proven by the same rules. Missing CFG edges,
+  unreachable blocks, malformed regions, or any analysis uncertainty preserve
+  the original retain/release operations.
 - **Constant propagation (planned):** Elide RC for compile-time-known lifetimes
 
-The paired-elimination and borrowed-parameter policies are selected by the
-native pipeline options, not stored in an IR lowering context. Production
-enables proven optimizations; the baseline profile disables them for
-conformance comparisons.
+The paired-elimination, borrowed-parameter, and temporary-borrow policies are
+selected independently by the native pipeline options, not stored in an IR
+lowering context. Production enables proven optimizations; the baseline profile
+disables them for conformance comparisons.
 
-**Pipeline position:** Borrowed-parameter analysis runs as part of RC insertion,
-before parameter RC operations are created. Paired elimination runs immediately
-after RC insertion. Both decisions occur before unrealized cast resolution and
-RC lowering, which keeps alias handling conservative and makes the inserted and
-optimized RC boundaries directly observable in tests.
+**Pipeline position:** Ownership summaries are computed before `func_to_clif`.
+Borrowed-parameter and temporary-field-borrow analysis run as independent parts
+of RC insertion before their respective RC operations are created. Temporary
+borrow lifetime dependencies extend owner liveness before insertion; parameter
+summary validation does not replace or bypass that dominance/lifetime analysis.
+Paired elimination runs immediately after RC insertion. All three decisions
+occur before unrealized cast resolution and RC lowering, which keeps alias
+handling conservative and makes the inserted and optimized RC boundaries
+directly observable in tests.
 
 #### Trusted ownership summaries across `func_to_clif`
 
@@ -294,10 +325,11 @@ only evidence is the cycle itself. Acyclic direct-call chains can therefore
 propagate borrowed parameters transitively while recursion stays conservative.
 
 RC insertion consumes only summaries produced and validated by the current
-pipeline run. Its local use analysis still treats every call without a trusted
-borrowed callee entry as an unknown-call barrier. Ownership summaries do not
-cover temporary field borrows or dominator-based lifetime extension; those are
-separate work tracked by #637.
+pipeline run. Its local parameter-use analysis still treats every call without
+a trusted borrowed callee entry as an unknown-call barrier. Summary validation
+and temporary-field-borrow analysis are independently selectable and compose:
+trusted forwarding may elide parameter ownership while dominance and lifetime
+dependencies separately govern field-derived temporaries.
 
 ### 3. RC Lowering Pass (PR 4)
 

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -226,9 +226,10 @@ into control flow and atomic operations by RC lowering.
   nested region, and every unknown operation are escapes. Closure, ability
   handler, and continuation capture therefore preserve owned-parameter RC.
   Analysis failure preserves the existing owned-parameter RC.
-  Calls are escape barriers even when the callee is direct: this pass does not
-  yet consume trusted ownership summaries, so it cannot prove that a forwarded
-  argument remains borrowed.
+  Calls remain escape barriers unless the call is direct and its callee has a
+  trusted ownership summary proving the corresponding parameter borrowed.
+  Indirect, external, unresolved, or otherwise unknown calls are always escape
+  barriers.
   The callee must also have the ordinary synchronous caller-lifetime guarantee:
   C ABI entry points, direct tail-call targets, and functions whose address
   escapes are ineligible because their caller may not retain an owning frame
@@ -250,6 +251,53 @@ before parameter RC operations are created. Paired elimination runs immediately
 after RC insertion. Both decisions occur before unrealized cast resolution and
 RC lowering, which keeps alias handling conservative and makes the inserted and
 optimized RC boundaries directly observable in tests.
+
+#### Trusted ownership summaries across `func_to_clif`
+
+Borrowed forwarding uses explicit pre-lowering metadata rather than rebuilding
+a call graph after `func` operations have been erased. Immediately before
+`func_to_clif`, the native pipeline computes a module-local summary for every
+defined function and stores it on `func.func` as the versioned
+`tribute.rc.parameter_ownership_v1` attribute. `func_to_clif` preserves this
+attribute unchanged on the corresponding `clif.func`; RC insertion is its only
+consumer. The producer also returns an opaque in-memory trust token containing
+the expected summaries. RC insertion requires that token and cross-checks every
+attribute against it, so textual metadata alone is never trusted.
+
+The attribute is a list with exactly one entry per function parameter. Each
+entry is the symbol `borrowed` or `owned`. A summary is trusted only when all of
+the following hold:
+
+- it was recomputed by the current native pipeline invocation, not merely found
+  on input IR;
+- its version, shape, and parameter count are exact;
+- its function symbol resolves uniquely to a module-local definition; and
+- the summarized parameter is still `tribute_rt.anyref` at RC insertion.
+
+Missing, malformed, stale, duplicate, or inconsistent metadata is ignored as a
+whole for that function. Ignored summaries mean every parameter is owned. This
+fail-closed rule also applies if lowering drops or changes the metadata.
+
+Summary computation is a monotone fixed point over the direct-call graph.
+Every `anyref` parameter starts `borrowed` and is demoted permanently to `owned`
+when a use escapes. Loads, pointer comparisons, destination-address stores, and
+transparent unrealized casts are local borrowed uses. Forwarding to parameter
+`i` of a uniquely resolved direct callee is borrowed only when that callee's
+entry `i` is borrowed. Return/tail calls, storing as a value, nested-region
+capture, indirect calls, external calls, unresolved calls, and unknown
+operations demote the parameter.
+
+Strongly connected components are solved to a fixed point, but recursive SCCs
+are not trusted for borrowed forwarding: all parameters participating in a
+direct or mutual recursive cycle are owned. This avoids circular proofs whose
+only evidence is the cycle itself. Acyclic direct-call chains can therefore
+propagate borrowed parameters transitively while recursion stays conservative.
+
+RC insertion consumes only summaries produced and validated by the current
+pipeline run. Its local use analysis still treats every call without a trusted
+borrowed callee entry as an unknown-call barrier. Ownership summaries do not
+cover temporary field borrows or dominator-based lifetime extension; those are
+separate work tracked by #637.
 
 ### 3. RC Lowering Pass (PR 4)
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -966,9 +966,15 @@ fn prepare_module_to_native(
     }
 
     // Phase 1 - Lower func dialect to clif dialect
+    let ownership_summaries;
     {
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
+        ownership_summaries = tribute_passes::native::ownership_summary::compute_and_attach(
+            ctx,
+            module,
+            &type_converter,
+        );
         func_to_clif::lower(ctx, module, type_converter).map_err(native_conversion_failure)?;
     }
 
@@ -1033,10 +1039,11 @@ fn prepare_module_to_native(
                 tribute_passes::native::rc_insertion::BorrowedParameterPolicy::ElideProvenBorrowed
             }
         };
-        tribute_passes::native::rc_insertion::insert_rc_with_policy(
+        tribute_passes::native::rc_insertion::insert_rc_with_trusted_summaries(
             ctx,
             module,
             borrowed_parameters,
+            &ownership_summaries,
         );
     }
 

--- a/tests/fixtures/optimizations/trusted_ownership_forwarding.trb
+++ b/tests/fixtures/optimizations/trusted_ownership_forwarding.trb
@@ -1,0 +1,25 @@
+extern "C" fn __tribute_print_nat(value: Nat) -> Nil
+
+enum BoxedNat {
+    Boxed(Nat)
+    Wrapped(BoxedNat)
+}
+
+fn read_leaf(boxed: BoxedNat) -> Nat {
+    case boxed {
+        Boxed(value) -> value
+        Wrapped(_) -> 0
+    }
+}
+
+fn read_middle(boxed: BoxedNat) -> Nat {
+    read_leaf(boxed) + read_leaf(boxed)
+}
+
+fn read_root(boxed: BoxedNat) -> Nat {
+    read_middle(boxed) + read_middle(boxed)
+}
+
+fn main() {
+    __tribute_print_nat(read_root(Boxed(10)))
+}

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -22,6 +22,8 @@ const DONE_CONTINUATION_DEDUP_STATE: &str =
 const PAIRED_RC_ELIMINATION: &str =
     include_str!("fixtures/optimizations/paired_rc_elimination.trb");
 const BORROWED_PARAMETERS: &str = include_str!("fixtures/optimizations/borrowed_parameters.trb");
+const TRUSTED_OWNERSHIP_FORWARDING: &str =
+    include_str!("fixtures/optimizations/trusted_ownership_forwarding.trb");
 
 fn native_optimization_options(
     paired_rc_elimination: PairedRcEliminationPolicy,
@@ -168,6 +170,81 @@ fn borrowed_parameters_preserve_native_execution() {
     }
 }
 
+#[test]
+fn trusted_ownership_forwarding_preserves_native_execution() {
+    for sanitize_address in [false, true] {
+        let preserved = compile_and_run_native_with_borrowed_parameters(
+            "trusted_ownership_forwarding_preserved.trb",
+            TRUSTED_OWNERSHIP_FORWARDING,
+            BorrowedParameterPolicy::Preserve,
+            sanitize_address,
+        );
+        let elided = compile_and_run_native_with_borrowed_parameters(
+            "trusted_ownership_forwarding_elided.trb",
+            TRUSTED_OWNERSHIP_FORWARDING,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            sanitize_address,
+        );
+        assert!(
+            preserved.status.success(),
+            "preserved pipeline failed with sanitize_address={sanitize_address}: {}",
+            String::from_utf8_lossy(&preserved.stderr)
+        );
+        assert!(
+            elided.status.success(),
+            "elided pipeline failed with sanitize_address={sanitize_address}: {}",
+            String::from_utf8_lossy(&elided.stderr)
+        );
+        assert_eq!(preserved.stdout, elided.stdout);
+        assert_eq!(String::from_utf8_lossy(&elided.stdout).trim(), "40");
+    }
+}
+
+#[salsa_test]
+fn trusted_ownership_forwarding_has_focused_ir(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "trusted_ownership_forwarding_snapshot.trb",
+        TRUSTED_OWNERSHIP_FORWARDING,
+    );
+    let preserved = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterBorrowedParameterOptimization,
+        native_optimization_options(
+            PairedRcEliminationPolicy::Disabled,
+            BorrowedParameterPolicy::Preserve,
+        ),
+    )
+    .expect("preserved forwarding IR should be available");
+    let elided = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterBorrowedParameterOptimization,
+        native_optimization_options(
+            PairedRcEliminationPolicy::Disabled,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        ),
+    )
+    .expect("elided forwarding IR should be available");
+    let preserved = focused_rc_ops(&preserved);
+    let elided = focused_rc_ops(&elided);
+    assert!(
+        preserved.matches("tribute_rt.retain").count()
+            > elided.matches("tribute_rt.retain").count(),
+        "preserved:\n{preserved}\nelided:\n{elided}"
+    );
+    assert_snapshot!("trusted_ownership_forwarding_preserved", preserved);
+    assert_snapshot!(
+        "trusted_ownership_forwarding_elided",
+        if elided.is_empty() {
+            "<no RC ops>"
+        } else {
+            &elided
+        }
+    );
+}
+
 #[salsa_test]
 fn paired_rc_elimination_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -260,22 +337,7 @@ fn borrowed_parameters_have_focused_before_after_ir(db: &salsa::DatabaseImpl) {
     let preserved_after = focused_rc_ops(&preserved_after);
 
     assert_eq!(before, preserved_after);
-    let before_retain = before.matches("tribute_rt.retain").count();
-    let before_release = before.matches("tribute_rt.release").count();
-    let after_retain = after.matches("tribute_rt.retain").count();
-    let after_release = after.matches("tribute_rt.release").count();
-    assert!(before_retain > after_retain, "before RC ops:\n{before}");
-    assert!(before_release > after_release, "before RC ops:\n{before}");
-    assert_eq!(before_retain - after_retain, 1);
-    assert_eq!(before_release - after_release, 2);
-    assert!(
-        after_retain > 0,
-        "escaping parameters must retain ownership"
-    );
-    assert!(
-        after_release > 0,
-        "escaping parameters must still be released"
-    );
+    assert_eq!(before, after, "recursive summaries must fail closed");
 
     assert_snapshot!("borrowed_parameters_before", before);
     assert_snapshot!("borrowed_parameters_after", after);

--- a/tests/snapshots/optimization_conformance__borrowed_parameters_after.snap
+++ b/tests/snapshots/optimization_conformance__borrowed_parameters_after.snap
@@ -2,5 +2,8 @@
 source: tests/optimization_conformance.rs
 expression: after
 ---
-%9 = tribute_rt.retain %8 : core.ptr
-tribute_rt.release %8 {alloc_size = 0}
+%1 = tribute_rt.retain %0 : core.ptr
+tribute_rt.release %0 {alloc_size = 0}
+%10 = tribute_rt.retain %9 : core.ptr
+tribute_rt.release %0 {alloc_size = 0}
+tribute_rt.release %9 {alloc_size = 0}

--- a/tests/snapshots/optimization_conformance__trusted_ownership_forwarding_elided.snap
+++ b/tests/snapshots/optimization_conformance__trusted_ownership_forwarding_elided.snap
@@ -1,0 +1,5 @@
+---
+source: tests/optimization_conformance.rs
+expression: elided
+---
+<no RC ops>

--- a/tests/snapshots/optimization_conformance__trusted_ownership_forwarding_preserved.snap
+++ b/tests/snapshots/optimization_conformance__trusted_ownership_forwarding_preserved.snap
@@ -1,0 +1,6 @@
+---
+source: tests/optimization_conformance.rs
+expression: preserved
+---
+%1 = tribute_rt.retain %0 : core.ptr
+tribute_rt.release %0 {alloc_size = 0}


### PR DESCRIPTION
## Summary

- compute conservative parameter-ownership summaries before `func_to_clif`
- carry versioned metadata through lowering and validate it against an in-memory trust token before RC insertion
- allow borrowed arguments to flow through trusted direct-call chains while recursive, indirect, external, missing, or inconsistent summaries remain owned
- compose trusted parameter summaries with the temporary field-borrow analysis from #794
- preserve independent policy controls and conservative behavior in legacy RC insertion helpers
- add focused IR snapshots, policy-composition coverage, and native/address-sanitized execution tests

## Why

The borrowed-parameter optimization treated every call as an escape, preventing safe retain/release elision across direct forwarding chains. The fixed-point summary pass exposes only proofs produced by the current pipeline invocation and fails closed whenever those proofs cannot be validated.

After #794 merged, this branch was merged with current `main` and the parameter and temporary borrow analyses were explicitly composed. Each analysis retains its own policy and lifetime requirements.

## Validation

- workspace Clippy with warnings denied and formatting checks
- `cargo check --workspace --all-targets`
- `cargo nextest run --workspace` (1,611 passed, 10 skipped)
- focused ownership/RC tests (41 passed)
- optimization conformance and sanitizer tests (10 passed)
- `git diff --check`

Closes #781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added trusted ownership summaries for parameter analysis to improve borrowed-parameter optimization safety.
  - RC insertion can now leverage validated summaries to allow non-escaping treatment through approved direct-call chains.
  - Introduced a new pipeline flow that computes summaries before RC insertion and composes parameter-borrow with temporary-borrow optimizations.

- **Bug Fixes**
  - Ownership metadata is validated fail-closed; missing, malformed, or inconsistent data defaults parameters to owned.

- **Tests**
  - Added new conformance gates and fixtures covering forwarding, recursion, external calls, and metadata validation; updated snapshot/execution expectations.

- **Documentation**
  - Expanded the RC optimization specification for trusted ownership summaries and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->