### PR TITLE
Carry canonical String identity into IR

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -640,6 +640,46 @@ impl<'db> IrLoweringCtx<'db> {
         )
     }
 
+    /// Create an `adt.enum` type with a stable source declaration identity.
+    pub fn adt_enum_type_with_definition(
+        &self,
+        ir: &mut IrContext,
+        name: Symbol,
+        variants: &[(Symbol, Vec<TypeRef>)],
+        definition: crate::typeck::DefinitionIdentity,
+    ) -> TypeRef {
+        let variants_attr: Vec<Attribute> = variants
+            .iter()
+            .map(|(variant_name, field_types)| {
+                let field_attrs: Vec<Attribute> =
+                    field_types.iter().map(|ty| Attribute::Type(*ty)).collect();
+                Attribute::List(vec![
+                    Attribute::Symbol(*variant_name),
+                    Attribute::List(field_attrs),
+                ])
+            })
+            .collect();
+
+        ir.types.intern(
+            TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("enum"))
+                .attr("name", Attribute::Symbol(name))
+                .attr("variants", Attribute::List(variants_attr))
+                .attr(
+                    "tribute.definition.source",
+                    Attribute::Int(definition.source as i128),
+                )
+                .attr(
+                    "tribute.definition.start",
+                    Attribute::Int(definition.start as i128),
+                )
+                .attr(
+                    "tribute.definition.end",
+                    Attribute::Int(definition.end as i128),
+                )
+                .build(),
+        )
+    }
+
     /// Create an `adt.typeref` type — a reference to a named type.
     pub fn adt_typeref(&self, ir: &mut IrContext, name: Symbol) -> TypeRef {
         ir.types.intern(

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -23,6 +23,8 @@ fn prescan_struct_fields<'db>(
     ir: &mut IrContext,
     decls: &[Decl<TypedRef<'db>>],
     prefix: &mut String,
+    well_known_string_definition: Option<crate::typeck::DefinitionIdentity>,
+    well_known_string_type: &mut Option<TypeRef>,
 ) {
     for decl in decls {
         match decl {
@@ -67,13 +69,29 @@ fn prescan_struct_fields<'db>(
                     })
                     .collect();
                 let qualified = qualified_type_name(ctx.db, &ctor_id);
-                let enum_ir_type = ctx.adt_enum_type(ir, qualified, &ir_variants);
+                let definition =
+                    crate::typeck::DefinitionIdentity::new(e.id, ctx.location(e.id).span);
+                let enum_ir_type = if well_known_string_definition == Some(definition) {
+                    ctx.adt_enum_type_with_definition(ir, qualified, &ir_variants, definition)
+                } else {
+                    ctx.adt_enum_type(ir, qualified, &ir_variants)
+                };
                 ctx.register_type(qualified, enum_ir_type);
+                if well_known_string_definition == Some(definition) {
+                    *well_known_string_type = Some(enum_ir_type);
+                }
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
                     let saved = crate::push_prefix(prefix, m.name);
-                    prescan_struct_fields(ctx, ir, body, prefix);
+                    prescan_struct_fields(
+                        ctx,
+                        ir,
+                        body,
+                        prefix,
+                        well_known_string_definition,
+                        well_known_string_type,
+                    );
                     prefix.truncate(saved);
                 }
             }
@@ -143,6 +161,7 @@ impl<'db> TypedModule<'db> {
             function_types,
             node_types,
             ability_conventions,
+            well_known_types,
         } = self;
         let module_location = span_map.get_or_default(ast.id);
         let location = Location::new(path, module_location);
@@ -163,7 +182,20 @@ impl<'db> TypedModule<'db> {
         prescan_definition_conventions(&mut ctx, &ast.decls, &mut String::new());
 
         // Pre-scan: register all struct field orders before lowering any declarations.
-        prescan_struct_fields(&mut ctx, ir, &ast.decls, &mut String::new());
+        let well_known_string_definition = well_known_types.string.map(|ty| ty.definition);
+        let mut well_known_string_type = None;
+        prescan_struct_fields(
+            &mut ctx,
+            ir,
+            &ast.decls,
+            &mut String::new(),
+            well_known_string_definition,
+            &mut well_known_string_type,
+        );
+
+        let well_known_types = tribute_ir::metadata::WellKnownTypes {
+            string: well_known_string_type,
+        };
 
         // Create the module block (top-down: create block first, push ops into it)
         let module_block = ir.create_block(BlockData {
@@ -187,6 +219,7 @@ impl<'db> TypedModule<'db> {
         });
 
         let module_op = core::module(ir, location, module_name, module_region);
+        well_known_types.attach(ir, module_op.op_ref());
         IrModule::new(ir, module_op.op_ref()).expect("valid core.module operation")
     }
 }

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -17,14 +17,51 @@ use super::super::TypedModule;
 use super::super::context::IrLoweringCtx;
 use super::{FuncSignature, IrBuilder, convert_annotation_to_ir_type, expr, qualified_type_name};
 
+struct PendingWellKnownType {
+    definition: crate::typeck::DefinitionIdentity,
+    ir_type: Option<TypeRef>,
+}
+
+struct WellKnownTypePrescan {
+    string: Option<PendingWellKnownType>,
+}
+
+impl WellKnownTypePrescan {
+    fn new(types: crate::typeck::WellKnownTypes<'_>) -> Self {
+        Self {
+            string: types.string.map(|ty| PendingWellKnownType {
+                definition: ty.definition,
+                ir_type: None,
+            }),
+        }
+    }
+
+    fn is_string(&self, definition: crate::typeck::DefinitionIdentity) -> bool {
+        self.string
+            .as_ref()
+            .is_some_and(|string| string.definition == definition)
+    }
+
+    fn record_string(&mut self, ir_type: TypeRef) {
+        if let Some(string) = &mut self.string {
+            string.ir_type = Some(ir_type);
+        }
+    }
+
+    fn finish(self) -> tribute_ir::metadata::WellKnownTypes {
+        tribute_ir::metadata::WellKnownTypes {
+            string: self.string.and_then(|string| string.ir_type),
+        }
+    }
+}
+
 /// Pre-scan declarations to register struct field orders.
 fn prescan_struct_fields<'db>(
     ctx: &mut IrLoweringCtx<'db>,
     ir: &mut IrContext,
     decls: &[Decl<TypedRef<'db>>],
     prefix: &mut String,
-    well_known_string_definition: Option<crate::typeck::DefinitionIdentity>,
-    well_known_string_type: &mut Option<TypeRef>,
+    well_known_types: &mut WellKnownTypePrescan,
 ) {
     for decl in decls {
         match decl {
@@ -71,27 +108,20 @@ fn prescan_struct_fields<'db>(
                 let qualified = qualified_type_name(ctx.db, &ctor_id);
                 let definition =
                     crate::typeck::DefinitionIdentity::new(e.id, ctx.location(e.id).span);
-                let enum_ir_type = if well_known_string_definition == Some(definition) {
+                let enum_ir_type = if well_known_types.is_string(definition) {
                     ctx.adt_enum_type_with_definition(ir, qualified, &ir_variants, definition)
                 } else {
                     ctx.adt_enum_type(ir, qualified, &ir_variants)
                 };
                 ctx.register_type(qualified, enum_ir_type);
-                if well_known_string_definition == Some(definition) {
-                    *well_known_string_type = Some(enum_ir_type);
+                if well_known_types.is_string(definition) {
+                    well_known_types.record_string(enum_ir_type);
                 }
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
                     let saved = crate::push_prefix(prefix, m.name);
-                    prescan_struct_fields(
-                        ctx,
-                        ir,
-                        body,
-                        prefix,
-                        well_known_string_definition,
-                        well_known_string_type,
-                    );
+                    prescan_struct_fields(ctx, ir, body, prefix, well_known_types);
                     prefix.truncate(saved);
                 }
             }
@@ -182,20 +212,16 @@ impl<'db> TypedModule<'db> {
         prescan_definition_conventions(&mut ctx, &ast.decls, &mut String::new());
 
         // Pre-scan: register all struct field orders before lowering any declarations.
-        let well_known_string_definition = well_known_types.string.map(|ty| ty.definition);
-        let mut well_known_string_type = None;
+        let mut well_known_types = WellKnownTypePrescan::new(well_known_types);
         prescan_struct_fields(
             &mut ctx,
             ir,
             &ast.decls,
             &mut String::new(),
-            well_known_string_definition,
-            &mut well_known_string_type,
+            &mut well_known_types,
         );
 
-        let well_known_types = tribute_ir::metadata::WellKnownTypes {
-            string: well_known_string_type,
-        };
+        let well_known_types = well_known_types.finish();
 
         // Create the module block (top-down: create block first, push ops into it)
         let module_block = ir.create_block(BlockData {

--- a/crates/tribute-front/src/ast_to_ir/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/mod.rs
@@ -86,6 +86,7 @@ pub struct TypedModule<'db> {
     pub function_types: HashMap<Symbol, TypeScheme<'db>>,
     pub node_types: HashMap<NodeId, Type<'db>>,
     pub ability_conventions: HashMap<AbilityId<'db>, CallingConvention>,
+    pub well_known_types: crate::typeck::WellKnownTypes<'db>,
 }
 
 impl<'db> TypedModule<'db> {

--- a/crates/tribute-front/src/typeck/checker/mod.rs
+++ b/crates/tribute-front/src/typeck/checker/mod.rs
@@ -32,8 +32,8 @@ use crate::ast::{
     Decl, FuncDefId, Module, NodeId, ResolvedRef, SpanMap, Type, TypeScheme, TypedRef,
 };
 
-use super::PreludeExports;
 use super::context::ModuleTypeEnv;
+use super::{DefinitionIdentity, PreludeExports, WellKnownType, WellKnownTypes};
 use crate::ast::CallingConvention;
 
 /// Result of module type checking.
@@ -46,6 +46,8 @@ pub struct ModuleCheckResult<'db> {
     pub node_types: Vec<(NodeId, Type<'db>)>,
     /// Ability-level calling-convention requirements.
     pub ability_conventions: Vec<(crate::ast::AbilityId<'db>, CallingConvention)>,
+    /// Prelude-defined semantic type identities.
+    pub well_known_types: WellKnownTypes<'db>,
 }
 
 /// Type checking mode.
@@ -145,7 +147,6 @@ impl<'db> TypeChecker<'db> {
         // Note: module_path starts empty because module.name is the file-derived name,
         // which is for external references, not internal function naming.
         self.collect_declarations(&module);
-
         // Phase 2: Type check each declaration with per-function inference
         // Each function gets its own FunctionInferenceContext with isolated constraints
         let decls: Vec<Decl<TypedRef<'db>>> = module
@@ -160,6 +161,7 @@ impl<'db> TypeChecker<'db> {
         // Export the function types (already finalized during per-function checking)
         let function_types = self.env.export_function_types();
         let ability_conventions = self.env.export_ability_conventions();
+        let well_known_types = self.env.well_known_types();
 
         // Convert node_types HashMap to Vec for Salsa compatibility
         // Sort by NodeId to ensure deterministic ordering for Salsa cache stability
@@ -175,6 +177,7 @@ impl<'db> TypeChecker<'db> {
             function_types,
             node_types,
             ability_conventions,
+            well_known_types,
         }
     }
 
@@ -189,6 +192,10 @@ impl<'db> TypeChecker<'db> {
         // Phase 1: Collect type definitions and function signatures
         // Note: module_path starts empty - prelude functions use simple names internally.
         self.collect_declarations(&module);
+        let string_declaration = module.decls.iter().find_map(|decl| match decl {
+            Decl::Enum(decl) if decl.name == "String" => Some(decl.id),
+            _ => None,
+        });
 
         // Phase 2: Type check all declarations with per-function inference
         let _decls: Vec<Decl<TypedRef<'db>>> = module
@@ -207,6 +214,19 @@ impl<'db> TypeChecker<'db> {
         let enum_variants = self.env.export_enum_variants();
         let method_index = self.env.export_method_index();
         let ability_conventions = self.env.export_ability_conventions();
+        let well_known_types = WellKnownTypes {
+            string: string_declaration.and_then(|declaration| {
+                self.env
+                    .lookup_type_def(Symbol::new("String"))
+                    .map(|scheme| WellKnownType {
+                        ty: scheme.body(self.db()),
+                        definition: DefinitionIdentity::new(
+                            declaration,
+                            self.span_map.get_or_default(declaration),
+                        ),
+                    })
+            }),
+        };
 
         PreludeExports::new(
             self.db(),
@@ -217,6 +237,7 @@ impl<'db> TypeChecker<'db> {
             enum_variants,
             method_index,
             ability_conventions,
+            well_known_types,
         )
     }
 

--- a/crates/tribute-front/src/typeck/checker/mod.rs
+++ b/crates/tribute-front/src/typeck/checker/mod.rs
@@ -33,7 +33,9 @@ use crate::ast::{
 };
 
 use super::context::ModuleTypeEnv;
-use super::{DefinitionIdentity, PreludeExports, WellKnownType, WellKnownTypes};
+use super::{
+    DefinitionIdentity, PreludeExports, StringType, WellKnownType, WellKnownTypeKey, WellKnownTypes,
+};
 use crate::ast::CallingConvention;
 
 /// Result of module type checking.
@@ -79,6 +81,27 @@ pub struct TypeChecker<'db> {
 }
 
 impl<'db> TypeChecker<'db> {
+    fn prelude_well_known_type(
+        &self,
+        module: &Module<ResolvedRef<'db>>,
+        key: impl WellKnownTypeKey,
+    ) -> Option<WellKnownType<'db>> {
+        let name = key.name();
+        let declaration = module.decls.iter().find_map(|decl| match decl {
+            Decl::Struct(decl) if decl.name == name => Some(decl.id),
+            Decl::Enum(decl) if decl.name == name => Some(decl.id),
+            _ => None,
+        })?;
+        let ty = self.env.lookup_type_def(name)?.body(self.db());
+        Some(WellKnownType {
+            ty,
+            definition: DefinitionIdentity::new(
+                declaration,
+                self.span_map.get_or_default(declaration),
+            ),
+        })
+    }
+
     /// Create a new type checker with the given span map.
     pub fn new(db: &'db dyn salsa::Database, span_map: SpanMap) -> Self {
         Self {
@@ -192,10 +215,7 @@ impl<'db> TypeChecker<'db> {
         // Phase 1: Collect type definitions and function signatures
         // Note: module_path starts empty - prelude functions use simple names internally.
         self.collect_declarations(&module);
-        let string_declaration = module.decls.iter().find_map(|decl| match decl {
-            Decl::Enum(decl) if decl.name == "String" => Some(decl.id),
-            _ => None,
-        });
+        let string_type = self.prelude_well_known_type(&module, StringType);
 
         // Phase 2: Type check all declarations with per-function inference
         let _decls: Vec<Decl<TypedRef<'db>>> = module
@@ -215,17 +235,7 @@ impl<'db> TypeChecker<'db> {
         let method_index = self.env.export_method_index();
         let ability_conventions = self.env.export_ability_conventions();
         let well_known_types = WellKnownTypes {
-            string: string_declaration.and_then(|declaration| {
-                self.env
-                    .lookup_type_def(Symbol::new("String"))
-                    .map(|scheme| WellKnownType {
-                        ty: scheme.body(self.db()),
-                        definition: DefinitionIdentity::new(
-                            declaration,
-                            self.span_map.get_or_default(declaration),
-                        ),
-                    })
-            }),
+            string: string_type,
         };
 
         PreludeExports::new(

--- a/crates/tribute-front/src/typeck/context.rs
+++ b/crates/tribute-front/src/typeck/context.rs
@@ -145,6 +145,8 @@ pub struct ModuleTypeEnv<'db> {
     /// Populated from function declarations (first param = receiver)
     /// and struct field accessors.
     method_index: HashMap<Symbol, Vec<MethodEntry<'db>>>,
+
+    well_known_types: super::WellKnownTypes<'db>,
 }
 
 impl<'db> ModuleTypeEnv<'db> {
@@ -173,6 +175,7 @@ impl<'db> ModuleTypeEnv<'db> {
             ability_defs,
             ability_conventions,
             method_index: HashMap::new(),
+            well_known_types: super::WellKnownTypes::empty(),
         }
     }
 
@@ -336,6 +339,7 @@ impl<'db> ModuleTypeEnv<'db> {
     /// This is called before type checking user code to make prelude's
     /// types available. The injected types contain only BoundVars (no UniVars).
     pub fn inject_prelude(&mut self, exports: &super::PreludeExports<'db>) {
+        self.well_known_types = exports.well_known_types(self.db);
         for (id, scheme) in exports.function_types(self.db) {
             self.function_types.insert(*id, *scheme);
         }
@@ -360,6 +364,10 @@ impl<'db> ModuleTypeEnv<'db> {
         for (ability, convention) in exports.ability_conventions(self.db) {
             self.ability_conventions.insert(*ability, *convention);
         }
+    }
+
+    pub fn well_known_types(&self) -> super::WellKnownTypes<'db> {
+        self.well_known_types
     }
 
     // =========================================================================

--- a/crates/tribute-front/src/typeck/mod.rs
+++ b/crates/tribute-front/src/typeck/mod.rs
@@ -41,6 +41,43 @@ use crate::ast::{
     TypeScheme, TypedRef,
 };
 
+/// Semantic identities supplied by the prelude and required downstream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub struct DefinitionIdentity {
+    pub source: u64,
+    pub start: usize,
+    pub end: usize,
+}
+
+impl DefinitionIdentity {
+    pub fn new(declaration: NodeId, span: trunk_ir::Span) -> Self {
+        Self {
+            source: declaration.source(),
+            start: span.start,
+            end: span.end,
+        }
+    }
+}
+
+/// Semantic identities supplied by the prelude and required downstream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub struct WellKnownType<'db> {
+    pub ty: Type<'db>,
+    pub definition: DefinitionIdentity,
+}
+
+/// Semantic identities supplied by the prelude and required downstream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub struct WellKnownTypes<'db> {
+    pub string: Option<WellKnownType<'db>>,
+}
+
+impl WellKnownTypes<'_> {
+    pub const fn empty() -> Self {
+        Self { string: None }
+    }
+}
+
 /// Salsa-tracked struct holding the complete type checking output.
 ///
 /// Bundles the typed AST module with function type schemes so that
@@ -65,6 +102,8 @@ pub struct TypeCheckOutput<'db> {
     /// Ability-level calling-convention requirements.
     #[returns(ref)]
     pub ability_conventions: Vec<(AbilityId<'db>, CallingConvention)>,
+    /// Prelude-defined semantic type identities.
+    pub well_known_types: WellKnownTypes<'db>,
     /// Source span information for AST nodes.
     pub span_map: SpanMap,
 }
@@ -105,6 +144,8 @@ pub struct PreludeExports<'db> {
     /// Ability-level calling-convention requirements exported by the prelude.
     #[returns(ref)]
     pub ability_conventions: Vec<(AbilityId<'db>, CallingConvention)>,
+    /// Prelude-defined semantic type identities.
+    pub well_known_types: WellKnownTypes<'db>,
 }
 
 /// Type check a module.
@@ -124,6 +165,7 @@ pub fn typecheck_module<'db>(
         result.function_types,
         result.node_types,
         result.ability_conventions,
+        result.well_known_types,
         span_map,
     )
 }

--- a/crates/tribute-front/src/typeck/mod.rs
+++ b/crates/tribute-front/src/typeck/mod.rs
@@ -72,6 +72,21 @@ pub struct WellKnownTypes<'db> {
     pub string: Option<WellKnownType<'db>>,
 }
 
+/// A typed key for extracting a semantic type from the prelude.
+pub trait WellKnownTypeKey: Copy {
+    fn name(self) -> Symbol;
+}
+
+/// Key for the prelude-defined `String` type.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct StringType;
+
+impl WellKnownTypeKey for StringType {
+    fn name(self) -> Symbol {
+        Symbol::new("String")
+    }
+}
+
 impl WellKnownTypes<'_> {
     pub const fn empty() -> Self {
         Self { string: None }

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -107,7 +107,7 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
         function_types: function_types_map,
         node_types: node_types_map,
         ability_conventions,
-        well_known_types: tribute_front::typeck::WellKnownTypes::empty(),
+        well_known_types: result.well_known_types,
     }
     .lower_to_ir(db, &mut ir, source.uri(db).as_str());
     print_module(&ir, module.op())

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -107,6 +107,7 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
         function_types: function_types_map,
         node_types: node_types_map,
         ability_conventions,
+        well_known_types: tribute_front::typeck::WellKnownTypes::empty(),
     }
     .lower_to_ir(db, &mut ir, source.uri(db).as_str());
     print_module(&ir, module.op())

--- a/crates/tribute-ir/src/lib.rs
+++ b/crates/tribute-ir/src/lib.rs
@@ -4,6 +4,7 @@
 //! built on top of the trunk-ir infrastructure.
 
 pub mod dialect;
+pub mod metadata;
 
 // Re-export common trunk-ir types for convenience
 pub use trunk_ir::{BlockId, ConversionError, IdVec, Span, Symbol, idvec};

--- a/crates/tribute-ir/src/metadata.rs
+++ b/crates/tribute-ir/src/metadata.rs
@@ -1,0 +1,28 @@
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::refs::{OpRef, TypeRef};
+use trunk_ir::types::Attribute;
+
+const STRING_TYPE_ATTR: &str = "tribute.well_known.string";
+
+/// Tribute semantic type identities attached to a root IR module.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WellKnownTypes {
+    pub string: Option<TypeRef>,
+}
+
+impl WellKnownTypes {
+    pub fn from_module(ctx: &IrContext, module: OpRef) -> Self {
+        Self {
+            string: ctx.op(module).attributes.get_type(STRING_TYPE_ATTR),
+        }
+    }
+
+    pub fn attach(self, ctx: &mut IrContext, module: OpRef) {
+        if let Some(string) = self.string {
+            ctx.op_mut(module)
+                .attributes
+                .insert(Symbol::new(STRING_TYPE_ATTR), Attribute::Type(string));
+        }
+    }
+}

--- a/crates/tribute-ir/src/metadata.rs
+++ b/crates/tribute-ir/src/metadata.rs
@@ -3,7 +3,7 @@ use trunk_ir::context::IrContext;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::types::Attribute;
 
-const STRING_TYPE_ATTR: &str = "tribute.well_known.string";
+const STRING_TYPE_ATTR: &str = "tribute.type.string";
 
 /// Tribute semantic type identities attached to a root IR module.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/crates/tribute-passes/src/native/const_to_native.rs
+++ b/crates/tribute-passes/src/native/const_to_native.rs
@@ -45,7 +45,7 @@ pub struct NativeConstAnalysis {
     content_to_symbol: HashMap<Vec<u8>, Symbol>,
     /// Whether the module contains any `adt.string_const` ops.
     has_string_consts: bool,
-    /// The String enum type (found by scanning IR types).
+    /// The exact prelude String enum type from module metadata.
     string_enum_ty: Option<TypeRef>,
 }
 
@@ -53,45 +53,6 @@ impl NativeConstAnalysis {
     pub fn is_empty(&self) -> bool {
         self.rodata.is_empty()
     }
-}
-
-/// Find the String enum type by scanning interned types.
-///
-/// Looks for an `adt.enum` type named "String" with variants "Leaf" and "Branch".
-fn find_string_enum_type(ctx: &IrContext) -> Option<TypeRef> {
-    for (ty_ref, td) in ctx.types.iter() {
-        if td.dialect != Symbol::new("adt") {
-            continue;
-        }
-        if td.attrs.get_symbol("name") != Some(Symbol::new("String")) {
-            continue;
-        }
-        // Check it has "variants" attribute with Leaf and Branch
-        if let Some(Attribute::List(variants)) = td.attrs.get("variants") {
-            let has_leaf = variants.iter().any(|v| {
-                if let Attribute::List(items) = v {
-                    items.first().is_some_and(
-                        |n| matches!(n, Attribute::Symbol(s) if *s == Symbol::new("Leaf")),
-                    )
-                } else {
-                    false
-                }
-            });
-            let has_branch = variants.iter().any(|v| {
-                if let Attribute::List(items) = v {
-                    items.first().is_some_and(
-                        |n| matches!(n, Attribute::Symbol(s) if *s == Symbol::new("Branch")),
-                    )
-                } else {
-                    false
-                }
-            });
-            if has_leaf && has_branch {
-                return Some(ty_ref);
-            }
-        }
-    }
-    None
 }
 
 /// Context for collecting const allocations during analysis.
@@ -169,11 +130,10 @@ pub fn analyze_consts(ctx: &IrContext, module: Module) -> NativeConstAnalysis {
         });
     }
 
-    let string_enum_ty = if collector.has_string_consts {
-        find_string_enum_type(ctx)
-    } else {
-        None
-    };
+    let string_enum_ty = collector
+        .has_string_consts
+        .then(|| tribute_ir::metadata::WellKnownTypes::from_module(ctx, module.op()).string)
+        .flatten();
 
     NativeConstAnalysis {
         content_to_symbol: collector.seen,
@@ -459,5 +419,66 @@ impl RewritePattern for StringConstNativePattern {
 
     fn name(&self) -> &'static str {
         "StringConstNativePattern"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+
+    fn type_alias(ctx: &IrContext, name: &str) -> TypeRef {
+        ctx.type_aliases()
+            .iter()
+            .find_map(|(alias, ty)| (*alias == name).then_some(*ty))
+            .unwrap_or_else(|| panic!("missing type alias !{name}"))
+    }
+
+    fn string_module(ctx: &mut IrContext) -> Module {
+        parse_test_module(
+            ctx,
+            r#"core.module @test {
+  !PreludeString = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !UserString = adt.enum() {name = @"user::String", variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  func.func @main() -> core.nil {
+    %string = adt.string_const {value = "hello"} : tribute_rt.anyref
+    func.return
+  }
+}"#,
+        )
+    }
+
+    #[test]
+    fn analysis_uses_exact_string_metadata_not_user_lookalike() {
+        let mut ctx = IrContext::new();
+        let module = string_module(&mut ctx);
+        let prelude_string = type_alias(&ctx, "PreludeString");
+        let user_string = type_alias(&ctx, "UserString");
+        tribute_ir::metadata::WellKnownTypes {
+            string: Some(prelude_string),
+        }
+        .attach(&mut ctx, module.op());
+
+        let analysis = analyze_consts(&ctx, module);
+
+        assert_eq!(analysis.string_enum_ty, Some(prelude_string));
+        assert_ne!(analysis.string_enum_ty, Some(user_string));
+    }
+
+    #[test]
+    fn lowering_rejects_missing_string_metadata() {
+        let mut ctx = IrContext::new();
+        let module = string_module(&mut ctx);
+        let analysis = analyze_consts(&ctx, module);
+
+        let error = lower(&mut ctx, module, &analysis).expect_err("metadata is required");
+
+        assert_eq!(error.boundary(), "const-to-native");
+        assert!(
+            error
+                .operations()
+                .iter()
+                .any(|illegal| { illegal.dialect == "adt" && illegal.name == "string_const" })
+        );
     }
 }

--- a/crates/tribute-passes/src/wasm/const_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/const_to_wasm.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::fmt;
 
 use trunk_ir::Symbol;
-use trunk_ir::adt_layout::get_enum_variants;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::adt;
 use trunk_ir::dialect::wasm as wasm_dialect;
@@ -111,44 +110,6 @@ impl ConstCollector {
     }
 }
 
-/// Find the canonical prelude String enum type.
-fn find_string_enum_type(ctx: &IrContext) -> Option<trunk_ir::TypeRef> {
-    ctx.types.iter().find_map(|(ty_ref, data)| {
-        if data.dialect != "adt" || data.name != "enum" {
-            return None;
-        }
-        if data.attrs.get_symbol("name") != Some(Symbol::new("String")) {
-            return None;
-        }
-        // TODO(#790): Consume the canonical prelude String TypeRef carried from
-        // the frontend instead of identifying it by name and structural layout.
-        let variants = get_enum_variants(ctx, ty_ref)?;
-        let [(leaf_tag, leaf_fields), (branch_tag, branch_fields)] = variants.as_slice() else {
-            return None;
-        };
-        let [leaf_ty] = leaf_fields.as_slice() else {
-            return None;
-        };
-        let [left_ty, right_ty, length_ty] = branch_fields.as_slice() else {
-            return None;
-        };
-
-        let is_type = |ty, dialect, name| {
-            let field = ctx.types.get(ty);
-            field.dialect == dialect && field.name == name
-        };
-        let is_anyref = |ty| is_type(ty, "tribute_rt", "anyref") || is_type(ty, "wasm", "anyref");
-
-        (leaf_tag == "Leaf"
-            && branch_tag == "Branch"
-            && is_type(*leaf_ty, "core", "bytes")
-            && is_anyref(*left_ty)
-            && is_anyref(*right_ty)
-            && is_type(*length_ty, "core", "i32"))
-        .then_some(ty_ref)
-    })
-}
-
 /// Walk all operations in a region recursively.
 fn walk_ops_in_region(
     ctx: &IrContext,
@@ -180,7 +141,7 @@ pub fn analyze_consts(ctx: &IrContext, module: Module) -> ConstAnalysis {
         allocations: collector.allocations,
         string_enum_ty: collector
             .has_string_consts
-            .then(|| find_string_enum_type(ctx))
+            .then(|| tribute_ir::metadata::WellKnownTypes::from_module(ctx, module.op()).string)
             .flatten(),
     }
 }
@@ -372,6 +333,20 @@ mod tests {
     use super::*;
     use trunk_ir::parser::parse_test_module;
 
+    fn type_alias(ctx: &IrContext, name: &str) -> trunk_ir::TypeRef {
+        ctx.type_aliases()
+            .iter()
+            .find_map(|(alias, ty)| (*alias == name).then_some(*ty))
+            .unwrap_or_else(|| panic!("missing type alias !{name}"))
+    }
+
+    fn attach_string_type(ctx: &mut IrContext, module: Module, string: trunk_ir::TypeRef) {
+        tribute_ir::metadata::WellKnownTypes {
+            string: Some(string),
+        }
+        .attach(ctx, module.op());
+    }
+
     fn string_module(ctx: &mut IrContext, values: &[&str]) -> Module {
         let constants = values
             .iter()
@@ -447,6 +422,8 @@ mod tests {
   }
 }"#,
         );
+        let string_ty = type_alias(&ctx, "String");
+        attach_string_type(&mut ctx, module, string_ty);
         let analysis = analyze_consts(&ctx, module);
 
         validate_for_wasm(&ctx, module, &analysis).expect("canonical String result type");
@@ -480,32 +457,55 @@ mod tests {
     }
 
     #[test]
-    fn validation_rejects_malformed_string_layouts() {
-        for variants in [
-            "[[@Leaf, [core.bytes]], [@Branch, [wasm.anyref, core.i32, core.i32]]]",
-            "[[@Leaf, [core.bytes]], [@Branch, [wasm.anyref, wasm.anyref, core.i32]], [@Extra, []]]",
-        ] {
-            let mut ctx = IrContext::new();
-            let module = parse_test_module(
-                &mut ctx,
-                &format!(
-                    r#"core.module @test {{
-  !String = adt.enum() {{name = @String, variants = {variants}}}
-  wasm.func @main() -> core.nil {{
-    %string = adt.string_const {{value = "hello"}} : wasm.anyref
+    fn user_string_lookalike_cannot_substitute_for_metadata_identity() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !PreludeString = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [wasm.anyref, wasm.anyref, core.i32]]]}
+  !UserString = adt.enum() {name = @"user::String", variants = [[@Leaf, [core.bytes]], [@Branch, [wasm.anyref, wasm.anyref, core.i32]]]}
+  wasm.func @main() -> core.nil {
+    %string = adt.string_const {value = "hello"} : wasm.anyref
     wasm.return
-  }}
-}}"#
-                ),
-            );
-            let analysis = analyze_consts(&ctx, module);
+  }
+}"#,
+        );
+        let prelude_string = type_alias(&ctx, "PreludeString");
+        let user_string = type_alias(&ctx, "UserString");
+        attach_string_type(&mut ctx, module, prelude_string);
 
-            assert_eq!(
-                validate_for_wasm(&ctx, module, &analysis),
-                Err(ConstValidationError::MissingCanonicalStringType),
-                "accepted malformed variants: {variants}"
-            );
-        }
+        let analysis = analyze_consts(&ctx, module);
+
+        assert_eq!(analysis.string_enum_ty, Some(prelude_string));
+        assert_ne!(analysis.string_enum_ty, Some(user_string));
+    }
+
+    #[test]
+    fn textual_ir_round_trip_drops_metadata_and_fails_conservatively() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [wasm.anyref, wasm.anyref, core.i32]]]}
+  wasm.func @main() -> core.nil {
+    %string = adt.string_const {value = "hello"} : wasm.anyref
+    wasm.return
+  }
+}"#,
+        );
+        let string_ty = type_alias(&ctx, "String");
+        attach_string_type(&mut ctx, module, string_ty);
+
+        let printed = trunk_ir::printer::print_module(&ctx, module.op());
+        let mut reparsed_ctx = IrContext::new();
+        let reparsed = parse_test_module(&mut reparsed_ctx, &printed);
+        let analysis = analyze_consts(&reparsed_ctx, reparsed);
+
+        assert_eq!(analysis.string_enum_ty, None);
+        assert_eq!(
+            validate_for_wasm(&reparsed_ctx, reparsed, &analysis),
+            Err(ConstValidationError::MissingCanonicalStringType)
+        );
     }
 
     #[test]

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -1206,6 +1206,15 @@ mod tests {
   }
 }"#,
         );
+        let string_ty = ctx
+            .type_aliases()
+            .iter()
+            .find_map(|(name, ty)| (*name == "String").then_some(*ty))
+            .expect("String alias");
+        tribute_ir::metadata::WellKnownTypes {
+            string: Some(string_ty),
+        }
+        .attach(&mut ctx, module.op());
 
         let error = lower_to_wasm(&mut ctx, module)
             .expect_err("non-reference string constant result must be rejected");

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -55,6 +55,12 @@ graph TD
 
 ## Lowering 경로
 
+String constant lowering reads the exact prelude `String` `TypeRef` from the
+root module's `tribute.well_known.string` metadata. It does not search interned
+ADT types by `String`, `Leaf`/`Branch`, or representation layout. Missing
+metadata is a lowering error whenever `adt.string_const` is present; this keeps
+hand-written or text-round-tripped IR from silently selecting a user lookalike.
+
 ### Native 타겟
 
 ```mermaid

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -56,7 +56,7 @@ graph TD
 ## Lowering 경로
 
 String constant lowering reads the exact prelude `String` `TypeRef` from the
-root module's `tribute.well_known.string` metadata. It does not search interned
+root module's `tribute.type.string` metadata. It does not search interned
 ADT types by `String`, `Leaf`/`Branch`, or representation layout. Missing
 metadata is a lowering error whenever `adt.string_const` is present; this keeps
 hand-written or text-round-tripped IR from silently selecting a user lookalike.

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -650,7 +650,7 @@ Prelude가 정의하는 well-known type은 type checking 결과의 별도 metada
 보존한다. 최소 metadata 집합인 `WellKnownTypes`는 prelude `String`의 semantic
 type과 stable declaration identity를 `TypedModule` 경계까지 전달하고,
 AST-to-IR lowering은 declaration identity를 직접 비교해 이를 정확한
-TrunkIR `TypeRef`로 변환해 root module의 `tribute.well_known.string` attribute에
+TrunkIR `TypeRef`로 변환해 root module의 `tribute.type.string` attribute에
 기록한다. Native/Wasm constant lowering은 이 attribute만 사용하며 이름이나
 layout scan으로 복구하지 않는다. Textual IR에서 attribute가 유실된 경우
 string constant lowering은 보수적으로 실패한다.

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -646,6 +646,15 @@ Tribute 컴파일러 파이프라인은 다음 원칙을 따른다:
 3. **선택적 캐싱**: 비용이 큰 패스만 `#[salsa::tracked]`로 캐싱
 4. **관심사 분리**: 패스 구현과 파이프라인 조합을 분리
 
+Prelude가 정의하는 well-known type은 type checking 결과의 별도 metadata로
+보존한다. 최소 metadata 집합인 `WellKnownTypes`는 prelude `String`의 semantic
+type과 stable declaration identity를 `TypedModule` 경계까지 전달하고,
+AST-to-IR lowering은 declaration identity를 직접 비교해 이를 정확한
+TrunkIR `TypeRef`로 변환해 root module의 `tribute.well_known.string` attribute에
+기록한다. Native/Wasm constant lowering은 이 attribute만 사용하며 이름이나
+layout scan으로 복구하지 않는다. Textual IR에서 attribute가 유실된 경우
+string constant lowering은 보수적으로 실패한다.
+
 ```rust
 // 패스 구현 (tribute-passes): 순수 변환만 담당
 pub fn typecheck(db: &dyn Database, module: Module) -> Module { ... }

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -99,7 +99,7 @@ native uses function pointers plus heap environments.
 literal operations.
 
 The root `core.module` carries Tribute-specific well-known type identities as
-`TypeRef` attributes. In particular, `tribute.well_known.string` is the exact
+`TypeRef` attributes. In particular, `tribute.type.string` is the exact
 `adt.enum` type produced from the prelude `String` declaration. String-literal
 lowering must consume this identity directly; it must not rediscover `String`
 by type name, variant names, or field layout. This metadata is semantic compiler
@@ -110,7 +110,7 @@ identity, not its name, when materializing this `TypeRef`.
 The current specialized textual printer for `core.module` does not serialize
 arbitrary module attributes. Consequently, parsing printed IR conservatively
 drops well-known type metadata. A backend may still process byte constants, but
-must reject `adt.string_const` when `tribute.well_known.string` is absent rather
+must reject `adt.string_const` when `tribute.type.string` is absent rather
 than scanning types for a plausible replacement. A future textual format may
 make these attributes round-trip explicitly.
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -98,6 +98,22 @@ native uses function pointers plus heap environments.
 `adt.*` represents target-independent product, sum, array, reference, and
 literal operations.
 
+The root `core.module` carries Tribute-specific well-known type identities as
+`TypeRef` attributes. In particular, `tribute.well_known.string` is the exact
+`adt.enum` type produced from the prelude `String` declaration. String-literal
+lowering must consume this identity directly; it must not rediscover `String`
+by type name, variant names, or field layout. This metadata is semantic compiler
+state rather than a nominal-layout convention. The frontend preserves the
+prelude declaration's stable identity through type checking and compares that
+identity, not its name, when materializing this `TypeRef`.
+
+The current specialized textual printer for `core.module` does not serialize
+arbitrary module attributes. Consequently, parsing printed IR conservatively
+drops well-known type metadata. A backend may still process byte constants, but
+must reject `adt.string_const` when `tribute.well_known.string` is absent rather
+than scanning types for a plausible replacement. A future textual format may
+make these attributes round-trip explicitly.
+
 ## Mid-Level Dialects
 
 `func.*` represents function definitions, direct calls, indirect calls, function

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -273,6 +273,7 @@ fn prelude_module<'db>(db: &'db dyn salsa::Database) -> Option<ast_typeck::TypeC
         result.function_types,
         result.node_types,
         result.ability_conventions,
+        result.well_known_types,
         span_map,
     ))
 }
@@ -418,6 +419,7 @@ fn merge_and_lower_to_ir<'db>(
         function_types: merged_fn_types,
         node_types: merged_node_types,
         ability_conventions: merged_ability_conventions,
+        well_known_types: typed.well_known_types(db),
     }
     .lower_to_ir_with_options(db, &mut ir, source_uri, options.ast_to_ir);
 
@@ -1253,6 +1255,7 @@ pub fn parse_and_lower_ast<'db>(
         result.function_types,
         result.node_types,
         result.ability_conventions,
+        result.well_known_types,
         span_map,
     ))
 }
@@ -1881,6 +1884,61 @@ fn main() ->{std::io::Io} Nil {
         assert!(result.is_some());
         let (ctx, m) = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
+    }
+
+    #[salsa_test]
+    fn well_known_string_metadata_uses_prelude_declaration_identity(db: &salsa::DatabaseImpl) {
+        let source = source_from_str(
+            "lookalike.trb",
+            r#"
+enum String {
+    Leaf(Bytes),
+    Branch(String, String, Nat),
+}
+
+fn main() -> String { "hello" }
+"#,
+        );
+        let typed = parse_and_lower_ast(db, source).expect("frontend output");
+        let canonical = typed
+            .well_known_types(db)
+            .string
+            .expect("prelude String identity");
+        let (ctx, module) =
+            merge_and_lower_to_ir(db, &typed, source, OptimizationOptions::production());
+        let string_ty = tribute_ir::metadata::WellKnownTypes::from_module(&ctx, module.op())
+            .string
+            .expect("String IR metadata");
+        let string_data = ctx.types.get(string_ty);
+
+        assert_eq!(
+            string_data.attrs.get("tribute.definition.source"),
+            Some(&trunk_ir::Attribute::Int(
+                canonical.definition.source as i128
+            ))
+        );
+        assert_eq!(
+            string_data.attrs.get("tribute.definition.start"),
+            Some(&trunk_ir::Attribute::Int(
+                canonical.definition.start as i128
+            ))
+        );
+        assert_eq!(
+            string_data.attrs.get("tribute.definition.end"),
+            Some(&trunk_ir::Attribute::Int(canonical.definition.end as i128))
+        );
+
+        let user_lookalike = ctx.types.iter().find_map(|(ty, data)| {
+            (ty != string_ty
+                && data.dialect == "adt"
+                && data.name == "enum"
+                && data.attrs.get_symbol("name") == Some(trunk_ir::Symbol::new("String")))
+            .then_some(ty)
+        });
+        assert!(
+            user_lookalike.is_some(),
+            "compatible user String must remain distinct from prelude String"
+        );
     }
 
     #[salsa_test]

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -6,7 +6,7 @@ core.module @direct_fn {
   !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !String = adt.enum() {name = @String, tribute.definition.end = 5768, tribute.definition.source = 4923843560778033168, tribute.definition.start = 5703, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
@@ -6,7 +6,7 @@ core.module @float_comparisons {
   !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !String = adt.enum() {name = @String, tribute.definition.end = 5768, tribute.definition.source = 4923843560778033168, tribute.definition.start = 5703, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -6,7 +6,7 @@ core.module @mixed_nested {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !String = adt.enum() {name = @String, tribute.definition.end = 5768, tribute.definition.source = 4923843560778033168, tribute.definition.start = 5703, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -6,7 +6,7 @@ core.module @resumptive_op {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !String = adt.enum() {name = @String, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
+  !String = adt.enum() {name = @String, tribute.definition.end = 5768, tribute.definition.source = 4923843560778033168, tribute.definition.start = 5703, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}


### PR DESCRIPTION
## Summary

- capture the canonical prelude `String` declaration identity in frontend well-known type metadata
- materialize a distinct canonical ADT `TypeRef` and attach it to the root IR module
- make Native and Wasm constant lowering consume that exact type instead of scanning names and layouts
- add user-lookalike, missing-metadata, and textual-round-trip regressions

## Why

Structural discovery could select a user-defined or malformed `String` lookalike. Preserving the ordinary prelude declaration's identity through AST-to-IR lowering removes that ambiguity without introducing a compiler-owned source type.

## Validation

- focused frontend and pass tests (647 passed)
- Native/Wasm E2E tests (63 passed, 1 skipped)
- `cargo nextest run --workspace` (1586 passed, 10 skipped)
- pre-commit Clippy and formatting checks

Closes #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable identification of the prelude’s canonical `String` type across compilation and lowering.
  - Preserved well-known type metadata on compiled modules.

- **Bug Fixes**
  - String constants no longer resolve to lookalike user-defined types with matching names or layouts.
  - Native and WebAssembly lowering now reports a clear error when required `String` metadata is unavailable.

- **Documentation**
  - Updated compiler and backend documentation to describe canonical `String` handling and metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->