### PR TITLE
Establish canonical runnable examples and CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,43 +18,22 @@ familiar syntax.
 ## Quick Example
 
 ```text
-struct User { name: String, age: Int }
+use abilities::Throw
+use std::io::{Io, print_line}
 
-fn greet(user: User) -> String {
-    "Hello, \{user.name}!"                // string interpolation
+fn fail() ->{Throw(String)} String {
+    Throw::throw("the failure was handled")
 }
 
-fn insa(user: User) -> String {
-    "안녕, " <> user.name <> "!"           // string concatenation
+fn recover() -> String {
+    handle fail() {
+        do value { value }
+        op Throw::throw(message) { "Recovered: " <> message }
+    }
 }
 
-// Abilities (algebraic effects)
-fn fetch_user(id: UserId) ->{Http, Async} User {
-    let response = Http::get("/users/\{id}")
-    response.await
-}
-
-// Function chaining powered by type-directed name resolution
-fn process(data: List(Int)) -> Int {
-    data
-        .filter(fn(x) x > 0)
-        .map(fn(x) x * 2)
-        .fold(0, fn(a, b) a + b)
-}
-
-// Equivalent to:
-fn process2(data: List(Int)) -> Int {
-    List::fold(
-        List::map(
-            List::filter(
-                data,
-                fn(x) x > 0
-            ),
-            fn(x) x * 2
-        ),
-        0,
-        fn(a, b) a + b
-    )
+fn main() ->{Io} Nil {
+    print_line(recover())
 }
 ```
 
@@ -79,28 +58,43 @@ npm install -g tree-sitter-cli
 cargo build
 
 # Run all tests
-cargo test
+cargo nextest run --workspace
 
-# Run the compiler on a .trb file
-cargo run --bin trbc -- <file.trb>
+# Compile one source file to a native executable
+cargo run -- compile lang-examples/native_effects.trb \
+  -o target/native-effects-example
 
-# If snapshot tests fail (insta)
-cargo insta review
+# Run the resulting executable
+./target/native-effects-example
 ```
+
+The `tribute` CLI compiles one source file at a time; file-module and package
+compilation are not implemented. There is no `run` subcommand. `compile`
+defaults to `--target native` and accepts these targets:
+
+- `native` writes a linked executable.
+- `wasm` writes a WasmGC module. Execute it with a compatible external runtime.
+- `none` validates the frontend and shared pipeline without writing an artifact.
+
+Use `-o` or `--output` to choose the artifact path. Without it, native removes
+the `.trb` extension and Wasm replaces it with `.wasm`.
+
+## Language Examples
+
+See [`lang-examples/README.md`](lang-examples/README.md) for exact native, Wasm,
+and invalid-example commands. It also classifies historical files as regression
+fixtures, design-only examples, or legacy samples.
 
 ## Development
 
 ```bash
-# Package-specific tests
-cargo test -p tribute-core
-cargo test -p tribute-passes
-cargo test -p tribute-trunk-ir
+# Focused package tests
+cargo nextest run -p tribute
+cargo nextest run -p tribute-passes
+
+# Review snapshot changes when a snapshot test fails
+cargo insta review
 ```
-
-## Language Examples
-
-See `lang-examples/` directory for sample `.trb` files demonstrating the
-language syntax.
 
 ## Design Documents
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ For Tree-sitter grammar development, install the Tree-sitter CLI:
 npm install -g tree-sitter-cli
 ```
 
+### Development prerequisites
+
+The commands below use these external tools:
+
+- [cargo-nextest](https://nexte.st/docs/installation/pre-built-binaries/) to run
+  the test suite
+- [cargo-insta](https://insta.rs/docs/cli/) to review snapshot changes
+- [Wasmtime](https://docs.wasmtime.dev/cli-install.html) to run Wasm examples
+
+The repository does not pin their CLI versions. CI installs the latest
+cargo-nextest and Wasmtime releases; use a Wasmtime release that accepts the
+`-Wgc=y,function-references=y` options shown in the example command.
+
 ## Building and Running
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ familiar syntax.
   (`fn`, `{}`, `;`, `struct`/`enum`)
 - **Multiple Targets**: Cranelift (native) and WasmGC
 
+Current implementation support is narrower than the language design. See the
+[compiler capability matrix](new-plans/capabilities.md) for audited frontend,
+native, and WasmGC status. Compilation alone is not execution evidence.
+
 ## Quick Example
 
 ```text
@@ -98,9 +102,10 @@ cargo insta review
 
 ## Design Documents
 
-The `new-plans/` directory contains the authoritative design documents for the
-language and compiler. If code or tests conflict with these documents, the
-documents are considered correct.
+The `new-plans/` directory contains the authoritative language and compiler
+design. [`new-plans/capabilities.md`](new-plans/capabilities.md) separately
+records what the current implementation has demonstrated; design intent alone
+is not a support claim.
 
 ## About the Name
 

--- a/lang-examples/README.md
+++ b/lang-examples/README.md
@@ -48,8 +48,9 @@ String: dynamic
 Bytes: bytes
 ```
 
-This command requires a recent Wasmtime with WasmGC and function references.
-Wasm `read_line` is unsupported. Existing Wasm `fn` and `op` ability tests are
+Install a compatible Wasmtime release as described in the
+[development prerequisites](../README.md#development-prerequisites). Wasm
+`read_line` is unsupported. Existing Wasm `fn` and `op` ability tests are
 compile-only, so these examples do not claim Wasm ability execution support.
 
 ## Canonical invalid example

--- a/lang-examples/README.md
+++ b/lang-examples/README.md
@@ -1,0 +1,116 @@
+# Tribute language examples
+
+The canonical examples in this directory are checked against the current
+single-source-file CLI. They use public APIs and are the best starting point for
+running Tribute today.
+
+## Canonical runnable examples
+
+### Native effects and I/O
+
+[`native_effects.trb`](native_effects.trb) handles the public
+`abilities::Throw` ability and writes through `std::io`.
+
+```bash
+cargo run -- compile lang-examples/native_effects.trb \
+  -o target/native-effects-example
+./target/native-effects-example
+```
+
+Expected standard output:
+
+```text
+Recovered: the failure was handled
+```
+
+Native currently has the broadest execution coverage, including handled
+abilities and `std::io::read_line`.
+
+### WasmGC dynamic output
+
+[`wasm_dynamic_output.trb`](wasm_dynamic_output.trb) builds dynamic `String` and
+`Bytes` values with concatenation and writes them through public `std::io`.
+
+```bash
+cargo run -- compile --target wasm \
+  lang-examples/wasm_dynamic_output.trb \
+  -o target/wasm-dynamic-output.wasm
+wasmtime -Wgc=y,function-references=y \
+  target/wasm-dynamic-output.wasm
+```
+
+Expected standard output:
+
+```text
+String: dynamic
+Bytes: bytes
+```
+
+This command requires a recent Wasmtime with WasmGC and function references.
+Wasm `read_line` is not supported. The Wasm backend compiles ability programs,
+but these examples do not claim ability execution support because that path
+lacks an execution test.
+
+## Canonical invalid example
+
+[`invalid_unresolved_name.trb`](invalid_unresolved_name.trb) deliberately refers
+to an undefined value. Validate it without producing a target artifact:
+
+```bash
+cargo run -- compile --target none \
+  lang-examples/invalid_unresolved_name.trb
+```
+
+The command must exit unsuccessfully and report:
+
+```text
+unresolved name `missing_value`
+```
+
+## Example classifications
+
+The repository also contains historical samples and compiler fixtures. Their
+classification is explicit so they are not mistaken for supported runnable
+documentation.
+
+### Regression fixture
+
+- `ability_core.trb` is included directly by a native handler execution test.
+  It is maintained for compiler regression coverage, produces no output, and is
+  not the canonical user-facing ability example.
+- `ability_core.wasm` is a legacy checked-in build artifact. It is not the
+  documented output of the current CLI.
+
+### Compile-only examples
+
+There are currently no maintained compile-only examples. `--target none` is
+useful for frontend validation, but successful compilation does not establish
+native or Wasm execution support.
+
+### Design-only examples
+
+- `modules_file/` illustrates the planned file-module/package layout. The
+  current CLI accepts one source file and does not load sibling modules, so
+  these files are not compilable as a package.
+
+### Legacy examples
+
+All remaining `.trb` files in this directory are legacy syntax demonstrations
+or milestone artifacts:
+
+- `add.trb`, `basic.trb`, `calc.trb`, `float.trb`,
+  `function_visibility.trb`, `functions.trb`, `generics.trb`, `hello.trb`,
+  `lambda.trb`, `let-destructuring.trb`, `let_advanced.trb`,
+  `let_bindings.trb`, `let_simple.trb`, and `let_with_function.trb`
+- `milestone3_test.trb`, `modules_inline.trb`, `modules_use.trb`,
+  `operator-functions.trb`, `option.trb`, `pattern_advanced.trb`,
+  `pattern_matching.trb`, `performance_test.trb`, `record-patterns.trb`,
+  `result.trb`, `simple_closure.trb`, `simple_function.trb`, and
+  `simple_test.trb`
+- `string_interpolation.trb`, `strings/`, `tuples.trb`,
+  `ufcs-qualified.trb`, `ufcs-simple.trb`, `zero-arg-comprehensive.trb`,
+  `zero-arg-no-parens.trb`, and `zero-arg-simple.trb`
+
+Some legacy files still compile or run through compatibility helpers; others
+fail current parsing, resolution, type checking, or entrypoint rules. They are
+retained only as historical material and are not supported command examples.

--- a/lang-examples/README.md
+++ b/lang-examples/README.md
@@ -2,7 +2,9 @@
 
 The canonical examples in this directory are checked against the current
 single-source-file CLI. They use public APIs and are the best starting point for
-running Tribute today.
+running Tribute today. The
+[compiler capability matrix](../new-plans/capabilities.md) is authoritative for
+the wider frontend and target status.
 
 ## Canonical runnable examples
 
@@ -47,9 +49,8 @@ Bytes: bytes
 ```
 
 This command requires a recent Wasmtime with WasmGC and function references.
-Wasm `read_line` is not supported. The Wasm backend compiles ability programs,
-but these examples do not claim ability execution support because that path
-lacks an execution test.
+Wasm `read_line` is unsupported. Existing Wasm `fn` and `op` ability tests are
+compile-only, so these examples do not claim Wasm ability execution support.
 
 ## Canonical invalid example
 
@@ -72,6 +73,14 @@ unresolved name `missing_value`
 The repository also contains historical samples and compiler fixtures. Their
 classification is explicit so they are not mistaken for supported runnable
 documentation.
+
+Current boundaries relevant to these files:
+
+- List expressions and general collection APIs are unsupported on all targets.
+- Inline modules have native execution evidence, but file-module loading,
+  package compilation, and separate Tribute-module linking are unsupported.
+- String/Bytes output through `std::io::print_line` is the only current
+  language-level Wasm execution claim.
 
 ### Regression fixture
 

--- a/lang-examples/invalid_unresolved_name.trb
+++ b/lang-examples/invalid_unresolved_name.trb
@@ -1,0 +1,3 @@
+fn main() -> Nil {
+    missing_value
+}

--- a/lang-examples/native_effects.trb
+++ b/lang-examples/native_effects.trb
@@ -1,0 +1,17 @@
+use abilities::Throw
+use std::io::{Io, print_line}
+
+fn fail() ->{Throw(String)} String {
+    Throw::throw("the failure was handled")
+}
+
+fn recover() -> String {
+    handle fail() {
+        do value { value }
+        op Throw::throw(message) { "Recovered: " <> message }
+    }
+}
+
+fn main() ->{Io} Nil {
+    print_line(recover())
+}

--- a/lang-examples/wasm_dynamic_output.trb
+++ b/lang-examples/wasm_dynamic_output.trb
@@ -1,0 +1,9 @@
+use std::io::{Io, print_line}
+
+fn main() ->{Io} Nil {
+    let kind = "dynamic"
+    let bytes = b" bytes"
+
+    print_line("String: " <> kind)
+    print_line(String::from_bytes(b"Bytes:" <> bytes))
+}


### PR DESCRIPTION
## Summary

- add canonical native, WasmGC, and invalid Tribute examples
- document exact compile, execute, and diagnostic commands with expected output
- update the root README to use current public APIs and the actual single-file CLI
- classify historical examples as regression, design-only, compile-only, or legacy material

## Validation

- documented native example compiled and printed `Recovered: the failure was handled`
- documented WasmGC example compiled and ran under Wasmtime with the expected String/Bytes output
- invalid example exited nonzero with the expected unresolved-name diagnostic
- focused Throw, Wasm output, and diagnostic tests
- `cargo nextest run --workspace` (1,622 passed, 10 skipped)
- `npx --no-install markdownlint-cli2 "**/*.md"` (39 files, 0 errors)
- Clippy and formatting via the commit hook

Closes #797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runnable examples demonstrating native effect handling and dynamic output for WebAssembly.
  * Added an intentionally invalid example for unresolved-name validation.
* **Documentation**
  * Updated quick-start examples to showcase algebraic effects.
  * Expanded CLI documentation, including compilation targets and output options.
  * Added guidance for building and running native and WebAssembly examples.
  * Documented example classifications, expected output, and current feature boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->