### PR TITLE
Gate canonical M0 examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -35,6 +36,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Test lint failure propagation
         run: .ci/test-lint.sh
@@ -55,6 +57,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -74,6 +77,8 @@ jobs:
 
   canonical-native:
     name: Canonical native example (${{ matrix.platform }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -89,6 +94,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -113,11 +119,14 @@ jobs:
 
   canonical-wasm:
     name: Canonical WasmGC example
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -149,11 +158,14 @@ jobs:
 
   canonical-diagnostic:
     name: Canonical invalid example
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -193,6 +205,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -220,6 +233,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,18 @@ jobs:
         run: cargo nextest run --workspace
 
   canonical-native:
-    name: Canonical native example
-    runs-on: [self-hosted, macOS]
+    name: Canonical native example (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macOS
+            runner_json: '["self-hosted", "macOS"]'
+            cache: false
+          - platform: Ubuntu
+            runner_json: '"ubuntu-latest"'
+            cache: true
+    runs-on: ${{ fromJSON(matrix.runner_json) }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -83,7 +93,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache: false
+          cache: ${{ matrix.cache }}
 
       - name: Compile canonical native example
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,110 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace
 
+  canonical-native:
+    name: Canonical native example
+    runs-on: [self-hosted, macOS]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+
+      - name: Compile canonical native example
+        run: |
+          cargo run --locked -- compile lang-examples/native_effects.trb \
+            -o target/native-effects-example
+
+      - name: Execute canonical native example
+        run: |
+          ./target/native-effects-example \
+            > target/native-effects-example.stdout
+
+      - name: Check canonical native output
+        run: |
+          diff -u \
+            tests/expected/native_effects.stdout \
+            target/native-effects-example.stdout
+
+  canonical-wasm:
+    name: Canonical WasmGC example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+
+      - name: Install wasmtime
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasmtime
+
+      - name: Compile canonical WasmGC example
+        run: |
+          cargo run --locked -- compile --target wasm \
+            lang-examples/wasm_dynamic_output.trb \
+            -o target/wasm-dynamic-output.wasm
+
+      - name: Execute canonical WasmGC example
+        run: |
+          wasmtime -Wgc=y,function-references=y \
+            target/wasm-dynamic-output.wasm \
+            > target/wasm-dynamic-output.stdout
+
+      - name: Check canonical WasmGC output
+        run: |
+          diff -u \
+            tests/expected/wasm_dynamic_output.stdout \
+            target/wasm-dynamic-output.stdout
+
+  canonical-diagnostic:
+    name: Canonical invalid example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Require canonical invalid CLI failure
+        shell: bash
+        run: |
+          mkdir -p target
+
+          set +e
+          cargo run --locked -- compile --target none \
+            lang-examples/invalid_unresolved_name.trb \
+            > target/invalid-unresolved-name.stdout \
+            2> target/invalid-unresolved-name.stderr
+          cli_status=$?
+          set -e
+
+          if [[ "$cli_status" -ne 1 ]]; then
+            echo "expected exit status 1, got $cli_status" >&2
+            exit 1
+          fi
+
+      - name: Check canonical semantic diagnostic
+        run: cargo nextest run --locked -p tribute --test canonical_smoke
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/tests/canonical_smoke.rs
+++ b/tests/canonical_smoke.rs
@@ -1,0 +1,45 @@
+//! Product-level assertions for the canonical M0 examples.
+
+use salsa_test_macros::salsa_test;
+use tribute::pipeline::compile_with_diagnostics;
+use tribute::{DiagnosticSeverity, SourceCst};
+use tribute_passes::CompilationPhase;
+
+const INVALID_SOURCE: &str = include_str!("../lang-examples/invalid_unresolved_name.trb");
+
+#[salsa_test]
+fn canonical_invalid_source_has_stable_unresolved_name_diagnostic(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "lang-examples/invalid_unresolved_name.trb",
+        INVALID_SOURCE,
+    );
+    let result = compile_with_diagnostics(db, source);
+
+    assert!(
+        result.module.is_none(),
+        "the canonical invalid source must not produce a module"
+    );
+
+    let matching: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.inner.message == "unresolved name `missing_value`")
+        .collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected one canonical unresolved-name diagnostic, got {:?}",
+        result.diagnostics
+    );
+
+    let diagnostic = matching[0];
+    assert_eq!(diagnostic.phase, CompilationPhase::NameResolution);
+    assert_eq!(diagnostic.inner.severity, DiagnosticSeverity::Error);
+
+    let span = diagnostic.inner.span;
+    let primary_source = INVALID_SOURCE
+        .get(span.start..span.end)
+        .expect("diagnostic span must be a valid UTF-8 source range");
+    assert_eq!(primary_source, "missing_value");
+}

--- a/tests/expected/native_effects.stdout
+++ b/tests/expected/native_effects.stdout
@@ -1,0 +1,1 @@
+Recovered: the failure was handled

--- a/tests/expected/wasm_dynamic_output.stdout
+++ b/tests/expected/wasm_dynamic_output.stdout
@@ -1,0 +1,2 @@
+String: dynamic
+Bytes: bytes


### PR DESCRIPTION
## Summary

- add separate CI gates for the canonical native, WasmGC, and invalid examples
- compare successful native and Wasm output byte-for-byte against committed oracles
- assert the canonical unresolved-name diagnostic structurally without matching ANSI-rendered stderr
- preserve the documented floating nextest and Wasmtime policy and avoid adding a compile-only gate

## Validation

- canonical native compile/run passed; exact 35-byte stdout matched
- canonical Wasm compile/run passed; exact 29-byte stdout matched
- canonical invalid CLI exited with status 1
- focused canonical diagnostic test: 1 passed
- `cargo nextest run --locked --workspace`: 1,623 passed, 10 skipped
- `cargo clippy --locked --workspace --all-targets -- -D warnings`: passed
- `cargo build --workspace`: passed
- `cargo fmt --all -- --check`: passed
- `.ci/test-lint.sh`: passed
- workflow YAML parse: passed
- `git diff --check`: passed
- both commit hooks independently reran clippy, formatting, and all 1,623 tests successfully
- markdownlint was not run because no Markdown changed

Closes #798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated checks for native and WebAssembly examples, including verification of expected program output.
  * Added validation for invalid source code, including compilation failure behavior, diagnostic location, and error classification.
  * Updated example expectations to cover recovered failures and dynamic string and byte output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->