### PR TITLE
Implement temporary RC field borrows

### DIFF
--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -39,6 +39,7 @@ use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::clif;
 use trunk_ir::dialect::core;
+use trunk_ir::dominance::DominatorTree;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::rewrite::Module;
 use trunk_ir::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
@@ -52,6 +53,13 @@ pub enum BorrowedParameterPolicy {
     Preserve,
     /// Omit parameter RC only when all uses are proven non-escaping.
     ElideProvenBorrowed,
+}
+
+/// Policy for eliding ownership of proven field-derived temporaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TemporaryBorrowPolicy {
+    Preserve,
+    ElideProvenFieldBorrows,
 }
 
 /// Check if a type is `tribute_rt.anyref` (RC-managed reference type).
@@ -158,6 +166,18 @@ struct LivenessInfo {
     live_out: HashMap<BlockRef, HashSet<ValueRef>>,
 }
 
+#[derive(Default)]
+struct TemporaryBorrowInfo {
+    borrowed: HashSet<ValueRef>,
+    lifetime_dependencies: HashMap<ValueRef, ValueRef>,
+}
+
+struct RcBorrowInfo<'a> {
+    parameters: &'a HashSet<ValueRef>,
+    temporaries: &'a HashSet<ValueRef>,
+    lifetime_dependencies: &'a HashMap<ValueRef, ValueRef>,
+}
+
 /// Collect all pointer-typed values in the function body.
 fn collect_ptr_values(ctx: &IrContext, body: RegionRef) -> HashSet<ValueRef> {
     let mut ptr_values = HashSet::new();
@@ -257,6 +277,7 @@ fn compute_use_def_sets(
     body: RegionRef,
     ptr_values: &HashSet<ValueRef>,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    lifetime_dependencies: &HashMap<ValueRef, ValueRef>,
 ) -> (
     HashMap<BlockRef, HashSet<ValueRef>>,
     HashMap<BlockRef, HashSet<ValueRef>>,
@@ -285,6 +306,11 @@ fn compute_use_def_sets(
                 {
                     uses.insert(aliased);
                 }
+                record_lifetime_dependencies(operand, lifetime_dependencies, |owner| {
+                    if !defs.contains(&owner) {
+                        uses.insert(owner);
+                    }
+                });
             }
             for &result_val in ctx.op_results(op) {
                 if is_anyref_type(ctx, ctx.value_ty(result_val))
@@ -309,8 +335,10 @@ fn compute_liveness(
     body: RegionRef,
     ptr_values: &HashSet<ValueRef>,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    lifetime_dependencies: &HashMap<ValueRef, ValueRef>,
 ) -> LivenessInfo {
-    let (use_sets, def_sets) = compute_use_def_sets(ctx, body, ptr_values, ptr_alias_map);
+    let (use_sets, def_sets) =
+        compute_use_def_sets(ctx, body, ptr_values, ptr_alias_map, lifetime_dependencies);
     let successor_map = build_successor_map(ctx, body);
     let block_refs: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
 
@@ -377,7 +405,12 @@ struct InsertionPlan {
 /// Insert reference counting operations for all `tribute_rt.anyref`-typed values,
 /// then lower all remaining `tribute_rt.anyref` types to `core.ptr`.
 pub fn insert_rc(ctx: &mut IrContext, module: Module) {
-    insert_rc_with_policy(ctx, module, BorrowedParameterPolicy::Preserve);
+    insert_rc_with_policies(
+        ctx,
+        module,
+        BorrowedParameterPolicy::Preserve,
+        TemporaryBorrowPolicy::Preserve,
+    );
 }
 
 /// Insert reference counting operations with an explicit borrowed-parameter
@@ -386,6 +419,22 @@ pub fn insert_rc_with_policy(
     ctx: &mut IrContext,
     module: Module,
     borrowed_parameters: BorrowedParameterPolicy,
+) {
+    insert_rc_with_policies(
+        ctx,
+        module,
+        borrowed_parameters,
+        TemporaryBorrowPolicy::Preserve,
+    );
+}
+
+/// Insert reference counting operations with independently selectable borrow
+/// policies, then lower all remaining `tribute_rt.anyref` types to `core.ptr`.
+pub fn insert_rc_with_policies(
+    ctx: &mut IrContext,
+    module: Module,
+    borrowed_parameters: BorrowedParameterPolicy,
+    temporary_borrows: TemporaryBorrowPolicy,
 ) {
     let Some(first_block) = module.first_block(ctx) else {
         return;
@@ -405,7 +454,7 @@ pub fn insert_rc_with_policy(
             } else {
                 BorrowedParameterPolicy::Preserve
             };
-            insert_rc_in_function(ctx, body, function_policy);
+            insert_rc_in_function(ctx, body, function_policy, temporary_borrows);
         }
     }
 
@@ -623,6 +672,7 @@ fn insert_rc_in_function(
     ctx: &mut IrContext,
     body: RegionRef,
     borrowed_parameter_policy: BorrowedParameterPolicy,
+    temporary_borrow_policy: TemporaryBorrowPolicy,
 ) {
     let mut ptr_values = collect_ptr_values(ctx, body);
 
@@ -631,13 +681,30 @@ fn insert_rc_in_function(
     }
 
     let ptr_alias_map = build_ptr_alias_map(ctx, body, &mut ptr_values);
-    let liveness = compute_liveness(ctx, body, &ptr_values, &ptr_alias_map);
+    let temporary_borrows = match temporary_borrow_policy {
+        TemporaryBorrowPolicy::Preserve => TemporaryBorrowInfo::default(),
+        TemporaryBorrowPolicy::ElideProvenFieldBorrows => {
+            analyze_temporary_borrows(ctx, body, &ptr_values, &ptr_alias_map)
+        }
+    };
+    let liveness = compute_liveness(
+        ctx,
+        body,
+        &ptr_values,
+        &ptr_alias_map,
+        &temporary_borrows.lifetime_dependencies,
+    );
     let borrowed_parameters = match borrowed_parameter_policy {
         BorrowedParameterPolicy::Preserve => HashSet::new(),
         BorrowedParameterPolicy::ElideProvenBorrowed => analyze_borrowed_parameters(ctx, body),
     };
 
     let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
+    let borrow_info = RcBorrowInfo {
+        parameters: &borrowed_parameters,
+        temporaries: &temporary_borrows.borrowed,
+        lifetime_dependencies: &temporary_borrows.lifetime_dependencies,
+    };
     for (block_idx, &block) in blocks.iter().enumerate() {
         insert_rc_in_block(
             ctx,
@@ -646,8 +713,255 @@ fn insert_rc_in_function(
             &ptr_values,
             &liveness,
             &ptr_alias_map,
-            &borrowed_parameters,
+            &borrow_info,
         );
+    }
+}
+
+fn analyze_temporary_borrows(
+    ctx: &IrContext,
+    body: RegionRef,
+    ptr_values: &HashSet<ValueRef>,
+    ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+) -> TemporaryBorrowInfo {
+    let dominance = DominatorTree::compute(ctx, body);
+    if !dominance.is_valid() {
+        return TemporaryBorrowInfo::default();
+    }
+
+    let mut info = TemporaryBorrowInfo::default();
+    for &block in &ctx.region(body).blocks {
+        if !dominance.is_reachable(block) {
+            continue;
+        }
+        for &op in &ctx.block(block).ops {
+            if !clif::Load::matches(ctx, op) || ctx.op_results(op).len() != 1 {
+                continue;
+            }
+            let temporary = ctx.op_result(op, 0);
+            if !is_anyref_value(ctx, temporary) {
+                continue;
+            }
+            let Some(&address) = ctx.op_operands(op).first() else {
+                continue;
+            };
+            let Some(owner) = resolve_temporary_owner(
+                ctx,
+                address,
+                ptr_values,
+                ptr_alias_map,
+                &mut HashSet::new(),
+            ) else {
+                continue;
+            };
+            if let Some(aliases) =
+                temporary_is_proven_borrowed(ctx, body, op, temporary, owner, &dominance)
+            {
+                info.borrowed.insert(temporary);
+                info.lifetime_dependencies.insert(temporary, owner);
+                for alias in aliases {
+                    info.lifetime_dependencies.insert(alias, owner);
+                }
+            }
+        }
+    }
+    info
+}
+
+fn resolve_temporary_owner(
+    ctx: &IrContext,
+    value: ValueRef,
+    ptr_values: &HashSet<ValueRef>,
+    ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    visited: &mut HashSet<ValueRef>,
+) -> Option<ValueRef> {
+    if !visited.insert(value) {
+        return None;
+    }
+    if ptr_values.contains(&value) {
+        return Some(value);
+    }
+    if let Some(&owner) = ptr_alias_map.get(&value) {
+        return resolve_temporary_owner(ctx, owner, ptr_values, ptr_alias_map, visited);
+    }
+    let ValueDef::OpResult(defining_op, _) = ctx.value_def(value) else {
+        return None;
+    };
+    if core::UnrealizedConversionCast::matches(ctx, defining_op)
+        || clif::Iadd::matches(ctx, defining_op)
+    {
+        let input = *ctx.op_operands(defining_op).first()?;
+        return resolve_temporary_owner(ctx, input, ptr_values, ptr_alias_map, visited);
+    }
+    None
+}
+
+fn temporary_is_proven_borrowed(
+    ctx: &IrContext,
+    body: RegionRef,
+    load: OpRef,
+    temporary: ValueRef,
+    owner: ValueRef,
+    dominance: &DominatorTree,
+) -> Option<Vec<ValueRef>> {
+    let load_block = ctx.op(load).parent_block?;
+    if !value_dominates_op(ctx, body, owner, load, dominance) {
+        return None;
+    }
+
+    let mut use_blocks = Vec::new();
+    let mut aliases = Vec::new();
+    let mut collector = TemporaryUseCollector {
+        ctx,
+        body,
+        load,
+        dominance,
+        visited: HashSet::new(),
+        use_blocks: &mut use_blocks,
+        aliases: &mut aliases,
+    };
+    if !collector.collect(temporary) {
+        return None;
+    }
+
+    for &user_block in &use_blocks {
+        if user_block != load_block && dominance.predecessors(user_block).len() > 1 {
+            return None;
+        }
+    }
+
+    for (index, &left) in use_blocks.iter().enumerate() {
+        for &right in &use_blocks[index + 1..] {
+            if !dominance.dominates(left, right) && !dominance.dominates(right, left) {
+                return None;
+            }
+        }
+    }
+
+    for &source in &ctx.region(body).blocks {
+        for &successor in dominance.successors(source) {
+            if dominance.dominates(successor, source)
+                && dominance.dominates(load_block, source)
+                && use_blocks
+                    .iter()
+                    .any(|&use_block| dominance.dominates(successor, use_block))
+            {
+                return None;
+            }
+        }
+    }
+
+    Some(aliases)
+}
+
+struct TemporaryUseCollector<'a> {
+    ctx: &'a IrContext,
+    body: RegionRef,
+    load: OpRef,
+    dominance: &'a DominatorTree,
+    visited: HashSet<ValueRef>,
+    use_blocks: &'a mut Vec<BlockRef>,
+    aliases: &'a mut Vec<ValueRef>,
+}
+
+impl TemporaryUseCollector<'_> {
+    fn collect(&mut self, value: ValueRef) -> bool {
+        if !self.visited.insert(value) {
+            return false;
+        }
+        for use_ in self.ctx.uses(value) {
+            let user = use_.user;
+            let Some(user_block) = self.ctx.op(user).parent_block else {
+                return false;
+            };
+            if self.ctx.block(user_block).parent_region != Some(self.body)
+                || !self.dominance.is_reachable(user_block)
+                || !op_dominates_op(self.ctx, self.load, user, self.dominance)
+            {
+                return false;
+            }
+            let operand_index = use_.operand_index as usize;
+            self.use_blocks.push(user_block);
+            if core::UnrealizedConversionCast::matches(self.ctx, user)
+                && operand_index == 0
+                && self.ctx.op_operands(user).len() == 1
+                && self.ctx.op_results(user).len() == 1
+            {
+                let alias = self.ctx.op_result(user, 0);
+                self.aliases.push(alias);
+                if !self.collect(alias) {
+                    return false;
+                }
+            } else if !is_proven_temporary_use(self.ctx, user, operand_index) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn value_dominates_op(
+    ctx: &IrContext,
+    body: RegionRef,
+    value: ValueRef,
+    op: OpRef,
+    dominance: &DominatorTree,
+) -> bool {
+    match ctx.value_def(value) {
+        ValueDef::BlockArg(block, _) => {
+            ctx.block(block).parent_region == Some(body)
+                && dominance.entry() == Some(block)
+                && dominance.dominates(block, ctx.op(op).parent_block.unwrap_or(block))
+        }
+        ValueDef::OpResult(defining_op, _) => op_dominates_op(ctx, defining_op, op, dominance),
+    }
+}
+
+fn op_dominates_op(
+    ctx: &IrContext,
+    defining_op: OpRef,
+    user: OpRef,
+    dominance: &DominatorTree,
+) -> bool {
+    let (Some(defining_block), Some(user_block)) =
+        (ctx.op(defining_op).parent_block, ctx.op(user).parent_block)
+    else {
+        return false;
+    };
+    if defining_block != user_block {
+        return dominance.dominates(defining_block, user_block);
+    }
+    let ops = &ctx.block(defining_block).ops;
+    let defining_index = ops.iter().position(|&op| op == defining_op);
+    let user_index = ops.iter().position(|&op| op == user);
+    defining_index
+        .zip(user_index)
+        .is_some_and(|(defining, use_)| defining < use_)
+}
+
+fn is_proven_temporary_use(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+    if clif::Load::matches(ctx, op) {
+        return operand_index == 0;
+    }
+    if clif::Store::matches(ctx, op) {
+        return operand_index == 1;
+    }
+    clif::Icmp::matches(ctx, op)
+}
+
+fn record_lifetime_dependencies(
+    value: ValueRef,
+    dependencies: &HashMap<ValueRef, ValueRef>,
+    mut record: impl FnMut(ValueRef),
+) {
+    let mut current = value;
+    let mut visited = HashSet::new();
+    while let Some(&owner) = dependencies.get(&current) {
+        if !visited.insert(owner) {
+            break;
+        }
+        record(owner);
+        current = owner;
     }
 }
 
@@ -726,7 +1040,7 @@ fn insert_rc_in_block(
     ptr_values: &HashSet<ValueRef>,
     liveness: &LivenessInfo,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
-    borrowed_parameters: &HashSet<ValueRef>,
+    borrow_info: &RcBorrowInfo<'_>,
 ) {
     let ops: Vec<OpRef> = ctx.block(block).ops.to_vec();
     let loc = ctx.block(block).location;
@@ -745,6 +1059,9 @@ fn insert_rc_in_block(
             if let Some(&aliased) = ptr_alias_map.get(&operand) {
                 last_use_in_block.insert(aliased, op_idx);
             }
+            record_lifetime_dependencies(operand, borrow_info.lifetime_dependencies, |owner| {
+                last_use_in_block.insert(owner, op_idx);
+            });
         }
     }
 
@@ -771,7 +1088,8 @@ fn insert_rc_in_block(
     if is_entry {
         let args: Vec<ValueRef> = ctx.block_args(block).to_vec();
         for arg_val in args {
-            if is_anyref_type(ctx, ctx.value_ty(arg_val)) && !borrowed_parameters.contains(&arg_val)
+            if is_anyref_type(ctx, ctx.value_ty(arg_val))
+                && !borrow_info.parameters.contains(&arg_val)
             {
                 let retain_op = tribute_rt::retain(ctx, loc, arg_val, ptr_ty);
                 plan.at_start.push(retain_op.op_ref());
@@ -800,6 +1118,9 @@ fn insert_rc_in_block(
             let result_ty = ctx.op_result_types(op).first().copied();
             if result_ty.is_some_and(|ty| is_anyref_type(ctx, ty)) {
                 let load_result = ctx.op_result(op, 0);
+                if borrow_info.temporaries.contains(&load_result) {
+                    continue;
+                }
                 let op_loc = ctx.op(op).location;
                 let retain_op = tribute_rt::retain(ctx, op_loc, load_result, ptr_ty);
                 plan.after
@@ -816,7 +1137,10 @@ fn insert_rc_in_block(
     let mut dying_values: HashSet<ValueRef> = HashSet::new();
 
     for v in &live_in {
-        if !live_out.contains(v) && !returned_values.contains(v) && !borrowed_parameters.contains(v)
+        if !live_out.contains(v)
+            && !returned_values.contains(v)
+            && !borrow_info.parameters.contains(v)
+            && !borrow_info.temporaries.contains(v)
         {
             dying_values.insert(*v);
         }
@@ -825,7 +1149,8 @@ fn insert_rc_in_block(
         if !live_out.contains(v)
             && !returned_values.contains(v)
             && !is_alloc_intermediate(ctx, *v)
-            && !borrowed_parameters.contains(v)
+            && !borrow_info.parameters.contains(v)
+            && !borrow_info.temporaries.contains(v)
         {
             dying_values.insert(*v);
         }
@@ -939,6 +1264,14 @@ mod tests {
     }
 
     fn run_pass_with_policy(ir: &str, policy: BorrowedParameterPolicy) -> String {
+        run_pass_with_policies(ir, policy, TemporaryBorrowPolicy::Preserve)
+    }
+
+    fn run_pass_with_policies(
+        ir: &str,
+        parameter_policy: BorrowedParameterPolicy,
+        temporary_policy: TemporaryBorrowPolicy,
+    ) -> String {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
         let validation = validate_use_chains(&ctx, module);
@@ -946,7 +1279,7 @@ mod tests {
             validation.is_ok(),
             "input fixture must have valid SSA use chains: {validation}"
         );
-        insert_rc_with_policy(&mut ctx, module, policy);
+        insert_rc_with_policies(&mut ctx, module, parameter_policy, temporary_policy);
         let validation = validate_use_chains(&ctx, module);
         assert!(
             validation.is_ok(),
@@ -968,6 +1301,27 @@ mod tests {
 
     fn assert_focused_rc(output: &str, expected: &str) {
         assert_eq!(focused_rc_ops(output), expected, "full IR:\n{output}");
+    }
+
+    fn run_temporary_borrow_comparison(ir: &str) -> (String, String) {
+        let preserved = run_pass_with_policies(
+            ir,
+            BorrowedParameterPolicy::Preserve,
+            TemporaryBorrowPolicy::Preserve,
+        );
+        let elided = run_pass_with_policies(
+            ir,
+            BorrowedParameterPolicy::Preserve,
+            TemporaryBorrowPolicy::ElideProvenFieldBorrows,
+        );
+        (preserved, elided)
+    }
+
+    fn rc_counts(output: &str) -> (usize, usize) {
+        (
+            output.matches("tribute_rt.retain").count(),
+            output.matches("tribute_rt.release").count(),
+        )
     }
 
     // =========================================================================
@@ -1015,6 +1369,20 @@ mod tests {
     %1 = clif.load %0 {offset = 0} : core.i32
     %2 = clif.load %0 {offset = 4} : core.i32
     clif.return %1
+  }
+}"#,
+        );
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn snapshot_temporary_field_borrow() {
+        let (_, output) = run_temporary_borrow_comparison(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    %2 = clif.load %1 {offset = 0} : core.i32
+    clif.return %2
   }
 }"#,
         );
@@ -1470,5 +1838,176 @@ mod tests {
                 "tribute_rt.release %0 {alloc_size = 0}"
             ),
         );
+    }
+
+    #[test]
+    fn temporary_borrow_in_dominated_subtree_elides_one_pair() {
+        let (preserved, elided) = run_temporary_borrow_comparison(
+            r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref, %1: core.i8) -> core.i32 {
+  ^entry:
+    clif.brif %1 [^borrow, ^exit]
+  ^borrow:
+    %2 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    clif.jump [^use]
+  ^use:
+    %3 = clif.load %2 {offset = 0} : core.i32
+    clif.return %3
+  ^exit:
+    %4 = clif.iconst {value = 0} : core.i32
+    clif.return %4
+  }
+}"#,
+        );
+        let (preserved_retains, preserved_releases) = rc_counts(&preserved);
+        let (elided_retains, elided_releases) = rc_counts(&elided);
+        assert_eq!(preserved_retains - elided_retains, 1, "{elided}");
+        assert_eq!(preserved_releases - elided_releases, 1, "{elided}");
+    }
+
+    #[test]
+    fn sibling_branch_uses_preserve_temporary_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref, %1: core.i8) -> core.i32 {
+  ^entry:
+    %2 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    clif.brif %1 [^left, ^right]
+  ^left:
+    %3 = clif.load %2 {offset = 0} : core.i32
+    clif.return %3
+  ^right:
+    %4 = clif.load %2 {offset = 4} : core.i32
+    clif.return %4
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+    }
+
+    #[test]
+    fn loop_carried_temporary_preserves_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+  ^entry:
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    clif.jump %1 [^loop]
+  ^loop(%2: tribute_rt.anyref):
+    %3 = clif.load %2 {offset = 0} : core.i32
+    clif.jump %2 [^loop]
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+    }
+
+    #[test]
+    fn nested_region_capture_preserves_temporary_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    func.func @capture() -> core.i32 {
+      %2 = clif.load %1 {offset = 0} : core.i32
+      func.return %2
+    }
+    clif.return
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+    }
+
+    #[test]
+    fn cast_alias_preserves_temporary_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    %2 = core.unrealized_conversion_cast %1 : core.ptr
+    %3 = clif.call %2 {callee = @opaque} : core.i32
+    clif.return %3
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+    }
+
+    #[test]
+    fn call_use_preserves_temporary_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    %2 = clif.call %1 {callee = @opaque} : core.nil
+    clif.return
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+    }
+
+    #[test]
+    fn stored_temporary_preserves_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref, %1: core.ptr) -> core.nil {
+    %2 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    clif.store %2, %1 {offset = 0}
+    clif.return
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+    }
+
+    #[test]
+    fn join_use_preserves_temporary_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref, %1: core.i8) -> core.i32 {
+  ^entry:
+    %2 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    clif.brif %1 [^left, ^right]
+  ^left:
+    clif.jump [^join]
+  ^right:
+    clif.jump [^join]
+  ^join:
+    %3 = clif.load %2 {offset = 0} : core.i32
+    clif.return %3
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+    }
+
+    #[test]
+    fn nested_field_borrows_have_independent_lifetimes() {
+        let ir = r#"core.module @test {
+  clif.func @f(%0: tribute_rt.anyref) -> core.nil {
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    %2 = clif.load %1 {offset = 8} : tribute_rt.anyref
+    %3 = clif.call %2 {callee = @opaque} : core.nil
+    clif.return
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        let (preserved_retains, preserved_releases) = rc_counts(&preserved);
+        let (elided_retains, elided_releases) = rc_counts(&elided);
+        assert_eq!(preserved_retains - elided_retains, 1, "{elided}");
+        assert_eq!(preserved_releases - elided_releases, 1, "{elided}");
+    }
+
+    #[test]
+    fn raw_allocation_address_preserves_temporary_ownership() {
+        let ir = r#"core.module @test {
+  clif.func @f() -> core.i32 {
+    %0 = clif.iconst {value = 24} : core.i64
+    %1 = clif.call %0 {callee = @__tribute_alloc} : core.ptr
+    %2 = clif.iconst {value = 8} : core.i64
+    %3 = clif.iadd %1, %2 : core.ptr
+    %4 = clif.load %3 {offset = 8} : tribute_rt.anyref
+    %5 = clif.load %4 {offset = 0} : core.i32
+    clif.return %5
+  }
+}"#;
+        let (preserved, elided) = run_temporary_borrow_comparison(ir);
+        assert_eq!(focused_rc_ops(&preserved), focused_rc_ops(&elided));
+        assert_eq!(rc_counts(&elided), (1, 1), "{elided}");
     }
 }

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_insertion__tests__snapshot_temporary_field_borrow.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_insertion__tests__snapshot_temporary_field_borrow.snap
@@ -1,0 +1,14 @@
+---
+source: crates/tribute-passes/src/native/rc_insertion.rs
+expression: output
+---
+core.module @test {
+  clif.func {sym_name = @f, type = core.func(core.i32, core.ptr)} {
+    ^bb0(%0: core.ptr):
+      %1 = tribute_rt.retain %0 : core.ptr
+      %2 = clif.load %0 {offset = 8} : core.ptr
+      %3 = clif.load %2 {offset = 0} : core.i32
+      tribute_rt.release %0 {alloc_size = 0}
+      clif.return %3
+  }
+}

--- a/crates/trunk-ir/src/dominance.rs
+++ b/crates/trunk-ir/src/dominance.rs
@@ -1,0 +1,287 @@
+//! Dominance analysis for single-region control-flow graphs.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::context::IrContext;
+use crate::{BlockRef, RegionRef};
+
+/// Block dominance information for one region.
+#[derive(Debug, Clone)]
+pub struct DominatorTree {
+    region: RegionRef,
+    entry: Option<BlockRef>,
+    predecessors: HashMap<BlockRef, Vec<BlockRef>>,
+    successors: HashMap<BlockRef, Vec<BlockRef>>,
+    reachable: HashSet<BlockRef>,
+    dominators: HashMap<BlockRef, HashSet<BlockRef>>,
+    valid: bool,
+}
+
+impl DominatorTree {
+    /// Compute dominance from the region's first block.
+    pub fn compute(ctx: &IrContext, region: RegionRef) -> Self {
+        let blocks = ctx.region(region).blocks.to_vec();
+        let block_set: HashSet<_> = blocks.iter().copied().collect();
+        let entry = blocks.first().copied();
+        let mut predecessors: HashMap<_, Vec<_>> = blocks
+            .iter()
+            .copied()
+            .map(|block| (block, Vec::new()))
+            .collect();
+        let mut successors = HashMap::new();
+        let mut valid = true;
+
+        for &block in &blocks {
+            let block_successors = ctx
+                .block(block)
+                .ops
+                .last()
+                .map(|&op| ctx.op(op).successors.to_vec())
+                .unwrap_or_default();
+            for &successor in &block_successors {
+                if !block_set.contains(&successor) {
+                    valid = false;
+                    continue;
+                }
+                predecessors
+                    .get_mut(&successor)
+                    .expect("region block has predecessor entry")
+                    .push(block);
+            }
+            successors.insert(block, block_successors);
+        }
+
+        let mut reachable = HashSet::new();
+        if let Some(entry) = entry {
+            let mut pending = vec![entry];
+            while let Some(block) = pending.pop() {
+                if !reachable.insert(block) {
+                    continue;
+                }
+                if let Some(block_successors) = successors.get(&block) {
+                    pending.extend(
+                        block_successors
+                            .iter()
+                            .copied()
+                            .filter(|successor| block_set.contains(successor)),
+                    );
+                }
+            }
+        }
+
+        let mut dominators = HashMap::new();
+        if let Some(entry) = entry {
+            for &block in &reachable {
+                let initial = if block == entry {
+                    HashSet::from([entry])
+                } else {
+                    reachable.clone()
+                };
+                dominators.insert(block, initial);
+            }
+
+            let mut changed = true;
+            while changed {
+                changed = false;
+                for &block in &blocks {
+                    if block == entry || !reachable.contains(&block) {
+                        continue;
+                    }
+                    let reachable_predecessors: Vec<_> = predecessors[&block]
+                        .iter()
+                        .copied()
+                        .filter(|predecessor| reachable.contains(predecessor))
+                        .collect();
+                    let Some((&first, rest)) = reachable_predecessors.split_first() else {
+                        valid = false;
+                        continue;
+                    };
+                    let mut next = dominators[&first].clone();
+                    for predecessor in rest {
+                        next.retain(|dominator| dominators[predecessor].contains(dominator));
+                    }
+                    next.insert(block);
+                    if next != dominators[&block] {
+                        dominators.insert(block, next);
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        Self {
+            region,
+            entry,
+            predecessors,
+            successors,
+            reachable,
+            dominators,
+            valid,
+        }
+    }
+
+    pub fn region(&self) -> RegionRef {
+        self.region
+    }
+
+    pub fn entry(&self) -> Option<BlockRef> {
+        self.entry
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.valid
+    }
+
+    pub fn is_reachable(&self, block: BlockRef) -> bool {
+        self.reachable.contains(&block)
+    }
+
+    pub fn dominates(&self, dominator: BlockRef, block: BlockRef) -> bool {
+        self.dominators
+            .get(&block)
+            .is_some_and(|dominators| dominators.contains(&dominator))
+    }
+
+    pub fn predecessors(&self, block: BlockRef) -> &[BlockRef] {
+        self.predecessors.get(&block).map_or(&[], Vec::as_slice)
+    }
+
+    pub fn successors(&self, block: BlockRef) -> &[BlockRef] {
+        self.successors.get(&block).map_or(&[], Vec::as_slice)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dialect::clif;
+    use crate::ops::DialectOp;
+    use crate::parser::parse_test_module;
+
+    fn function_cfg(ir: &str) -> (IrContext, RegionRef, Vec<BlockRef>) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        let module_block = module.first_block(&ctx).expect("module body");
+        let function =
+            clif::Func::from_op(&ctx, ctx.block(module_block).ops[0]).expect("clif.func");
+        let region = function.body(&ctx);
+        let blocks = ctx.region(region).blocks.to_vec();
+        (ctx, region, blocks)
+    }
+
+    #[test]
+    fn diamond_join_is_dominated_only_by_entry() {
+        let (ctx, region, blocks) = function_cfg(
+            r#"core.module @test {
+  clif.func @f(%0: core.i8) -> core.nil {
+  ^entry:
+    clif.brif %0 [^left, ^right]
+  ^left:
+    clif.jump [^join]
+  ^right:
+    clif.jump [^join]
+  ^join:
+    clif.return
+  }
+}"#,
+        );
+        let dominance = DominatorTree::compute(&ctx, region);
+        assert!(dominance.is_valid());
+        assert!(dominance.dominates(blocks[0], blocks[3]));
+        assert!(!dominance.dominates(blocks[1], blocks[3]));
+        assert!(!dominance.dominates(blocks[2], blocks[3]));
+    }
+
+    #[test]
+    fn branch_local_block_dominates_its_descendant() {
+        let (ctx, region, blocks) = function_cfg(
+            r#"core.module @test {
+  clif.func @f(%0: core.i8) -> core.nil {
+  ^entry:
+    clif.brif %0 [^left, ^exit]
+  ^left:
+    clif.jump [^child]
+  ^child:
+    clif.return
+  ^exit:
+    clif.return
+  }
+}"#,
+        );
+        let dominance = DominatorTree::compute(&ctx, region);
+        assert!(dominance.dominates(blocks[1], blocks[2]));
+        assert!(!dominance.dominates(blocks[1], blocks[3]));
+    }
+
+    #[test]
+    fn loop_header_dominates_loop_body_and_exit() {
+        let (ctx, region, blocks) = function_cfg(
+            r#"core.module @test {
+  clif.func @f(%0: core.i8) -> core.nil {
+  ^entry:
+    clif.jump [^header]
+  ^header:
+    clif.brif %0 [^body, ^exit]
+  ^body:
+    clif.jump [^header]
+  ^exit:
+    clif.return
+  }
+}"#,
+        );
+        let dominance = DominatorTree::compute(&ctx, region);
+        assert!(dominance.dominates(blocks[1], blocks[2]));
+        assert!(dominance.dominates(blocks[1], blocks[3]));
+        assert!(!dominance.dominates(blocks[2], blocks[1]));
+    }
+
+    #[test]
+    fn unreachable_blocks_have_no_dominance_relation() {
+        let (ctx, region, blocks) = function_cfg(
+            r#"core.module @test {
+  clif.func @f() -> core.nil {
+  ^entry:
+    clif.return
+  ^dead:
+    clif.return
+  }
+}"#,
+        );
+        let dominance = DominatorTree::compute(&ctx, region);
+        assert!(!dominance.is_reachable(blocks[1]));
+        assert!(!dominance.dominates(blocks[1], blocks[1]));
+        assert!(!dominance.dominates(blocks[0], blocks[1]));
+    }
+
+    #[test]
+    fn successor_outside_region_marks_analysis_invalid() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @f() -> core.nil {
+  ^entry:
+    clif.jump [^exit]
+  ^exit:
+    clif.return
+  }
+  clif.func @g() -> core.nil {
+  ^entry:
+    clif.return
+  }
+}"#,
+        );
+        let module_block = module.first_block(&ctx).expect("module body");
+        let first = clif::Func::from_op(&ctx, ctx.block(module_block).ops[0]).expect("first func");
+        let second =
+            clif::Func::from_op(&ctx, ctx.block(module_block).ops[1]).expect("second func");
+        let first_region = first.body(&ctx);
+        let first_entry = ctx.region(first_region).blocks[0];
+        let second_entry = ctx.region(second.body(&ctx)).blocks[0];
+        let jump = *ctx.block(first_entry).ops.last().expect("jump");
+        ctx.op_mut(jump).successors[0] = second_entry;
+
+        let dominance = DominatorTree::compute(&ctx, first_region);
+        assert!(!dominance.is_valid());
+    }
+}

--- a/crates/trunk-ir/src/lib.rs
+++ b/crates/trunk-ir/src/lib.rs
@@ -29,6 +29,7 @@ pub mod ops;
 
 // === IR core structures ===
 pub mod context;
+pub mod dominance;
 pub mod refs;
 pub mod types;
 

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -236,14 +236,41 @@ into control flow and atomic operations by RC lowering.
   For a proven borrowed parameter, RC insertion omits both the entry `retain`
   and every parameter `release`; this keeps acquisition and release decisions
   under one ownership proof instead of matching generated releases afterward.
-- **Temporary borrow analysis (planned):** Identify temporary values, including
-  field loads, that don't need RC ops
+- **Temporary field borrows:** RC insertion may omit ownership acquisition and
+  release for an `anyref` result of `clif.load` when the load is proven to be a
+  field-derived temporary borrow. The analysis runs on lowered Clif, where an
+  `adt.struct_get` is represented by `clif.load`; it does not match
+  `adt.struct_get` directly.
+
+  The load address must resolve directly to an RC-managed owner, optionally
+  through transparent unrealized pointer casts and address calculations. The
+  resolved owner must be an RC-managed value tracked by RC liveness; a raw
+  `core.ptr` derived from `__tribute_alloc` is not sufficient ownership proof.
+  The owner definition must dominate the field load, the field load must
+  dominate every use of its result, and every result use must remain in the
+  same function region. The only initially accepted uses are further field
+  loads through the temporary, pointer comparisons, and stores that use it
+  solely as the destination address. Unrealized pointer casts are transparent
+  only when every use of the cast result satisfies these same rules. Returning
+  or storing the temporary or an alias as a value, passing either to any call
+  or branch, forwarding either as a block argument, capture by a nested region,
+  or any unknown operation prevents elision.
+
+  The owner's lifetime must also be extended through every accepted use of the
+  temporary. RC liveness therefore treats those uses as uses of the owner before
+  insertion. A temporary is rejected when its uses occur in sibling dominator
+  subtrees, after a join not dominated by its load, on a loop-carried path, or
+  anywhere else that does not establish one dominated, non-escaping lifetime.
+  Nested field loads are considered independently and are eligible only when
+  each loaded owner's lifetime is proven by the same rules. Missing CFG edges,
+  unreachable blocks, malformed regions, or any analysis uncertainty preserve
+  the original retain/release operations.
 - **Constant propagation (planned):** Elide RC for compile-time-known lifetimes
 
-The paired-elimination and borrowed-parameter policies are selected by the
-native pipeline options, not stored in an IR lowering context. Production
-enables proven optimizations; the baseline profile disables them for
-conformance comparisons.
+The paired-elimination, borrowed-parameter, and temporary-borrow policies are
+selected by the native pipeline options, not stored in an IR lowering context.
+Production enables proven optimizations; the baseline profile disables them
+for conformance comparisons.
 
 **Pipeline position:** Borrowed-parameter analysis runs as part of RC insertion,
 before parameter RC operations are created. Paired elimination runs immediately

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -133,6 +133,7 @@ impl OptimizationOptions {
 pub struct NativeOptimizationOptions {
     pub paired_rc_elimination: PairedRcEliminationPolicy,
     pub borrowed_parameters: BorrowedParameterPolicy,
+    pub temporary_borrows: TemporaryBorrowPolicy,
 }
 
 impl NativeOptimizationOptions {
@@ -140,6 +141,7 @@ impl NativeOptimizationOptions {
         Self {
             paired_rc_elimination: PairedRcEliminationPolicy::Enabled,
             borrowed_parameters: BorrowedParameterPolicy::ElideProvenBorrowed,
+            temporary_borrows: TemporaryBorrowPolicy::ElideProvenFieldBorrows,
         }
     }
 
@@ -147,6 +149,7 @@ impl NativeOptimizationOptions {
         Self {
             paired_rc_elimination: PairedRcEliminationPolicy::Disabled,
             borrowed_parameters: BorrowedParameterPolicy::Preserve,
+            temporary_borrows: TemporaryBorrowPolicy::Preserve,
         }
     }
 }
@@ -163,6 +166,13 @@ pub enum PairedRcEliminationPolicy {
 pub enum BorrowedParameterPolicy {
     Preserve,
     ElideProvenBorrowed,
+}
+
+/// Policy for eliding ownership of proven field-derived native temporaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Update)]
+pub enum TemporaryBorrowPolicy {
+    Preserve,
+    ElideProvenFieldBorrows,
 }
 
 impl Default for OptimizationOptions {
@@ -185,6 +195,8 @@ pub enum NativePipelineStage {
     AfterRcInsertion,
     /// After borrowed-parameter-aware insertion, before paired elimination.
     AfterBorrowedParameterOptimization,
+    /// After temporary field-borrow-aware insertion, before paired elimination.
+    AfterTemporaryBorrowOptimization,
     /// After optional local RC optimization, before cast resolution and lowering.
     AfterRcOptimization,
 }
@@ -1033,10 +1045,30 @@ fn prepare_module_to_native(
                 tribute_passes::native::rc_insertion::BorrowedParameterPolicy::ElideProvenBorrowed
             }
         };
-        tribute_passes::native::rc_insertion::insert_rc_with_policy(
+        let temporary_borrows = if matches!(
+            stop_after,
+            Some(
+                NativePipelineStage::AfterRcInsertion
+                    | NativePipelineStage::AfterBorrowedParameterOptimization
+            )
+        ) {
+            TemporaryBorrowPolicy::Preserve
+        } else {
+            optimizations.temporary_borrows
+        };
+        let temporary_borrows = match temporary_borrows {
+            TemporaryBorrowPolicy::Preserve => {
+                tribute_passes::native::rc_insertion::TemporaryBorrowPolicy::Preserve
+            }
+            TemporaryBorrowPolicy::ElideProvenFieldBorrows => {
+                tribute_passes::native::rc_insertion::TemporaryBorrowPolicy::ElideProvenFieldBorrows
+            }
+        };
+        tribute_passes::native::rc_insertion::insert_rc_with_policies(
             ctx,
             module,
             borrowed_parameters,
+            temporary_borrows,
         );
     }
 
@@ -1045,6 +1077,10 @@ fn prepare_module_to_native(
     }
 
     if stop_after == Some(NativePipelineStage::AfterBorrowedParameterOptimization) {
+        return Ok(None);
+    }
+
+    if stop_after == Some(NativePipelineStage::AfterTemporaryBorrowOptimization) {
         return Ok(None);
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,7 +8,7 @@ use salsa::Database;
 use tribute::TributeDatabaseImpl;
 use tribute::pipeline::{
     BorrowedParameterPolicy, CompilationConfig, NativeOptimizationOptions, OptimizationOptions,
-    PairedRcEliminationPolicy, compile_to_native_binary, link_native_binary,
+    PairedRcEliminationPolicy, TemporaryBorrowPolicy, compile_to_native_binary, link_native_binary,
 };
 use tribute_front::SourceCst;
 use tribute_front::ast_to_ir::{AstToIrOptions, DoneContinuationPolicy};
@@ -72,9 +72,7 @@ pub fn compile_and_run_native(source_name: &str, source_code: &str) -> Output {
         source_name,
         source_code,
         false,
-        DoneContinuationPolicy::PerCompilationUnit,
-        PairedRcEliminationPolicy::Enabled,
-        BorrowedParameterPolicy::ElideProvenBorrowed,
+        NativeTestOptimizations::production(),
         NativeStdin::Null,
     )
 }
@@ -90,9 +88,10 @@ pub fn compile_and_run_native_with_done_continuation_dedup(
         source_name,
         source_code,
         false,
-        policy,
-        PairedRcEliminationPolicy::Enabled,
-        BorrowedParameterPolicy::ElideProvenBorrowed,
+        NativeTestOptimizations {
+            done_continuation: policy,
+            ..NativeTestOptimizations::production()
+        },
         NativeStdin::Null,
     )
 }
@@ -108,9 +107,12 @@ pub fn compile_and_run_native_with_paired_rc_elimination(
         source_name,
         source_code,
         false,
-        DoneContinuationPolicy::PerCompilationUnit,
-        policy,
-        BorrowedParameterPolicy::Preserve,
+        NativeTestOptimizations {
+            paired_rc_elimination: policy,
+            borrowed_parameters: BorrowedParameterPolicy::Preserve,
+            temporary_borrows: TemporaryBorrowPolicy::Preserve,
+            ..NativeTestOptimizations::production()
+        },
         NativeStdin::Null,
     )
 }
@@ -127,9 +129,34 @@ pub fn compile_and_run_native_with_borrowed_parameters(
         source_name,
         source_code,
         sanitize_address,
-        DoneContinuationPolicy::PerCompilationUnit,
-        PairedRcEliminationPolicy::Disabled,
-        policy,
+        NativeTestOptimizations {
+            paired_rc_elimination: PairedRcEliminationPolicy::Disabled,
+            borrowed_parameters: policy,
+            temporary_borrows: TemporaryBorrowPolicy::Preserve,
+            ..NativeTestOptimizations::production()
+        },
+        NativeStdin::Null,
+    )
+}
+
+/// Compile and run with explicit temporary field-borrow selection.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_temporary_borrows(
+    source_name: &str,
+    source_code: &str,
+    policy: TemporaryBorrowPolicy,
+    sanitize_address: bool,
+) -> Output {
+    compile_and_run_native_impl(
+        source_name,
+        source_code,
+        sanitize_address,
+        NativeTestOptimizations {
+            paired_rc_elimination: PairedRcEliminationPolicy::Disabled,
+            borrowed_parameters: BorrowedParameterPolicy::Preserve,
+            temporary_borrows: policy,
+            ..NativeTestOptimizations::production()
+        },
         NativeStdin::Null,
     )
 }
@@ -145,9 +172,7 @@ pub fn compile_and_run_native_with_stdin(
         source_name,
         source_code,
         false,
-        DoneContinuationPolicy::PerCompilationUnit,
-        PairedRcEliminationPolicy::Enabled,
-        BorrowedParameterPolicy::ElideProvenBorrowed,
+        NativeTestOptimizations::production(),
         NativeStdin::Bytes(stdin),
     )
 }
@@ -160,9 +185,7 @@ pub fn compile_and_run_native_with_closed_stdin(source_name: &str, source_code: 
         source_name,
         source_code,
         false,
-        DoneContinuationPolicy::PerCompilationUnit,
-        PairedRcEliminationPolicy::Enabled,
-        BorrowedParameterPolicy::ElideProvenBorrowed,
+        NativeTestOptimizations::production(),
         NativeStdin::Closed,
     )
 }
@@ -208,9 +231,7 @@ pub fn compile_and_run_native_asan(source_name: &str, source_code: &str) -> Outp
         source_name,
         source_code,
         true,
-        DoneContinuationPolicy::PerCompilationUnit,
-        PairedRcEliminationPolicy::Enabled,
-        BorrowedParameterPolicy::ElideProvenBorrowed,
+        NativeTestOptimizations::production(),
         NativeStdin::Null,
     )
 }
@@ -222,13 +243,30 @@ enum NativeStdin<'a> {
     Closed,
 }
 
+#[derive(Clone, Copy)]
+struct NativeTestOptimizations {
+    done_continuation: DoneContinuationPolicy,
+    paired_rc_elimination: PairedRcEliminationPolicy,
+    borrowed_parameters: BorrowedParameterPolicy,
+    temporary_borrows: TemporaryBorrowPolicy,
+}
+
+impl NativeTestOptimizations {
+    const fn production() -> Self {
+        Self {
+            done_continuation: DoneContinuationPolicy::PerCompilationUnit,
+            paired_rc_elimination: PairedRcEliminationPolicy::Enabled,
+            borrowed_parameters: BorrowedParameterPolicy::ElideProvenBorrowed,
+            temporary_borrows: TemporaryBorrowPolicy::ElideProvenFieldBorrows,
+        }
+    }
+}
+
 fn compile_and_run_native_impl(
     source_name: &str,
     source_code: &str,
     sanitize_address: bool,
-    done_continuation: DoneContinuationPolicy,
-    paired_rc_elimination: PairedRcEliminationPolicy,
-    borrowed_parameters: BorrowedParameterPolicy,
+    test_optimizations: NativeTestOptimizations,
     stdin: NativeStdin<'_>,
 ) -> Output {
     use tribute::database::parse_with_thread_local;
@@ -240,10 +278,13 @@ fn compile_and_run_native_impl(
         let source_file = SourceCst::from_path(db, source_name, source_rope.clone(), tree);
 
         let optimizations = OptimizationOptions {
-            ast_to_ir: AstToIrOptions { done_continuation },
+            ast_to_ir: AstToIrOptions {
+                done_continuation: test_optimizations.done_continuation,
+            },
             native: NativeOptimizationOptions {
-                paired_rc_elimination,
-                borrowed_parameters,
+                paired_rc_elimination: test_optimizations.paired_rc_elimination,
+                borrowed_parameters: test_optimizations.borrowed_parameters,
+                temporary_borrows: test_optimizations.temporary_borrows,
             },
         };
         let object_bytes =

--- a/tests/fixtures/optimizations/temporary_field_borrows.trb
+++ b/tests/fixtures/optimizations/temporary_field_borrows.trb
@@ -1,0 +1,29 @@
+extern "C" fn __tribute_print_nat(value: Nat) -> Nil
+
+enum Inner {
+    Value(Nat)
+    Empty
+}
+
+enum Outer {
+    Wrapped(Inner)
+    Missing
+}
+
+fn read_nested(outer: Outer) -> Nat {
+    case outer {
+        Wrapped(inner) -> case inner {
+            Value(value) -> value
+            Empty -> 0
+        }
+        Missing -> 0
+    }
+}
+
+fn main() {
+    let inner = Value(10)
+    let outer = Wrapped(inner)
+    let first = read_nested(outer)
+    let second = read_nested(outer)
+    __tribute_print_nat(first + second)
+}

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -6,12 +6,13 @@ use common::{
     compile_and_run_native_with_borrowed_parameters,
     compile_and_run_native_with_done_continuation_dedup,
     compile_and_run_native_with_paired_rc_elimination,
+    compile_and_run_native_with_temporary_borrows,
 };
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
 use tribute::pipeline::{
     BorrowedParameterPolicy, NativeOptimizationOptions, NativePipelineStage, OptimizationOptions,
-    PairedRcEliminationPolicy, SharedPipelineStage, dump_native_ir_at_stage,
+    PairedRcEliminationPolicy, SharedPipelineStage, TemporaryBorrowPolicy, dump_native_ir_at_stage,
     dump_shared_ir_at_stage,
 };
 use tribute_front::SourceCst;
@@ -22,6 +23,8 @@ const DONE_CONTINUATION_DEDUP_STATE: &str =
 const PAIRED_RC_ELIMINATION: &str =
     include_str!("fixtures/optimizations/paired_rc_elimination.trb");
 const BORROWED_PARAMETERS: &str = include_str!("fixtures/optimizations/borrowed_parameters.trb");
+const TEMPORARY_FIELD_BORROWS: &str =
+    include_str!("fixtures/optimizations/temporary_field_borrows.trb");
 
 fn native_optimization_options(
     paired_rc_elimination: PairedRcEliminationPolicy,
@@ -31,6 +34,18 @@ fn native_optimization_options(
         native: NativeOptimizationOptions {
             paired_rc_elimination,
             borrowed_parameters,
+            temporary_borrows: TemporaryBorrowPolicy::Preserve,
+        },
+        ..OptimizationOptions::production()
+    }
+}
+
+fn temporary_borrow_options(temporary_borrows: TemporaryBorrowPolicy) -> OptimizationOptions {
+    OptimizationOptions {
+        native: NativeOptimizationOptions {
+            paired_rc_elimination: PairedRcEliminationPolicy::Disabled,
+            borrowed_parameters: BorrowedParameterPolicy::Preserve,
+            temporary_borrows,
         },
         ..OptimizationOptions::production()
     }
@@ -168,6 +183,40 @@ fn borrowed_parameters_preserve_native_execution() {
     }
 }
 
+#[test]
+fn temporary_field_borrows_preserve_native_execution_with_sanitizer() {
+    for sanitize_address in [false, true] {
+        let preserved = compile_and_run_native_with_temporary_borrows(
+            "temporary_field_borrows_preserved.trb",
+            TEMPORARY_FIELD_BORROWS,
+            TemporaryBorrowPolicy::Preserve,
+            sanitize_address,
+        );
+        let elided = compile_and_run_native_with_temporary_borrows(
+            "temporary_field_borrows_elided.trb",
+            TEMPORARY_FIELD_BORROWS,
+            TemporaryBorrowPolicy::ElideProvenFieldBorrows,
+            sanitize_address,
+        );
+
+        assert!(
+            preserved.status.success(),
+            "preserved pipeline failed with sanitize_address={sanitize_address}: {}",
+            String::from_utf8_lossy(&preserved.stderr)
+        );
+        assert!(
+            elided.status.success(),
+            "elided pipeline failed with sanitize_address={sanitize_address}: {}",
+            String::from_utf8_lossy(&elided.stderr)
+        );
+        let preserved_stdout = String::from_utf8_lossy(&preserved.stdout);
+        let elided_stdout = String::from_utf8_lossy(&elided.stdout);
+        assert_eq!(preserved_stdout.trim(), "20");
+        assert_eq!(elided_stdout.trim(), "20");
+        assert_eq!(preserved.stdout, elided.stdout);
+    }
+}
+
 #[salsa_test]
 fn paired_rc_elimination_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -279,6 +328,50 @@ fn borrowed_parameters_have_focused_before_after_ir(db: &salsa::DatabaseImpl) {
 
     assert_snapshot!("borrowed_parameters_before", before);
     assert_snapshot!("borrowed_parameters_after", after);
+}
+
+#[salsa_test]
+fn temporary_field_borrows_have_focused_before_after_ir(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "temporary_field_borrows_snapshot.trb",
+        TEMPORARY_FIELD_BORROWS,
+    );
+    let before = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterBorrowedParameterOptimization,
+        temporary_borrow_options(TemporaryBorrowPolicy::Preserve),
+    )
+    .expect("preserved temporary RC insertion IR should be available");
+    let after = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterTemporaryBorrowOptimization,
+        temporary_borrow_options(TemporaryBorrowPolicy::ElideProvenFieldBorrows),
+    )
+    .expect("temporary-borrow IR should be available");
+    let preserved_after = dump_native_ir_at_stage(
+        db,
+        source,
+        NativePipelineStage::AfterTemporaryBorrowOptimization,
+        temporary_borrow_options(TemporaryBorrowPolicy::Preserve),
+    )
+    .expect("preserved temporary-borrow stage IR should be available");
+    let before = focused_rc_ops(&before);
+    let after = focused_rc_ops(&after);
+    let preserved_after = focused_rc_ops(&preserved_after);
+    assert_eq!(before, preserved_after);
+    let before_retain = before.matches("tribute_rt.retain").count();
+    let before_release = before.matches("tribute_rt.release").count();
+    let after_retain = after.matches("tribute_rt.retain").count();
+    let after_release = after.matches("tribute_rt.release").count();
+    assert!(before_retain > after_retain, "before RC ops:\n{before}");
+    assert!(before_release > after_release, "before RC ops:\n{before}");
+    assert_eq!(before_retain - after_retain, before_release - after_release);
+
+    assert_snapshot!("temporary_field_borrows_before", before);
+    assert_snapshot!("temporary_field_borrows_after", after);
 }
 
 #[salsa_test]

--- a/tests/snapshots/optimization_conformance__temporary_field_borrows_after.snap
+++ b/tests/snapshots/optimization_conformance__temporary_field_borrows_after.snap
@@ -1,0 +1,6 @@
+---
+source: tests/optimization_conformance.rs
+expression: after
+---
+%1 = tribute_rt.retain %0 : core.ptr
+tribute_rt.release %0 {alloc_size = 0}

--- a/tests/snapshots/optimization_conformance__temporary_field_borrows_before.snap
+++ b/tests/snapshots/optimization_conformance__temporary_field_borrows_before.snap
@@ -1,0 +1,8 @@
+---
+source: tests/optimization_conformance.rs
+expression: before
+---
+%1 = tribute_rt.retain %0 : core.ptr
+%8 = tribute_rt.retain %7 : core.ptr
+tribute_rt.release %0 {alloc_size = 0}
+tribute_rt.release %7 {alloc_size = 0}


### PR DESCRIPTION
## Summary

- add reusable single-region CFG dominance analysis
- conservatively elide RC ownership for proven Clif field-load temporaries
- extend tracked owner liveness across accepted temporary uses
- fail closed for joins, loops, captures, calls, escapes, malformed CFGs, and raw allocation pointers
- add policy gates, focused IR snapshots, native execution parity, and ASan coverage

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` (1600 passed, 10 skipped)
- `cargo nextest run -p tribute-passes -E 'test(rc_insertion)'` (37 passed)
- `cargo nextest run --test optimization_conformance` (8 passed)

Closes #637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional optimization that reduces unnecessary ownership operations for proven field-derived temporary values.
  * Added pipeline controls and a diagnostic stage for enabling or preserving this optimization.
  * Added control-flow dominance analysis support for more reliable optimization decisions.

* **Bug Fixes**
  * Preserved correct retain/release behavior across casts, branches, joins, and nested field accesses.

* **Tests**
  * Added conformance coverage, snapshots, and runtime comparisons for optimized and baseline behavior.

* **Documentation**
  * Documented temporary field borrow requirements and optimization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->