### PR TITLE
Preserve declaration identity for nominal types

### DIFF
--- a/crates/tribute-front/src/ast/phases.rs
+++ b/crates/tribute-front/src/ast/phases.rs
@@ -123,19 +123,41 @@ impl<'db> FuncDefId<'db> {
     }
 }
 
-/// A unique identifier for a type definition (struct or enum).
+/// The origin of a nominal type definition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub enum TypeOrigin {
+    /// A source declaration, identified independently of its spelling.
+    Source(NodeId),
+    /// A synthetic identity used by isolated tests and pre-resolution helpers.
+    Synthetic,
+}
+
+/// A unique identifier for a nominal type definition.
 ///
 /// TypeDefId identifies the type definition itself, not its constructors.
 ///
-/// TypeDefId is interned (not tracked) so that the same qualified name
-/// always produces the same TypeDefId, regardless of where it's created.
+/// Different source declarations remain distinct even when their display names
+/// are identical.
 #[salsa::interned(debug)]
 pub struct TypeDefId<'db> {
+    pub origin: TypeOrigin,
     /// The fully qualified name (e.g., `"std::option::Option"`).
     pub qualified: Symbol,
 }
 
 impl<'db> TypeDefId<'db> {
+    pub fn source(db: &'db dyn salsa::Database, qualified: Symbol, declaration: NodeId) -> Self {
+        Self::new(db, TypeOrigin::Source(declaration), qualified)
+    }
+
+    pub fn synthetic(db: &'db dyn salsa::Database, qualified: Symbol) -> Self {
+        Self::new(db, TypeOrigin::Synthetic, qualified)
+    }
+
+    pub fn with_qualified(self, db: &'db dyn salsa::Database, qualified: Symbol) -> Self {
+        Self::new(db, self.origin(db), qualified)
+    }
+
     /// Returns the unqualified type name (last segment).
     pub fn name(self, db: &'db dyn salsa::Database) -> Symbol {
         self.qualified(db).last_segment()

--- a/crates/tribute-front/src/ast/types.rs
+++ b/crates/tribute-front/src/ast/types.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 use trunk_ir::Symbol;
 
 use super::NodeId;
-use super::phases::FuncDefId;
+use super::phases::{FuncDefId, TypeDefId};
 
 /// A monomorphic type.
 ///
@@ -96,6 +96,8 @@ pub enum TypeKind<'db> {
     // === Compound types ===
     /// Named type (struct, enum, or type alias) with optional type arguments.
     Named {
+        /// Resolved nominal declaration identity.
+        id: TypeDefId<'db>,
         /// The type name (may be qualified path like `std::List`)
         name: Symbol,
         /// Type arguments for generic types
@@ -143,7 +145,7 @@ pub enum TypeKind<'db> {
     Error,
 }
 
-impl TypeKind<'_> {
+impl<'db> TypeKind<'db> {
     /// Returns the canonical name for primitive types, or `None` for compound/variable types.
     pub fn primitive_name(&self) -> Option<&'static str> {
         match self {
@@ -159,10 +161,12 @@ impl TypeKind<'_> {
         }
     }
 
-    /// Create the String type (prelude-defined enum, not a primitive).
-    pub fn string() -> Self {
+    /// Create a synthetic String type for isolated contexts.
+    pub fn string(db: &'db dyn salsa::Database) -> Self {
+        let name = Symbol::new("String");
         Self::Named {
-            name: Symbol::new("String"),
+            id: TypeDefId::synthetic(db, name),
+            name,
             args: vec![],
         }
     }
@@ -202,7 +206,7 @@ impl fmt::Display for TypeKind<'_> {
             Self::Rune => f.write_str("Rune"),
             Self::Nil => f.write_str("Nil"),
             Self::Never => f.write_str("Never"),
-            Self::Named { name, args } => {
+            Self::Named { name, args, .. } => {
                 name.with_str(|s| f.write_str(s))?;
                 if !args.is_empty() {
                     let args = args

--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -863,6 +863,7 @@ mod tests {
         let ty = AstType::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![int_ty],
             },

--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -1,10 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use trunk_ir::Symbol;
-
 use crate::ast::{
-    Decl, Expr, ExprKind, FuncDefId, Module, ResolvedRef, Stmt, Type, TypeKind, TypeScheme,
-    TypedRef,
+    Decl, Expr, ExprKind, FuncDefId, Module, ResolvedRef, Stmt, Type, TypeDefId, TypeKind,
+    TypeScheme, TypedRef,
 };
 
 /// Collect all generic function instantiations from a typed module.
@@ -86,8 +84,15 @@ fn extract_recursive<'db>(
             }
             extract_recursive(db, *sr, *cr, type_args)
         }
-        (TypeKind::Named { name: sn, args: sa }, TypeKind::Named { name: cn, args: ca }) => {
-            if sn != cn || sa.len() != ca.len() {
+        (
+            TypeKind::Named {
+                id: si, args: sa, ..
+            },
+            TypeKind::Named {
+                id: ci, args: ca, ..
+            },
+        ) => {
+            if si != ci || sa.len() != ca.len() {
                 return false;
             }
             for (s, c) in sa.iter().zip(ca.iter()) {
@@ -268,9 +273,9 @@ impl<'db> InstantiationCollector<'db> {
 pub fn collect_type_instantiations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
-) -> HashMap<Symbol, HashSet<Vec<Type<'db>>>> {
-    let generic_types = collect_generic_type_names(module);
-    let mut result: HashMap<Symbol, HashSet<Vec<Type<'db>>>> = HashMap::new();
+) -> HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>> {
+    let generic_types = collect_generic_type_ids(db, module);
+    let mut result: HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>> = HashMap::new();
 
     let mut visitor = TypeInstantiationVisitor {
         db,
@@ -281,25 +286,38 @@ pub fn collect_type_instantiations<'db>(
     result
 }
 
-/// Collect names of all struct/enum declarations that have type parameters.
-fn collect_generic_type_names(module: &Module<TypedRef<'_>>) -> HashSet<Symbol> {
-    let mut names = HashSet::new();
-    collect_generic_type_names_inner(&module.decls, &mut names);
-    names
+/// Collect declaration identities of all generic struct/enum declarations.
+fn collect_generic_type_ids<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+) -> HashSet<TypeDefId<'db>> {
+    let mut ids = HashSet::new();
+    let mut prefix = String::new();
+    collect_generic_type_ids_inner(db, &module.decls, &mut prefix, &mut ids);
+    ids
 }
 
-fn collect_generic_type_names_inner(decls: &[Decl<TypedRef<'_>>], names: &mut HashSet<Symbol>) {
+fn collect_generic_type_ids_inner<'db>(
+    db: &'db dyn salsa::Database,
+    decls: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+    ids: &mut HashSet<TypeDefId<'db>>,
+) {
     for decl in decls {
         match decl {
             Decl::Struct(s) if !s.type_params.is_empty() => {
-                names.insert(s.name);
+                let qualified = crate::qualified_symbol(prefix, s.name);
+                ids.insert(TypeDefId::source(db, qualified, s.id));
             }
             Decl::Enum(e) if !e.type_params.is_empty() => {
-                names.insert(e.name);
+                let qualified = crate::qualified_symbol(prefix, e.name);
+                ids.insert(TypeDefId::source(db, qualified, e.id));
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
-                    collect_generic_type_names_inner(body, names);
+                    let saved = crate::push_prefix(prefix, m.name);
+                    collect_generic_type_ids_inner(db, body, prefix, ids);
+                    prefix.truncate(saved);
                 }
             }
             _ => {}
@@ -307,18 +325,17 @@ fn collect_generic_type_names_inner(decls: &[Decl<TypedRef<'_>>], names: &mut Ha
     }
 }
 
-/// Recursively walk a Type and collect all `Named { name, args }` where
-/// `args` is non-empty and `name` is a known generic type.
+/// Recursively walk a Type and collect all declaration-backed generic types.
 fn collect_from_type<'db>(
     db: &'db dyn salsa::Database,
     ty: Type<'db>,
-    generic_types: &HashSet<Symbol>,
-    result: &mut HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+    generic_types: &HashSet<TypeDefId<'db>>,
+    result: &mut HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
 ) {
     match ty.kind(db) {
-        TypeKind::Named { name, args } => {
-            if !args.is_empty() && generic_types.contains(name) {
-                result.entry(*name).or_default().insert(args.clone());
+        TypeKind::Named { id, args, .. } => {
+            if !args.is_empty() && generic_types.contains(id) {
+                result.entry(*id).or_default().insert(args.clone());
             }
             // Recurse into type arguments (e.g., List(Option(Int)) → collect Option(Int))
             for arg in args {
@@ -359,8 +376,8 @@ fn collect_from_type<'db>(
 
 struct TypeInstantiationVisitor<'a, 'db> {
     db: &'db dyn salsa::Database,
-    generic_types: &'a HashSet<Symbol>,
-    instantiations: &'a mut HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+    generic_types: &'a HashSet<TypeDefId<'db>>,
+    instantiations: &'a mut HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
 }
 
 impl<'a, 'db> TypeInstantiationVisitor<'a, 'db> {
@@ -626,6 +643,7 @@ mod tests {
         let text = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Text")),
                 name: trunk_ir::Symbol::new("Text"),
                 args: vec![],
             },
@@ -651,6 +669,7 @@ mod tests {
         let option_bv = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option")),
                 name: trunk_ir::Symbol::new("Option"),
                 args: vec![bv0],
             },
@@ -670,6 +689,7 @@ mod tests {
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option")),
                 name: trunk_ir::Symbol::new("Option"),
                 args: vec![int],
             },
@@ -713,22 +733,24 @@ mod tests {
     fn test_collect_type_from_named() {
         let db = TestDb::default();
         let int = Type::new(&db, TypeKind::Int);
+        let option_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option"));
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: option_id,
                 name: trunk_ir::Symbol::new("Option"),
                 args: vec![int],
             },
         );
 
         let mut generic_types = HashSet::new();
-        generic_types.insert(trunk_ir::Symbol::new("Option"));
+        generic_types.insert(option_id);
 
         let mut result = HashMap::new();
         collect_from_type(&db, option_int, &generic_types, &mut result);
 
         assert_eq!(result.len(), 1);
-        let option_insts = result.get(&trunk_ir::Symbol::new("Option")).unwrap();
+        let option_insts = result.get(&option_id).unwrap();
         assert!(option_insts.contains(&vec![int]));
     }
 
@@ -736,9 +758,12 @@ mod tests {
     fn test_collect_type_nested() {
         let db = TestDb::default();
         let int = Type::new(&db, TypeKind::Int);
+        let option_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option"));
+        let list_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List"));
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: option_id,
                 name: trunk_ir::Symbol::new("Option"),
                 args: vec![int],
             },
@@ -746,30 +771,33 @@ mod tests {
         let list_option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: list_id,
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![option_int],
             },
         );
 
         let mut generic_types = HashSet::new();
-        generic_types.insert(trunk_ir::Symbol::new("Option"));
-        generic_types.insert(trunk_ir::Symbol::new("List"));
+        generic_types.insert(option_id);
+        generic_types.insert(list_id);
 
         let mut result = HashMap::new();
         collect_from_type(&db, list_option_int, &generic_types, &mut result);
 
         assert_eq!(result.len(), 2);
-        assert!(result[&trunk_ir::Symbol::new("Option")].contains(&vec![int]));
-        assert!(result[&trunk_ir::Symbol::new("List")].contains(&vec![option_int]));
+        assert!(result[&option_id].contains(&vec![int]));
+        assert!(result[&list_id].contains(&vec![option_int]));
     }
 
     #[test]
     fn test_collect_type_in_func_params() {
         let db = TestDb::default();
         let int = Type::new(&db, TypeKind::Int);
+        let pair_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Pair"));
         let pair_int_int = Type::new(
             &db,
             TypeKind::Named {
+                id: pair_id,
                 name: trunk_ir::Symbol::new("Pair"),
                 args: vec![int, int],
             },
@@ -785,13 +813,13 @@ mod tests {
         );
 
         let mut generic_types = HashSet::new();
-        generic_types.insert(trunk_ir::Symbol::new("Pair"));
+        generic_types.insert(pair_id);
 
         let mut result = HashMap::new();
         collect_from_type(&db, func_ty, &generic_types, &mut result);
 
         assert_eq!(result.len(), 1);
-        assert!(result[&trunk_ir::Symbol::new("Pair")].contains(&vec![int, int]));
+        assert!(result[&pair_id].contains(&vec![int, int]));
     }
 
     #[test]
@@ -802,6 +830,7 @@ mod tests {
         let unknown = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Unknown")),
                 name: trunk_ir::Symbol::new("Unknown"),
                 args: vec![int],
             },

--- a/crates/tribute-front/src/monomorphize/mangle.rs
+++ b/crates/tribute-front/src/monomorphize/mangle.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use trunk_ir::Symbol;
 
-use crate::ast::{Type, TypeKind};
+use crate::ast::{Type, TypeDefId, TypeKind};
 
 /// Generate a mangled symbol for a specialized generic function or type.
 ///
@@ -26,6 +26,20 @@ pub fn mangle_name(db: &dyn salsa::Database, base: Symbol, type_args: &[Type<'_>
     Symbol::from_dynamic(&buf)
 }
 
+pub fn mangle_type_name(
+    db: &dyn salsa::Database,
+    id: TypeDefId<'_>,
+    name: Symbol,
+    type_args: &[Type<'_>],
+) -> Symbol {
+    mangle_name(db, nominal_mangle_base(db, id, name), type_args)
+}
+
+fn nominal_mangle_base(db: &dyn salsa::Database, id: TypeDefId<'_>, name: Symbol) -> Symbol {
+    let qualified = id.qualified(db);
+    if qualified == name { name } else { qualified }
+}
+
 fn write_type_mangled(
     db: &dyn salsa::Database,
     ty: Type<'_>,
@@ -40,8 +54,8 @@ fn write_type_mangled(
         TypeKind::Rune => f.write_str("Rune"),
         TypeKind::Nil => f.write_str("Nil"),
         TypeKind::Never => f.write_str("Never"),
-        TypeKind::Named { name, args } => {
-            name.with_str(|s| f.write_str(s))?;
+        TypeKind::Named { id, name, args } => {
+            nominal_mangle_base(db, *id, *name).with_str(|s| f.write_str(s))?;
             if !args.is_empty() {
                 f.write_str("$0$")?;
                 write_type_mangled_list(db, args, f)?;
@@ -121,6 +135,7 @@ mod tests {
         let text_ty = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Text")),
                 name: Symbol::new("Text"),
                 args: vec![],
             },
@@ -137,6 +152,7 @@ mod tests {
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Option")),
                 name: Symbol::new("Option"),
                 args: vec![int_ty],
             },
@@ -153,6 +169,7 @@ mod tests {
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Option")),
                 name: Symbol::new("Option"),
                 args: vec![int_ty],
             },
@@ -160,12 +177,54 @@ mod tests {
         let list_option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![option_int],
             },
         );
         let result = mangle_name(&db, base, &[list_option_int]);
         assert_eq!(result.to_string(), "f$List$0$Option$0$Int$1$1");
+    }
+
+    #[test]
+    fn test_same_spelled_source_types_mangle_distinctly() {
+        let db = TestDb::default();
+        let base = Symbol::new("identity");
+        let name = Symbol::new("Thing");
+        let int_ty = Type::new(&db, TypeKind::Int);
+        let a_thing = Type::new(
+            &db,
+            TypeKind::Named {
+                id: crate::ast::TypeDefId::source(
+                    &db,
+                    Symbol::new("A::Thing"),
+                    crate::ast::NodeId::from_raw(1),
+                ),
+                name,
+                args: vec![int_ty],
+            },
+        );
+        let b_thing = Type::new(
+            &db,
+            TypeKind::Named {
+                id: crate::ast::TypeDefId::source(
+                    &db,
+                    Symbol::new("B::Thing"),
+                    crate::ast::NodeId::from_raw(2),
+                ),
+                name,
+                args: vec![int_ty],
+            },
+        );
+
+        assert_eq!(
+            mangle_name(&db, base, &[a_thing]).to_string(),
+            "identity$A::Thing$0$Int$1"
+        );
+        assert_eq!(
+            mangle_name(&db, base, &[b_thing]).to_string(),
+            "identity$B::Thing$0$Int$1"
+        );
     }
 
     #[test]
@@ -176,6 +235,7 @@ mod tests {
         let text_ty = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Text")),
                 name: Symbol::new("Text"),
                 args: vec![],
             },
@@ -183,6 +243,7 @@ mod tests {
         let pair = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Pair")),
                 name: Symbol::new("Pair"),
                 args: vec![int_ty, text_ty],
             },

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -15,13 +15,13 @@ use crate::ast::{
 };
 
 use super::collect::extract_type_args;
-use super::mangle::mangle_name;
+use super::mangle::mangle_type_name;
 
 /// Rewrite map: original FuncDefId → list of (type_args, mangled_name) pairs.
 pub type RewriteMap<'db> = HashMap<FuncDefId<'db>, Vec<(Vec<Type<'db>>, Symbol)>>;
 
-/// Type rewrite map: type name → set of (type_args, mangled_name) pairs.
-pub type TypeRewriteMap<'db> = HashMap<Symbol, Vec<(Vec<Type<'db>>, Symbol)>>;
+/// Type rewrite map: declaration identity → specialized argument/name pairs.
+pub type TypeRewriteMap<'db> = HashMap<TypeDefId<'db>, Vec<(Vec<Type<'db>>, Symbol)>>;
 
 /// Rewrite all generic function call sites in a module to use specialized versions.
 pub fn rewrite_module<'db>(
@@ -248,19 +248,19 @@ impl<'a, 'db> CallSiteRewriter<'a, 'db> {
 /// Build a type rewrite map from collected type instantiations.
 pub fn build_type_rewrite_map<'db>(
     db: &'db dyn salsa::Database,
-    instantiations: &HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+    instantiations: &HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
 ) -> TypeRewriteMap<'db> {
     let mut map = TypeRewriteMap::new();
-    for (name, type_arg_sets) in instantiations {
+    for (id, type_arg_sets) in instantiations {
         let mut entries: Vec<(Vec<Type<'db>>, Symbol)> = type_arg_sets
             .iter()
             .map(|type_args| {
-                let mangled = mangle_name(db, *name, type_args);
+                let mangled = mangle_type_name(db, *id, id.qualified(db), type_args);
                 (type_args.clone(), mangled)
             })
             .collect();
         entries.sort_by_key(|e| e.1);
-        map.insert(*name, entries);
+        map.insert(*id, entries);
     }
     map
 }
@@ -315,16 +315,17 @@ pub fn rewrite_type<'db>(
     map: &TypeRewriteMap<'db>,
 ) -> Type<'db> {
     match ty.kind(db) {
-        TypeKind::Named { name, args } if !args.is_empty() => {
+        TypeKind::Named { id, name, args } if !args.is_empty() => {
             // The rewrite map is keyed on the original (un-rewritten) args as
             // collected from the module, so look up using `args` directly —
             // not the recursively rewritten ones.
-            if let Some(entries) = map.get(name)
+            if let Some(entries) = map.get(id)
                 && let Some((_, mangled)) = entries.iter().find(|(ta, _)| ta == args)
             {
                 return Type::new(
                     db,
                     TypeKind::Named {
+                        id: id.with_qualified(db, *mangled),
                         name: *mangled,
                         args: vec![],
                     },
@@ -338,6 +339,7 @@ pub fn rewrite_type<'db>(
             Type::new(
                 db,
                 TypeKind::Named {
+                    id: *id,
                     name: *name,
                     args: rewritten_args,
                 },
@@ -440,7 +442,7 @@ fn rewrite_typed_ref_type<'db>(
         ResolvedRef::TypeDef { id } => {
             if let Some(mangled) = find_mangled_for_typedef(db, *id, tr.ty, map) {
                 ResolvedRef::TypeDef {
-                    id: TypeDefId::new(db, mangled),
+                    id: id.with_qualified(db, mangled),
                 }
             } else {
                 tr.resolved.clone()
@@ -464,8 +466,8 @@ fn find_mangled_for_ctor<'db>(
     };
     // Check if the result type is a Named type with args
     match result_ty.kind(db) {
-        TypeKind::Named { name, args } if !args.is_empty() => {
-            let entries = map.get(name)?;
+        TypeKind::Named { id, args, .. } if !args.is_empty() => {
+            let entries = map.get(id)?;
             // Match against the original args stored in the map.
             let (_, mangled) = entries.iter().find(|(ta, _)| ta == args)?;
             Some(*mangled)
@@ -481,8 +483,8 @@ fn find_mangled_for_typedef<'db>(
     map: &TypeRewriteMap<'db>,
 ) -> Option<Symbol> {
     match ty.kind(db) {
-        TypeKind::Named { name, args } if !args.is_empty() => {
-            let entries = map.get(name)?;
+        TypeKind::Named { id, args, .. } if !args.is_empty() => {
+            let entries = map.get(id)?;
             // Match against the original args stored in the map.
             let (_, mangled) = entries.iter().find(|(ta, _)| ta == args)?;
             Some(*mangled)
@@ -754,12 +756,13 @@ mod tests {
     }
 
     fn make_type_rewrite_map<'db>(
-        _db: &'db dyn salsa::Database,
+        db: &'db dyn salsa::Database,
         entries: Vec<(Symbol, Vec<Type<'db>>, Symbol)>,
     ) -> TypeRewriteMap<'db> {
         let mut map = TypeRewriteMap::new();
         for (name, args, mangled) in entries {
-            map.entry(name).or_default().push((args, mangled));
+            let id = TypeDefId::synthetic(db, name);
+            map.entry(id).or_default().push((args, mangled));
         }
         map
     }
@@ -771,6 +774,7 @@ mod tests {
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Option")),
                 name: Symbol::new("Option"),
                 args: vec![int],
             },
@@ -782,12 +786,37 @@ mod tests {
 
         let result = rewrite_type(&db, option_int, &map);
         match result.kind(&db) {
-            TypeKind::Named { name, args } => {
+            TypeKind::Named { name, args, .. } => {
                 assert_eq!(name.to_string(), "Option$Int");
                 assert!(args.is_empty());
             }
             other => panic!("expected Named, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_type_rewrite_map_keeps_same_spelled_source_types_distinct() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let a_id = TypeDefId::source(
+            &db,
+            Symbol::new("A::Thing"),
+            crate::ast::NodeId::from_raw(1),
+        );
+        let b_id = TypeDefId::source(
+            &db,
+            Symbol::new("B::Thing"),
+            crate::ast::NodeId::from_raw(2),
+        );
+        let mut instantiations = HashMap::new();
+        instantiations.insert(a_id, HashSet::from([vec![int]]));
+        instantiations.insert(b_id, HashSet::from([vec![int]]));
+
+        let map = build_type_rewrite_map(&db, &instantiations);
+
+        assert_eq!(map.len(), 2);
+        assert_eq!(map[&a_id][0].1.to_string(), "A::Thing$Int");
+        assert_eq!(map[&b_id][0].1.to_string(), "B::Thing$Int");
     }
 
     #[test]
@@ -804,6 +833,7 @@ mod tests {
         let text = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Text")),
                 name: Symbol::new("Text"),
                 args: vec![],
             },
@@ -819,6 +849,7 @@ mod tests {
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Option")),
                 name: Symbol::new("Option"),
                 args: vec![int],
             },
@@ -840,7 +871,7 @@ mod tests {
         let result = rewrite_type(&db, func_ty, &map);
         match result.kind(&db) {
             TypeKind::Func { params, .. } => match params[0].kind(&db) {
-                TypeKind::Named { name, args } => {
+                TypeKind::Named { name, args, .. } => {
                     assert_eq!(name.to_string(), "Option$Int");
                     assert!(args.is_empty());
                 }
@@ -857,6 +888,7 @@ mod tests {
         let unknown = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Unknown")),
                 name: Symbol::new("Unknown"),
                 args: vec![int],
             },
@@ -879,6 +911,7 @@ mod tests {
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Option")),
                 name: Symbol::new("Option"),
                 args: vec![int],
             },
@@ -886,6 +919,7 @@ mod tests {
         let pair_option_int_bool = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Pair")),
                 name: Symbol::new("Pair"),
                 args: vec![option_int, bool_ty],
             },
@@ -904,7 +938,7 @@ mod tests {
 
         let result = rewrite_type(&db, pair_option_int_bool, &map);
         match result.kind(&db) {
-            TypeKind::Named { name, args } => {
+            TypeKind::Named { name, args, .. } => {
                 assert_eq!(name.to_string(), "Pair$Option$0$Int$1$Bool");
                 assert!(args.is_empty());
             }

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -7,11 +7,11 @@ use trunk_ir::Symbol;
 use crate::ast::{
     Arm, Decl, EnumDecl, Expr, ExprKind, FieldDecl, FieldPattern, FuncDecl, FuncDefId, HandlerArm,
     HandlerKind, Module, NodeId, Pattern, PatternKind, Stmt, StructDecl, Type, TypeAnnotation,
-    TypeAnnotationKind, TypeKind, TypeScheme, TypedRef, VariantDecl,
+    TypeAnnotationKind, TypeDefId, TypeKind, TypeScheme, TypedRef, VariantDecl,
 };
 use crate::typeck::subst::substitute_bound_vars;
 
-use super::mangle::mangle_name;
+use super::mangle::{mangle_name, mangle_type_name};
 
 /// Generate specialized copies of generic functions for each instantiation.
 ///
@@ -78,13 +78,13 @@ pub fn generate_specializations<'db>(
 pub fn generate_struct_specializations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
-    instantiations: &HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+    instantiations: &HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
 ) -> Vec<StructDecl> {
-    let struct_decls = collect_struct_decls(module);
+    let struct_decls = collect_struct_decls(db, module);
     let mut entries: Vec<(Symbol, StructDecl)> = Vec::new();
 
-    for (name, type_arg_sets) in instantiations {
-        let Some(decl) = struct_decls.get(name) else {
+    for (id, type_arg_sets) in instantiations {
+        let Some(decl) = struct_decls.get(id) else {
             continue;
         };
         if decl.type_params.is_empty() {
@@ -92,7 +92,7 @@ pub fn generate_struct_specializations<'db>(
         }
 
         for type_args in type_arg_sets {
-            let mangled = mangle_name(db, *name, type_args);
+            let mangled = mangle_type_name(db, *id, id.qualified(db), type_args);
             let specialized = specialize_struct_decl(db, decl, type_args, mangled);
             entries.push((mangled, specialized));
         }
@@ -106,13 +106,13 @@ pub fn generate_struct_specializations<'db>(
 pub fn generate_enum_specializations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
-    instantiations: &HashMap<Symbol, HashSet<Vec<Type<'db>>>>,
+    instantiations: &HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
 ) -> Vec<EnumDecl> {
-    let enum_decls = collect_enum_decls(module);
+    let enum_decls = collect_enum_decls(db, module);
     let mut entries: Vec<(Symbol, EnumDecl)> = Vec::new();
 
-    for (name, type_arg_sets) in instantiations {
-        let Some(decl) = enum_decls.get(name) else {
+    for (id, type_arg_sets) in instantiations {
+        let Some(decl) = enum_decls.get(id) else {
             continue;
         };
         if decl.type_params.is_empty() {
@@ -120,7 +120,7 @@ pub fn generate_enum_specializations<'db>(
         }
 
         for type_args in type_arg_sets {
-            let mangled = mangle_name(db, *name, type_args);
+            let mangled = mangle_type_name(db, *id, id.qualified(db), type_args);
             let specialized = specialize_enum_decl(db, decl, type_args, mangled);
             entries.push((mangled, specialized));
         }
@@ -258,12 +258,16 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
         TypeKind::Rune => TypeAnnotationKind::Named(Symbol::new("Rune")),
         TypeKind::Nil => TypeAnnotationKind::Named(Symbol::new("Nil")),
         TypeKind::Never => TypeAnnotationKind::Named(Symbol::new("Never")),
-        TypeKind::Named { name, args } => {
+        TypeKind::Named {
+            id: type_id,
+            name,
+            args,
+        } => {
             if args.is_empty() {
                 TypeAnnotationKind::Named(*name)
             } else {
                 // Use mangled name for generic types with args
-                let mangled = mangle_name(db, *name, args);
+                let mangled = mangle_type_name(db, *type_id, *name, args);
                 TypeAnnotationKind::Named(mangled)
             }
         }
@@ -331,28 +335,32 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
     TypeAnnotation { id, kind }
 }
 
-fn collect_struct_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a StructDecl> {
+fn collect_struct_decls<'a, 'db>(
+    db: &'db dyn salsa::Database,
+    module: &'a Module<TypedRef<'db>>,
+) -> HashMap<TypeDefId<'db>, &'a StructDecl> {
     let mut map = HashMap::new();
     let mut prefix = String::new();
-    collect_struct_decls_inner(&module.decls, &mut prefix, &mut map);
+    collect_struct_decls_inner(db, &module.decls, &mut prefix, &mut map);
     map
 }
 
-fn collect_struct_decls_inner<'a>(
-    decls: &'a [Decl<TypedRef<'_>>],
+fn collect_struct_decls_inner<'a, 'db>(
+    db: &'db dyn salsa::Database,
+    decls: &'a [Decl<TypedRef<'db>>],
     prefix: &mut String,
-    map: &mut HashMap<Symbol, &'a StructDecl>,
+    map: &mut HashMap<TypeDefId<'db>, &'a StructDecl>,
 ) {
     for decl in decls {
         match decl {
             Decl::Struct(s) => {
                 let qualified = crate::qualified_symbol(prefix, s.name);
-                map.insert(qualified, s);
+                map.insert(TypeDefId::source(db, qualified, s.id), s);
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
                     let len = crate::push_prefix(prefix, m.name);
-                    collect_struct_decls_inner(body, prefix, map);
+                    collect_struct_decls_inner(db, body, prefix, map);
                     prefix.truncate(len);
                 }
             }
@@ -361,28 +369,32 @@ fn collect_struct_decls_inner<'a>(
     }
 }
 
-fn collect_enum_decls<'a>(module: &'a Module<TypedRef<'_>>) -> HashMap<Symbol, &'a EnumDecl> {
+fn collect_enum_decls<'a, 'db>(
+    db: &'db dyn salsa::Database,
+    module: &'a Module<TypedRef<'db>>,
+) -> HashMap<TypeDefId<'db>, &'a EnumDecl> {
     let mut map = HashMap::new();
     let mut prefix = String::new();
-    collect_enum_decls_inner(&module.decls, &mut prefix, &mut map);
+    collect_enum_decls_inner(db, &module.decls, &mut prefix, &mut map);
     map
 }
 
-fn collect_enum_decls_inner<'a>(
-    decls: &'a [Decl<TypedRef<'_>>],
+fn collect_enum_decls_inner<'a, 'db>(
+    db: &'db dyn salsa::Database,
+    decls: &'a [Decl<TypedRef<'db>>],
     prefix: &mut String,
-    map: &mut HashMap<Symbol, &'a EnumDecl>,
+    map: &mut HashMap<TypeDefId<'db>, &'a EnumDecl>,
 ) {
     for decl in decls {
         match decl {
             Decl::Enum(e) => {
                 let qualified = crate::qualified_symbol(prefix, e.name);
-                map.insert(qualified, e);
+                map.insert(TypeDefId::source(db, qualified, e.id), e);
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
                     let len = crate::push_prefix(prefix, m.name);
-                    collect_enum_decls_inner(body, prefix, map);
+                    collect_enum_decls_inner(db, body, prefix, map);
                     prefix.truncate(len);
                 }
             }
@@ -962,6 +974,7 @@ mod tests {
         let ty = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Text")),
                 name: Symbol::new("Text"),
                 args: vec![],
             },
@@ -980,6 +993,7 @@ mod tests {
         let ty = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Option")),
                 name: Symbol::new("Option"),
                 args: vec![int],
             },

--- a/crates/tribute-front/src/resolve/mod.rs
+++ b/crates/tribute-front/src/resolve/mod.rs
@@ -168,7 +168,7 @@ fn collect_definition<'db>(
         Decl::Struct(s) => {
             // Struct is both a type and a constructor
             let qualified = qualified_symbol(prefix, s.name);
-            let type_def_id = TypeDefId::new(db, qualified);
+            let type_def_id = TypeDefId::source(db, qualified, s.id);
             let ctor_id = CtorId::new(db, qualified);
             env.add_type(s.name, type_def_id);
             env.add_constructor(s.name, ctor_id, None, s.fields.len());
@@ -191,7 +191,7 @@ fn collect_definition<'db>(
         Decl::Enum(e) => {
             // Enum is a type, and each variant is a constructor
             let qualified = qualified_symbol(prefix, e.name);
-            let type_def_id = TypeDefId::new(db, qualified);
+            let type_def_id = TypeDefId::source(db, qualified, e.id);
             env.add_type(e.name, type_def_id);
 
             // Add each variant as a constructor in the enum's namespace

--- a/crates/tribute-front/src/tdnr/resolver.rs
+++ b/crates/tribute-front/src/tdnr/resolver.rs
@@ -25,6 +25,11 @@ pub struct TdnrResolver<'db> {
     /// Multiple candidates with different receiver types can share the same method name
     /// (e.g., `String::len` and `Bytes::len` both register under `len`).
     method_index: HashMap<Symbol, Vec<MethodEntry<'db>>>,
+    /// Declaration-backed nominal identities used when rebuilding types from
+    /// source annotations during TDNR.
+    type_identities: HashMap<Symbol, crate::ast::TypeDefId<'db>>,
+    /// Lexical module prefix used while resolving expression-local annotations.
+    current_prefix: String,
 }
 
 impl<'db> TdnrResolver<'db> {
@@ -33,11 +38,16 @@ impl<'db> TdnrResolver<'db> {
         Self {
             db,
             method_index: HashMap::new(),
+            type_identities: HashMap::new(),
+            current_prefix: String::new(),
         }
     }
 
     /// Resolve method calls in a module.
     pub fn resolve_module(mut self, module: Module<TypedRef<'db>>) -> Module<TypedRef<'db>> {
+        let mut prefix = String::new();
+        self.collect_type_identities(&module.decls, &mut prefix);
+
         // Phase 1: Build method index from function declarations
         self.build_method_index(&module);
 
@@ -81,7 +91,34 @@ impl<'db> TdnrResolver<'db> {
     /// (no additional prefix), so FuncDefIds match what the rest of the pipeline expects.
     pub fn index_external_module(&mut self, module: &Module<TypedRef<'db>>) {
         let mut prefix = String::new();
+        self.collect_type_identities(&module.decls, &mut prefix);
+        prefix.clear();
         self.index_decls(&module.decls, &mut prefix);
+    }
+
+    fn collect_type_identities(&mut self, decls: &[Decl<TypedRef<'db>>], prefix: &mut String) {
+        for decl in decls {
+            match decl {
+                Decl::Struct(struct_decl) => {
+                    let qualified = qualified_symbol(prefix, struct_decl.name);
+                    let id = crate::ast::TypeDefId::source(self.db, qualified, struct_decl.id);
+                    self.type_identities.insert(qualified, id);
+                }
+                Decl::Enum(enum_decl) => {
+                    let qualified = qualified_symbol(prefix, enum_decl.name);
+                    let id = crate::ast::TypeDefId::source(self.db, qualified, enum_decl.id);
+                    self.type_identities.insert(qualified, id);
+                }
+                Decl::Module(module) => {
+                    if let Some(body) = &module.body {
+                        let saved = push_prefix(prefix, module.name);
+                        self.collect_type_identities(body, prefix);
+                        prefix.truncate(saved);
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 
     /// Recursively index declarations, including nested modules.
@@ -113,7 +150,7 @@ impl<'db> TdnrResolver<'db> {
                     let func_id = FuncDefId::new(self.db, qualified);
 
                     // Build function type from parameter and return type annotations
-                    let func_ty = self.build_func_type(func);
+                    let func_ty = self.build_func_type(func, prefix);
 
                     // Register under method name only; receiver type filtering at lookup time
                     self.method_index
@@ -171,8 +208,10 @@ impl<'db> TdnrResolver<'db> {
                                 },
                             }
                         };
-                        let self_ty = self.annotation_to_type(&Some(self_annotation));
-                        let field_ty = self.annotation_to_type(&Some(field.ty.clone()));
+                        let self_ty =
+                            self.annotation_to_type_in_scope(&Some(self_annotation), prefix);
+                        let field_ty =
+                            self.annotation_to_type_in_scope(&Some(field.ty.clone()), prefix);
 
                         let effect = crate::ast::EffectRow::pure(self.db);
                         let func_ty = Type::new(
@@ -208,21 +247,21 @@ impl<'db> TdnrResolver<'db> {
     }
 
     /// Build a function type from parameter and return type annotations.
-    fn build_func_type(&self, func: &FuncDecl<TypedRef<'db>>) -> Type<'db> {
+    fn build_func_type(&self, func: &FuncDecl<TypedRef<'db>>, prefix: &str) -> Type<'db> {
         use crate::ast::TypeKind;
 
         // Convert parameter types from annotations
         let params: Vec<Type<'db>> = func
             .params
             .iter()
-            .map(|p| self.annotation_to_type(&p.ty))
+            .map(|p| self.annotation_to_type_in_scope(&p.ty, prefix))
             .collect();
 
         // Get return type from annotation or infer from body
         let result = func
             .return_ty
             .as_ref()
-            .map(|ann| self.annotation_to_type(&Some(ann.clone())))
+            .map(|ann| self.annotation_to_type_in_scope(&Some(ann.clone()), prefix))
             .unwrap_or_else(|| {
                 // Try to get return type from body expression
                 self.get_expr_type(&func.body)
@@ -230,7 +269,7 @@ impl<'db> TdnrResolver<'db> {
             });
 
         // Convert effect annotations to EffectRow
-        let effect = self.annotations_to_effect_row(&func.effects);
+        let effect = self.annotations_to_effect_row(&func.effects, prefix);
 
         Type::new(
             self.db,
@@ -247,6 +286,7 @@ impl<'db> TdnrResolver<'db> {
     fn annotations_to_effect_row(
         &self,
         annotations: &Option<Vec<crate::ast::TypeAnnotation>>,
+        prefix: &str,
     ) -> crate::ast::EffectRow<'db> {
         use crate::ast::EffectRow;
 
@@ -265,13 +305,22 @@ impl<'db> TdnrResolver<'db> {
             self.db,
             anns,
             "",
-            &mut |ann| self.annotation_to_type(&Some(ann.clone())),
+            &mut |ann| self.annotation_to_type_in_scope(&Some(ann.clone()), prefix),
             || unreachable!("TDNR does not support open effect rows"),
         )
     }
 
     /// Convert a type annotation to a Type.
+    #[cfg(test)]
     fn annotation_to_type(&self, annotation: &Option<crate::ast::TypeAnnotation>) -> Type<'db> {
+        self.annotation_to_type_in_scope(annotation, &self.current_prefix)
+    }
+
+    fn annotation_to_type_in_scope(
+        &self,
+        annotation: &Option<crate::ast::TypeAnnotation>,
+        prefix: &str,
+    ) -> Type<'db> {
         use crate::ast::{TypeAnnotationKind, TypeKind};
 
         let Some(ann) = annotation else {
@@ -284,25 +333,26 @@ impl<'db> TdnrResolver<'db> {
                 if let Some(kind) = name.with_str(TypeKind::from_primitive_name) {
                     Type::new(self.db, kind)
                 } else {
-                    // User-defined type
-                    Type::new(
-                        self.db,
-                        TypeKind::Named {
-                            name: *name,
-                            args: vec![],
-                        },
-                    )
+                    self.nominal_type_in_scope(*name, prefix)
                 }
             }
             TypeAnnotationKind::Path(path) if !path.is_empty() => {
                 let name = crate::qualified_path_symbol(path).unwrap();
-                Type::new(self.db, TypeKind::Named { name, args: vec![] })
+                let id = self.lookup_type_identity(name, prefix);
+                Type::new(
+                    self.db,
+                    TypeKind::Named {
+                        id,
+                        name,
+                        args: vec![],
+                    },
+                )
             }
             TypeAnnotationKind::App { ctor, args } => {
-                let ctor_ty = self.annotation_to_type(&Some((**ctor).clone()));
+                let ctor_ty = self.annotation_to_type_in_scope(&Some((**ctor).clone()), prefix);
                 let arg_tys: Vec<Type<'db>> = args
                     .iter()
-                    .map(|a| self.annotation_to_type(&Some(a.clone())))
+                    .map(|a| self.annotation_to_type_in_scope(&Some(a.clone()), prefix))
                     .collect();
                 Type::new(
                     self.db,
@@ -314,6 +364,47 @@ impl<'db> TdnrResolver<'db> {
             }
             _ => Type::new(self.db, TypeKind::Error),
         }
+    }
+
+    fn nominal_type(&self, name: Symbol) -> Type<'db> {
+        self.nominal_type_in_scope(name, &self.current_prefix)
+    }
+
+    fn nominal_type_in_scope(&self, name: Symbol, prefix: &str) -> Type<'db> {
+        let id = self.lookup_type_identity(name, prefix);
+        Type::new(
+            self.db,
+            TypeKind::Named {
+                id,
+                name,
+                args: vec![],
+            },
+        )
+    }
+
+    fn lookup_type_identity(&self, name: Symbol, prefix: &str) -> crate::ast::TypeDefId<'db> {
+        let spelling = name.to_string();
+        if spelling.contains("::") {
+            return self
+                .type_identities
+                .get(&name)
+                .copied()
+                .unwrap_or_else(|| crate::ast::TypeDefId::synthetic(self.db, name));
+        }
+
+        let mut scope = prefix.trim_end_matches("::");
+        while !scope.is_empty() {
+            let candidate = Symbol::from_dynamic(&format!("{scope}::{spelling}"));
+            if let Some(id) = self.type_identities.get(&candidate) {
+                return *id;
+            }
+            scope = scope.rsplit_once("::").map_or("", |(parent, _)| parent);
+        }
+
+        self.type_identities
+            .get(&name)
+            .copied()
+            .unwrap_or_else(|| crate::ast::TypeDefId::synthetic(self.db, name))
     }
 
     /// Check if a type annotation has a determinable type constructor name.
@@ -362,9 +453,11 @@ impl<'db> TdnrResolver<'db> {
         &mut self,
         module: crate::ast::ModuleDecl<TypedRef<'db>>,
     ) -> crate::ast::ModuleDecl<TypedRef<'db>> {
+        let saved = push_prefix(&mut self.current_prefix, module.name);
         let body = module
             .body
             .map(|decls| decls.into_iter().map(|d| self.resolve_decl(d)).collect());
+        self.current_prefix.truncate(saved);
 
         crate::ast::ModuleDecl {
             id: module.id,
@@ -573,7 +666,7 @@ impl<'db> TdnrResolver<'db> {
             ExprKind::IntLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Int)),
             ExprKind::FloatLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Float)),
             ExprKind::BoolLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Bool)),
-            ExprKind::StringLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::string())),
+            ExprKind::StringLit(_) => Some(self.nominal_type(Symbol::new("String"))),
             ExprKind::BytesLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Bytes)),
             ExprKind::RuneLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Rune)),
             ExprKind::Nil => Some(Type::new(self.db, crate::ast::TypeKind::Nil)),
@@ -909,6 +1002,7 @@ mod tests {
         let option_int = Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, option_name),
                 name: option_name,
                 args: vec![int_ty],
             },
@@ -944,7 +1038,7 @@ mod tests {
 
         let ty = resolver.get_expr_type(&expr);
         let Some(ty) = ty else { return false };
-        matches!(ty.kind(db), TypeKind::Named { name, args } if *name == option_name && args.len() == 1 && matches!(args[0].kind(db), TypeKind::Int))
+        matches!(ty.kind(db), TypeKind::Named { name, args, .. } if *name == option_name && args.len() == 1 && matches!(args[0].kind(db), TypeKind::Int))
     }
 
     #[salsa_test]
@@ -963,6 +1057,7 @@ mod tests {
         let point_ty = Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, point_name),
                 name: point_name,
                 args: vec![],
             },
@@ -1009,6 +1104,7 @@ mod tests {
         let ty = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Foo")),
                 name: Symbol::new("Foo"),
                 args: vec![],
             },
@@ -1026,6 +1122,7 @@ mod tests {
         let list_named = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![],
             },
@@ -1052,6 +1149,7 @@ mod tests {
         let map_named = Type::new(
             &db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(&db, Symbol::new("Map")),
                 name: Symbol::new("Map"),
                 args: vec![],
             },
@@ -1064,7 +1162,7 @@ mod tests {
                 args: vec![int_ty],
             },
         );
-        let string_ty = Type::new(&db, TypeKind::string());
+        let string_ty = Type::new(&db, TypeKind::string(&db));
         let outer_app = Type::new(
             &db,
             TypeKind::App {
@@ -1087,7 +1185,7 @@ mod tests {
             (TypeKind::Nat, "Nat"),
             (TypeKind::Float, "Float"),
             (TypeKind::Bool, "Bool"),
-            (TypeKind::string(), "String"),
+            (TypeKind::string(&db), "String"),
             (TypeKind::Bytes, "Bytes"),
             (TypeKind::Rune, "Rune"),
             (TypeKind::Nil, "Nil"),
@@ -1133,6 +1231,7 @@ mod tests {
         let foo_ty = Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, type_name),
                 name: type_name,
                 args: vec![],
             },
@@ -1157,6 +1256,7 @@ mod tests {
         let receiver_ty = Some(Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, type_name),
                 name: type_name,
                 args: vec![],
             },
@@ -1185,6 +1285,7 @@ mod tests {
         let foo_ty = Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, type_name),
                 name: type_name,
                 args: vec![],
             },
@@ -1219,6 +1320,7 @@ mod tests {
         let receiver_ty = Some(Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, type_name),
                 name: type_name,
                 args: vec![],
             },
@@ -1244,6 +1346,7 @@ mod tests {
         let receiver_ty = Some(Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, Symbol::new("Foo")),
                 name: Symbol::new("Foo"),
                 args: vec![],
             },
@@ -1272,6 +1375,7 @@ mod tests {
         let list_named = Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: type_name,
                 args: vec![],
             },

--- a/crates/tribute-front/src/tdnr/resolver.rs
+++ b/crates/tribute-front/src/tdnr/resolver.rs
@@ -30,6 +30,8 @@ pub struct TdnrResolver<'db> {
     type_identities: HashMap<Symbol, crate::ast::TypeDefId<'db>>,
     /// Lexical module prefix used while resolving expression-local annotations.
     current_prefix: String,
+    /// Canonical prelude String type, when an external prelude is indexed.
+    string_type: Option<Type<'db>>,
 }
 
 impl<'db> TdnrResolver<'db> {
@@ -40,6 +42,7 @@ impl<'db> TdnrResolver<'db> {
             method_index: HashMap::new(),
             type_identities: HashMap::new(),
             current_prefix: String::new(),
+            string_type: None,
         }
     }
 
@@ -90,6 +93,25 @@ impl<'db> TdnrResolver<'db> {
     /// External module functions are indexed with their original qualified names
     /// (no additional prefix), so FuncDefIds match what the rest of the pipeline expects.
     pub fn index_external_module(&mut self, module: &Module<TypedRef<'db>>) {
+        if self.string_type.is_none() {
+            self.string_type = module.decls.iter().find_map(|decl| {
+                let (name, declaration) = match decl {
+                    Decl::Struct(decl) => (decl.name, decl.id),
+                    Decl::Enum(decl) => (decl.name, decl.id),
+                    _ => return None,
+                };
+                (name == "String").then(|| {
+                    Type::new(
+                        self.db,
+                        TypeKind::Named {
+                            id: crate::ast::TypeDefId::source(self.db, name, declaration),
+                            name,
+                            args: vec![],
+                        },
+                    )
+                })
+            });
+        }
         let mut prefix = String::new();
         self.collect_type_identities(&module.decls, &mut prefix);
         prefix.clear();
@@ -364,10 +386,6 @@ impl<'db> TdnrResolver<'db> {
             }
             _ => Type::new(self.db, TypeKind::Error),
         }
-    }
-
-    fn nominal_type(&self, name: Symbol) -> Type<'db> {
-        self.nominal_type_in_scope(name, &self.current_prefix)
     }
 
     fn nominal_type_in_scope(&self, name: Symbol, prefix: &str) -> Type<'db> {
@@ -666,7 +684,10 @@ impl<'db> TdnrResolver<'db> {
             ExprKind::IntLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Int)),
             ExprKind::FloatLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Float)),
             ExprKind::BoolLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Bool)),
-            ExprKind::StringLit(_) => Some(self.nominal_type(Symbol::new("String"))),
+            ExprKind::StringLit(_) => Some(
+                self.string_type
+                    .unwrap_or_else(|| Type::new(self.db, TypeKind::string(self.db))),
+            ),
             ExprKind::BytesLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Bytes)),
             ExprKind::RuneLit(_) => Some(Type::new(self.db, crate::ast::TypeKind::Rune)),
             ExprKind::Nil => Some(Type::new(self.db, crate::ast::TypeKind::Nil)),
@@ -884,6 +905,51 @@ mod tests {
 
         assert!(ty.is_some());
         assert!(matches!(*ty.unwrap().kind(&db), TypeKind::Bool));
+    }
+
+    #[test]
+    fn test_string_literal_type_ignores_scope_shadowing() {
+        let db = test_db();
+        let mut resolver = TdnrResolver::new(&db);
+        let name = Symbol::new("String");
+        let user_id = crate::ast::TypeDefId::source(&db, name, crate::ast::NodeId::from_raw(2));
+        resolver.type_identities.insert(name, user_id);
+
+        let expr = Expr::new(fresh_node_id(), ExprKind::StringLit("hello".to_owned()));
+        let ty = resolver.get_expr_type(&expr).expect("String literal type");
+        let TypeKind::Named { id, .. } = ty.kind(&db) else {
+            panic!("String literal should have a nominal type");
+        };
+
+        assert_ne!(*id, user_id);
+        assert_eq!(id.origin(&db), crate::ast::TypeOrigin::Synthetic);
+    }
+
+    #[test]
+    fn test_string_literal_preserves_indexed_prelude_identity() {
+        let db = test_db();
+        let mut resolver = TdnrResolver::new(&db);
+        let name = Symbol::new("String");
+        let prelude_id = crate::ast::TypeDefId::source(&db, name, crate::ast::NodeId::from_raw(1));
+        let user_id = crate::ast::TypeDefId::source(&db, name, crate::ast::NodeId::from_raw(2));
+        resolver.string_type = Some(Type::new(
+            &db,
+            TypeKind::Named {
+                id: prelude_id,
+                name,
+                args: vec![],
+            },
+        ));
+        resolver.type_identities.insert(name, user_id);
+
+        let expr = Expr::new(fresh_node_id(), ExprKind::StringLit("hello".to_owned()));
+        let ty = resolver.get_expr_type(&expr).expect("String literal type");
+        let TypeKind::Named { id, .. } = ty.kind(&db) else {
+            panic!("String literal should have a nominal type");
+        };
+
+        assert_eq!(*id, prelude_id);
+        assert_ne!(*id, user_id);
     }
 
     #[test]

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -102,7 +102,6 @@ impl<'db> TypeChecker<'db> {
                 next_bound_var += 1;
                 Type::new(self.db(), TypeKind::BoundVar { index })
             });
-
         // Build effect row from annotations (effects don't have BoundVars for now)
         let (effect, effect_origins) = match &func.effects {
             Some(anns) => {
@@ -219,7 +218,11 @@ impl<'db> TypeChecker<'db> {
         let args: Vec<Type<'db>> = (0..type_params.len() as u32)
             .map(|i| Type::new(self.db(), TypeKind::BoundVar { index: i }))
             .collect();
-        let struct_ty = self.env.named_type(qualified_name, args);
+        let struct_ty = self.env.named_type_with_id(
+            crate::ast::TypeDefId::source(self.db(), qualified_name, s.id),
+            qualified_name,
+            args,
+        );
 
         let scheme = TypeScheme::new(self.db(), type_params.clone(), Vec::new(), struct_ty);
         self.env.register_type_def(qualified_name, scheme);
@@ -274,7 +277,11 @@ impl<'db> TypeChecker<'db> {
         let args: Vec<Type<'db>> = (0..type_params.len() as u32)
             .map(|i| Type::new(self.db(), TypeKind::BoundVar { index: i }))
             .collect();
-        let enum_ty = self.env.named_type(qualified_name, args);
+        let enum_ty = self.env.named_type_with_id(
+            crate::ast::TypeDefId::source(self.db(), qualified_name, e.id),
+            qualified_name,
+            args,
+        );
 
         let scheme = TypeScheme::new(self.db(), type_params.clone(), Vec::new(), enum_ty);
         self.env.register_type_def(qualified_name, scheme);
@@ -418,12 +425,12 @@ impl<'db> TypeChecker<'db> {
             }
             TypeAnnotationKind::App { ctor, args } => {
                 let ctor_ty = self.annotation_to_type_for_sig(ctor, type_var_map, next_bound_var);
-                if let TypeKind::Named { name, .. } = ctor_ty.kind(self.db()) {
+                if let TypeKind::Named { id, name, .. } = ctor_ty.kind(self.db()) {
                     let arg_types: Vec<Type<'db>> = args
                         .iter()
                         .map(|a| self.annotation_to_type_for_sig(a, type_var_map, next_bound_var))
                         .collect();
-                    self.env.named_type(*name, arg_types)
+                    self.env.named_type_with_id(*id, *name, arg_types)
                 } else {
                     self.env.error_type()
                 }
@@ -483,12 +490,12 @@ impl<'db> TypeChecker<'db> {
             }
             TypeAnnotationKind::App { ctor, args } => {
                 let ctor_ty = self.annotation_to_type_for_ctor(ctor, type_param_indices);
-                if let TypeKind::Named { name, .. } = ctor_ty.kind(self.db()) {
+                if let TypeKind::Named { id, name, .. } = ctor_ty.kind(self.db()) {
                     let arg_types: Vec<Type<'db>> = args
                         .iter()
                         .map(|a| self.annotation_to_type_for_ctor(a, type_param_indices))
                         .collect();
-                    self.env.named_type(*name, arg_types)
+                    self.env.named_type_with_id(*id, *name, arg_types)
                 } else {
                     self.env.error_type()
                 }

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -23,6 +23,11 @@ impl<'db> TypeChecker<'db> {
 
     /// Collect type definitions and function signatures from declarations.
     pub(crate) fn collect_declarations(&mut self, module: &Module<ResolvedRef<'db>>) {
+        self.predeclare_nominal_types(&module.decls);
+        self.collect_declarations_in_order(module);
+    }
+
+    fn collect_declarations_in_order(&mut self, module: &Module<ResolvedRef<'db>>) {
         for decl in &module.decls {
             match decl {
                 Decl::Function(func) => {
@@ -54,13 +59,60 @@ impl<'db> TypeChecker<'db> {
                             name: Some(m.name),
                             decls: body.clone(),
                         };
-                        self.collect_declarations(&inner_module);
+                        self.collect_declarations_in_order(&inner_module);
                         // Restore prefix
                         self.prefix.truncate(prev_len);
                     }
                 }
             }
         }
+    }
+
+    /// Register every nominal declaration before converting any annotations.
+    fn predeclare_nominal_types(&mut self, decls: &[Decl<ResolvedRef<'db>>]) {
+        for decl in decls {
+            match decl {
+                Decl::Struct(s) => {
+                    self.predeclare_nominal_type(s.name, s.id, &s.type_params);
+                }
+                Decl::Enum(e) => {
+                    self.predeclare_nominal_type(e.name, e.id, &e.type_params);
+                }
+                Decl::Module(module) => {
+                    if let Some(body) = &module.body {
+                        let saved = crate::push_prefix(&mut self.prefix, module.name);
+                        self.predeclare_nominal_types(body);
+                        self.prefix.truncate(saved);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn predeclare_nominal_type(
+        &mut self,
+        name: Symbol,
+        declaration: crate::ast::NodeId,
+        params: &[crate::ast::TypeParamDecl],
+    ) {
+        let qualified = crate::qualified_symbol(&mut self.current_prefix().to_owned(), name);
+        let type_params: Vec<TypeParam> = params
+            .iter()
+            .map(|param| TypeParam::named(param.name))
+            .collect();
+        let args = (0..type_params.len() as u32)
+            .map(|index| Type::new(self.db(), TypeKind::BoundVar { index }))
+            .collect();
+        let ty = self.env.named_type_with_id(
+            crate::ast::TypeDefId::source(self.db(), qualified, declaration),
+            qualified,
+            args,
+        );
+        self.env.register_type_def(
+            qualified,
+            TypeScheme::new(self.db(), type_params, Vec::new(), ty),
+        );
     }
 
     /// Collect a function's type signature.
@@ -259,8 +311,11 @@ impl<'db> TypeChecker<'db> {
                 Some((field_name, field_ty))
             })
             .collect();
-        self.env
-            .register_struct_fields(qualified_name, type_params, fields);
+        self.env.register_struct_fields(
+            crate::ast::TypeDefId::source(self.db(), qualified_name, s.id),
+            type_params,
+            fields,
+        );
     }
 
     /// Collect an enum definition.

--- a/crates/tribute-front/src/typeck/checker/collect.rs
+++ b/crates/tribute-front/src/typeck/checker/collect.rs
@@ -418,7 +418,8 @@ impl<'db> TypeChecker<'db> {
             TypeAnnotationKind::Named(name) => self.primitive_or_named_type(*name),
             TypeAnnotationKind::Path(parts) if !parts.is_empty() => {
                 if let Some(name) = crate::qualified_path_symbol(parts) {
-                    self.env.named_type(name, vec![])
+                    self.env
+                        .named_type_in_scope(name, vec![], self.current_prefix())
                 } else {
                     self.env.error_type()
                 }
@@ -528,7 +529,8 @@ impl<'db> TypeChecker<'db> {
             }
             TypeAnnotationKind::Path(parts) if !parts.is_empty() => {
                 if let Some(name) = crate::qualified_path_symbol(parts) {
-                    self.env.named_type(name, vec![])
+                    self.env
+                        .named_type_in_scope(name, vec![], self.current_prefix())
                 } else {
                     self.env.error_type()
                 }
@@ -549,8 +551,6 @@ impl<'db> TypeChecker<'db> {
             self.env.float_type()
         } else if name == "Bool" {
             self.env.bool_type()
-        } else if name == "String" {
-            self.env.string_type()
         } else if name == "Bytes" {
             self.env.bytes_type()
         } else if name == "Rune" {
@@ -560,7 +560,8 @@ impl<'db> TypeChecker<'db> {
         } else if name == "Never" {
             self.env.never_type()
         } else {
-            self.env.named_type(name, vec![])
+            self.env
+                .named_type_in_scope(name, vec![], self.current_prefix())
         }
     }
 }

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -859,7 +859,7 @@ impl<'db> TypeChecker<'db> {
     /// otherwise (None, empty vec).
     fn extract_struct_info(&self, ty: Type<'db>) -> (Option<Symbol>, Vec<Type<'db>>) {
         match ty.kind(self.db()) {
-            TypeKind::Named { name, args } => (Some(*name), args.clone()),
+            TypeKind::Named { name, args, .. } => (Some(*name), args.clone()),
             TypeKind::App { ctor, args } => {
                 if let TypeKind::Named { name, .. } = ctor.kind(self.db()) {
                     (Some(*name), args.clone())
@@ -881,7 +881,7 @@ impl<'db> TypeChecker<'db> {
     ) -> Type<'db> {
         let list_sym = Symbol::new("List");
         match ty.kind(self.db()) {
-            TypeKind::Named { name, args } if *name == list_sym && args.len() == 1 => args[0],
+            TypeKind::Named { name, args, .. } if *name == list_sym && args.len() == 1 => args[0],
             TypeKind::App { ctor, args } if args.len() == 1 => {
                 if let TypeKind::Named { name, .. } = ctor.kind(self.db())
                     && *name == list_sym
@@ -2113,12 +2113,12 @@ impl<'db> TypeChecker<'db> {
             }
             TypeAnnotationKind::App { ctor, args } => {
                 let ctor_ty = self.annotation_to_type_with_ctx(ctx, ctor);
-                if let TypeKind::Named { name, .. } = ctor_ty.kind(self.db()) {
+                if let TypeKind::Named { id, name, .. } = ctor_ty.kind(self.db()) {
                     let arg_types: Vec<Type<'db>> = args
                         .iter()
                         .map(|a| self.annotation_to_type_with_ctx(ctx, a))
                         .collect();
-                    ctx.named_type(*name, arg_types)
+                    ctx.named_type_with_id(*id, *name, arg_types)
                 } else {
                     ctx.error_type()
                 }
@@ -2403,7 +2403,8 @@ mod tests {
     use trunk_ir::Symbol;
 
     use crate::ast::{
-        EffectRow, FuncDefId, NodeId, SpanMap, Type, TypeAnnotation, TypeAnnotationKind, TypeKind,
+        EffectRow, FuncDefId, NodeId, SpanMap, Type, TypeAnnotation, TypeAnnotationKind, TypeDefId,
+        TypeKind,
     };
     use crate::typeck::{FunctionInferenceContext, ModuleTypeEnv};
 
@@ -2469,7 +2470,7 @@ mod tests {
         let ty = checker.annotation_to_type_with_ctx(&mut ctx, &ann);
 
         // Should be Named { name: "MyType", args: [] }
-        if let TypeKind::Named { name, args } = ty.kind(db) {
+        if let TypeKind::Named { name, args, .. } = ty.kind(db) {
             assert_eq!(*name, Symbol::new("MyType"));
             assert!(args.is_empty());
         } else {
@@ -2490,7 +2491,7 @@ mod tests {
         let ty = checker.annotation_to_type_with_ctx(&mut ctx, &ann);
 
         // Qualified type identity preserves the complete path.
-        if let TypeKind::Named { name, args } = ty.kind(db) {
+        if let TypeKind::Named { name, args, .. } = ty.kind(db) {
             assert_eq!(*name, Symbol::new("std::Option"));
             assert!(args.is_empty());
         } else {
@@ -2516,7 +2517,7 @@ mod tests {
         let ty = checker.annotation_to_type_with_ctx(&mut ctx, &ann);
 
         // Should be Named { name: "List", args: [Int] }
-        if let TypeKind::Named { name, args } = ty.kind(db) {
+        if let TypeKind::Named { name, args, .. } = ty.kind(db) {
             assert_eq!(*name, Symbol::new("List"));
             assert_eq!(args.len(), 1);
             assert_eq!(args[0], Type::new(db, TypeKind::Int));
@@ -2615,7 +2616,7 @@ mod tests {
         if let TypeKind::Tuple(elems) = ty.kind(db) {
             assert_eq!(elems.len(), 2);
             assert_eq!(elems[0], Type::new(db, TypeKind::Int));
-            assert_eq!(elems[1], Type::new(db, TypeKind::string()));
+            assert_eq!(elems[1], Type::new(db, TypeKind::string(db)));
         } else {
             panic!("Tuple annotation should be Tuple type");
         }
@@ -2758,6 +2759,7 @@ mod tests {
         let list_ty = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![int_ty],
             },
@@ -2774,10 +2776,11 @@ mod tests {
         let mut ctx = make_test_ctx(db, &env);
 
         // List<String> → String
-        let string_ty = Type::new(db, TypeKind::string());
+        let string_ty = Type::new(db, TypeKind::string(db));
         let list_ty = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![string_ty],
             },
@@ -2817,6 +2820,7 @@ mod tests {
         let option_ty = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, Symbol::new("Option")),
                 name: Symbol::new("Option"),
                 args: vec![int_ty],
             },
@@ -2842,6 +2846,7 @@ mod tests {
         let list_ty = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![],
             },
@@ -2868,6 +2873,7 @@ mod tests {
         let inner_list = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![int_ty],
             },
@@ -2875,6 +2881,7 @@ mod tests {
         let outer_list = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![inner_list],
             },

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -2090,8 +2090,6 @@ impl<'db> TypeChecker<'db> {
                     ctx.float_type()
                 } else if *name == "Bool" {
                     ctx.bool_type()
-                } else if *name == "String" {
-                    ctx.string_type()
                 } else if *name == "Bytes" {
                     ctx.bytes_type()
                 } else if *name == "Rune" {
@@ -2101,12 +2099,12 @@ impl<'db> TypeChecker<'db> {
                 } else if *name == "Never" {
                     ctx.never_type()
                 } else {
-                    ctx.named_type(*name, vec![])
+                    ctx.named_type_in_scope(*name, vec![], self.current_prefix())
                 }
             }
             TypeAnnotationKind::Path(parts) if !parts.is_empty() => {
                 if let Some(name) = crate::qualified_path_symbol(parts) {
-                    ctx.named_type(name, vec![])
+                    ctx.named_type_in_scope(name, vec![], self.current_prefix())
                 } else {
                     ctx.error_type()
                 }

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -853,16 +853,19 @@ impl<'db> TypeChecker<'db> {
         }
     }
 
-    /// Extract struct name and type arguments from a type.
+    /// Extract struct declaration identity and type arguments from a type.
     ///
-    /// Returns (Some(struct_name), type_args) if the type is a Named or App type,
+    /// Returns (Some(struct_id), type_args) if the type is a Named or App type,
     /// otherwise (None, empty vec).
-    fn extract_struct_info(&self, ty: Type<'db>) -> (Option<Symbol>, Vec<Type<'db>>) {
+    fn extract_struct_info(
+        &self,
+        ty: Type<'db>,
+    ) -> (Option<crate::ast::TypeDefId<'db>>, Vec<Type<'db>>) {
         match ty.kind(self.db()) {
-            TypeKind::Named { name, args, .. } => (Some(*name), args.clone()),
+            TypeKind::Named { id, args, .. } => (Some(*id), args.clone()),
             TypeKind::App { ctor, args } => {
-                if let TypeKind::Named { name, .. } = ctor.kind(self.db()) {
-                    (Some(*name), args.clone())
+                if let TypeKind::Named { id, .. } = ctor.kind(self.db()) {
+                    (Some(*id), args.clone())
                 } else {
                     (None, vec![])
                 }
@@ -900,11 +903,11 @@ impl<'db> TypeChecker<'db> {
     fn lookup_field_type_from_struct(
         &self,
         ctx: &mut FunctionInferenceContext<'_, 'db>,
-        struct_name: Symbol,
+        struct_id: crate::ast::TypeDefId<'db>,
         field_name: Symbol,
         type_args: &[Type<'db>],
     ) -> Option<Type<'db>> {
-        let (type_params, field_ty) = self.env.lookup_struct_field(struct_name, field_name)?;
+        let (type_params, field_ty) = self.env.lookup_struct_field(struct_id, field_name)?;
         if type_params.is_empty() || type_args.is_empty() {
             Some(field_ty)
         } else {
@@ -922,13 +925,13 @@ impl<'db> TypeChecker<'db> {
         receiver_ty: Type<'db>,
         field_name: Symbol,
     ) -> Option<Type<'db>> {
-        // Extract struct name from receiver type
-        let struct_name = match receiver_ty.kind(self.db()) {
-            TypeKind::Named { name, .. } => *name,
+        // Extract struct declaration identity from receiver type.
+        let struct_id = match receiver_ty.kind(self.db()) {
+            TypeKind::Named { id, .. } => *id,
             TypeKind::App { ctor, .. } => {
                 // Recursively extract from constructor
                 match ctor.kind(self.db()) {
-                    TypeKind::Named { name, .. } => *name,
+                    TypeKind::Named { id, .. } => *id,
                     _ => return None,
                 }
             }
@@ -940,7 +943,7 @@ impl<'db> TypeChecker<'db> {
         };
 
         // Look up field in ModuleTypeEnv
-        let (type_params, field_ty) = self.env.lookup_struct_field(struct_name, field_name)?;
+        let (type_params, field_ty) = self.env.lookup_struct_field(struct_id, field_name)?;
 
         // Substitute BoundVars with actual type arguments if any
         let actual_args: Vec<Type<'db>> = match receiver_ty.kind(self.db()) {
@@ -1445,11 +1448,11 @@ impl<'db> TypeChecker<'db> {
             }
             PatternKind::Record { fields, .. } => {
                 let resolved_ty = resolve(ty);
-                let (struct_name, type_args) = self.extract_struct_info(resolved_ty);
+                let (struct_id, type_args) = self.extract_struct_info(resolved_ty);
                 for field in fields {
-                    let field_ty = struct_name
-                        .and_then(|name| {
-                            self.lookup_field_type_from_struct(ctx, name, field.name, &type_args)
+                    let field_ty = struct_id
+                        .and_then(|id| {
+                            self.lookup_field_type_from_struct(ctx, id, field.name, &type_args)
                         })
                         .map(resolve)
                         .unwrap_or_else(|| ctx.fresh_type_var());
@@ -1606,12 +1609,12 @@ impl<'db> TypeChecker<'db> {
                 }
             }
             PatternKind::Record { fields, .. } => {
-                let (struct_name, type_args) = self.extract_struct_info(ty);
+                let (struct_id, type_args) = self.extract_struct_info(ty);
 
                 for field in fields {
-                    let field_ty = struct_name
-                        .and_then(|name| {
-                            self.lookup_field_type_from_struct(ctx, name, field.name, &type_args)
+                    let field_ty = struct_id
+                        .and_then(|id| {
+                            self.lookup_field_type_from_struct(ctx, id, field.name, &type_args)
                         })
                         .unwrap_or_else(|| ctx.fresh_type_var());
 
@@ -1826,14 +1829,14 @@ impl<'db> TypeChecker<'db> {
                 fields,
                 rest,
             } => {
-                let (struct_name, type_args) = self.extract_struct_info(expected);
+                let (struct_id, type_args) = self.extract_struct_info(expected);
 
                 let converted_fields = fields
                     .into_iter()
                     .map(|f| {
-                        let field_expected = struct_name
-                            .and_then(|name| {
-                                self.lookup_field_type_from_struct(ctx, name, f.name, &type_args)
+                        let field_expected = struct_id
+                            .and_then(|id| {
+                                self.lookup_field_type_from_struct(ctx, id, f.name, &type_args)
                             })
                             .unwrap_or_else(|| ctx.fresh_type_var());
 

--- a/crates/tribute-front/src/typeck/context.rs
+++ b/crates/tribute-front/src/typeck/context.rs
@@ -141,8 +141,8 @@ pub struct ModuleTypeEnv<'db> {
     /// Type definitions (struct/enum names to their types).
     type_defs: HashMap<Symbol, TypeScheme<'db>>,
 
-    /// Struct field definitions: struct_name → (type_params, [(field_name, field_type)])
-    struct_fields: HashMap<Symbol, StructFieldInfo<'db>>,
+    /// Struct field definitions keyed by nominal declaration identity.
+    struct_fields: HashMap<TypeDefId<'db>, StructFieldInfo<'db>>,
 
     /// Enum variant information: enum_name → [variant_names]
     /// Used for exhaustiveness checking in case expressions.
@@ -248,12 +248,11 @@ impl<'db> ModuleTypeEnv<'db> {
     /// Register struct field information.
     pub fn register_struct_fields(
         &mut self,
-        struct_name: Symbol,
+        struct_id: TypeDefId<'db>,
         type_params: Vec<TypeParam>,
         fields: Vec<(Symbol, Type<'db>)>,
     ) {
-        self.struct_fields
-            .insert(struct_name, (type_params, fields));
+        self.struct_fields.insert(struct_id, (type_params, fields));
     }
 
     /// Register enum variant information.
@@ -314,10 +313,10 @@ impl<'db> ModuleTypeEnv<'db> {
     /// Returns (type_params, field_type) if found.
     pub fn lookup_struct_field(
         &self,
-        struct_name: Symbol,
+        struct_id: TypeDefId<'db>,
         field_name: Symbol,
     ) -> Option<(&[TypeParam], Type<'db>)> {
-        let (type_params, fields) = self.struct_fields.get(&struct_name)?;
+        let (type_params, fields) = self.struct_fields.get(&struct_id)?;
         for (name, ty) in fields {
             if *name == field_name {
                 return Some((type_params.as_slice(), *ty));
@@ -382,8 +381,8 @@ impl<'db> ModuleTypeEnv<'db> {
         for (name, scheme) in exports.type_defs(self.db) {
             self.type_defs.insert(*name, *scheme);
         }
-        for (name, info) in exports.struct_fields(self.db) {
-            self.struct_fields.insert(*name, info.clone());
+        for (id, info) in exports.struct_fields(self.db) {
+            self.struct_fields.insert(*id, info.clone());
         }
         for (name, variants) in exports.enum_variants(self.db) {
             self.enum_variants.insert(*name, variants.clone());
@@ -460,13 +459,16 @@ impl<'db> ModuleTypeEnv<'db> {
     /// Export struct field definitions for PreludeExports.
     ///
     /// Results are sorted alphabetically by struct name for deterministic output.
-    pub fn export_struct_fields(&self) -> Vec<(Symbol, StructFieldInfo<'db>)> {
+    pub fn export_struct_fields(&self) -> Vec<(TypeDefId<'db>, StructFieldInfo<'db>)> {
         let mut result: Vec<_> = self
             .struct_fields
             .iter()
             .map(|(k, v)| (*k, v.clone()))
             .collect();
-        result.sort_by(|(a, _), (b, _)| a.with_str(|a| b.with_str(|b| a.cmp(b))));
+        result.sort_by(|(a, _), (b, _)| {
+            a.qualified(self.db)
+                .with_str(|a| b.qualified(self.db).with_str(|b| a.cmp(b)))
+        });
         result
     }
 
@@ -555,7 +557,7 @@ impl<'db> ModuleTypeEnv<'db> {
         self.well_known_types
             .string
             .map(|string| string.ty)
-            .unwrap_or_else(|| self.named_type(Symbol::new("String"), vec![]))
+            .unwrap_or_else(|| Type::new(self.db, TypeKind::string(self.db)))
     }
 
     /// Create the Bytes type.
@@ -654,13 +656,31 @@ mod tests {
     use salsa_test_macros::salsa_test;
     use trunk_ir::Symbol;
 
-    use crate::ast::{CtorId, FuncDefId, Type, TypeKind, TypeScheme};
+    use crate::ast::{
+        CtorId, FuncDefId, NodeId, Type, TypeDefId, TypeKind, TypeOrigin, TypeScheme,
+    };
 
     use super::ModuleTypeEnv;
 
     // =========================================================================
     // Export ordering tests - verify deterministic output
     // =========================================================================
+
+    #[salsa_test]
+    fn string_type_fallback_ignores_user_string(db: &dyn salsa::Database) {
+        let mut env = ModuleTypeEnv::new(db);
+        let name = Symbol::new("String");
+        let user_id = TypeDefId::source(db, name, NodeId::from_raw(1));
+        let user_ty = env.named_type_with_id(user_id, name, vec![]);
+        env.register_type_def(name, TypeScheme::mono(db, user_ty));
+
+        let string_ty = env.string_type();
+        let TypeKind::Named { id, .. } = string_ty.kind(db) else {
+            panic!("String fallback should be nominal");
+        };
+        assert_ne!(*id, user_id);
+        assert_eq!(id.origin(db), TypeOrigin::Synthetic);
+    }
 
     #[salsa_test]
     fn test_export_function_types_sorted(db: &dyn salsa::Database) {
@@ -782,14 +802,17 @@ mod tests {
         let int_ty = Type::new(db, TypeKind::Int);
         let fields = vec![(Symbol::new("x"), int_ty)];
 
-        env.register_struct_fields(Symbol::new("Zebra"), vec![], fields.clone());
-        env.register_struct_fields(Symbol::new("Alpha"), vec![], fields.clone());
-        env.register_struct_fields(Symbol::new("Middle"), vec![], fields);
+        let zebra = TypeDefId::synthetic(db, Symbol::new("Zebra"));
+        let alpha = TypeDefId::synthetic(db, Symbol::new("Alpha"));
+        let middle = TypeDefId::synthetic(db, Symbol::new("Middle"));
+        env.register_struct_fields(zebra, vec![], fields.clone());
+        env.register_struct_fields(alpha, vec![], fields.clone());
+        env.register_struct_fields(middle, vec![], fields);
 
         let exported = env.export_struct_fields();
 
         // Should be sorted alphabetically by struct name
-        let names: Vec<_> = exported.iter().map(|(name, _)| *name).collect();
+        let names: Vec<_> = exported.iter().map(|(id, _)| id.qualified(db)).collect();
         assert_eq!(
             names,
             vec![

--- a/crates/tribute-front/src/typeck/context.rs
+++ b/crates/tribute-front/src/typeck/context.rs
@@ -291,6 +291,25 @@ impl<'db> ModuleTypeEnv<'db> {
         self.type_defs.get(&name).copied()
     }
 
+    /// Look up a type definition from a lexical module scope.
+    pub fn lookup_type_def_in_scope(&self, name: Symbol, prefix: &str) -> Option<TypeScheme<'db>> {
+        let spelling = name.to_string();
+        if spelling.contains("::") {
+            return self.lookup_type_def(name);
+        }
+
+        let mut scope = prefix.trim_end_matches("::");
+        while !scope.is_empty() {
+            let candidate = Symbol::from_dynamic(&format!("{scope}::{spelling}"));
+            if let Some(scheme) = self.lookup_type_def(candidate) {
+                return Some(scheme);
+            }
+            scope = scope.rsplit_once("::").map_or("", |(parent, _)| parent);
+        }
+
+        self.lookup_type_def(name)
+    }
+
     /// Look up struct field type by struct name and field name.
     /// Returns (type_params, field_type) if found.
     pub fn lookup_struct_field(
@@ -533,7 +552,10 @@ impl<'db> ModuleTypeEnv<'db> {
 
     /// Create the String type (prelude-defined enum).
     pub fn string_type(&self) -> Type<'db> {
-        self.named_type(Symbol::new("String"), vec![])
+        self.well_known_types
+            .string
+            .map(|string| string.ty)
+            .unwrap_or_else(|| self.named_type(Symbol::new("String"), vec![]))
     }
 
     /// Create the Bytes type.
@@ -597,8 +619,18 @@ impl<'db> ModuleTypeEnv<'db> {
 
     /// Create a named type.
     pub fn named_type(&self, name: Symbol, args: Vec<Type<'db>>) -> Type<'db> {
+        self.named_type_in_scope(name, args, "")
+    }
+
+    /// Create a named type using lexical module lookup.
+    pub fn named_type_in_scope(
+        &self,
+        name: Symbol,
+        args: Vec<Type<'db>>,
+        prefix: &str,
+    ) -> Type<'db> {
         let id = self
-            .lookup_type_def(name)
+            .lookup_type_def_in_scope(name, prefix)
             .and_then(|scheme| match scheme.body(self.db).kind(self.db) {
                 TypeKind::Named { id, .. } => Some(*id),
                 _ => None,

--- a/crates/tribute-front/src/typeck/context.rs
+++ b/crates/tribute-front/src/typeck/context.rs
@@ -11,8 +11,8 @@ use std::collections::HashMap;
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    AbilityId, CallingConvention, CtorId, EffectRow, FuncDefId, OpDeclKind, Type, TypeKind,
-    TypeParam, TypeScheme,
+    AbilityId, CallingConvention, CtorId, EffectRow, FuncDefId, OpDeclKind, Type, TypeDefId,
+    TypeKind, TypeParam, TypeScheme,
 };
 
 // =========================================================================
@@ -89,8 +89,9 @@ pub fn extract_type_name_from_type<'db>(
 
 /// Check if a method entry's receiver type matches an actual receiver type.
 ///
-/// Compares by type constructor name, allowing generic types to match
-/// (e.g., `Option(a)` matches `Option(Int)`).
+/// Compares nominal types by declaration identity, allowing their generic
+/// arguments to differ (e.g., `Option(a)` matches `Option(Int)`). Primitive
+/// receivers continue to match by their compiler-defined names.
 pub fn receiver_type_matches<'db>(
     db: &'db dyn salsa::Database,
     entry: &MethodEntry<'db>,
@@ -99,9 +100,22 @@ pub fn receiver_type_matches<'db>(
     let Some(declared) = entry.receiver_ty(db) else {
         return false;
     };
-    let declared_name = extract_type_name_from_type(db, declared);
-    let actual_name = extract_type_name_from_type(db, actual);
-    declared_name.is_some() && declared_name == actual_name
+    fn same_constructor<'db>(
+        db: &'db dyn salsa::Database,
+        declared: Type<'db>,
+        actual: Type<'db>,
+    ) -> bool {
+        match (declared.kind(db), actual.kind(db)) {
+            (TypeKind::App { ctor: left, .. }, _) => same_constructor(db, *left, actual),
+            (_, TypeKind::App { ctor: right, .. }) => same_constructor(db, declared, *right),
+            (TypeKind::Named { id: left, .. }, TypeKind::Named { id: right, .. }) => left == right,
+            (left, right) => {
+                left.primitive_name().is_some() && left.primitive_name() == right.primitive_name()
+            }
+        }
+    }
+
+    same_constructor(db, declared, actual)
 }
 
 /// Module-level type environment.
@@ -519,7 +533,7 @@ impl<'db> ModuleTypeEnv<'db> {
 
     /// Create the String type (prelude-defined enum).
     pub fn string_type(&self) -> Type<'db> {
-        Type::new(self.db, TypeKind::string())
+        self.named_type(Symbol::new("String"), vec![])
     }
 
     /// Create the Bytes type.
@@ -583,7 +597,23 @@ impl<'db> ModuleTypeEnv<'db> {
 
     /// Create a named type.
     pub fn named_type(&self, name: Symbol, args: Vec<Type<'db>>) -> Type<'db> {
-        Type::new(self.db, TypeKind::Named { name, args })
+        let id = self
+            .lookup_type_def(name)
+            .and_then(|scheme| match scheme.body(self.db).kind(self.db) {
+                TypeKind::Named { id, .. } => Some(*id),
+                _ => None,
+            })
+            .unwrap_or_else(|| TypeDefId::synthetic(self.db, name));
+        self.named_type_with_id(id, name, args)
+    }
+
+    pub fn named_type_with_id(
+        &self,
+        id: TypeDefId<'db>,
+        name: Symbol,
+        args: Vec<Type<'db>>,
+    ) -> Type<'db> {
+        Type::new(self.db, TypeKind::Named { id, name, args })
     }
 }
 
@@ -813,6 +843,7 @@ mod tests {
             let receiver = Type::new(
                 db,
                 TypeKind::Named {
+                    id: crate::ast::TypeDefId::synthetic(db, Symbol::new(name)),
                     name: Symbol::new(name),
                     args: vec![],
                 },
@@ -863,6 +894,7 @@ mod tests {
         Type::new(
             db,
             TypeKind::Named {
+                id: crate::ast::TypeDefId::synthetic(db, Symbol::from_dynamic(name)),
                 name: Symbol::from_dynamic(name),
                 args: vec![],
             },
@@ -959,6 +991,42 @@ mod tests {
         let bar = named(&db, "Bar");
         let entry = method_entry(&db, "m", func(&db, &[foo], Type::new(&db, TypeKind::Int)));
         assert!(!receiver_type_matches(&db, &entry, bar));
+    }
+
+    #[test]
+    fn test_receiver_type_rejects_same_spelling_from_different_declarations() {
+        let db = salsa::DatabaseImpl::new();
+        let name = Symbol::new("Thing");
+        let first = Type::new(
+            &db,
+            TypeKind::Named {
+                id: crate::ast::TypeDefId::source(
+                    &db,
+                    Symbol::new("A::Thing"),
+                    crate::ast::NodeId::from_raw(1),
+                ),
+                name,
+                args: vec![],
+            },
+        );
+        let second = Type::new(
+            &db,
+            TypeKind::Named {
+                id: crate::ast::TypeDefId::source(
+                    &db,
+                    Symbol::new("B::Thing"),
+                    crate::ast::NodeId::from_raw(2),
+                ),
+                name,
+                args: vec![],
+            },
+        );
+        let entry = method_entry(
+            &db,
+            "method",
+            func(&db, &[first], Type::new(&db, TypeKind::Int)),
+        );
+        assert!(!receiver_type_matches(&db, &entry, second));
     }
 
     #[salsa_test]

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -683,6 +683,16 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         self.env.named_type(name, args)
     }
 
+    /// Create a named type using lexical module lookup.
+    pub fn named_type_in_scope(
+        &self,
+        name: Symbol,
+        args: Vec<Type<'db>>,
+        prefix: &str,
+    ) -> Type<'db> {
+        self.env.named_type_in_scope(name, args, prefix)
+    }
+
     /// Create a named type while preserving its resolved declaration identity.
     pub fn named_type_with_id(
         &self,

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -682,12 +682,22 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     pub fn named_type(&self, name: Symbol, args: Vec<Type<'db>>) -> Type<'db> {
         self.env.named_type(name, args)
     }
+
+    /// Create a named type while preserving its resolved declaration identity.
+    pub fn named_type_with_id(
+        &self,
+        id: crate::ast::TypeDefId<'db>,
+        name: Symbol,
+        args: Vec<Type<'db>>,
+    ) -> Type<'db> {
+        self.env.named_type_with_id(id, name, args)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::TypeParam;
+    use crate::ast::{TypeDefId, TypeParam};
     use salsa_test_macros::salsa_test;
 
     /// Create a type parameter with just a name.
@@ -995,6 +1005,7 @@ mod tests {
         let result_ty = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, type_name),
                 name: type_name,
                 args: vec![bound_var],
             },
@@ -1047,12 +1058,12 @@ mod tests {
             }
 
             // Results should be Named types with the UniVar as argument
-            let r1_ok = if let TypeKind::Named { name, args } = r1.kind(db) {
+            let r1_ok = if let TypeKind::Named { name, args, .. } = r1.kind(db) {
                 *name == type_name && args.len() == 1 && args[0] == p1[0]
             } else {
                 false
             };
-            let r2_ok = if let TypeKind::Named { name, args } = r2.kind(db) {
+            let r2_ok = if let TypeKind::Named { name, args, .. } = r2.kind(db) {
                 *name == type_name && args.len() == 1 && args[0] == p2[0]
             } else {
                 false

--- a/crates/tribute-front/src/typeck/mod.rs
+++ b/crates/tribute-front/src/typeck/mod.rs
@@ -37,8 +37,8 @@ pub use solver::{RowSubst, SolveError, TypeSolver, TypeSubst};
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    AbilityId, CallingConvention, CtorId, FuncDefId, Module, NodeId, ResolvedRef, Type, TypeParam,
-    TypeScheme, TypedRef,
+    AbilityId, CallingConvention, CtorId, FuncDefId, Module, NodeId, ResolvedRef, Type, TypeDefId,
+    TypeParam, TypeScheme, TypedRef,
 };
 
 /// Semantic identities supplied by the prelude and required downstream.
@@ -145,9 +145,9 @@ pub struct PreludeExports<'db> {
     #[returns(ref)]
     pub type_defs: Vec<(Symbol, TypeScheme<'db>)>,
 
-    /// Struct field definitions: struct_name → (type_params, [(field_name, field_type)]).
+    /// Struct field definitions keyed by nominal declaration identity.
     #[returns(ref)]
-    pub struct_fields: Vec<(Symbol, (Vec<TypeParam>, Vec<(Symbol, Type<'db>)>))>,
+    pub struct_fields: Vec<(TypeDefId<'db>, (Vec<TypeParam>, Vec<(Symbol, Type<'db>)>))>,
 
     /// Enum variant information: enum_name → [variant_names].
     #[returns(ref)]

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -178,12 +178,19 @@ impl<'db> TypeSubst<'db> {
                     ty
                 }
             }
-            TypeKind::Named { name, args } => {
+            TypeKind::Named { id, name, args } => {
                 let args = args
                     .iter()
                     .map(|a| self.apply_with_rows(db, *a, row_subst))
                     .collect();
-                Type::new(db, TypeKind::Named { name: *name, args })
+                Type::new(
+                    db,
+                    TypeKind::Named {
+                        id: *id,
+                        name: *name,
+                        args,
+                    },
+                )
             }
             TypeKind::Func {
                 params,
@@ -466,7 +473,7 @@ impl<'db> TypeSubst<'db> {
                     ty
                 }
             }
-            TypeKind::Named { name, args } => {
+            TypeKind::Named { id, name, args } => {
                 let new_args: Vec<_> = args
                     .iter()
                     .map(|a| self.replace_univars_with_bound(db, *a, row_subst, var_to_index))
@@ -474,6 +481,7 @@ impl<'db> TypeSubst<'db> {
                 Type::new(
                     db,
                     TypeKind::Named {
+                        id: *id,
                         name: *name,
                         args: new_args,
                     },
@@ -823,15 +831,17 @@ impl<'db> TypeSolver<'db> {
             // Structural unification for compound types
             (
                 &TypeKind::Named {
-                    name: n1,
+                    id: i1,
                     args: ref a1,
+                    ..
                 },
                 &TypeKind::Named {
-                    name: n2,
+                    id: i2,
                     args: ref a2,
+                    ..
                 },
             ) => {
-                if n1 != n2 || a1.len() != a2.len() {
+                if i1 != i2 || a1.len() != a2.len() {
                     return Err(SolveError::TypeMismatch {
                         expected: t1,
                         actual: t2,
@@ -1295,8 +1305,15 @@ impl<'db> TypeSolver<'db> {
             | (TypeKind::Bytes, TypeKind::Bytes)
             | (TypeKind::Rune, TypeKind::Rune)
             | (TypeKind::Nil, TypeKind::Nil) => true,
-            (TypeKind::Named { name: n1, args: a1 }, TypeKind::Named { name: n2, args: a2 }) => {
-                n1 == n2
+            (
+                TypeKind::Named {
+                    id: i1, args: a1, ..
+                },
+                TypeKind::Named {
+                    id: i2, args: a2, ..
+                },
+            ) => {
+                i1 == i2
                     && a1.len() == a2.len()
                     && a1
                         .iter()
@@ -1469,7 +1486,7 @@ impl<'db> TypeSolver<'db> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{AbilityId, Effect, EffectRow, UniVarSource};
+    use crate::ast::{AbilityId, Effect, EffectRow, TypeDefId, UniVarSource};
     use trunk_ir::Symbol;
 
     fn test_db() -> salsa::DatabaseImpl {
@@ -1548,6 +1565,7 @@ mod tests {
         let list_ty = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![var_ty],
             },
@@ -1855,6 +1873,7 @@ mod tests {
         let list_var = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![var_ty],
             },
@@ -1862,6 +1881,7 @@ mod tests {
         let list_int = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![int_ty],
             },
@@ -1884,6 +1904,7 @@ mod tests {
         let list_int = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![int_ty],
             },
@@ -1891,6 +1912,7 @@ mod tests {
         let option_int = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option")),
                 name: trunk_ir::Symbol::new("Option"),
                 args: vec![int_ty],
             },
@@ -1898,6 +1920,43 @@ mod tests {
 
         let result = solver.unify_types(list_int, option_int);
         assert!(matches!(result, Err(SolveError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_unify_named_types_rejects_same_spelling_with_different_identity() {
+        let db = test_db();
+        let mut solver = TypeSolver::new(&db);
+        let name = Symbol::new("Thing");
+        let int_ty = Type::new(&db, TypeKind::Int);
+        let first = Type::new(
+            &db,
+            TypeKind::Named {
+                id: TypeDefId::source(
+                    &db,
+                    Symbol::new("A::Thing"),
+                    crate::ast::NodeId::from_raw(1),
+                ),
+                name,
+                args: vec![int_ty],
+            },
+        );
+        let second = Type::new(
+            &db,
+            TypeKind::Named {
+                id: TypeDefId::source(
+                    &db,
+                    Symbol::new("B::Thing"),
+                    crate::ast::NodeId::from_raw(2),
+                ),
+                name,
+                args: vec![int_ty],
+            },
+        );
+
+        assert!(matches!(
+            solver.unify_types(first, second),
+            Err(SolveError::TypeMismatch { .. })
+        ));
     }
 
     #[test]
@@ -1911,6 +1970,7 @@ mod tests {
         let list_ctor = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![],
             },
@@ -1991,6 +2051,7 @@ mod tests {
         let list_never = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![never_ty],
             },
@@ -1998,6 +2059,7 @@ mod tests {
         let list_int = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![int_ty],
             },
@@ -2819,6 +2881,7 @@ mod tests {
         let list_ctor = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![],
             },
@@ -2826,6 +2889,7 @@ mod tests {
         let option_ctor = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option")),
                 name: trunk_ir::Symbol::new("Option"),
                 args: vec![],
             },

--- a/crates/tribute-front/src/typeck/subst.rs
+++ b/crates/tribute-front/src/typeck/subst.rs
@@ -58,7 +58,7 @@ pub fn substitute_bound_vars<'db>(
                 }
             }
         }
-        TypeKind::Named { name, args } => {
+        TypeKind::Named { id, name, args } => {
             let mut new_args = Vec::with_capacity(args.len());
             for arg in args {
                 match substitute_bound_vars(db, *arg, subst) {
@@ -69,6 +69,7 @@ pub fn substitute_bound_vars<'db>(
             SubstResult::Ok(Type::new(
                 db,
                 TypeKind::Named {
+                    id: *id,
                     name: *name,
                     args: new_args,
                 },
@@ -286,9 +287,10 @@ fn freshen_effect_vars_inner<'db>(
         };
 
     match ty.kind(db) {
-        TypeKind::Named { name, args } => Type::new(
+        TypeKind::Named { id, name, args } => Type::new(
             db,
             TypeKind::Named {
+                id: *id,
                 name: *name,
                 args: args
                     .iter()
@@ -411,7 +413,7 @@ fn freshen_effect_vars_inner<'db>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{AbilityId, CallingConvention, EffectRow};
+    use crate::ast::{AbilityId, CallingConvention, EffectRow, TypeDefId};
     use crate::typeck::TypeSolver;
     use salsa_test_macros::salsa_test;
     use trunk_ir::Symbol;
@@ -506,6 +508,7 @@ mod tests {
         let list_ty = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![bound_var],
             },
@@ -518,6 +521,7 @@ mod tests {
         let expected = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![int_ty],
             },
@@ -590,6 +594,7 @@ mod tests {
         let list_ty = Type::new(
             db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(db, trunk_ir::Symbol::new("List")),
                 name: Symbol::new("List"),
                 args: vec![bound_var],
             },

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -166,7 +166,9 @@ fn tdnr_function_summary_inner<'db>(
     }
     let result = checker.check_module(resolved);
 
-    let module = tribute_front::tdnr::resolve_tdnr(db, result.module, std::iter::empty());
+    let prelude_modules: Vec<_> = prelude.iter().map(|p| &p.typed_module).collect();
+    let module =
+        tribute_front::tdnr::resolve_tdnr(db, result.module, prelude_modules.iter().copied());
     let body = function_body(&module, &function_name);
     let mut summary = TdnrSummary::default();
     collect_tdnr_summary(db, body, &mut summary);

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -114,6 +114,32 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
 }
 
 #[salsa::tracked]
+fn run_frontend_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) {
+    let parsed = tribute_front::query::parsed_ast(db, source);
+    assert!(parsed.is_some(), "Should parse successfully");
+
+    let parsed = parsed.unwrap();
+    let ast = parsed.module(db).clone();
+    let span_map = parsed.span_map(db).clone();
+    let prelude = load_prelude(db);
+
+    let mut env = tribute_front::resolve::build_env(db, &ast);
+    if let Some(ref p) = prelude {
+        env.merge(&p.env);
+    }
+    let resolved = tribute_front::resolve::resolve_with_env(db, ast, env, span_map.clone());
+
+    let mut checker = tribute_front::typeck::TypeChecker::new(db, span_map);
+    if let Some(ref p) = prelude {
+        checker.inject_prelude(&p.exports);
+    }
+    let result = checker.check_module(resolved);
+
+    let prelude_modules: Vec<_> = prelude.iter().map(|p| &p.typed_module).collect();
+    let _ = tribute_front::tdnr::resolve_tdnr(db, result.module, prelude_modules.iter().copied());
+}
+
+#[salsa::tracked]
 fn tdnr_function_summary_inner<'db>(
     db: &'db dyn salsa::Database,
     source: SourceCst,
@@ -322,4 +348,16 @@ pub fn run_ast_pipeline_with_ir(db: &dyn salsa::Database, source: SourceCst) -> 
 /// Panics if any error diagnostics were emitted during the pipeline.
 pub fn run_ast_pipeline(db: &dyn salsa::Database, source: SourceCst) {
     let _ = run_ast_pipeline_with_ir(db, source);
+}
+
+/// Run the full AST pipeline and return error diagnostic messages.
+pub fn ast_pipeline_error_messages(db: &dyn salsa::Database, source: SourceCst) -> Vec<String> {
+    run_frontend_pipeline_inner(db, source);
+    run_frontend_pipeline_inner::accumulated::<Diagnostic>(db, source)
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.inner.severity == tribute_core::diagnostic::DiagnosticSeverity::Error
+        })
+        .map(|diagnostic| diagnostic.inner.message.clone())
+        .collect()
 }

--- a/crates/tribute-front/tests/nominal_type_identity.rs
+++ b/crates/tribute-front/tests/nominal_type_identity.rs
@@ -1,0 +1,55 @@
+mod common;
+
+use common::ast_pipeline_error_messages;
+use salsa_test_macros::salsa_test;
+use tribute_front::SourceCst;
+
+#[salsa_test]
+fn unqualified_annotation_uses_nested_module_type_identity(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "nested_nominal_annotation.trb",
+        r#"
+pub mod A {
+    pub struct Thing { value: Nat }
+
+    pub mod Inner {
+        pub fn forward(thing: Thing) -> A::Thing {
+            thing
+        }
+    }
+}
+"#,
+    );
+
+    assert_eq!(
+        ast_pipeline_error_messages(db, source),
+        Vec::<String>::new()
+    );
+}
+
+#[salsa_test]
+fn string_literal_keeps_canonical_prelude_identity_when_shadowed(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "shadowed_string_literal.trb",
+        r#"
+enum String {
+    Fake
+}
+
+fn take_user_string(_value: String) {}
+
+fn main() {
+    take_user_string("hello")
+}
+"#,
+    );
+
+    let errors = ast_pipeline_error_messages(db, source);
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert!(
+        errors[0].contains("expected `String`, found `String`"),
+        "{errors:?}"
+    );
+}

--- a/crates/tribute-front/tests/nominal_type_identity.rs
+++ b/crates/tribute-front/tests/nominal_type_identity.rs
@@ -53,3 +53,111 @@ fn main() {
         "{errors:?}"
     );
 }
+
+#[salsa_test]
+fn forward_nominal_annotations_use_source_identity(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "forward_nominal_annotations.trb",
+        r#"
+fn make_bare() -> Later {
+    Later { value: 1 }
+}
+
+fn make_qualified() -> A::Later {
+    A::Later { value: 2 }
+}
+
+fn read_bare(value: Later) -> Nat {
+    value.value
+}
+
+fn read_qualified(value: A::Later) -> Nat {
+    value.value
+}
+
+struct Holder {
+    value: FieldLater
+}
+
+struct Later {
+    value: Nat
+}
+
+pub mod A {
+    pub struct Later {
+        value: Nat
+    }
+}
+
+struct FieldLater {
+    value: Nat
+}
+
+fn unwrap(holder: Holder) -> FieldLater {
+    holder.value
+}
+"#,
+    );
+
+    assert_eq!(
+        ast_pipeline_error_messages(db, source),
+        Vec::<String>::new()
+    );
+}
+
+#[salsa_test]
+fn nested_struct_fields_and_record_patterns_use_declaration_identity(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "nested_struct_fields.trb",
+        r#"
+pub mod A {
+    pub struct Thing {
+        value: Nat
+    }
+
+    pub fn field(thing: Thing) -> Nat {
+        thing.value
+    }
+
+    pub fn destructure(thing: Thing) -> Nat {
+        let A::Thing { value } = thing
+        value
+    }
+}
+"#,
+    );
+
+    assert_eq!(
+        ast_pipeline_error_messages(db, source),
+        Vec::<String>::new()
+    );
+}
+
+#[salsa_test]
+fn nested_record_pattern_preserves_field_type(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "nested_record_pattern_field_type.trb",
+        r#"
+pub mod A {
+    pub struct Thing {
+        value: String
+    }
+
+    pub fn invalid(thing: Thing) -> Nat {
+        let A::Thing { value } = thing
+        value
+    }
+}
+"#,
+    );
+
+    let errors = ast_pipeline_error_messages(db, source);
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert!(
+        errors[0].contains("expected `String`, found `Nat`"),
+        "{errors:?}"
+    );
+}

--- a/crates/tribute-front/tests/nominal_type_identity.rs
+++ b/crates/tribute-front/tests/nominal_type_identity.rs
@@ -77,7 +77,11 @@ fn read_qualified(value: A::Later) -> Nat {
 }
 
 struct Holder {
-    value: FieldLater
+    value: Wrapper(FieldLater)
+}
+
+struct Wrapper(a) {
+    value: a
 }
 
 struct Later {
@@ -95,7 +99,7 @@ struct FieldLater {
 }
 
 fn unwrap(holder: Holder) -> FieldLater {
-    holder.value
+    holder.value.value
 }
 "#,
     );

--- a/crates/tribute-front/tests/ufcs_method_call.rs
+++ b/crates/tribute-front/tests/ufcs_method_call.rs
@@ -290,6 +290,38 @@ fn score_b(thing: B::Thing) -> Nat { thing.score() }
     );
 }
 
+#[salsa_test]
+fn string_literal_method_uses_prelude_identity_when_shadowed(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "shadowed_string_tdnr.trb",
+        r#"
+enum String {
+    Fake
+}
+
+fn len(_value: String) -> Nat {
+    99
+}
+
+fn test() -> Nat {
+    "hello".len()
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, source, "test"),
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![TdnrCall {
+                target: "String::len".to_owned(),
+                arg_count: 1,
+            }],
+        }
+    );
+}
+
 // ========================================================================
 // Snapshot Tests (verify IR output)
 // ========================================================================

--- a/crates/tribute-front/tests/ufcs_method_call.rs
+++ b/crates/tribute-front/tests/ufcs_method_call.rs
@@ -125,6 +125,7 @@ struct Point { x: Nat, y: Nat }
 fn test(p: Point) -> Nat {
     p.x
 }
+
 "#,
     );
 
@@ -240,6 +241,49 @@ fn test(i: Item) -> Nat {
             method_calls: vec![],
             calls: vec![TdnrCall {
                 target: "Outer::score".to_owned(),
+                arg_count: 1,
+            }],
+        }
+    );
+}
+
+#[salsa_test]
+fn test_tdnr_distinguishes_same_short_type_name_in_nested_modules(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "nested_same_name.trb",
+        r#"
+pub mod A {
+    pub struct Thing { value: Nat }
+    pub fn score(thing: Thing) -> Nat { thing.value }
+}
+
+pub mod B {
+    pub struct Thing { value: Nat }
+    pub fn score(thing: Thing) -> Nat { thing.value + 1 }
+}
+
+fn score_a(thing: A::Thing) -> Nat { thing.score() }
+fn score_b(thing: B::Thing) -> Nat { thing.score() }
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, source, "score_a"),
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![TdnrCall {
+                target: "A::score".to_owned(),
+                arg_count: 1,
+            }],
+        }
+    );
+    assert_eq!(
+        tdnr_function_summary(db, source, "score_b"),
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![TdnrCall {
+                target: "B::score".to_owned(),
                 arg_count: 1,
             }],
         }

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -40,6 +40,25 @@ cannot express a required invariant.
 
 ---
 
+## Nominal Type Identity
+
+The resolved AST stores a declaration-backed identity on every named type.
+Source declarations derive that identity from their declaration node and carry
+it through annotation conversion, type checking, substitution, TDNR receiver
+matching, and AST-to-IR lowering. Reconstructing a named type from an
+unqualified symbol alone is not sound.
+
+TDNR annotation reconstruction uses the current module prefix: a qualified path
+and a local unqualified reference must select the same declaration identity as
+ordinary type resolution. Generic type collection and rewrite maps are keyed by
+that identity rather than by display symbols.
+
+Specialization mangling uses the declaration's qualified identity when needed
+to distinguish same-spelled declarations. When the qualified identity equals
+the existing display name, the ordinary mangle remains unchanged.
+
+---
+
 ## Semantic Model
 
 ### 동적 의미론

--- a/new-plans/type-inference.md
+++ b/new-plans/type-inference.md
@@ -15,6 +15,13 @@
 | 중복 label | 금지 | 허용 (런타임 모호성) |
 | 암묵적 polymorphism | `fn(a) -> b` = `fn(a) ->{e} b` | 항상 명시 |
 
+### Nominal Type Equality
+
+Named types unify only when their resolved declaration identities match and
+their type arguments unify pairwise. The source spelling is diagnostic
+presentation, not semantic identity. Substitution and generalization preserve
+the declaration identity of every named type.
+
 ---
 
 ## Effect Row Syntax

--- a/new-plans/types.md
+++ b/new-plans/types.md
@@ -6,6 +6,18 @@
 
 Tribute는 `struct`와 `enum` 두 키워드로 타입을 선언한다.
 
+### Nominal Identity
+
+Every `struct` and `enum` declaration introduces a distinct nominal type
+identity. Identity comes from the resolved declaration, not from the displayed
+type name alone. Two declarations with the same short name remain different
+types, including declarations in different nested modules.
+
+Qualified and locally unqualified references to one declaration resolve to the
+same identity. Type display remains source-oriented and may use the same short
+spelling for different declarations; equality, unification, method receiver
+selection, and specialization must still compare declaration identity.
+
 ## Primitive Numeric Types
 
 `Float`는 IEEE 754 부동소수점 값을 표현한다. 현재 산술/비교 연산은

--- a/src/lsp/type_index.rs
+++ b/src/lsp/type_index.rs
@@ -53,7 +53,7 @@ pub fn print_ast_type(db: &dyn salsa::Database, ty: Type<'_>) -> String {
             name.unwrap_or_else(|| format!("?{}", display_index))
         }
 
-        TypeKind::Named { name, args } => {
+        TypeKind::Named { name, args, .. } => {
             if args.is_empty() {
                 name.to_string()
             } else {
@@ -278,7 +278,7 @@ impl<'a, 'db> TypeCollector<'a, 'db> {
                 self.add_entry(expr.id, float_ty);
             }
             ExprKind::StringLit(_) => {
-                let string_ty = Type::new(self.db, TypeKind::string());
+                let string_ty = Type::new(self.db, TypeKind::string(self.db));
                 self.add_entry(expr.id, string_ty);
             }
             ExprKind::BytesLit(_) => {
@@ -484,7 +484,7 @@ pub fn type_index<'db>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tribute_front::ast::UniVarId;
+    use tribute_front::ast::{TypeDefId, UniVarId};
 
     fn make_source(db: &dyn salsa::Database, text: &str) -> SourceCst {
         SourceCst::from_source_str(db, "test.trb", text)
@@ -512,6 +512,7 @@ mod tests {
         let list_ty = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![int_ty],
             },
@@ -649,6 +650,7 @@ mod tests {
         let ctor_ty = Type::new(
             &db,
             TypeKind::Named {
+                id: TypeDefId::synthetic(&db, trunk_ir::Symbol::new("List")),
                 name: trunk_ir::Symbol::new("List"),
                 args: vec![],
             },

--- a/tests/e2e_native.rs
+++ b/tests/e2e_native.rs
@@ -109,6 +109,38 @@ fn main() {
 }
 
 #[test]
+fn test_native_nested_generic_types_keep_declaration_identity() {
+    assert_native_output(
+        "nested_generic_nominal_identity.trb",
+        r#"
+pub mod A {
+    pub struct Token(a) {}
+
+    pub fn tag(_value: Token(Nat)) -> Nat {
+        1
+    }
+}
+
+pub mod B {
+    pub struct Token(a) {}
+
+    pub fn tag(_value: Token(Nat)) -> Nat {
+        12
+    }
+}
+
+fn main() {
+    let a = A::Token {}
+    let b = B::Token {}
+    __tribute_print_nat(a.tag())
+    __tribute_print_nat(b.tag())
+}
+"#,
+        "1\n12",
+    );
+}
+
+#[test]
 fn test_native_let_binding() {
     assert_native_output(
         "let_binding.trb",

--- a/tests/e2e_native.rs
+++ b/tests/e2e_native.rs
@@ -79,6 +79,36 @@ fn main() {
 }
 
 #[test]
+fn test_native_generic_specializations_distinguish_same_spelled_source_types() {
+    assert_native_output(
+        "generic_same_spelled_source_types.trb",
+        r#"
+pub mod A {
+    pub struct Thing { value: Nat }
+}
+
+pub mod B {
+    pub struct Thing { value: Nat }
+}
+
+fn keep(value: a) -> a {
+    value
+}
+
+fn accept_a(_value: A::Thing) {}
+fn accept_b(_value: B::Thing) {}
+
+fn main() {
+    accept_a(keep(A::Thing { value: 1 }))
+    accept_b(keep(B::Thing { value: 2 }))
+    __tribute_print_nat(3)
+}
+"#,
+        "3",
+    );
+}
+
+#[test]
 fn test_native_let_binding() {
     assert_native_output(
         "let_binding.trb",


### PR DESCRIPTION
Closes #811.

## Summary

- define nominal types by source declaration identity rather than display spelling
- preserve that identity through resolution, type checking, solving, substitution, TDNR, and LSP adaptation
- key generic type collection/rewrite/specialization by declaration identity and qualify mangles only when needed to avoid collisions
- cover same-spelled declarations in solver, TDNR method resolution, mangling/rewrite maps, and native generic specialization execution

## Why this is separate

This is the representation-independent foundation extracted from #810. It keeps the general nominal-type model reviewable and lets #810 contain only the compiler-owned canonical List binding plus List syntax, IR, native representation, API, documentation, and acceptance tests. #810 will be retargeted to this branch.

No List literal/pattern lowering, List dialect/native layout, List intrinsic/API, or List-specific language contract is included here.

## Validation

- `cargo fmt --all -- --check`
- `node /Users/kroisse/workspace/tribute/main/node_modules/markdownlint-cli2/markdownlint-cli2.mjs 'new-plans/**/*.md'`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features` (1645 passed, 1 skipped)
- pre-commit hook (clippy, fmt, 1645 passed, 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nominal type equality so identically spelled named types from different modules/scopes remain distinct.
  * Fixed TDNR receiver/method resolution and generic specialization so mangling and rewriting disambiguate same short names using declaration identity.
  * Corrected scope-aware type resolution in nested modules, including field access and record patterns.
  * Improved string literal typing to preserve the prelude `String` identity when shadowed.
* **Documentation**
  * Added guidance on nominal type identity/equality and how specialization uses declaration identity.
* **Tests**
  * Expanded unit and native e2e coverage for shadowed `String`, nested modules, record patterns, and generic specialization identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->