### PR TITLE
#821: Specify unified source-logical callable and control IR boundary

### DIFF
--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -1,10 +1,226 @@
-# CPS 기반 Effect Handling 파이프라인
+# Direct control and CPS effect-handling pipeline
 
-이 문서는 현재 구현 기준의 ability lowering 전략을 설명한다.
+This document defines the logical direct-style/CPS boundary and records the
+current compatibility implementation used while M2 migrates to it.
 
 핵심 전략은 **tail-call CPS + evidence-based handler dispatch**이다.
 WasmGC yield bubbling, `YieldResult` 중심 trampoline, `cont.*` dialect 직접
 lowering은 현재 경로가 아니다.
+
+## M2 direct-style boundary
+
+The target pipeline is:
+
+```text
+typed AST
+  -> verified direct-style tribute_control IR
+  -> shared CPS legalization in tribute-passes
+  -> ability.* / effect.* / closure.* IR
+  -> target-specific lowering
+```
+
+This boundary is specified by #821 but is not implemented merely because this
+document describes it. #822 adds the dialect, #823 adds conversion over
+synthetic IR, #824 migrates frontend emission, #825 makes legalization
+mandatory in both backend pipelines, and #826 removes the superseded
+frontend-owned normalization and continuation construction.
+
+`tribute_control` contains only `perform`, `handle`, `handler`, `resume`, and
+`yield`, plus the opaque affine `resume_token<input, answer>` type. Their full
+structural contracts are in [ir.md](ir.md#direct-style-control). Ordinary
+calls and data operations stay in their existing dialects. There is no
+effectful invocation operation: existing direct/indirect call operations and
+their callable convention metadata already distinguish `Direct`,
+`EvidenceDirect`, and `Cps`. Every ability operation invocation, whether
+declared `fn` or `op`, is `tribute_control.perform`. Its required
+`operation_kind = @fn | @op` metadata preserves the kind established by source
+typechecking.
+
+Source effects and worker conventions do not change at this boundary:
+
+```text
+Direct < EvidenceDirect < Cps
+```
+
+Effect rows continue to contain ability identities rather than operation
+identities. Closed empty, fn-only, general-op, and open-row convention
+selection retain their existing meanings. ANF is a representation invariant
+inside each executable region, not a source phase and not the identity of the
+dialect. The operation kind and callable convention are distinct facts:
+typechecking never infers `fn` from a tail-resumptive-looking `op` body, and
+the frontend does not select a dispatch representation.
+
+### Pre-CPS callable shape
+
+The `tribute-control-pre-cps` boundary uses source-logical callable signatures
+for every convention:
+
+- `func.func` entry block arguments are exactly the source parameters, and its
+  result is the source result.
+- `closure.lambda` block arguments and its `closure<func<...>>` result type use
+  the same source-logical parameters and result.
+- `func.call` and `func.call_indirect` pass only source arguments and produce
+  the source result.
+- Definitions, lambdas, function/closure types, and call sites carry the
+  existing `CallingConvention` metadata. They do not encode the convention by
+  pre-inserting operands.
+
+Consequently, neither `EvidenceDirect` nor `Cps` has a hidden evidence
+parameter at this boundary, and `Cps` has no frontend-created `done_k`.
+The typing/convention analysis has already established convention metadata,
+which `tribute-front` preserves without constructing its physical ABI.
+
+At this same boundary, `tribute-front` emits every ability invocation as
+`tribute_control.perform` and copies the typechecked declaration kind into
+`operation_kind`. It does not emit `ability.call`, `ability.perform`, or
+`effect.dispatch_*`, infer kind from the handler body, or choose tail versus
+CPS dispatch.
+
+Issue #823 signature-converts definitions and every matching direct/indirect call
+site together, before closure extraction:
+
+| Convention | Physical parameters after #823 | Physical result during M2 |
+| ---- | ---- | ---- |
+| `Direct` | source parameters | source result |
+| `EvidenceDirect` | evidence, then source parameters | source result |
+| `Cps` | evidence, `done_k`, then source parameters | current opaque compatibility control result |
+
+The parameter order is the existing `CallableAbi` order. For `Cps`, `done_k`
+accepts the source result and returns the same opaque control-result type as
+the worker. During M2 that physical type may remain the current compatibility
+`anyref`; this table does not make it a permanent logical result or select the
+future `Never`/`Step` policy owned by #774.
+
+The conversion uses TrunkIR's `TypeConverter` and signature-conversion support
+to rewrite `func.func` entry arguments, `core.func` types, closure types,
+`closure.lambda` entries, and direct and indirect call sites consistently.
+It threads the current evidence value into `EvidenceDirect` and `Cps` calls.
+It converts a `Cps` body `func.return value` into
+`return done_k(value)` in the compatibility representation; direct-style
+control points and structured-region yields are converted with the same body
+continuation. A call whose metadata and callable type disagree is a conversion
+failure, not a reason to guess hidden operands.
+
+In the same #823 legalization, each `tribute_control.perform` is converted
+from its typechecked `operation_kind`: `@fn` produces the existing
+`ability.call`/tail-dispatch path without capturing the suffix, while `@op`
+produces the existing `ability.perform`/CPS path. This decision is not encoded
+in `CallableAbi`, and the pass must not infer or change the operation kind.
+
+This joint signature conversion is why a separate
+`tribute_control.invoke` operation is unnecessary. Callable convention
+metadata selects the conversion, while existing call and closure operations
+continue to represent invocation and construction.
+
+Root source `main` is the one composition-owned delimiter. Its external worker
+remains `Direct` for a pure entry or `EvidenceDirect` for an `Io` entry; it is
+never exposed to a backend as `Cps`. If evaluating its body requires a `Cps`
+chain only because of a generic/open callback, #823 closes that body with a
+compiler-generated terminal continuation while retaining the external
+signature. A Direct root obtains the existing empty-evidence value for the
+internal chain; an EvidenceDirect root uses its newly inserted evidence
+argument. The root orchestration/conversion layer, not `tribute-front`, owns
+this delimiter and the final source-result return.
+
+### Logical CPS legalization
+
+The shared conversion lowers one executable region as
+`convert_region(region, exit_k)`. `exit_k` is a logical continuation for the
+region result; it is not a selected backend carrier. The conversion consumes
+operations from left to right:
+
+- An ordinary direct operation stays in its existing dialect and its result
+  flows to the remaining suffix.
+- A `Cps` `func.call` or `func.call_indirect` uses its existing convention
+  metadata and the jointly converted callable type. Conversion supplies
+  evidence and a continuation for the suffix using `CallableAbi` order.
+- `tribute_control.perform` branches only on its verified `operation_kind`.
+  For `@fn`, conversion does not capture the suffix and produces the existing
+  `ability.call`/`effect.dispatch_tail` path; the returned operation result
+  flows through the ordinary suffix. For `@op`, it captures the current suffix
+  and all selected enclosing structured exits up to the matching dynamic
+  handle boundary, then produces the existing
+  `ability.perform`/`effect.dispatch_cps` path. Operands are packed only at
+  that lower boundary. For `op -> Never`, conversion captures no suffix and
+  supplies a real zero-capture reject continuation to the existing required
+  ABI operand.
+- `tribute_control.yield value` invokes the region's `exit_k(value)`.
+
+At `scf.if`, case lowering, a guarded arm, or short-circuit selection, each
+executable branch is converted independently with an exit continuation that
+first reaches the structured merge and then runs the enclosing suffix. The
+condition, scrutinee, and preceding strict values are evaluated once in source
+order. Only the selected branch, guard, or right-hand side executes.
+
+`tribute_control.handle` creates a delimiter:
+
+1. Normal body yield enters the completion region exactly once; completion
+   yield continues through the enclosing `exit_k`.
+2. The nearest dynamically installed matching handler receives the operation
+   arguments. A `fn` arm yields the operation result and resumes
+   automatically.
+3. A resumptive general `op` arm receives an affine resumption. Its
+   `tribute_control.resume` supplies the performed operation's result, runs
+   the captured body continuation, and then runs the arm-local suffix with the
+   returned handle answer. A source `op -> Never` arm receives no resumption
+   and cannot contain `resume`.
+4. A general arm that yields without resuming completes that handle directly.
+   It bypasses the abandoned performed-computation suffix and the completion
+   region.
+5. A nested handle introduces the same delimiter recursively. A resumed path
+   re-enters every selected case/conditional/short-circuit/nested-handle frame
+   captured between the perform and its handler. A non-resumed path abandons
+   those frames.
+
+The converter must derive all continuations from regions, block suffixes,
+`tribute_control.yield`, verified `operation_kind`, and callable convention
+metadata. It must not rescan the typed AST, inspect AST containment, infer an
+operation kind, or add construct-specific rules for case, guard, short-circuit,
+or nested handles.
+
+The affine `resume_token` is a logical ownership capability. It may be unused
+or consumed once. Source `op -> Never`, identified by canonical `core.never`
+rather than an erased `anyref` placeholder, creates no token. Closure capture
+transfers the token's static ownership path; copying, storing, returning, or
+yielding it is invalid. Operation-local verification checks token/result types
+and rejects a token or nested `resume` in a `Never` handler. Whole-IR
+validation follows use-def and closure-capture edges to enforce one static
+ownership path and lexical association with one resumptive general handler.
+
+Static SSA validation does not prove dynamic one-shot behavior after capture:
+the same closure value may be invoked repeatedly. Conversion must therefore
+lower a captured resumption with runtime consumed state, and a second
+invocation must be rejected or trap before re-entering the continuation. This
+is the existing scoped-resumption runtime responsibility, not a backend
+carrier-selection decision. Conversion consumes the direct token and does not
+expose it in post-CPS IR.
+
+The `op -> Never` reject continuation is a compiler-generated closure with the
+ordinary continuation ABI, no captures, and a `func.unreachable` body. It may
+be shared within one compilation unit. `ability.perform` receives that typed
+closure, and `effect.dispatch_cps` receives its ordinary closure-to-`anyref`
+conversion. Null, an in-band sentinel, and arbitrary `anyref` are invalid
+substitutes. Invocation traps because a `Never` handler is forbidden to
+resume; the adapter is an ABI guard, not a source path or backend carrier
+choice.
+
+### Legalization boundaries
+
+The named `tribute-control-pre-cps` boundary accepts verified
+`tribute_control.*` beside ordinary high-level and mid-level dialects.
+Frontend conformance makes all existing `ability.*`, `effect.*`, and legacy
+CPS-dispatch operations illegal. During a partial #823 rewrite, source and
+lowered operations may coexist transiently; that transient state is not the
+named pre-CPS boundary.
+
+Successful shared conversion verifies the partial
+`tribute-control-post-cps` target, whose defining rule is
+`illegal_dialect("tribute_control")`. Any residual direct-control operation is
+a conversion failure at its source location. Later shared passes may still
+consume `ability.*`, `effect.*`, and `closure.*`. Native and Wasm
+backend-ready Tribute boundaries independently reject residual
+`tribute_control.*`, `ability.*`, and `effect.*`; they do not rely only on a
+previous pass having run.
 
 논리적 CPS 함수는 source result를 직접 반환하지 않는다. 완료 값은 `done_k`의
 인자로 전달되고 함수와 continuation의 control result는 `Never`다. 아래 예시의
@@ -13,7 +229,7 @@ continuation chain의 결과를 되돌려 보내기 위해 사용하는 compatib
 향후 control lowering은 이를 true tail call의 `Never` 또는 trampoline의 `Step`으로
 대체할 수 있다.
 
-## Private CPS completion carrier (#815)
+## Current private CPS completion carrier (#815)
 
 Until #774 supplies a general logical/backend control-result separation, the
 narrow #815 compatibility protocol at a handle boundary is:
@@ -62,8 +278,9 @@ The shared evidence ABI threads the dynamic tag through `effect.extend`,
 and Wasm obtain the same tag from the selected evidence marker before invoking
 that closure. Shared lowering compares integer owner tags; it does not require
 target-independent reference equality or an owner allocation. This is a
-single private compatibility representation, not #818's `tribute.control`
-dialect and not #774's general backend carrier-selection policy.
+single private compatibility representation, not the logical
+`tribute_control` semantic contract and not #774's general backend
+carrier-selection policy.
 
 현재 compatibility representation에서 캡처 없는 identity `done_k`의 함수 본문은
 컴파일 단위 전체에서 동일하다. AST-to-IR lowering은 이 내부 함수 정의를 compilation
@@ -79,7 +296,19 @@ separate compilation이 도입되면 backend의 link-once 정책으로 합칠 �
 ### `fn` operation: direct dispatch
 
 `fn`으로 선언된 ability operation은 tail-resumptive임을 선언부에서 보장한다.
-호출 지점은 continuation을 만들지 않고 `ability.call`로 내려간다.
+Typechecking은 이 source kind를 보존하고 frontend는 모든 ability invocation과
+마찬가지로 direct-style `perform`을 만든다:
+
+```text
+%result = tribute_control.perform %arg {
+  ability_ref = @Logger,
+  op_name = @log,
+  operation_kind = @fn
+}
+```
+
+Issue #823 semantic legalization이 `operation_kind = @fn`을 보고 continuation을
+만들지 않은 채 기존 `ability.call` 경로로 내린다:
 
 ```text
 %result = ability.call %arg
@@ -111,8 +340,19 @@ and indirect-call representation:
 
 ### `op` operation: tail-call CPS dispatch
 
-`op`으로 선언된 general operation은 명시적인 continuation closure와 함께
-`ability.perform`으로 내려간다.
+`op`으로 선언된 general operation도 frontend에서는 source-logical 결과를 갖는
+direct-style `perform`이다:
+
+```text
+%result = tribute_control.perform {
+  ability_ref = @State,
+  op_name = @get,
+  operation_kind = @op
+}
+```
+
+Issue #823 semantic legalization이 `operation_kind = @op`을 보고 block suffix에서
+명시적인 continuation closure를 구성한 뒤 `ability.perform`으로 내린다.
 
 ```text
 %result = ability.perform %continuation, %arg
@@ -146,7 +386,19 @@ func.return %result
 Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므로,
 `ability.perform` 이후의 같은 function-body ops는 dead code가 된다.
 
-### 값/계산 lowering 경계
+이 lowering은 source kind를 재분류하지 않는다. 일반 `op` handler가 실제로
+항상 tail-resumptive인지 분석하여 tail path로 최적화하는 작업은 표준 `@op`
+semantic lowering 이후의 별도 IR optimization이다.
+
+### Current pre-M2 frontend value/computation boundary
+
+The following `ast_to_ir` normalization and `lower_value`/`lower_comp` split is
+the current implementation baseline. Its compositional behavior is evidence
+for the M2 region conversion and must remain correct during migration, but
+frontend-owned normalization and continuation construction are not the
+permanent phase boundary. After #824, `tribute-front` emits verified
+direct-style regions; after #826, superseded CPS-only frontend machinery is
+removed.
 
 `ast_to_ir`는 lowering 직전에 작은 typed-AST A-normalization을 한 번 수행한다.
 이것은 새 HIR, source language phase, 또는 source effect 의미가 아니다. 기존
@@ -269,8 +521,9 @@ expression variant가 없으므로 unary strict-child normalization은 적용 �
 
 `#816`은 현재 `anyref` compatibility carrier를 보존한다. #815 adds only the
 owner-tagged private escape protocol above. General logical/backend
-control-result selection remains #774 work, and a direct-style
-`tribute.control` dialect remains #818 work.
+control-result selection remains #774 work. The direct-style
+`tribute_control` contract is fixed above; implementation and migration remain
+owned by Issues #822 through #826.
 
 Rust lowering은 sealed answer domain marker로 이 경계를 표현한다. `Ambient`는
 함수/바깥 CPS chain의 control answer, `HandleAnswer`는 handle delimiter 안의
@@ -366,9 +619,9 @@ __tribute_evidence_lookup_handler(ev: ptr, ability_id: i32) -> ptr
 Effect 발생 시점에서 이미 handler closure로 tail-call되므로,
 `lower_handle_dispatch`는 body result에 `done` handler를 적용하는 역할만 한다.
 
-## Shared Middle-End Pipeline
+## Current shared middle-end pipeline
 
-현재 shared pipeline의 핵심 순서는 다음과 같다.
+Until #823-#825 land, the implemented shared pipeline remains:
 
 ```text
 ast_to_ir
@@ -386,11 +639,14 @@ ast_to_ir
 Future effect specialization and handler inlining use the same validation
 contract defined in `optimizations.md`.
 
-`ast_to_ir` 단계에서 effectful function과 closure는 evidence parameter와
-현재 compatibility CPS representation을 반영한 IR로 생성된다. Shared lowering removes
-high-level dispatch operations and emits `effect.*` ABI operations. Backends
-then lower `effect.*` into evidence runtime calls, closure decomposition, and
-target-specific indirect calls.
+In this current baseline, `ast_to_ir` creates effectful functions and closures
+with evidence parameters and the compatibility CPS representation. This is
+descriptive, not the permanent ownership boundary. The M2 target inserts
+`tribute_control` CPS legalization before the existing ability/effect passes;
+after #824 the frontend does not construct continuations, and #826 removes the
+superseded path. Shared lowering still emits the same `effect.*` ABI
+operations, which backends lower into evidence runtime calls, closure
+decomposition, and target-specific indirect calls.
 
 ## Effect ABI Boundary
 
@@ -414,9 +670,11 @@ Rules:
 - Backend-ready conversion targets must reject residual `effect.*` operations.
 - Shared passes must not inspect Marker field numbers, handler-table storage
   layout, closure field positions, or backend function-pointer representation.
-- Payload values are already packed into a single value by the frontend or
-  earlier shared lowering. Missing payloads are represented explicitly by a
-  target-independent null/empty value before reaching `effect.*`.
+- Payload values are already packed into a single value by shared lowering.
+  The M2 frontend retains source-logical `tribute_control.perform` operands
+  and does not pack them for a dispatch strategy. Missing payloads are
+  represented explicitly by a target-independent null/empty value before
+  reaching `effect.*`.
 
 ## Backend Implications
 

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -39,16 +39,15 @@ type과 source parameter/result만 사용하며 evidence, environment, `done_k`�
 Issue #823은 closure extraction 전에 전체 callable graph를 하나의 단위로
 변환한다:
 
-| Convention | #823 이후 physical parameter | 현재 physical result |
+| Convention | #823 이후 physical parameter | result |
 | ---- | ---- | ---- |
 | `Direct` | 소스 parameter | 소스 result |
 | `EvidenceDirect` | evidence 뒤 소스 parameter | 소스 result |
-| `Cps` | evidence, `done_k`, source parameter 순서 | 현재 opaque compatibility control result |
+| `Cps` | evidence, `done_k`, source parameter 순서 | logical `core.never`, physical empty result |
 
 Parameter 순서는 기존 `CallableAbi` 순서다. `Cps`의 `done_k`는 source result를
-받고 worker와 같은 opaque control-result type을 반환한다. 현재 physical type은
-compatibility `anyref`를 유지할 수 있지만, 이는 영구 logical result나 #774의
-향후 `Never`/`Step` 정책이 아니다.
+받고 logical `core.never`를 반환한다. Control lowering 뒤 worker와 continuation은
+result vector가 비어 있으며 제어 값을 반환하지 않는다.
 
 Conversion은 먼저 모든 logical callable type, definition, lambda, `func_ref`,
 direct/indirect call, return의 대응 관계를 검증하고 physical symbol과 type을
@@ -65,13 +64,23 @@ direct/indirect call, return의 대응 관계를 검증하고 physical symbol과
   worker에 전달하므로 named function도 다른 closure와 같은 `call_indirect` ABI를
   갖는다. 기존 closure lowering은 이 `closure.new`를 `func.constant`와 physical
   closure struct로 바꾼다.
-- `tribute_control.call`과 `call_indirect`는 각각 physical `func.call`과
-  `func.call_indirect`가 된다. 현재 evidence와 `Cps` suffix continuation을
-  `CallableAbi` 순서로 삽입하고, indirect call의 environment는 후속 closure
-  lowering이 삽입한다.
+- `Direct`/`EvidenceDirect`의 `tribute_control.call`과 `call_indirect`는 각각
+  physical `func.call`과 `func.call_indirect`가 된다. `Cps` call은 suffix를
+  `done_k`로 전달하고 named target에는 `func.tail_call`, dynamic target에는
+  `func.tail_call_indirect`를 쓴다. Evidence와 environment는 `CallableAbi`
+  순서로 삽입한다.
 - `tribute_control.return`은 `Direct`/`EvidenceDirect`에서 `func.return`이 된다.
-  `Cps`에서는 `done_k(value)`를 호출하고 compatibility control result를
-  `func.return`한다.
+  `Cps`에서는 `done_k(value)`로 `func.tail_call_indirect`하며 뒤에
+  `func.return`이나 result가 없다.
+
+알려진 CPS target으로의 최종 이전은 `func.tail_call`, closure, continuation,
+`done_k`처럼 동적인 target으로의 이전은 `func.tail_call_indirect`를 사용한다.
+Shared IR의 caller/callee result는 `core.never`이고 target signature의 result
+vector는 비어 있어야 한다. `Step`, trampoline 또는 반환되는 control value는
+이 경로에 없다.
+생성한 continuation, `done_k`, handler-dispatch function에도
+`tribute.calling_convention = 2`를 붙여 backend-ready verifier가 semantic role을
+식별하게 한다.
 
 기존 `CallableAbi::interpose_environment`에 따라 extracted lambda와 `func_ref`
 adapter의 최종 parameter 순서는 `Direct`에서 `environment, source...`,
@@ -86,10 +95,11 @@ Metadata/type/symbol 불일치는 conversion failure이며 hidden operand를 추
 builder를 재사용하되 `tribute_control` 전용 graph pattern은 #823이 구현한다.
 
 같은 #823 legalization에서 각 `tribute_control.perform`을 typecheck된
-`operation_kind`에 따라 변환한다. `@fn`은 suffix를 capture하지 않고 기존
-`ability.call`/tail-dispatch 경로를 만들며, `@op`은 기존
-`ability.perform`/CPS 경로를 만든다. 이 결정은 `CallableAbi`에 encode하지 않으며
-pass가 operation kind를 추론하거나 변경해서는 안 된다.
+`operation_kind`에 따라 변환한다. `@fn`은 suffix를 capture하지 않고
+`ability.call`을, `@op`은 `ability.perform`과 필요한 `ability.handle_dispatch`
+표면을 만든다. #823은 `effect.dispatch_*`나 `effect.extend`를 만들지 않는다.
+이 결정은 `CallableAbi`에 encode하지 않으며 pass가 operation kind를 추론하거나
+변경해서는 안 된다.
 
 Root `main` delimiter와 external ABI 조합 책임은
 [implementation.md](implementation.md#직접형-제어-소유권)을 따른다.
@@ -106,11 +116,12 @@ operation을 왼쪽에서 오른쪽으로 소비한다:
   suffix continuation을 공급한다. `Direct`와 `EvidenceDirect` call result는
   일반 suffix로 흐른다.
 - `tribute_control.perform`은 검증된 `operation_kind`만으로 분기한다. `@fn`이면
-  suffix를 capture하지 않고 기존 `ability.call`/`effect.dispatch_tail` 경로를
-  만들며 반환된 operation result가 일반 suffix로 흐른다. `@op`이면 현재
-  suffix와 일치하는 dynamic handle boundary까지 선택된 모든 enclosing
-  structured exit를 capture한 뒤 기존 `ability.perform`/`effect.dispatch_cps`
-  경로를 만든다. Operand packing은 이 lower 경계에서만 수행한다.
+  suffix를 capture하지 않고 `ability.call`을 만들며 반환된 operation result가
+  일반 suffix로 흐른다. `@op`이면 현재 suffix와 일치하는 dynamic handle
+  boundary까지 선택된 모든 enclosing structured exit를 capture한 뒤
+  `ability.perform`을 만든다. 후속 `lower_ability_perform`이 각각
+  `effect.dispatch_tail`과 `effect.dispatch_cps`로 낮춘다. Operand packing은
+  이 lower 경계에서만 수행한다.
   `op -> Never`에는 suffix를 capture하지 않고 기존 필수 ABI operand에 실제
   zero-capture reject continuation을 공급한다.
 - `tribute_control.yield value`는 region의 `exit_k(value)`를 호출한다.
@@ -122,14 +133,16 @@ source 순서로 한 번만 평가하며 선택된 branch, guard, 오른쪽 항�
 
 `tribute_control.handle`은 delimiter를 만든다:
 
-1. Normal body yield는 completion region에 정확히 한 번 들어가며 completion
+1. 정상 body yield는 completion region에 정확히 한 번 들어가며 completion
    yield는 enclosing `exit_k`를 계속 실행한다.
 2. Dynamic하게 설치된 handler 중 가장 가까운 일치 handler가 operation
    argument를 받는다. `fn` arm은 operation result를 yield하고 자동으로 resume한다.
 3. Resumptive general `op` arm은 affine resumption을 받는다.
    `tribute_control.resume`은 수행된 operation result를 공급하고 capture한 body
    continuation을 실행한 뒤, 반환된 handle answer로 arm-local suffix를 실행한다.
-   Source `op -> Never` arm은 resumption을 받지 않고 `resume`을 포함할 수 없다.
+   Source `op -> Never` arm은 resumption을 받지 않고 `resume`을 포함할 수 없으며
+   yield type은 enclosing handle result type과 같아야 한다. Converter는 rewrite
+   전에 verifier와 같은 조건을 확인한다.
 4. Resume하지 않고 yield하는 general arm은 해당 handle을 직접 완료한다. 포기된
    performed-computation suffix와 completion region을 건너뛴다.
 5. Nested handle은 같은 delimiter를 재귀적으로 만든다. Resumed path는 perform과
@@ -167,78 +180,44 @@ named pre-CPS boundary가 아니다.
 `tribute-control-post-cps` target과 Tribute type walk를 검증한다. 남은
 `tribute_control` operation 또는 `callable`/`resume_token` type은 source
 location에서 conversion failure가 된다. 이 경계에는 일관된 physical
-`func.*`/`closure.*`/`core.func` graph와 lowered ability/effect operation만
-남는다. Native와 Wasm의 backend-ready Tribute boundary는 남은
-`tribute_control.*`, `ability.*`, `effect.*`를 각각 독립적으로 거부한다.
+`func.*`/`closure.*`/`core.func` graph와 logical `ability.*` dispatch 표면만
+남는다. 이후 기존 `lower_closure_lambda`, `prepare_closure_lowering`,
+`lower_closures_in_func`가 closure 표면을 소비하고, `lower_ability_perform`,
+`resolve_evidence`, `lower_handle_dispatch`가 `ability.*`를 `effect.*`까지
+낮춘다. Native와 Wasm의 evidence pass가 `effect.*`를 backend ABI로 제거한다.
+Backend-ready Tribute boundary는 남은 `tribute_control.*`, `ability.*`,
+`effect.*`를 각각 독립적으로 거부한다.
 
 논리적 CPS 함수는 source result를 직접 반환하지 않는다. 완료 값은 `done_k`의
-인자로 전달되고 함수와 continuation의 control result는 `Never`다. 아래 예시의
-`anyref` result와 `func.return %result`는 현재 구현이 true tail call 대신
-continuation chain의 결과를 되돌려 보내기 위해 사용하는 compatibility carrier다.
-향후 control lowering은 이를 true tail call의 `Never` 또는 trampoline의 `Step`으로
-대체할 수 있다.
+인자로만 전달되고 logical control result는 `core.never`다. Physical control
+lowering은 이를 empty-result 함수와 proper tail transfer로 바꾸며 반환되는
+control value를 만들지 않는다. Resume하지 않는 handler arm도
+`Escape`를 반환하는 대신 해당 handle의 exit continuation으로 직접 tail
+transfer하므로 completion region과 포기한 suffix를 구조적으로 건너뛴다.
 
-## 현재 비공개 CPS 완료 전달체 (#815)
+Final native/Wasm backend-ready 경계는 `Cps` worker, continuation, `done_k`,
+handler-dispatch의 result vector가 비어 있고 모든 CPS transfer가
+`func.tail_call` 또는 `func.tail_call_indirect`로 끝나는지 검사한다.
+`Step`, trampoline, CPS control-result 역할의 `anyref`와
+`__tribute_cps_control` private enum은 거부한다. Boxed source value, erased effect
+payload, closure environment와 dispatch closure field에 쓰는 일반 `anyref`는 이
+검사의 대상이 아니다.
 
-Until #774 supplies a general logical/backend control-result separation, the
-narrow #815 compatibility protocol at a handle boundary is:
+## 현재 마이그레이션 호환 전달체
+
+현재 live pipeline은 잠시 다음 owner-tagged private carrier를 사용할 수 있다:
 
 ```text
 __tribute_cps_control = Normal(anyref) | Escape(owner_tag: i32, payload: anyref)
 ```
 
-This is neither a source type nor an ABI convention. Its physical ABI remains
-`anyref`; only lowering code that has constructed the carrier, or received it
-at a boundary documented to produce it, may use `adt.variant_is`,
-`adt.variant_cast`, or `adt.variant_get`. In particular, arbitrary source
-values, public ADTs, and in-band sentinels must never be tested as this carrier.
-`owner_tag` is the existing runtime-unique prompt tag allocated for each
-dynamic handler installation. It is an integer token, not a syntactic tag, a
-source value, a closure/reference identity, or a newly allocated owner object.
-
-The body of a handle receives a `Normal`-producing done continuation. Raw CPS
-producers are adapted to `Normal` only when that exact private continuation is
-passed to them. A general `op` handler arm that completes without resuming
-returns `Escape(owner_tag, value)`, where the tag is read from the evidence
-marker that selected that handler. `Normal(value)` alone continues through the
-performed computation's normal continuation and then the handle's `do` clause.
-
-The protocol composes through every nested handle answer:
-
-- `Normal(value)` runs that handle's `do` clause and then continues normally.
-- `Escape(owner, value)` at a non-owner handle is forwarded unchanged. It does
-  not run that handle's `do` clause, any source continuation, or a resumed
-  handler arm's strict suffix.
-- `Escape(owner, value)` at the matching dynamic owner completes that handle
-  with `value`, bypassing its `do` clause. Its parent receives this as an
-  ordinary normal completion.
-
-Consequently, a `HandleAnswer` remains an opaque, proven private carrier while
-it can cross a handle delimiter. The matching dynamic owner consumes an
-`Escape` before the final source cast; `Normal` has already run the selected
-handle's `do` clause. The final source boundary therefore receives the resolved
-logical value and performs no carrier probe or tag-specific unwrap. This
-preserves #817's compositional `lower_value`/`lower_comp` API: no AST
-containment scan, special case/short-circuit mode, duplicate raw lowering path,
-or source effect-row or worker-convention change is introduced.
-
-The shared evidence ABI threads the dynamic tag through `effect.extend`,
-`ability.handle_dispatch`, and the general handler-dispatch closure. Native
-and Wasm obtain the same tag from the selected evidence marker before invoking
-that closure. Shared lowering compares integer owner tags; it does not require
-target-independent reference equality or an owner allocation. 이는 하나의
-private compatibility representation일 뿐 logical
-`tribute_control` semantic contract도, #774의 general backend carrier-selection
-정책도 아니다.
-
-현재 compatibility representation에서 캡처 없는 identity `done_k`의 함수 본문은
-컴파일 단위 전체에서 동일하다. AST-to-IR lowering은 이 내부 함수 정의를 compilation
-root에 한 번만 만들고 모든 사용 지점에서 같은 함수 심볼을 참조한다. 다만 각 사용
-지점의 null environment와 `closure.new`는 SSA 영역 가시성을 지키기 위해 해당 영역에
-각각 생성한다. 독립적으로 codegen되는 compilation unit은 자체 정의를 가지며, 향후
-separate compilation이 도입되면 backend의 link-once 정책으로 합칠 수 있다.
-이 deduplication은 독립적으로 끌 수 있어야 하며, 동일한 frontend IR
-경계에서 enabled/disabled snapshot과 native 실행 결과를 비교한다.
+이 값은 source type이나 영구 ABI가 아니다. 생성 또는 수신이 증명된 값만
+`adt.variant_is`/`cast`/`get`으로 검사할 수 있고, 임의의 source ADT, `anyref`,
+in-band sentinel은 검사할 수 없다. `Normal`은 해당 handle의 completion을
+실행하고, 일치하지 않는 owner의 `Escape`는 전달하며, 일치하는 owner만 handle을
+완료한다. 이 protocol은 #826에서 제거할 migration detail이다. #774는
+logical/physical control 분리의 관련 배경으로 남지만, 이 migration의 최종
+carrier는 tail-call-only로 이미 결정되었다.
 
 ## 핵심 설계
 
@@ -281,7 +260,7 @@ and indirect-call representation:
 suffix에서 continuation closure를 구성해 `ability.perform`으로 내린다.
 
 ```text
-%result = ability.perform %continuation, %arg
+ability.perform %continuation, %arg
   { ability_ref = @State, op_name = @get }
 ```
 
@@ -290,7 +269,7 @@ Shared lowering converts it to a target-independent effect ABI operation:
 ```text
 %payload = cast %arg to anyref
 %cont = cast %continuation to anyref
-%result = effect.dispatch_cps %ev, %cont, %payload
+effect.dispatch_cps %ev, %cont, %payload
   { ability_ref = @State, op_name = @get }
 ```
 
@@ -300,13 +279,11 @@ tail-calls it:
 ```text
 %marker = ability.evidence_lookup %ev { ability_ref = @State }
 %handler = adt.struct_get %marker, MarkerField::HandlerDispatch
-%owner_tag = adt.struct_get %marker, MarkerField::PromptTag
 %fn = adt.struct_get %handler, 0
 %env = adt.struct_get %handler, 1
 %op_idx = arith.const <hash(State, get)>
-%result = func.call_indirect %fn(
-  %ev, %env, %continuation_anyref, %owner_tag, %op_idx, %arg_anyref)
-func.return %result
+func.tail_call_indirect %fn(
+  %ev, %env, %continuation_anyref, %op_idx, %arg_anyref)
 ```
 
 Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므로,
@@ -342,7 +319,7 @@ semantic lowering API는 다음 두 경계를 유지한다.
 
 ```text
 lower_value(expr)       -> source ValueRef
-lower_comp(expr, k)     -> 현재 logical control result
+lower_comp(expr, k)     -> logical core.never
 ```
 
 `lower_value`는 source value를 만드는 직접 평가만 한다. 잠재적으로 `Cps`인
@@ -367,42 +344,31 @@ lambda-specific pass.
 
 ### Root `main` delimiter
 
-Root `main` is the one target-independent CPS delimiter. Its valid source
-residual-effect contract remains the existing pure-or-`Io` entry contract; a
-residual general effect is still diagnosed before backend lowering. The
-concrete-effect prescan therefore keeps the top-level root `main` worker at
-its `Direct` or `EvidenceDirect` seed even when evaluating its body must use
-`Cps` solely because it calls a generic/open callback worker. Nested-module
-functions named `main` are ordinary workers and are not this delimiter.
+Root `main`은 하나뿐인 target-independent CPS delimiter다. Source residual-effect
+계약은 기존 pure-or-`Io` entry를 유지하며 residual general effect는 backend 전에
+거부한다. Nested module의 `main`은 일반 worker다.
 
-When that root body is a computation, frontend lowering supplies the shared
-identity `done_k`, lowers with `lower_comp`, and converts the completed opaque
-compatibility result to the root source return type at this one sanctioned
-entry boundary before `func.return`. A Direct root creates empty evidence
-through the existing evidence placeholder path; an EvidenceDirect root uses
-its ABI evidence argument. This closes an implementation-level open callback
-convention without changing source effects or asking native/Wasm backends to
-accept a `Cps` `main`. Backend-ready conversion continues to reject genuine
-residual `effect.*` operations.
+Target-independent 경계는 Direct/EvidenceDirect export wrapper가 source result
+type의 completion cell과 이를 capture한 root `done_k`를 소유한다는 추상 조합
+계약만 정한다. Shared IR에서 CPS entry와 `done_k`의 result는 `core.never`이며,
+`func.tail_call`과 `func.tail_call_indirect` verifier도 caller/callee의
+`core.never` 일치를 검사한다.
 
-The source entry contract returns `Nil`, so the delimiter materializes that
-`Nil` after the completed control chain and deliberately discards its opaque
-completion payload; it never exposes the carrier as a source value.
+Issue #825는 native/Wasm signature lowering에서 이 CPS signature를 target의 empty-result
+signature로 바꾼 뒤 실제 wrapper와 ordinary call을 합성한다. Wasm에서는 현재
+nil/void machinery처럼 target이 지원하는 표현을 사용한다. Root `done_k`는 source
+result를 cell에 정확히 한 번 쓰고 target empty result로 반환하며, wrapper는
+proper-tail-call chain이 끝난 뒤 cell을 읽어 source result로 반환한다. Shared
+`core.func<Return, ...>`와 `func.call`의 단일 logical result 계약을 유지하고 새
+zero-result call 형상을 요구하지 않으며 두 번째 control carrier도 도입하지
+않는다. 이 adapter는 answer-type polymorphism, trampoline, in-band sentinel 또는
+control carrier가 아니다.
 
-`lower_comp`는 normalized top-level CPS producer (`op`, Cps named/local/computed
-call, structured case/short-circuit/resume)를 만났을 때 그 결과를 받는
-continuation으로 나머지 normalized block을 lowering한다. 결과는 compatibility
-`anyref` carrier를 감싼 opaque control result이며 `func.return`, `scf.yield`, CPS
-call/perform 같은 control sink에서만 소비한다. source cast, constructor, 또는
-source call argument로 사용할 수 없다.
-
-Convention metadata가 없는 synthetic compatibility continuation은
-creation-time evidence를 closure environment에 capture하지 않는다. Closure lowering은
-그 continuation의 가장 가까운 physical `func.func` entry 첫 argument가 evidence
-type일 때에만, 새 lifted entry의 injected evidence argument로 그 정확한 SSA value를
-remap한다. Explicit capture가 같은 value를 이미 소유하면 capture 의미를 우선한다.
-따라서 nested synthetic continuation도 invocation-time ABI evidence를 다음 lifted
-function으로 전달하며, 임의의 evidence-typed 외부 value를 type만으로 치환하지 않는다.
+`lower_comp(expr, k)`는 normalized CPS producer와 남은 suffix를 연결하고 logical
+`core.never` control만 만든다. Source value를 반환하거나 cast·constructor·source
+call argument로 전달할 control result는 없다. Synthetic continuation은
+invocation-time evidence를 ABI parameter로 전달하며, closure lowering은 가장
+가까운 physical entry의 정확한 evidence SSA value만 remap한다.
 
 Strict subexpression은 normalization에서 source 순서대로 atomized된 뒤 같은
 computation 안에서 이어진다.
@@ -421,18 +387,13 @@ scrutinee와 guard는 이 규칙을 따른다. 선택적 위치는 독립 evalua
 
 - `&&`/`||`의 RHS는 선택된 `scf.if` region 안에서만 lowering한다.
 - case arm과 guard는 scrutinee가 선택한 arm region 안에서만 lowering한다.
-- `handle`은 source-value 위치에서는 `Direct`로 보이지만, lowering domain은
-  context-sensitive다. `Ambient` 또는 `HandleAnswer` parent에서는
-  `lower_handle_comp`가 private carrier를 유지해 nested non-owner `Escape`를
-  전달한다. 오직 source/ambient entry가 `lower_handle_source`를 사용하며,
-  dynamic owner가 control을 소비한 뒤 logical value를 cast한다. Raw
-  Direct/EvidenceDirect entry는 handle 전체를 정확히 한 번 normalize하고,
-  이미 normalized CPS parent는 다시 normalize하지 않는다.
-- `resume`은 computation producer다. resumed `Normal`만 arm의 strict suffix로
-  들어간다. suffix가 현재 owner의 `Escape`를 돌려 주면 enclosing `do`가 볼
-  `Normal`로 retag하고, foreign `Escape`는 suffix, `do`, source continuation을
-  건너뛰어 그대로 전달한다. resume does not cast a `HandleAnswer` to a source
-  result.
+- `handle`은 body completion, resumptive suffix, non-resuming handle exit에 서로
+  다른 continuation을 준다. Non-resuming arm은 handle exit로 tail transfer하여
+  completion과 포기한 suffix를 건너뛴다. Raw Direct/EvidenceDirect entry는 handle
+  전체를 정확히 한 번 변환하고 이미 변환한 CPS parent는 다시 변환하지 않는다.
+- `resume`은 수행 지점 continuation으로 tail transfer한다. Resumed result는
+  arm-local strict suffix로 들어가며 그 suffix도 다음 continuation으로 tail
+  transfer한다. Source result로 변환되는 중간 control value는 없다.
 - `handle` body와 handler arm은 설치된 evidence/handler boundary 안에서만
   lowering한다.
 - case guard는 pattern match 뒤 arm-local strict evaluation으로 lowering한다.
@@ -444,30 +405,21 @@ nested-call lifting과 반복 containment scan을 대체한다. 현재 AST에는
 expression variant가 없으므로 unary strict-child normalization은 적용 대상이
 아니다.
 
-`#816`은 현재 `anyref` compatibility carrier를 보존한다. #815는 위의
-owner-tagged private escape protocol만 추가한다. General logical/backend
-control-result 선택은 계속 #774의 작업이다. 직접형 `tribute_control` contract는
-위에서 확정했으며 구현과 migration은 Issues #822부터 #826까지가 담당한다.
-
-Rust lowering은 sealed answer domain marker로 이 경계를 표현한다. `Ambient`는
-함수/바깥 CPS chain의 control answer, `HandleAnswer`는 handle delimiter 안의
-delimited answer, `TailResume`는 `fn` handler arm의 좁은 `ability.yield` endpoint다.
-`ContinuationRef<D>`와 `ControlResultRef<D>`는 marker가 다른 carrier를 섞을 수
-없게 한다. source value conversion is only after the dynamic owner has consumed
-the private carrier at a source boundary; resume remains entirely in the
-private answer domains.
+현재 #815/#816의 sealed answer-domain marker와 owner-tagged carrier는 migration
+동안만 proof-only inspection을 강제한다. #823-#825가 proper tail transfer를
+구성하고 #826이 이 carrier와 전용 result marker를 제거한다.
 
 ### `handle`: evidence extension + handler closures
 
 `handle` lowering은 두 종류의 dispatch closure를 만든다.
 
-- `handler_dispatch`: `(k, owner_tag, op_idx, value) -> anyref`
+- `handler_dispatch`: `(k, op_idx, value) -> ()`
   - general `op` handlers용
-  - `owner_tag` is the selected Marker's dynamic prompt owner; `resume`은
-    continuation closure 호출로 lowering된다.
+  - closure environment가 handle exit를 소유하며 `resume`과 non-resuming exit는
+    각 continuation으로 indirect tail transfer한다.
 - `tr_dispatch_fn`: `(op_idx, value) -> anyref`
   - `fn` handlers용
-  - continuation 없이 handler 결과가 inline result가 된다.
+  - `anyref`는 erased source result이며 CPS control carrier가 아니다.
 
 `resolve_evidence`는 handler boundary에서 새 marker를 만들어 evidence를
 확장한다.
@@ -571,8 +523,8 @@ representation을 갖는 effectful function과 closure를 만든다. 이는 현�
 설명이지 영구 ownership boundary가 아니다. 계획한 target은 기존 ability/effect
 pass 앞에 `tribute_control` CPS legalization을 삽입한다. #824 뒤에는 frontend가
 continuation을 구성하지 않고 #826이 대체된 path를 제거한다. Shared lowering은
-계속 같은 `effect.*` ABI operation을 emit하며 backend가 이를 evidence runtime
-call, closure decomposition, target-specific indirect call로 lower한다.
+`effect.*` ABI를 emit하며 backend가 이를 evidence runtime call, closure
+decomposition과 proper tail transfer로 lower한다.
 
 ## Effect ABI Boundary
 
@@ -585,7 +537,7 @@ Initial operations:
   { ability_ref } -> evidence`
 - `effect.dispatch_tail(evidence, payload) { ability_ref, op_name } -> result`
 - `effect.dispatch_cps(evidence, continuation, payload)
-  { ability_ref, op_name } -> result`
+  { ability_ref, op_name } -> ()`
 
 Rules:
 
@@ -593,6 +545,8 @@ Rules:
   ability-dispatch lowering boundary.
 - `effect.*` operations may remain after shared lowering and before
   backend-specific effect ABI lowering.
+- `effect.dispatch_cps`는 control result를 만들지 않으며 backend lowering은
+  handler-dispatch closure로 proper indirect tail transfer한다.
 - Backend-ready conversion targets must reject residual `effect.*` operations.
 - Shared passes must not inspect Marker field numbers, handler-table storage
   layout, closure field positions, or backend function-pointer representation.
@@ -616,12 +570,13 @@ WasmGC도 같은 shared middle-end를 사용한다. `wasm/evidence_to_wasm`은
 `effect.extend`를 marker construction + `__tribute_evidence_extend` helper
 call로 낮추고, `effect.dispatch_tail` / `effect.dispatch_cps`는
 `__tribute_evidence_lookup`, marker closure field access, closure
-table-index/env unpacking, and `wasm.call_indirect`로 낮춘다.
+table-index/env unpacking으로 낮춘다. CPS control transfer는
+`func.tail_call_indirect`를 거쳐 `wasm.return_call_indirect`가 된다. Source data를
+반환하는 일반 indirect call은 계속 `wasm.call_indirect`를 사용할 수 있다.
 
 현재 WasmGC backend에는 이전 yield bubbling/trampoline 설계의 builtin 타입
-(`Step`, `Continuation`, `ResumeWrapper`)이 남아 있다. 이 타입들은 active effect
-ABI의 의미론적 기준이 아니며, WasmGC backend 우선순위를 올리기 전에 실제 필요
-여부를 정리해야 한다.
+(`Step`, `Continuation`, `ResumeWrapper`)이 남아 있지만 #826 완료 뒤에는 모두
+제거되어야 한다.
 
 ## 폐기된 접근
 

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -12,13 +12,13 @@ lowering은 현재 경로가 아니다.
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="direct-style-control-boundary"></a>
 
-## 직접형 제어 경계
+## 직접형 호출 대상과 제어 경계
 
 모든 ability operation invocation은 typechecking이 확정한
-`operation_kind = @fn | @op`를 가진 `tribute_control.perform`이다. 일반
-direct/indirect call은 기존 operation과 callable convention metadata를 사용한다.
-Operation kind는 source 의미이고 callable convention과 별개이므로 frontend나
-conversion이 body 형상에서 이를 추론하거나 재분류하지 않는다.
+`operation_kind = @fn | @op`를 가진 `tribute_control.perform`이다. 일반 callable도
+`tribute_control.func`, `lambda`, `func_ref`, `call`, `call_indirect`, `return`을
+사용한다. Operation kind와 callable convention은 typechecking 결과이며
+frontend나 conversion이 body 형상에서 추론하거나 재분류하지 않는다.
 
 ```text
 Direct < EvidenceDirect < Cps
@@ -29,34 +29,15 @@ Effect row, convention 순서, 실행 region 내부의 ANF invariant는 바뀌�
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="pre-cps-callable-shape"></a>
 
-### Pre-CPS 호출 대상 형상
+### CPS 변환 전 호출 대상 형상
 
-`tribute-control-pre-cps` 경계에서는 모든 convention이 source-logical callable
-signature를 사용한다:
+입력 형상은 [ir.md](ir.md#direct-style-control)의 operation/type 계약을 따른다.
+모든 callable은 exact `tribute.calling_convention` code 0/1/2를 가진 logical
+type과 source parameter/result만 사용하며 evidence, environment, `done_k`는
+아직 없다.
 
-- `func.func` entry block argument는 정확히 source parameter이며 result는 source
-  result다.
-- `closure.lambda` block argument와 `closure<func<...>>` result type도 같은
-  source-logical parameter와 result를 사용한다.
-- `func.call`과 `func.call_indirect`는 source argument만 전달하고 source
-  result를 만든다.
-- Definition, lambda, function/closure type, call site는 기존
-  `CallingConvention` metadata를 운반한다. Operand를 미리 삽입해서 convention을
-  encode하지 않는다.
-
-따라서 이 경계에서 `EvidenceDirect`와 `Cps`에는 hidden evidence parameter가
-없고 `Cps`에도 frontend가 만든 `done_k`가 없다. Typing/convention analysis가
-convention metadata를 이미 확정하며, `tribute-front`는 physical ABI를 구성하지
-않고 그 metadata를 보존한다.
-
-같은 경계에서 `tribute-front`는 모든 ability invocation을
-`tribute_control.perform`으로 emit하고 typecheck된 declaration kind를
-`operation_kind`에 복사한다. `ability.call`, `ability.perform`,
-`effect.dispatch_*`를 emit하거나, handler body에서 kind를 추론하거나, tail/CPS
-dispatch를 선택하지 않는다.
-
-Issue #823은 closure extraction 전에 definition과 일치하는 모든
-direct/indirect call site를 함께 signature-convert한다:
+Issue #823은 closure extraction 전에 전체 callable graph를 하나의 단위로
+변환한다:
 
 | Convention | #823 이후 physical parameter | 현재 physical result |
 | ---- | ---- | ---- |
@@ -69,14 +50,40 @@ Parameter 순서는 기존 `CallableAbi` 순서다. `Cps`의 `done_k`는 source 
 compatibility `anyref`를 유지할 수 있지만, 이는 영구 logical result나 #774의
 향후 `Never`/`Step` 정책이 아니다.
 
-Conversion은 TrunkIR의 `TypeConverter`와 signature-conversion 지원을 사용한다.
-변환 대상은 `func.func` entry argument, `core.func` type, closure type,
-`closure.lambda` entry, direct/indirect call site를 일관되게 rewrite한다. 현재
-evidence value를 `EvidenceDirect`와 `Cps` call에 전달한다. Compatibility
-representation에서 `Cps` body의 `func.return value`를
-`return done_k(value)`로 바꾸고, 직접형 control point와 structured-region
-yield를 동일한 body continuation으로 변환한다. Metadata와 callable type이
-불일치하는 call은 conversion failure이며 hidden operand를 추측할 이유가 아니다.
+Conversion은 먼저 모든 logical callable type, definition, lambda, `func_ref`,
+direct/indirect call, return의 대응 관계를 검증하고 physical symbol과 type을
+계획한 뒤 함께 rewrite한다:
+
+- `tribute_control.func`는 `func.func`와 physical `core.func`를 만든다.
+- `tribute_control.lambda`는 physical `closure.lambda`와
+  `closure.closure<core.func<...>>`를 만든다. 이 단계의 signature에는
+  `CallableAbi` hidden parameter가 있지만 environment는 없으며, 기존 closure
+  lowering이 environment를 interpose한다.
+- `tribute_control.func_ref`는 빈 environment의 `closure.new`와 env-bearing
+  adapter `func.func`를 만든다. Adapter는 result callable의 같거나 더 강한
+  convention을 사용하고 필요한 hidden operand와 source argument를 대상 physical
+  worker에 전달하므로 named function도 다른 closure와 같은 `call_indirect` ABI를
+  갖는다. 기존 closure lowering은 이 `closure.new`를 `func.constant`와 physical
+  closure struct로 바꾼다.
+- `tribute_control.call`과 `call_indirect`는 각각 physical `func.call`과
+  `func.call_indirect`가 된다. 현재 evidence와 `Cps` suffix continuation을
+  `CallableAbi` 순서로 삽입하고, indirect call의 environment는 후속 closure
+  lowering이 삽입한다.
+- `tribute_control.return`은 `Direct`/`EvidenceDirect`에서 `func.return`이 된다.
+  `Cps`에서는 `done_k(value)`를 호출하고 compatibility control result를
+  `func.return`한다.
+
+기존 `CallableAbi::interpose_environment`에 따라 extracted lambda와 `func_ref`
+adapter의 최종 parameter 순서는 `Direct`에서 `environment, source...`,
+`EvidenceDirect`에서 `evidence, environment, source...`, `Cps`에서
+`evidence, environment, done_k, source...`다. `call_indirect`도 같은 순서로
+environment를 삽입한다.
+
+생성한 physical definition, lambda, adapter, direct/indirect call에는 logical
+type의 convention을 기존 `tribute.calling_convention` attribute로 복사한다.
+Metadata/type/symbol 불일치는 conversion failure이며 hidden operand를 추측하지
+않는다. 현재 TrunkIR의 `TypeConverter`, function signature conversion, dialect
+builder를 재사용하되 `tribute_control` 전용 graph pattern은 #823이 구현한다.
 
 같은 #823 legalization에서 각 `tribute_control.perform`을 typecheck된
 `operation_kind`에 따라 변환한다. `@fn`은 suffix를 capture하지 않고 기존
@@ -84,9 +91,8 @@ yield를 동일한 body continuation으로 변환한다. Metadata와 callable ty
 `ability.perform`/CPS 경로를 만든다. 이 결정은 `CallableAbi`에 encode하지 않으며
 pass가 operation kind를 추론하거나 변경해서는 안 된다.
 
-별도 `tribute_control.invoke`는 필요하지 않다. Root `main` delimiter와 external
-ABI 조합 책임은 [implementation.md](implementation.md#직접형-제어-소유권)을
-따른다.
+Root `main` delimiter와 external ABI 조합 책임은
+[implementation.md](implementation.md#직접형-제어-소유권)을 따른다.
 
 ### 논리적 CPS 적법화
 
@@ -95,10 +101,10 @@ Shared conversion은 실행 가능한 region 하나를
 logical continuation이며 선택된 backend carrier가 아니다. Conversion은
 operation을 왼쪽에서 오른쪽으로 소비한다:
 
-- 일반 direct operation은 기존 dialect에 남고 그 result는 남은 suffix로 흐른다.
-- `Cps` `func.call` 또는 `func.call_indirect`는 기존 convention metadata와 함께
-  변환된 callable type을 사용한다. Conversion은 `CallableAbi` 순서로 evidence와
-  suffix continuation을 공급한다.
+- 일반 value operation은 기존 dialect에 남고 그 result는 남은 suffix로 흐른다.
+- `tribute_control.call` 또는 `call_indirect`의 convention이 `Cps`이면 현재
+  suffix continuation을 공급한다. `Direct`와 `EvidenceDirect` call result는
+  일반 suffix로 흐른다.
 - `tribute_control.perform`은 검증된 `operation_kind`만으로 분기한다. `@fn`이면
   suffix를 capture하지 않고 기존 `ability.call`/`effect.dispatch_tail` 경로를
   만들며 반환된 operation result가 일반 suffix로 흐른다. `@op`이면 현재
@@ -150,18 +156,20 @@ sentinel, 임의의 `anyref`는 대체할 수 없으며 호출되면 trap한다.
 ### 적법화 경계
 
 `tribute-control-pre-cps` named boundary는 검증된 `tribute_control.*`과 일반
-high-level/mid-level dialect의 공존을 허용한다. Frontend 적합성 검사는 기존
-`ability.*`, `effect.*`, legacy CPS-dispatch operation을 모두 illegal로 만든다.
-Issue #823의 partial rewrite 도중에는 source operation과 lowered operation이
-일시적으로 공존할 수 있지만 이 상태는 named pre-CPS boundary가 아니다.
+value/structured dialect만 허용한다. Frontend 적합성 검사는 `func.*`,
+`closure.*`, `core.func`, `closure.closure`, 기존 `ability.*`, `effect.*`,
+legacy CPS-dispatch operation을 모두 거부한다. Issue #823의 partial rewrite
+도중에는 logical/physical operation이 일시적으로 공존할 수 있지만 이 상태는
+named pre-CPS boundary가 아니다.
 
 성공한 shared conversion은 defining rule이
 `illegal_dialect("tribute_control")`인 partial
-`tribute-control-post-cps` target을 검증한다. 남은 direct-control operation은
-source location에서 conversion failure가 된다. 이후 shared pass는
-`ability.*`, `effect.*`, `closure.*`를 계속 소비할 수 있다. Native와 Wasm의
-backend-ready Tribute boundary는 남은 `tribute_control.*`, `ability.*`,
-`effect.*`를 각각 독립적으로 거부하며 앞선 pass 실행 여부에만 의존하지 않는다.
+`tribute-control-post-cps` target과 Tribute type walk를 검증한다. 남은
+`tribute_control` operation 또는 `callable`/`resume_token` type은 source
+location에서 conversion failure가 된다. 이 경계에는 일관된 physical
+`func.*`/`closure.*`/`core.func` graph와 lowered ability/effect operation만
+남는다. Native와 Wasm의 backend-ready Tribute boundary는 남은
+`tribute_control.*`, `ability.*`, `effect.*`를 각각 독립적으로 거부한다.
 
 논리적 CPS 함수는 source result를 직접 반환하지 않는다. 완료 값은 `done_k`의
 인자로 전달되고 함수와 continuation의 control result는 `Never`다. 아래 예시의

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -2,12 +2,11 @@
 
 이 문서는 직접형 IR을 CPS로 바꾸는 conversion source of truth다. Operation
 구조와 verifier 계약은 [ir.md](ir.md#direct-style-control), 계층별 소유권과
-마이그레이션 순서는 [implementation.md](implementation.md#직접형-제어-소유권)를
+pipeline 조합은 [implementation.md](implementation.md#직접형-제어-소유권)를
 따른다.
 
 핵심 전략은 **tail-call CPS + evidence-based handler dispatch**이다.
-WasmGC yield bubbling, `YieldResult` 중심 trampoline, `cont.*` dialect 직접
-lowering은 현재 경로가 아니다.
+모든 CPS 이전은 proper tail call이며 제어 값을 반환하지 않는다.
 
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="direct-style-control-boundary"></a>
@@ -36,10 +35,10 @@ Effect row, convention 순서, 실행 region 내부의 ANF invariant는 바뀌�
 type과 source parameter/result만 사용하며 evidence, environment, `done_k`는
 아직 없다.
 
-Issue #823은 closure extraction 전에 전체 callable graph를 하나의 단위로
-변환한다:
+`tribute_control_to_cps`는 closure extraction 전에 전체 callable graph를 하나의
+단위로 변환한다:
 
-| Convention | #823 이후 physical parameter | result |
+| Convention | Physical parameter | Result |
 | ---- | ---- | ---- |
 | `Direct` | 소스 parameter | 소스 result |
 | `EvidenceDirect` | evidence 뒤 소스 parameter | 소스 result |
@@ -51,7 +50,7 @@ result vector가 비어 있으며 제어 값을 반환하지 않는다.
 
 Conversion은 먼저 모든 logical callable type, definition, lambda, `func_ref`,
 direct/indirect call, return의 대응 관계를 검증하고 physical symbol과 type을
-계획한 뒤 함께 rewrite한다:
+계산한 뒤 함께 rewrite한다:
 
 - `tribute_control.func`는 `func.func`와 physical `core.func`를 만든다.
 - `tribute_control.lambda`는 physical `closure.lambda`와
@@ -76,8 +75,7 @@ direct/indirect call, return의 대응 관계를 검증하고 physical symbol과
 알려진 CPS target으로의 최종 이전은 `func.tail_call`, closure, continuation,
 `done_k`처럼 동적인 target으로의 이전은 `func.tail_call_indirect`를 사용한다.
 Shared IR의 caller/callee result는 `core.never`이고 target signature의 result
-vector는 비어 있어야 한다. `Step`, trampoline 또는 반환되는 control value는
-이 경로에 없다.
+vector는 비어 있어야 한다.
 생성한 continuation, `done_k`, handler-dispatch function에도
 `tribute.calling_convention = 2`를 붙여 backend-ready verifier가 semantic role을
 식별하게 한다.
@@ -91,13 +89,14 @@ environment를 삽입한다.
 생성한 physical definition, lambda, adapter, direct/indirect call에는 logical
 type의 convention을 기존 `tribute.calling_convention` attribute로 복사한다.
 Metadata/type/symbol 불일치는 conversion failure이며 hidden operand를 추측하지
-않는다. 현재 TrunkIR의 `TypeConverter`, function signature conversion, dialect
-builder를 재사용하되 `tribute_control` 전용 graph pattern은 #823이 구현한다.
+않는다. TrunkIR의 `TypeConverter`, function signature conversion, dialect
+builder를 재사용하되 `tribute_control` 전용 graph pattern은
+`tribute_control_to_cps`가 소유한다.
 
-같은 #823 legalization에서 각 `tribute_control.perform`을 typecheck된
+같은 legalization에서 각 `tribute_control.perform`을 typecheck된
 `operation_kind`에 따라 변환한다. `@fn`은 suffix를 capture하지 않고
 `ability.call`을, `@op`은 `ability.perform`과 필요한 `ability.handle_dispatch`
-표면을 만든다. #823은 `effect.dispatch_*`나 `effect.extend`를 만들지 않는다.
+표면을 만든다. 이 pass는 `effect.dispatch_*`나 `effect.extend`를 만들지 않는다.
 이 결정은 `CallableAbi`에 encode하지 않으며 pass가 operation kind를 추론하거나
 변경해서는 안 된다.
 
@@ -126,10 +125,13 @@ operation을 왼쪽에서 오른쪽으로 소비한다:
   zero-capture reject continuation을 공급한다.
 - `tribute_control.yield value`는 region의 `exit_k(value)`를 호출한다.
 
-`scf.if`, case lowering, guarded arm, short-circuit selection에서는 각 실행 branch를
-독립적으로 변환한다. 각 branch의 exit continuation은 먼저 structured merge에
-도달한 뒤 enclosing suffix를 실행한다. Condition, scrutinee, 앞선 strict value는
-source 순서로 한 번만 평가하며 선택된 branch, guard, 오른쪽 항만 실행한다.
+일반 structured control은 기존 `scf.*` dialect에 남고
+`tribute_control_to_cps`가 region과 suffix를 재귀적으로 변환한다.
+`tribute_control.if`는 추가하지 않는다. `scf.if`, case lowering, guarded arm,
+short-circuit selection의 각 실행 branch는 독립적으로 변환한다. 각 branch의 exit
+continuation은 먼저 structured merge에 도달한 뒤 enclosing suffix를 실행한다.
+Condition, scrutinee, 앞선 strict value는 source 순서로 한 번만 평가하며 선택된
+branch, guard, 오른쪽 항만 실행한다.
 
 `tribute_control.handle`은 delimiter를 만든다:
 
@@ -171,7 +173,7 @@ sentinel, 임의의 `anyref`는 대체할 수 없으며 호출되면 trap한다.
 `tribute-control-pre-cps` named boundary는 검증된 `tribute_control.*`과 일반
 value/structured dialect만 허용한다. Frontend 적합성 검사는 `func.*`,
 `closure.*`, `core.func`, `closure.closure`, 기존 `ability.*`, `effect.*`,
-legacy CPS-dispatch operation을 모두 거부한다. Issue #823의 partial rewrite
+legacy CPS-dispatch operation을 모두 거부한다. Partial rewrite
 도중에는 logical/physical operation이 일시적으로 공존할 수 있지만 이 상태는
 named pre-CPS boundary가 아니다.
 
@@ -203,28 +205,13 @@ handler-dispatch의 result vector가 비어 있고 모든 CPS transfer가
 payload, closure environment와 dispatch closure field에 쓰는 일반 `anyref`는 이
 검사의 대상이 아니다.
 
-## 현재 마이그레이션 호환 전달체
-
-현재 live pipeline은 잠시 다음 owner-tagged private carrier를 사용할 수 있다:
-
-```text
-__tribute_cps_control = Normal(anyref) | Escape(owner_tag: i32, payload: anyref)
-```
-
-이 값은 source type이나 영구 ABI가 아니다. 생성 또는 수신이 증명된 값만
-`adt.variant_is`/`cast`/`get`으로 검사할 수 있고, 임의의 source ADT, `anyref`,
-in-band sentinel은 검사할 수 없다. `Normal`은 해당 handle의 completion을
-실행하고, 일치하지 않는 owner의 `Escape`는 전달하며, 일치하는 owner만 handle을
-완료한다. 이 protocol은 #826에서 제거할 migration detail이다. #774는
-logical/physical control 분리의 관련 배경으로 남지만, 이 migration의 최종
-carrier는 tail-call-only로 이미 결정되었다.
-
 ## 핵심 설계
 
 ### `fn` operation: direct dispatch
 
-직접형 입력은 위 규칙의 `operation_kind = @fn` perform이며, #823은
-continuation을 만들지 않고 기존 `ability.call` 경로로 내린다:
+직접형 입력은 위 규칙의 `operation_kind = @fn` perform이며,
+`tribute_control_to_cps`는 continuation을 만들지 않고 기존 `ability.call`
+경로로 내린다:
 
 ```text
 %result = ability.call %arg
@@ -239,7 +226,7 @@ Shared lowering converts it to a target-independent effect ABI operation:
   { ability_ref = @Logger, op_name = @log }
 ```
 
-Native lowering then lowers that ABI operation to the current evidence lookup
+Native lowering then lowers that ABI operation to the evidence lookup
 and indirect-call representation:
 
 ```text
@@ -256,8 +243,9 @@ and indirect-call representation:
 
 ### `op` operation: tail-call CPS dispatch
 
-직접형 입력은 위 규칙의 `operation_kind = @op` perform이며, #823은 block
-suffix에서 continuation closure를 구성해 `ability.perform`으로 내린다.
+직접형 입력은 위 규칙의 `operation_kind = @op` perform이며,
+`tribute_control_to_cps`는 block suffix에서 continuation closure를 구성해
+`ability.perform`으로 내린다.
 
 ```text
 ability.perform %continuation, %arg
@@ -293,55 +281,6 @@ Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므
 항상 tail-resumptive인지 분석하여 tail path로 최적화하는 작업은 표준 `@op`
 semantic lowering 이후의 별도 IR optimization이다.
 
-### 현재 frontend 값/계산 경계
-
-다음 `ast_to_ir` normalization과 `lower_value`/`lower_comp` 분리는 현재
-implementation baseline이다. Compositional 동작은 직접형 region conversion의
-근거이며 migration 도중에도 정확해야 한다. 그러나 frontend-owned
-normalization과 continuation 구성은 영구 phase boundary가 아니다. #824 뒤에는
-`tribute-front`가 검증된 직접형 region을 emit하고 #826 뒤에는 대체된 CPS-only
-frontend machinery를 제거한다.
-
-`ast_to_ir`는 lowering 직전에 작은 typed-AST A-normalization을 한 번 수행한다.
-이것은 새 HIR, source language phase, 또는 source effect 의미가 아니다. 기존
-`Expr<TypedRef>` / `Stmt<TypedRef>`만을 반환하는 target-independent administrative
-layer이며, CPS computation entry에서 strict child를 source 순서대로 fresh typed
-local에 bind한다. 따라서 block CPS lowering은 nested-call 문법 탐색이 아니라
-정상형 block만 소비한다.
-
-정규화는 CPS child만이 아니라 같은 strict sequence의 모든 non-atomic child를
-atomize한다. call의 computed callee와 arguments, constructor/tuple/list element,
-record spread/field는 source 순서로 처리한다. short-circuit RHS, case guard/arm,
-lambda body, handle body와 handler arm은 독립 region 안에서 재귀 정규화되며
-바깥으로 hoist하지 않는다.
-
-semantic lowering API는 다음 두 경계를 유지한다.
-
-```text
-lower_value(expr)       -> source ValueRef
-lower_comp(expr, k)     -> logical core.never
-```
-
-`lower_value`는 source value를 만드는 직접 평가만 한다. 잠재적으로 `Cps`인
-expression을 받으면 raw lowering하지 않고 lowering invariant 위반으로 거부한다.
-lambda construction은 lambda body 또는 호출의 latent effect와 관계없이 이 경로에
-남는다. `Direct`,
-`EvidenceDirect`, `Cps`의 선택은 source effect row와 function-level convention에
-의해서만 결정되며, 이 경계가 source row 의미를 바꾸지 않는다.
-
-Worker convention selection starts from the concrete-effect prescan. Before
-lowering bodies, `ast_to_ir` monotonically promotes a `Direct` or
-`EvidenceDirect` definition to `Cps` when `evaluation_control_class(body)` is
-`Cps`, then repeats over all definitions until no convention changes. It never
-demotes a worker. This lets a promoted named callee and recursive call graph
-propagate Cps requirements while leaving a pure unannotated worker `Direct`.
-For example, an `Option::map`-style worker that invokes an open-effect callback
-is promoted to `Cps` even though its concrete declared effect row is empty.
-Lambda construction remains a direct expression. Its worker convention is
-already selected from the inferred lambda function type, whose open effect row
-conservatively selects `Cps`, so definition promotion does not need a separate
-lambda-specific pass.
-
 ### Root `main` delimiter
 
 Root `main`은 하나뿐인 target-independent CPS delimiter다. Source residual-effect
@@ -354,60 +293,15 @@ type의 completion cell과 이를 capture한 root `done_k`를 소유한다는 �
 `func.tail_call`과 `func.tail_call_indirect` verifier도 caller/callee의
 `core.never` 일치를 검사한다.
 
-Issue #825는 native/Wasm signature lowering에서 이 CPS signature를 target의 empty-result
-signature로 바꾼 뒤 실제 wrapper와 ordinary call을 합성한다. Wasm에서는 현재
-nil/void machinery처럼 target이 지원하는 표현을 사용한다. Root `done_k`는 source
-result를 cell에 정확히 한 번 쓰고 target empty result로 반환하며, wrapper는
+Target signature lowering은 이 CPS signature를 native/Wasm empty-result
+signature로 바꾼 뒤 실제 wrapper와 ordinary call을 합성한다. Wasm은 nil/void
+machinery처럼 target이 지원하는 표현을 사용한다. Root `done_k`는 source result를
+cell에 정확히 한 번 쓰고 target empty result로 반환하며, wrapper는
 proper-tail-call chain이 끝난 뒤 cell을 읽어 source result로 반환한다. Shared
 `core.func<Return, ...>`와 `func.call`의 단일 logical result 계약을 유지하고 새
 zero-result call 형상을 요구하지 않으며 두 번째 control carrier도 도입하지
 않는다. 이 adapter는 answer-type polymorphism, trampoline, in-band sentinel 또는
 control carrier가 아니다.
-
-`lower_comp(expr, k)`는 normalized CPS producer와 남은 suffix를 연결하고 logical
-`core.never` control만 만든다. Source value를 반환하거나 cast·constructor·source
-call argument로 전달할 control result는 없다. Synthetic continuation은
-invocation-time evidence를 ABI parameter로 전달하며, closure lowering은 가장
-가까운 physical entry의 정확한 evidence SSA value만 remap한다.
-
-Strict subexpression은 normalization에서 source 순서대로 atomized된 뒤 같은
-computation 안에서 이어진다.
-
-```text
-consume(effectful(), pure_arg)
-
-let __cps_tmp0 = effectful()
-let __cps_tmp1 = pure_arg
-consume(__cps_tmp0, __cps_tmp1)
-```
-
-callee와 argument, tuple/constructor/record 요소, unary/binary operand, case
-scrutinee와 guard는 이 규칙을 따른다. 선택적 위치는 독립 evaluation region을
-만들고 그 region의 continuation을 공유한다.
-
-- `&&`/`||`의 RHS는 선택된 `scf.if` region 안에서만 lowering한다.
-- case arm과 guard는 scrutinee가 선택한 arm region 안에서만 lowering한다.
-- `handle`은 body completion, resumptive suffix, non-resuming handle exit에 서로
-  다른 continuation을 준다. Non-resuming arm은 handle exit로 tail transfer하여
-  completion과 포기한 suffix를 건너뛴다. Raw Direct/EvidenceDirect entry는 handle
-  전체를 정확히 한 번 변환하고 이미 변환한 CPS parent는 다시 변환하지 않는다.
-- `resume`은 수행 지점 continuation으로 tail transfer한다. Resumed result는
-  arm-local strict suffix로 들어가며 그 suffix도 다음 continuation으로 tail
-  transfer한다. Source result로 변환되는 중간 control value는 없다.
-- `handle` body와 handler arm은 설치된 evidence/handler boundary 안에서만
-  lowering한다.
-- case guard는 pattern match 뒤 arm-local strict evaluation으로 lowering한다.
-  handler arm의 `resume`은 arm-local computation의 continuation을 사용한다.
-
-따라서 실행되지 않은 branch는 eager하게 실행되지 않고, CPS producer가 handler
-boundary 밖의 continuation을 캡처하지 않는다. 이 compositional path가 ad-hoc
-nested-call lifting과 반복 containment scan을 대체한다. 현재 AST에는 unary
-expression variant가 없으므로 unary strict-child normalization은 적용 대상이
-아니다.
-
-현재 #815/#816의 sealed answer-domain marker와 owner-tagged carrier는 migration
-동안만 proof-only inspection을 강제한다. #823-#825가 proper tail transfer를
-구성하고 #826이 이 carrier와 전용 result marker를 제거한다.
 
 ### `handle`: evidence extension + handler closures
 
@@ -433,7 +327,7 @@ ABI instead of constructing the concrete Marker layout directly:
 ```
 
 Backends lower `effect.extend` to their own evidence representation. The native
-backend maps it to the current `__tribute_evidence_extend` ABI.
+backend maps it to the `__tribute_evidence_extend` ABI.
 
 ```text
 struct Marker {
@@ -491,40 +385,36 @@ __tribute_evidence_lookup_handler(ev: ptr, ability_id: i32) -> ptr
 
 ### `ability.handle_dispatch`
 
-현재 구현에서 `ability.handle_dispatch`는 runtime dispatch loop가 아니다.
-Effect 발생 시점에서 이미 handler closure로 tail-call되므로,
+`ability.handle_dispatch`는 runtime dispatch loop가 아니다. Effect 발생 시점에서
+이미 handler closure로 tail-call되므로,
 `lower_handle_dispatch`는 body result에 `done` handler를 적용하는 역할만 한다.
 
 <!-- markdownlint-disable-next-line MD033 -->
-<a id="current-shared-middle-end-pipeline"></a>
+<a id="shared-middle-end-pipeline"></a>
 
-## 현재 공통 middle-end 파이프라인
+## 공통 middle-end 파이프라인
 
-Issues #823-#825를 구현하기 전까지 현재 구현된 shared pipeline은 다음과 같다:
+Callable/control과 effect 관련 pass의 순서는 다음과 같다:
 
 ```text
-ast_to_ir
+ast_to_ir (tribute_control callable/control + ordinary value IR)
+→ tribute_control_to_cps
 → lower_closure_lambda
-→ intrinsic_to_arith
-→ closure_lower
+→ prepare_closure_lowering
+→ lower_closures_in_func
 → lower_ability_perform
-→ convert_tail_resumptive
 → resolve_evidence
 → lower_handle_dispatch
 → effect ABI verification
-→ backend-specific lowering
+→ backend-specific effect/signature/tail-call lowering
+→ backend-ready verification
 ```
 
-향후 effect specialization과 handler inlining은 `optimizations.md`에 정의한 동일한
-validation contract를 사용한다.
-
-현재 baseline에서 `ast_to_ir`는 evidence parameter와 compatibility CPS
-representation을 갖는 effectful function과 closure를 만든다. 이는 현재 구현의
-설명이지 영구 ownership boundary가 아니다. 계획한 target은 기존 ability/effect
-pass 앞에 `tribute_control` CPS legalization을 삽입한다. #824 뒤에는 frontend가
-continuation을 구성하지 않고 #826이 대체된 path를 제거한다. Shared lowering은
-`effect.*` ABI를 emit하며 backend가 이를 evidence runtime call, closure
-decomposition과 proper tail transfer로 lower한다.
+`tribute_control_to_cps`의 출력은 physical `func.*`/`closure.*` callable 표면과
+logical `ability.*` dispatch 표면이다. Closure pass가 전자를 소비하고,
+ability/evidence pass가 후자를 `effect.*`까지 낮춘 뒤 backend가 evidence runtime
+call, closure decomposition과 proper tail transfer로 제거한다. 다른 일반
+최적화는 이 경계 사이에 놓일 수 있지만 각 named legality를 바꾸지 않는다.
 
 ## Effect ABI Boundary
 
@@ -559,7 +449,7 @@ Rules:
 
 ### Native
 
-Native target은 현재 주 개발 경로다. Evidence runtime은 `tribute-runtime`의
+Evidence runtime은 `tribute-runtime`의
 `__tribute_evidence_*` C ABI 함수로 제공되고, native effect ABI lowering은
 `effect.*`를 marker lookup helper, runtime evidence extension, closure
 decomposition, and indirect calls로 변환한다.
@@ -573,19 +463,3 @@ call로 낮추고, `effect.dispatch_tail` / `effect.dispatch_cps`는
 table-index/env unpacking으로 낮춘다. CPS control transfer는
 `func.tail_call_indirect`를 거쳐 `wasm.return_call_indirect`가 된다. Source data를
 반환하는 일반 indirect call은 계속 `wasm.call_indirect`를 사용할 수 있다.
-
-현재 WasmGC backend에는 이전 yield bubbling/trampoline 설계의 builtin 타입
-(`Step`, `Continuation`, `ResumeWrapper`)이 남아 있지만 #826 완료 뒤에는 모두
-제거되어야 한다.
-
-## 폐기된 접근
-
-다음 접근은 현재 구현 기준의 active path가 아니다.
-
-- WasmGC yield bubbling
-- Koka-style `YieldResult { Done, Shift }`를 effectful return type으로 전파
-- `cont_to_yield_bubbling` pass
-- `cont.*` dialect를 libmprompt 또는 stack switching으로 직접 lowering
-
-관련 과거 설계는 git history에서 확인할 수 있지만, 새 구현 작업의 기준으로
-사용하지 않는다.

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -1,55 +1,30 @@
 # 직접형 제어와 CPS 효과 처리 파이프라인
 
-이 문서는 logical direct-style/CPS 경계를 정의하고 M2가 해당 경계로
-마이그레이션하는 동안 사용하는 현재 compatibility implementation을 기록한다.
+이 문서는 직접형 IR을 CPS로 바꾸는 conversion source of truth다. Operation
+구조와 verifier 계약은 [ir.md](ir.md#direct-style-control), 계층별 소유권과
+마이그레이션 순서는 [implementation.md](implementation.md#직접형-제어-소유권)를
+따른다.
 
 핵심 전략은 **tail-call CPS + evidence-based handler dispatch**이다.
 WasmGC yield bubbling, `YieldResult` 중심 trampoline, `cont.*` dialect 직접
 lowering은 현재 경로가 아니다.
 
 <!-- markdownlint-disable-next-line MD033 -->
-<a id="m2-direct-style-boundary"></a>
+<a id="direct-style-control-boundary"></a>
 
-## M2 직접형 경계
+## 직접형 제어 경계
 
-목표 pipeline은 다음과 같다:
-
-```text
-typed AST
-  -> verified direct-style tribute_control IR
-  -> shared CPS legalization in tribute-passes
-  -> ability.* / effect.* / closure.* IR
-  -> target-specific lowering
-```
-
-이 경계는 #821에서 명세하지만 문서에 적었다는 사실만으로 구현된 것은 아니다.
-Issue #822가 dialect를 추가하고, #823이 synthetic IR의 conversion을 추가하며, #824가
-frontend emission을 마이그레이션한다. #825는 두 backend pipeline에서
-legalization을 필수로 만들고, #826은 대체된 frontend-owned normalization과
-continuation 구성을 제거한다.
-
-`tribute_control`에는 `perform`, `handle`, `handler`, `resume`, `yield`와 opaque
-affine `resume_token<input, answer>` type만 있다. 전체 structural contract는
-[ir.md](ir.md#direct-style-control)에 있다. 일반 call과 data operation은 기존
-dialect에 남는다. Effectful invocation operation은 따로 두지 않는다. 기존
-direct/indirect call operation과 callable convention metadata가 이미 `Direct`,
-`EvidenceDirect`, `Cps`를 구분한다. `fn` 또는 `op`으로 선언했는지와 무관하게 모든
-ability operation invocation은 `tribute_control.perform`이다. 필수
-`operation_kind = @fn | @op` metadata가 source typechecking에서 확정한 kind를
-보존한다.
-
-이 경계는 source effect와 worker convention을 바꾸지 않는다:
+모든 ability operation invocation은 typechecking이 확정한
+`operation_kind = @fn | @op`를 가진 `tribute_control.perform`이다. 일반
+direct/indirect call은 기존 operation과 callable convention metadata를 사용한다.
+Operation kind는 source 의미이고 callable convention과 별개이므로 frontend나
+conversion이 body 형상에서 이를 추론하거나 재분류하지 않는다.
 
 ```text
 Direct < EvidenceDirect < Cps
 ```
 
-Effect row는 operation identity가 아니라 ability identity를 계속 담는다. Closed
-empty, fn-only, general-op, open-row convention 선택은 기존 의미를 유지한다. ANF는
-각 실행 가능한 region 내부의 representation invariant이며 source phase나
-dialect의 정체성이 아니다. Operation kind와 callable convention은 서로 다른
-사실이다. Typechecking은 tail-resumptive처럼 보이는 `op` body에서 `fn`을 추론하지
-않고 frontend는 dispatch representation을 선택하지 않는다.
+Effect row, convention 순서, 실행 region 내부의 ANF invariant는 바뀌지 않는다.
 
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="pre-cps-callable-shape"></a>
@@ -83,16 +58,16 @@ dispatch를 선택하지 않는다.
 Issue #823은 closure extraction 전에 definition과 일치하는 모든
 direct/indirect call site를 함께 signature-convert한다:
 
-| Convention | #823 이후 physical parameter | M2 동안의 physical result |
+| Convention | #823 이후 physical parameter | 현재 physical result |
 | ---- | ---- | ---- |
 | `Direct` | 소스 parameter | 소스 result |
 | `EvidenceDirect` | evidence 뒤 소스 parameter | 소스 result |
 | `Cps` | evidence, `done_k`, source parameter 순서 | 현재 opaque compatibility control result |
 
-Parameter 순서는 기존 `CallableAbi` 순서다. `Cps`에서 `done_k`는 source result를
-받고 worker와 같은 opaque control-result type을 반환한다. M2 동안 그 physical
-type은 현재 compatibility `anyref`를 유지할 수 있다. 이 표는 이를 영구 logical
-result로 만들거나 #774가 소유하는 향후 `Never`/`Step` 정책을 선택하지 않는다.
+Parameter 순서는 기존 `CallableAbi` 순서다. `Cps`의 `done_k`는 source result를
+받고 worker와 같은 opaque control-result type을 반환한다. 현재 physical type은
+compatibility `anyref`를 유지할 수 있지만, 이는 영구 logical result나 #774의
+향후 `Never`/`Step` 정책이 아니다.
 
 Conversion은 TrunkIR의 `TypeConverter`와 signature-conversion 지원을 사용한다.
 변환 대상은 `func.func` entry argument, `core.func` type, closure type,
@@ -109,19 +84,9 @@ yield를 동일한 body continuation으로 변환한다. Metadata와 callable ty
 `ability.perform`/CPS 경로를 만든다. 이 결정은 `CallableAbi`에 encode하지 않으며
 pass가 operation kind를 추론하거나 변경해서는 안 된다.
 
-이 joint signature conversion 때문에 별도 `tribute_control.invoke` operation이
-필요하지 않다. Callable convention metadata가 conversion을 선택하고 기존 call과
-closure operation이 invocation과 construction을 계속 나타낸다.
-
-Root source `main`은 composition layer가 소유하는 유일한 delimiter다. External
-worker는 pure entry에는 `Direct`, `Io` entry에는 `EvidenceDirect`를 유지하며
-backend에 `Cps`로 노출되지 않는다. Generic/open callback 때문에 body 평가에
-`Cps` chain이 필요한 경우 #823이 external signature를 유지한 채 compiler가 만든
-terminal continuation으로 body를 닫는다. Direct root는 internal chain에 기존
-empty-evidence value를 사용하고 EvidenceDirect root는 새로 삽입한 evidence
-argument를 사용한다. `tribute-front`가 아니라 root
-orchestration/conversion layer가 이 delimiter와 최종 source-result return을
-소유한다.
+별도 `tribute_control.invoke`는 필요하지 않다. Root `main` delimiter와 external
+ABI 조합 책임은 [implementation.md](implementation.md#직접형-제어-소유권)을
+따른다.
 
 ### 논리적 CPS 적법화
 
@@ -171,29 +136,16 @@ Converter는 region, block suffix, `tribute_control.yield`, 검증된
 operation kind를 추론하거나 case, guard, short-circuit, nested handle 전용 규칙을
 추가해서는 안 된다.
 
-Affine `resume_token`은 logical ownership capability다. 사용하지 않거나 한 번
-소비할 수 있다. Erased `anyref` placeholder가 아니라 canonical `core.never`로
-식별한 source `op -> Never`는 token을 만들지 않는다. Closure capture는 token의
-static ownership path를 이전한다. Copy, store, return, yield는 invalid이다.
-Operation-local verification은 token/result type을 검사하고 `Never` handler의
-token이나 nested `resume`을 거부한다. Whole-IR validation은 use-def와
-closure-capture edge를 따라가 single static ownership path와 resumptive general
-handler 하나와의 lexical association을 강제한다.
+Affine `resume_token`의 type/placement는 operation-local verifier가, use-def와
+closure-capture를 지나는 single static ownership path는 whole-IR verifier가
+검사한다. Static SSA 검사는 capture된 closure의 반복 호출을 막지 못하므로
+conversion은 runtime consumed state를 만들고 두 번째 호출을 continuation
+재진입 전에 거부하거나 trap한다. Token은 post-CPS IR에 남지 않는다.
 
-Static SSA validation은 capture 뒤의 dynamic one-shot 동작을 증명하지 못한다.
-같은 closure value를 반복 호출할 수 있기 때문이다. 따라서 conversion은
-capture된 resumption을 runtime consumed state와 함께 lower해야 하며, 두 번째
-호출은 continuation에 다시 진입하기 전에 거부하거나 trap해야 한다. 이는 기존
-scoped-resumption runtime 책임이며 backend carrier-selection 결정이 아니다.
-Conversion은 직접형 token을 소비하고 post-CPS IR에 노출하지 않는다.
-
-`op -> Never` reject continuation은 compiler가 만드는 closure다. 일반
-continuation ABI를 사용하고 capture가 없으며 body는 `func.unreachable`이다.
-Compilation unit 하나에서 공유할 수 있다. `ability.perform`은 이 typed closure를
-받고 `effect.dispatch_cps`는 일반 closure-to-`anyref` conversion 결과를 받는다.
-Null, in-band sentinel, 임의의 `anyref`는 invalid substitute다. `Never` handler는
-resume할 수 없으므로 호출되면 trap한다. 이 adapter는 ABI guard이며 source
-path나 backend carrier 선택이 아니다.
+Canonical `core.never`인 source `op -> Never`는 token과 source suffix
+continuation을 만들지 않는다. 기존 ABI에는 capture가 없고 body가
+`func.unreachable`인 typed reject continuation을 전달한다. Null, in-band
+sentinel, 임의의 `anyref`는 대체할 수 없으며 호출되면 trap한다.
 
 ### 적법화 경계
 
@@ -266,8 +218,8 @@ The shared evidence ABI threads the dynamic tag through `effect.extend`,
 `ability.handle_dispatch`, and the general handler-dispatch closure. Native
 and Wasm obtain the same tag from the selected evidence marker before invoking
 that closure. Shared lowering compares integer owner tags; it does not require
-target-independent reference equality or an owner allocation. This is a
-이는 하나의 private compatibility representation일 뿐 logical
+target-independent reference equality or an owner allocation. 이는 하나의
+private compatibility representation일 뿐 logical
 `tribute_control` semantic contract도, #774의 general backend carrier-selection
 정책도 아니다.
 
@@ -284,20 +236,8 @@ separate compilation이 도입되면 backend의 link-once 정책으로 합칠 �
 
 ### `fn` operation: direct dispatch
 
-`fn`으로 선언된 ability operation은 tail-resumptive임을 선언부에서 보장한다.
-Typechecking은 이 source kind를 보존하고 frontend는 모든 ability invocation과
-마찬가지로 direct-style `perform`을 만든다:
-
-```text
-%result = tribute_control.perform %arg {
-  ability_ref = @Logger,
-  op_name = @log,
-  operation_kind = @fn
-}
-```
-
-Issue #823의 semantic legalization은 `operation_kind = @fn`을 보고 continuation을
-만들지 않은 채 기존 `ability.call` 경로로 내린다:
+직접형 입력은 위 규칙의 `operation_kind = @fn` perform이며, #823은
+continuation을 만들지 않고 기존 `ability.call` 경로로 내린다:
 
 ```text
 %result = ability.call %arg
@@ -329,19 +269,8 @@ and indirect-call representation:
 
 ### `op` operation: tail-call CPS dispatch
 
-`op`으로 선언된 general operation도 frontend에서는 source-logical 결과를 갖는
-direct-style `perform`이다:
-
-```text
-%result = tribute_control.perform {
-  ability_ref = @State,
-  op_name = @get,
-  operation_kind = @op
-}
-```
-
-Issue #823의 semantic legalization은 `operation_kind = @op`을 보고 block suffix에서
-명시적인 continuation closure를 구성한 뒤 `ability.perform`으로 내린다.
+직접형 입력은 위 규칙의 `operation_kind = @op` perform이며, #823은 block
+suffix에서 continuation closure를 구성해 `ability.perform`으로 내린다.
 
 ```text
 %result = ability.perform %continuation, %arg
@@ -379,10 +308,10 @@ Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므
 항상 tail-resumptive인지 분석하여 tail path로 최적화하는 작업은 표준 `@op`
 semantic lowering 이후의 별도 IR optimization이다.
 
-### 현재 pre-M2 frontend 값/계산 경계
+### 현재 frontend 값/계산 경계
 
 다음 `ast_to_ir` normalization과 `lower_value`/`lower_comp` 분리는 현재
-implementation baseline이다. Compositional 동작은 M2 region conversion의
+implementation baseline이다. Compositional 동작은 직접형 region conversion의
 근거이며 migration 도중에도 정확해야 한다. 그러나 frontend-owned
 normalization과 continuation 구성은 영구 phase boundary가 아니다. #824 뒤에는
 `tribute-front`가 검증된 직접형 region을 emit하고 #826 뒤에는 대체된 CPS-only
@@ -631,8 +560,8 @@ validation contract를 사용한다.
 
 현재 baseline에서 `ast_to_ir`는 evidence parameter와 compatibility CPS
 representation을 갖는 effectful function과 closure를 만든다. 이는 현재 구현의
-설명이지 영구 ownership boundary가 아니다. M2 target은 기존 ability/effect pass
-앞에 `tribute_control` CPS legalization을 삽입한다. #824 뒤에는 frontend가
+설명이지 영구 ownership boundary가 아니다. 계획한 target은 기존 ability/effect
+pass 앞에 `tribute_control` CPS legalization을 삽입한다. #824 뒤에는 frontend가
 continuation을 구성하지 않고 #826이 대체된 path를 제거한다. Shared lowering은
 계속 같은 `effect.*` ABI operation을 emit하며 backend가 이를 evidence runtime
 call, closure decomposition, target-specific indirect call로 lower한다.
@@ -659,7 +588,7 @@ Rules:
 - Backend-ready conversion targets must reject residual `effect.*` operations.
 - Shared passes must not inspect Marker field numbers, handler-table storage
   layout, closure field positions, or backend function-pointer representation.
-- Payload value는 shared lowering에서 이미 single value로 pack한다. M2 frontend는
+- Payload value는 shared lowering에서 이미 single value로 pack한다. 직접형 frontend는
   source-logical `tribute_control.perform` operand를 유지하며 dispatch 전략에
   맞춰 pack하지 않는다. 누락된 payload는 `effect.*`에 도달하기 전에
   target-independent null/empty value로 명시적으로 표현한다.

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -1,15 +1,18 @@
-# Direct control and CPS effect-handling pipeline
+# 직접형 제어와 CPS 효과 처리 파이프라인
 
-This document defines the logical direct-style/CPS boundary and records the
-current compatibility implementation used while M2 migrates to it.
+이 문서는 logical direct-style/CPS 경계를 정의하고 M2가 해당 경계로
+마이그레이션하는 동안 사용하는 현재 compatibility implementation을 기록한다.
 
 핵심 전략은 **tail-call CPS + evidence-based handler dispatch**이다.
 WasmGC yield bubbling, `YieldResult` 중심 trampoline, `cont.*` dialect 직접
 lowering은 현재 경로가 아니다.
 
-## M2 direct-style boundary
+<!-- markdownlint-disable-next-line MD033 -->
+<a id="m2-direct-style-boundary"></a>
 
-The target pipeline is:
+## M2 직접형 경계
+
+목표 pipeline은 다음과 같다:
 
 ```text
 typed AST
@@ -19,208 +22,194 @@ typed AST
   -> target-specific lowering
 ```
 
-This boundary is specified by #821 but is not implemented merely because this
-document describes it. #822 adds the dialect, #823 adds conversion over
-synthetic IR, #824 migrates frontend emission, #825 makes legalization
-mandatory in both backend pipelines, and #826 removes the superseded
-frontend-owned normalization and continuation construction.
+이 경계는 #821에서 명세하지만 문서에 적었다는 사실만으로 구현된 것은 아니다.
+Issue #822가 dialect를 추가하고, #823이 synthetic IR의 conversion을 추가하며, #824가
+frontend emission을 마이그레이션한다. #825는 두 backend pipeline에서
+legalization을 필수로 만들고, #826은 대체된 frontend-owned normalization과
+continuation 구성을 제거한다.
 
-`tribute_control` contains only `perform`, `handle`, `handler`, `resume`, and
-`yield`, plus the opaque affine `resume_token<input, answer>` type. Their full
-structural contracts are in [ir.md](ir.md#direct-style-control). Ordinary
-calls and data operations stay in their existing dialects. There is no
-effectful invocation operation: existing direct/indirect call operations and
-their callable convention metadata already distinguish `Direct`,
-`EvidenceDirect`, and `Cps`. Every ability operation invocation, whether
-declared `fn` or `op`, is `tribute_control.perform`. Its required
-`operation_kind = @fn | @op` metadata preserves the kind established by source
-typechecking.
+`tribute_control`에는 `perform`, `handle`, `handler`, `resume`, `yield`와 opaque
+affine `resume_token<input, answer>` type만 있다. 전체 structural contract는
+[ir.md](ir.md#direct-style-control)에 있다. 일반 call과 data operation은 기존
+dialect에 남는다. Effectful invocation operation은 따로 두지 않는다. 기존
+direct/indirect call operation과 callable convention metadata가 이미 `Direct`,
+`EvidenceDirect`, `Cps`를 구분한다. `fn` 또는 `op`으로 선언했는지와 무관하게 모든
+ability operation invocation은 `tribute_control.perform`이다. 필수
+`operation_kind = @fn | @op` metadata가 source typechecking에서 확정한 kind를
+보존한다.
 
-Source effects and worker conventions do not change at this boundary:
+이 경계는 source effect와 worker convention을 바꾸지 않는다:
 
 ```text
 Direct < EvidenceDirect < Cps
 ```
 
-Effect rows continue to contain ability identities rather than operation
-identities. Closed empty, fn-only, general-op, and open-row convention
-selection retain their existing meanings. ANF is a representation invariant
-inside each executable region, not a source phase and not the identity of the
-dialect. The operation kind and callable convention are distinct facts:
-typechecking never infers `fn` from a tail-resumptive-looking `op` body, and
-the frontend does not select a dispatch representation.
+Effect row는 operation identity가 아니라 ability identity를 계속 담는다. Closed
+empty, fn-only, general-op, open-row convention 선택은 기존 의미를 유지한다. ANF는
+각 실행 가능한 region 내부의 representation invariant이며 source phase나
+dialect의 정체성이 아니다. Operation kind와 callable convention은 서로 다른
+사실이다. Typechecking은 tail-resumptive처럼 보이는 `op` body에서 `fn`을 추론하지
+않고 frontend는 dispatch representation을 선택하지 않는다.
 
-### Pre-CPS callable shape
+<!-- markdownlint-disable-next-line MD033 -->
+<a id="pre-cps-callable-shape"></a>
 
-The `tribute-control-pre-cps` boundary uses source-logical callable signatures
-for every convention:
+### Pre-CPS 호출 대상 형상
 
-- `func.func` entry block arguments are exactly the source parameters, and its
-  result is the source result.
-- `closure.lambda` block arguments and its `closure<func<...>>` result type use
-  the same source-logical parameters and result.
-- `func.call` and `func.call_indirect` pass only source arguments and produce
-  the source result.
-- Definitions, lambdas, function/closure types, and call sites carry the
-  existing `CallingConvention` metadata. They do not encode the convention by
-  pre-inserting operands.
+`tribute-control-pre-cps` 경계에서는 모든 convention이 source-logical callable
+signature를 사용한다:
 
-Consequently, neither `EvidenceDirect` nor `Cps` has a hidden evidence
-parameter at this boundary, and `Cps` has no frontend-created `done_k`.
-The typing/convention analysis has already established convention metadata,
-which `tribute-front` preserves without constructing its physical ABI.
+- `func.func` entry block argument는 정확히 source parameter이며 result는 source
+  result다.
+- `closure.lambda` block argument와 `closure<func<...>>` result type도 같은
+  source-logical parameter와 result를 사용한다.
+- `func.call`과 `func.call_indirect`는 source argument만 전달하고 source
+  result를 만든다.
+- Definition, lambda, function/closure type, call site는 기존
+  `CallingConvention` metadata를 운반한다. Operand를 미리 삽입해서 convention을
+  encode하지 않는다.
 
-At this same boundary, `tribute-front` emits every ability invocation as
-`tribute_control.perform` and copies the typechecked declaration kind into
-`operation_kind`. It does not emit `ability.call`, `ability.perform`, or
-`effect.dispatch_*`, infer kind from the handler body, or choose tail versus
-CPS dispatch.
+따라서 이 경계에서 `EvidenceDirect`와 `Cps`에는 hidden evidence parameter가
+없고 `Cps`에도 frontend가 만든 `done_k`가 없다. Typing/convention analysis가
+convention metadata를 이미 확정하며, `tribute-front`는 physical ABI를 구성하지
+않고 그 metadata를 보존한다.
 
-Issue #823 signature-converts definitions and every matching direct/indirect call
-site together, before closure extraction:
+같은 경계에서 `tribute-front`는 모든 ability invocation을
+`tribute_control.perform`으로 emit하고 typecheck된 declaration kind를
+`operation_kind`에 복사한다. `ability.call`, `ability.perform`,
+`effect.dispatch_*`를 emit하거나, handler body에서 kind를 추론하거나, tail/CPS
+dispatch를 선택하지 않는다.
 
-| Convention | Physical parameters after #823 | Physical result during M2 |
+Issue #823은 closure extraction 전에 definition과 일치하는 모든
+direct/indirect call site를 함께 signature-convert한다:
+
+| Convention | #823 이후 physical parameter | M2 동안의 physical result |
 | ---- | ---- | ---- |
-| `Direct` | source parameters | source result |
-| `EvidenceDirect` | evidence, then source parameters | source result |
-| `Cps` | evidence, `done_k`, then source parameters | current opaque compatibility control result |
+| `Direct` | 소스 parameter | 소스 result |
+| `EvidenceDirect` | evidence 뒤 소스 parameter | 소스 result |
+| `Cps` | evidence, `done_k`, source parameter 순서 | 현재 opaque compatibility control result |
 
-The parameter order is the existing `CallableAbi` order. For `Cps`, `done_k`
-accepts the source result and returns the same opaque control-result type as
-the worker. During M2 that physical type may remain the current compatibility
-`anyref`; this table does not make it a permanent logical result or select the
-future `Never`/`Step` policy owned by #774.
+Parameter 순서는 기존 `CallableAbi` 순서다. `Cps`에서 `done_k`는 source result를
+받고 worker와 같은 opaque control-result type을 반환한다. M2 동안 그 physical
+type은 현재 compatibility `anyref`를 유지할 수 있다. 이 표는 이를 영구 logical
+result로 만들거나 #774가 소유하는 향후 `Never`/`Step` 정책을 선택하지 않는다.
 
-The conversion uses TrunkIR's `TypeConverter` and signature-conversion support
-to rewrite `func.func` entry arguments, `core.func` types, closure types,
-`closure.lambda` entries, and direct and indirect call sites consistently.
-It threads the current evidence value into `EvidenceDirect` and `Cps` calls.
-It converts a `Cps` body `func.return value` into
-`return done_k(value)` in the compatibility representation; direct-style
-control points and structured-region yields are converted with the same body
-continuation. A call whose metadata and callable type disagree is a conversion
-failure, not a reason to guess hidden operands.
+Conversion은 TrunkIR의 `TypeConverter`와 signature-conversion 지원을 사용한다.
+변환 대상은 `func.func` entry argument, `core.func` type, closure type,
+`closure.lambda` entry, direct/indirect call site를 일관되게 rewrite한다. 현재
+evidence value를 `EvidenceDirect`와 `Cps` call에 전달한다. Compatibility
+representation에서 `Cps` body의 `func.return value`를
+`return done_k(value)`로 바꾸고, 직접형 control point와 structured-region
+yield를 동일한 body continuation으로 변환한다. Metadata와 callable type이
+불일치하는 call은 conversion failure이며 hidden operand를 추측할 이유가 아니다.
 
-In the same #823 legalization, each `tribute_control.perform` is converted
-from its typechecked `operation_kind`: `@fn` produces the existing
-`ability.call`/tail-dispatch path without capturing the suffix, while `@op`
-produces the existing `ability.perform`/CPS path. This decision is not encoded
-in `CallableAbi`, and the pass must not infer or change the operation kind.
+같은 #823 legalization에서 각 `tribute_control.perform`을 typecheck된
+`operation_kind`에 따라 변환한다. `@fn`은 suffix를 capture하지 않고 기존
+`ability.call`/tail-dispatch 경로를 만들며, `@op`은 기존
+`ability.perform`/CPS 경로를 만든다. 이 결정은 `CallableAbi`에 encode하지 않으며
+pass가 operation kind를 추론하거나 변경해서는 안 된다.
 
-This joint signature conversion is why a separate
-`tribute_control.invoke` operation is unnecessary. Callable convention
-metadata selects the conversion, while existing call and closure operations
-continue to represent invocation and construction.
+이 joint signature conversion 때문에 별도 `tribute_control.invoke` operation이
+필요하지 않다. Callable convention metadata가 conversion을 선택하고 기존 call과
+closure operation이 invocation과 construction을 계속 나타낸다.
 
-Root source `main` is the one composition-owned delimiter. Its external worker
-remains `Direct` for a pure entry or `EvidenceDirect` for an `Io` entry; it is
-never exposed to a backend as `Cps`. If evaluating its body requires a `Cps`
-chain only because of a generic/open callback, #823 closes that body with a
-compiler-generated terminal continuation while retaining the external
-signature. A Direct root obtains the existing empty-evidence value for the
-internal chain; an EvidenceDirect root uses its newly inserted evidence
-argument. The root orchestration/conversion layer, not `tribute-front`, owns
-this delimiter and the final source-result return.
+Root source `main`은 composition layer가 소유하는 유일한 delimiter다. External
+worker는 pure entry에는 `Direct`, `Io` entry에는 `EvidenceDirect`를 유지하며
+backend에 `Cps`로 노출되지 않는다. Generic/open callback 때문에 body 평가에
+`Cps` chain이 필요한 경우 #823이 external signature를 유지한 채 compiler가 만든
+terminal continuation으로 body를 닫는다. Direct root는 internal chain에 기존
+empty-evidence value를 사용하고 EvidenceDirect root는 새로 삽입한 evidence
+argument를 사용한다. `tribute-front`가 아니라 root
+orchestration/conversion layer가 이 delimiter와 최종 source-result return을
+소유한다.
 
-### Logical CPS legalization
+### 논리적 CPS 적법화
 
-The shared conversion lowers one executable region as
-`convert_region(region, exit_k)`. `exit_k` is a logical continuation for the
-region result; it is not a selected backend carrier. The conversion consumes
-operations from left to right:
+Shared conversion은 실행 가능한 region 하나를
+`convert_region(region, exit_k)`로 lower한다. `exit_k`는 region result를 위한
+logical continuation이며 선택된 backend carrier가 아니다. Conversion은
+operation을 왼쪽에서 오른쪽으로 소비한다:
 
-- An ordinary direct operation stays in its existing dialect and its result
-  flows to the remaining suffix.
-- A `Cps` `func.call` or `func.call_indirect` uses its existing convention
-  metadata and the jointly converted callable type. Conversion supplies
-  evidence and a continuation for the suffix using `CallableAbi` order.
-- `tribute_control.perform` branches only on its verified `operation_kind`.
-  For `@fn`, conversion does not capture the suffix and produces the existing
-  `ability.call`/`effect.dispatch_tail` path; the returned operation result
-  flows through the ordinary suffix. For `@op`, it captures the current suffix
-  and all selected enclosing structured exits up to the matching dynamic
-  handle boundary, then produces the existing
-  `ability.perform`/`effect.dispatch_cps` path. Operands are packed only at
-  that lower boundary. For `op -> Never`, conversion captures no suffix and
-  supplies a real zero-capture reject continuation to the existing required
-  ABI operand.
-- `tribute_control.yield value` invokes the region's `exit_k(value)`.
+- 일반 direct operation은 기존 dialect에 남고 그 result는 남은 suffix로 흐른다.
+- `Cps` `func.call` 또는 `func.call_indirect`는 기존 convention metadata와 함께
+  변환된 callable type을 사용한다. Conversion은 `CallableAbi` 순서로 evidence와
+  suffix continuation을 공급한다.
+- `tribute_control.perform`은 검증된 `operation_kind`만으로 분기한다. `@fn`이면
+  suffix를 capture하지 않고 기존 `ability.call`/`effect.dispatch_tail` 경로를
+  만들며 반환된 operation result가 일반 suffix로 흐른다. `@op`이면 현재
+  suffix와 일치하는 dynamic handle boundary까지 선택된 모든 enclosing
+  structured exit를 capture한 뒤 기존 `ability.perform`/`effect.dispatch_cps`
+  경로를 만든다. Operand packing은 이 lower 경계에서만 수행한다.
+  `op -> Never`에는 suffix를 capture하지 않고 기존 필수 ABI operand에 실제
+  zero-capture reject continuation을 공급한다.
+- `tribute_control.yield value`는 region의 `exit_k(value)`를 호출한다.
 
-At `scf.if`, case lowering, a guarded arm, or short-circuit selection, each
-executable branch is converted independently with an exit continuation that
-first reaches the structured merge and then runs the enclosing suffix. The
-condition, scrutinee, and preceding strict values are evaluated once in source
-order. Only the selected branch, guard, or right-hand side executes.
+`scf.if`, case lowering, guarded arm, short-circuit selection에서는 각 실행 branch를
+독립적으로 변환한다. 각 branch의 exit continuation은 먼저 structured merge에
+도달한 뒤 enclosing suffix를 실행한다. Condition, scrutinee, 앞선 strict value는
+source 순서로 한 번만 평가하며 선택된 branch, guard, 오른쪽 항만 실행한다.
 
-`tribute_control.handle` creates a delimiter:
+`tribute_control.handle`은 delimiter를 만든다:
 
-1. Normal body yield enters the completion region exactly once; completion
-   yield continues through the enclosing `exit_k`.
-2. The nearest dynamically installed matching handler receives the operation
-   arguments. A `fn` arm yields the operation result and resumes
-   automatically.
-3. A resumptive general `op` arm receives an affine resumption. Its
-   `tribute_control.resume` supplies the performed operation's result, runs
-   the captured body continuation, and then runs the arm-local suffix with the
-   returned handle answer. A source `op -> Never` arm receives no resumption
-   and cannot contain `resume`.
-4. A general arm that yields without resuming completes that handle directly.
-   It bypasses the abandoned performed-computation suffix and the completion
-   region.
-5. A nested handle introduces the same delimiter recursively. A resumed path
-   re-enters every selected case/conditional/short-circuit/nested-handle frame
-   captured between the perform and its handler. A non-resumed path abandons
-   those frames.
+1. Normal body yield는 completion region에 정확히 한 번 들어가며 completion
+   yield는 enclosing `exit_k`를 계속 실행한다.
+2. Dynamic하게 설치된 handler 중 가장 가까운 일치 handler가 operation
+   argument를 받는다. `fn` arm은 operation result를 yield하고 자동으로 resume한다.
+3. Resumptive general `op` arm은 affine resumption을 받는다.
+   `tribute_control.resume`은 수행된 operation result를 공급하고 capture한 body
+   continuation을 실행한 뒤, 반환된 handle answer로 arm-local suffix를 실행한다.
+   Source `op -> Never` arm은 resumption을 받지 않고 `resume`을 포함할 수 없다.
+4. Resume하지 않고 yield하는 general arm은 해당 handle을 직접 완료한다. 포기된
+   performed-computation suffix와 completion region을 건너뛴다.
+5. Nested handle은 같은 delimiter를 재귀적으로 만든다. Resumed path는 perform과
+   handler 사이에서 capture된 모든 case/conditional/short-circuit/nested-handle
+   frame에 다시 진입한다. Non-resumed path는 해당 frame을 포기한다.
 
-The converter must derive all continuations from regions, block suffixes,
-`tribute_control.yield`, verified `operation_kind`, and callable convention
-metadata. It must not rescan the typed AST, inspect AST containment, infer an
-operation kind, or add construct-specific rules for case, guard, short-circuit,
-or nested handles.
+Converter는 region, block suffix, `tribute_control.yield`, 검증된
+`operation_kind`, callable convention metadata에서 모든 continuation을
+도출해야 한다. Typed AST를 다시 scan하거나 AST containment를 검사하거나
+operation kind를 추론하거나 case, guard, short-circuit, nested handle 전용 규칙을
+추가해서는 안 된다.
 
-The affine `resume_token` is a logical ownership capability. It may be unused
-or consumed once. Source `op -> Never`, identified by canonical `core.never`
-rather than an erased `anyref` placeholder, creates no token. Closure capture
-transfers the token's static ownership path; copying, storing, returning, or
-yielding it is invalid. Operation-local verification checks token/result types
-and rejects a token or nested `resume` in a `Never` handler. Whole-IR
-validation follows use-def and closure-capture edges to enforce one static
-ownership path and lexical association with one resumptive general handler.
+Affine `resume_token`은 logical ownership capability다. 사용하지 않거나 한 번
+소비할 수 있다. Erased `anyref` placeholder가 아니라 canonical `core.never`로
+식별한 source `op -> Never`는 token을 만들지 않는다. Closure capture는 token의
+static ownership path를 이전한다. Copy, store, return, yield는 invalid이다.
+Operation-local verification은 token/result type을 검사하고 `Never` handler의
+token이나 nested `resume`을 거부한다. Whole-IR validation은 use-def와
+closure-capture edge를 따라가 single static ownership path와 resumptive general
+handler 하나와의 lexical association을 강제한다.
 
-Static SSA validation does not prove dynamic one-shot behavior after capture:
-the same closure value may be invoked repeatedly. Conversion must therefore
-lower a captured resumption with runtime consumed state, and a second
-invocation must be rejected or trap before re-entering the continuation. This
-is the existing scoped-resumption runtime responsibility, not a backend
-carrier-selection decision. Conversion consumes the direct token and does not
-expose it in post-CPS IR.
+Static SSA validation은 capture 뒤의 dynamic one-shot 동작을 증명하지 못한다.
+같은 closure value를 반복 호출할 수 있기 때문이다. 따라서 conversion은
+capture된 resumption을 runtime consumed state와 함께 lower해야 하며, 두 번째
+호출은 continuation에 다시 진입하기 전에 거부하거나 trap해야 한다. 이는 기존
+scoped-resumption runtime 책임이며 backend carrier-selection 결정이 아니다.
+Conversion은 직접형 token을 소비하고 post-CPS IR에 노출하지 않는다.
 
-The `op -> Never` reject continuation is a compiler-generated closure with the
-ordinary continuation ABI, no captures, and a `func.unreachable` body. It may
-be shared within one compilation unit. `ability.perform` receives that typed
-closure, and `effect.dispatch_cps` receives its ordinary closure-to-`anyref`
-conversion. Null, an in-band sentinel, and arbitrary `anyref` are invalid
-substitutes. Invocation traps because a `Never` handler is forbidden to
-resume; the adapter is an ABI guard, not a source path or backend carrier
-choice.
+`op -> Never` reject continuation은 compiler가 만드는 closure다. 일반
+continuation ABI를 사용하고 capture가 없으며 body는 `func.unreachable`이다.
+Compilation unit 하나에서 공유할 수 있다. `ability.perform`은 이 typed closure를
+받고 `effect.dispatch_cps`는 일반 closure-to-`anyref` conversion 결과를 받는다.
+Null, in-band sentinel, 임의의 `anyref`는 invalid substitute다. `Never` handler는
+resume할 수 없으므로 호출되면 trap한다. 이 adapter는 ABI guard이며 source
+path나 backend carrier 선택이 아니다.
 
-### Legalization boundaries
+### 적법화 경계
 
-The named `tribute-control-pre-cps` boundary accepts verified
-`tribute_control.*` beside ordinary high-level and mid-level dialects.
-Frontend conformance makes all existing `ability.*`, `effect.*`, and legacy
-CPS-dispatch operations illegal. During a partial #823 rewrite, source and
-lowered operations may coexist transiently; that transient state is not the
-named pre-CPS boundary.
+`tribute-control-pre-cps` named boundary는 검증된 `tribute_control.*`과 일반
+high-level/mid-level dialect의 공존을 허용한다. Frontend 적합성 검사는 기존
+`ability.*`, `effect.*`, legacy CPS-dispatch operation을 모두 illegal로 만든다.
+Issue #823의 partial rewrite 도중에는 source operation과 lowered operation이
+일시적으로 공존할 수 있지만 이 상태는 named pre-CPS boundary가 아니다.
 
-Successful shared conversion verifies the partial
-`tribute-control-post-cps` target, whose defining rule is
-`illegal_dialect("tribute_control")`. Any residual direct-control operation is
-a conversion failure at its source location. Later shared passes may still
-consume `ability.*`, `effect.*`, and `closure.*`. Native and Wasm
-backend-ready Tribute boundaries independently reject residual
-`tribute_control.*`, `ability.*`, and `effect.*`; they do not rely only on a
-previous pass having run.
+성공한 shared conversion은 defining rule이
+`illegal_dialect("tribute_control")`인 partial
+`tribute-control-post-cps` target을 검증한다. 남은 direct-control operation은
+source location에서 conversion failure가 된다. 이후 shared pass는
+`ability.*`, `effect.*`, `closure.*`를 계속 소비할 수 있다. Native와 Wasm의
+backend-ready Tribute boundary는 남은 `tribute_control.*`, `ability.*`,
+`effect.*`를 각각 독립적으로 거부하며 앞선 pass 실행 여부에만 의존하지 않는다.
 
 논리적 CPS 함수는 source result를 직접 반환하지 않는다. 완료 값은 `done_k`의
 인자로 전달되고 함수와 continuation의 control result는 `Never`다. 아래 예시의
@@ -229,7 +218,7 @@ continuation chain의 결과를 되돌려 보내기 위해 사용하는 compatib
 향후 control lowering은 이를 true tail call의 `Never` 또는 trampoline의 `Step`으로
 대체할 수 있다.
 
-## Current private CPS completion carrier (#815)
+## 현재 비공개 CPS 완료 전달체 (#815)
 
 Until #774 supplies a general logical/backend control-result separation, the
 narrow #815 compatibility protocol at a handle boundary is:
@@ -278,9 +267,9 @@ The shared evidence ABI threads the dynamic tag through `effect.extend`,
 and Wasm obtain the same tag from the selected evidence marker before invoking
 that closure. Shared lowering compares integer owner tags; it does not require
 target-independent reference equality or an owner allocation. This is a
-single private compatibility representation, not the logical
-`tribute_control` semantic contract and not #774's general backend
-carrier-selection policy.
+이는 하나의 private compatibility representation일 뿐 logical
+`tribute_control` semantic contract도, #774의 general backend carrier-selection
+정책도 아니다.
 
 현재 compatibility representation에서 캡처 없는 identity `done_k`의 함수 본문은
 컴파일 단위 전체에서 동일하다. AST-to-IR lowering은 이 내부 함수 정의를 compilation
@@ -307,7 +296,7 @@ Typechecking은 이 source kind를 보존하고 frontend는 모든 ability invoc
 }
 ```
 
-Issue #823 semantic legalization이 `operation_kind = @fn`을 보고 continuation을
+Issue #823의 semantic legalization은 `operation_kind = @fn`을 보고 continuation을
 만들지 않은 채 기존 `ability.call` 경로로 내린다:
 
 ```text
@@ -351,7 +340,7 @@ direct-style `perform`이다:
 }
 ```
 
-Issue #823 semantic legalization이 `operation_kind = @op`을 보고 block suffix에서
+Issue #823의 semantic legalization은 `operation_kind = @op`을 보고 block suffix에서
 명시적인 continuation closure를 구성한 뒤 `ability.perform`으로 내린다.
 
 ```text
@@ -390,15 +379,14 @@ Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므
 항상 tail-resumptive인지 분석하여 tail path로 최적화하는 작업은 표준 `@op`
 semantic lowering 이후의 별도 IR optimization이다.
 
-### Current pre-M2 frontend value/computation boundary
+### 현재 pre-M2 frontend 값/계산 경계
 
-The following `ast_to_ir` normalization and `lower_value`/`lower_comp` split is
-the current implementation baseline. Its compositional behavior is evidence
-for the M2 region conversion and must remain correct during migration, but
-frontend-owned normalization and continuation construction are not the
-permanent phase boundary. After #824, `tribute-front` emits verified
-direct-style regions; after #826, superseded CPS-only frontend machinery is
-removed.
+다음 `ast_to_ir` normalization과 `lower_value`/`lower_comp` 분리는 현재
+implementation baseline이다. Compositional 동작은 M2 region conversion의
+근거이며 migration 도중에도 정확해야 한다. 그러나 frontend-owned
+normalization과 continuation 구성은 영구 phase boundary가 아니다. #824 뒤에는
+`tribute-front`가 검증된 직접형 region을 emit하고 #826 뒤에는 대체된 CPS-only
+frontend machinery를 제거한다.
 
 `ast_to_ir`는 lowering 직전에 작은 typed-AST A-normalization을 한 번 수행한다.
 이것은 새 HIR, source language phase, 또는 source effect 의미가 아니다. 기존
@@ -519,11 +507,10 @@ nested-call lifting과 반복 containment scan을 대체한다. 현재 AST에는
 expression variant가 없으므로 unary strict-child normalization은 적용 대상이
 아니다.
 
-`#816`은 현재 `anyref` compatibility carrier를 보존한다. #815 adds only the
-owner-tagged private escape protocol above. General logical/backend
-control-result selection remains #774 work. The direct-style
-`tribute_control` contract is fixed above; implementation and migration remain
-owned by Issues #822 through #826.
+`#816`은 현재 `anyref` compatibility carrier를 보존한다. #815는 위의
+owner-tagged private escape protocol만 추가한다. General logical/backend
+control-result 선택은 계속 #774의 작업이다. 직접형 `tribute_control` contract는
+위에서 확정했으며 구현과 migration은 Issues #822부터 #826까지가 담당한다.
 
 Rust lowering은 sealed answer domain marker로 이 경계를 표현한다. `Ambient`는
 함수/바깥 CPS chain의 control answer, `HandleAnswer`는 handle delimiter 안의
@@ -619,9 +606,12 @@ __tribute_evidence_lookup_handler(ev: ptr, ability_id: i32) -> ptr
 Effect 발생 시점에서 이미 handler closure로 tail-call되므로,
 `lower_handle_dispatch`는 body result에 `done` handler를 적용하는 역할만 한다.
 
-## Current shared middle-end pipeline
+<!-- markdownlint-disable-next-line MD033 -->
+<a id="current-shared-middle-end-pipeline"></a>
 
-Until #823-#825 land, the implemented shared pipeline remains:
+## 현재 공통 middle-end 파이프라인
+
+Issues #823-#825를 구현하기 전까지 현재 구현된 shared pipeline은 다음과 같다:
 
 ```text
 ast_to_ir
@@ -636,17 +626,16 @@ ast_to_ir
 → backend-specific lowering
 ```
 
-Future effect specialization and handler inlining use the same validation
-contract defined in `optimizations.md`.
+향후 effect specialization과 handler inlining은 `optimizations.md`에 정의한 동일한
+validation contract를 사용한다.
 
-In this current baseline, `ast_to_ir` creates effectful functions and closures
-with evidence parameters and the compatibility CPS representation. This is
-descriptive, not the permanent ownership boundary. The M2 target inserts
-`tribute_control` CPS legalization before the existing ability/effect passes;
-after #824 the frontend does not construct continuations, and #826 removes the
-superseded path. Shared lowering still emits the same `effect.*` ABI
-operations, which backends lower into evidence runtime calls, closure
-decomposition, and target-specific indirect calls.
+현재 baseline에서 `ast_to_ir`는 evidence parameter와 compatibility CPS
+representation을 갖는 effectful function과 closure를 만든다. 이는 현재 구현의
+설명이지 영구 ownership boundary가 아니다. M2 target은 기존 ability/effect pass
+앞에 `tribute_control` CPS legalization을 삽입한다. #824 뒤에는 frontend가
+continuation을 구성하지 않고 #826이 대체된 path를 제거한다. Shared lowering은
+계속 같은 `effect.*` ABI operation을 emit하며 backend가 이를 evidence runtime
+call, closure decomposition, target-specific indirect call로 lower한다.
 
 ## Effect ABI Boundary
 
@@ -670,11 +659,10 @@ Rules:
 - Backend-ready conversion targets must reject residual `effect.*` operations.
 - Shared passes must not inspect Marker field numbers, handler-table storage
   layout, closure field positions, or backend function-pointer representation.
-- Payload values are already packed into a single value by shared lowering.
-  The M2 frontend retains source-logical `tribute_control.perform` operands
-  and does not pack them for a dispatch strategy. Missing payloads are
-  represented explicitly by a target-independent null/empty value before
-  reaching `effect.*`.
+- Payload value는 shared lowering에서 이미 single value로 pack한다. M2 frontend는
+  source-logical `tribute_control.perform` operand를 유지하며 dispatch 전략에
+  맞춰 pack하지 않는다. 누락된 payload는 `effect.*`에 도달하기 전에
+  target-independent null/empty value로 명시적으로 표현한다.
 
 ## Backend Implications
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -62,9 +62,11 @@ tribute        -> tribute-front + tribute-passes
 - `tribute-passes`는
   [atomic callable/control conversion](cps-effects.md#pre-cps-callable-shape)과
   post-CPS legality를 소유한다.
-- Root `tribute` crate는 frontend emission과 shared conversion을 조합한다. Root
-  `main`의 external Direct/EvidenceDirect ABI를 유지하면서 internal terminal
-  continuation과 empty/inserted evidence를 구성하는 책임도 이 계층과 #823에 있다.
+- Root `tribute` crate는 frontend emission과 shared conversion을 조합한다.
+  Target-independent root bridge는 completion cell과 terminal continuation의 추상
+  조합 계약만 정한다. #825가 `core.never` CPS signature를 target empty-result
+  signature로 내린 뒤 external Direct/EvidenceDirect wrapper와 ordinary call을
+  합성한다.
 
 검증 책임은 구현 계층과 분리한다:
 
@@ -81,24 +83,36 @@ tribute        -> tribute-front + tribute-passes
 
 구현 순서는 다음과 같다:
 
-1. #822가 `tribute-ir`에 callable/control type과 operation, verifier를 구현한다.
+1. #822가 `tribute-ir`에 callable/control type과 operation, verifier, 선택한
+   custom assembly와 round-trip/negative test를 구현한다.
 2. #823이 `tribute-passes`에 atomic callable/control conversion과 legality를
-   구현한다.
+   구현하고 generic `func.tail_call_indirect`를 추가해 direct/indirect CPS
+   transfer를 모두 physical tail operation으로 만든다.
 3. #824가 `tribute-front`를 `tribute_control` callable/control emission으로
    전환한다.
-4. #825가 root pipeline에 conversion과 backend residual 검사를 조합한다.
+4. #825가 `core.never` CPS signature를 native/Wasm empty-result signature로
+   내린 뒤 root/export completion-cell wrapper와 ordinary call을 합성하고,
+   `func.tail_call_indirect` target lowering 및 backend residual 검사를 구현한다.
 5. #826이 migrated coverage를 확인한 뒤 frontend-owned physical callable ABI,
-   CPS normalization과 continuation 구성, 중복 compatibility lowering을 제거한다.
+   CPS normalization/continuation 구성, `anyref` control carrier,
+   `Normal | Escape`와 legacy trampoline builtin을 제거한다.
 
 Issue #823과 #824의 준비 작업은 #822 뒤에 병행할 수 있지만, 두 계약이 합의되고 #825가
 조합하기 전에는 새 경계가 live라고 주장할 수 없다. Partial rewrite 내부의
 direct/lowered operation 공존은 허용하지만 named boundary에는 허용하지 않는다.
+Issue #822 test는 `func` 선언/정의와 선택적 추가 attribute,
+`lambda`의 빈/비어 있지 않은 명시적 capture와 선택적 추가 attribute에 대한
+print-parse-print round trip을 포함한다. 출력기는 빈 capture도 `captures []`로
+출력한다. 알 수 없는 convention, signature와 body argument 불일치, operation의
+중복 `tribute.calling_convention` 저장은 parse 또는 verifier에서 거부한다.
 
-이 작업은 #774가 소유하는 `Never`/`Step`/trampoline carrier 선택을 하지 않는다.
-현재 owner-tagged private `Normal | Escape(owner_tag, payload)` protocol은
-compatibility implementation으로 남을 수 있지만, 해당 private carrier임이
-증명된 value만 검사할 수 있다. Source `op -> Never`의 canonical `core.never`와
-typed zero-capture `func.unreachable` adapter를 포함한 conversion 세부는
+이 migration은 #774에서 분리된 tail-call-only slice를 구현한다. Logical CPS
+result는 `core.never`, physical CPS ABI는 empty result이며 `Step`, trampoline,
+compatibility control-result `anyref`를 선택하지 않는다. #774는
+logical/physical control 분리의 관련 배경으로 남는다. 현재 owner-tagged private
+`Normal | Escape(owner_tag, payload)`는 migration 동안 증명된 value에만 접근하고
+Issue #826에서 제거한다. Source `op -> Never`의 canonical `core.never`와 typed
+zero-capture `func.unreachable` adapter를 포함한 conversion 세부는
 [cps-effects.md](cps-effects.md#direct-style-control-boundary)를 따른다.
 
 Source syntax, effect-row semantics, `Direct < EvidenceDirect < Cps` 순서, ability
@@ -428,7 +442,12 @@ Direct/EvidenceDirect seed로 유지하고 shared identity continuation으로 co
 닫은 뒤 복구한 source value를 정상 반환한다. 이 frontend-owned closing step은
 migration baseline이지 영구 phase boundary가 아니다. #824 뒤에는 frontend가
 direct-style control을 emit하고 `tribute-passes`의 shared conversion이 root
-computation을 닫는다. 실제 residual general effect는 backend entrypoint 전에 계속
+computation의 추상 completion-cell 계약을 만든다. 이 단계의 CPS entry와
+`done_k`는 `core.never`를 반환한다. #825는 target signature lowering이 이를
+empty result로 바꾼 뒤에만 Direct/EvidenceDirect export wrapper의 ordinary call을
+합성한다. Wrapper는 typed completion cell을 소유하고 root `done_k`가 이를 쓴 뒤
+target call이 돌아오면 cell을 읽는다. Shared `func.call`에 zero-result 형상을
+추가하지 않는다. 실제 residual general effect는 backend entrypoint 전에 계속
 거부하며 nested-module `main`은 특별하지 않다.
 
 기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
@@ -443,11 +462,11 @@ runtime ABI 또는 host import로 operation을 완전히 lower해야 한다.
 fn cps(ev: Evidence, done_k: fn(T) -> Never, args...) -> Never
 ```
 
-현재 IR은 true tail call이 모든 경로에서 보장되지 않으므로 continuation chain의
-행정적 반환값을 `anyref`로 전달하는 compatibility representation을 사용한다.
-`anyref`는 source result가 아니며 `Cps` convention의 영구적인 의미도 아니다.
-Control lowering이 분리되면 true tail-call backend는 `Never`, trampoline
-backend는 `Step`, 기존 경로는 `anyref` carrier를 선택할 수 있다.
+최종 physical ABI는 empty result를 쓰고 direct transfer는 `func.tail_call`,
+closure/continuation/`done_k` transfer는 `func.tail_call_indirect`를 쓴다. 현재
+`anyref` control carrier는 migration 동안만 허용하며 #826에서 제거한다. Boxed
+source value, payload, closure environment 같은 일반 reference erasure는 유지할 수
+있다.
 
 ### 런타임 함수
 
@@ -525,8 +544,8 @@ boundary에서는 contextual convention에 맞는 adapter를 사용한다. 명�
 닫힌 빈 row이므로 Direct를 사용한다.
 
 여기서 `Cps`는 source result를 직접 반환하지 않고 `done_k`로 전달한다는
-논리적 convention이다. 실제 lowered result carrier는 control-lowering 전략이
-`Never`, `Step`, 또는 compatibility `anyref` 중에서 결정한다.
+논리적 convention이다. Lowering은 `core.never`를 empty-result proper tail
+transfer로 바꾸며 대체 carrier를 선택하지 않는다.
 
 따라서 `fn`과 `op`를 함께 선언한 ability는 함수 ABI를 정할 때 `Cps`로
 분류한다. 이는 안전한 **ability 단위 상한**이다. 다만 CPS 함수 안에서도 개별
@@ -775,9 +794,9 @@ yield bubbling / `YieldResult` trampoline 방식은 active path가 아니다.
 
 Wasm lowering은 `effect.extend`, `effect.dispatch_tail`,
 `effect.dispatch_cps`를 evidence helper, closure unpacking, and
-`wasm.call_indirect`로 낮춘다. 남아 있는 `Step`, `Continuation`,
-`ResumeWrapper` builtin 타입은 과거 trampoline 경로의 호환 흔적이며, 새 effect
-ABI lowering의 의미론적 기준이 아니다.
+direct `wasm.return_call` 또는 indirect `wasm.return_call_indirect`로 낮춘다.
+일반 source data call은 계속 `wasm.call_indirect`를 사용할 수 있다. 남아 있는
+`Step`, `Continuation`, `ResumeWrapper` builtin은 #826에서 제거한다.
 
 ### WASM / Native 공통: CPS Tail-Call Effect Handling
 
@@ -804,10 +823,11 @@ WASM:   → lower_to_wasm [includes evidence_to_wasm] → emit_wasm
 Native: → evidence_to_native → lower_to_clif → emit_native
 ```
 
-계획한 직접형 target은 physical callable/closure/effect lowering 전에 검증된
-`tribute_control` callable/control emission과 shared CPS legalization을 삽입한다.
-Issue #823과 #824가 합의한 뒤 정확한 pipeline splice는 #825가 소유한다. 이 문서는 해당
-splice가 이미 구현되었다고 주장하지 않는다.
+계획한 직접형 target은 frontend emission 뒤 `tribute_control_to_cps`를 실행한다.
+그 출력은 physical callable/closure 표면과 logical `ability.*` 표면이며, 위의
+기존 closure, ability/evidence, backend effect ABI pass가 순서대로 소비한다.
+Issue #823과 #824가 합의한 뒤 정확한 pipeline splice는 #825가 소유한다. 이 문서는
+해당 splice가 이미 구현되었다고 주장하지 않는다.
 
 ---
 
@@ -816,7 +836,7 @@ splice가 이미 구현되었다고 주장하지 않는다.
 ### WasmGC
 
 런타임의 GC가 자동으로 처리한다. 다만 현재 주요 구현 경로는 native이며,
-WasmGC continuation/trampoline 객체 설계는 active path가 아니다.
+WasmGC CPS continuation은 closure로 표현하고 trampoline object는 만들지 않는다.
 
 ### Cranelift: Reference Counting
 
@@ -896,16 +916,55 @@ pub fn compile(db, source: SourceCst) -> Module {
 다음은 계획한 직접형 topology이며 Issue #825가 #823과 #824를 조합하기 전까지 현재
 live pipeline이 아니다:
 
-```text
-source
-  -> parse / merge prelude / resolve / typecheck / TDNR
-  -> tribute-front emits verified tribute_control callable/control + ordinary value IR
-  -> tribute-passes atomically legalizes callable/control to physical CPS IR
-  -> existing closure / ability / evidence / effect ABI passes
-  -> canonicalize / DCE / resolve casts
-  -> native or Wasm lowering
-  -> backend-ready residual-control verification
-  -> emit
+```mermaid
+flowchart TB
+    subgraph input["입력"]
+        source["Tribute source"]
+    end
+
+    subgraph frontend["Frontend"]
+        parse["parse / prelude / resolve"]
+        typecheck["typecheck / TDNR"]
+        direct["검증된 tribute_control callable/control IR"]
+    end
+
+    subgraph shared["Shared legalization과 lowering"]
+        cps["atomic tribute_control_to_cps (#823)"]
+        physical["physical func/closure + logical ability dispatch"]
+        closure["closure lowering"]
+        ability["ability/evidence lowering"]
+        effect["target-independent effect ABI"]
+    end
+
+    subgraph targets["Proper tail-call lowering (#825)"]
+        native_tail["Native direct/indirect return_call"]
+        wasm_tail["Wasm return_call/return_call_indirect"]
+    end
+
+    subgraph verify["Backend-ready 검증"]
+        native_ready["native full boundary"]
+        wasm_ready["Wasm emission boundary"]
+    end
+
+    subgraph output["출력"]
+        native_bin["native binary"]
+        wasm_bin[".wasm"]
+    end
+
+    source --> parse
+    parse --> typecheck
+    typecheck --> direct
+    direct --> cps
+    cps --> physical
+    physical --> closure
+    closure --> ability
+    ability --> effect
+    effect --> native_tail
+    effect --> wasm_tail
+    native_tail --> native_ready
+    wasm_tail --> wasm_ready
+    native_ready --> native_bin
+    wasm_ready --> wasm_bin
 ```
 
 현재 compatibility topology는
@@ -920,20 +979,25 @@ Migrated coverage가 #826의 frontend-owned CPS 구성 제거를 허용할 때�
 | **Frontend** | `resolve` | tribute.* ops | func.*, adt.* | ✓ |
 | | `inline_constants` | const refs | inlined values | |
 | | `typecheck` | type.var | solved or generalized typed AST | ✓ |
-| **Closure** | `lambda_lift` | lambdas | top-level funcs | |
-| | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
-| | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
+| | `lambda_lift` | lambdas | top-level funcs | |
 | | `tdnr` | x.method() | Type::method(x) | |
 | **직접형 제어 (계획)** | `ast_to_ir` | typed AST | 검증된 `tribute_control` callable/control + 일반 value IR | frontend, #824 계획 |
-| | `tribute_control_to_cps` | logical callable/control + typechecked metadata | atomic physical func/closure graph + kind-directed ability/effect CPS IR | shared, #823 계획 |
-| **Ability (현재 compatibility)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
-| | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |
+| | `tribute_control_to_cps` | logical callable/control + typechecked metadata | physical func/closure/tail-call + logical `ability.*`; `effect.*` 없음 | shared, #823 계획 |
+| **Closure (공유 후속)** | `lower_closure_lambda` | closure.lambda | func.func + closure.new | module-wide |
+| | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
+| | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
+| **Ability/evidence (공유 후속)** | `lower_ability_perform` | ability.perform/call | effect.dispatch_* + evidence lookup | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | module-wide setup before function-local lowering |
 | | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |
+| **Ability (현재 compatibility 전용)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
+| | `tail_resumptive` | legacy ability suspension shape | optimized legacy shape | function-anchored |
 | **Backend effect ABI** | `native/evidence runtime decls` | evidence runtime stubs | native extern declarations | module-wide |
-| | `native/evidence` | effect.* | native runtime calls + call_indirect | function-anchored |
+| | `native/evidence` | effect.* | native runtime + func tail transfer | function-anchored |
+| | `func_to_clif` | func.tail_call / indirect | clif.return_call / indirect | function-anchored, #825 |
 | | `wasm/evidence runtime funcs` | evidence runtime stubs | wasm evidence helpers | module-wide |
-| | `wasm/evidence_to_wasm` | effect.* | wasm.call + wasm.call_indirect | function-anchored |
+| | `wasm/evidence_to_wasm` | effect.* | wasm helpers + indirect return_call | function-anchored |
+| | `func_to_wasm` | func.tail_call / indirect | wasm.return_call / indirect | function-anchored, #825 |
+| **Migration cleanup** | #826 cleanup | compatibility CPS/frontend path | carrier와 legacy trampoline builtin 없음 | module-wide |
 | **Lowering** | `ast_to_ir case lowering` | tribute.case | scf.if | frontend lowering, not a pass |
 | | `canonicalize`, local `dce`, `scf_to_cf` | func.func body | canonical body / cf blocks | function-anchored |
 | | `global_dce` | module symbols | reachable funcs | module-wide |

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -38,6 +38,175 @@ TrunkIR validation follows the layered model in `new-plans/ir.md`:
 Do not add a separate semantic-contract DSL unless these existing mechanisms
 cannot express a required invariant.
 
+## M2 direct-style control ownership
+
+Issue #821 fixes the design contract; it does not make the new pipeline live.
+The M2 target moves continuation construction out of `tribute-front`:
+
+```text
+typed AST
+  -> tribute-front: verified tribute_control direct-style IR
+  -> tribute-passes: shared CPS legalization
+  -> existing ability/effect/closure lowering
+  -> native or Wasm lowering
+```
+
+The dependency direction is mandatory:
+
+```text
+tribute-front  -> tribute-ir + trunk-ir
+tribute-passes -> tribute-ir + trunk-ir
+tribute        -> tribute-front + tribute-passes
+```
+
+`tribute-front` must not depend on `tribute-passes`. The root `tribute` crate
+orchestrates frontend emission followed by shared conversion.
+
+The dialect identifier is exactly `tribute_control`, and its minimal operations
+are `tribute_control.perform`, `tribute_control.handle`,
+`tribute_control.handler`, `tribute_control.resume`, and
+`tribute_control.yield`. The fixed structural and verifier contracts are in
+[ir.md](ir.md#direct-style-control); the conversion contract is in
+[cps-effects.md](cps-effects.md#m2-direct-style-boundary).
+
+ANF remains an invariant of frontend output. It does not move ordinary calls,
+arithmetic, ADT/list/closure construction, or structured selection into
+`tribute_control`. There is no new effectful invocation operation:
+`func.call`, `func.call_indirect`, and callable convention metadata already
+provide the necessary `Direct < EvidenceDirect < Cps` distinction. In
+contrast, every source ability invocation, both `fn` and `op`, uses
+`tribute_control.perform` with the required typechecked
+`operation_kind = @fn | @op`. Typechecking preserves that source-semantic
+distinction; `tribute-front` copies it into IR and does not choose a dispatch
+strategy.
+
+Pre-CPS definitions, lambdas, direct calls, and indirect calls keep only their
+source-logical parameters and source result. `EvidenceDirect` has no hidden
+evidence operand yet, and `Cps` has neither evidence nor a frontend-created
+`done_k`; convention metadata is the phase marker. #823 uses the existing
+`CallableAbi` ordering to signature-convert the entire callable graph:
+
+```text
+Direct         (source...)                 -> source result
+EvidenceDirect (evidence, source...)       -> source result
+Cps            (evidence, done_k, source...) -> compatibility control result
+```
+
+The same conversion rewrites `func.func`, `closure.lambda`, `core.func` and
+closure types, entry block arguments, `func.call`, and `func.call_indirect`.
+A `Cps` logical return invokes `done_k`; an `EvidenceDirect` body receives the
+new evidence argument used by lowered ability invocations. In the same #823
+legalization, `operation_kind = @fn` becomes `ability.call`/tail dispatch
+without suffix capture, while `operation_kind = @op` becomes
+`ability.perform`/CPS dispatch with a suffix continuation. `CallableAbi`
+governs callable signatures; it does not encode or infer operation kind.
+Conversion runs before closure extraction so a lambda and every
+direct/indirect use agree on one physical signature. Metadata/type disagreement
+fails conversion.
+
+Root source `main` retains its external Direct or EvidenceDirect ABI. #823 and
+the root `tribute` pipeline own its internal terminal continuation: they close
+an implementation-level CPS body, use empty evidence for a Direct root or the
+inserted argument for an EvidenceDirect root, and return the logical source
+result. `tribute-front` does not build this delimiter after #824.
+
+The implementation must preserve these validation responsibilities:
+
+- `tribute-ir` owns typed wrappers, parser/printer round trips, and local
+  verifiers for all `tribute_control` operations and
+  `resume_token<input, answer>`. The `perform` verifier requires
+  `operation_kind = @fn | @op`; frontend conformance checks it against the
+  typechecked declaration and verifies kind-specific argument/result types.
+- The containing `tribute_control.handle` verifier checks handler placement,
+  uniqueness, region shape, block arguments, terminators, and type agreement.
+- Whole-IR verification follows use-def and closure-capture edges for one
+  static ownership path of a resume token and checks SSA visibility. It cannot
+  prove how many times a captured closure is invoked; converted resumptions
+  carry runtime one-shot state and reject or trap a second dynamic invocation.
+  This is not conversion legality.
+- `tribute-passes` owns the conversion patterns and the
+  `tribute-control-post-cps` target. It must reject every residual
+  `tribute_control.*` operation after successful conversion.
+- The Tribute native and Wasm pipelines each reject residual
+  `tribute_control.*`, `ability.*`, and `effect.*` before their backend-ready
+  boundary. Generic `trunk-ir` remains free of Tribute-specific semantics.
+
+The full `tribute-control-pre-cps` frontend-conformance target makes existing
+`ability.*`, `effect.*`, and legacy CPS-dispatch operations illegal. Only the
+in-progress partial rewrite in #823 may temporarily contain those lowered
+operations beside residual `tribute_control.*`; neither named boundary treats
+that coexistence as successful conformance.
+
+The current TrunkIR dialect macro can represent this fixed five-operation,
+fixed-region surface, and the generic parser/printer already round-trips one
+`dialect.operation` separator plus ordinary regions and block arguments.
+TrunkIR's current `validate_operation_verifiers` entrypoint directly calls its
+builtin verifiers; it has no dialect callback registry. #822 must therefore
+expose the Tribute-specific local validator from `tribute-ir`, and the
+frontend/pre-CPS boundary must call it alongside generic SSA/use-chain
+validation. A later generic verifier registry is optional infrastructure, but
+no `tribute_control` rule may be implemented in `trunk-ir`.
+
+The region strategy is uniform. The converter threads a logical exit
+continuation through each block suffix. Selected case/conditional arms, guards,
+and short-circuit right-hand sides receive an exit that reaches their merge
+and then the enclosing suffix. Handle bodies introduce delimiters; completion
+regions run only on normal body completion; resumptive general handler arms
+may consume their affine resumption and then continue through arm-local strict
+work. A source `op -> Never` arm receives no resume token and contains no
+`tribute_control.resume`. Nested handles apply the same rule recursively.
+Strict values evaluate once, left to right, and unselected regions never
+evaluate.
+
+The M2 implementation order is:
+
+1. #822 implements and tests the verified dialect in `tribute-ir`.
+2. #823 converts synthetic direct-style IR in `tribute-passes`, including
+   kind-directed `perform` lowering, nested regions, resume suffixes,
+   simultaneous `CallableAbi` signature conversion, and post-CPS legality. It
+   consumes `operation_kind`; it never infers or changes it.
+3. #824 changes `tribute-front` to emit the direct dialect for every `fn` and
+   `op` invocation, copying the typechecked kind without emitting
+   `ability.call`, `ability.perform`, or `effect.dispatch_*`, while retaining
+   the dependency graph above.
+4. #825 composes conversion in `tribute` and makes native/Wasm residual-control
+   rejection mandatory.
+5. #826 removes superseded typed-AST CPS normalization, frontend continuation
+   construction, and duplicate compatibility lowering after migrated coverage
+   passes.
+
+Preparatory #823 and #824 work may proceed after #822, but integration cannot
+claim the new boundary until the shared contracts agree. During migration, a
+partial conversion may transiently contain direct and lowered operations
+together. The named post-CPS boundary never does.
+
+The logical contract deliberately does not select `Never`, `Step`, a
+trampoline, or another backend carrier. #774 owns logical-versus-physical
+control-result selection. The current owner-tagged private
+`Normal | Escape(owner_tag, payload)` completion protocol may remain as an M2
+compatibility implementation, but no `tribute_control` operation exposes its
+tag, variants, or representation. Only values proven to be that private
+carrier may be inspected by its compatibility lowering.
+
+For source `op -> Never`, #823 still satisfies the current mandatory
+continuation operand of `ability.perform` and `effect.dispatch_cps`. It passes
+a compiler-generated, typed, zero-capture continuation closure whose body is
+`func.unreachable`. The adapter captures no source suffix and traps if a
+malformed path invokes it. It may be deduplicated per compilation unit. Null,
+in-band sentinels, and arbitrary `anyref` are never accepted as continuation
+substitutes, and no new IR operation is required.
+
+TrunkIR already defines `core.never`. #824 must use that canonical type for a
+direct-style source `Never` result so #822/#823 can recognize the no-token
+case structurally. The current pre-M2 `convert_type` mapping of `Never` to an
+`anyref` placeholder is compatibility behavior and must not cross the
+`tribute-control-pre-cps` boundary.
+
+M2 does not change source syntax, effect-row semantics, the convention order,
+ability optimization policy, or multi-file compilation. It does not select
+`Never`/`Step`/trampoline carriers and does not move Tribute semantics into
+generic `trunk-ir`.
+
 ---
 
 ## Nominal Type Identity
@@ -200,6 +369,11 @@ fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
 `resume`은 키워드이므로 단독으로 값이 될 수 없고, 호출 위치(`resume expr`)에서만
 사용할 수 있다. 다만 `fn() resume state`처럼 람다 안에서 호출하는 것은 가능하며,
 이 경우 continuation의 affine 사용(최대 1회 호출)은 런타임에서 보장해야 한다.
+`tribute_control`의 정적 verifier는 이 캡처까지 이어지는 단일 ownership path와
+금지된 escape만 확인한다. 동일 closure의 동적 재호출 가능성은 정적으로 제거되지
+않으므로, CPS conversion이 생성한 resumption은 consumed state를 유지하고 두 번째
+호출을 재진입 전에 거부하거나 trap해야 한다. Source `op -> Never` handler는
+resumption을 만들지 않으며 `resume_token` block argument도 받지 않는다.
 
 ---
 
@@ -348,14 +522,17 @@ Compiler-owned ambient ability `std::io::Io`만 요구하는 함수는 현재
 `Io`와 `Throw(std::io::Error)`가 함께 있으면 `Throw` 때문에 `Cps`로 승격된다.
 자세한 표준 I/O 계약은 [io.md](io.md)를 따른다.
 
-Root `main` is a frontend CPS delimiter, not a `Cps` backend entry ABI. Its
-valid source residual contract remains pure or `Io`. If its body only needs
-the stronger implementation convention because it calls a generic/open
-callback worker, AST-to-IR keeps root `main` at its Direct/EvidenceDirect
-seed, closes that computation with the shared identity continuation, and
-returns the recovered source value normally. A genuine residual general effect
-is still rejected before the backend entrypoint; nested-module `main` is not
-special.
+In the current pre-M2 implementation, root `main` is a frontend CPS delimiter,
+not a `Cps` backend entry ABI. Its valid source residual contract remains pure
+or `Io`. If its body only needs the stronger implementation convention because
+it calls a generic/open callback worker, current AST-to-IR keeps root `main` at
+its Direct/EvidenceDirect seed, closes that computation with the shared
+identity continuation, and returns the recovered source value normally. This
+frontend-owned closing step is a migration baseline, not the permanent phase
+boundary. After #824, the frontend emits direct-style control and shared
+conversion in `tribute-passes` closes the root computation. A genuine residual
+general effect is still rejected before the backend entrypoint;
+nested-module `main` is not special.
 
 기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
 Frontend shared lowering은 private intrinsic stub을 `tribute_io.write`와
@@ -430,6 +607,12 @@ ability containing any op  → Cps
 open or otherwise unknown e → Cps
 ```
 
+This ability-level convention bound does not erase an operation declaration's
+source `fn`/`op` kind. Typechecking stores that kind on the resolved operation,
+and #824 copies it to each `tribute_control.perform.operation_kind`. #823
+consumes it directly; neither `CallingConvention`, handler-body analysis, nor
+the effect-row bound reconstructs or changes it.
+
 Effect annotation 생략은 closed-empty 추론이 아니다.
 
 ```text
@@ -495,7 +678,8 @@ plain/CPS worker 복제나 specialization은 후속 최적화로 검토한다.
 
 ### 변환 범위
 
-모든 코드를 CPS로 변환하지 않는다. Ability operation 지점에서만 continuation 캡처가 필요하다:
+모든 코드를 CPS로 변환하지 않는다. Ability operation 중 typechecked
+`operation_kind = @op` 지점에서만 continuation 캡처가 필요하다:
 
 ```text
 생략 annotation의 semantic type       → open row, indirect call은 Cps
@@ -527,8 +711,10 @@ fn map(xs: List(a), f: fn(a) ->{e} b) ->{e} List(b)
 
 #### 1. 선언 수준 보장 (`fn` operation)
 
-`fn`으로 선언된 operation은 **호출 지점에서** continuation 캡처 코드를
-생성하지 않는다. Evidence에서 handler 함수를 조회하여 직접 호출한다:
+`fn`으로 선언된 operation도 pre-CPS frontend IR에서는
+`tribute_control.perform { operation_kind = @fn }`이다. #823은 보존된 kind를
+보고 continuation 캡처 코드를 생성하지 않으며, evidence에서 handler 함수를
+조회하여 직접 호출하는 경로로 내린다:
 
 ```rust
 // fn operation 호출 → shift 없이 직접 호출
@@ -575,12 +761,20 @@ fn run_state_optimized(comp, init_state) {
 }
 ```
 
-이 분석은 best-effort이며, 복잡한 handler에서는 적용되지 않을 수 있다.
+이 분석은 표준 `operation_kind = @op` semantic lowering 이후에만 실행할 수 있는
+별도 best-effort IR optimization이다. #823은 handler body를 분석하여 `op`을
+`fn`으로 재분류하거나 이 최적화를 semantic legalization과 결합하지 않는다.
+복잡한 handler에서는 적용되지 않을 수 있으며, 적용 여부가 source meaning이나
+pre-CPS IR을 바꾸지 않는다.
 
-#### `op -> Never` 최적화
+#### `op -> Never` semantics
 
-`-> Never`를 반환하는 operation은 continuation을 캡처하지 않는다.
-Handler arm에서도 `-> k`를 사용하지 않으므로 continuation 관련 오버헤드가 없다.
+`-> Never`를 반환하는 operation은 source semantics상 resume할 수 없다.
+`tribute_control.handler`는 이 arm에 `resume_token`을 노출하지 않고, nested
+region을 포함한 arm body의 `tribute_control.resume`을 verifier가 거부한다.
+따라서 conversion은 source suffix를 캡처하지 않는다. 다만 현재
+`ability.perform`/`effect.dispatch_cps` ABI를 만족시키기 위해 이미 규정한
+zero-capture reject continuation adapter는 전달한다.
 
 ---
 
@@ -669,7 +863,7 @@ op SomeOp::cancel() { fallback_value }      // 0회: 암묵적 drop
 ```
 
 항상 resume하지 않는 operation은 `-> Never`로 선언한다.
-`-> Never`는 continuation 캡처 자체를 생략하는 최적화를 가능하게 한다.
+`-> Never`는 direct-style IR에서 resume token을 만들지 않는다.
 `op -> Never` handler body에서는 `resume`을 사용할 수 없다.
 
 ---
@@ -690,7 +884,8 @@ ABI lowering의 의미론적 기준이 아니다.
 
 ### WASM / Native 공통: CPS Tail-Call Effect Handling
 
-Effect handling은 tail-call CPS 방식으로 처리된다.
+The following describes the current pre-M2 compatibility pipeline. Effect
+handling is implemented with tail-call CPS.
 `lower_ability_perform`이 `ability.perform`과 `ability.call`을 target-independent
 `effect.dispatch_cps` / `effect.dispatch_tail` ABI operation으로 변환한다.
 `resolve_evidence`는 handler 설치를 `effect.extend`로 표현한다.
@@ -703,7 +898,7 @@ native runtime call 또는 Wasm evidence helper와 indirect call로 제거한다
 **파이프라인 분기:**
 
 ```text
-공통: parse → resolve → typecheck → tdnr → ast_to_ir
+현재 공통: parse → resolve → typecheck → tdnr → ast_to_ir
       → evidence_params → prepare_closure_lowering → lower_closures_in_func
       → lower_ability_perform → resolve_evidence → lower_handle_dispatch
       → dce → resolve_casts
@@ -711,6 +906,11 @@ native runtime call 또는 Wasm evidence helper와 indirect call로 제거한다
 WASM:   → lower_to_wasm [includes evidence_to_wasm] → emit_wasm
 Native: → evidence_to_native → lower_to_clif → emit_native
 ```
+
+The M2 target inserts verified `tribute_control` emission and shared CPS
+legalization before continuation-dependent closure/effect lowering. #825 owns
+the exact pipeline splice after #823 and #824 agree; this document does not
+claim that splice is already implemented.
 
 ---
 
@@ -796,67 +996,25 @@ pub fn compile(db, source: SourceCst) -> Module {
 
 ### 파이프라인 구조
 
-```mermaid
-flowchart TB
-    subgraph input["Input"]
-        source["Tribute Source (.trb)"]
-    end
+The following is the planned M2 topology, not the current live pipeline until
+Issue #825 composes #823 and #824:
 
-    subgraph frontend["Frontend Passes"]
-        parse["parse_cst + lower_cst"]
-        prelude["merge_with_prelude"]
-        resolve["resolve"]
-        const_inline["inline_constants"]
-        typecheck["typecheck"]
-    end
-
-    subgraph closure["Closure Processing"]
-        lambda_lift["lambda_lift"]
-        closure_prep["prepare_closure_lowering"]
-        closure_func["lower_closures_in_func"]
-        tdnr["tdnr"]
-    end
-
-    subgraph ability["Ability Processing"]
-        evidence["evidence_insert"]
-        resolve_ev["resolve_evidence"]
-        tail_opt["convert_tail_resumptive"]
-    end
-
-    subgraph lowering["Final Lowering"]
-        lower_case["lower_case"]
-        dce["dce"]
-    end
-
-    subgraph backends["Code Generation"]
-        wasm["WasmGC Backend"]
-        cranelift["Cranelift Backend"]
-        future["(Future)"]
-    end
-
-    subgraph output["Output"]
-        wasm_bin[".wasm"]
-        native["native binary"]
-    end
-
-    source --> parse
-    parse -->|"tribute.* ops"| prelude
-    prelude --> resolve
-    resolve -->|"func.*, adt.*"| const_inline
-    const_inline --> typecheck
-    typecheck -->|"typed module"| lambda_lift
-    lambda_lift -->|"closure signatures"| closure_prep
-    closure_prep -->|"closure.new"| closure_func
-    closure_func -->|"call_indirect + evidence"| tdnr
-    tdnr --> evidence
-    evidence -->|"+evidence param"| resolve_ev
-    resolve_ev -->|"dispatch closures"| tail_opt
-    tail_opt --> lower_case
-    lower_case -->|"scf.if"| dce
-    dce --> wasm & cranelift & future
-    wasm -->|"WasmGC ops"| wasm_bin
-    cranelift -->|"clif.* ops"| native
+```text
+source
+  -> parse / merge prelude / resolve / typecheck / TDNR
+  -> tribute-front emits verified tribute_control + ordinary TrunkIR
+  -> tribute-passes legalizes tribute_control to CPS
+  -> existing closure / ability / evidence / effect ABI passes
+  -> canonicalize / DCE / resolve casts
+  -> native or Wasm lowering
+  -> backend-ready residual-control verification
+  -> emit
 ```
+
+The current compatibility topology is recorded in
+[cps-effects.md](cps-effects.md#current-shared-middle-end-pipeline). It remains
+live only until migrated coverage permits #826 to remove frontend-owned CPS
+construction.
 
 ### 패스 분류
 
@@ -869,7 +1027,9 @@ flowchart TB
 | | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
 | | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
 | | `tdnr` | x.method() | Type::method(x) | |
-| **Ability** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
+| **Direct control (M2 target)** | `ast_to_ir` | typed AST | verified `tribute_control` with typechecked operation kind + ordinary IR | frontend, planned #824 |
+| | `tribute_control_to_cps` | `tribute_control` + operation-kind/convention metadata | kind-directed ability/effect/closure CPS IR | shared, planned #823 |
+| **Ability (current compatibility)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
 | | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | module-wide setup before function-local lowering |
 | | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -38,18 +38,12 @@ TrunkIR validation follows the layered model in `new-plans/ir.md`:
 Do not add a separate semantic-contract DSL unless these existing mechanisms
 cannot express a required invariant.
 
-## M2 직접형 제어 소유권
+## 직접형 제어 소유권
 
-Issue #821은 design contract를 확정하지만 새 pipeline을 live 상태로 만들지는
-않는다. M2 target은 continuation 구성을 `tribute-front` 밖으로 옮긴다:
-
-```text
-typed AST
-  -> tribute-front: verified tribute_control direct-style IR
-  -> tribute-passes: shared CPS legalization
-  -> existing ability/effect/closure lowering
-  -> native or Wasm lowering
-```
+Issue #821은 continuation 구성을 `tribute-front`에서 shared pass로 옮기는 계약을
+정한다. 구조와 의미의 source of truth는
+[ir.md](ir.md#direct-style-control), conversion 규칙은
+[cps-effects.md](cps-effects.md#direct-style-control-boundary)이다.
 
 Dependency direction은 다음과 같이 고정한다:
 
@@ -59,147 +53,58 @@ tribute-passes -> tribute-ir + trunk-ir
 tribute        -> tribute-front + tribute-passes
 ```
 
-`tribute-front`는 `tribute-passes`에 의존해서는 안 된다. Root `tribute` crate가
-frontend emission 뒤의 shared conversion을 orchestrate한다.
+`tribute-front`는 `tribute-passes`에 의존하지 않는다. 각 계층의 책임은 다음과
+같다:
 
-Dialect identifier는 정확히 `tribute_control`이며 최소 operation은
-`tribute_control.perform`, `tribute_control.handle`,
-`tribute_control.handler`, `tribute_control.resume`,
-`tribute_control.yield`다. 고정된 structural/verifier contract는
-[ir.md](ir.md#direct-style-control)에, conversion contract는
-[cps-effects.md](cps-effects.md#m2-direct-style-boundary)에 있다.
+- `tribute-front`는 source-logical callable signature를 유지하고, 모든 `fn`/`op`
+  invocation을 typecheck된 `operation_kind = @fn | @op`를 가진
+  `tribute_control.perform`으로 emit한다. Dispatch 전략이나 continuation
+  representation은 선택하지 않는다.
+- `tribute-passes`는 #823의 `CallableAbi` signature conversion, kind-directed
+  `perform` lowering, region/suffix conversion, post-CPS legality를 소유한다.
+- Root `tribute` crate는 frontend emission과 shared conversion을 조합한다. Root
+  `main`의 external Direct/EvidenceDirect ABI를 유지하면서 internal terminal
+  continuation과 empty/inserted evidence를 구성하는 책임도 이 계층과 #823에 있다.
 
-ANF는 frontend output의 invariant로 유지한다. 일반 call, 산술,
-ADT/list/closure 구성, structured selection을 `tribute_control`로 옮기지 않는다.
-새 effectful invocation operation도 추가하지 않는다. `func.call`,
-`func.call_indirect`, callable convention metadata가 이미 필요한
-`Direct < EvidenceDirect < Cps` 구분을 제공한다. 반면 source ability
-invocation은 `fn`과 `op` 모두 필수 typechecked
-`operation_kind = @fn | @op`를 가진 `tribute_control.perform`을 사용한다.
-Typechecking이 이 source-semantic 구분을 보존하고 `tribute-front`는 이를 IR에
-복사할 뿐 dispatch 전략을 선택하지 않는다.
+검증 책임은 구현 계층과 분리한다:
 
-Pre-CPS definition, lambda, direct call, indirect call은 source-logical
-parameter와 source result만 유지한다. `EvidenceDirect`에는 아직 hidden evidence
-operand가 없고 `Cps`에는 evidence와 frontend가 만든 `done_k`가 모두 없다.
-Convention metadata가 phase marker다. #823은 기존 `CallableAbi` 순서로 전체
-callable graph를 signature-convert한다:
-
-```text
-Direct         (source...)                 -> source result
-EvidenceDirect (evidence, source...)       -> source result
-Cps            (evidence, done_k, source...) -> compatibility control result
-```
-
-같은 conversion이 `func.func`, `closure.lambda`, `core.func`/closure type, entry
-block argument, `func.call`, `func.call_indirect`를 rewrite한다. `Cps` logical
-return은 `done_k`를 호출하고 `EvidenceDirect` body는 lowered ability invocation이
-사용하는 새 evidence argument를 받는다. 같은 #823 legalization에서
-`operation_kind = @fn`은 suffix capture 없는 `ability.call`/tail dispatch가 되고
-`operation_kind = @op`은 suffix continuation을 받는 `ability.perform`/CPS
-dispatch가 된다. `CallableAbi`는 callable signature를 규정할 뿐 operation kind를
-encode하거나 추론하지 않는다. Conversion은 closure extraction 전에 실행하므로
-lambda와 모든 direct/indirect use가 하나의 physical signature에 합의한다.
-Metadata/type 불일치는 conversion failure다.
-
-Root source `main`은 external Direct 또는 EvidenceDirect ABI를 유지한다. #823과
-root `tribute` pipeline이 internal terminal continuation을 소유한다. 이 계층은
-implementation-level CPS body를 닫고, Direct root에는 empty evidence를,
-EvidenceDirect root에는 삽입된 argument를 사용하며, logical source result를
-반환한다. #824 뒤에는 `tribute-front`가 이 delimiter를 만들지 않는다.
-
-Implementation은 다음 validation 책임을 보존해야 한다:
-
-- `tribute-ir`는 모든 `tribute_control` operation과
-  `resume_token<input, answer>`의 typed wrapper, parser/printer round trip,
-  local verifier를 소유한다. `perform` verifier는
-  `operation_kind = @fn | @op`를 요구하며 frontend 적합성 검사는 typecheck된
-  declaration과 대조하고 kind별 argument/result type을 검증한다.
+- `tribute-ir`는 `tribute_control` typed wrapper, parser/printer round trip,
+  operation-local verifier를 소유한다. 현재 TrunkIR에는 dialect callback registry가
+  없으므로 #822가 Tribute 전용 validator를 노출하고 frontend 경계가 generic
+  SSA/use-chain validation과 함께 호출한다.
 - Containing `tribute_control.handle` verifier는 handler placement, uniqueness,
-  region shape, block argument, terminator, type agreement를 검사한다.
-- Whole-IR verification은 use-def와 closure-capture edge를 따라 resume token의
-  single static ownership path와 SSA visibility를 확인한다. Capture된 closure의
-  동적 호출 횟수는 증명할 수 없으므로 converted resumption은 runtime one-shot
-  state를 운반하고 두 번째 dynamic invocation을 거부하거나 trap한다. 이는
-  conversion legality가 아니다.
-- `tribute-passes`는 conversion pattern과 `tribute-control-post-cps` target을
-  소유한다. 성공한 conversion 뒤 남은 모든 `tribute_control.*` operation을
-  거부해야 한다.
-- Tribute native/Wasm pipeline은 각각 backend-ready boundary 전에 남은
-  `tribute_control.*`, `ability.*`, `effect.*`를 거부한다. Generic
-  `trunk-ir`에는 Tribute 전용 semantics를 넣지 않는다.
+  region 형상, block argument, terminator, type agreement를 검사한다.
+- Whole-IR verifier는 SSA visibility와 `resume_token`의 single static ownership
+  path를 검사한다. Closure capture 뒤의 동적 재호출은 증명할 수 없으므로
+  converted resumption이 runtime one-shot state로 두 번째 호출을 거부하거나
+  trap한다.
+- `tribute-passes`와 backend pipeline은 각각 post-CPS 및 backend-ready target을
+  검증한다. 성공한 경계에는 residual `tribute_control.*`이 없고 backend-ready
+  경계에는 `tribute_control.*`, `ability.*`, `effect.*`이 없다.
 
-Full `tribute-control-pre-cps` frontend-conformance target은 기존 `ability.*`,
-`effect.*`, legacy CPS-dispatch operation을 illegal로 만든다. #823에서 진행
-중인 partial rewrite만 lowered operation과 남은 `tribute_control.*`을 일시적으로
-함께 포함할 수 있다. 어느 named boundary도 이 공존을 성공한 적합성으로 보지
-않는다.
+구현 순서는 다음과 같다:
 
-현재 TrunkIR dialect macro는 이 고정된 five-operation/fixed-region surface를
-표현할 수 있으며 generic parser/printer는 하나의 `dialect.operation`
-separator와 일반 region/block argument를 이미 round-trip한다. TrunkIR의 현재
-`validate_operation_verifiers` entrypoint는 builtin verifier를 직접 호출하고
-dialect callback registry가 없다. 따라서 #822는 `tribute-ir`의 Tribute 전용
-local validator를 노출해야 하며 frontend/pre-CPS boundary는 이를 generic
-SSA/use-chain validation과 함께 호출해야 한다. 향후 generic verifier registry는
-optional infrastructure지만 어떤 `tribute_control` 규칙도 `trunk-ir`에
-구현해서는 안 된다.
+1. #822가 `tribute-ir`에 dialect와 local verifier를 구현한다.
+2. #823이 `tribute-passes`에 conversion과 legality를 구현한다.
+3. #824가 `tribute-front`를 직접형 emission으로 전환한다.
+4. #825가 root pipeline에 conversion과 backend residual 검사를 조합한다.
+5. #826이 migrated coverage를 확인한 뒤 frontend-owned CPS normalization과
+   continuation 구성, 중복 compatibility lowering을 제거한다.
 
-Region 전략은 일관된다. Converter가 각 block suffix에 logical exit
-continuation을 전달한다. 선택된 case/conditional arm, guard, short-circuit
-오른쪽 항은 merge에 도달한 뒤 enclosing suffix를 실행하는 exit를 받는다.
-Handle body는 delimiter를 만들고 completion region은 body가 정상 완료될 때만
-실행된다. Resumptive general handler arm은 affine resumption을 소비한 뒤
-arm-local strict work를 계속할 수 있다. Source `op -> Never` arm은 resume
-token을 받지 않고 `tribute_control.resume`을 포함하지 않는다. Nested handle도
-동일한 규칙을 재귀적으로 적용한다. Strict value는 왼쪽에서 오른쪽으로 한 번만
-평가하며 선택되지 않은 region은 평가하지 않는다.
+Issue #823과 #824의 준비 작업은 #822 뒤에 병행할 수 있지만, 두 계약이 합의되고 #825가
+조합하기 전에는 새 경계가 live라고 주장할 수 없다. Partial rewrite 내부의
+direct/lowered operation 공존은 허용하지만 named boundary에는 허용하지 않는다.
 
-M2 구현 순서는 다음과 같다:
+이 작업은 #774가 소유하는 `Never`/`Step`/trampoline carrier 선택을 하지 않는다.
+현재 owner-tagged private `Normal | Escape(owner_tag, payload)` protocol은
+compatibility implementation으로 남을 수 있지만, 해당 private carrier임이
+증명된 value만 검사할 수 있다. Source `op -> Never`의 canonical `core.never`와
+typed zero-capture `func.unreachable` adapter를 포함한 conversion 세부는
+[cps-effects.md](cps-effects.md#direct-style-control-boundary)를 따른다.
 
-1. #822가 `tribute-ir`에 검증된 dialect를 구현하고 테스트한다.
-2. #823이 `tribute-passes`에서 synthetic direct-style IR을 변환한다. 여기에는
-   kind에 따른 `perform` lowering, nested region, resume suffix,
-   `CallableAbi` signature 동시 변환, post-CPS legality가 포함된다.
-   `operation_kind`를 소비할 뿐 추론하거나 변경하지 않는다.
-3. #824가 `tribute-front`를 변경해 모든 `fn`/`op` invocation에 직접형 dialect를
-   emit한다. Typecheck된 kind를 복사하며 `ability.call`, `ability.perform`,
-   `effect.dispatch_*`를 emit하지 않고 위 dependency graph를 유지한다.
-4. #825가 `tribute`에서 conversion을 조합하고 native/Wasm residual-control
-   rejection을 필수로 만든다.
-5. #826이 migrated coverage가 통과한 뒤 대체된 typed-AST CPS normalization,
-   frontend continuation 구성, 중복 compatibility lowering을 제거한다.
-
-Issues #823과 #824의 준비 작업은 #822 뒤에 진행할 수 있지만 shared contract가 합의되기
-전에는 integration이 새 boundary를 구현했다고 주장할 수 없다. Migration 도중
-partial conversion에는 direct/lowered operation이 일시적으로 공존할 수 있으나
-named post-CPS boundary에는 절대 공존하지 않는다.
-
-Logical contract는 의도적으로 `Never`, `Step`, trampoline 또는 다른 backend
-carrier를 선택하지 않는다. Logical/physical control-result 선택은 #774가
-소유한다. 현재 owner-tagged private
-`Normal | Escape(owner_tag, payload)` completion protocol은 M2 compatibility
-implementation으로 남을 수 있지만 어떤 `tribute_control` operation도 tag,
-variant, representation을 노출하지 않는다. 해당 private carrier임이 증명된
-value만 compatibility lowering에서 검사할 수 있다.
-
-Source `op -> Never`에 대해 #823은 현재 `ability.perform`과
-`effect.dispatch_cps`의 필수 continuation operand를 계속 만족시킨다.
-Compiler-generated typed zero-capture continuation closure를 전달하며 body는
-`func.unreachable`이다. Adapter는 source suffix를 capture하지 않고 malformed
-path가 호출하면 trap한다. Compilation unit마다 deduplicate할 수 있다. Null,
-in-band sentinel, 임의의 `anyref`를 continuation substitute로 허용하지 않으며 새
-IR operation도 필요하지 않다.
-
-TrunkIR은 이미 `core.never`를 정의한다. #824는 직접형 source `Never` result에
-이 canonical type을 사용해야 #822/#823이 no-token case를 구조적으로 인식할 수
-있다. 현재 pre-M2 `convert_type`이 `Never`를 `anyref` placeholder로 mapping하는
-동작은 compatibility behavior이며 `tribute-control-pre-cps` boundary를 넘어서는
-안 된다.
-
-M2는 source syntax, effect-row semantics, convention 순서, ability optimization
-정책, multi-file compilation을 변경하지 않는다. `Never`/`Step`/trampoline
-carrier를 선택하지 않고 Tribute semantics를 generic `trunk-ir`로 옮기지 않는다.
+Source syntax, effect-row semantics, `Direct < EvidenceDirect < Cps` 순서, ability
+optimization 정책, multi-file compilation은 변경하지 않으며 Tribute semantics를
+generic `trunk-ir`로 옮기지 않는다.
 
 ---
 
@@ -516,7 +421,7 @@ Compiler-owned ambient ability `std::io::Io`만 요구하는 함수는 현재
 `Io`와 `Throw(std::io::Error)`가 함께 있으면 `Throw` 때문에 `Cps`로 승격된다.
 자세한 표준 I/O 계약은 [io.md](io.md)를 따른다.
 
-현재 pre-M2 implementation에서 root `main`은 frontend CPS delimiter이며 `Cps`
+현재 implementation에서 root `main`은 frontend CPS delimiter이며 `Cps`
 backend entry ABI가 아니다. Valid source residual contract는 pure 또는 `Io`를
 유지한다. Generic/open callback worker 호출 때문에 body에 더 강한 implementation
 convention만 필요한 경우 현재 AST-to-IR은 root `main`을
@@ -877,7 +782,7 @@ ABI lowering의 의미론적 기준이 아니다.
 
 ### WASM / Native 공통: CPS Tail-Call Effect Handling
 
-다음은 현재 pre-M2 compatibility pipeline을 설명한다. Effect handling은
+다음은 현재 compatibility pipeline을 설명한다. Effect handling은
 tail-call CPS로 구현한다.
 `lower_ability_perform`이 `ability.perform`과 `ability.call`을 target-independent
 `effect.dispatch_cps` / `effect.dispatch_tail` ABI operation으로 변환한다.
@@ -900,7 +805,7 @@ WASM:   → lower_to_wasm [includes evidence_to_wasm] → emit_wasm
 Native: → evidence_to_native → lower_to_clif → emit_native
 ```
 
-M2 target은 continuation-dependent closure/effect lowering 전에 검증된
+계획한 직접형 target은 continuation-dependent closure/effect lowering 전에 검증된
 `tribute_control` emission과 shared CPS legalization을 삽입한다. #823과 #824가
 합의한 뒤 정확한 pipeline splice는 #825가 소유한다. 이 문서는 해당 splice가
 이미 구현되었다고 주장하지 않는다.
@@ -989,7 +894,7 @@ pub fn compile(db, source: SourceCst) -> Module {
 
 ### 파이프라인 구조
 
-다음은 계획한 M2 topology이며 Issue #825가 #823과 #824를 조합하기 전까지 현재
+다음은 계획한 직접형 topology이며 Issue #825가 #823과 #824를 조합하기 전까지 현재
 live pipeline이 아니다:
 
 ```text
@@ -1020,7 +925,7 @@ Migrated coverage가 #826의 frontend-owned CPS 구성 제거를 허용할 때�
 | | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
 | | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
 | | `tdnr` | x.method() | Type::method(x) | |
-| **직접형 제어 (M2 target)** | `ast_to_ir` | typed AST | typecheck된 operation kind를 갖는 검증된 `tribute_control` + 일반 IR | frontend, #824 계획 |
+| **직접형 제어 (계획)** | `ast_to_ir` | typed AST | typecheck된 operation kind를 갖는 검증된 `tribute_control` + 일반 IR | frontend, #824 계획 |
 | | `tribute_control_to_cps` | `tribute_control` + operation-kind/convention metadata | kind-directed ability/effect/closure CPS IR | shared, #823 계획 |
 | **Ability (현재 compatibility)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
 | | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -38,10 +38,10 @@ TrunkIR validation follows the layered model in `new-plans/ir.md`:
 Do not add a separate semantic-contract DSL unless these existing mechanisms
 cannot express a required invariant.
 
-## M2 direct-style control ownership
+## M2 직접형 제어 소유권
 
-Issue #821 fixes the design contract; it does not make the new pipeline live.
-The M2 target moves continuation construction out of `tribute-front`:
+Issue #821은 design contract를 확정하지만 새 pipeline을 live 상태로 만들지는
+않는다. M2 target은 continuation 구성을 `tribute-front` 밖으로 옮긴다:
 
 ```text
 typed AST
@@ -51,7 +51,7 @@ typed AST
   -> native or Wasm lowering
 ```
 
-The dependency direction is mandatory:
+Dependency direction은 다음과 같이 고정한다:
 
 ```text
 tribute-front  -> tribute-ir + trunk-ir
@@ -59,32 +59,31 @@ tribute-passes -> tribute-ir + trunk-ir
 tribute        -> tribute-front + tribute-passes
 ```
 
-`tribute-front` must not depend on `tribute-passes`. The root `tribute` crate
-orchestrates frontend emission followed by shared conversion.
+`tribute-front`는 `tribute-passes`에 의존해서는 안 된다. Root `tribute` crate가
+frontend emission 뒤의 shared conversion을 orchestrate한다.
 
-The dialect identifier is exactly `tribute_control`, and its minimal operations
-are `tribute_control.perform`, `tribute_control.handle`,
-`tribute_control.handler`, `tribute_control.resume`, and
-`tribute_control.yield`. The fixed structural and verifier contracts are in
-[ir.md](ir.md#direct-style-control); the conversion contract is in
-[cps-effects.md](cps-effects.md#m2-direct-style-boundary).
+Dialect identifier는 정확히 `tribute_control`이며 최소 operation은
+`tribute_control.perform`, `tribute_control.handle`,
+`tribute_control.handler`, `tribute_control.resume`,
+`tribute_control.yield`다. 고정된 structural/verifier contract는
+[ir.md](ir.md#direct-style-control)에, conversion contract는
+[cps-effects.md](cps-effects.md#m2-direct-style-boundary)에 있다.
 
-ANF remains an invariant of frontend output. It does not move ordinary calls,
-arithmetic, ADT/list/closure construction, or structured selection into
-`tribute_control`. There is no new effectful invocation operation:
-`func.call`, `func.call_indirect`, and callable convention metadata already
-provide the necessary `Direct < EvidenceDirect < Cps` distinction. In
-contrast, every source ability invocation, both `fn` and `op`, uses
-`tribute_control.perform` with the required typechecked
-`operation_kind = @fn | @op`. Typechecking preserves that source-semantic
-distinction; `tribute-front` copies it into IR and does not choose a dispatch
-strategy.
+ANF는 frontend output의 invariant로 유지한다. 일반 call, 산술,
+ADT/list/closure 구성, structured selection을 `tribute_control`로 옮기지 않는다.
+새 effectful invocation operation도 추가하지 않는다. `func.call`,
+`func.call_indirect`, callable convention metadata가 이미 필요한
+`Direct < EvidenceDirect < Cps` 구분을 제공한다. 반면 source ability
+invocation은 `fn`과 `op` 모두 필수 typechecked
+`operation_kind = @fn | @op`를 가진 `tribute_control.perform`을 사용한다.
+Typechecking이 이 source-semantic 구분을 보존하고 `tribute-front`는 이를 IR에
+복사할 뿐 dispatch 전략을 선택하지 않는다.
 
-Pre-CPS definitions, lambdas, direct calls, and indirect calls keep only their
-source-logical parameters and source result. `EvidenceDirect` has no hidden
-evidence operand yet, and `Cps` has neither evidence nor a frontend-created
-`done_k`; convention metadata is the phase marker. #823 uses the existing
-`CallableAbi` ordering to signature-convert the entire callable graph:
+Pre-CPS definition, lambda, direct call, indirect call은 source-logical
+parameter와 source result만 유지한다. `EvidenceDirect`에는 아직 hidden evidence
+operand가 없고 `Cps`에는 evidence와 frontend가 만든 `done_k`가 모두 없다.
+Convention metadata가 phase marker다. #823은 기존 `CallableAbi` 순서로 전체
+callable graph를 signature-convert한다:
 
 ```text
 Direct         (source...)                 -> source result
@@ -92,120 +91,115 @@ EvidenceDirect (evidence, source...)       -> source result
 Cps            (evidence, done_k, source...) -> compatibility control result
 ```
 
-The same conversion rewrites `func.func`, `closure.lambda`, `core.func` and
-closure types, entry block arguments, `func.call`, and `func.call_indirect`.
-A `Cps` logical return invokes `done_k`; an `EvidenceDirect` body receives the
-new evidence argument used by lowered ability invocations. In the same #823
-legalization, `operation_kind = @fn` becomes `ability.call`/tail dispatch
-without suffix capture, while `operation_kind = @op` becomes
-`ability.perform`/CPS dispatch with a suffix continuation. `CallableAbi`
-governs callable signatures; it does not encode or infer operation kind.
-Conversion runs before closure extraction so a lambda and every
-direct/indirect use agree on one physical signature. Metadata/type disagreement
-fails conversion.
+같은 conversion이 `func.func`, `closure.lambda`, `core.func`/closure type, entry
+block argument, `func.call`, `func.call_indirect`를 rewrite한다. `Cps` logical
+return은 `done_k`를 호출하고 `EvidenceDirect` body는 lowered ability invocation이
+사용하는 새 evidence argument를 받는다. 같은 #823 legalization에서
+`operation_kind = @fn`은 suffix capture 없는 `ability.call`/tail dispatch가 되고
+`operation_kind = @op`은 suffix continuation을 받는 `ability.perform`/CPS
+dispatch가 된다. `CallableAbi`는 callable signature를 규정할 뿐 operation kind를
+encode하거나 추론하지 않는다. Conversion은 closure extraction 전에 실행하므로
+lambda와 모든 direct/indirect use가 하나의 physical signature에 합의한다.
+Metadata/type 불일치는 conversion failure다.
 
-Root source `main` retains its external Direct or EvidenceDirect ABI. #823 and
-the root `tribute` pipeline own its internal terminal continuation: they close
-an implementation-level CPS body, use empty evidence for a Direct root or the
-inserted argument for an EvidenceDirect root, and return the logical source
-result. `tribute-front` does not build this delimiter after #824.
+Root source `main`은 external Direct 또는 EvidenceDirect ABI를 유지한다. #823과
+root `tribute` pipeline이 internal terminal continuation을 소유한다. 이 계층은
+implementation-level CPS body를 닫고, Direct root에는 empty evidence를,
+EvidenceDirect root에는 삽입된 argument를 사용하며, logical source result를
+반환한다. #824 뒤에는 `tribute-front`가 이 delimiter를 만들지 않는다.
 
-The implementation must preserve these validation responsibilities:
+Implementation은 다음 validation 책임을 보존해야 한다:
 
-- `tribute-ir` owns typed wrappers, parser/printer round trips, and local
-  verifiers for all `tribute_control` operations and
-  `resume_token<input, answer>`. The `perform` verifier requires
-  `operation_kind = @fn | @op`; frontend conformance checks it against the
-  typechecked declaration and verifies kind-specific argument/result types.
-- The containing `tribute_control.handle` verifier checks handler placement,
-  uniqueness, region shape, block arguments, terminators, and type agreement.
-- Whole-IR verification follows use-def and closure-capture edges for one
-  static ownership path of a resume token and checks SSA visibility. It cannot
-  prove how many times a captured closure is invoked; converted resumptions
-  carry runtime one-shot state and reject or trap a second dynamic invocation.
-  This is not conversion legality.
-- `tribute-passes` owns the conversion patterns and the
-  `tribute-control-post-cps` target. It must reject every residual
-  `tribute_control.*` operation after successful conversion.
-- The Tribute native and Wasm pipelines each reject residual
-  `tribute_control.*`, `ability.*`, and `effect.*` before their backend-ready
-  boundary. Generic `trunk-ir` remains free of Tribute-specific semantics.
+- `tribute-ir`는 모든 `tribute_control` operation과
+  `resume_token<input, answer>`의 typed wrapper, parser/printer round trip,
+  local verifier를 소유한다. `perform` verifier는
+  `operation_kind = @fn | @op`를 요구하며 frontend 적합성 검사는 typecheck된
+  declaration과 대조하고 kind별 argument/result type을 검증한다.
+- Containing `tribute_control.handle` verifier는 handler placement, uniqueness,
+  region shape, block argument, terminator, type agreement를 검사한다.
+- Whole-IR verification은 use-def와 closure-capture edge를 따라 resume token의
+  single static ownership path와 SSA visibility를 확인한다. Capture된 closure의
+  동적 호출 횟수는 증명할 수 없으므로 converted resumption은 runtime one-shot
+  state를 운반하고 두 번째 dynamic invocation을 거부하거나 trap한다. 이는
+  conversion legality가 아니다.
+- `tribute-passes`는 conversion pattern과 `tribute-control-post-cps` target을
+  소유한다. 성공한 conversion 뒤 남은 모든 `tribute_control.*` operation을
+  거부해야 한다.
+- Tribute native/Wasm pipeline은 각각 backend-ready boundary 전에 남은
+  `tribute_control.*`, `ability.*`, `effect.*`를 거부한다. Generic
+  `trunk-ir`에는 Tribute 전용 semantics를 넣지 않는다.
 
-The full `tribute-control-pre-cps` frontend-conformance target makes existing
-`ability.*`, `effect.*`, and legacy CPS-dispatch operations illegal. Only the
-in-progress partial rewrite in #823 may temporarily contain those lowered
-operations beside residual `tribute_control.*`; neither named boundary treats
-that coexistence as successful conformance.
+Full `tribute-control-pre-cps` frontend-conformance target은 기존 `ability.*`,
+`effect.*`, legacy CPS-dispatch operation을 illegal로 만든다. #823에서 진행
+중인 partial rewrite만 lowered operation과 남은 `tribute_control.*`을 일시적으로
+함께 포함할 수 있다. 어느 named boundary도 이 공존을 성공한 적합성으로 보지
+않는다.
 
-The current TrunkIR dialect macro can represent this fixed five-operation,
-fixed-region surface, and the generic parser/printer already round-trips one
-`dialect.operation` separator plus ordinary regions and block arguments.
-TrunkIR's current `validate_operation_verifiers` entrypoint directly calls its
-builtin verifiers; it has no dialect callback registry. #822 must therefore
-expose the Tribute-specific local validator from `tribute-ir`, and the
-frontend/pre-CPS boundary must call it alongside generic SSA/use-chain
-validation. A later generic verifier registry is optional infrastructure, but
-no `tribute_control` rule may be implemented in `trunk-ir`.
+현재 TrunkIR dialect macro는 이 고정된 five-operation/fixed-region surface를
+표현할 수 있으며 generic parser/printer는 하나의 `dialect.operation`
+separator와 일반 region/block argument를 이미 round-trip한다. TrunkIR의 현재
+`validate_operation_verifiers` entrypoint는 builtin verifier를 직접 호출하고
+dialect callback registry가 없다. 따라서 #822는 `tribute-ir`의 Tribute 전용
+local validator를 노출해야 하며 frontend/pre-CPS boundary는 이를 generic
+SSA/use-chain validation과 함께 호출해야 한다. 향후 generic verifier registry는
+optional infrastructure지만 어떤 `tribute_control` 규칙도 `trunk-ir`에
+구현해서는 안 된다.
 
-The region strategy is uniform. The converter threads a logical exit
-continuation through each block suffix. Selected case/conditional arms, guards,
-and short-circuit right-hand sides receive an exit that reaches their merge
-and then the enclosing suffix. Handle bodies introduce delimiters; completion
-regions run only on normal body completion; resumptive general handler arms
-may consume their affine resumption and then continue through arm-local strict
-work. A source `op -> Never` arm receives no resume token and contains no
-`tribute_control.resume`. Nested handles apply the same rule recursively.
-Strict values evaluate once, left to right, and unselected regions never
-evaluate.
+Region 전략은 일관된다. Converter가 각 block suffix에 logical exit
+continuation을 전달한다. 선택된 case/conditional arm, guard, short-circuit
+오른쪽 항은 merge에 도달한 뒤 enclosing suffix를 실행하는 exit를 받는다.
+Handle body는 delimiter를 만들고 completion region은 body가 정상 완료될 때만
+실행된다. Resumptive general handler arm은 affine resumption을 소비한 뒤
+arm-local strict work를 계속할 수 있다. Source `op -> Never` arm은 resume
+token을 받지 않고 `tribute_control.resume`을 포함하지 않는다. Nested handle도
+동일한 규칙을 재귀적으로 적용한다. Strict value는 왼쪽에서 오른쪽으로 한 번만
+평가하며 선택되지 않은 region은 평가하지 않는다.
 
-The M2 implementation order is:
+M2 구현 순서는 다음과 같다:
 
-1. #822 implements and tests the verified dialect in `tribute-ir`.
-2. #823 converts synthetic direct-style IR in `tribute-passes`, including
-   kind-directed `perform` lowering, nested regions, resume suffixes,
-   simultaneous `CallableAbi` signature conversion, and post-CPS legality. It
-   consumes `operation_kind`; it never infers or changes it.
-3. #824 changes `tribute-front` to emit the direct dialect for every `fn` and
-   `op` invocation, copying the typechecked kind without emitting
-   `ability.call`, `ability.perform`, or `effect.dispatch_*`, while retaining
-   the dependency graph above.
-4. #825 composes conversion in `tribute` and makes native/Wasm residual-control
-   rejection mandatory.
-5. #826 removes superseded typed-AST CPS normalization, frontend continuation
-   construction, and duplicate compatibility lowering after migrated coverage
-   passes.
+1. #822가 `tribute-ir`에 검증된 dialect를 구현하고 테스트한다.
+2. #823이 `tribute-passes`에서 synthetic direct-style IR을 변환한다. 여기에는
+   kind에 따른 `perform` lowering, nested region, resume suffix,
+   `CallableAbi` signature 동시 변환, post-CPS legality가 포함된다.
+   `operation_kind`를 소비할 뿐 추론하거나 변경하지 않는다.
+3. #824가 `tribute-front`를 변경해 모든 `fn`/`op` invocation에 직접형 dialect를
+   emit한다. Typecheck된 kind를 복사하며 `ability.call`, `ability.perform`,
+   `effect.dispatch_*`를 emit하지 않고 위 dependency graph를 유지한다.
+4. #825가 `tribute`에서 conversion을 조합하고 native/Wasm residual-control
+   rejection을 필수로 만든다.
+5. #826이 migrated coverage가 통과한 뒤 대체된 typed-AST CPS normalization,
+   frontend continuation 구성, 중복 compatibility lowering을 제거한다.
 
-Preparatory #823 and #824 work may proceed after #822, but integration cannot
-claim the new boundary until the shared contracts agree. During migration, a
-partial conversion may transiently contain direct and lowered operations
-together. The named post-CPS boundary never does.
+Issues #823과 #824의 준비 작업은 #822 뒤에 진행할 수 있지만 shared contract가 합의되기
+전에는 integration이 새 boundary를 구현했다고 주장할 수 없다. Migration 도중
+partial conversion에는 direct/lowered operation이 일시적으로 공존할 수 있으나
+named post-CPS boundary에는 절대 공존하지 않는다.
 
-The logical contract deliberately does not select `Never`, `Step`, a
-trampoline, or another backend carrier. #774 owns logical-versus-physical
-control-result selection. The current owner-tagged private
-`Normal | Escape(owner_tag, payload)` completion protocol may remain as an M2
-compatibility implementation, but no `tribute_control` operation exposes its
-tag, variants, or representation. Only values proven to be that private
-carrier may be inspected by its compatibility lowering.
+Logical contract는 의도적으로 `Never`, `Step`, trampoline 또는 다른 backend
+carrier를 선택하지 않는다. Logical/physical control-result 선택은 #774가
+소유한다. 현재 owner-tagged private
+`Normal | Escape(owner_tag, payload)` completion protocol은 M2 compatibility
+implementation으로 남을 수 있지만 어떤 `tribute_control` operation도 tag,
+variant, representation을 노출하지 않는다. 해당 private carrier임이 증명된
+value만 compatibility lowering에서 검사할 수 있다.
 
-For source `op -> Never`, #823 still satisfies the current mandatory
-continuation operand of `ability.perform` and `effect.dispatch_cps`. It passes
-a compiler-generated, typed, zero-capture continuation closure whose body is
-`func.unreachable`. The adapter captures no source suffix and traps if a
-malformed path invokes it. It may be deduplicated per compilation unit. Null,
-in-band sentinels, and arbitrary `anyref` are never accepted as continuation
-substitutes, and no new IR operation is required.
+Source `op -> Never`에 대해 #823은 현재 `ability.perform`과
+`effect.dispatch_cps`의 필수 continuation operand를 계속 만족시킨다.
+Compiler-generated typed zero-capture continuation closure를 전달하며 body는
+`func.unreachable`이다. Adapter는 source suffix를 capture하지 않고 malformed
+path가 호출하면 trap한다. Compilation unit마다 deduplicate할 수 있다. Null,
+in-band sentinel, 임의의 `anyref`를 continuation substitute로 허용하지 않으며 새
+IR operation도 필요하지 않다.
 
-TrunkIR already defines `core.never`. #824 must use that canonical type for a
-direct-style source `Never` result so #822/#823 can recognize the no-token
-case structurally. The current pre-M2 `convert_type` mapping of `Never` to an
-`anyref` placeholder is compatibility behavior and must not cross the
-`tribute-control-pre-cps` boundary.
+TrunkIR은 이미 `core.never`를 정의한다. #824는 직접형 source `Never` result에
+이 canonical type을 사용해야 #822/#823이 no-token case를 구조적으로 인식할 수
+있다. 현재 pre-M2 `convert_type`이 `Never`를 `anyref` placeholder로 mapping하는
+동작은 compatibility behavior이며 `tribute-control-pre-cps` boundary를 넘어서는
+안 된다.
 
-M2 does not change source syntax, effect-row semantics, the convention order,
-ability optimization policy, or multi-file compilation. It does not select
-`Never`/`Step`/trampoline carriers and does not move Tribute semantics into
-generic `trunk-ir`.
+M2는 source syntax, effect-row semantics, convention 순서, ability optimization
+정책, multi-file compilation을 변경하지 않는다. `Never`/`Step`/trampoline
+carrier를 선택하지 않고 Tribute semantics를 generic `trunk-ir`로 옮기지 않는다.
 
 ---
 
@@ -522,17 +516,16 @@ Compiler-owned ambient ability `std::io::Io`만 요구하는 함수는 현재
 `Io`와 `Throw(std::io::Error)`가 함께 있으면 `Throw` 때문에 `Cps`로 승격된다.
 자세한 표준 I/O 계약은 [io.md](io.md)를 따른다.
 
-In the current pre-M2 implementation, root `main` is a frontend CPS delimiter,
-not a `Cps` backend entry ABI. Its valid source residual contract remains pure
-or `Io`. If its body only needs the stronger implementation convention because
-it calls a generic/open callback worker, current AST-to-IR keeps root `main` at
-its Direct/EvidenceDirect seed, closes that computation with the shared
-identity continuation, and returns the recovered source value normally. This
-frontend-owned closing step is a migration baseline, not the permanent phase
-boundary. After #824, the frontend emits direct-style control and shared
-conversion in `tribute-passes` closes the root computation. A genuine residual
-general effect is still rejected before the backend entrypoint;
-nested-module `main` is not special.
+현재 pre-M2 implementation에서 root `main`은 frontend CPS delimiter이며 `Cps`
+backend entry ABI가 아니다. Valid source residual contract는 pure 또는 `Io`를
+유지한다. Generic/open callback worker 호출 때문에 body에 더 강한 implementation
+convention만 필요한 경우 현재 AST-to-IR은 root `main`을
+Direct/EvidenceDirect seed로 유지하고 shared identity continuation으로 computation을
+닫은 뒤 복구한 source value를 정상 반환한다. 이 frontend-owned closing step은
+migration baseline이지 영구 phase boundary가 아니다. #824 뒤에는 frontend가
+direct-style control을 emit하고 `tribute-passes`의 shared conversion이 root
+computation을 닫는다. 실제 residual general effect는 backend entrypoint 전에 계속
+거부하며 nested-module `main`은 특별하지 않다.
 
 기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
 Frontend shared lowering은 private intrinsic stub을 `tribute_io.write`와
@@ -607,11 +600,11 @@ ability containing any op  → Cps
 open or otherwise unknown e → Cps
 ```
 
-This ability-level convention bound does not erase an operation declaration's
-source `fn`/`op` kind. Typechecking stores that kind on the resolved operation,
-and #824 copies it to each `tribute_control.perform.operation_kind`. #823
-consumes it directly; neither `CallingConvention`, handler-body analysis, nor
-the effect-row bound reconstructs or changes it.
+이 ability-level convention bound는 operation declaration의 source `fn`/`op`
+kind를 erase하지 않는다. Typechecking이 resolve된 operation에 kind를 저장하고
+Issue #824가 각 `tribute_control.perform.operation_kind`에 이를 복사한다. #823은 이를
+직접 소비하며 `CallingConvention`, handler-body analysis, effect-row bound 중
+어느 것도 kind를 재구성하거나 변경하지 않는다.
 
 Effect annotation 생략은 closed-empty 추론이 아니다.
 
@@ -767,7 +760,7 @@ fn run_state_optimized(comp, init_state) {
 복잡한 handler에서는 적용되지 않을 수 있으며, 적용 여부가 source meaning이나
 pre-CPS IR을 바꾸지 않는다.
 
-#### `op -> Never` semantics
+#### `op -> Never` 의미
 
 `-> Never`를 반환하는 operation은 source semantics상 resume할 수 없다.
 `tribute_control.handler`는 이 arm에 `resume_token`을 노출하지 않고, nested
@@ -884,8 +877,8 @@ ABI lowering의 의미론적 기준이 아니다.
 
 ### WASM / Native 공통: CPS Tail-Call Effect Handling
 
-The following describes the current pre-M2 compatibility pipeline. Effect
-handling is implemented with tail-call CPS.
+다음은 현재 pre-M2 compatibility pipeline을 설명한다. Effect handling은
+tail-call CPS로 구현한다.
 `lower_ability_perform`이 `ability.perform`과 `ability.call`을 target-independent
 `effect.dispatch_cps` / `effect.dispatch_tail` ABI operation으로 변환한다.
 `resolve_evidence`는 handler 설치를 `effect.extend`로 표현한다.
@@ -907,10 +900,10 @@ WASM:   → lower_to_wasm [includes evidence_to_wasm] → emit_wasm
 Native: → evidence_to_native → lower_to_clif → emit_native
 ```
 
-The M2 target inserts verified `tribute_control` emission and shared CPS
-legalization before continuation-dependent closure/effect lowering. #825 owns
-the exact pipeline splice after #823 and #824 agree; this document does not
-claim that splice is already implemented.
+M2 target은 continuation-dependent closure/effect lowering 전에 검증된
+`tribute_control` emission과 shared CPS legalization을 삽입한다. #823과 #824가
+합의한 뒤 정확한 pipeline splice는 #825가 소유한다. 이 문서는 해당 splice가
+이미 구현되었다고 주장하지 않는다.
 
 ---
 
@@ -996,8 +989,8 @@ pub fn compile(db, source: SourceCst) -> Module {
 
 ### 파이프라인 구조
 
-The following is the planned M2 topology, not the current live pipeline until
-Issue #825 composes #823 and #824:
+다음은 계획한 M2 topology이며 Issue #825가 #823과 #824를 조합하기 전까지 현재
+live pipeline이 아니다:
 
 ```text
 source
@@ -1011,10 +1004,10 @@ source
   -> emit
 ```
 
-The current compatibility topology is recorded in
-[cps-effects.md](cps-effects.md#current-shared-middle-end-pipeline). It remains
-live only until migrated coverage permits #826 to remove frontend-owned CPS
-construction.
+현재 compatibility topology는
+[cps-effects.md](cps-effects.md#current-shared-middle-end-pipeline)에 기록한다.
+Migrated coverage가 #826의 frontend-owned CPS 구성 제거를 허용할 때까지만 live로
+유지한다.
 
 ### 패스 분류
 
@@ -1027,9 +1020,9 @@ construction.
 | | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
 | | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
 | | `tdnr` | x.method() | Type::method(x) | |
-| **Direct control (M2 target)** | `ast_to_ir` | typed AST | verified `tribute_control` with typechecked operation kind + ordinary IR | frontend, planned #824 |
-| | `tribute_control_to_cps` | `tribute_control` + operation-kind/convention metadata | kind-directed ability/effect/closure CPS IR | shared, planned #823 |
-| **Ability (current compatibility)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
+| **직접형 제어 (M2 target)** | `ast_to_ir` | typed AST | typecheck된 operation kind를 갖는 검증된 `tribute_control` + 일반 IR | frontend, #824 계획 |
+| | `tribute_control_to_cps` | `tribute_control` + operation-kind/convention metadata | kind-directed ability/effect/closure CPS IR | shared, #823 계획 |
+| **Ability (현재 compatibility)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
 | | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | module-wide setup before function-local lowering |
 | | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -40,8 +40,7 @@ cannot express a required invariant.
 
 ## 직접형 제어 소유권
 
-Issue #821은 continuation 구성을 `tribute-front`에서 shared pass로 옮기는 계약을
-정한다. 구조와 의미의 source of truth는
+구조와 의미의 source of truth는
 [ir.md](ir.md#direct-style-control), conversion 규칙은
 [cps-effects.md](cps-effects.md#direct-style-control-boundary)이다.
 
@@ -59,59 +58,33 @@ tribute        -> tribute-front + tribute-passes
 - `tribute-front`는 [논리 callable/control 계약](ir.md#direct-style-control)을
   emit하고 `func.*`, `closure.*`, `core.func` 또는 dispatch representation을
   만들지 않는다.
+- `tribute-ir`는 callable/control type과 operation, custom assembly, local
+  verifier와 Tribute-specific whole-IR verifier를 소유한다.
 - `tribute-passes`는
   [atomic callable/control conversion](cps-effects.md#pre-cps-callable-shape)과
-  post-CPS legality를 소유한다.
+  post-CPS legality, generic `func.tail_call_indirect`를 소유한다.
 - Root `tribute` crate는 frontend emission과 shared conversion을 조합한다.
   Target-independent root bridge는 completion cell과 terminal continuation의 추상
-  조합 계약만 정한다. #825가 `core.never` CPS signature를 target empty-result
-  signature로 내린 뒤 external Direct/EvidenceDirect wrapper와 ordinary call을
-  합성한다.
+  조합 계약만 정한다.
+- Native/Wasm signature lowering은 `core.never` CPS signature를 target
+  empty-result signature로 내린 뒤 external Direct/EvidenceDirect wrapper와
+  ordinary call을 합성한다.
 
 검증 책임은 구현 계층과 분리한다:
 
-- `tribute-ir`는 dialect type/operation, parser/printer, local verifier와
-  Tribute-specific whole-IR verifier를 소유한다. 현재 TrunkIR에는 dialect
-  callback registry가 없으므로 #822가 validator를 노출하고 frontend 경계가
-  generic SSA/use-chain validation과 함께 호출한다. 세부 검증 계약은
-  [ir.md](ir.md#direct-style-control)를 따른다.
+- Frontend 경계는 `tribute-ir` validator와 generic SSA/use-chain validation을
+  함께 호출한다. 세부 검증 계약은 [ir.md](ir.md#direct-style-control)를 따른다.
 - Whole-IR verifier는 static affine path를, converted resumption runtime은
   closure 재호출에 대한 dynamic one-shot enforcement를 소유한다.
 - `tribute-passes`와 backend pipeline은 각각 post-CPS 및 backend-ready target을
   검증한다. 성공한 경계에는 residual `tribute_control` operation/type이 없고
   backend-ready 경계에는 `tribute_control.*`, `ability.*`, `effect.*`이 없다.
 
-구현 순서는 다음과 같다:
-
-1. #822가 `tribute-ir`에 callable/control type과 operation, verifier, 선택한
-   custom assembly와 round-trip/negative test를 구현한다.
-2. #823이 `tribute-passes`에 atomic callable/control conversion과 legality를
-   구현하고 generic `func.tail_call_indirect`를 추가해 direct/indirect CPS
-   transfer를 모두 physical tail operation으로 만든다.
-3. #824가 `tribute-front`를 `tribute_control` callable/control emission으로
-   전환한다.
-4. #825가 `core.never` CPS signature를 native/Wasm empty-result signature로
-   내린 뒤 root/export completion-cell wrapper와 ordinary call을 합성하고,
-   `func.tail_call_indirect` target lowering 및 backend residual 검사를 구현한다.
-5. #826이 migrated coverage를 확인한 뒤 frontend-owned physical callable ABI,
-   CPS normalization/continuation 구성, `anyref` control carrier,
-   `Normal | Escape`와 legacy trampoline builtin을 제거한다.
-
-Issue #823과 #824의 준비 작업은 #822 뒤에 병행할 수 있지만, 두 계약이 합의되고 #825가
-조합하기 전에는 새 경계가 live라고 주장할 수 없다. Partial rewrite 내부의
-direct/lowered operation 공존은 허용하지만 named boundary에는 허용하지 않는다.
-Issue #822 test는 `func` 선언/정의와 선택적 추가 attribute,
-`lambda`의 빈/비어 있지 않은 명시적 capture와 선택적 추가 attribute에 대한
-print-parse-print round trip을 포함한다. 출력기는 빈 capture도 `captures []`로
-출력한다. 알 수 없는 convention, signature와 body argument 불일치, operation의
-중복 `tribute.calling_convention` 저장은 parse 또는 verifier에서 거부한다.
-
-이 migration은 #774에서 분리된 tail-call-only slice를 구현한다. Logical CPS
-result는 `core.never`, physical CPS ABI는 empty result이며 `Step`, trampoline,
-compatibility control-result `anyref`를 선택하지 않는다. #774는
-logical/physical control 분리의 관련 배경으로 남는다. 현재 owner-tagged private
-`Normal | Escape(owner_tag, payload)`는 migration 동안 증명된 value에만 접근하고
-Issue #826에서 제거한다. Source `op -> Never`의 canonical `core.never`와 typed
+Logical CPS result는 `core.never`, physical CPS ABI는 empty result다. 모든 CPS
+이전은 direct/indirect proper tail call이며 backend-ready IR은 CPS control-result
+`anyref`, private control enum, `Step`과 trampoline을 거부한다. Boxed source
+value, effect payload, closure environment의 일반 reference erasure에는
+`anyref`를 사용할 수 있다. Source `op -> Never`의 canonical `core.never`와 typed
 zero-capture `func.unreachable` adapter를 포함한 conversion 세부는
 [cps-effects.md](cps-effects.md#direct-style-control-boundary)를 따른다.
 
@@ -176,7 +149,7 @@ is not an intrinsic. User code depends only on the public function signature and
 canonical `List(a)` contract; the private intrinsic, shared operation, and native
 node layout are not separately addressable collection APIs.
 
-For M1, native may lower the operations to private immutable singly linked
+Native may lower the operations to private immutable singly linked
 RC-managed nodes with empty represented by a private null sentinel. Each
 non-empty node owns its element when reference-typed and its tail. Existing RTTI,
 RC insertion, deep release, and borrowed-field rules apply after the private
@@ -186,11 +159,12 @@ uniqueness proof is an optional optimization and cannot change semantics.
 
 WasmGC selects its own private GC layout. Native layout choices are not shared
 IR conventions and do not establish Wasm execution parity. Full RRB trees,
-efficient concatenation, slicing, and transients remain post-M1 work.
+efficient concatenation, slicing, and transients are outside the canonical
+`List` contract.
 
-## Canonical M1 Native Calculator
+## Canonical Native Calculator
 
-The canonical M1 native calculator is a single-file, public-API-only native
+The canonical native calculator is a single-file, public-API-only native
 program at `lang-examples/native_calculator.trb`. It establishes an executable
 integration contract for canonical `String`, `Bytes`, `List`, `Int`, and
 `std::io`; it does not expose compiler intrinsics, runtime ABI symbols, or test
@@ -230,9 +204,8 @@ functions.
   `error: input failure` once and terminate. No `Throw(std::io::Error)` escapes
   the entrypoint.
 
-Arithmetic overflow policy and additional operators are outside this M1
-integration contract. Its executable fixtures use only representable operands
-and results.
+Arithmetic overflow policy and additional operators are outside this integration
+contract. Its executable fixtures use only representable operands and results.
 
 ---
 
@@ -337,7 +310,7 @@ struct Marker {
 Operation table 대신 handler boundary에서 두 종류의 dispatch closure를 만든다:
 
 - `tr_dispatch_fn`: `fn` operation 전용. `(op_idx, value) -> anyref`
-- `handler_dispatch`: `op` operation 전용. `(k, op_idx, value) -> anyref`
+- `handler_dispatch`: `op` operation 전용. `(k, op_idx, value) -> ()`
 
 `op_idx`는 ability 이름과 operation 이름의 stable hash로 계산한다. 호출 지점과
 handler dispatch closure가 같은 hash 함수를 사용하므로, handler arm 등록 순서에
@@ -434,21 +407,15 @@ Compiler-owned ambient ability `std::io::Io`만 요구하는 함수는 현재
 `Io`와 `Throw(std::io::Error)`가 함께 있으면 `Throw` 때문에 `Cps`로 승격된다.
 자세한 표준 I/O 계약은 [io.md](io.md)를 따른다.
 
-현재 implementation에서 root `main`은 frontend CPS delimiter이며 `Cps`
-backend entry ABI가 아니다. Valid source residual contract는 pure 또는 `Io`를
-유지한다. Generic/open callback worker 호출 때문에 body에 더 강한 implementation
-convention만 필요한 경우 현재 AST-to-IR은 root `main`을
-Direct/EvidenceDirect seed로 유지하고 shared identity continuation으로 computation을
-닫은 뒤 복구한 source value를 정상 반환한다. 이 frontend-owned closing step은
-migration baseline이지 영구 phase boundary가 아니다. #824 뒤에는 frontend가
-direct-style control을 emit하고 `tribute-passes`의 shared conversion이 root
-computation의 추상 completion-cell 계약을 만든다. 이 단계의 CPS entry와
-`done_k`는 `core.never`를 반환한다. #825는 target signature lowering이 이를
-empty result로 바꾼 뒤에만 Direct/EvidenceDirect export wrapper의 ordinary call을
-합성한다. Wrapper는 typed completion cell을 소유하고 root `done_k`가 이를 쓴 뒤
-target call이 돌아오면 cell을 읽는다. Shared `func.call`에 zero-result 형상을
-추가하지 않는다. 실제 residual general effect는 backend entrypoint 전에 계속
-거부하며 nested-module `main`은 특별하지 않다.
+Root `main`은 CPS delimiter이지만 `Cps` backend entry ABI가 아니다. Valid source
+residual contract는 pure 또는 `Io`이며 residual general effect는 backend
+entrypoint 전에 거부한다. Frontend는 root body도 direct-style control로 emit하고
+shared conversion은 typed completion cell과 `core.never` root `done_k`의 추상
+계약을 만든다. Target signature lowering이 CPS entry를 empty result로 바꾼 뒤에만
+Direct/EvidenceDirect export wrapper의 ordinary call을 합성한다. Wrapper는
+completion cell을 소유하고 root `done_k`가 이를 쓴 뒤 target call이 돌아오면
+cell을 읽는다. Shared `func.call`에 zero-result 형상을 추가하지 않으며
+nested-module `main`은 특별하지 않다.
 
 기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
 Frontend shared lowering은 private intrinsic stub을 `tribute_io.write`와
@@ -463,10 +430,9 @@ fn cps(ev: Evidence, done_k: fn(T) -> Never, args...) -> Never
 ```
 
 최종 physical ABI는 empty result를 쓰고 direct transfer는 `func.tail_call`,
-closure/continuation/`done_k` transfer는 `func.tail_call_indirect`를 쓴다. 현재
-`anyref` control carrier는 migration 동안만 허용하며 #826에서 제거한다. Boxed
-source value, payload, closure environment 같은 일반 reference erasure는 유지할 수
-있다.
+closure/continuation/`done_k` transfer는 `func.tail_call_indirect`를 쓴다. CPS
+control carrier로 `anyref`를 사용할 수 없다. Boxed source value, payload, closure
+environment 같은 일반 reference erasure에는 사용할 수 있다.
 
 ### 런타임 함수
 
@@ -525,9 +491,9 @@ open or otherwise unknown e → Cps
 
 이 ability-level convention bound는 operation declaration의 source `fn`/`op`
 kind를 erase하지 않는다. Typechecking이 resolve된 operation에 kind를 저장하고
-Issue #824가 각 `tribute_control.perform.operation_kind`에 이를 복사한다. #823은 이를
-직접 소비하며 `CallingConvention`, handler-body analysis, effect-row bound 중
-어느 것도 kind를 재구성하거나 변경하지 않는다.
+frontend가 각 `tribute_control.perform.operation_kind`에 이를 복사한다.
+`tribute_control_to_cps`는 이를 직접 소비하며 `CallingConvention`, handler-body
+analysis, effect-row bound 중 어느 것도 kind를 재구성하거나 변경하지 않는다.
 
 Effect annotation 생략은 closed-empty 추론이 아니다.
 
@@ -628,9 +594,9 @@ fn map(xs: List(a), f: fn(a) ->{e} b) ->{e} List(b)
 #### 1. 선언 수준 보장 (`fn` operation)
 
 `fn`으로 선언된 operation도 pre-CPS frontend IR에서는
-`tribute_control.perform { operation_kind = @fn }`이다. #823은 보존된 kind를
-보고 continuation 캡처 코드를 생성하지 않으며, evidence에서 handler 함수를
-조회하여 직접 호출하는 경로로 내린다:
+`tribute_control.perform { operation_kind = @fn }`이다.
+`tribute_control_to_cps`는 보존된 kind를 보고 continuation 캡처 코드를 생성하지
+않으며, evidence에서 handler 함수를 조회하여 직접 호출하는 경로로 내린다:
 
 ```rust
 // fn operation 호출 → shift 없이 직접 호출
@@ -646,10 +612,9 @@ Reader, Logger 등 대부분의 실용적 ability가 `fn`으로 선언되므로,
 이 최적화가 큰 효과를 낸다.
 
 `Io` 함수도 continuation을 받지 않는다는 점에서는 `fn` operation과 같지만,
-handler dispatch가 없으므로 marker lookup도 수행하지 않는다. 현재는 ABI 안정성과
-effectful call 규칙의 단순성을 위해 evidence를 계속 전달한다. 현재 representation의
-`Io`-only entrypoint는 empty evidence를 사용할 수 있지만 이는 backend 구현
-세부사항이다.
+handler dispatch가 없으므로 marker lookup도 수행하지 않는다. Uniform
+`EvidenceDirect` ABI를 위해 evidence를 계속 전달한다. `Io`-only entrypoint의
+empty evidence 표현은 backend 구현 세부사항이다.
 
 #### 2. Handler 수준 분석 (`op` operation)
 
@@ -678,19 +643,19 @@ fn run_state_optimized(comp, init_state) {
 ```
 
 이 분석은 표준 `operation_kind = @op` semantic lowering 이후에만 실행할 수 있는
-별도 best-effort IR optimization이다. #823은 handler body를 분석하여 `op`을
-`fn`으로 재분류하거나 이 최적화를 semantic legalization과 결합하지 않는다.
-복잡한 handler에서는 적용되지 않을 수 있으며, 적용 여부가 source meaning이나
-pre-CPS IR을 바꾸지 않는다.
+별도 best-effort IR optimization이다. `tribute_control_to_cps`는 handler body를
+분석하여 `op`을 `fn`으로 재분류하거나 이 최적화를 semantic legalization과
+결합하지 않는다. 복잡한 handler에서는 적용되지 않을 수 있으며, 적용 여부가
+source meaning이나 pre-CPS IR을 바꾸지 않는다.
 
 #### `op -> Never` 의미
 
 `-> Never`를 반환하는 operation은 source semantics상 resume할 수 없다.
 `tribute_control.handler`는 이 arm에 `resume_token`을 노출하지 않고, nested
 region을 포함한 arm body의 `tribute_control.resume`을 verifier가 거부한다.
-따라서 conversion은 source suffix를 캡처하지 않는다. 다만 현재
-`ability.perform`/`effect.dispatch_cps` ABI를 만족시키기 위해 이미 규정한
-zero-capture reject continuation adapter는 전달한다.
+따라서 conversion은 source suffix를 캡처하지 않는다.
+`ability.perform`/`effect.dispatch_cps` ABI의 continuation operand에는 이미
+규정한 zero-capture reject continuation adapter를 전달한다.
 
 ---
 
@@ -788,20 +753,17 @@ op SomeOp::cancel() { fallback_value }      // 0회: 암묵적 drop
 
 ### WasmGC
 
-WasmGC는 당분간 후순위 타겟이지만, active path는 native와 같은 shared
-middle-end의 tail-call CPS / effect ABI 결과를 입력으로 받는다. 과거 설계의
-yield bubbling / `YieldResult` trampoline 방식은 active path가 아니다.
+WasmGC는 native와 같은 shared middle-end의 tail-call CPS / effect ABI 결과를
+입력으로 받는다.
 
 Wasm lowering은 `effect.extend`, `effect.dispatch_tail`,
 `effect.dispatch_cps`를 evidence helper, closure unpacking, and
 direct `wasm.return_call` 또는 indirect `wasm.return_call_indirect`로 낮춘다.
-일반 source data call은 계속 `wasm.call_indirect`를 사용할 수 있다. 남아 있는
-`Step`, `Continuation`, `ResumeWrapper` builtin은 #826에서 제거한다.
+일반 source data call은 계속 `wasm.call_indirect`를 사용할 수 있다.
 
 ### WASM / Native 공통: CPS Tail-Call Effect Handling
 
-다음은 현재 compatibility pipeline을 설명한다. Effect handling은
-tail-call CPS로 구현한다.
+Effect handling은 tail-call CPS로 구현한다.
 `lower_ability_perform`이 `ability.perform`과 `ability.call`을 target-independent
 `effect.dispatch_cps` / `effect.dispatch_tail` ABI operation으로 변환한다.
 `resolve_evidence`는 handler 설치를 `effect.extend`로 표현한다.
@@ -814,20 +776,21 @@ native runtime call 또는 Wasm evidence helper와 indirect call로 제거한다
 **파이프라인 분기:**
 
 ```text
-현재 공통: parse → resolve → typecheck → tdnr → ast_to_ir
-      → evidence_params → prepare_closure_lowering → lower_closures_in_func
+공통: parse → resolve → typecheck → tdnr → ast_to_ir
+      → tribute_control_to_cps
+      → lower_closure_lambda → prepare_closure_lowering → lower_closures_in_func
       → lower_ability_perform → resolve_evidence → lower_handle_dispatch
-      → dce → resolve_casts
+      → effect ABI verification → dce → resolve_casts
 
-WASM:   → lower_to_wasm [includes evidence_to_wasm] → emit_wasm
-Native: → evidence_to_native → lower_to_clif → emit_native
+WASM:   → lower_to_wasm [includes evidence_to_wasm and empty-result mapping]
+        → backend-ready verification → emit_wasm
+Native: → evidence_to_native → lower_to_clif [includes empty-result mapping]
+        → backend-ready verification → emit_native
 ```
 
-계획한 직접형 target은 frontend emission 뒤 `tribute_control_to_cps`를 실행한다.
-그 출력은 physical callable/closure 표면과 logical `ability.*` 표면이며, 위의
-기존 closure, ability/evidence, backend effect ABI pass가 순서대로 소비한다.
-Issue #823과 #824가 합의한 뒤 정확한 pipeline splice는 #825가 소유한다. 이 문서는
-해당 splice가 이미 구현되었다고 주장하지 않는다.
+`tribute_control_to_cps`의 출력은 physical callable/closure 표면과 logical
+`ability.*` 표면이며, closure, ability/evidence, backend effect ABI pass가
+순서대로 소비한다.
 
 ---
 
@@ -835,8 +798,8 @@ Issue #823과 #824가 합의한 뒤 정확한 pipeline splice는 #825가 소유�
 
 ### WasmGC
 
-런타임의 GC가 자동으로 처리한다. 다만 현재 주요 구현 경로는 native이며,
-WasmGC CPS continuation은 closure로 표현하고 trampoline object는 만들지 않는다.
+런타임의 GC가 자동으로 처리한다. WasmGC CPS continuation은 closure로 표현하며
+trampoline object는 허용하지 않는다.
 
 ### Cranelift: Reference Counting
 
@@ -864,15 +827,9 @@ Cranelift 타겟에서는 **Reference Counting**을 채택한다.
 
 **Continuation과 RC:**
 
-- Yield bubbling에서 continuation은 ADT struct로 캡처됨
-- 캡처된 라이브 변수들은 struct 필드로 저장되어 RC가 자동 관리
-- Resume 시 struct에서 필드를 꺼내 복원
-
-**단계적 구현:**
-
-1. Phase 2: malloc/free 단순 할당 (누수 허용)
-2. Phase 3: RC retain/release 삽입
-3. Future: Cycle detection (필요시)
+- Continuation closure는 live value를 environment field로 캡처한다.
+- RC insertion은 해당 environment와 캡처한 reference의 ownership을 관리한다.
+- Resume은 environment에서 live value를 복원하고 continuation을 한 번 소비한다.
 
 ---
 
@@ -913,8 +870,7 @@ pub fn compile(db, source: SourceCst) -> Module {
 
 ### 파이프라인 구조
 
-다음은 계획한 직접형 topology이며 Issue #825가 #823과 #824를 조합하기 전까지 현재
-live pipeline이 아니다:
+직접형 callable/control부터 backend-ready 검증까지의 topology는 다음과 같다:
 
 ```mermaid
 flowchart TB
@@ -929,14 +885,14 @@ flowchart TB
     end
 
     subgraph shared["Shared legalization과 lowering"]
-        cps["atomic tribute_control_to_cps (#823)"]
+        cps["atomic tribute_control_to_cps"]
         physical["physical func/closure + logical ability dispatch"]
         closure["closure lowering"]
         ability["ability/evidence lowering"]
         effect["target-independent effect ABI"]
     end
 
-    subgraph targets["Proper tail-call lowering (#825)"]
+    subgraph targets["Proper tail-call lowering"]
         native_tail["Native direct/indirect return_call"]
         wasm_tail["Wasm return_call/return_call_indirect"]
     end
@@ -967,11 +923,6 @@ flowchart TB
     wasm_ready --> wasm_bin
 ```
 
-현재 compatibility topology는
-[cps-effects.md](cps-effects.md#current-shared-middle-end-pipeline)에 기록한다.
-Migrated coverage가 #826의 frontend-owned CPS 구성 제거를 허용할 때까지만 live로
-유지한다.
-
 ### 패스 분류
 
 | 카테고리 | 패스 | 입력 | 출력 | 캐싱 |
@@ -981,23 +932,20 @@ Migrated coverage가 #826의 frontend-owned CPS 구성 제거를 허용할 때�
 | | `typecheck` | type.var | solved or generalized typed AST | ✓ |
 | | `lambda_lift` | lambdas | top-level funcs | |
 | | `tdnr` | x.method() | Type::method(x) | |
-| **직접형 제어 (계획)** | `ast_to_ir` | typed AST | 검증된 `tribute_control` callable/control + 일반 value IR | frontend, #824 계획 |
-| | `tribute_control_to_cps` | logical callable/control + typechecked metadata | physical func/closure/tail-call + logical `ability.*`; `effect.*` 없음 | shared, #823 계획 |
+| **직접형 제어** | `ast_to_ir` | typed AST | 검증된 `tribute_control` callable/control + 일반 value IR | frontend |
+| | `tribute_control_to_cps` | logical callable/control + typechecked metadata | physical func/closure/tail-call + logical `ability.*`; `effect.*` 없음 | shared |
 | **Closure (공유 후속)** | `lower_closure_lambda` | closure.lambda | func.func + closure.new | module-wide |
 | | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
 | | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
 | **Ability/evidence (공유 후속)** | `lower_ability_perform` | ability.perform/call | effect.dispatch_* + evidence lookup | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | module-wide setup before function-local lowering |
 | | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |
-| **Ability (현재 compatibility 전용)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
-| | `tail_resumptive` | legacy ability suspension shape | optimized legacy shape | function-anchored |
 | **Backend effect ABI** | `native/evidence runtime decls` | evidence runtime stubs | native extern declarations | module-wide |
 | | `native/evidence` | effect.* | native runtime + func tail transfer | function-anchored |
-| | `func_to_clif` | func.tail_call / indirect | clif.return_call / indirect | function-anchored, #825 |
+| | `func_to_clif` | func.tail_call / indirect | clif.return_call / indirect | function-anchored |
 | | `wasm/evidence runtime funcs` | evidence runtime stubs | wasm evidence helpers | module-wide |
 | | `wasm/evidence_to_wasm` | effect.* | wasm helpers + indirect return_call | function-anchored |
-| | `func_to_wasm` | func.tail_call / indirect | wasm.return_call / indirect | function-anchored, #825 |
-| **Migration cleanup** | #826 cleanup | compatibility CPS/frontend path | carrier와 legacy trampoline builtin 없음 | module-wide |
+| | `func_to_wasm` | func.tail_call / indirect | wasm.return_call / indirect | function-anchored |
 | **Lowering** | `ast_to_ir case lowering` | tribute.case | scf.if | frontend lowering, not a pass |
 | | `canonicalize`, local `dce`, `scf_to_cf` | func.func body | canonical body / cf blocks | function-anchored |
 | | `global_dce` | module symbols | reachable funcs | module-wide |
@@ -1075,7 +1023,6 @@ fn infer_function(db, func_id: FunctionId) -> InferenceResult
 
 - `FunctionId`, `TypeId` 등 안정적인 ID 체계 필요
 - 모듈 구조와 개별 항목 분리
-- 점진적 마이그레이션 전략 (일부 패스부터 적용)
 
 이를 통해 "함수 하나 수정 시 해당 함수만 재처리"하는 진정한 incremental compilation이 가능해진다.
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -56,40 +56,39 @@ tribute        -> tribute-front + tribute-passes
 `tribute-front`는 `tribute-passes`에 의존하지 않는다. 각 계층의 책임은 다음과
 같다:
 
-- `tribute-front`는 source-logical callable signature를 유지하고, 모든 `fn`/`op`
-  invocation을 typecheck된 `operation_kind = @fn | @op`를 가진
-  `tribute_control.perform`으로 emit한다. Dispatch 전략이나 continuation
-  representation은 선택하지 않는다.
-- `tribute-passes`는 #823의 `CallableAbi` signature conversion, kind-directed
-  `perform` lowering, region/suffix conversion, post-CPS legality를 소유한다.
+- `tribute-front`는 [논리 callable/control 계약](ir.md#direct-style-control)을
+  emit하고 `func.*`, `closure.*`, `core.func` 또는 dispatch representation을
+  만들지 않는다.
+- `tribute-passes`는
+  [atomic callable/control conversion](cps-effects.md#pre-cps-callable-shape)과
+  post-CPS legality를 소유한다.
 - Root `tribute` crate는 frontend emission과 shared conversion을 조합한다. Root
   `main`의 external Direct/EvidenceDirect ABI를 유지하면서 internal terminal
   continuation과 empty/inserted evidence를 구성하는 책임도 이 계층과 #823에 있다.
 
 검증 책임은 구현 계층과 분리한다:
 
-- `tribute-ir`는 `tribute_control` typed wrapper, parser/printer round trip,
-  operation-local verifier를 소유한다. 현재 TrunkIR에는 dialect callback registry가
-  없으므로 #822가 Tribute 전용 validator를 노출하고 frontend 경계가 generic
-  SSA/use-chain validation과 함께 호출한다.
-- Containing `tribute_control.handle` verifier는 handler placement, uniqueness,
-  region 형상, block argument, terminator, type agreement를 검사한다.
-- Whole-IR verifier는 SSA visibility와 `resume_token`의 single static ownership
-  path를 검사한다. Closure capture 뒤의 동적 재호출은 증명할 수 없으므로
-  converted resumption이 runtime one-shot state로 두 번째 호출을 거부하거나
-  trap한다.
+- `tribute-ir`는 dialect type/operation, parser/printer, local verifier와
+  Tribute-specific whole-IR verifier를 소유한다. 현재 TrunkIR에는 dialect
+  callback registry가 없으므로 #822가 validator를 노출하고 frontend 경계가
+  generic SSA/use-chain validation과 함께 호출한다. 세부 검증 계약은
+  [ir.md](ir.md#direct-style-control)를 따른다.
+- Whole-IR verifier는 static affine path를, converted resumption runtime은
+  closure 재호출에 대한 dynamic one-shot enforcement를 소유한다.
 - `tribute-passes`와 backend pipeline은 각각 post-CPS 및 backend-ready target을
-  검증한다. 성공한 경계에는 residual `tribute_control.*`이 없고 backend-ready
-  경계에는 `tribute_control.*`, `ability.*`, `effect.*`이 없다.
+  검증한다. 성공한 경계에는 residual `tribute_control` operation/type이 없고
+  backend-ready 경계에는 `tribute_control.*`, `ability.*`, `effect.*`이 없다.
 
 구현 순서는 다음과 같다:
 
-1. #822가 `tribute-ir`에 dialect와 local verifier를 구현한다.
-2. #823이 `tribute-passes`에 conversion과 legality를 구현한다.
-3. #824가 `tribute-front`를 직접형 emission으로 전환한다.
+1. #822가 `tribute-ir`에 callable/control type과 operation, verifier를 구현한다.
+2. #823이 `tribute-passes`에 atomic callable/control conversion과 legality를
+   구현한다.
+3. #824가 `tribute-front`를 `tribute_control` callable/control emission으로
+   전환한다.
 4. #825가 root pipeline에 conversion과 backend residual 검사를 조합한다.
-5. #826이 migrated coverage를 확인한 뒤 frontend-owned CPS normalization과
-   continuation 구성, 중복 compatibility lowering을 제거한다.
+5. #826이 migrated coverage를 확인한 뒤 frontend-owned physical callable ABI,
+   CPS normalization과 continuation 구성, 중복 compatibility lowering을 제거한다.
 
 Issue #823과 #824의 준비 작업은 #822 뒤에 병행할 수 있지만, 두 계약이 합의되고 #825가
 조합하기 전에는 새 경계가 live라고 주장할 수 없다. Partial rewrite 내부의
@@ -805,10 +804,10 @@ WASM:   → lower_to_wasm [includes evidence_to_wasm] → emit_wasm
 Native: → evidence_to_native → lower_to_clif → emit_native
 ```
 
-계획한 직접형 target은 continuation-dependent closure/effect lowering 전에 검증된
-`tribute_control` emission과 shared CPS legalization을 삽입한다. #823과 #824가
-합의한 뒤 정확한 pipeline splice는 #825가 소유한다. 이 문서는 해당 splice가
-이미 구현되었다고 주장하지 않는다.
+계획한 직접형 target은 physical callable/closure/effect lowering 전에 검증된
+`tribute_control` callable/control emission과 shared CPS legalization을 삽입한다.
+Issue #823과 #824가 합의한 뒤 정확한 pipeline splice는 #825가 소유한다. 이 문서는 해당
+splice가 이미 구현되었다고 주장하지 않는다.
 
 ---
 
@@ -900,8 +899,8 @@ live pipeline이 아니다:
 ```text
 source
   -> parse / merge prelude / resolve / typecheck / TDNR
-  -> tribute-front emits verified tribute_control + ordinary TrunkIR
-  -> tribute-passes legalizes tribute_control to CPS
+  -> tribute-front emits verified tribute_control callable/control + ordinary value IR
+  -> tribute-passes atomically legalizes callable/control to physical CPS IR
   -> existing closure / ability / evidence / effect ABI passes
   -> canonicalize / DCE / resolve casts
   -> native or Wasm lowering
@@ -925,8 +924,8 @@ Migrated coverage가 #826의 frontend-owned CPS 구성 제거를 허용할 때�
 | | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
 | | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
 | | `tdnr` | x.method() | Type::method(x) | |
-| **직접형 제어 (계획)** | `ast_to_ir` | typed AST | typecheck된 operation kind를 갖는 검증된 `tribute_control` + 일반 IR | frontend, #824 계획 |
-| | `tribute_control_to_cps` | `tribute_control` + operation-kind/convention metadata | kind-directed ability/effect/closure CPS IR | shared, #823 계획 |
+| **직접형 제어 (계획)** | `ast_to_ir` | typed AST | 검증된 `tribute_control` callable/control + 일반 value IR | frontend, #824 계획 |
+| | `tribute_control_to_cps` | logical callable/control + typechecked metadata | atomic physical func/closure graph + kind-directed ability/effect CPS IR | shared, #823 계획 |
 | **Ability (현재 compatibility)** | `ast_to_ir evidence params` | effectful funcs | +ev param | |
 | | `lower_ability_perform`, `tail_resumptive` | ability.perform/call | effect.dispatch_* | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | module-wide setup before function-local lowering |

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -48,7 +48,7 @@ Partial conversion may leave unknown operations for later passes. Full
 conversion boundaries, such as backend-ready native IR, must reject unknown
 operations.
 
-직접형 제어 마이그레이션은 다음과 같은 이름의 경계를 사용한다:
+직접형 제어 pipeline은 다음과 같은 이름의 경계를 사용한다:
 
 | 경계 | `ConversionTarget` mode | 필수 적법성 |
 | ---- | ---- | ---- |
@@ -57,8 +57,9 @@ operations.
 | `tribute-backend-ready-native` | Tribute full 경계 뒤 generic Cranelift 경계 | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, conversion cast가 없다. 명시적으로 열거한 native infrastructure와 `clif.*` operation만 남는다. |
 | `tribute-backend-ready-wasm` | 기존 emission-ready 검사 전에 high-level operation을 partial 방식으로 거부 | backend-ready Wasm IR 전에 `tribute_control`, `ability`, `effect`를 명시적으로 illegal로 지정하며, emission 전에는 `wasm_gc`도 illegal이다. |
 
-현재 API에서는 `ConversionTarget::new().illegal_dialect("tribute_control")`와
-partial verification을 조합해 post-CPS helper를 구현할 수 있다. Full mode에서는
+Post-CPS helper는
+`ConversionTarget::new().illegal_dialect("tribute_control")`와 partial
+verification을 조합한다. Full mode에서는
 unknown operation이 legal하지 않으므로 frontend 적합성 target과 backend full
 target이 legal dialect와 operation을 열거해야 한다. `ConversionTarget`은
 operation 적법성만 검사하므로 Tribute whole-IR type walk가 pre-CPS의
@@ -178,8 +179,8 @@ type, callable ABI, backend carrier가 아니며 continuation representation을
 검사할 권한도 아니다. Logical result가 `Never`인 source general operation은
 canonical `core.never` TypeRef를 사용하고 resumption을 만들지 않으며
 `resume_token`도 노출하지 않는다. Verifier가 erased type을 추측하지 않고
-non-resumptive case를 식별해야 하므로 현재 legacy frontend의 `Never`용 `anyref`
-placeholder는 이 새 경계에서 valid하지 않다.
+non-resumptive case를 식별해야 하므로 `Never`용 `anyref` placeholder는 이
+경계에서 valid하지 않다.
 
 ### 사용자 정의 어셈블리 형식
 
@@ -218,7 +219,7 @@ tribute_control.func @decl(%x: T) -> R convention(direct)
 parameter/result, 필수 convention, 명시적 `captures [...]`, 선택적 추가
 attribute와 body를 출력하고 entry label을 생략한다. `captures [...]`는 capture가
 없어도 `captures []`로 항상 출력하며 canonical 순서는 convention, captures,
-선택적 attributes, body다. `func_ref`, `call`, `call_indirect`, `return`은 현재
+선택적 attributes, body다. `func_ref`, `call`, `call_indirect`, `return`은
 generic assembly가 모든 정보를 손실 없이 표현하므로 custom format을 만들지
 않는다.
 
@@ -526,6 +527,8 @@ Frontend output은 모든 실행 가능한 region 내부에서 strict ANF다. St
 왼쪽에서 오른쪽으로 정확히 한 번 평가한다. 선택된 case/conditional arm, case
 guard, short-circuit 오른쪽 항은 선택된 `scf.*` region 안에 남고 hoist하지
 않는다. Handler body와 nested handle body는 독립적인 실행 region이다.
+일반 structured control은 기존 `scf.*` dialect에 남으며
+`tribute_control_to_cps`가 그 region과 suffix를 재귀적으로 변환한다.
 
 Shared CPS conversion은 남은 operation과 enclosing region exit를 위한 명시적인
 logical continuation으로 region을 lower한다:
@@ -572,7 +575,7 @@ native uses function pointers plus heap environments.
 `adt.*` represents target-independent product, sum, array, reference, and
 literal operations.
 
-`list.*` represents the opaque canonical `List(a)` sequence contract. M1 uses
+`list.*` represents the opaque canonical `List(a)` sequence contract. It uses
 `list.empty`, `list.prepend`, `list.is_empty`, `list.head`, and `list.tail`.
 These operations carry element/result types but no variant tags, node field
 indices, allocation sizes, or target layout metadata. `list.prepend` is
@@ -690,7 +693,7 @@ Important stage invariants:
 | Shared CPS legalization | 전체 callable graph가 physical `CallableAbi`와 direct/indirect tail transfer를 사용하며 `tribute_control` operation/type이 남지 않음 |
 | Shared lowering | 명시된 경계에서 high-level ability dispatch operation이 제거됨 |
 | Effect ABI | `effect.*` operations preserve dispatch semantics without backend layout details |
-| Backend lowering | Backend-ready 검증이 성공하고 `effect.*` 및 compatibility CPS carrier가 남지 않음 |
+| Backend lowering | Backend-ready 검증이 성공하고 `effect.*`, CPS control carrier, trampoline이 남지 않음 |
 
 ## Type Model
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -21,7 +21,7 @@ Infrastructure
 High-level
   tribute   unresolved or source-level frontend constructs
   tribute_control
-            target-independent direct-style effect control
+            Tribute-specific source-logical callables and direct-style control
   ability   evidence and handler dispatch semantics
   effect    target-independent effect ABI
   closure   closure construction and decomposition
@@ -48,24 +48,26 @@ Partial conversion may leave unknown operations for later passes. Full
 conversion boundaries, such as backend-ready native IR, must reject unknown
 operations.
 
-직접형 control 마이그레이션은 다음과 같은 이름의 경계를 사용한다:
+직접형 제어 마이그레이션은 다음과 같은 이름의 경계를 사용한다:
 
 | 경계 | `ConversionTarget` mode | 필수 적법성 |
 | ---- | ---- | ---- |
-| `tribute-control-pre-cps` | frontend 적합성 검사에는 full, 마이그레이션 pass 조합 중에는 partial | `tribute_control.*`은 `core`, `func`, `scf`, `arith`, `adt`, `list`, `closure`, `tribute_rt`, `tribute_io`와 공존할 수 있다. 기존 `ability.*`, `effect.*`, legacy CPS 구성 operation은 illegal이다. |
-| `tribute-control-post-cps` | shared CPS 변환 뒤 partial | `tribute_control` dialect 전체가 illegal이다. 기존 `ability.perform`, `ability.call`, handler/evidence operation, `effect.*`, `closure.*`, 일반 dialect는 이후 shared pass를 위해 공존할 수 있다. |
+| `tribute-control-pre-cps` | frontend 적합성 검사에는 full, 변환 중에는 partial | `tribute_control.*`은 `core.module`, `core.never`와 일반 `core` 값 type, `scf`, `arith`, `adt`, `list`, `tribute_rt`, `tribute_io`와 공존할 수 있다. `func.*`, `closure.*`, `core.func`, 기존 `ability.*`, `effect.*`, legacy CPS 구성 operation은 illegal이다. |
+| `tribute-control-post-cps` | shared CPS 변환 뒤 partial | `tribute_control` dialect의 모든 operation과 type이 illegal이다. Physical `func.*`, `closure.*`, `core.func`, 기존 `ability.*`, `effect.*`, 일반 dialect는 이후 pass를 위해 공존할 수 있다. |
 | `tribute-backend-ready-native` | Tribute full 경계 뒤 generic Cranelift 경계 | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, conversion cast가 없다. 명시적으로 열거한 native infrastructure와 `clif.*` operation만 남는다. |
 | `tribute-backend-ready-wasm` | 기존 emission-ready 검사 전에 high-level operation을 partial 방식으로 거부 | backend-ready Wasm IR 전에 `tribute_control`, `ability`, `effect`를 명시적으로 illegal로 지정하며, emission 전에는 `wasm_gc`도 illegal이다. |
 
 현재 API에서는 `ConversionTarget::new().illegal_dialect("tribute_control")`와
 partial verification을 조합해 post-CPS helper를 구현할 수 있다. Full mode에서는
 unknown operation이 legal하지 않으므로 frontend 적합성 target과 backend full
-target이 legal dialect와 operation을 열거해야 한다. `func.func`,
-`closure.lambda` 또는 다른 region 소유 container를 recursively legal로
-표시해서는 안 된다. 그렇게 하면 nested region의 illegal control operation이
-가려진다. Generic `trunk-ir`의 Cranelift 경계는 Tribute에 독립적으로 유지한다.
-이를 호출하기 전에 Tribute 전용 high-level dialect를 명시적으로 거부하는 책임은
-Tribute pipeline에 있다.
+target이 legal dialect와 operation을 열거해야 한다. `ConversionTarget`은
+operation 적법성만 검사하므로 Tribute whole-IR type walk가 pre-CPS의
+`core.func`/`closure.closure`와 post-CPS의 `tribute_control.callable`/
+`resume_token`을 별도로 거부한다. 이 walk는 operand/result, block argument,
+type attribute와 nested type parameter를 재귀적으로 검사한다. Region 소유
+operation을 recursively legal로 표시해서 nested illegal operation을 가려서는
+안 된다. Generic `trunk-ir`의 Cranelift 경계는 Tribute에 독립적으로 유지하며,
+그 전에 Tribute pipeline이 high-level dialect를 거부한다.
 
 하나의 rewrite 도중에는 source `tribute_control.*`과 새
 `ability.*`/`effect.*` 결과가 일시적으로 공존할 수 있다. 이는 partial
@@ -111,7 +113,7 @@ resolution, type checking, TDNR, and AST-to-IR lowering.
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="direct-style-control"></a>
 
-### 직접형 제어
+### 직접형 호출 대상과 제어
 
 `tribute_control.*`은 typed frontend lowering과 shared CPS conversion 사이의
 target-independent 직접형 경계다. Dialect identifier는 정확히
@@ -119,32 +121,44 @@ target-independent 직접형 경계다. Dialect identifier는 정확히
 `<dialect>.<operation>` 쌍으로 parse하므로 dialect identifier 안에 점을 넣는
 등 separator를 하나 더 사용하는 표기는 invalid이다.
 
-이 dialect는 CPS pass가 변환해야 하는 control construct만 모델링한다. ANF는
-input invariant이지 dialect의 정체성이 아니다. 산술, 일반 direct/indirect call,
-ADT/list/tuple/record 구성, closure, structured selection은 기존 dialect에
-남는다. 특히 `tribute_control.invoke`는 없다. `func.call`,
-`func.call_indirect`, `closure.lambda`가 이미 callable type과 shared
-conversion에 필요한 `Direct < EvidenceDirect < Cps` convention metadata를
-운반한다. 새 invocation operation을 추가하면 control fact를 더하지 못한 채
-기존 operation만 중복한다.
+이 dialect는 CPS legalization 전의 Tribute 고유 callable과 effect-control
+의미를 함께 소유한다. ANF는 input invariant이지 dialect의 정체성이 아니다.
+산술, ADT/list/tuple/record 구성과 structured selection은 기존 dialect에 남지만,
+`func.*`, `closure.*`, `core.func`는 physical 표현이므로 이 경계에 나타나지
+않는다.
 
-pre-CPS 경계에서 모든 `func.func`, `closure.lambda`, `func.call`,
-`func.call_indirect` signature는 convention과 무관하게 source-logical 형상을
-유지한다. Source parameter를 받고 source result를 내며 hidden evidence나
-`done_k` operand가 없다. Definition/lambda와 해당 callable type에는 convention
-metadata가 필수다. Shared conversion은 definition과 모든 direct/indirect call
-site를 기존 `CallableAbi`에 맞춰 함께 rewrite한다. 전체 규칙은
+논리 callable type은
+`tribute_control.callable(Result, Params...) {tribute.calling_convention = N}`이다.
+`Result`와 `Params`는 source-logical type이며 기존 code `Direct = 0`,
+`EvidenceDirect = 1`, `Cps = 2`를 그대로 사용한다. 이 metadata는 typechecking
+결과를 복사한 것으로 body에서 추론하지 않는다. Legalization은 이를 기존
+`CallableAbi`와 physical `core.func`, `closure.closure` 및
+`tribute.calling_convention` operation attribute로 바꾼다. Type verifier는
+result 하나와 parameter 0개 이상, convention domain, 모든 component type의
+resolution을 검사하며 physical `core.func`나 `closure.closure`를 component로
+허용하지 않는다. 전체 규칙은
 [cps-effects.md](cps-effects.md#pre-cps-callable-shape)에 있다.
 
 최소 operation 집합은 다음과 같다:
 
 | Operation | 용도 |
 | ---- | ---- |
+| `tribute_control.func` | named source callable의 선언 또는 정의 |
+| `tribute_control.lambda` | capture를 가진 source lambda와 callable value 생성 |
+| `tribute_control.func_ref` | named function을 first-class callable value로 참조 |
+| `tribute_control.call` | named source callable 직접 호출 |
+| `tribute_control.call_indirect` | source callable value 간접 호출 |
+| `tribute_control.return` | `func` 또는 `lambda` body의 logical result 반환 |
 | `tribute_control.perform` | source `fn` 또는 general `op` 하나를 semantic kind를 보존한 직접형으로 호출 |
 | `tribute_control.handle` | 직접형 computation, completion arm, handler table의 경계를 설정 |
 | `tribute_control.handler` | handle 안의 `fn` 또는 general `op` handler arm을 기술 |
 | `tribute_control.resume` | resumptive general handler arm에 바인딩된 affine resumption을 소비 |
 | `tribute_control.yield` | 실행 가능한 `tribute_control` region을 logical value로 종료 |
+
+`func.tail_call`, `func.constant`, `func.unreachable`의 logical 복제는 없다. Tail
+형상은 legalization 결과이고 named function value는 `func_ref`가 표현한다.
+`func.constant`는 후속 physical closure lowering이 만들며 `func.unreachable`은
+reject adapter 같은 compiler helper 안에서만 legalization 뒤에 사용한다.
 
 이 dialect는 opaque type `tribute_control.resume_token<input, answer>`도
 소유한다. `input`은 중단된 operation continuation이 받는 값이고, `answer`는
@@ -155,6 +169,104 @@ canonical `core.never` TypeRef를 사용하고 resumption을 만들지 않으며
 `resume_token`도 노출하지 않는다. Verifier가 erased type을 추측하지 않고
 non-resumptive case를 식별해야 하므로 현재 legacy frontend의 `Never`용 `anyref`
 placeholder는 이 새 경계에서 valid하지 않다.
+
+#### `tribute_control.func`
+
+```text
+tribute_control.func {sym_name = @id, type = !Callable} (%x: T) { ... }
+```
+
+- **형상:** 피연산자와 결과는 없다. `sym_name: Symbol`과
+  `type: tribute_control.callable(Result, Params...)`가 필수다. 선언은 region이
+  없고 정의는 source parameter만 block argument로 받는 single-block `body`
+  하나이며 `tribute_control.return`으로 끝난다. Foreign ABI 같은 비제어
+  attribute는 보존한다.
+- **의미:** source named function의 logical signature와 typechecking이 선택한
+  convention을 정의하며 hidden evidence, environment, `done_k`를 포함하지 않는다.
+- **검증:** local verifier는 attribute, region, block argument, return type을
+  callable type과 맞춘다. Whole-IR verifier는 symbol uniqueness를 검사한다.
+- **소유권과 값 흐름:** body는 isolated-from-above다. Source local과 parameter만
+  block argument로 들어온다.
+- **위치:** source function 또는 extern declaration 전체 span이다.
+
+#### `tribute_control.lambda`
+
+```text
+%f = tribute_control.lambda [%capture0, ...] : !Callable { ... }
+```
+
+- **형상:** 피연산자는 typechecking된 capture를 source 순서로 나열한다. 결과는
+  `tribute_control.callable` 하나이고 필수 attribute는 없다. Single-block body는
+  source parameter만 block argument로 받으며 `tribute_control.return`으로 끝난다.
+- **의미:** source lambda를 만들며 body는 lexical capture와 parameter를 사용한다.
+- **검증:** local verifier는 result signature, block argument, return type을
+  맞춘다. Whole-IR verifier는 body의 외부 SSA reference와 capture 집합이 정확히
+  일치하는지 검사한다.
+- **소유권과 값 흐름:** capture는 일반 SSA use이며 다른 hidden operand는 없다.
+- **위치:** source lambda 전체 span이다.
+
+#### `tribute_control.func_ref`
+
+```text
+%f = tribute_control.func_ref {func_ref = @id} : !Callable
+```
+
+- **형상:** 피연산자와 region은 없고 terminator가 아니다. `func_ref: Symbol`이
+  필수이며 결과는 `tribute_control.callable` 하나다.
+- **의미:** named function을 first-class source value로 만든다. Source가 named
+  function을 higher-order value로 사용할 수 있으므로 필요하다. Result는 대상과
+  같은 source signature이며 convention은 대상 worker와 같거나 더 강할 수 있다.
+- **검증:** local verifier는 attribute와 result 형상을 검사한다. Whole-IR
+  verifier는 symbol resolution, source signature 일치와 convention 순서를
+  검사한다.
+- **소유권과 값 흐름:** 결과는 일반 SSA value다.
+- **위치:** named function을 값으로 사용한 source reference span이다.
+
+#### `tribute_control.call`
+
+```text
+%result = tribute_control.call %arg0, ... {callee = @f} : Result
+```
+
+- **형상:** declaration 순서의 source argument, source-logical result 하나,
+  `callee: Symbol`을 가지며 region이 없는 non-terminator다.
+- **의미:** named source callable을 직접 호출한다.
+- **검증:** local verifier는 attribute와 resolved operand/result를 검사한다.
+  Whole-IR verifier는 callee `tribute_control.func`의 arity/type을 맞춘다.
+- **소유권과 값 흐름:** argument/result는 일반 SSA value이고 hidden operand는
+  없다.
+- **위치:** callee와 argument를 포함한 source call span이다.
+
+#### `tribute_control.call_indirect`
+
+```text
+%result = tribute_control.call_indirect %callee, %arg0, ... : Result
+```
+
+- **형상:** `tribute_control.callable` callee, source argument, callee type의
+  source-logical result 하나를 가지며 attribute/region이 없는 non-terminator다.
+- **의미:** lambda, `func_ref`, parameter 또는 capture로 얻은 callable을 호출한다.
+- **검증:** local verifier는 callee signature와 argument/result type을 맞춘다.
+- **소유권과 값 흐름:** callee와 argument는 일반 SSA use이고 environment,
+  evidence, `done_k`는 없다.
+- **위치:** callee와 argument를 포함한 source indirect-call span이다.
+
+#### `tribute_control.return`
+
+```text
+tribute_control.return %value
+```
+
+- **형상:** source-logical result 하나를 받고 결과/attribute/region은 없다.
+  `tribute_control.func` 또는 `lambda` body의 terminator이며 다른 위치에서는
+  invalid이다.
+- **의미:** enclosing callable의 logical result를 반환한다.
+- **지역 검증:** enclosing callable result와 operand type을 맞춘다.
+- **소유권과 값 흐름:** 일반 SSA value를 소비한다.
+- **위치:** source return 또는 implicit body-result expression span이다.
+
+Callable operation의 physical lowering은
+[cps-effects.md](cps-effects.md#pre-cps-callable-shape)에만 정의한다.
 
 #### `tribute_control.perform`
 
@@ -499,7 +611,7 @@ source
   -> name resolution
   -> type checking
   -> TDNR
-  -> AST-to-IR (source-logical callable + tribute_control IR)
+  -> AST-to-IR (tribute_control callable/control + ordinary value IR)
   -> shared CPS legalization
   -> shared lowering and optimization
   -> Wasm or native lowering
@@ -514,8 +626,8 @@ Important stage invariants:
 | Resolution | Names, constructors, and variable references are resolved |
 | Type check | Type variables and effect rows are solved |
 | TDNR | Method-style calls are converted to resolved calls |
-| AST-to-IR | Source-logical callable signature, 검증된 `tribute_control` 구조, valid SSA use chain |
-| Shared CPS legalization | Callable signature과 모든 call site가 physical `CallableAbi`를 사용하며 `tribute_control.*`이 남지 않음 |
+| AST-to-IR | `tribute_control.callable`과 callable/control operation, valid SSA use chain |
+| Shared CPS legalization | 전체 callable graph가 physical `CallableAbi`를 사용하며 `tribute_control` operation/type이 남지 않음 |
 | Shared lowering | 명시된 경계에서 high-level ability dispatch operation이 제거됨 |
 | Effect ABI | `effect.*` operations preserve dispatch semantics without backend layout details |
 | Backend lowering | Backend-ready target verification succeeds and no `effect.*` operations remain |

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -20,6 +20,8 @@ Infrastructure
 
 High-level
   tribute   unresolved or source-level frontend constructs
+  tribute_control
+            target-independent direct-style effect control
   ability   evidence and handler dispatch semantics
   effect    target-independent effect ABI
   closure   closure construction and decomposition
@@ -45,6 +47,32 @@ An unspecified operation is `Unknown`, not legal.
 Partial conversion may leave unknown operations for later passes. Full
 conversion boundaries, such as backend-ready native IR, must reject unknown
 operations.
+
+The direct-control migration uses these named boundaries:
+
+| Boundary | `ConversionTarget` mode | Required legality |
+| ---- | ---- | ---- |
+| `tribute-control-pre-cps` | Full for frontend conformance; partial while composing migration passes | `tribute_control.*` may coexist with `core`, `func`, `scf`, `arith`, `adt`, `list`, `closure`, `tribute_rt`, and `tribute_io`. Existing `ability.*`, `effect.*`, and legacy CPS construction operations are illegal. |
+| `tribute-control-post-cps` | Partial after the shared CPS conversion | The entire `tribute_control` dialect is illegal. Existing `ability.perform`, `ability.call`, handler/evidence operations, `effect.*`, `closure.*`, and ordinary dialects may coexist for their subsequent shared passes. |
+| `tribute-backend-ready-native` | Full Tribute boundary followed by the generic Cranelift boundary | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, and conversion casts are absent. Only the explicitly listed native infrastructure and `clif.*` operations remain. |
+| `tribute-backend-ready-wasm` | Partial high-level rejection followed by the existing emission-ready checks | `tribute_control`, `ability`, and `effect` are explicitly illegal before backend-ready Wasm IR; `wasm_gc` is additionally illegal before emission. |
+
+The post-CPS helper is implementable with the current API as
+`ConversionTarget::new().illegal_dialect("tribute_control")` plus partial
+verification. Frontend conformance and backend full targets must enumerate
+their legal dialects and operations because unknown is not legal in full mode.
+They must not mark `func.func`, `closure.lambda`, or another region-owning
+container recursively legal: doing so would hide illegal control operations in
+nested regions. The generic `trunk-ir` Cranelift boundary remains
+Tribute-agnostic; the Tribute pipeline owns the explicit rejection of
+Tribute-specific high-level dialects before invoking it.
+
+Transiently, one rewrite may contain both source `tribute_control.*` and its
+new `ability.*`/`effect.*` output. That is an implementation state inside
+partial conversion, not a successful named boundary. Successful
+`tribute-control-post-cps` verification reports every residual
+`tribute_control.*` operation with its source location as a conversion
+failure.
 
 ## Validation Layers
 
@@ -80,6 +108,315 @@ interfaces describe behavior, not validation phases.
 
 `tribute.*` represents source-level constructs that should disappear after
 resolution, type checking, TDNR, and AST-to-IR lowering.
+
+### Direct-style control
+
+`tribute_control.*` is the target-independent, direct-style boundary between
+typed frontend lowering and shared CPS conversion. The dialect identifier is
+exactly `tribute_control`. TrunkIR parses a qualified operation as one
+`<dialect>.<operation>` pair, so spellings with another separator, such as a
+dot inside the dialect identifier, are invalid.
+
+The dialect models only control constructs that the CPS pass must transform.
+ANF is an input invariant, not the dialect's identity. Arithmetic, ordinary
+direct and indirect calls, ADT/list/tuple/record construction, closures, and
+structured selection remain in their existing dialects. In particular, there
+is no `tribute_control.invoke`: `func.call`, `func.call_indirect`, and
+`closure.lambda` already carry the callable type and
+`Direct < EvidenceDirect < Cps` convention metadata needed by shared
+conversion. A new invocation operation would duplicate those operations
+without adding a control fact.
+
+At the pre-CPS boundary, all `func.func`, `closure.lambda`, `func.call`, and
+`func.call_indirect` signatures are source-logical regardless of convention:
+source parameters in, source result out, with no hidden evidence or `done_k`
+operands. Convention metadata is required on the definition/lambda and its
+callable type. Shared conversion rewrites definitions and all direct/indirect
+call sites together to the existing `CallableAbi`; the complete rule is in
+[cps-effects.md](cps-effects.md#pre-cps-callable-shape).
+
+The minimal operation set is:
+
+| Operation | Purpose |
+| ---- | ---- |
+| `tribute_control.perform` | Invoke one source `fn` or general `op` in direct style, retaining its semantic kind |
+| `tribute_control.handle` | Delimit a direct-style computation, its completion arm, and its handler table |
+| `tribute_control.handler` | Describe one `fn` or general `op` handler arm inside a handle |
+| `tribute_control.resume` | Consume the affine resumption bound by a resumptive general handler arm |
+| `tribute_control.yield` | Terminate one executable `tribute_control` region with its logical value |
+
+The dialect also owns the opaque type
+`tribute_control.resume_token<input, answer>`. `input` is the value accepted
+by the suspended operation's continuation, and `answer` is the logical result
+of running that continuation through the enclosing handle. The type is not a
+source type, callable ABI, backend carrier, or permission to inspect a
+continuation representation. A source general operation whose logical result
+is `Never` uses the canonical `core.never` TypeRef, creates no resumption, and
+exposes no `resume_token`. The current pre-M2 frontend's `anyref` placeholder
+for `Never` is not valid at this new boundary because a verifier must identify
+the non-resumptive case without guessing from an erased type.
+
+#### `tribute_control.perform`
+
+```text
+%result = tribute_control.perform %arg0, ... {
+  ability_ref = !State,
+  op_name = @get,
+  operation_kind = @op
+} : ResultType
+```
+
+- **Operands:** zero or more already-evaluated source arguments in declaration
+  order. Values retain their logical types; tuple packing and erasure are
+  conversion work.
+- **Results:** exactly one logical operation result. A source `Never` result is
+  `core.never`; it does not select a physical `Never` control carrier.
+- **Attributes:** required `ability_ref: Type`, `op_name: Symbol`, and
+  `operation_kind: Symbol`. `operation_kind` is exactly `fn` or `op` and is
+  copied from the typechecked operation declaration. It is source-semantic
+  metadata, not a lowering hint inferred from the body or use site.
+- **Regions and block arguments:** none.
+- **Terminator:** none; this is not a terminator in direct-style IR.
+- **Semantics:** invokes the source operation with its declared kind. For
+  `operation_kind = @fn`, the selected handler result automatically resumes
+  direct-style evaluation; shared conversion does not capture a
+  continuation and uses the existing tail-dispatch path. For
+  `operation_kind = @op`, a matching handler may resume, in which case
+  execution continues after the operation and the result becomes `%result`.
+  If it does not resume, the selected general handler completes the matching
+  handle and the apparent suffix is not evaluated. A source `op -> Never`
+  cannot resume and therefore never constructs a logical resumption or
+  captures the apparent suffix.
+
+| `operation_kind` | Direct-style result | Required shared lowering | Matching handler shape |
+| ---- | ---- | ---- | ---- |
+| `@fn` | Declared source result | No suffix capture; `ability.call` then tail dispatch | No resume token; yield the declared operation result for automatic resumption |
+| `@op` | Declared source result, using canonical `core.never` for `Never` | Capture the suffix for `ability.perform` and CPS dispatch, except use the reject adapter without suffix capture for `Never` | Final resume token except for `Never`; yield the handle answer on non-resumption |
+
+- **Local verification:** requires the three attributes, checks the
+  `operation_kind` domain, requires exactly one result and no regions, and
+  requires resolved operand/result types rather than inference variables.
+  Symbol-aware frontend conformance additionally checks that `ability_ref` and
+  `op_name` resolve to an operation declaration whose declared `fn`/`op` kind,
+  parameter types, and result type equal the attributes, operands, and result.
+  Neither verifier may infer the kind from control flow, handlers, result type,
+  or calling convention. The `tribute_control.handler` and containing-handle
+  verifiers apply the corresponding handler row above to handler entries.
+- **Ownership and value flow:** operands are ordinary SSA uses. The operation
+  creates no source-visible continuation value; shared CPS conversion owns
+  continuation construction. For `@fn`, conversion produces
+  `ability.call`/tail dispatch without a continuation. For `@op`, conversion
+  produces `ability.perform`/CPS dispatch with the suffix continuation. For
+  `op -> Never`, it instead supplies the existing ability/effect ABI with a
+  real zero-capture reject continuation whose body is `func.unreachable`; it
+  does not capture the source suffix. Null, an in-band sentinel, or arbitrary
+  `anyref` is not a continuation.
+- **Location:** the source location of the ability-operation call, covering
+  the qualified callee and arguments when available.
+
+Every source ability invocation uses `tribute_control.perform` at this
+boundary. The shared conversion is the first phase that chooses a dispatch
+representation, using `operation_kind` without reclassifying it. In
+particular, an `@op` whose handler body appears always tail-resumptive remains
+an `@op`; recognizing and optimizing that shape is a later IR optimization
+after semantic lowering.
+
+The reject continuation is compatibility glue for the existing
+`ability.perform` and `effect.dispatch_cps` operand contract, both of which
+require an explicit continuation. It has the same callable ABI as an ordinary
+lowered continuation, contains no captures, and traps if invoked. It may be
+deduplicated per compilation unit, but each use passes a typed closure value
+through the normal closure-to-`anyref` conversion. This rule preserves source
+`Never` semantics without adding an operation or choosing the physical CPS
+result carrier.
+
+#### `tribute_control.handle`
+
+```text
+%answer = tribute_control.handle : AnswerType
+  body {
+    ...
+    tribute_control.yield %body_value
+  }
+  completion(%completed: BodyType) {
+    ...
+    tribute_control.yield %answer_value
+  }
+  handlers {
+    tribute_control.handler ... { ... }
+    ...
+  }
+```
+
+- **Operands:** none. Values captured by executable regions use normal
+  enclosing SSA visibility.
+- **Results:** exactly one logical handle result.
+- **Attributes:** none are required. Dynamic prompt/owner tags and backend
+  carrier choices are deliberately absent.
+- **Regions:** exactly three, in the fixed order `body`, `completion`,
+  `handlers`.
+- **Block arguments:** `body` has one block and no arguments. `completion` has
+  one block with exactly one argument, whose type equals the value yielded by
+  `body`. `handlers` has one block with no arguments and contains only
+  `tribute_control.handler` entries.
+- **Terminators:** `body` and `completion` end in
+  `tribute_control.yield`. The `handlers` block is a declarative table and has
+  no terminator.
+- **Semantics:** normal completion of `body` evaluates `completion` exactly
+  once and returns its value. A general handler arm that finishes without
+  resuming returns its arm value as the handle result and bypasses
+  `completion`. A tail-resumptive `fn` arm returns an operation result that is
+  fed automatically to the suspended computation.
+- **Local verification:** enforces the fixed region count, single-block
+  shapes, block-argument counts, terminators, yielded type equalities, and that
+  every direct child of `handlers` is a unique
+  `(ability_ref, op_name)` `tribute_control.handler`. Its result type must
+  equal the completion yield type and every general handler's answer type.
+- **Ownership and value flow:** the operation owns the delimited resumption
+  capabilities created when its body performs resumptive general operations.
+  They are exposed only as `resume_token` block arguments of resumptive
+  general handler entries. Values leave executable regions only through
+  `tribute_control.yield`.
+- **Location:** the complete source `handle` expression. Region/block
+  locations use the corresponding body, completion arm, and handler-list
+  spans.
+
+The frontend always materializes a completion region. When source omits a
+`do` arm, the region is the identity operation on the body result. This removes
+an optional structural case from conversion without changing source
+semantics.
+
+#### `tribute_control.handler`
+
+```text
+tribute_control.handler {
+  ability_ref = !State,
+  op_name = @get,
+  kind = @op,
+  operation_result_type = ResultType
+} (%arg0: Arg0Type, ..., %resume:
+    tribute_control.resume_token<ResultType, AnswerType>) {
+  ...
+  tribute_control.yield %answer
+}
+```
+
+- **Operands and results:** none. It is a declarative entry owned by the
+  surrounding `tribute_control.handle`.
+- **Attributes:** required `ability_ref: Type`, `op_name: Symbol`,
+  `kind: Symbol`, and `operation_result_type: Type`. `kind` is exactly `fn` or
+  `op`.
+- **Regions:** exactly one executable `body` region with one block.
+- **Block arguments:** source operation arguments appear first, in declaration
+  order and at logical types. A resumptive `op` entry has one final
+  `resume_token<operation_result_type, handle-result-type>` argument. An `op`
+  whose `operation_result_type` is source `Never` has no token, and a `fn`
+  entry has no token.
+- **Terminator:** the body ends in `tribute_control.yield`. For `fn`, the
+  yielded type equals `operation_result_type` and is automatically resumed.
+  For `op`, the yielded type equals the token's `answer` type and is the
+  enclosing handle result when the arm completes without transferring control
+  through `resume`.
+- **Local verification:** checks required attributes and domains, one block,
+  the final terminator, token position/parameters, and the yield rules above.
+  A general handler whose `operation_result_type` is `Never` must have no
+  token argument and no `tribute_control.resume` anywhere in its body,
+  including nested regions.
+  Parent placement, uniqueness, and equality with the enclosing handle result
+  are checked by the local verifier of the containing handle. Symbol-aware
+  frontend conformance also checks that the referenced declaration has the
+  same `kind`, argument types, and `operation_result_type`; no verifier
+  reclassifies a general `op` from its body shape.
+- **Ownership and value flow:** when present, the final token argument is
+  affine. It may be unused, meaning the continuation is dropped, or have one
+  static ownership path to a `tribute_control.resume`. Capturing it in a
+  closure transfers that static path to the closure; copying, storing,
+  returning, yielding, or otherwise escaping it is invalid. Static SSA
+  validation cannot prove that a captured closure is dynamically invoked only
+  once, so the lowered resumption must also enforce one-shot consumption at
+  runtime and reject or trap a second invocation. A `fn` arm and an
+  `op -> Never` arm have no continuation capability.
+- **Location:** the source handler arm, including its operation header.
+
+#### `tribute_control.resume`
+
+```text
+%answer = tribute_control.resume %resume, %value : AnswerType
+```
+
+- **Operands:** exactly two. `%resume` has
+  `resume_token<InputType, AnswerType>` and `%value` has `InputType`.
+- **Results:** exactly one `AnswerType`.
+- **Attributes and regions:** none.
+- **Terminator:** none. Strict work after `resume` remains explicit in the
+  enclosing region and executes only after the resumed computation returns.
+- **Semantics:** consumes the nearest lexically enclosing general handler's
+  one-shot resumption, supplies `%value` to the suspended `perform`, and
+  returns the logical result obtained when that resumed computation reaches
+  the handle boundary. It is invalid in a `fn` or `op -> Never` arm.
+- **Local verification:** enforces operand/result arity and the three type
+  equalities implied by `resume_token<InputType, AnswerType>`.
+- **Ownership and value flow:** consumes the token. The token may reach this
+  operation through explicit closure capture, but must retain a single static
+  use-def path from its handler block argument. Affine-use validation is a
+  whole-IR check because it follows captures and nested regions. If capture
+  makes repeated dynamic invocation possible, the converted continuation's
+  runtime one-shot state is the final enforcement boundary.
+- **Location:** the source `resume` expression.
+
+#### `tribute_control.yield`
+
+```text
+tribute_control.yield %value
+```
+
+- **Operands:** exactly one logical value.
+- **Results, attributes, and regions:** none.
+- **Terminator:** this operation is the terminator of a `handle` body,
+  completion region, or handler body. It is invalid elsewhere.
+- **Local verification:** enforces its own shape. The owning operation verifies
+  placement and the yielded type.
+- **Ownership and value flow:** transfers an ordinary logical value to the
+  owning structured operation. A `resume_token` may never be yielded.
+- **Location:** the source expression producing the region result, or the
+  owning `handle` location for a synthesized identity completion.
+
+#### Structured continuation invariant
+
+Frontend output is in strict ANF inside every executable region. Strict
+children are evaluated once, left to right. A selected case/conditional arm,
+case guard, or short-circuit right-hand side remains inside its selected
+`scf.*` region and is not hoisted. Handler bodies and nested handle bodies are
+independent executable regions.
+
+Shared CPS conversion lowers a region with an explicit logical continuation
+for its remaining operations and its enclosing region exits:
+
+1. The continuation at an operation includes the strict suffix in its current
+   block.
+2. At a case, conditional, or short-circuit operation, each branch receives a
+   continuation that first reaches that structured operation's merge and then
+   the enclosing suffix. Only the selected branch evaluates.
+3. A handle body receives a delimiter continuation. Normal body completion
+   enters `completion` and then the enclosing continuation.
+4. An `operation_kind = @fn` perform does not capture a continuation. Shared
+   conversion dispatches it through the tail path, and the automatically
+   resumed operation result flows into the ordinary remaining block suffix.
+5. A resumptive general handler's resume token denotes the suspended body
+   continuation. `tribute_control.resume` invokes it and then continues with
+   the arm-local strict suffix. If the arm never resumes, its yield completes
+   the matching handle directly and bypasses the suspended suffix and
+   completion region. A source `op -> Never` arm receives no token and can
+   only take this non-resuming path.
+6. A nested handle installs its own delimiter. A perform is handled by the
+   nearest dynamically installed matching handler; resuming re-enters every
+   selected structured frame between the perform and that handler. Non-resume
+   completion abandons those frames.
+
+This single region/suffix rule covers case arms and guards, conditionals,
+short-circuit right-hand sides, nested handle bodies and arms, resume paths,
+and strict work enclosing all of them. No AST containment scan or
+construct-specific continuation convention is part of the dialect contract.
 
 `ability.*` represents effect evidence and handler dispatch. Ability operations
 are lowered through the effect pipeline; ability-related types may remain until
@@ -194,7 +531,8 @@ source
   -> name resolution
   -> type checking
   -> TDNR
-  -> AST-to-IR
+  -> AST-to-IR (source-logical callable + tribute_control IR)
+  -> shared CPS legalization
   -> shared lowering and optimization
   -> Wasm or native lowering
   -> backend-ready full conversion target
@@ -208,8 +546,9 @@ Important stage invariants:
 | Resolution | Names, constructors, and variable references are resolved |
 | Type check | Type variables and effect rows are solved |
 | TDNR | Method-style calls are converted to resolved calls |
-| AST-to-IR | IR structure and SSA use chains are valid |
-| Shared lowering | Source-level and high-level ability dispatch operations are removed at claimed boundaries |
+| AST-to-IR | Source-logical callable signatures, verified `tribute_control` structure, and valid SSA use chains |
+| Shared CPS legalization | Callable signatures and all call sites use the physical `CallableAbi`; no `tribute_control.*` remains |
+| Shared lowering | High-level ability dispatch operations are removed at their claimed boundaries |
 | Effect ABI | `effect.*` operations preserve dispatch semantics without backend layout details |
 | Backend lowering | Backend-ready target verification succeeds and no `effect.*` operations remain |
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -153,7 +153,7 @@ type, callable ABI, backend carrier가 아니며 continuation representation을
 검사할 권한도 아니다. Logical result가 `Never`인 source general operation은
 canonical `core.never` TypeRef를 사용하고 resumption을 만들지 않으며
 `resume_token`도 노출하지 않는다. Verifier가 erased type을 추측하지 않고
-non-resumptive case를 식별해야 하므로 현재 pre-M2 frontend의 `Never`용 `anyref`
+non-resumptive case를 식별해야 하므로 현재 legacy frontend의 `Never`용 `anyref`
 placeholder는 이 새 경계에서 valid하지 않다.
 
 #### `tribute_control.perform`
@@ -173,7 +173,9 @@ placeholder는 이 새 경계에서 valid하지 않다.
 - **속성:** `ability_ref: Type`, `op_name: Symbol`,
   `operation_kind: Symbol`이 필수다. `operation_kind`는 정확히 `fn` 또는 `op`이며
   typecheck된 operation declaration에서 복사한다. 이는 body나 use site에서
-  추론하는 lowering hint가 아니라 source-semantic metadata다.
+  추론하는 lowering hint가 아니라 source-semantic metadata다. 모든 source
+  ability invocation이 이 operation을 사용하며 shared conversion은 kind를
+  재분류하지 않는다.
 - **영역과 block argument:** 없다.
 - **종결자:** 아니다. 직접형 IR에서 이 operation은 terminator가 아니다.
 - **의미:** 선언된 kind로 source operation을 호출한다.
@@ -186,11 +188,6 @@ placeholder는 이 새 경계에서 valid하지 않다.
   resume할 수 없으므로 logical resumption을 만들거나 겉으로 보이는 suffix를
   capture하지 않는다.
 
-| `operation_kind` | 직접형 result | 필수 shared lowering | 일치하는 handler 형상 |
-| ---- | ---- | ---- | ---- |
-| `@fn` | 선언된 source result | suffix capture 없이 `ability.call` 뒤 tail dispatch | resume token 없이 선언된 operation result를 yield하여 자동 resume |
-| `@op` | 선언된 source result. `Never`에는 canonical `core.never` 사용 | `ability.perform`과 CPS dispatch를 위해 suffix를 capture하되, `Never`에는 suffix capture 없는 reject adapter 사용 | `Never`를 제외하면 마지막에 resume token을 받고, resume하지 않을 때 handle answer를 yield |
-
 - **지역 검증:** 세 attribute를 요구하고 `operation_kind` domain을
   검사하며, result가 정확히 하나이고 region은 없으며 operand/result type이
   inference variable이 아니라 resolve되었는지 확인한다. Symbol-aware frontend
@@ -198,8 +195,8 @@ placeholder는 이 새 경계에서 valid하지 않다.
   `fn`/`op` kind, parameter type, result type이 attribute, operand, result와
   일치하는지도 확인한다. 어떤 verifier도 control flow, handler, result type,
   calling convention에서 kind를 추론해서는 안 된다.
-  `tribute_control.handler`와 containing-handle verifier는 handler entry에 위 표의
-  해당 handler 형상을 적용한다.
+  `tribute_control.handler`와 containing-handle verifier는 handler entry에 아래
+  계약의 kind별 형상을 적용한다.
 - **소유권과 값 흐름:** operand는 일반 SSA use다. 이 operation은
   source-visible continuation value를 만들지 않으며 continuation 구성은 shared
   CPS conversion이 소유한다. `@fn`에는 continuation 없는 `ability.call`/tail
@@ -207,23 +204,11 @@ placeholder는 이 새 경계에서 valid하지 않다.
   dispatch를 만든다. `op -> Never`에는 대신 기존 ability/effect ABI가 요구하는
   실제 zero-capture reject continuation을 공급하며 그 body는
   `func.unreachable`이다. 이 continuation은 source suffix를 capture하지 않는다.
-  Null, in-band sentinel, 임의의 `anyref`는 continuation이 아니다.
+  Null, in-band sentinel, 임의의 `anyref`는 continuation이 아니다. ABI adapter의
+  전체 규칙은
+  [cps-effects.md](cps-effects.md#direct-style-control-boundary)를 따른다.
 - **위치:** 가능하면 qualified callee와 argument를 모두 포함하는
   ability-operation call의 source location이다.
-
-이 경계에서는 모든 source ability invocation이 `tribute_control.perform`을
-사용한다. Shared conversion이 `operation_kind`를 재분류하지 않고 dispatch
-representation을 선택하는 첫 phase다. 특히 handler body가 항상
-tail-resumptive처럼 보이는 `@op`도 `@op`으로 유지된다. 해당 형상을 인식하고
-최적화하는 작업은 semantic lowering 뒤의 후속 IR optimization이다.
-
-Reject continuation은 명시적인 continuation을 요구하는 기존
-`ability.perform`과 `effect.dispatch_cps` operand contract를 위한 compatibility
-glue다. 일반 lowered continuation과 같은 callable ABI를 사용하고 capture가
-없으며 호출되면 trap한다. Compilation unit마다 deduplicate할 수 있지만 각 use는
-typed closure value를 일반 closure-to-`anyref` conversion을 통해 전달한다. 이
-규칙은 operation을 추가하거나 physical CPS result carrier를 선택하지 않으면서
-source `Never` 의미를 보존한다.
 
 #### `tribute_control.handle`
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -48,31 +48,30 @@ Partial conversion may leave unknown operations for later passes. Full
 conversion boundaries, such as backend-ready native IR, must reject unknown
 operations.
 
-The direct-control migration uses these named boundaries:
+직접형 control 마이그레이션은 다음과 같은 이름의 경계를 사용한다:
 
-| Boundary | `ConversionTarget` mode | Required legality |
+| 경계 | `ConversionTarget` mode | 필수 적법성 |
 | ---- | ---- | ---- |
-| `tribute-control-pre-cps` | Full for frontend conformance; partial while composing migration passes | `tribute_control.*` may coexist with `core`, `func`, `scf`, `arith`, `adt`, `list`, `closure`, `tribute_rt`, and `tribute_io`. Existing `ability.*`, `effect.*`, and legacy CPS construction operations are illegal. |
-| `tribute-control-post-cps` | Partial after the shared CPS conversion | The entire `tribute_control` dialect is illegal. Existing `ability.perform`, `ability.call`, handler/evidence operations, `effect.*`, `closure.*`, and ordinary dialects may coexist for their subsequent shared passes. |
-| `tribute-backend-ready-native` | Full Tribute boundary followed by the generic Cranelift boundary | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, and conversion casts are absent. Only the explicitly listed native infrastructure and `clif.*` operations remain. |
-| `tribute-backend-ready-wasm` | Partial high-level rejection followed by the existing emission-ready checks | `tribute_control`, `ability`, and `effect` are explicitly illegal before backend-ready Wasm IR; `wasm_gc` is additionally illegal before emission. |
+| `tribute-control-pre-cps` | frontend 적합성 검사에는 full, 마이그레이션 pass 조합 중에는 partial | `tribute_control.*`은 `core`, `func`, `scf`, `arith`, `adt`, `list`, `closure`, `tribute_rt`, `tribute_io`와 공존할 수 있다. 기존 `ability.*`, `effect.*`, legacy CPS 구성 operation은 illegal이다. |
+| `tribute-control-post-cps` | shared CPS 변환 뒤 partial | `tribute_control` dialect 전체가 illegal이다. 기존 `ability.perform`, `ability.call`, handler/evidence operation, `effect.*`, `closure.*`, 일반 dialect는 이후 shared pass를 위해 공존할 수 있다. |
+| `tribute-backend-ready-native` | Tribute full 경계 뒤 generic Cranelift 경계 | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, conversion cast가 없다. 명시적으로 열거한 native infrastructure와 `clif.*` operation만 남는다. |
+| `tribute-backend-ready-wasm` | 기존 emission-ready 검사 전에 high-level operation을 partial 방식으로 거부 | backend-ready Wasm IR 전에 `tribute_control`, `ability`, `effect`를 명시적으로 illegal로 지정하며, emission 전에는 `wasm_gc`도 illegal이다. |
 
-The post-CPS helper is implementable with the current API as
-`ConversionTarget::new().illegal_dialect("tribute_control")` plus partial
-verification. Frontend conformance and backend full targets must enumerate
-their legal dialects and operations because unknown is not legal in full mode.
-They must not mark `func.func`, `closure.lambda`, or another region-owning
-container recursively legal: doing so would hide illegal control operations in
-nested regions. The generic `trunk-ir` Cranelift boundary remains
-Tribute-agnostic; the Tribute pipeline owns the explicit rejection of
-Tribute-specific high-level dialects before invoking it.
+현재 API에서는 `ConversionTarget::new().illegal_dialect("tribute_control")`와
+partial verification을 조합해 post-CPS helper를 구현할 수 있다. Full mode에서는
+unknown operation이 legal하지 않으므로 frontend 적합성 target과 backend full
+target이 legal dialect와 operation을 열거해야 한다. `func.func`,
+`closure.lambda` 또는 다른 region 소유 container를 recursively legal로
+표시해서는 안 된다. 그렇게 하면 nested region의 illegal control operation이
+가려진다. Generic `trunk-ir`의 Cranelift 경계는 Tribute에 독립적으로 유지한다.
+이를 호출하기 전에 Tribute 전용 high-level dialect를 명시적으로 거부하는 책임은
+Tribute pipeline에 있다.
 
-Transiently, one rewrite may contain both source `tribute_control.*` and its
-new `ability.*`/`effect.*` output. That is an implementation state inside
-partial conversion, not a successful named boundary. Successful
-`tribute-control-post-cps` verification reports every residual
-`tribute_control.*` operation with its source location as a conversion
-failure.
+하나의 rewrite 도중에는 source `tribute_control.*`과 새
+`ability.*`/`effect.*` 결과가 일시적으로 공존할 수 있다. 이는 partial
+conversion 내부의 구현 상태이지 성공한 named boundary가 아니다. 성공한
+`tribute-control-post-cps` verification은 남은 모든 `tribute_control.*`
+operation을 source location과 함께 conversion failure로 보고한다.
 
 ## Validation Layers
 
@@ -109,52 +108,53 @@ interfaces describe behavior, not validation phases.
 `tribute.*` represents source-level constructs that should disappear after
 resolution, type checking, TDNR, and AST-to-IR lowering.
 
-### Direct-style control
+<!-- markdownlint-disable-next-line MD033 -->
+<a id="direct-style-control"></a>
 
-`tribute_control.*` is the target-independent, direct-style boundary between
-typed frontend lowering and shared CPS conversion. The dialect identifier is
-exactly `tribute_control`. TrunkIR parses a qualified operation as one
-`<dialect>.<operation>` pair, so spellings with another separator, such as a
-dot inside the dialect identifier, are invalid.
+### 직접형 제어
 
-The dialect models only control constructs that the CPS pass must transform.
-ANF is an input invariant, not the dialect's identity. Arithmetic, ordinary
-direct and indirect calls, ADT/list/tuple/record construction, closures, and
-structured selection remain in their existing dialects. In particular, there
-is no `tribute_control.invoke`: `func.call`, `func.call_indirect`, and
-`closure.lambda` already carry the callable type and
-`Direct < EvidenceDirect < Cps` convention metadata needed by shared
-conversion. A new invocation operation would duplicate those operations
-without adding a control fact.
+`tribute_control.*`은 typed frontend lowering과 shared CPS conversion 사이의
+target-independent 직접형 경계다. Dialect identifier는 정확히
+`tribute_control`이다. TrunkIR은 qualified operation을 하나의
+`<dialect>.<operation>` 쌍으로 parse하므로 dialect identifier 안에 점을 넣는
+등 separator를 하나 더 사용하는 표기는 invalid이다.
 
-At the pre-CPS boundary, all `func.func`, `closure.lambda`, `func.call`, and
-`func.call_indirect` signatures are source-logical regardless of convention:
-source parameters in, source result out, with no hidden evidence or `done_k`
-operands. Convention metadata is required on the definition/lambda and its
-callable type. Shared conversion rewrites definitions and all direct/indirect
-call sites together to the existing `CallableAbi`; the complete rule is in
-[cps-effects.md](cps-effects.md#pre-cps-callable-shape).
+이 dialect는 CPS pass가 변환해야 하는 control construct만 모델링한다. ANF는
+input invariant이지 dialect의 정체성이 아니다. 산술, 일반 direct/indirect call,
+ADT/list/tuple/record 구성, closure, structured selection은 기존 dialect에
+남는다. 특히 `tribute_control.invoke`는 없다. `func.call`,
+`func.call_indirect`, `closure.lambda`가 이미 callable type과 shared
+conversion에 필요한 `Direct < EvidenceDirect < Cps` convention metadata를
+운반한다. 새 invocation operation을 추가하면 control fact를 더하지 못한 채
+기존 operation만 중복한다.
 
-The minimal operation set is:
+pre-CPS 경계에서 모든 `func.func`, `closure.lambda`, `func.call`,
+`func.call_indirect` signature는 convention과 무관하게 source-logical 형상을
+유지한다. Source parameter를 받고 source result를 내며 hidden evidence나
+`done_k` operand가 없다. Definition/lambda와 해당 callable type에는 convention
+metadata가 필수다. Shared conversion은 definition과 모든 direct/indirect call
+site를 기존 `CallableAbi`에 맞춰 함께 rewrite한다. 전체 규칙은
+[cps-effects.md](cps-effects.md#pre-cps-callable-shape)에 있다.
 
-| Operation | Purpose |
+최소 operation 집합은 다음과 같다:
+
+| Operation | 용도 |
 | ---- | ---- |
-| `tribute_control.perform` | Invoke one source `fn` or general `op` in direct style, retaining its semantic kind |
-| `tribute_control.handle` | Delimit a direct-style computation, its completion arm, and its handler table |
-| `tribute_control.handler` | Describe one `fn` or general `op` handler arm inside a handle |
-| `tribute_control.resume` | Consume the affine resumption bound by a resumptive general handler arm |
-| `tribute_control.yield` | Terminate one executable `tribute_control` region with its logical value |
+| `tribute_control.perform` | source `fn` 또는 general `op` 하나를 semantic kind를 보존한 직접형으로 호출 |
+| `tribute_control.handle` | 직접형 computation, completion arm, handler table의 경계를 설정 |
+| `tribute_control.handler` | handle 안의 `fn` 또는 general `op` handler arm을 기술 |
+| `tribute_control.resume` | resumptive general handler arm에 바인딩된 affine resumption을 소비 |
+| `tribute_control.yield` | 실행 가능한 `tribute_control` region을 logical value로 종료 |
 
-The dialect also owns the opaque type
-`tribute_control.resume_token<input, answer>`. `input` is the value accepted
-by the suspended operation's continuation, and `answer` is the logical result
-of running that continuation through the enclosing handle. The type is not a
-source type, callable ABI, backend carrier, or permission to inspect a
-continuation representation. A source general operation whose logical result
-is `Never` uses the canonical `core.never` TypeRef, creates no resumption, and
-exposes no `resume_token`. The current pre-M2 frontend's `anyref` placeholder
-for `Never` is not valid at this new boundary because a verifier must identify
-the non-resumptive case without guessing from an erased type.
+이 dialect는 opaque type `tribute_control.resume_token<input, answer>`도
+소유한다. `input`은 중단된 operation continuation이 받는 값이고, `answer`는
+그 continuation을 enclosing handle까지 실행한 logical result다. 이 type은 source
+type, callable ABI, backend carrier가 아니며 continuation representation을
+검사할 권한도 아니다. Logical result가 `Never`인 source general operation은
+canonical `core.never` TypeRef를 사용하고 resumption을 만들지 않으며
+`resume_token`도 노출하지 않는다. Verifier가 erased type을 추측하지 않고
+non-resumptive case를 식별해야 하므로 현재 pre-M2 frontend의 `Never`용 `anyref`
+placeholder는 이 새 경계에서 valid하지 않다.
 
 #### `tribute_control.perform`
 
@@ -166,69 +166,64 @@ the non-resumptive case without guessing from an erased type.
 } : ResultType
 ```
 
-- **Operands:** zero or more already-evaluated source arguments in declaration
-  order. Values retain their logical types; tuple packing and erasure are
-  conversion work.
-- **Results:** exactly one logical operation result. A source `Never` result is
-  `core.never`; it does not select a physical `Never` control carrier.
-- **Attributes:** required `ability_ref: Type`, `op_name: Symbol`, and
-  `operation_kind: Symbol`. `operation_kind` is exactly `fn` or `op` and is
-  copied from the typechecked operation declaration. It is source-semantic
-  metadata, not a lowering hint inferred from the body or use site.
-- **Regions and block arguments:** none.
-- **Terminator:** none; this is not a terminator in direct-style IR.
-- **Semantics:** invokes the source operation with its declared kind. For
-  `operation_kind = @fn`, the selected handler result automatically resumes
-  direct-style evaluation; shared conversion does not capture a
-  continuation and uses the existing tail-dispatch path. For
-  `operation_kind = @op`, a matching handler may resume, in which case
-  execution continues after the operation and the result becomes `%result`.
-  If it does not resume, the selected general handler completes the matching
-  handle and the apparent suffix is not evaluated. A source `op -> Never`
-  cannot resume and therefore never constructs a logical resumption or
-  captures the apparent suffix.
+- **피연산자:** declaration 순서로 놓인, 이미 평가된 source argument 0개 이상이다.
+  값은 logical type을 유지하며 tuple packing과 erasure는 conversion이 담당한다.
+- **결과:** logical operation result 하나만 만든다. Source `Never` result는
+  `core.never`이며 physical `Never` control carrier를 선택하지 않는다.
+- **속성:** `ability_ref: Type`, `op_name: Symbol`,
+  `operation_kind: Symbol`이 필수다. `operation_kind`는 정확히 `fn` 또는 `op`이며
+  typecheck된 operation declaration에서 복사한다. 이는 body나 use site에서
+  추론하는 lowering hint가 아니라 source-semantic metadata다.
+- **영역과 block argument:** 없다.
+- **종결자:** 아니다. 직접형 IR에서 이 operation은 terminator가 아니다.
+- **의미:** 선언된 kind로 source operation을 호출한다.
+  `operation_kind = @fn`이면 선택된 handler result가 직접형 평가를 자동으로
+  resume한다. Shared conversion은 continuation을 capture하지 않고 기존 tail
+  dispatch 경로를 사용한다. `operation_kind = @op`이면 일치하는 handler가
+  resume할 수 있으며, 이 경우 operation 뒤에서 실행을 계속하고 `%result`가
+  결과가 된다. Resume하지 않으면 선택된 general handler가 일치하는 handle을
+  완료하고 겉으로 보이는 suffix는 평가하지 않는다. Source `op -> Never`는
+  resume할 수 없으므로 logical resumption을 만들거나 겉으로 보이는 suffix를
+  capture하지 않는다.
 
-| `operation_kind` | Direct-style result | Required shared lowering | Matching handler shape |
+| `operation_kind` | 직접형 result | 필수 shared lowering | 일치하는 handler 형상 |
 | ---- | ---- | ---- | ---- |
-| `@fn` | Declared source result | No suffix capture; `ability.call` then tail dispatch | No resume token; yield the declared operation result for automatic resumption |
-| `@op` | Declared source result, using canonical `core.never` for `Never` | Capture the suffix for `ability.perform` and CPS dispatch, except use the reject adapter without suffix capture for `Never` | Final resume token except for `Never`; yield the handle answer on non-resumption |
+| `@fn` | 선언된 source result | suffix capture 없이 `ability.call` 뒤 tail dispatch | resume token 없이 선언된 operation result를 yield하여 자동 resume |
+| `@op` | 선언된 source result. `Never`에는 canonical `core.never` 사용 | `ability.perform`과 CPS dispatch를 위해 suffix를 capture하되, `Never`에는 suffix capture 없는 reject adapter 사용 | `Never`를 제외하면 마지막에 resume token을 받고, resume하지 않을 때 handle answer를 yield |
 
-- **Local verification:** requires the three attributes, checks the
-  `operation_kind` domain, requires exactly one result and no regions, and
-  requires resolved operand/result types rather than inference variables.
-  Symbol-aware frontend conformance additionally checks that `ability_ref` and
-  `op_name` resolve to an operation declaration whose declared `fn`/`op` kind,
-  parameter types, and result type equal the attributes, operands, and result.
-  Neither verifier may infer the kind from control flow, handlers, result type,
-  or calling convention. The `tribute_control.handler` and containing-handle
-  verifiers apply the corresponding handler row above to handler entries.
-- **Ownership and value flow:** operands are ordinary SSA uses. The operation
-  creates no source-visible continuation value; shared CPS conversion owns
-  continuation construction. For `@fn`, conversion produces
-  `ability.call`/tail dispatch without a continuation. For `@op`, conversion
-  produces `ability.perform`/CPS dispatch with the suffix continuation. For
-  `op -> Never`, it instead supplies the existing ability/effect ABI with a
-  real zero-capture reject continuation whose body is `func.unreachable`; it
-  does not capture the source suffix. Null, an in-band sentinel, or arbitrary
-  `anyref` is not a continuation.
-- **Location:** the source location of the ability-operation call, covering
-  the qualified callee and arguments when available.
+- **지역 검증:** 세 attribute를 요구하고 `operation_kind` domain을
+  검사하며, result가 정확히 하나이고 region은 없으며 operand/result type이
+  inference variable이 아니라 resolve되었는지 확인한다. Symbol-aware frontend
+  적합성 검사는 `ability_ref`와 `op_name`이 resolve한 operation declaration의
+  `fn`/`op` kind, parameter type, result type이 attribute, operand, result와
+  일치하는지도 확인한다. 어떤 verifier도 control flow, handler, result type,
+  calling convention에서 kind를 추론해서는 안 된다.
+  `tribute_control.handler`와 containing-handle verifier는 handler entry에 위 표의
+  해당 handler 형상을 적용한다.
+- **소유권과 값 흐름:** operand는 일반 SSA use다. 이 operation은
+  source-visible continuation value를 만들지 않으며 continuation 구성은 shared
+  CPS conversion이 소유한다. `@fn`에는 continuation 없는 `ability.call`/tail
+  dispatch를, `@op`에는 suffix continuation을 받는 `ability.perform`/CPS
+  dispatch를 만든다. `op -> Never`에는 대신 기존 ability/effect ABI가 요구하는
+  실제 zero-capture reject continuation을 공급하며 그 body는
+  `func.unreachable`이다. 이 continuation은 source suffix를 capture하지 않는다.
+  Null, in-band sentinel, 임의의 `anyref`는 continuation이 아니다.
+- **위치:** 가능하면 qualified callee와 argument를 모두 포함하는
+  ability-operation call의 source location이다.
 
-Every source ability invocation uses `tribute_control.perform` at this
-boundary. The shared conversion is the first phase that chooses a dispatch
-representation, using `operation_kind` without reclassifying it. In
-particular, an `@op` whose handler body appears always tail-resumptive remains
-an `@op`; recognizing and optimizing that shape is a later IR optimization
-after semantic lowering.
+이 경계에서는 모든 source ability invocation이 `tribute_control.perform`을
+사용한다. Shared conversion이 `operation_kind`를 재분류하지 않고 dispatch
+representation을 선택하는 첫 phase다. 특히 handler body가 항상
+tail-resumptive처럼 보이는 `@op`도 `@op`으로 유지된다. 해당 형상을 인식하고
+최적화하는 작업은 semantic lowering 뒤의 후속 IR optimization이다.
 
-The reject continuation is compatibility glue for the existing
-`ability.perform` and `effect.dispatch_cps` operand contract, both of which
-require an explicit continuation. It has the same callable ABI as an ordinary
-lowered continuation, contains no captures, and traps if invoked. It may be
-deduplicated per compilation unit, but each use passes a typed closure value
-through the normal closure-to-`anyref` conversion. This rule preserves source
-`Never` semantics without adding an operation or choosing the physical CPS
-result carrier.
+Reject continuation은 명시적인 continuation을 요구하는 기존
+`ability.perform`과 `effect.dispatch_cps` operand contract를 위한 compatibility
+glue다. 일반 lowered continuation과 같은 callable ABI를 사용하고 capture가
+없으며 호출되면 trap한다. Compilation unit마다 deduplicate할 수 있지만 각 use는
+typed closure value를 일반 closure-to-`anyref` conversion을 통해 전달한다. 이
+규칙은 operation을 추가하거나 physical CPS result carrier를 선택하지 않으면서
+source `Never` 의미를 보존한다.
 
 #### `tribute_control.handle`
 
@@ -248,43 +243,38 @@ result carrier.
   }
 ```
 
-- **Operands:** none. Values captured by executable regions use normal
-  enclosing SSA visibility.
-- **Results:** exactly one logical handle result.
-- **Attributes:** none are required. Dynamic prompt/owner tags and backend
-  carrier choices are deliberately absent.
-- **Regions:** exactly three, in the fixed order `body`, `completion`,
-  `handlers`.
-- **Block arguments:** `body` has one block and no arguments. `completion` has
-  one block with exactly one argument, whose type equals the value yielded by
-  `body`. `handlers` has one block with no arguments and contains only
-  `tribute_control.handler` entries.
-- **Terminators:** `body` and `completion` end in
-  `tribute_control.yield`. The `handlers` block is a declarative table and has
-  no terminator.
-- **Semantics:** normal completion of `body` evaluates `completion` exactly
-  once and returns its value. A general handler arm that finishes without
-  resuming returns its arm value as the handle result and bypasses
-  `completion`. A tail-resumptive `fn` arm returns an operation result that is
-  fed automatically to the suspended computation.
-- **Local verification:** enforces the fixed region count, single-block
-  shapes, block-argument counts, terminators, yielded type equalities, and that
-  every direct child of `handlers` is a unique
-  `(ability_ref, op_name)` `tribute_control.handler`. Its result type must
-  equal the completion yield type and every general handler's answer type.
-- **Ownership and value flow:** the operation owns the delimited resumption
-  capabilities created when its body performs resumptive general operations.
-  They are exposed only as `resume_token` block arguments of resumptive
-  general handler entries. Values leave executable regions only through
-  `tribute_control.yield`.
-- **Location:** the complete source `handle` expression. Region/block
-  locations use the corresponding body, completion arm, and handler-list
-  spans.
+- **피연산자:** 없다. 실행 가능한 region이 capture하는 값은 일반 enclosing SSA
+  visibility를 사용한다.
+- **결과:** logical handle result 하나만 만든다.
+- **속성:** 필수 attribute는 없다. Dynamic prompt/owner tag와 backend
+  carrier 선택은 의도적으로 포함하지 않는다.
+- **영역:** 고정된 `body`, `completion`, `handlers` 순서로 정확히 세 개다.
+- **Block argument:** `body`는 argument가 없는 block 하나다. `completion`은
+  argument가 정확히 하나인 block 하나이며, 그 type은 `body`가 yield한 value의
+  type과 같다. `handlers`는 argument가 없는 block 하나이며
+  `tribute_control.handler` entry만 포함한다.
+- **종결자:** `body`와 `completion`은 `tribute_control.yield`로 끝난다.
+  `handlers` block은 선언적 table이며 terminator가 없다.
+- **의미:** `body`가 정상 완료되면 `completion`을 정확히 한 번 평가하고 그 값을
+  반환한다. Resume하지 않고 완료된 general handler arm은 arm value를 handle
+  result로 반환하고 `completion`을 건너뛴다. Tail-resumptive `fn` arm은 중단된
+  computation에 자동으로 공급되는 operation result를 반환한다.
+- **지역 검증:** 고정된 region 개수, single-block 형상, block-argument
+  개수, terminator, yield type equality를 강제한다. 또한 `handlers`의 모든
+  direct child가 유일한 `(ability_ref, op_name)`
+  `tribute_control.handler`인지 확인한다. Result type은 completion yield type과
+  모든 general handler의 answer type과 같아야 한다.
+- **소유권과 값 흐름:** 이 operation은 body가 resumptive general
+  operation을 수행할 때 생기는 delimited resumption capability를 소유한다.
+  해당 capability는 resumptive general handler entry의 `resume_token` block
+  argument로만 노출된다. 값은 `tribute_control.yield`를 통해서만 실행 가능한
+  region 밖으로 나간다.
+- **위치:** 전체 source `handle` expression이다. Region/block location은 각각
+  대응하는 body, completion arm, handler-list span을 사용한다.
 
-The frontend always materializes a completion region. When source omits a
-`do` arm, the region is the identity operation on the body result. This removes
-an optional structural case from conversion without changing source
-semantics.
+Frontend는 항상 completion region을 materialize한다. Source에 `do` arm이 없으면
+이 region은 body result에 대한 identity operation이다. Source 의미를 바꾸지
+않으면서 conversion의 optional structural case를 없앤다.
 
 #### `tribute_control.handler`
 
@@ -301,42 +291,38 @@ tribute_control.handler {
 }
 ```
 
-- **Operands and results:** none. It is a declarative entry owned by the
-  surrounding `tribute_control.handle`.
-- **Attributes:** required `ability_ref: Type`, `op_name: Symbol`,
-  `kind: Symbol`, and `operation_result_type: Type`. `kind` is exactly `fn` or
-  `op`.
-- **Regions:** exactly one executable `body` region with one block.
-- **Block arguments:** source operation arguments appear first, in declaration
-  order and at logical types. A resumptive `op` entry has one final
-  `resume_token<operation_result_type, handle-result-type>` argument. An `op`
-  whose `operation_result_type` is source `Never` has no token, and a `fn`
-  entry has no token.
-- **Terminator:** the body ends in `tribute_control.yield`. For `fn`, the
-  yielded type equals `operation_result_type` and is automatically resumed.
-  For `op`, the yielded type equals the token's `answer` type and is the
-  enclosing handle result when the arm completes without transferring control
-  through `resume`.
-- **Local verification:** checks required attributes and domains, one block,
-  the final terminator, token position/parameters, and the yield rules above.
-  A general handler whose `operation_result_type` is `Never` must have no
-  token argument and no `tribute_control.resume` anywhere in its body,
-  including nested regions.
-  Parent placement, uniqueness, and equality with the enclosing handle result
-  are checked by the local verifier of the containing handle. Symbol-aware
-  frontend conformance also checks that the referenced declaration has the
-  same `kind`, argument types, and `operation_result_type`; no verifier
-  reclassifies a general `op` from its body shape.
-- **Ownership and value flow:** when present, the final token argument is
-  affine. It may be unused, meaning the continuation is dropped, or have one
-  static ownership path to a `tribute_control.resume`. Capturing it in a
-  closure transfers that static path to the closure; copying, storing,
-  returning, yielding, or otherwise escaping it is invalid. Static SSA
-  validation cannot prove that a captured closure is dynamically invoked only
-  once, so the lowered resumption must also enforce one-shot consumption at
-  runtime and reject or trap a second invocation. A `fn` arm and an
-  `op -> Never` arm have no continuation capability.
-- **Location:** the source handler arm, including its operation header.
+- **피연산자와 결과:** 없다. Surrounding `tribute_control.handle`이 소유하는
+  declarative entry다.
+- **속성:** `ability_ref: Type`, `op_name: Symbol`, `kind: Symbol`,
+  `operation_result_type: Type`이 필수다. `kind`는 정확히 `fn` 또는 `op`이다.
+- **영역:** block 하나를 가진 실행 가능한 `body` region 하나만 있다.
+- **Block argument:** source operation argument가 declaration 순서와 logical
+  type으로 먼저 나온다. Resumptive `op` entry는 마지막에
+  `resume_token<operation_result_type, handle-result-type>` argument 하나를
+  갖는다. `operation_result_type`이 source `Never`인 `op`에는 token이 없고
+  `fn` entry에도 token이 없다.
+- **종결자:** body는 `tribute_control.yield`로 끝난다. `fn`에서는 yield
+  type이 `operation_result_type`과 같고 자동으로 resume한다. `op`에서는 yield
+  type이 token의 `answer` type과 같으며, arm이 `resume`을 통해 control을
+  넘기지 않고 완료되면 enclosing handle result가 된다.
+- **지역 검증:** 필수 attribute와 domain, block 하나, 마지막
+  terminator, token 위치/parameter, 위 yield 규칙을 확인한다.
+  `operation_result_type`이 `Never`인 general handler는 token argument가 없어야
+  하며 nested region을 포함한 body 어디에도 `tribute_control.resume`이 없어야
+  한다. Parent placement, uniqueness, enclosing handle result와의 equality는
+  containing handle의 local verifier가 확인한다. Symbol-aware frontend 적합성
+  검사는 참조된 declaration의 `kind`, argument type,
+  `operation_result_type`도 동일한지 확인하며, 어떤 verifier도 body 형상으로
+  general `op`을 재분류하지 않는다.
+- **소유권과 값 흐름:** 마지막 token argument가 있으면 affine이다.
+  사용하지 않아 continuation을 drop하거나, `tribute_control.resume`까지 하나의
+  static ownership path를 가질 수 있다. Closure가 이를 capture하면 그 static
+  path가 closure로 이전된다. Copy, store, return, yield 또는 다른 방식의
+  escape는 invalid이다. Static SSA validation은 capture한 closure가 dynamic하게
+  한 번만 호출되는지 증명할 수 없으므로 lowered resumption은 runtime에서도
+  one-shot consumption을 강제하고 두 번째 호출을 거부하거나 trap해야 한다.
+  `fn` arm과 `op -> Never` arm에는 continuation capability가 없다.
+- **위치:** operation header를 포함한 source handler arm이다.
 
 #### `tribute_control.resume`
 
@@ -344,25 +330,25 @@ tribute_control.handler {
 %answer = tribute_control.resume %resume, %value : AnswerType
 ```
 
-- **Operands:** exactly two. `%resume` has
-  `resume_token<InputType, AnswerType>` and `%value` has `InputType`.
-- **Results:** exactly one `AnswerType`.
-- **Attributes and regions:** none.
-- **Terminator:** none. Strict work after `resume` remains explicit in the
-  enclosing region and executes only after the resumed computation returns.
-- **Semantics:** consumes the nearest lexically enclosing general handler's
-  one-shot resumption, supplies `%value` to the suspended `perform`, and
-  returns the logical result obtained when that resumed computation reaches
-  the handle boundary. It is invalid in a `fn` or `op -> Never` arm.
-- **Local verification:** enforces operand/result arity and the three type
-  equalities implied by `resume_token<InputType, AnswerType>`.
-- **Ownership and value flow:** consumes the token. The token may reach this
-  operation through explicit closure capture, but must retain a single static
-  use-def path from its handler block argument. Affine-use validation is a
-  whole-IR check because it follows captures and nested regions. If capture
-  makes repeated dynamic invocation possible, the converted continuation's
-  runtime one-shot state is the final enforcement boundary.
-- **Location:** the source `resume` expression.
+- **피연산자:** 정확히 두 개다. `%resume`은
+  `resume_token<InputType, AnswerType>`이고 `%value`는 `InputType`이다.
+- **결과:** `AnswerType` 하나만 만든다.
+- **속성과 영역:** 없다.
+- **종결자:** 아니다. `resume` 뒤의 strict work는 enclosing region에
+  명시적으로 남으며 resumed computation이 반환한 뒤에만 실행된다.
+- **의미:** lexical하게 가장 가까운 enclosing general handler의 one-shot
+  resumption을 소비하고, 중단된 `perform`에 `%value`를 공급하며, resumed
+  computation이 handle boundary에 도달했을 때 얻는 logical result를 반환한다.
+  `fn` 또는 `op -> Never` arm에서는 invalid이다.
+- **지역 검증:** operand/result arity와
+  `resume_token<InputType, AnswerType>`이 요구하는 세 type equality를 강제한다.
+- **소유권과 값 흐름:** token을 소비한다. Explicit closure capture를 통해
+  token이 이 operation에 도달할 수 있지만 handler block argument에서 시작하는
+  single static use-def path를 유지해야 한다. Affine-use validation은 capture와
+  nested region을 따라가므로 whole-IR check다. Capture 때문에 반복적인 dynamic
+  invocation이 가능하면 converted continuation의 runtime one-shot state가 최종
+  enforcement boundary다.
+- **위치:** source `resume` expression이다.
 
 #### `tribute_control.yield`
 
@@ -370,53 +356,50 @@ tribute_control.handler {
 tribute_control.yield %value
 ```
 
-- **Operands:** exactly one logical value.
-- **Results, attributes, and regions:** none.
-- **Terminator:** this operation is the terminator of a `handle` body,
-  completion region, or handler body. It is invalid elsewhere.
-- **Local verification:** enforces its own shape. The owning operation verifies
-  placement and the yielded type.
-- **Ownership and value flow:** transfers an ordinary logical value to the
-  owning structured operation. A `resume_token` may never be yielded.
-- **Location:** the source expression producing the region result, or the
-  owning `handle` location for a synthesized identity completion.
+- **피연산자:** logical value 하나만 받는다.
+- **결과, 속성, 영역:** 없다.
+- **종결자:** `handle` body, completion region, handler body의 terminator다.
+  다른 위치에서는 invalid이다.
+- **지역 검증:** 자체 형상을 강제한다. Owning operation이 placement와
+  yield type을 검사한다.
+- **소유권과 값 흐름:** 일반 logical value를 owning structured
+  operation으로 전달한다. `resume_token`은 절대 yield할 수 없다.
+- **위치:** region result를 만드는 source expression이다. 합성한 identity
+  completion에는 owning `handle` location을 사용한다.
 
-#### Structured continuation invariant
+#### 구조화된 continuation 불변 조건
 
-Frontend output is in strict ANF inside every executable region. Strict
-children are evaluated once, left to right. A selected case/conditional arm,
-case guard, or short-circuit right-hand side remains inside its selected
-`scf.*` region and is not hoisted. Handler bodies and nested handle bodies are
-independent executable regions.
+Frontend output은 모든 실행 가능한 region 내부에서 strict ANF다. Strict child는
+왼쪽에서 오른쪽으로 정확히 한 번 평가한다. 선택된 case/conditional arm, case
+guard, short-circuit 오른쪽 항은 선택된 `scf.*` region 안에 남고 hoist하지
+않는다. Handler body와 nested handle body는 독립적인 실행 region이다.
 
-Shared CPS conversion lowers a region with an explicit logical continuation
-for its remaining operations and its enclosing region exits:
+Shared CPS conversion은 남은 operation과 enclosing region exit를 위한 명시적인
+logical continuation으로 region을 lower한다:
 
-1. The continuation at an operation includes the strict suffix in its current
-   block.
-2. At a case, conditional, or short-circuit operation, each branch receives a
-   continuation that first reaches that structured operation's merge and then
-   the enclosing suffix. Only the selected branch evaluates.
-3. A handle body receives a delimiter continuation. Normal body completion
-   enters `completion` and then the enclosing continuation.
-4. An `operation_kind = @fn` perform does not capture a continuation. Shared
-   conversion dispatches it through the tail path, and the automatically
-   resumed operation result flows into the ordinary remaining block suffix.
-5. A resumptive general handler's resume token denotes the suspended body
-   continuation. `tribute_control.resume` invokes it and then continues with
-   the arm-local strict suffix. If the arm never resumes, its yield completes
-   the matching handle directly and bypasses the suspended suffix and
-   completion region. A source `op -> Never` arm receives no token and can
-   only take this non-resuming path.
-6. A nested handle installs its own delimiter. A perform is handled by the
-   nearest dynamically installed matching handler; resuming re-enters every
-   selected structured frame between the perform and that handler. Non-resume
-   completion abandons those frames.
+1. Operation 위치의 continuation은 현재 block의 strict suffix를 포함한다.
+2. Case, conditional, short-circuit operation에서는 각 branch가 먼저 해당
+   structured operation의 merge에 도달한 뒤 enclosing suffix를 실행하는
+   continuation을 받는다. 선택된 branch만 평가한다.
+3. Handle body는 delimiter continuation을 받는다. Body가 정상 완료되면
+   `completion`에 들어간 뒤 enclosing continuation을 실행한다.
+4. `operation_kind = @fn`인 perform은 continuation을 capture하지 않는다.
+   Shared conversion이 tail path로 dispatch하며 자동으로 resume된 operation
+   result는 일반적인 남은 block suffix로 흐른다.
+5. Resumptive general handler의 resume token은 중단된 body continuation을
+   가리킨다. `tribute_control.resume`이 이를 호출한 뒤 arm-local strict
+   suffix를 계속 실행한다. Arm이 resume하지 않으면 yield가 일치하는 handle을
+   직접 완료하고 중단된 suffix와 completion region을 건너뛴다. Source
+   `op -> Never` arm은 token을 받지 않으며 이 non-resuming path만 취할 수 있다.
+6. Nested handle은 자체 delimiter를 설치한다. Perform은 dynamic하게 설치된
+   handler 중 가장 가까운 일치 handler가 처리한다. Resume하면 perform과 해당
+   handler 사이에서 선택된 모든 structured frame에 다시 진입한다. Resume하지
+   않고 완료하면 그 frame을 포기한다.
 
-This single region/suffix rule covers case arms and guards, conditionals,
-short-circuit right-hand sides, nested handle bodies and arms, resume paths,
-and strict work enclosing all of them. No AST containment scan or
-construct-specific continuation convention is part of the dialect contract.
+이 단일 region/suffix 규칙은 case arm과 guard, conditional, short-circuit
+오른쪽 항, nested handle body와 arm, resume path, 그리고 이들을 감싸는 strict
+work를 모두 다룬다. AST containment scan이나 construct-specific continuation
+convention은 dialect contract에 포함되지 않는다.
 
 `ability.*` represents effect evidence and handler dispatch. Ability operations
 are lowered through the effect pipeline; ability-related types may remain until
@@ -546,9 +529,9 @@ Important stage invariants:
 | Resolution | Names, constructors, and variable references are resolved |
 | Type check | Type variables and effect rows are solved |
 | TDNR | Method-style calls are converted to resolved calls |
-| AST-to-IR | Source-logical callable signatures, verified `tribute_control` structure, and valid SSA use chains |
-| Shared CPS legalization | Callable signatures and all call sites use the physical `CallableAbi`; no `tribute_control.*` remains |
-| Shared lowering | High-level ability dispatch operations are removed at their claimed boundaries |
+| AST-to-IR | Source-logical callable signature, 검증된 `tribute_control` 구조, valid SSA use chain |
+| Shared CPS legalization | Callable signature과 모든 call site가 physical `CallableAbi`를 사용하며 `tribute_control.*`이 남지 않음 |
+| Shared lowering | 명시된 경계에서 high-level ability dispatch operation이 제거됨 |
 | Effect ABI | `effect.*` operations preserve dispatch semantics without backend layout details |
 | Backend lowering | Backend-ready target verification succeeds and no `effect.*` operations remain |
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -55,7 +55,7 @@ operations.
 | `tribute-control-pre-cps` | frontend 적합성 검사에는 full, 변환 중에는 partial | `tribute_control.*`은 `core.module`, `core.never`와 일반 `core` 값 type, `scf`, `arith`, `adt`, `list`, `tribute_rt`, `tribute_io`와 공존할 수 있다. `func.*`, `closure.*`, `core.func`, 기존 `ability.*`, `effect.*`, legacy CPS 구성 operation은 illegal이다. |
 | `tribute-control-post-cps` | shared CPS 변환 뒤 partial | `tribute_control` dialect의 모든 operation과 type이 illegal이다. Physical `func.*`, `closure.*`, `core.func`, 기존 `ability.*`, `effect.*`, 일반 dialect는 이후 pass를 위해 공존할 수 있다. |
 | `tribute-backend-ready-native` | Tribute full 경계 뒤 generic Cranelift 경계 | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, conversion cast가 없다. 명시적으로 열거한 native infrastructure와 `clif.*` operation만 남는다. |
-| `tribute-backend-ready-wasm` | 기존 emission-ready 검사 전에 high-level operation을 partial 방식으로 거부 | backend-ready Wasm IR 전에 `tribute_control`, `ability`, `effect`를 명시적으로 illegal로 지정하며, emission 전에는 `wasm_gc`도 illegal이다. |
+| `tribute-backend-ready-wasm` | emission-ready full 경계 | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, `wasm_gc`, `core.unrealized_conversion_cast`가 없다. 명시적으로 열거한 Wasm infrastructure와 `wasm.*` operation만 legal이며 unknown operation은 illegal이다. |
 
 Post-CPS helper는
 `ConversionTarget::new().illegal_dialect("tribute_control")`와 partial

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -62,12 +62,21 @@ partial verification을 조합해 post-CPS helper를 구현할 수 있다. Full 
 unknown operation이 legal하지 않으므로 frontend 적합성 target과 backend full
 target이 legal dialect와 operation을 열거해야 한다. `ConversionTarget`은
 operation 적법성만 검사하므로 Tribute whole-IR type walk가 pre-CPS의
-`core.func`/`closure.closure`와 post-CPS의 `tribute_control.callable`/
-`resume_token`을 별도로 거부한다. 이 walk는 operand/result, block argument,
-type attribute와 nested type parameter를 재귀적으로 검사한다. Region 소유
+`core.func`/`closure.closure`와 post-CPS의
+`tribute_control.callable`/`resume_token`을 별도로 거부한다. 같은 walk는
+`tribute-backend-ready-native`와 `tribute-backend-ready-wasm`에서도 필수이며
+남은 두 `tribute_control` type을 거부한다. 함수·호출 signature, operand/result,
+block argument, type attribute와 nested type parameter를 재귀적으로 검사하며,
+operation 적법성 검사와 모두 통과해야 named boundary가 성립한다. Region 소유
 operation을 recursively legal로 표시해서 nested illegal operation을 가려서는
 안 된다. Generic `trunk-ir`의 Cranelift 경계는 Tribute에 독립적으로 유지하며,
-그 전에 Tribute pipeline이 high-level dialect를 거부한다.
+그 전에 Tribute pipeline이 high-level dialect와 type을 거부한다.
+
+최종 native/Wasm 경계는 `tribute.calling_convention = 2` (`Cps`)인 worker와 생성된
+continuation/`done_k`/handler-dispatch의 result가 비어 있는지도 검사한다.
+CPS control result 역할의 `anyref`, nominal `__tribute_cps_control` enum과
+result-producing CPS dispatch는 illegal이다. Boxed source value, effect payload,
+closure environment와 dispatch field의 일반 `anyref` 사용은 허용한다.
 
 하나의 rewrite 도중에는 source `tribute_control.*`과 새
 `ability.*`/`effect.*` 결과가 일시적으로 공존할 수 있다. 이는 partial
@@ -155,8 +164,10 @@ resolution을 검사하며 physical `core.func`나 `closure.closure`를 componen
 | `tribute_control.resume` | resumptive general handler arm에 바인딩된 affine resumption을 소비 |
 | `tribute_control.yield` | 실행 가능한 `tribute_control` region을 logical value로 종료 |
 
-`func.tail_call`, `func.constant`, `func.unreachable`의 logical 복제는 없다. Tail
-형상은 legalization 결과이고 named function value는 `func_ref`가 표현한다.
+`func.tail_call`, `func.tail_call_indirect`, `func.constant`, `func.unreachable`의
+logical 복제는 없다. Tail 형상은 legalization 결과이고 named function value는
+`func_ref`가 표현한다. Legalization은 알려진 target에 `func.tail_call`, closure,
+continuation과 `done_k` target에 새 `func.tail_call_indirect`를 만들 수 있다.
 `func.constant`는 후속 physical closure lowering이 만들며 `func.unreachable`은
 reject adapter 같은 compiler helper 안에서만 legalization 뒤에 사용한다.
 
@@ -169,6 +180,47 @@ canonical `core.never` TypeRef를 사용하고 resumption을 만들지 않으며
 `resume_token`도 노출하지 않는다. Verifier가 erased type을 추측하지 않고
 non-resumptive case를 식별해야 하므로 현재 legacy frontend의 `Never`용 `anyref`
 placeholder는 이 새 경계에서 valid하지 않다.
+
+### 사용자 정의 어셈블리 형식
+
+`tribute_control.func`와 `tribute_control.lambda`만 custom parse/print를 요구한다.
+간결한 convention 문법은 `convention(direct)`,
+`convention(evidence_direct)`, `convention(cps)`이며 각각 callable type의
+`tribute.calling_convention = 0`, `1`, `2`로 round trip한다. Parser는 signature와
+keyword로 `tribute_control.callable`을 만들고 convention을 type에만 저장한다.
+출력기도 type attribute만 읽으며 body에서 추론하거나 operation에 중복
+attribute를 쓰지 않는다. 추가 operation attribute에
+`tribute.calling_convention`을 다시 적으면 parser 또는 verifier가 거부한다.
+
+```text
+tribute_control.func @f(%x: T) -> R convention(cps)
+    attributes {visibility = @private} {
+  ...
+}
+
+tribute_control.func @decl(%x: T) -> R convention(direct)
+
+%f = tribute_control.lambda(%x: T) -> R convention(cps)
+    captures [%captured] attributes {debug_name = "apply"} {
+  ...
+}
+
+%g = tribute_control.lambda() -> R convention(direct)
+    captures [] {
+  ...
+}
+```
+
+`func` 형식은 `func.func`처럼 symbol, 분해된 logical parameter/result, 선택적
+추가 attribute와 선택적 body를 출력한다. Body가 있으면 entry block label을
+생략하고 signature parameter를 entry argument로 복원하며 declaration은 body가
+없다. `lambda` 형식은 `closure.lambda`처럼 SSA result, 분해된 source
+parameter/result, 필수 convention, 명시적 `captures [...]`, 선택적 추가
+attribute와 body를 출력하고 entry label을 생략한다. `captures [...]`는 capture가
+없어도 `captures []`로 항상 출력하며 canonical 순서는 convention, captures,
+선택적 attributes, body다. `func_ref`, `call`, `call_indirect`, `return`은 현재
+generic assembly가 모든 정보를 손실 없이 표현하므로 custom format을 만들지
+않는다.
 
 #### `tribute_control.func`
 
@@ -343,8 +395,8 @@ Callable operation의 physical lowering은
 - **피연산자:** 없다. 실행 가능한 region이 capture하는 값은 일반 enclosing SSA
   visibility를 사용한다.
 - **결과:** logical handle result 하나만 만든다.
-- **속성:** 필수 attribute는 없다. Dynamic prompt/owner tag와 backend
-  carrier 선택은 의도적으로 포함하지 않는다.
+- **속성:** 필수 attribute는 없다. Dynamic prompt/owner tag와 physical tail-call
+  표현은 이 operation의 의미 attribute가 아니라 legalization 계약이다.
 - **영역:** 고정된 `body`, `completion`, `handlers` 순서로 정확히 세 개다.
 - **Block argument:** `body`는 argument가 없는 block 하나다. `completion`은
   argument가 정확히 하나인 block 하나이며, 그 type은 `body`가 yield한 value의
@@ -402,13 +454,17 @@ tribute_control.handler {
   type이 `operation_result_type`과 같고 자동으로 resume한다. `op`에서는 yield
   type이 token의 `answer` type과 같으며, arm이 `resume`을 통해 control을
   넘기지 않고 완료되면 enclosing handle result가 된다.
+  `operation_result_type`이 source `Never`인 `op`에는 token이 없고 yield type은
+  enclosing `tribute_control.handle` result type과 같아야 한다.
 - **지역 검증:** 필수 attribute와 domain, block 하나, 마지막
   terminator, token 위치/parameter, 위 yield 규칙을 확인한다.
   `operation_result_type`이 `Never`인 general handler는 token argument가 없어야
   하며 nested region을 포함한 body 어디에도 `tribute_control.resume`이 없어야
-  한다. Parent placement, uniqueness, enclosing handle result와의 equality는
-  containing handle의 local verifier가 확인한다. Symbol-aware frontend 적합성
-  검사는 참조된 declaration의 `kind`, argument type,
+  한다. Parent placement, uniqueness와 `op -> Never` yield를 포함한 enclosing
+  handle result와의 equality는 containing handle의 local verifier가 확인하고,
+  converter도 rewrite 전에 같은 equality와 resume 부재를 검사해 위반을
+  conversion failure로 보고한다. Symbol-aware frontend 적합성 검사는 참조된
+  declaration의 `kind`, argument type,
   `operation_result_type`도 동일한지 확인하며, 어떤 verifier도 body 형상으로
   general `op`을 재분류하지 않는다.
 - **소유권과 값 흐름:** 마지막 token argument가 있으면 affine이다.
@@ -558,6 +614,10 @@ make these attributes round-trip explicitly.
 
 `func.*` represents function definitions, direct calls, indirect calls, function
 references, returns, tail calls, and unreachable control flow.
+`func.tail_call_indirect`는 callable operand와 argument를 받고 result가 없는
+terminator다. Shared verifier는 callee `core.func`와 enclosing caller의 result가
+모두 `core.never`인지 검사한다. Native/Wasm signature lowering은 이를 empty result
+vector로 바꾸고 각각 indirect return-call로 낮춘다.
 
 `scf.*` represents structured control flow, including pattern/case regions and
 region yields. Loop-like forms may be introduced by optimization passes such as
@@ -627,10 +687,10 @@ Important stage invariants:
 | Type check | Type variables and effect rows are solved |
 | TDNR | Method-style calls are converted to resolved calls |
 | AST-to-IR | `tribute_control.callable`과 callable/control operation, valid SSA use chain |
-| Shared CPS legalization | 전체 callable graph가 physical `CallableAbi`를 사용하며 `tribute_control` operation/type이 남지 않음 |
+| Shared CPS legalization | 전체 callable graph가 physical `CallableAbi`와 direct/indirect tail transfer를 사용하며 `tribute_control` operation/type이 남지 않음 |
 | Shared lowering | 명시된 경계에서 high-level ability dispatch operation이 제거됨 |
 | Effect ABI | `effect.*` operations preserve dispatch semantics without backend layout details |
-| Backend lowering | Backend-ready target verification succeeds and no `effect.*` operations remain |
+| Backend lowering | Backend-ready 검증이 성공하고 `effect.*` 및 compatibility CPS carrier가 남지 않음 |
 
 ## Type Model
 
@@ -646,5 +706,3 @@ representation.
 - Final closure environment representation for each backend.
 - Reusable conversion targets for effect ABI lowering boundaries.
 - Debug/source-map representation.
-- WasmGC reactivation strategy for lowering shared tail-call CPS IR into
-  closure, table, and evidence representations.

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -37,7 +37,7 @@ trunk-ir-wasm-backend/    # trunk-ir만 의존
 tribute-passes/           # tribute-ir 의존
 ├── wasm/lower.rs         # Wasm lowering pipeline orchestration
 ├── wasm/evidence_to_wasm.rs
-│                         # effect.* → evidence helpers + call_indirect
+│                         # effect.* → evidence helpers + call/return_call
 ├── wasm/tribute_rt_to_wasm.rs
 ├── wasm/const_to_wasm.rs
 ├── wasm/intrinsic_to_wasm.rs
@@ -64,6 +64,7 @@ tribute-ir (High-level)
 ├── closure.new
 ├── effect.extend
 ├── effect.dispatch_tail / effect.dispatch_cps
+├── func.tail_call / func.tail_call_indirect
 │
 ▼ tribute-passes/wasm/lower.rs
 │
@@ -71,7 +72,10 @@ trunk-ir (Mid-level)
 ├── wasm.struct_new       # 인스턴스 생성
 ├── wasm.struct_get/set   # 필드 접근
 ├── wasm.array_new        # 배열 생성
-├── wasm.call_indirect    # dispatch closure 호출
+├── wasm.call_indirect    # ordinary indirect 호출
+├── wasm.return_call      # direct proper tail transfer
+├── wasm.return_call_indirect
+│                         # indirect proper tail transfer
 ├── wasm.func             # evidence lookup/extend helpers
 │
 ▼ trunk-ir-wasm-backend
@@ -81,11 +85,11 @@ trunk-ir (Mid-level)
 WebAssembly Binary
 ```
 
-Effect lowering is target-specific. Shared ability lowering produces
-`effect.*` operations and must not inspect Marker field numbers or closure
-layout. `wasm/evidence_to_wasm` is the Wasm boundary that removes those
-operations by generating evidence lookup/extend helpers, unpacking closure
-structs `(table_idx, env)`, and emitting `wasm.call_indirect`.
+Effect lowering은 target별로 수행한다. Shared ability lowering은 `effect.*`를
+만들며 Marker field 번호나 closure layout을 검사하지 않는다.
+`wasm/evidence_to_wasm`은 evidence lookup/extend helper를 만들고 closure struct
+`(table_idx, env)`를 풀어 semantic role에 맞는 일반 호출 또는 proper-tail call을
+emit하여 해당 operation을 제거하는 Wasm 경계다.
 
 ### Entrypoint contract
 
@@ -98,6 +102,32 @@ the `EvidenceDirect` ABI. Other residual effects are rejected by the frontend.
 Printing program results belongs in explicit standard I/O calls such as
 `std::io::print_line`, which shared lowering maps to the target-independent I/O
 boundary described in [io.md](io.md), not in backend entrypoint lowering.
+
+CPS root가 필요한 export는
+[직접형 wrapper와 completion cell](cps-effects.md#root-main-delimiter)을 사용한다.
+Shared IR은 completion cell과 `core.never` root `done_k`의 추상 조합 계약만
+보존한다. #825가 CPS signature를 Wasm empty-result signature로 내린 뒤 현재
+nil/void machinery에 맞는 wrapper와 ordinary call을 합성한다. Wrapper는 root
+`done_k`가 typed cell을 쓴 뒤 call이 돌아오면 이를 읽는다. Shared `func.call`에
+zero-result 형상을 추가하지 않으며, 이 bridge는 trampoline이나 `anyref` control
+carrier가 아니다.
+
+### 올바른 꼬리 호출 계약
+
+[WebAssembly 3.0 validation](https://webassembly.github.io/spec/core/valid/instructions.html#valid-return-call-indirect)은
+`return_call`, `return_call_indirect`, `return_call_ref`의 tail-call 형식과 caller
+result matching을 정의한다. Tribute는 다음 경로를 구현한다:
+
+| Shared IR | Wasm IR | Encoder |
+| ---- | ---- | ---- |
+| `func.tail_call` | `wasm.return_call` | `wasm_encoder::Instruction::ReturnCall` |
+| `func.tail_call_indirect` | `wasm.return_call_indirect` | `wasm_encoder::Instruction::ReturnCallIndirect { type_index, table_index }` |
+
+`func.tail_call_indirect` lowering은 callee table index와 argument를 기존
+`call_indirect`와 같은 순서로 평가하고, callee `core.func`에서 `type_index`를
+결정한다. CPS caller/callee의 result vector는 모두 비어 있어야 하며
+`wasm.return_call_indirect`는 result local을 만들지 않는다. 일반 source-data
+indirect call만 `wasm.call_indirect`를 유지한다.
 
 ### Dynamic basic output
 
@@ -143,8 +173,8 @@ claims require focused Wasm evidence.
 
 ### Type Section 생성
 
-수집된 타입 정보로 WasmGC type section을 생성한다. Builtin type index layout은
-현재 고정되어 있고, user-defined type은 그 뒤에 배치된다:
+수집된 타입 정보로 WasmGC type section을 생성한다. 다음 표는 migration 전 현재
+고정 layout이며 user-defined type은 그 뒤에 배치된다:
 
 | Index | Type |
 | ---: | --- |
@@ -158,6 +188,11 @@ claims require focused Wasm evidence.
 | 7 | `Continuation` legacy trampoline struct |
 | 8 | `ResumeWrapper` legacy trampoline struct |
 | 9+ | user-defined structs, arrays, variants, closures |
+
+Issue #826 완료 시 `Step`, `Continuation`, `ResumeWrapper`를 삭제하고 builtin/user index를
+다시 계산한다. 최종 layout은 이 세 index를 예약하거나 호환 placeholder를
+남겨서는 안 된다. `_closure` environment와 Marker의 dispatch closure field는
+일반 reference erasure이므로 계속 `anyref`를 사용할 수 있다.
 
 ```wasm
 ;; 생성된 type section 예시
@@ -212,22 +247,25 @@ wasm dialect는 WasmGC 인스턴스 연산만 포함:
 
 ---
 
-## Current Work Items
+## 선택한 마이그레이션 작업
 
-- Remove or repurpose the legacy `Step`, `Continuation`, and `ResumeWrapper`
-  builtin types once the old trampoline path is fully retired.
-- Promote the current Wasm backend-ready partial boundary, which rejects
-  residual `ability.*` and `effect.*`, into a full emission boundary once
-  remaining later-stage infrastructure such as unresolved casts is cleaned up.
-- Keep pass-level textual IR fixtures for `effect.extend`,
-  `effect.dispatch_tail`, and `effect.dispatch_cps` so the Wasm and native
-  lowering paths cannot drift silently.
+- #823은 generic `func.tail_call_indirect`와 empty-result verifier contract를
+  제공한다.
+- #825는 `wasm.return_call_indirect` operation, func-to-Wasm rewrite와
+  `Instruction::ReturnCallIndirect` emission을 구현한다.
+- #826은 `Step`, `Continuation`, `ResumeWrapper` 및 compatibility control carrier
+  관련 type/emission path를 삭제한다.
+- 최종 Wasm emission boundary는 residual `tribute_control.*`, `ability.*`,
+  `effect.*`, compatibility carrier와 result-producing CPS transfer를 거부한다.
+- `effect.extend`, `effect.dispatch_tail`, `effect.dispatch_cps`와 direct/indirect
+  tail-call fixture를 함께 유지해 native/Wasm 경로의 drift를 막는다.
 
 ---
 
 ## References
 
 - [Wasm 3.0 Release](https://webassembly.org/news/2025-09-17-wasm-3.0/)
+- [WebAssembly 3.0 tail-call validation](https://webassembly.github.io/spec/core/valid/instructions.html#valid-return-call-indirect)
 - [WasmGC Proposal](https://github.com/WebAssembly/gc/blob/main/proposals/gc/Overview.md)
 - [Cranelift Stack Maps](https://bytecodealliance.org/articles/new-stack-maps-for-wasmtime)
 - [MLIR Dialects](https://mlir.llvm.org/docs/Dialects/)

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -185,8 +185,10 @@ user-defined type은 그 뒤에 배치된다:
 | 5 | `Evidence` array |
 | 6+ | user-defined structs, arrays, variants, closures |
 
-Builtin layout은 CPS control carrier나 trampoline placeholder index를 예약하지
-않는다. `_closure` environment와 Marker의 dispatch closure field는 일반 reference
+이 표는 backend-ready builtin layout의 규범적 최종 계약이다. Emitter와 layout
+verifier는 `_closure` 3, `_Marker` 4, `Evidence` 5, user-defined type 6+를 정확히
+사용하며 CPS control carrier나 trampoline placeholder index를 예약하지 않는다.
+`_closure` environment와 Marker의 dispatch closure field는 일반 reference
 erasure이므로 계속 `anyref`를 사용할 수 있다.
 
 ```wasm

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -4,9 +4,8 @@
 
 ## Overview
 
-Tribute의 Wasm backend는 WasmGC (Wasm 3.0) 표현을 emit한다. 현재 주요 구현
-경로는 native이지만, Wasm backend도 같은 shared middle-end와 effect ABI를
-입력으로 받는다. 백엔드는 다음 원칙을 따른다:
+Tribute의 Wasm backend는 WasmGC (Wasm 3.0) 표현을 emit하고 native와 같은 shared
+middle-end와 effect ABI를 입력으로 받는다. 백엔드는 다음 원칙을 따른다:
 
 1. **타겟 독립적 IR 유지**: trunk-ir는 특정 타겟에 종속되지 않음
 2. **Backend-specific 타입 처리**: WasmGC 타입 정의는 백엔드에서 처리
@@ -106,8 +105,8 @@ boundary described in [io.md](io.md), not in backend entrypoint lowering.
 CPS root가 필요한 export는
 [직접형 wrapper와 completion cell](cps-effects.md#root-main-delimiter)을 사용한다.
 Shared IR은 completion cell과 `core.never` root `done_k`의 추상 조합 계약만
-보존한다. #825가 CPS signature를 Wasm empty-result signature로 내린 뒤 현재
-nil/void machinery에 맞는 wrapper와 ordinary call을 합성한다. Wrapper는 root
+보존한다. Wasm signature lowering이 CPS signature를 empty-result signature로
+내린 뒤 nil/void machinery에 맞는 wrapper와 ordinary call을 합성한다. Wrapper는 root
 `done_k`가 typed cell을 쓴 뒤 call이 돌아오면 이를 읽는다. Shared `func.call`에
 zero-result 형상을 추가하지 않으며, 이 bridge는 trampoline이나 `anyref` control
 carrier가 아니다.
@@ -149,9 +148,9 @@ the standard-library I/O wrapper explicitly converts them to `Bytes`.
 WasmGC must lower the same representation-independent `list.*` sequence
 operations to a target-private GC layout and eliminate them before the
 backend-ready boundary. It is not required to share native's linked-node/null
-layout. The M1 native implementation and compile-only shared frontend evidence
-do not by themselves establish Wasm compilation or execution support; capability
-claims require focused Wasm evidence.
+layout. Native implementation and shared frontend evidence do not by themselves
+establish Wasm compilation or execution support; capability claims require
+focused Wasm evidence.
 
 ---
 
@@ -173,26 +172,22 @@ claims require focused Wasm evidence.
 
 ### Type Section 생성
 
-수집된 타입 정보로 WasmGC type section을 생성한다. 다음 표는 migration 전 현재
-고정 layout이며 user-defined type은 그 뒤에 배치된다:
+수집된 타입 정보로 WasmGC type section을 생성한다. Builtin layout은 다음과 같고
+user-defined type은 그 뒤에 배치된다:
 
 | Index | Type |
 | ---: | --- |
 | 0 | `BoxedF64` |
 | 1 | `BytesArray` |
 | 2 | `BytesStruct` |
-| 3 | `Step` legacy trampoline struct |
-| 4 | `_closure { table_idx: i32, env: anyref }` |
-| 5 | `_Marker { ability_id: i32, prompt_tag: i32, tr_dispatch_fn: anyref, handler_dispatch: anyref }` |
-| 6 | `Evidence` array |
-| 7 | `Continuation` legacy trampoline struct |
-| 8 | `ResumeWrapper` legacy trampoline struct |
-| 9+ | user-defined structs, arrays, variants, closures |
+| 3 | `_closure { table_idx: i32, env: anyref }` |
+| 4 | `_Marker { ability_id: i32, prompt_tag: i32, tr_dispatch_fn: anyref, handler_dispatch: anyref }` |
+| 5 | `Evidence` array |
+| 6+ | user-defined structs, arrays, variants, closures |
 
-Issue #826 완료 시 `Step`, `Continuation`, `ResumeWrapper`를 삭제하고 builtin/user index를
-다시 계산한다. 최종 layout은 이 세 index를 예약하거나 호환 placeholder를
-남겨서는 안 된다. `_closure` environment와 Marker의 dispatch closure field는
-일반 reference erasure이므로 계속 `anyref`를 사용할 수 있다.
+Builtin layout은 CPS control carrier나 trampoline placeholder index를 예약하지
+않는다. `_closure` environment와 Marker의 dispatch closure field는 일반 reference
+erasure이므로 계속 `anyref`를 사용할 수 있다.
 
 ```wasm
 ;; 생성된 type section 예시
@@ -236,29 +231,17 @@ wasm dialect는 WasmGC 인스턴스 연산만 포함:
 
 타입 정의 (type section)는 백엔드가 이 연산들에서 추론하여 생성한다.
 
-### tribute-wasm-backend 제거
+### 크레이트 역할 분담
 
-별도 `tribute-wasm-backend` 크레이트는 현재 사용하지 않는다. 역할 분담은 다음과
-같다:
+역할 분담은 다음과 같다:
 
 - Lowering → tribute-passes
 - Emission → trunk-ir-wasm-backend
 - 조율 → tribute main crate
 
----
-
-## 선택한 마이그레이션 작업
-
-- #823은 generic `func.tail_call_indirect`와 empty-result verifier contract를
-  제공한다.
-- #825는 `wasm.return_call_indirect` operation, func-to-Wasm rewrite와
-  `Instruction::ReturnCallIndirect` emission을 구현한다.
-- #826은 `Step`, `Continuation`, `ResumeWrapper` 및 compatibility control carrier
-  관련 type/emission path를 삭제한다.
-- 최종 Wasm emission boundary는 residual `tribute_control.*`, `ability.*`,
-  `effect.*`, compatibility carrier와 result-producing CPS transfer를 거부한다.
-- `effect.extend`, `effect.dispatch_tail`, `effect.dispatch_cps`와 direct/indirect
-  tail-call fixture를 함께 유지해 native/Wasm 경로의 drift를 막는다.
+최종 Wasm emission boundary는 residual `tribute_control.*`, `ability.*`,
+`effect.*`, CPS control carrier, trampoline과 result-producing CPS transfer를
+거부한다.
 
 ---
 


### PR DESCRIPTION
## Context

This is the design gate for parent issue #818. It defines Tribute's unified source-logical callable and effect-control boundary.

The authoritative `new-plans/` documents contain only durable final architecture, semantic, verifier, and backend contracts. GitHub issue and milestone metadata owns implementation sequencing, temporary compatibility state, cleanup ownership, and task-specific rollout and validation plans; the design documents do not record issue-by-issue migration state.

## Design summary

- Defines `tribute_control` as the target-independent owner of Tribute-specific source-logical callable and direct-style effect-control semantics.
- Adds `tribute_control.callable(Result, Params...) {tribute.calling_convention = N}`, preserving `Direct = 0`, `EvidenceDirect = 1`, and `Cps = 2` without exposing a physical ABI.
- Defines the six minimal callable operations: `tribute_control.func`, `lambda`, `func_ref`, `call`, `call_indirect`, and `return`.
- Gives `tribute_control.func` and `lambda` custom assembly modeled on `func.func` and `closure.lambda`. `convention(direct|evidence_direct|cps)` round-trips only through the callable type's `tribute.calling_convention`; lambda captures are always explicit, including `captures []`, and optional extra attributes are preserved. The other callable operations keep generic assembly.
- Represents every source ability invocation, both `fn` and general `op`, as `tribute_control.perform` with required typechecked `operation_kind = @fn | @op` metadata. Legalization uses that metadata directly and never infers or reclassifies an operation kind.
- Keeps `fn` handler arms automatically resumptive without a token, general resumptive `op` arms affine, and `op -> Never` arms token-free. A non-resumptive arm cannot contain `resume`, and its `yield` must match the enclosing `handle` result type.
- Separates static resume-token ownership checks from runtime one-shot enforcement after closure capture.

## Structured regions and conversion boundaries

The design specifies strict left-to-right region/suffix semantics for conditionals, case arms and guards, short-circuit RHS regions, nested handles, resume paths, and enclosing strict work. General structured control remains in `scf.*`; `tribute_control_to_cps` recursively transforms its regions and suffixes, and no `tribute_control.if` operation is introduced. Unselected regions are never evaluated, and ANF remains an input invariant rather than the dialect identity.

The full `tribute-control-pre-cps` frontend-conformance boundary permits only source-logical `tribute_control` callable/control operations with ordinary value IR. It rejects pre-lowering `func.*`, `closure.*`, `core.func`, existing `ability.*`, `effect.*`, and legacy CPS dispatch operations. Temporary coexistence is allowed only inside partial conversion.

`tribute_control_to_cps` atomically converts definitions, lambdas, named references, direct and indirect calls, returns, and their signatures. Shared CPS workers, continuations, and `done_k` retain logical `core.never` results; known transfers use `func.tail_call`, and dynamic closure/continuation transfers use `func.tail_call_indirect`. The pass emits the physical callable/closure surface consumed by `lower_closure_lambda`, `prepare_closure_lowering`, and `lower_closures_in_func`, plus the logical `ability.*` dispatch surface consumed by `lower_ability_perform`, `resolve_evidence`, and `lower_handle_dispatch`. Target evidence lowering removes the later `effect.*` surface, so no stage double-lowers closure or dispatch IR.

Native and Wasm signature lowering maps shared `core.never` CPS signatures to target empty-result signatures before synthesizing the Direct/EvidenceDirect root completion-cell wrapper and its ordinary target call. This preserves the one-result shared `core.func`/`func.call` model and introduces no second control carrier.

Post-CPS legality rejects every residual `tribute_control` operation and type. Backend-ready native and Wasm checks repeat the recursive whole-IR type walk across signatures, operands/results, block arguments, attributes, and nested type parameters, rejecting residual `tribute_control.callable` and `resume_token` as well as illegal operations. The Wasm backend-ready boundary is full: it rejects every residual high-level or conversion operation, allows only explicitly enumerated Wasm infrastructure and `wasm.*`, and treats unknown operations as illegal. Its builtin table is the normative final layout: `_closure` is index 3, `_Marker` is 4, `Evidence` is 5, and user-defined types begin at 6, with no control-carrier or trampoline placeholder indices. The Mermaid diagram records the frontend, atomic legalization, downstream shared passes, target proper-tail lowering, and backend-ready verification pipeline.

## Selected physical control path and non-goals

The final architecture uses tail-call-only CPS on native and Wasm. CPS control produces no returned value: direct transfers use `func.tail_call`; indirect closure, continuation, handler-dispatch, and `done_k` transfers use `func.tail_call_indirect`. Wasm lowers the latter through `wasm.return_call_indirect` to `wasm_encoder::Instruction::ReturnCallIndirect`.

The final path contains no CPS control-result `anyref`, private return carrier, `Step`, or trampoline. Ordinary reference erasure remains valid for boxed source values, effect payloads, closure environments, and dispatch fields. Tail-resumptive carrier selection is fixed by this design; historical and rollout tracking remains outside the authoritative design documents.

An apparently tail-resumptive general `op` remains an `op`; recognizing and optimizing that shape is a separate IR optimization. This design does not change source syntax, effect-row semantics, ability optimization policy, multi-file compilation, or generic `trunk-ir` semantics.

## Validation

- `/Users/kroisse/workspace/tribute/main/node_modules/.bin/markdownlint-cli2 "**/*.md" "#node_modules"` — 40 files, 0 errors
- `git diff --check HEAD` and `git diff --check origin/main` — passed
- Focused scans for issue/milestone/tracking terms, stale dialect spelling and carrier alternatives, custom assembly round trips and negative cases, root-bridge phase separation, and required callable/control contracts — passed
- No Mermaid CLI/package is installed locally; the fenced diagram was structurally inspected and its Markdown fencing passed repository lint
- Pre-commit hook:
  - `cargo clippy --workspace` — passed (`dev` profile completed in 4.06s)
  - `cargo fmt -- --check` — passed
  - `cargo nextest run --workspace` — 1,737 passed, 0 skipped in 64.404s

Closes #821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the direct-style control and CPS legalization pipeline, including the direct-control boundary contract and pre-/post-CPS legality boundaries.
  * Clarified how `fn` vs `op` affects tail dispatch vs continuation capture, plus `-> Never` handling and resumptions’ ownership/completion semantics.
  * Expanded the Tribute direct-control contract (callable/control ops, verification/typing, and continuation invariants) and updated pipeline stage expectations.
  * Refreshed Wasm backend lowering guidance, including tail-call mappings and updated WasmGC layout notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->