### PR TITLE
Fix handler result type propagation before TDNR

### DIFF
--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1915,6 +1915,16 @@ impl<'db> TypeChecker<'db> {
         arm: HandlerArm<ResolvedRef<'db>>,
         handle_ctx: Option<&super::super::func_context::HandleContext<'db>>,
     ) -> HandlerArm<TypedRef<'db>> {
+        ctx.with_scope(|ctx| self.convert_handler_arm_in_scope(ctx, arm, handle_ctx))
+    }
+
+    /// Convert a handler arm within its arm-local scope.
+    fn convert_handler_arm_in_scope(
+        &self,
+        ctx: &mut FunctionInferenceContext<'_, 'db>,
+        arm: HandlerArm<ResolvedRef<'db>>,
+        handle_ctx: Option<&super::super::func_context::HandleContext<'db>>,
+    ) -> HandlerArm<TypedRef<'db>> {
         let kind = match arm.kind {
             HandlerKind::Do { binding } => {
                 let binding = if let Some(handle_ctx) = handle_ctx {
@@ -2409,16 +2419,21 @@ impl<'db> TypeChecker<'db> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use salsa_test_macros::salsa_test;
     use trunk_ir::Symbol;
 
     use crate::ast::{
-        EffectRow, FuncDefId, NodeId, SpanMap, Type, TypeAnnotation, TypeAnnotationKind, TypeDefId,
-        TypeKind,
+        AbilityId, EffectRow, Expr, ExprKind, FuncDefId, HandlerArm, HandlerKind, LocalId, NodeId,
+        OpDeclKind, Pattern, PatternKind, ResolvedRef, SpanMap, Type, TypeAnnotation,
+        TypeAnnotationKind, TypeDefId, TypeKind, TypedRef,
     };
+    use crate::typeck::context::{AbilityInfo, AbilityOpInfo};
+    use crate::typeck::func_context::HandleContext;
     use crate::typeck::{FunctionInferenceContext, ModuleTypeEnv};
 
-    use super::TypeChecker;
+    use super::{Mode, TypeChecker};
 
     /// Helper to create a TypeChecker for testing.
     fn make_test_checker(db: &dyn salsa::Database) -> TypeChecker<'_> {
@@ -2440,6 +2455,156 @@ mod tests {
             id: NodeId::from_raw(0),
             kind,
         }
+    }
+
+    fn bind_pattern<'db>(id: usize, name: Symbol, local_id: LocalId) -> Pattern<ResolvedRef<'db>> {
+        Pattern::new(
+            NodeId::from_raw(id),
+            PatternKind::Bind {
+                name,
+                local_id: Some(local_id),
+            },
+        )
+    }
+
+    fn local_expr<'db>(id: usize, name: Symbol, local_id: LocalId) -> Expr<ResolvedRef<'db>> {
+        Expr::new(
+            NodeId::from_raw(id),
+            ExprKind::Var(ResolvedRef::local(local_id, name)),
+        )
+    }
+
+    fn handler_body_type<'db>(handler: &HandlerArm<TypedRef<'db>>) -> Type<'db> {
+        let ExprKind::Var(reference) = &*handler.body.kind else {
+            panic!("handler body should be a variable reference");
+        };
+        reference.ty
+    }
+
+    #[salsa_test]
+    fn test_handler_do_binding_does_not_leak(db: &dyn salsa::Database) {
+        let checker = make_test_checker(db);
+        let env = ModuleTypeEnv::new(db);
+        let mut ctx = make_test_ctx(db, &env);
+        let name = Symbol::new("result");
+        let body_ty = Type::new(db, TypeKind::Nat);
+        let handle_ctx = HandleContext {
+            body_ty,
+            body_effect: EffectRow::pure(db),
+        };
+
+        let do_arm = HandlerArm {
+            id: NodeId::from_raw(1),
+            kind: HandlerKind::Do {
+                binding: bind_pattern(2, name, LocalId::new(1)),
+            },
+            body: local_expr(3, name, LocalId::new(1)),
+        };
+        let converted_do =
+            checker.convert_handler_arm_with_ctx(&mut ctx, do_arm, Some(&handle_ctx));
+        assert_eq!(handler_body_type(&converted_do), body_ty);
+
+        let ability = ResolvedRef::ability(AbilityId::source(db, Symbol::new("Test")));
+        let op_arm = HandlerArm {
+            id: NodeId::from_raw(4),
+            kind: HandlerKind::Op {
+                ability,
+                op: Symbol::new("get"),
+                params: vec![],
+                resume_local_id: None,
+            },
+            body: local_expr(5, name, LocalId::UNRESOLVED),
+        };
+        let converted_op =
+            checker.convert_handler_arm_with_ctx(&mut ctx, op_arm, Some(&handle_ctx));
+        assert!(
+            matches!(
+                handler_body_type(&converted_op).kind(db),
+                TypeKind::UniVar { .. }
+            ),
+            "do-arm binding should not type an unresolved name in a later operation arm"
+        );
+
+        let outside = checker.check_expr_with_ctx(
+            &mut ctx,
+            local_expr(6, name, LocalId::UNRESOLVED),
+            Mode::Infer,
+        );
+        let ExprKind::Var(reference) = &*outside.kind else {
+            panic!("outside expression should be a variable reference");
+        };
+        assert!(
+            matches!(reference.ty.kind(db), TypeKind::UniVar { .. }),
+            "do-arm binding should not type an unresolved name outside the handle"
+        );
+    }
+
+    #[salsa_test]
+    fn test_same_name_handler_bindings_are_independent(db: &dyn salsa::Database) {
+        let mut checker = make_test_checker(db);
+        let ability_id = AbilityId::source(db, Symbol::new("Choice"));
+        let nat_op = Symbol::new("nat");
+        let bool_op = Symbol::new("bool");
+        let nat_ty = Type::new(db, TypeKind::Nat);
+        let bool_ty = Type::new(db, TypeKind::Bool);
+        checker.env.register_ability(
+            ability_id,
+            AbilityInfo {
+                id: ability_id,
+                type_params: vec![],
+                operations: HashMap::from([
+                    (
+                        nat_op,
+                        AbilityOpInfo {
+                            name: nat_op,
+                            kind: OpDeclKind::Op,
+                            param_types: vec![nat_ty],
+                            return_type: Type::new(db, TypeKind::Nil),
+                        },
+                    ),
+                    (
+                        bool_op,
+                        AbilityOpInfo {
+                            name: bool_op,
+                            kind: OpDeclKind::Op,
+                            param_types: vec![bool_ty],
+                            return_type: Type::new(db, TypeKind::Nil),
+                        },
+                    ),
+                ]),
+            },
+        );
+
+        let mut ctx = make_test_ctx(db, &checker.env);
+        let name = Symbol::new("value");
+        let ability = ResolvedRef::ability(ability_id);
+        let make_arm = |id, op, local_id| HandlerArm {
+            id: NodeId::from_raw(id),
+            kind: HandlerKind::Op {
+                ability: ability.clone(),
+                op,
+                params: vec![bind_pattern(id + 1, name, local_id)],
+                resume_local_id: None,
+            },
+            body: local_expr(id + 2, name, local_id),
+        };
+
+        let nat_arm = checker.convert_handler_arm_with_ctx(
+            &mut ctx,
+            make_arm(10, nat_op, LocalId::new(10)),
+            None,
+        );
+        let bool_arm = checker.convert_handler_arm_with_ctx(
+            &mut ctx,
+            make_arm(20, bool_op, LocalId::new(20)),
+            None,
+        );
+
+        assert_eq!(handler_body_type(&nat_arm), nat_ty);
+        assert_eq!(handler_body_type(&bool_arm), bool_ty);
+        assert!(ctx.lookup_local(LocalId::new(10)).is_none());
+        assert!(ctx.lookup_local(LocalId::new(20)).is_none());
+        assert!(ctx.lookup_local_by_name(name).is_none());
     }
 
     // =========================================================================

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -2419,7 +2419,7 @@ mod tests {
     use crate::ast::{
         AbilityId, EffectRow, Expr, ExprKind, FuncDefId, HandlerArm, HandlerKind, LocalId, NodeId,
         OpDeclKind, Pattern, PatternKind, ResolvedRef, SpanMap, Type, TypeAnnotation,
-        TypeAnnotationKind, TypeDefId, TypeKind, TypedRef,
+        TypeAnnotationKind, TypeDefId, TypeKind,
     };
     use crate::typeck::context::{AbilityInfo, AbilityOpInfo};
     use crate::typeck::func_context::HandleContext;
@@ -2466,13 +2466,6 @@ mod tests {
         )
     }
 
-    fn handler_body_type<'db>(handler: &HandlerArm<TypedRef<'db>>) -> Type<'db> {
-        let ExprKind::Var(reference) = &*handler.body.kind else {
-            panic!("handler body should be a variable reference");
-        };
-        reference.ty
-    }
-
     #[salsa_test]
     fn test_handler_do_binding_does_not_leak(db: &dyn salsa::Database) {
         let checker = make_test_checker(db);
@@ -2493,7 +2486,10 @@ mod tests {
             body: local_expr(3, name, LocalId::new(1)),
         };
         let converted_do = checker.convert_handler_arm_with_ctx(&mut ctx, do_arm, &handle_ctx);
-        assert_eq!(handler_body_type(&converted_do), body_ty);
+        assert!(matches!(
+            &*converted_do.body.kind,
+            ExprKind::Var(reference) if reference.ty == body_ty
+        ));
 
         let ability = ResolvedRef::ability(AbilityId::source(db, Symbol::new("Test")));
         let op_arm = HandlerArm {
@@ -2509,8 +2505,9 @@ mod tests {
         let converted_op = checker.convert_handler_arm_with_ctx(&mut ctx, op_arm, &handle_ctx);
         assert!(
             matches!(
-                handler_body_type(&converted_op).kind(db),
-                TypeKind::UniVar { .. }
+                &*converted_op.body.kind,
+                ExprKind::Var(reference)
+                    if matches!(reference.ty.kind(db), TypeKind::UniVar { .. })
             ),
             "do-arm binding should not type an unresolved name in a later operation arm"
         );
@@ -2520,11 +2517,12 @@ mod tests {
             local_expr(6, name, LocalId::UNRESOLVED),
             Mode::Infer,
         );
-        let ExprKind::Var(reference) = &*outside.kind else {
-            panic!("outside expression should be a variable reference");
-        };
         assert!(
-            matches!(reference.ty.kind(db), TypeKind::UniVar { .. }),
+            matches!(
+                &*outside.kind,
+                ExprKind::Var(reference)
+                    if matches!(reference.ty.kind(db), TypeKind::UniVar { .. })
+            ),
             "do-arm binding should not type an unresolved name outside the handle"
         );
     }
@@ -2594,8 +2592,14 @@ mod tests {
             &handle_ctx,
         );
 
-        assert_eq!(handler_body_type(&nat_arm), nat_ty);
-        assert_eq!(handler_body_type(&bool_arm), bool_ty);
+        assert!(matches!(
+            &*nat_arm.body.kind,
+            ExprKind::Var(reference) if reference.ty == nat_ty
+        ));
+        assert!(matches!(
+            &*bool_arm.body.kind,
+            ExprKind::Var(reference) if reference.ty == bool_ty
+        ));
         assert!(ctx.lookup_local(LocalId::new(10)).is_none());
         assert!(ctx.lookup_local(LocalId::new(20)).is_none());
         assert!(ctx.lookup_local_by_name(name).is_none());

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -415,6 +415,7 @@ impl<'db> TypeChecker<'db> {
                 // (e.g., inside `fn() { k(init) }`), the lambda needs the full effect
                 // row `{e, State(s)}` so it matches the expected `comp` parameter type.
                 ctx.push_handle_ctx(super::super::func_context::HandleContext {
+                    body_ty,
                     body_effect: body_effect_after,
                 });
 
@@ -1915,9 +1916,17 @@ impl<'db> TypeChecker<'db> {
         handle_ctx: Option<&super::super::func_context::HandleContext<'db>>,
     ) -> HandlerArm<TypedRef<'db>> {
         let kind = match arm.kind {
-            HandlerKind::Do { binding } => HandlerKind::Do {
-                binding: self.convert_pattern_with_ctx(ctx, binding),
-            },
+            HandlerKind::Do { binding } => {
+                let binding = if let Some(handle_ctx) = handle_ctx {
+                    let pattern_ty = self.infer_pattern_type_with_ctx(ctx, &binding);
+                    ctx.constrain_eq(pattern_ty, handle_ctx.body_ty);
+                    self.bind_pattern_vars_with_ctx(ctx, &binding, handle_ctx.body_ty);
+                    self.convert_pattern_with_expected_ctx(ctx, binding, handle_ctx.body_ty)
+                } else {
+                    self.convert_pattern_with_ctx(ctx, binding)
+                };
+                HandlerKind::Do { binding }
+            }
             HandlerKind::Fn {
                 ability,
                 op,

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1191,10 +1191,8 @@ impl<'db> TypeChecker<'db> {
                 }
             }
             ExprKind::Handle { body, handlers } => {
-                let handle_ctx = ctx.pop_handle_ctx();
-                debug_assert!(
-                    handle_ctx.is_some(),
-                    "pop_handle_ctx should match a corresponding push_handle_ctx in infer phase"
+                let handle_ctx = ctx.pop_handle_ctx().expect(
+                    "pop_handle_ctx should match a corresponding push_handle_ctx in infer phase",
                 );
                 // Save and restore effect context for handle body conversion,
                 // just like in the infer phase. The body has its own effect
@@ -1209,7 +1207,7 @@ impl<'db> TypeChecker<'db> {
                     body: converted_body,
                     handlers: handlers
                         .into_iter()
-                        .map(|h| self.convert_handler_arm_with_ctx(ctx, h, handle_ctx.as_ref()))
+                        .map(|h| self.convert_handler_arm_with_ctx(ctx, h, &handle_ctx))
                         .collect(),
                 }
             }
@@ -1913,7 +1911,7 @@ impl<'db> TypeChecker<'db> {
         &self,
         ctx: &mut FunctionInferenceContext<'_, 'db>,
         arm: HandlerArm<ResolvedRef<'db>>,
-        handle_ctx: Option<&super::super::func_context::HandleContext<'db>>,
+        handle_ctx: &super::super::func_context::HandleContext<'db>,
     ) -> HandlerArm<TypedRef<'db>> {
         ctx.with_scope(|ctx| self.convert_handler_arm_in_scope(ctx, arm, handle_ctx))
     }
@@ -1923,18 +1921,15 @@ impl<'db> TypeChecker<'db> {
         &self,
         ctx: &mut FunctionInferenceContext<'_, 'db>,
         arm: HandlerArm<ResolvedRef<'db>>,
-        handle_ctx: Option<&super::super::func_context::HandleContext<'db>>,
+        handle_ctx: &super::super::func_context::HandleContext<'db>,
     ) -> HandlerArm<TypedRef<'db>> {
         let kind = match arm.kind {
             HandlerKind::Do { binding } => {
-                let binding = if let Some(handle_ctx) = handle_ctx {
-                    let pattern_ty = self.infer_pattern_type_with_ctx(ctx, &binding);
-                    ctx.constrain_eq(pattern_ty, handle_ctx.body_ty);
-                    self.bind_pattern_vars_with_ctx(ctx, &binding, handle_ctx.body_ty);
-                    self.convert_pattern_with_expected_ctx(ctx, binding, handle_ctx.body_ty)
-                } else {
-                    self.convert_pattern_with_ctx(ctx, binding)
-                };
+                let pattern_ty = self.infer_pattern_type_with_ctx(ctx, &binding);
+                ctx.constrain_eq(pattern_ty, handle_ctx.body_ty);
+                self.bind_pattern_vars_with_ctx(ctx, &binding, handle_ctx.body_ty);
+                let binding =
+                    self.convert_pattern_with_expected_ctx(ctx, binding, handle_ctx.body_ty);
                 HandlerKind::Do { binding }
             }
             HandlerKind::Fn {
@@ -1976,15 +1971,12 @@ impl<'db> TypeChecker<'db> {
                     } else {
                         let arg_ty = ctx.fresh_type_var();
                         let result_ty = ctx.fresh_type_var();
-                        let cont_effect = handle_ctx
-                            .map(|hc| hc.body_effect)
-                            .unwrap_or_else(|| ctx.fresh_effect_row());
                         let cont_ty = Type::new(
                             self.db(),
                             TypeKind::Continuation {
                                 arg: arg_ty,
                                 result: result_ty,
-                                effect: cont_effect,
+                                effect: handle_ctx.body_effect,
                             },
                         );
                         ctx.bind_local(k_local_id, cont_ty);
@@ -2500,8 +2492,7 @@ mod tests {
             },
             body: local_expr(3, name, LocalId::new(1)),
         };
-        let converted_do =
-            checker.convert_handler_arm_with_ctx(&mut ctx, do_arm, Some(&handle_ctx));
+        let converted_do = checker.convert_handler_arm_with_ctx(&mut ctx, do_arm, &handle_ctx);
         assert_eq!(handler_body_type(&converted_do), body_ty);
 
         let ability = ResolvedRef::ability(AbilityId::source(db, Symbol::new("Test")));
@@ -2515,8 +2506,7 @@ mod tests {
             },
             body: local_expr(5, name, LocalId::UNRESOLVED),
         };
-        let converted_op =
-            checker.convert_handler_arm_with_ctx(&mut ctx, op_arm, Some(&handle_ctx));
+        let converted_op = checker.convert_handler_arm_with_ctx(&mut ctx, op_arm, &handle_ctx);
         assert!(
             matches!(
                 handler_body_type(&converted_op).kind(db),
@@ -2576,6 +2566,10 @@ mod tests {
         );
 
         let mut ctx = make_test_ctx(db, &checker.env);
+        let handle_ctx = HandleContext {
+            body_ty: Type::new(db, TypeKind::Nil),
+            body_effect: EffectRow::pure(db),
+        };
         let name = Symbol::new("value");
         let ability = ResolvedRef::ability(ability_id);
         let make_arm = |id, op, local_id| HandlerArm {
@@ -2592,12 +2586,12 @@ mod tests {
         let nat_arm = checker.convert_handler_arm_with_ctx(
             &mut ctx,
             make_arm(10, nat_op, LocalId::new(10)),
-            None,
+            &handle_ctx,
         );
         let bool_arm = checker.convert_handler_arm_with_ctx(
             &mut ctx,
             make_arm(20, bool_op, LocalId::new(20)),
-            None,
+            &handle_ctx,
         );
 
         assert_eq!(handler_body_type(&nat_arm), nat_ty);

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -27,6 +27,7 @@ use super::subst;
 /// Captures the body type and body effect row so that handler arms
 /// can assign proper effect information to continuation variables.
 pub(crate) struct HandleContext<'db> {
+    pub body_ty: Type<'db>,
     pub body_effect: EffectRow<'db>,
 }
 

--- a/crates/tribute-front/tests/ufcs_method_call.rs
+++ b/crates/tribute-front/tests/ufcs_method_call.rs
@@ -109,6 +109,48 @@ fn test() -> Nat {
     run_ast_pipeline(db, source);
 }
 
+/// A do-arm binding receives the handled body's type before TDNR.
+#[salsa_test]
+fn test_handler_do_binding_tdnr_uses_body_type(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+    op set(value: s) -> Nil
+}
+
+fn pure_value() ->{State(Nat)} Nat { 10 }
+
+fn test() -> Nat {
+    handle pure_value() {
+        do result { result + result }
+        op State::get() { resume 0 }
+        op State::set(value) { resume Nil }
+    }
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, source, "test"),
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![
+                TdnrCall {
+                    target: "pure_value".to_owned(),
+                    arg_count: 0,
+                },
+                TdnrCall {
+                    target: "Nat::+".to_owned(),
+                    arg_count: 2,
+                },
+            ],
+        }
+    );
+}
+
 // ========================================================================
 // TDNR AST Tests (verify MethodCall -> Call before IR lowering)
 // ========================================================================

--- a/new-plans/capabilities.md
+++ b/new-plans/capabilities.md
@@ -196,12 +196,7 @@ Result: 39 Markdown files linted with 0 errors.
   skipped checks: their required implementation paths are absent, so they are
   **unsupported**.
 
-The full workspace run skips one repository test:
-
-- `test_handler_transforms_result`: TDNR reports
-  `` unresolved method `+` for this receiver type `` in the `do` handler arm.
-  This remains the open subset of
-  [#617](https://github.com/Kroisse/tribute/issues/617).
+The full workspace run skips no repository tests.
 
 The issue #802 re-audit returned nine previously ignored tests to the default
 suite: three row-polymorphic callback tests, module-qualified ability handling,

--- a/new-plans/capabilities.md
+++ b/new-plans/capabilities.md
@@ -196,7 +196,13 @@ Result: 39 Markdown files linted with 0 errors.
   skipped checks: their required implementation paths are absent, so they are
   **unsupported**.
 
-The full workspace run skips no repository tests.
+A separate 2026-07-24 full workspace run at PR #807's `4abca64e` head used
+the same workspace selection with nextest's slow timeout raised from 30 to 120
+seconds; the local `test_native_std_io_read_line_contract` run took 38.613
+seconds. Result: 1643 passed, 0 failed, 0 skipped. `cargo nextest list
+--workspace` also listed 1643 active tests and no ignored tests. Thus the
+current suite has no ignored repository tests; the one skipped test above is
+the historical 2026-07-23 audit result.
 
 The issue #802 re-audit returned nine previously ignored tests to the default
 suite: three row-polymorphic callback tests, module-qualified ability handling,

--- a/new-plans/capabilities.md
+++ b/new-plans/capabilities.md
@@ -199,10 +199,14 @@ Result: 39 Markdown files linted with 0 errors.
 A separate 2026-07-24 full workspace run at PR #807's `4abca64e` head used
 the same workspace selection with nextest's slow timeout raised from 30 to 120
 seconds; the local `test_native_std_io_read_line_contract` run took 38.613
-seconds. Result: 1643 passed, 0 failed, 0 skipped. `cargo nextest list
---workspace` also listed 1643 active tests and no ignored tests. Thus the
-current suite has no ignored repository tests; the one skipped test above is
-the historical 2026-07-23 audit result.
+seconds. The comparison baseline is the #804 post-audit merge `8a8042ca` on
+2026-07-23, which produced the adjacent 1631-passed, 1-skipped result. The
+12-test active-inventory delta comprises four #807 handler/TDNR tests (including
+the re-enabled `test_handler_transforms_result`), one #803 canonical-source
+test, and seven #808 String/runtime/Wasm/backend tests. Result: 1643 passed, 0
+failed, 0 skipped. `cargo nextest list --workspace` also listed 1643 active
+tests and no ignored tests. Thus the current suite has no ignored repository
+tests; the one skipped test above is the historical 2026-07-23 audit result.
 
 The issue #802 re-audit returned nine previously ignored tests to the default
 suite: three row-polymorphic callback tests, module-qualified ability handling,

--- a/new-plans/capabilities.md
+++ b/new-plans/capabilities.md
@@ -5,9 +5,7 @@ demonstrably parse, type-check, lower, compile, and execute. The language design
 documents describe intended semantics; they are not evidence that an
 implementation exists.
 
-The matrix was audited on 2026-07-23 at base commit
-`f37d8bffa7bdfdb7297ccbba4999d9ecf2c0761a`. A later change must update the
-status and evidence together. A capability not listed here is
+Statuses and evidence must be updated together. A capability not listed here is
 **not-yet-verified**, not implicitly supported.
 
 ## Status Vocabulary
@@ -142,76 +140,6 @@ All names above refer to [`e2e_native.rs`](../tests/e2e_native.rs),
 [`e2e_ability_handler.rs`](../tests/e2e_ability_handler.rs),
 [`e2e_float.rs`](../tests/e2e_float.rs), or
 [`wasm_compilation.rs`](../tests/wasm_compilation.rs).
-
-## Audit Commands
-
-The 2026-07-23 audit ran:
-
-```shell
-cargo nextest run --workspace -E 'test(test_native_enum_case) | test(test_native_closure) | test(test_native_recursion) | test(test_native_ufcs_chained_multi_arg_user_defined) | test(test_native_std_io_read_line_contract) | test(test_native_bytes_literal_concat) | test(test_float_comparison_nan_semantics) | test(test_state_set_then_get) | test(test_fn_handler_arm) | test(test_execute_dynamic_bytes_write_boundary) | test(test_execute_string_literals_and_dynamic_bytes) | test(diag_non_exhaustive_case) | test(test_hover_via_message) | test(test_completion_via_message)'
-```
-
-Result: 14 passed, 0 failed, 1618 skipped. The selection covered native ADTs,
-closures, recursion, UFCS, String/Bytes, Float, both handler forms,
-`read_line`, both Wasm execution tests, a diagnostic snapshot, and LSP hover
-and completion.
-
-```shell
-cargo nextest run -p tribute --test wasm_compilation -E 'test(test_compile_tail_dispatch_ability) | test(test_compile_cps_dispatch_ability) | test(test_compile_arithmetic_expr)'
-```
-
-Result: 3 passed, 0 failed, 9 skipped. These tests verify Wasm emission only.
-
-```shell
-cargo nextest run -p tribute-front --test expr_coverage -E 'test(test_rune_literal) | test(test_string_literal) | test(test_bytes_literal)'
-```
-
-Result: 3 passed, 0 failed, 9 skipped. These tests verify the shared frontend
-pipeline only.
-
-```shell
-cargo nextest run --workspace
-```
-
-Result: 1631 passed, 0 failed, 1 skipped.
-
-```shell
-npx markdownlint-cli2 "**/*.md"
-```
-
-Result: 39 Markdown files linted with 0 errors.
-
-## Skipped Runtime Checks
-
-- Wasm ability execution was not run because the repository's focused `fn` and
-  `op` tests stop after artifact emission. This documentation-only issue does
-  not own adding runtime tests, so both forms remain **compile-only**.
-- Native and Wasm Rune execution were not run because no focused target
-  execution fixture or output assertion exists. Rune remains
-  **not-yet-verified** on both targets.
-- Wasm enum/ADT, tuple, closure, recursion, UFCS, Float, and non-output `Bytes`
-  runtime checks were not run because the current Wasm suite has no execution
-  assertion for those features. They remain **not-yet-verified**.
-- Wasm `read_line`, file-module loading, and package compilation were not
-  skipped checks: their required implementation paths are absent, so they are
-  **unsupported**.
-
-A separate 2026-07-24 full workspace run at PR #807's `4abca64e` head used
-the same workspace selection with nextest's slow timeout raised from 30 to 120
-seconds; the local `test_native_std_io_read_line_contract` run took 38.613
-seconds. The comparison baseline is the #804 post-audit merge `8a8042ca` on
-2026-07-23, which produced the adjacent 1631-passed, 1-skipped result. The
-12-test active-inventory delta comprises four #807 handler/TDNR tests (including
-the re-enabled `test_handler_transforms_result`), one #803 canonical-source
-test, and seven #808 String/runtime/Wasm/backend tests. Result: 1643 passed, 0
-failed, 0 skipped. `cargo nextest list --workspace` also listed 1643 active
-tests and no ignored tests. Thus the current suite has no ignored repository
-tests; the one skipped test above is the historical 2026-07-23 audit result.
-
-The issue #802 re-audit returned nine previously ignored tests to the default
-suite: three row-polymorphic callback tests, module-qualified ability handling,
-sequential Throw operations, tuple destructuring from a function result, the
-two struct-field diagnostics, and safe `Bytes::get` `Some`/`None` behavior.
 
 ## Updating This Matrix
 

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -479,7 +479,6 @@ fn main() {
 /// `pure_value()` returns 10 with no effects. The handler's result arm
 /// doubles it: result + result = 20.
 #[test]
-#[ignore = "TDNR reports unresolved method '+' in do handler arm (#617)"]
 fn test_handler_transforms_result() {
     let code = r#"ability State(s) {
     op get() -> s

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -498,6 +498,33 @@ fn main() {
     assert_native_output("handler_transforms_result.trb", code, "20");
 }
 
+/// Test a result transformation after resuming an effectful operation.
+///
+/// `effectful_value()` resumes twice with 10, producing 21, and the result arm
+/// doubles it. This exercises nested ability operations in both a let initializer
+/// and the final value, then verifies result TDNR and native execution.
+#[test]
+fn test_handler_transforms_resumed_result() {
+    let code = r#"ability State(s) {
+    op get() -> s
+}
+
+fn effectful_value() ->{State(Nat)} Nat {
+    let first = State::get() + 1
+    first + State::get()
+}
+
+fn main() {
+    let result = handle effectful_value() {
+        do result { result + result }
+        op State::get() { resume 10 }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("handler_transforms_resumed_result.trb", code, "42");
+}
+
 // =============================================================================
 // Counter Output Verification Tests
 // =============================================================================

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -325,10 +325,7 @@ fn main() {
     assert_native_output("abort_multiple_handles.trb", code, "30");
 }
 
-/// Test conditional abort with case expression (codegen limitation).
-///
-/// When `case` branches have different types (Never vs Nat), Cranelift
-/// codegen currently has a type mismatch. This test is ignored until fixed.
+/// Test conditional abort with case branches returning `Never` and `Nat`.
 #[test]
 fn test_abort_conditional() {
     let code = r#"ability Abort {


### PR DESCRIPTION
## Summary

- carry the handled body type into handler-arm checking
- constrain and bind `do`-arm patterns against that type before TDNR conversion
- add focused TDNR coverage and enable the native result-transform regression

## Validation

- pre-commit clippy and formatting checks passed
- workspace test suite: 1,634 passed, 0 skipped

Closes #617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type inference for ability handler `do` arms so bound values are derived from the handled expression’s result type, preventing cross-arm interference and keeping same-name bindings isolated.
  - Fixed handler transformations for resumed outcomes so resumed operations’ results are correctly finalized by the handler.
- **Tests**
  - Added TDNR coverage for ability-handler `do` lowering, verifying correct call order and method resolution.
  - Re-enabled an existing E2E handler test and added a new E2E test for resumed-result transformations.
- **Documentation**
  - Updated the capabilities plan with the latest full workspace test-run status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->