### PR TITLE
#823: Legalize tribute_control callable/control IR in tribute-passes

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -1313,7 +1313,7 @@ fn lower_cps_call_expr<'db, D: ControlDomain>(
                 arg_values = pack_ability_args(builder, location, arg_values);
                 let ability_name = ability.qualified(builder.db());
                 let ability_ref = builder.ctx.ability_ref_type(builder.ir, ability_name, &[]);
-                let perform = ability::perform(
+                let perform = ability::legacy_perform(
                     builder.ir,
                     location,
                     continuation,

--- a/crates/tribute-front/src/ast_to_ir/lower/handle.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/handle.rs
@@ -3,11 +3,11 @@
 //! Lowers `handle` expressions using CPS-based effect handling:
 //! - Body is wrapped in a `closure.lambda` that returns an opaque compatibility
 //!   control answer through the `anyref` ABI
-//! - Handler dispatch uses `ability.handle_dispatch`
+//! - Handler dispatch uses the explicit `ability.legacy_handle_dispatch` shim
 //! - Continuation calls use `func.call_indirect` (not `ability.resume`)
 //!
-//! Ability operation calls are lowered to `ability.perform` with CPS
-//! continuations.
+//! Ability operation calls use the explicit legacy compatibility forms until
+//! the frontend/pipeline migration is complete.
 
 use std::collections::HashSet;
 
@@ -33,7 +33,7 @@ use super::control::{
     resume_into_current,
 };
 
-/// Lower a `fn` (tail-resumptive) ability operation call using `ability.call`.
+/// Lower a `fn` operation through the explicit legacy compatibility form.
 ///
 /// This does not create a continuation closure or use CPS. The result flows
 /// inline — no `func.return` is inserted, and subsequent code continues
@@ -52,8 +52,8 @@ pub(super) fn lower_ability_fn_call<'db>(
     // Pack multiple arguments into a tuple if needed (with boxing)
     let packed_args = super::expr::pack_ability_args(builder, location, args);
 
-    // Emit ability.call (direct call, no continuation)
-    let call_op = ability::call(
+    // Emit the legacy direct call (no continuation).
+    let call_op = ability::legacy_call(
         builder.ir,
         location,
         packed_args,
@@ -144,7 +144,7 @@ fn lower_handle_answer<'db, D: ControlDomain>(
     builder.ir.push_op(builder.block, owner_tag.op_ref());
 
     // 5. Emit ability.handle_dispatch.
-    let dispatch_op = ability::handle_dispatch(
+    let dispatch_op = ability::legacy_handle_dispatch(
         builder.ir,
         location,
         body_yr,

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -2,7 +2,7 @@
 //!
 //! Verifies that:
 //! - `resume` expressions lower to `func.call_indirect` on the continuation
-//! - Ability op calls in blocks produce `ability.perform` with CPS continuations
+//! - Ability op calls in blocks produce `ability.legacy_perform` with CPS continuations
 //! - Handle expressions produce `ability.handle_dispatch` with handler closures
 //! - Nested ability op calls chain continuations correctly
 
@@ -89,7 +89,7 @@ fn main() { }
 // CPS Block Lowering Tests
 // ========================================================================
 
-/// A single ability op call in a block should produce `ability.perform`
+/// A single ability op call in a block should produce `ability.legacy_perform`
 /// with a trivial identity continuation.
 #[salsa_test]
 fn test_single_ability_op_in_block(db: &salsa::DatabaseImpl) {
@@ -115,7 +115,7 @@ fn main() { }
 }
 
 /// An ability op call followed by a pure expression should produce
-/// `ability.perform` with a continuation that evaluates the remaining code.
+/// `ability.legacy_perform` with a continuation that evaluates the remaining code.
 #[salsa_test]
 fn test_ability_op_then_pure_expr(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -141,7 +141,7 @@ fn main() { }
 }
 
 /// Two sequential ability op calls should chain continuations:
-/// the first continuation contains the second `ability.perform`.
+/// the first continuation contains the second `ability.legacy_perform`.
 #[salsa_test]
 fn test_sequential_ability_ops(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -946,7 +946,7 @@ fn main() { }
 // ========================================================================
 
 /// An ability op with multiple arguments should pack them into a tuple
-/// before passing to `ability.perform`.
+/// before passing to `ability.legacy_perform`.
 #[salsa_test]
 fn test_multi_arg_ability_op(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(

--- a/crates/tribute-front/tests/snapshots/cps_lowering__ability_op_then_pure_expr.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__ability_op_then_pure_expr.snap
@@ -4,7 +4,7 @@ expression: ir_text
 ---
 core.module @test {
   func.func @get_value(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %1 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %2 = core.unrealized_conversion_cast %1 : core.i32
       func.return %2
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__cps_case_guard_stays_in_matched_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__cps_case_guard_stays_in_matched_arm.snap
@@ -7,7 +7,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @effectful(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
       func.return %2
   }
   func.func @run(%0: !t1, %1: tribute_rt.anyref, %2: core.i1) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__cps_case_scrutinee_keeps_outer_consumer.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__cps_case_scrutinee_keeps_outer_consumer.snap
@@ -7,7 +7,7 @@ core.module @test {
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
   func.func @effectful(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
       func.return %2
   }
   func.func @after(%0: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__cps_handler_case_arm_resumes_local_continuation.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__cps_handler_case_arm_resumes_local_continuation.snap
@@ -8,7 +8,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @read_log(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Log}, op_name = @value} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Log}, op_name = @value} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -17,7 +17,7 @@ core.module @test {
   }
   func.func @run(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
-          %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %4 = ability.legacy_perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           func.return %4
       }
       %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -96,7 +96,7 @@ core.module @test {
       }
       %55 = arith.const {value = 0} : tribute_rt.anyref
       %56 = effect.fresh_prompt_tag : core.i32
-      %57 = ability.handle_dispatch %7, %56, %8, %55 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %57 = ability.legacy_handle_dispatch %7, %56, %8, %55 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb18(%58: tribute_rt.anyref):
               %59 = core.unrealized_conversion_cast %58 : core.i32

--- a/crates/tribute-front/tests/snapshots/cps_lowering__cps_short_circuit_rhs_keeps_outer_consumer.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__cps_short_circuit_rhs_keeps_outer_consumer.snap
@@ -7,7 +7,7 @@ core.module @test {
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
   func.func @effectful(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
       func.return %2
   }
   func.func @after(%0: core.i1) -> core.i1 attributes {tribute.calling_convention = 0} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__cps_values_flow_through_mixed_strict_aggregates.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__cps_values_flow_through_mixed_strict_aggregates.snap
@@ -21,7 +21,7 @@ core.module @test {
     }
   }
   func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @run(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_in_cps_parent_is_not_renormalized.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_in_cps_parent_is_not_renormalized.snap
@@ -8,7 +8,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -63,7 +63,7 @@ core.module @test {
           }
           %36 = arith.const {value = 0} : tribute_rt.anyref
           %37 = effect.fresh_prompt_tag : core.i32
-          %38 = ability.handle_dispatch %10, %37, %11, %36 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+          %38 = ability.legacy_handle_dispatch %10, %37, %11, %36 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
               ability.done {
                 ^bb12(%39: tribute_rt.anyref):
                   %40 = core.unrealized_conversion_cast %39 : core.i32
@@ -84,7 +84,7 @@ core.module @test {
           }
           func.return %38
       }
-      %49 = ability.perform %2 {ability_ref = core.ability_ref() {name = @Trace}, op_name = @before} : tribute_rt.anyref
+      %49 = ability.legacy_perform %2 {ability_ref = core.ability_ref() {name = @Trace}, op_name = @before} : tribute_rt.anyref
       func.return %49
   }
   func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_is_source_value_in_strict_constructor_and_call_contexts.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_is_source_value_in_strict_constructor_and_call_contexts.snap
@@ -9,7 +9,7 @@ core.module @test {
   !Boxed = adt.enum() {name = @Boxed, variants = [[@Boxed, [tribute_rt.anyref]]]}
 
   func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @consume(%0: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 0} {
@@ -83,7 +83,7 @@ core.module @test {
       }
       %34 = arith.const {value = 0} : tribute_rt.anyref
       %35 = effect.fresh_prompt_tag : core.i32
-      %36 = ability.handle_dispatch %8, %35, %9, %34 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %36 = ability.legacy_handle_dispatch %8, %35, %9, %34 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb11(%37: tribute_rt.anyref):
               %38 = core.unrealized_conversion_cast %37 : core.i32

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_do_and_op_arms.snap
@@ -8,7 +8,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @get_state(%0: !t1) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %1 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %2 = core.unrealized_conversion_cast %1 : core.i32
       func.return %2
   }
@@ -105,7 +105,7 @@ core.module @test {
       }
       %58 = arith.const {value = 0} : tribute_rt.anyref
       %59 = effect.fresh_prompt_tag : core.i32
-      %60 = ability.handle_dispatch %11, %59, %12, %58 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %60 = ability.legacy_handle_dispatch %11, %59, %12, %58 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb18(%61: tribute_rt.anyref):
               %62 = core.unrealized_conversion_cast %61 : core.i32

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handle_with_fn_handler.snap
@@ -8,7 +8,7 @@ core.module @test {
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
 
   func.func @get_state(%0: !t1) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %1 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %2 = core.unrealized_conversion_cast %1 : core.i32
       func.return %2
   }
@@ -86,7 +86,7 @@ core.module @test {
           func.return %37
       }
       %50 = effect.fresh_prompt_tag : core.i32
-      %51 = ability.handle_dispatch %11, %50, %12, %32 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %51 = ability.legacy_handle_dispatch %11, %50, %12, %32 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb13(%52: tribute_rt.anyref):
               %53 = core.unrealized_conversion_cast %52 : core.i32

--- a/crates/tribute-front/tests/snapshots/cps_lowering__handler_lambda_captures_resume_for_strict_consumer.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__handler_lambda_captures_resume_for_strict_consumer.snap
@@ -18,7 +18,7 @@ core.module @test {
       %0 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %1 = closure.new %0 {func_ref = @"test::__lambda_0"} : !t0
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
-          %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %4 = ability.legacy_perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           func.return %4
       }
       %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -76,7 +76,7 @@ core.module @test {
       }
       %46 = arith.const {value = 0} : tribute_rt.anyref
       %47 = effect.fresh_prompt_tag : core.i32
-      %48 = ability.handle_dispatch %7, %47, %8, %46 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %48 = ability.legacy_handle_dispatch %7, %47, %8, %46 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb13(%49: tribute_rt.anyref):
               %50 = func.call_indirect %1, %49 : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__multi_arg_ability_op.snap
@@ -11,7 +11,7 @@ core.module @test {
       %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
       %4 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
       %5 = adt.struct_new %3, %4 {type = !__ability_args_tuple} : tribute_rt.anyref
-      %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
+      %6 = ability.legacy_call %5 {ability_ref = core.ability_ref() {name = @KV}, op_name = @put} : tribute_rt.anyref
       %7 = core.unrealized_conversion_cast %6 : core.nil
       func.return %7
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_argument.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_argument.snap
@@ -7,7 +7,7 @@ core.module @test {
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
   func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @add_one(%0: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_case_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_case_arm.snap
@@ -7,7 +7,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @run(%0: !t1, %1: tribute_rt.anyref, %2: core.i1) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handle_body.snap
@@ -8,7 +8,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -76,7 +76,7 @@ core.module @test {
       }
       %42 = arith.const {value = 0} : tribute_rt.anyref
       %43 = effect.fresh_prompt_tag : core.i32
-      %44 = ability.handle_dispatch %16, %43, %17, %42 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %44 = ability.legacy_handle_dispatch %16, %43, %17, %42 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb12(%45: tribute_rt.anyref):
               %46 = core.unrealized_conversion_cast %45 : core.i32

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_handler_arm.snap
@@ -8,7 +8,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @read_log(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Log}, op_name = @value} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Log}, op_name = @value} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -17,7 +17,7 @@ core.module @test {
   }
   func.func @run(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
-          %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %4 = ability.legacy_perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           func.return %4
       }
       %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -67,7 +67,7 @@ core.module @test {
       }
       %38 = arith.const {value = 0} : tribute_rt.anyref
       %39 = effect.fresh_prompt_tag : core.i32
-      %40 = ability.handle_dispatch %7, %39, %8, %38 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %40 = ability.legacy_handle_dispatch %7, %39, %8, %38 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb12(%41: tribute_rt.anyref):
               %42 = core.unrealized_conversion_cast %1 : !t0

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_call_in_short_circuit_rhs.snap
@@ -6,7 +6,7 @@ core.module @test {
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @read(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @get} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @get} : tribute_rt.anyref
       func.return %2
   }
   func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_closure_call.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__nested_effectful_closure_call.snap
@@ -8,7 +8,7 @@ core.module @test {
 
   func.func @run(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
       %2 = closure.lambda(%3: !t0, %4: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
-          %5 = ability.perform %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %5 = ability.legacy_perform %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           func.return %5
       }
       %6 = closure.lambda(%7: tribute_rt.anyref) -> tribute_rt.anyref [%1] {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__normalized_direct_regions_do_not_reenter_raw_lowering.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__normalized_direct_regions_do_not_reenter_raw_lowering.snap
@@ -9,7 +9,7 @@ core.module @test {
   !Boxed = adt.enum() {name = @Boxed, variants = [[@Boxed, [tribute_rt.anyref]]]}
 
   func.func @read(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Flag}, op_name = @read} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -77,7 +77,7 @@ core.module @test {
                       }
                       %49 = arith.const {value = 0} : tribute_rt.anyref
                       %50 = effect.fresh_prompt_tag : core.i32
-                      %51 = ability.handle_dispatch %23, %50, %24, %49 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+                      %51 = ability.legacy_handle_dispatch %23, %50, %24, %49 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
                           ability.done {
                             ^bb16(%52: tribute_rt.anyref):
                               %53 = core.unrealized_conversion_cast %52 : core.i1
@@ -114,7 +114,7 @@ core.module @test {
           %69 = func.call_indirect %68, %67 : tribute_rt.anyref
           func.return %69
       }
-      %70 = ability.perform %2 {ability_ref = core.ability_ref() {name = @Trace}, op_name = @before} : tribute_rt.anyref
+      %70 = ability.legacy_perform %2 {ability_ref = core.ability_ref() {name = @Trace}, op_name = @before} : tribute_rt.anyref
       func.return %70
   }
   func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__record_spread_capture_survives_cps_continuation.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__record_spread_capture_survives_cps_continuation.snap
@@ -36,7 +36,7 @@ core.module @test {
           %17 = func.call_indirect %15, %16 : tribute_rt.anyref
           func.return %17
       }
-      %18 = ability.perform %3 {ability_ref = core.ability_ref() {name = @Trace}, op_name = @before} : tribute_rt.anyref
+      %18 = ability.legacy_perform %3 {ability_ref = core.ability_ref() {name = @Trace}, op_name = @before} : tribute_rt.anyref
       func.return %18
   }
   func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {

--- a/crates/tribute-front/tests/snapshots/cps_lowering__resume_in_op_handler.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__resume_in_op_handler.snap
@@ -99,7 +99,7 @@ core.module @test {
       }
       %57 = arith.const {value = 0} : tribute_rt.anyref
       %58 = effect.fresh_prompt_tag : core.i32
-      %59 = ability.handle_dispatch %10, %58, %11, %57 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %59 = ability.legacy_handle_dispatch %10, %58, %11, %57 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb18(%60: tribute_rt.anyref):
               %61 = core.unrealized_conversion_cast %60 : core.i32

--- a/crates/tribute-front/tests/snapshots/cps_lowering__sequential_ability_ops.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__sequential_ability_ops.snap
@@ -5,9 +5,9 @@ expression: ir_text
 core.module @test {
   func.func @set_and_get(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> core.i32 attributes {tribute.calling_convention = 1} {
       %1 = arith.const {value = 42} : core.i32
-      %2 = ability.call %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %2 = ability.legacy_call %1 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
       %3 = core.unrealized_conversion_cast %2 : core.nil
-      %4 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %4 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %5 = core.unrealized_conversion_cast %4 : core.i32
       func.return %5
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__single_ability_op_in_block.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__single_ability_op_in_block.snap
@@ -4,7 +4,7 @@ expression: ir_text
 ---
 core.module @test {
   func.func @get_state(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %1 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %2 = core.unrealized_conversion_cast %1 : core.i32
       func.return %2
   }

--- a/crates/tribute-front/tests/snapshots/cps_lowering__strict_consumer_after_resume_uses_arm_continuation.snap
+++ b/crates/tribute-front/tests/snapshots/cps_lowering__strict_consumer_after_resume_uses_arm_continuation.snap
@@ -18,7 +18,7 @@ core.module @test {
       %0 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %1 = closure.new %0 {func_ref = @"test::__lambda_0"} : !t0
       %2 = closure.lambda(%3: tribute_rt.anyref) -> tribute_rt.anyref {
-          %4 = ability.perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %4 = ability.legacy_perform %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           func.return %4
       }
       %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -72,7 +72,7 @@ core.module @test {
       }
       %42 = arith.const {value = 0} : tribute_rt.anyref
       %43 = effect.fresh_prompt_tag : core.i32
-      %44 = ability.handle_dispatch %7, %43, %8, %42 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %44 = ability.legacy_handle_dispatch %7, %43, %8, %42 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb12(%45: tribute_rt.anyref):
               %46 = func.call_indirect %1, %45 : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
@@ -7,7 +7,7 @@ core.module @test {
   !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
 
   func.func @get_count(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Counter}, op_name = @inc} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Counter}, op_name = @inc} : tribute_rt.anyref
       func.return %2
   }
   func.func @use_counter(%0: !t1, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
@@ -4,7 +4,7 @@ expression: ir_text
 ---
 core.module @test {
   func.func @effectful(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}), %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Foo}, op_name = @bar} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Foo}, op_name = @bar} : tribute_rt.anyref
       func.return %2
   }
   func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
@@ -8,7 +8,7 @@ core.module @test {
   !t1 = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
 
   func.func @use_ask(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = ability.perform %1 {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask} : tribute_rt.anyref
+      %2 = ability.legacy_perform %1 {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask} : tribute_rt.anyref
       func.return %2
   }
   func.func @"test::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
@@ -67,7 +67,7 @@ core.module @test {
       }
       %34 = arith.const {value = 0} : tribute_rt.anyref
       %35 = effect.fresh_prompt_tag : core.i32
-      %36 = ability.handle_dispatch %8, %35, %9, %34 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %36 = ability.legacy_handle_dispatch %8, %35, %9, %34 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb11(%37: tribute_rt.anyref):
               %38 = core.unrealized_conversion_cast %37 : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -9,11 +9,11 @@ core.module @test {
   !t2 = closure.closure(core.func(tribute_rt.anyref, !t1, tribute_rt.anyref))
 
   func.func @counter(%0: !t1) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %1 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %2 = core.unrealized_conversion_cast %1 : core.i32
       %3 = arith.const {value = 1} : core.i32
       %4 = func.call %2, %3 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
-      %5 = ability.call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %5 = ability.legacy_call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
       %6 = core.unrealized_conversion_cast %5 : core.nil
       func.return %2
   }
@@ -110,7 +110,7 @@ core.module @test {
       }
       %65 = arith.const {value = 0} : tribute_rt.anyref
       %66 = effect.fresh_prompt_tag : core.i32
-      %67 = ability.handle_dispatch %10, %66, %11, %65 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %67 = ability.legacy_handle_dispatch %10, %66, %11, %65 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb20(%68: tribute_rt.anyref):
               %69 = core.unrealized_conversion_cast %1 : !t0

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
@@ -102,7 +102,7 @@ core.module @test {
       }
       %60 = arith.const {value = 0} : tribute_rt.anyref
       %61 = effect.fresh_prompt_tag : core.i32
-      %62 = ability.handle_dispatch %13, %61, %14, %60 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %62 = ability.legacy_handle_dispatch %13, %61, %14, %60 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb18(%63: tribute_rt.anyref):
               %64 = core.unrealized_conversion_cast %63 : core.i32
@@ -128,7 +128,7 @@ core.module @test {
   }
   func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: !t1) -> core.i32 {tribute.calling_convention = 1} {
-          %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %2 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           %3 = core.unrealized_conversion_cast %2 : core.i32
           func.return %3
       }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -9,11 +9,11 @@ core.module @test {
   !t2 = closure.closure(core.func(core.i32, !t1))
 
   func.func @counter(%0: !t1) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %1 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       %2 = core.unrealized_conversion_cast %1 : core.i32
       %3 = arith.const {value = 1} : core.i32
       %4 = func.call %2, %3 {callee = @"Int::+", tribute.calling_convention = 0} : core.i32
-      %5 = ability.call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %5 = ability.legacy_call %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
       %6 = core.unrealized_conversion_cast %5 : core.nil
       func.return %2
   }
@@ -111,7 +111,7 @@ core.module @test {
       }
       %60 = arith.const {value = 0} : tribute_rt.anyref
       %61 = effect.fresh_prompt_tag : core.i32
-      %62 = ability.handle_dispatch %13, %61, %14, %60 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %62 = ability.legacy_handle_dispatch %13, %61, %14, %60 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb18(%63: tribute_rt.anyref):
               %64 = core.unrealized_conversion_cast %63 : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
@@ -102,7 +102,7 @@ core.module @test {
       }
       %60 = arith.const {value = 0} : tribute_rt.anyref
       %61 = effect.fresh_prompt_tag : core.i32
-      %62 = ability.handle_dispatch %13, %61, %14, %60 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %62 = ability.legacy_handle_dispatch %13, %61, %14, %60 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb18(%63: tribute_rt.anyref):
               %64 = core.unrealized_conversion_cast %63 : core.i32
@@ -128,11 +128,11 @@ core.module @test {
   }
   func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
       %0 = closure.lambda(%1: !t1) -> core.i32 {tribute.calling_convention = 1} {
-          %2 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %2 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           %3 = core.unrealized_conversion_cast %2 : core.i32
           %4 = arith.const {value = 1} : core.i32
           %5 = func.call %3, %4 {callee = @"Nat::+", tribute.calling_convention = 0} : core.i32
-          %6 = ability.call %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+          %6 = ability.legacy_call %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
           %7 = core.unrealized_conversion_cast %6 : core.nil
           func.return %3
       }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
@@ -101,7 +101,7 @@ core.module @test {
       }
       %65 = arith.const {value = 0} : tribute_rt.anyref
       %66 = effect.fresh_prompt_tag : core.i32
-      %67 = ability.handle_dispatch %10, %66, %11, %65 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %67 = ability.legacy_handle_dispatch %10, %66, %11, %65 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb20(%68: tribute_rt.anyref):
               %69 = core.unrealized_conversion_cast %1 : !t0

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -101,7 +101,7 @@ core.module @test {
       }
       %65 = arith.const {value = 0} : tribute_rt.anyref
       %66 = effect.fresh_prompt_tag : core.i32
-      %67 = ability.handle_dispatch %10, %66, %11, %65 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %67 = ability.legacy_handle_dispatch %10, %66, %11, %65 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb20(%68: tribute_rt.anyref):
               %69 = core.unrealized_conversion_cast %1 : !t0
@@ -131,7 +131,7 @@ core.module @test {
       %0 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %1 = closure.new %0 {func_ref = @"test::__lambda_1"} : !t0
       %2 = closure.lambda(%3: !t1, %4: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
-          %5 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+          %5 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
           %6 = core.unrealized_conversion_cast %4 : !t0
           %7 = func.call_indirect %6, %5 : tribute_rt.anyref
           func.return %7

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
@@ -69,7 +69,7 @@ core.module @test {
       }
       %39 = arith.const {value = 0} : tribute_rt.anyref
       %40 = effect.fresh_prompt_tag : core.i32
-      %41 = ability.handle_dispatch %13, %40, %14, %39 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
+      %41 = ability.legacy_handle_dispatch %13, %40, %14, %39 {result_type = tribute_rt.anyref, tag = 0} : tribute_rt.anyref {
           ability.done {
             ^bb11(%42: tribute_rt.anyref):
               %43 = core.unrealized_conversion_cast %42 : core.i32
@@ -99,7 +99,7 @@ core.module @test {
       %1 = closure.new %0 {func_ref = @"test::__lambda_0"} : !t1
       %2 = closure.lambda(%3: !t0, %4: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 2} {
           %5 = closure.lambda(%6: !t0) -> core.i32 {tribute.calling_convention = 1} {
-              %7 = ability.call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+              %7 = ability.legacy_call {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
               %8 = core.unrealized_conversion_cast %7 : core.i32
               func.return %8
           }

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -34,7 +34,13 @@ mod ability {
     #[attr(ability_ref: Type, op_name: Symbol)]
     fn perform(continuation: (), #[rest] values: ()) -> result {}
 
-    /// Handler dispatch over a proven private CPS answer.
+    /// Legacy frontend form using the carrier pipeline's null-or-single-value
+    /// payload convention until the frontend/pipeline migration is complete.
+    #[attr(ability_ref: Type, op_name: Symbol)]
+    fn legacy_perform(continuation: (), #[rest] values: ()) -> result {}
+
+    /// Legacy carrier-based handler dispatch retained only for the production
+    /// frontend path until that path migrates to `tribute_control`.
     ///
     /// Runs the `Normal` path or a matching-owner `Escape` path and forwards
     /// a foreign `Escape` unchanged through the escape region.
@@ -61,10 +67,31 @@ mod ability {
     ///   body { ... handler arms ... }
     /// ```
     #[attr(tag: u32, result_type: Type)]
-    fn handle_dispatch(value: (), owner_tag: (), handler_fn: (), tr_dispatch_fn: ()) -> result {
+    fn legacy_handle_dispatch(
+        value: (),
+        owner_tag: (),
+        handler_fn: (),
+        tr_dispatch_fn: (),
+    ) -> result {
         #[region(body)]
         {}
         #[region(escape)]
+        {}
+    }
+
+    /// Resultless proper-tail handler delimiter emitted by
+    /// `tribute_control_to_cps`.
+    ///
+    /// `ability_refs` is ordered to match pairs in `dispatchers`. Each pair is
+    /// `(tr_dispatch_fn, handler_dispatch)`, using typed reject closures when a
+    /// handled ability has no operation of that kind. `resolve_evidence`
+    /// allocates one runtime-unique prompt identity for the delimiter and
+    /// shares it across every pair. The body entry block receives the extended
+    /// evidence. Every body path ends in a proper tail transfer or
+    /// `func.unreachable`.
+    #[attr(ability_refs: any)]
+    fn handle_dispatch(evidence: (), #[rest] dispatchers: ()) {
+        #[region(body)]
         {}
     }
 
@@ -101,6 +128,11 @@ mod ability {
     /// Lowered to: evidence lookup → tr_dispatch_fn(op_idx, value) → result.
     #[attr(ability_ref: Type, op_name: Symbol)]
     fn call(#[rest] values: ()) -> result {}
+
+    /// Legacy frontend form using the carrier pipeline's null-or-single-value
+    /// payload convention until the frontend/pipeline migration is complete.
+    #[attr(ability_ref: Type, op_name: Symbol)]
+    fn legacy_call(#[rest] values: ()) -> result {}
 }
 
 // === Hash-Based Dispatch ===
@@ -119,6 +151,43 @@ pub fn compute_op_idx(ability_ref: Option<Symbol>, op_name: Option<Symbol>) -> u
     op_name.hash(&mut hasher);
 
     (hasher.finish() % 0x7FFFFFFF) as u32
+}
+
+/// Canonical target-independent payload product for one ability operation.
+///
+/// A product is used even for zero and one operand so the effect ABI never
+/// needs a null or another in-band sentinel for an empty payload.
+pub fn operation_payload_type_ref(
+    ctx: &mut trunk_ir::IrContext,
+    ability_ref: trunk_ir::TypeRef,
+    op_name: Symbol,
+    fields: impl IntoIterator<Item = trunk_ir::TypeRef>,
+) -> trunk_ir::TypeRef {
+    use trunk_ir::types::{Attribute, TypeDataBuilder};
+
+    let ability_name = ctx.types.get(ability_ref).attrs.get_symbol("name");
+    let op_idx = compute_op_idx(ability_name, Some(op_name));
+    let fields = fields
+        .into_iter()
+        .enumerate()
+        .map(|(index, ty)| {
+            Attribute::List(vec![
+                Attribute::Symbol(Symbol::from_dynamic(&format!("arg{index}"))),
+                Attribute::Type(ty),
+            ])
+        })
+        .collect();
+    ctx.types.intern(
+        TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("struct"))
+            .attr(
+                "name",
+                Attribute::Symbol(Symbol::from_dynamic(&format!(
+                    "__tribute_ability_payload_{op_idx:08x}"
+                ))),
+            )
+            .attr("fields", Attribute::List(fields))
+            .build(),
+    )
 }
 
 /// Compute the stable runtime ability ID for an ability reference type.
@@ -195,7 +264,7 @@ use trunk_ir::dialect::core;
 use trunk_ir::refs::TypeRef;
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 
-/// Compiler-private #815 completion carrier identity.
+/// Compiler-private legacy completion carrier identity.
 ///
 /// The carrier remains physically `anyref`; only frontend construction and
 /// `lower_handle_dispatch` may materialize or inspect this type.
@@ -203,7 +272,7 @@ pub const CPS_CONTROL_TYPE_NAME: &str = "__tribute_cps_control";
 pub const CPS_CONTROL_NORMAL_VARIANT: &str = "Normal";
 pub const CPS_CONTROL_ESCAPE_VARIANT: &str = "Escape";
 
-/// Return the canonical private completion-carrier enum used by #815.
+/// Return the canonical private legacy completion-carrier enum.
 ///
 /// Keeping this constructor in `tribute-ir` preserves structural interning
 /// identity across frontend and shared-pass lowering without introducing a

--- a/crates/tribute-ir/src/dialect/closure.rs
+++ b/crates/tribute-ir/src/dialect/closure.rs
@@ -145,7 +145,8 @@ fn starts_attr_dict(input: &str) -> bool {
     let rest = input.strip_prefix('{').unwrap_or("");
     let rest = rest.trim_start();
     // Must start with an ident char (letter or _)
-    let after_ident = rest.trim_start_matches(|c: char| c.is_ascii_alphanumeric() || c == '_');
+    let after_ident =
+        rest.trim_start_matches(|c: char| c.is_ascii_alphanumeric() || c == '_' || c == '.');
     // Must have consumed at least one ident char, then whitespace + '='
     if after_ident.len() == rest.len() {
         return false; // no ident consumed

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -1700,30 +1700,44 @@ pub fn validate_local(ctx: &IrContext, module: Module) -> ValidationResult {
     ValidationResult { errors }
 }
 
+fn is_core_module(ctx: &IrContext, op: OpRef) -> bool {
+    let data = ctx.op(op);
+    data.dialect == Symbol::new("core") && data.name == Symbol::new("module")
+}
+
+fn walk_symbol_scope_ops(ctx: &IrContext, region: RegionRef, callback: &mut impl FnMut(OpRef)) {
+    for block in ctx.region(region).blocks.iter().copied() {
+        for op in ctx.block(block).ops.iter().copied() {
+            if is_core_module(ctx, op) {
+                continue;
+            }
+            callback(op);
+            for nested in ctx.op(op).regions.iter().copied() {
+                walk_symbol_scope_ops(ctx, nested, callback);
+            }
+        }
+    }
+}
+
 fn collect_funcs(
     ctx: &IrContext,
     region: RegionRef,
     funcs: &mut HashMap<Symbol, OpRef>,
     errors: &mut Vec<ValidationError>,
 ) {
-    for block in ctx.region(region).blocks.iter().copied() {
-        for op in ctx.block(block).ops.iter().copied() {
-            if is_control_op(ctx, op, "func")
-                && let Some(symbol) = ctx.op(op).attributes.get_symbol("sym_name")
-                && let Some(previous) = funcs.insert(symbol, op)
-            {
-                push_op_error(
-                    ctx,
-                    op,
-                    errors,
-                    format!("duplicate function symbol @{symbol}; first defined by {previous}"),
-                );
-            }
-            for nested in ctx.op(op).regions.iter().copied() {
-                collect_funcs(ctx, nested, funcs, errors);
-            }
+    walk_symbol_scope_ops(ctx, region, &mut |op| {
+        if is_control_op(ctx, op, "func")
+            && let Some(symbol) = ctx.op(op).attributes.get_symbol("sym_name")
+            && let Some(previous) = funcs.insert(symbol, op)
+        {
+            push_op_error(
+                ctx,
+                op,
+                errors,
+                format!("duplicate function symbol @{symbol}; first defined by {previous}"),
+            );
         }
-    }
+    });
 }
 
 fn same_source_signature(ctx: &IrContext, left: TypeRef, right: TypeRef) -> bool {
@@ -1742,7 +1756,7 @@ fn validate_symbol_uses(
     funcs: &HashMap<Symbol, OpRef>,
     errors: &mut Vec<ValidationError>,
 ) {
-    walk_region_ops(ctx, body, &mut |op| {
+    walk_symbol_scope_ops(ctx, body, &mut |op| {
         if is_control_op(ctx, op, "func_ref") {
             let Some(symbol) = ctx.op(op).attributes.get_symbol("func_ref") else {
                 return;
@@ -1813,6 +1827,39 @@ fn validate_symbol_uses(
             );
         }
     });
+}
+
+fn validate_module_symbol_scopes(
+    ctx: &IrContext,
+    module_op: OpRef,
+    errors: &mut Vec<ValidationError>,
+) {
+    let regions = ctx.op(module_op).regions.to_vec();
+    let mut funcs = HashMap::new();
+    for region in regions.iter().copied() {
+        collect_funcs(ctx, region, &mut funcs, errors);
+    }
+    for region in regions.iter().copied() {
+        validate_symbol_uses(ctx, region, &funcs, errors);
+    }
+
+    fn visit_nested_modules(ctx: &IrContext, region: RegionRef, errors: &mut Vec<ValidationError>) {
+        for block in ctx.region(region).blocks.iter().copied() {
+            for op in ctx.block(block).ops.iter().copied() {
+                if is_core_module(ctx, op) {
+                    validate_module_symbol_scopes(ctx, op, errors);
+                } else {
+                    for nested in ctx.op(op).regions.iter().copied() {
+                        visit_nested_modules(ctx, nested, errors);
+                    }
+                }
+            }
+        }
+    }
+
+    for region in regions {
+        visit_nested_modules(ctx, region, errors);
+    }
 }
 
 fn collect_external_references(
@@ -2238,9 +2285,7 @@ pub fn validate_whole_ir(
     let Some(body) = module.body(ctx) else {
         return ValidationResult { errors };
     };
-    let mut funcs = HashMap::new();
-    collect_funcs(ctx, body, &mut funcs, &mut errors);
-    validate_symbol_uses(ctx, body, &funcs, &mut errors);
+    validate_module_symbol_scopes(ctx, module.op(), &mut errors);
     validate_lambda_captures(ctx, body, &mut errors);
     let declarations = declaration_map(declarations, &mut errors);
     validate_declaration_uses(ctx, body, &declarations, &mut errors);
@@ -3290,6 +3335,41 @@ mod tests {
         );
         let excess = validate_whole_ir(&excess_ctx, excess_module, &[]);
         assert!(messages(&excess).contains("capture list contains unused external value"));
+    }
+
+    #[test]
+    fn whole_ir_resolves_same_named_functions_per_nested_module() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @outer {
+  core.module @integers {
+    !callable = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+    tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct) {
+      tribute_control.return %value
+    }
+    tribute_control.func @use(%value: core.i32) -> core.i32 convention(direct) {
+      %reference = tribute_control.func_ref {func_ref = @id} : !callable
+      %direct = tribute_control.call %value {callee = @id} : core.i32
+      %indirect = tribute_control.call_indirect %reference, %direct : core.i32
+      tribute_control.return %indirect
+    }
+  }
+  core.module @booleans {
+    !callable = tribute_control.callable(core.bool, core.bool) {tribute.calling_convention = 0}
+    tribute_control.func @id(%value: core.bool) -> core.bool convention(direct) {
+      tribute_control.return %value
+    }
+    tribute_control.func @use(%value: core.bool) -> core.bool convention(direct) {
+      %reference = tribute_control.func_ref {func_ref = @id} : !callable
+      %direct = tribute_control.call %value {callee = @id} : core.bool
+      %indirect = tribute_control.call_indirect %reference, %direct : core.bool
+      tribute_control.return %indirect
+    }
+  }
+}"#,
+        );
+
+        let result = validate_whole_ir(&ctx, module, &[]);
+        assert!(result.is_ok(), "{:?}", result.errors);
     }
 
     #[test]

--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -24,6 +24,7 @@ pub mod lower_handle_dispatch;
 pub mod native;
 pub mod resolve_evidence;
 pub mod tail_resumptive;
+pub mod tribute_control_to_cps;
 pub mod type_converter;
 pub mod wasm;
 

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -9,14 +9,16 @@
 //!   { ability_ref: @State, op_name: @get }
 //!
 //! // Output:
-//! %payload = cast %args to anyref (or null)
+//! %payload = pack %args into the canonical operation product
 //! %cont = cast %continuation to anyref
 //! %result = effect.dispatch_cps %evidence, %cont, %payload
 //!   { ability_ref: @State, op_name: @get }
 //! func.return %result
 //! ```
 //!
-//! Uses `PatternApplicator` for declarative op-level rewriting. This is an
+//! The explicitly named legacy operations retain the old null-or-single-value
+//! carrier payload ABI until the frontend/pipeline migration is complete. Uses
+//! `PatternApplicator` for declarative op-level rewriting. This is an
 //! intermediate best-effort pass: the final `ability-lowered` boundary is
 //! established by `LowerHandleDispatch` after evidence resolution.
 
@@ -88,13 +90,17 @@ impl RewritePattern for LowerPerformPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(perform_op) = ability::Perform::from_op(ctx, op) else {
+        let legacy = if ability::Perform::from_op(ctx, op).is_ok() {
+            false
+        } else if ability::LegacyPerform::from_op(ctx, op).is_ok() {
+            true
+        } else {
             return false;
         };
 
         let location = ctx.op(op).location;
-        let ability_ref_type = perform_op.ability_ref(ctx);
-        let op_name_sym = perform_op.op_name(ctx);
+        let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
+        let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
 
         // Operands: [continuation, ...values]
         let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
@@ -113,21 +119,19 @@ impl RewritePattern for LowerPerformPattern {
             return false;
         };
 
-        // === 2. Build payload (pack args or null) ===
-        assert!(
-            value_operands.len() <= 1,
-            "ability.perform expects at most 1 value operand (multi-arg should be tuple-packed), \
-             got {}",
-            value_operands.len()
-        );
-        let shift_value_val = if let Some(&sv) = value_operands.first() {
-            let cast = core::unrealized_conversion_cast(ctx, location, sv, t.anyref);
-            rewriter.insert_op(cast.op_ref());
-            cast.result(ctx)
+        // === 2. Build the canonical payload product. ===
+        let shift_value_val = if legacy {
+            pack_legacy_payload(ctx, rewriter, location, value_operands, t.anyref)
         } else {
-            let null_op = adt::ref_null(ctx, location, t.anyref, t.anyref);
-            rewriter.insert_op(null_op.op_ref());
-            null_op.result(ctx)
+            pack_payload(
+                ctx,
+                rewriter,
+                location,
+                ability_ref_type,
+                op_name_sym,
+                value_operands,
+                t.anyref,
+            )
         };
 
         // === 3. Cast continuation closure to anyref ===
@@ -211,13 +215,17 @@ impl RewritePattern for LowerCallPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(call_op) = ability::Call::from_op(ctx, op) else {
+        let legacy = if ability::Call::from_op(ctx, op).is_ok() {
+            false
+        } else if ability::LegacyCall::from_op(ctx, op).is_ok() {
+            true
+        } else {
             return false;
         };
 
         let location = ctx.op(op).location;
-        let ability_ref_type = call_op.ability_ref(ctx);
-        let op_name_sym = call_op.op_name(ctx);
+        let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
+        let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
 
         // Operands: [...values]
         let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
@@ -235,21 +243,19 @@ impl RewritePattern for LowerCallPattern {
             return false;
         };
 
-        // === 2. Build payload (pack args or null) ===
-        assert!(
-            value_operands.len() <= 1,
-            "ability.call expects at most 1 value operand (multi-arg should be tuple-packed), \
-             got {}",
-            value_operands.len()
-        );
-        let shift_value_val = if let Some(&sv) = value_operands.first() {
-            let cast = core::unrealized_conversion_cast(ctx, location, sv, t.anyref);
-            rewriter.insert_op(cast.op_ref());
-            cast.result(ctx)
+        // === 2. Build the canonical payload product. ===
+        let shift_value_val = if legacy {
+            pack_legacy_payload(ctx, rewriter, location, value_operands, t.anyref)
         } else {
-            let null_op = adt::ref_null(ctx, location, t.anyref, t.anyref);
-            rewriter.insert_op(null_op.op_ref());
-            null_op.result(ctx)
+            pack_payload(
+                ctx,
+                rewriter,
+                location,
+                ability_ref_type,
+                op_name_sym,
+                value_operands,
+                t.anyref,
+            )
         };
 
         // === 3. Dispatch through target-independent effect ABI ===
@@ -274,6 +280,59 @@ impl RewritePattern for LowerCallPattern {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+fn pack_payload(
+    ctx: &mut IrContext,
+    rewriter: &mut PatternRewriter<'_>,
+    location: trunk_ir::types::Location,
+    ability_ref: TypeRef,
+    op_name: Symbol,
+    values: &[ValueRef],
+    anyref: TypeRef,
+) -> ValueRef {
+    let payload_type = ability::operation_payload_type_ref(
+        ctx,
+        ability_ref,
+        op_name,
+        values
+            .iter()
+            .map(|value| ctx.value_ty(*value))
+            .collect::<Vec<_>>(),
+    );
+    let payload = adt::struct_new(
+        ctx,
+        location,
+        values.iter().copied(),
+        payload_type,
+        payload_type,
+    );
+    rewriter.insert_op(payload.op_ref());
+    let erased = core::unrealized_conversion_cast(ctx, location, payload.result(ctx), anyref);
+    rewriter.insert_op(erased.op_ref());
+    erased.result(ctx)
+}
+
+fn pack_legacy_payload(
+    ctx: &mut IrContext,
+    rewriter: &mut PatternRewriter<'_>,
+    location: trunk_ir::types::Location,
+    values: &[ValueRef],
+    anyref: TypeRef,
+) -> ValueRef {
+    assert!(
+        values.len() <= 1,
+        "legacy ability payloads must already be tuple-packed"
+    );
+    if let Some(&value) = values.first() {
+        let erased = core::unrealized_conversion_cast(ctx, location, value, anyref);
+        rewriter.insert_op(erased.op_ref());
+        erased.result(ctx)
+    } else {
+        let null = adt::ref_null(ctx, location, anyref, anyref);
+        rewriter.insert_op(null.op_ref());
+        null.result(ctx)
+    }
+}
 
 /// Check if a TypeRef is `core.nil` (void return type in Cranelift).
 fn is_nil_type(ctx: &IrContext, ty: trunk_ir::TypeRef) -> bool {
@@ -419,6 +478,39 @@ mod tests {
 
         let ir_text = print_module(&ctx, module.op());
         assert_snapshot!(ir_text);
+    }
+
+    #[test]
+    fn legacy_operations_keep_the_carrier_payload_abi() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  func.func @legacy_perform(%ev: {ev_ty}) -> tribute_rt.anyref {{
+    %k = arith.const {{value = 0}} : tribute_rt.anyref
+    %result = ability.legacy_perform %k {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : tribute_rt.anyref
+    func.return %result
+  }}
+  func.func @legacy_call(%ev: {ev_ty}, %value: core.i32) -> tribute_rt.anyref {{
+    %result = ability.legacy_call %value {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}} : tribute_rt.anyref
+    func.return %result
+  }}
+}}"#
+            ),
+        );
+
+        lower_ability_perform(&mut ctx, module);
+
+        let ir = print_module(&ctx, module.op());
+        assert!(!ir.contains("ability.legacy_"));
+        assert!(!ir.contains("__tribute_ability_payload_"));
+        assert!(ir.contains("adt.ref_null"));
+        assert_eq!(ir.matches("effect.dispatch_").count(), 2);
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &ir);
     }
 
     #[test]

--- a/crates/tribute-passes/src/lower_handle_dispatch.rs
+++ b/crates/tribute-passes/src/lower_handle_dispatch.rs
@@ -1,10 +1,9 @@
-//! Lower `ability.handle_dispatch` to inline done-handler application.
+//! Lower final and legacy `ability.*handle_dispatch` delimiters.
 //!
-//! In the tail-call CPS design, effect operations are handled via tail calls
-//! to handler_dispatch closures (see `lower_ability_perform`). By the time
-//! `ability.handle_dispatch` is reached, the body result is already the final
-//! value. This pass applies the done handler to the body result and, as the
-//! final shared ability conversion, establishes the `ability-lowered` boundary.
+//! The final resultless form is structurally spliced after evidence resolution.
+//! The explicitly named legacy form retains the carrier-based done/escape
+//! compatibility path until the frontend/pipeline migration is complete. As the final shared ability
+//! conversion, this pass establishes the `ability-lowered` boundary.
 //!
 //! Uses `PatternApplicator` for declarative op-level rewriting.
 
@@ -45,7 +44,7 @@ pub fn ability_lowered_target() -> ConversionTarget {
     ConversionTarget::new().illegal_dialect("ability")
 }
 
-/// Lower all `ability.handle_dispatch` ops and establish the ability boundary.
+/// Lower final and legacy handle delimiters and establish the ability boundary.
 ///
 /// The final partial conversion rejects every residual `ability.*` operation
 /// while allowing unknown operations owned by later lowering stages.
@@ -75,7 +74,7 @@ impl Pass for LowerHandleDispatch {
     }
 }
 
-/// Pattern: `ability.handle_dispatch` → inline done handler body.
+/// Lower the resultless final delimiter or the legacy carrier delimiter.
 struct LowerHandleDispatchPattern;
 
 impl RewritePattern for LowerHandleDispatchPattern {
@@ -85,13 +84,40 @@ impl RewritePattern for LowerHandleDispatchPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(dispatch_op) = ability::HandleDispatch::from_op(ctx, op) else {
+        if let Ok(dispatch_op) = ability::HandleDispatch::from_op(ctx, op) {
+            let body = dispatch_op.body(ctx);
+            let blocks = ctx.region(body).blocks.to_vec();
+            let [body_block] = blocks.as_slice() else {
+                return false;
+            };
+
+            // `resolve_evidence` has already replaced the body's evidence
+            // argument. The final delimiter is resultless, so exhausting it is
+            // a structural splice only: no carrier inspection and no returned
+            // control value are involved.
+            if ctx
+                .block_args(*body_block)
+                .iter()
+                .any(|arg| !ctx.uses(*arg).is_empty())
+            {
+                return false;
+            }
+            let body_ops = ctx.block(*body_block).ops.to_vec();
+            for body_op in body_ops {
+                ctx.detach_op(body_op);
+                rewriter.insert_op(body_op);
+            }
+            rewriter.erase_op(vec![]);
+            return true;
+        }
+
+        let Ok(dispatch_op) = ability::LegacyHandleDispatch::from_op(ctx, op) else {
             return false;
         };
 
         let location = ctx.op(op).location;
         // operand[0] = body result and is proven by frontend construction to
-        // be the private #815 carrier. owner_tag is a dynamic i32 token, never
+        // be the private legacy carrier. owner_tag is a dynamic i32 token, never
         // a source value or a syntactic prompt tag.
         let body_result = ctx.op_operands(op)[0];
         let owner_tag = dispatch_op.owner_tag(ctx);
@@ -99,7 +125,7 @@ impl RewritePattern for LowerHandleDispatchPattern {
         let handler_body = dispatch_op.body(ctx);
         let escape_body = dispatch_op.escape(ctx);
 
-        // The frontend proves that this operand is the private #815 carrier:
+        // The frontend proves that this operand is the private legacy carrier:
         // the body normal continuation constructs `Normal`, and general op
         // arms construct `Escape`. Never apply these probes to a source SSA
         // value or a public ADT.
@@ -149,7 +175,7 @@ impl RewritePattern for LowerHandleDispatchPattern {
 }
 
 /// Build the Normal branch. Its carrier proof comes from the matching
-/// `ability.handle_dispatch` operand and the preceding private variant test.
+/// `ability.legacy_handle_dispatch` operand and the preceding private variant test.
 fn completion_region(
     ctx: &mut IrContext,
     location: Location,
@@ -403,7 +429,7 @@ mod tests {
     %owner = arith.const {value = 1} : core.i32
     %handler_fn = arith.const {value = 0} : tribute_rt.anyref
     %tr_dispatch_fn = arith.const {value = 0} : tribute_rt.anyref
-    %result = ability.handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
+    %result = ability.legacy_handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
       ability.done {
         ^bb0(%v: tribute_rt.anyref):
           scf.yield %v
@@ -442,7 +468,7 @@ mod tests {
     %owner = arith.const {value = 1} : core.i32
     %handler_fn = arith.const {value = 0} : tribute_rt.anyref
     %tr_dispatch_fn = arith.const {value = 0} : tribute_rt.anyref
-    %result = ability.handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = core.i32} : core.i32 {
+    %result = ability.legacy_handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = core.i32} : core.i32 {
       ability.done {
         ^bb0(%v: tribute_rt.anyref):
           %one = arith.const {value = 1} : core.i32
@@ -481,7 +507,7 @@ mod tests {
     %owner = arith.const {value = 1} : core.i32
     %handler_fn = arith.const {value = 0} : tribute_rt.anyref
     %tr_dispatch_fn = arith.const {value = 0} : tribute_rt.anyref
-    %result = ability.handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
+    %result = ability.legacy_handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
       ability.suspend {ability_ref = core.ability_ref() {name = @State}, op_name = @get} {
         ^bb0(%k: tribute_rt.anyref, %sv: tribute_rt.anyref):
           scf.yield %k
@@ -518,7 +544,7 @@ mod tests {
     %owner = arith.const {value = 1} : core.i32
     %handler_fn = arith.const {value = 0} : tribute_rt.anyref
     %tr_dispatch_fn = arith.const {value = 0} : tribute_rt.anyref
-    %result = ability.handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
+    %result = ability.legacy_handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
       ability.done {
         ^bb0(%v: tribute_rt.anyref):
           scf.yield %v
@@ -570,7 +596,7 @@ mod tests {
     %owner = arith.const {value = 1} : core.i32
     %handler_fn = arith.const {value = 0} : tribute_rt.anyref
     %tr_dispatch_fn = arith.const {value = 0} : tribute_rt.anyref
-    %result = ability.handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
+    %result = ability.legacy_handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 1, result_type = tribute_rt.anyref} : tribute_rt.anyref {
       ability.done {
         ^bb0(%v: tribute_rt.anyref):
           scf.yield %v
@@ -587,7 +613,7 @@ mod tests {
     %owner = arith.const {value = 2} : core.i32
     %handler_fn = arith.const {value = 0} : tribute_rt.anyref
     %tr_dispatch_fn = arith.const {value = 0} : tribute_rt.anyref
-    %result = ability.handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 2, result_type = tribute_rt.anyref} : tribute_rt.anyref {
+    %result = ability.legacy_handle_dispatch %body, %owner, %handler_fn, %tr_dispatch_fn {tag = 2, result_type = tribute_rt.anyref} : tribute_rt.anyref {
       ability.done {
         ^bb0(%v: tribute_rt.anyref):
           scf.yield %v
@@ -610,7 +636,7 @@ mod tests {
         lower_handle_dispatch(&mut ctx, selected).unwrap();
 
         let ir_text = print_module(&ctx, module.op());
-        assert_eq!(ir_text.matches("ability.handle_dispatch").count(), 1);
+        assert_eq!(ir_text.matches("ability.legacy_handle_dispatch").count(), 1);
         assert!(ir_text.contains("func.func @untouched"));
         assert!(ir_text.contains("tag = 2"));
     }
@@ -636,5 +662,41 @@ mod tests {
         assert_eq!(error.operations()[0].dialect, Symbol::new("ability"));
         assert_eq!(error.operations()[0].name, Symbol::new("perform"));
         assert_eq!(error.operations()[0].legality, LegalityCheck::Illegal);
+    }
+
+    #[test]
+    fn malformed_final_delimiters_are_not_structurally_spliced() {
+        let malformed = [
+            r#"ability.handle_dispatch %ev {ability_refs = []} {
+      ^first(%inner: !evidence):
+        func.unreachable
+      ^second:
+        func.unreachable
+    }"#,
+            r#"ability.handle_dispatch %ev {ability_refs = []} {
+      ^body(%inner: !evidence):
+        test.consume %inner
+        func.unreachable
+    }"#,
+        ];
+        for operation in malformed {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    r#"core.module @test {{
+  !marker = adt.struct() {{fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}}
+  !evidence = core.array(!marker)
+  func.func @run(%ev: !evidence) -> core.never {{
+    {operation}
+  }}
+}}"#
+                ),
+            );
+            let before = print_module(&ctx, module.op());
+            let error = lower_handle_dispatch(&mut ctx, module).unwrap_err();
+            assert_eq!(error.boundary(), "ability-lowered");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
     }
 }

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -10,6 +10,8 @@
 //! first parameter.
 
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::fmt;
 
 use tribute_ir::dialect::ability::{self, evidence_abi};
 use tribute_ir::dialect::effect;
@@ -32,6 +34,180 @@ use trunk_ir::types::{Attribute, TypeDataBuilder};
 fn i32_type_ref(ctx: &mut IrContext) -> TypeRef {
     ctx.types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
+}
+
+#[derive(Debug)]
+pub(crate) struct ResolveEvidenceError {
+    op: OpRef,
+    source_location: String,
+    message: String,
+}
+
+impl ResolveEvidenceError {
+    pub(crate) fn op(&self) -> OpRef {
+        self.op
+    }
+}
+
+impl fmt::Display for ResolveEvidenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} at {}: {}",
+            self.op, self.source_location, self.message
+        )
+    }
+}
+
+impl Error for ResolveEvidenceError {}
+
+struct FinalHandleDispatchShape {
+    evidence: ValueRef,
+    dispatcher_pairs: Vec<(TypeRef, ValueRef, ValueRef)>,
+    body: RegionRef,
+    body_evidence: ValueRef,
+}
+
+fn final_handle_dispatch_shape(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<FinalHandleDispatchShape, ResolveEvidenceError> {
+    let data = ctx.op(op);
+    let error = |message: String| ResolveEvidenceError {
+        op,
+        source_location: format!(
+            "{}:{}:{}",
+            ctx.paths.get(data.location.path),
+            data.location.span.start,
+            data.location.span.end
+        ),
+        message,
+    };
+    let operands = ctx.op_operands(op);
+    if !ctx.op_result_types(op).is_empty() {
+        return Err(error(
+            "final ability.handle_dispatch must be resultless".into(),
+        ));
+    }
+    let Some((&evidence, dispatchers)) = operands.split_first() else {
+        return Err(error(
+            "final ability.handle_dispatch requires an evidence operand".into(),
+        ));
+    };
+    if !dispatchers.len().is_multiple_of(2) {
+        return Err(error(
+            "final ability.handle_dispatch dispatcher operands must form exact pairs".into(),
+        ));
+    }
+    let Some(Attribute::List(ability_refs)) = data.attributes.get("ability_refs") else {
+        return Err(error(
+            "final ability.handle_dispatch requires an ability_refs list".into(),
+        ));
+    };
+    if ability_refs.len() * 2 != dispatchers.len() {
+        return Err(error(format!(
+            "ability_refs cardinality {} does not match {} dispatcher operands",
+            ability_refs.len(),
+            dispatchers.len()
+        )));
+    }
+    let mut dispatcher_pairs = Vec::with_capacity(ability_refs.len());
+    for (ability_ref, pair) in ability_refs.iter().zip(dispatchers.chunks_exact(2)) {
+        let Attribute::Type(ability_ref) = ability_ref else {
+            return Err(error("every ability_refs entry must be a type".into()));
+        };
+        let ty = ctx.types.get(*ability_ref);
+        if ty.dialect != Symbol::new("core") || ty.name != Symbol::new("ability_ref") {
+            return Err(error(
+                "every ability_refs entry must be a core.ability_ref type".into(),
+            ));
+        }
+        dispatcher_pairs.push((*ability_ref, pair[0], pair[1]));
+    }
+    let [body] = data.regions.as_slice() else {
+        return Err(error(
+            "final ability.handle_dispatch requires exactly one body region".into(),
+        ));
+    };
+    let [body_block] = ctx.region(*body).blocks.as_slice() else {
+        return Err(error(
+            "final ability.handle_dispatch body must have exactly one block".into(),
+        ));
+    };
+    let [body_evidence] = ctx.block_args(*body_block) else {
+        return Err(error(
+            "final ability.handle_dispatch body must have one evidence argument".into(),
+        ));
+    };
+    if ctx.value_ty(*body_evidence) != ctx.value_ty(evidence)
+        || !ability::is_evidence_type_ref(ctx, ctx.value_ty(evidence))
+    {
+        return Err(error(
+            "final ability.handle_dispatch evidence operand and body argument must have the evidence type"
+                .into(),
+        ));
+    }
+    let Some(&terminator) = ctx.block(*body_block).ops.last() else {
+        return Err(error(
+            "final ability.handle_dispatch body must end in a proper tail transfer".into(),
+        ));
+    };
+    let terminator_data = ctx.op(terminator);
+    let proper_tail = (terminator_data.dialect == Symbol::new("func")
+        && matches!(
+            terminator_data
+                .name
+                .with_str(|name| name.to_owned())
+                .as_str(),
+            "tail_call" | "tail_call_indirect" | "unreachable"
+        ))
+        || (terminator_data.dialect == Symbol::new("ability")
+            && matches!(
+                terminator_data
+                    .name
+                    .with_str(|name| name.to_owned())
+                    .as_str(),
+                "perform" | "handle_dispatch"
+            ))
+        || (terminator_data.dialect == Symbol::new("scf")
+            && matches!(
+                terminator_data
+                    .name
+                    .with_str(|name| name.to_owned())
+                    .as_str(),
+                "if" | "switch"
+            ));
+    if !proper_tail {
+        return Err(error(
+            "final ability.handle_dispatch body must end in a proper tail transfer".into(),
+        ));
+    }
+    Ok(FinalHandleDispatchShape {
+        evidence,
+        dispatcher_pairs,
+        body: *body,
+        body_evidence: *body_evidence,
+    })
+}
+
+pub(crate) fn validate_final_handle_dispatches(
+    ctx: &IrContext,
+    module: Module,
+) -> Result<(), ResolveEvidenceError> {
+    fn visit(ctx: &IrContext, op: OpRef) -> Result<(), ResolveEvidenceError> {
+        if ability::HandleDispatch::matches(ctx, op) {
+            final_handle_dispatch_shape(ctx, op)?;
+        }
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child)?;
+                }
+            }
+        }
+        Ok(())
+    }
+    visit(ctx, module.op())
 }
 
 // ============================================================================
@@ -232,7 +408,9 @@ fn collect_handler_root_functions(
 fn region_contains_handle_dispatch(ctx: &IrContext, region: RegionRef) -> bool {
     for &block in ctx.region(region).blocks.iter() {
         for &op in ctx.block(block).ops.iter() {
-            if ability::HandleDispatch::from_op(ctx, op).is_ok() {
+            if ability::LegacyHandleDispatch::from_op(ctx, op).is_ok()
+                || ability::HandleDispatch::from_op(ctx, op).is_ok()
+            {
                 return true;
             }
             for &nested in ctx.op(op).regions.iter() {
@@ -252,7 +430,7 @@ fn collect_handled_abilities_by_tag(
 ) -> HashMap<u32, Vec<TypeRef>> {
     let mut map = HashMap::new();
     for &op in ctx.block(block).ops.iter() {
-        if let Ok(dispatch_op) = ability::HandleDispatch::from_op(ctx, op) {
+        if let Ok(dispatch_op) = ability::LegacyHandleDispatch::from_op(ctx, op) {
             let tag = dispatch_op.tag(ctx);
             let abilities = collect_abilities_from_body_region(ctx, dispatch_op.body(ctx));
             map.insert(tag, abilities);
@@ -299,7 +477,7 @@ fn transform_handler_roots(
     module: Module,
     handler_root_fns: &HashSet<Symbol>,
     fns_with_evidence: &mut HashSet<Symbol>,
-) -> HashSet<Symbol> {
+) -> Result<HashSet<Symbol>, ResolveEvidenceError> {
     let func_ops: Vec<OpRef> = module.ops(ctx);
 
     // Phase 1: Add evidence params to effect-polymorphic handler roots.
@@ -384,7 +562,7 @@ fn transform_handler_roots(
             &handled_by_tag,
             fns_with_evidence,
             prepend_evidence,
-        );
+        )?;
 
         for &block in blocks.iter().skip(1) {
             let handled_by_tag = collect_handled_abilities_by_tag(ctx, block);
@@ -395,11 +573,11 @@ fn transform_handler_roots(
                 &handled_by_tag,
                 fns_with_evidence,
                 prepend_evidence,
-            );
+            )?;
         }
     }
 
-    polymorphic_roots
+    Ok(polymorphic_roots)
 }
 
 /// Update call sites across the module to pass evidence to newly-evidenced
@@ -512,7 +690,7 @@ fn transform_shifts_in_module(
     ctx: &mut IrContext,
     module: Module,
     fns_with_evidence: &HashSet<Symbol>,
-) {
+) -> Result<(), ResolveEvidenceError> {
     let func_ops: Vec<OpRef> = module.ops(ctx);
     for func_op_ref in func_ops {
         let Ok(func_op) = func::Func::from_op(ctx, func_op_ref) else {
@@ -550,9 +728,10 @@ fn transform_shifts_in_module(
                 &handled_by_tag,
                 fns_with_evidence,
                 false, // replace evidence (already present as first arg)
-            );
+            )?;
         }
     }
+    Ok(())
 }
 
 /// Transform shifts in a single block.
@@ -574,13 +753,57 @@ fn transform_shifts_in_block(
     handled_by_tag: &HashMap<u32, Vec<TypeRef>>,
     fns_with_evidence: &HashSet<Symbol>,
     prepend_evidence: bool,
-) {
+) -> Result<(), ResolveEvidenceError> {
     let ops: Vec<OpRef> = ctx.block(block).ops.to_vec();
 
     for op in ops {
+        // Final resultless delimiter. Its operands are explicit and typed:
+        // [evidence, tr_dispatch_0, handler_dispatch_0, ...].
+        // The ability_refs list has exactly one entry per dispatch pair.
+        if ability::HandleDispatch::from_op(ctx, op).is_ok() {
+            let location = ctx.op(op).location;
+            let shape = final_handle_dispatch_shape(ctx, op)?;
+            let mut current_ev = shape.evidence;
+            let i32_ty = i32_type_ref(ctx);
+            let prompt = func::call(
+                ctx,
+                location,
+                std::iter::empty::<ValueRef>(),
+                i32_ty,
+                Symbol::new("__tribute_next_tag"),
+            );
+            let prompt_tag = prompt.result(ctx);
+            ctx.insert_op_before(block, op, prompt.op_ref());
+            let evidence_ty = ability::evidence_adt_type_ref(ctx);
+            for (ability_ref, tr_dispatch, handler_dispatch) in shape.dispatcher_pairs {
+                let extend = effect::extend(
+                    ctx,
+                    location,
+                    current_ev,
+                    prompt_tag,
+                    tr_dispatch,
+                    handler_dispatch,
+                    evidence_ty,
+                    ability_ref,
+                );
+                current_ev = extend.result(ctx);
+                ctx.insert_op_before(block, op, extend.op_ref());
+            }
+
+            ctx.replace_all_uses(shape.body_evidence, current_ev);
+            transform_shifts_in_region(
+                ctx,
+                shape.body,
+                current_ev,
+                fns_with_evidence,
+                prepend_evidence,
+            )?;
+            continue;
+        }
+
         // Handle ability.handle_dispatch — extend evidence before
         // the body closure call and transform the handler body region.
-        if let Ok(dispatch_op) = ability::HandleDispatch::from_op(ctx, op) {
+        if let Ok(dispatch_op) = ability::LegacyHandleDispatch::from_op(ctx, op) {
             let loc = ctx.op(op).location;
             let tag = dispatch_op.tag(ctx);
             let abilities = handled_by_tag.get(&tag).cloned().unwrap_or_default();
@@ -693,7 +916,7 @@ fn transform_shifts_in_block(
                 current_ev,
                 fns_with_evidence,
                 prepend_evidence,
-            );
+            )?;
             continue;
         }
 
@@ -805,9 +1028,10 @@ fn transform_shifts_in_block(
         // Recursively transform nested regions
         let regions: Vec<RegionRef> = ctx.op(op).regions.to_vec();
         for region in regions {
-            transform_shifts_in_region(ctx, region, ev_value, fns_with_evidence, prepend_evidence);
+            transform_shifts_in_region(ctx, region, ev_value, fns_with_evidence, prepend_evidence)?;
         }
     }
+    Ok(())
 }
 
 /// Transform shifts in a region.
@@ -817,7 +1041,7 @@ fn transform_shifts_in_region(
     ev_value: ValueRef,
     fns_with_evidence: &HashSet<Symbol>,
     prepend_evidence: bool,
-) {
+) -> Result<(), ResolveEvidenceError> {
     let blocks: Vec<BlockRef> = ctx.region(region).blocks.to_vec();
     for block in blocks {
         let handled_by_tag = collect_handled_abilities_by_tag(ctx, block);
@@ -828,8 +1052,9 @@ fn transform_shifts_in_region(
             &handled_by_tag,
             fns_with_evidence,
             prepend_evidence,
-        );
+        )?;
     }
+    Ok(())
 }
 
 // ============================================================================
@@ -841,7 +1066,12 @@ fn transform_shifts_in_region(
 /// Transforms `ability.evidence_lookup` and `ability.handle_dispatch`
 /// into evidence-based dispatch using runtime function calls. This enables
 /// proper handler dispatch at runtime.
-pub(crate) fn resolve_evidence_dispatch(ctx: &mut IrContext, module: Module) {
+pub(crate) fn resolve_evidence_dispatch(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), ResolveEvidenceError> {
+    validate_final_handle_dispatches(ctx, module)?;
+
     // Ensure runtime helpers exist
     ensure_runtime_functions(ctx, module);
 
@@ -851,7 +1081,7 @@ pub(crate) fn resolve_evidence_dispatch(ctx: &mut IrContext, module: Module) {
     // Transform handler-root functions first
     let handler_root_fns = collect_handler_root_functions(ctx, module, &fns_with_evidence);
     let newly_evidenced = if !handler_root_fns.is_empty() {
-        transform_handler_roots(ctx, module, &handler_root_fns, &mut fns_with_evidence)
+        transform_handler_roots(ctx, module, &handler_root_fns, &mut fns_with_evidence)?
     } else {
         HashSet::new()
     };
@@ -871,9 +1101,10 @@ pub(crate) fn resolve_evidence_dispatch(ctx: &mut IrContext, module: Module) {
             .copied()
             .collect();
         if !non_root_evidence_fns.is_empty() {
-            transform_shifts_in_module(ctx, module, &non_root_evidence_fns);
+            transform_shifts_in_module(ctx, module, &non_root_evidence_fns)?;
         }
     }
+    Ok(())
 }
 
 /// PassManager-friendly wrapper for [`resolve_evidence_dispatch`].
@@ -887,8 +1118,7 @@ impl Pass for ResolveEvidenceDispatch {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
-        resolve_evidence_dispatch(ctx, target.into());
-        Ok(())
+        resolve_evidence_dispatch(ctx, target.into()).map_err(Into::into)
     }
 }
 
@@ -899,7 +1129,11 @@ impl Pass for ResolveEvidenceDispatch {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ops::ControlFlow;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
     use trunk_ir::types::TypeDataBuilder;
+    use trunk_ir::walk::{WalkAction, walk_op};
 
     #[test]
     fn test_compute_ability_id() {
@@ -958,6 +1192,181 @@ mod tests {
 
         // Same ability name but different type params should produce different IDs
         assert_ne!(id_with_params, id_no_params);
+    }
+
+    fn final_dispatch_fixture(operation: &str) -> String {
+        format!(
+            r#"core.module @test {{
+  !marker = adt.struct() {{fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}}
+  !evidence = core.array(!marker)
+  func.func @test(%ev: !evidence, %prompt: core.i32, %tr: core.ptr, %handler: core.ptr, %tr2: core.ptr, %handler2: core.ptr) -> core.never {{
+    {operation}
+  }}
+}}"#
+        )
+    }
+
+    #[test]
+    fn final_handle_dispatch_extends_each_ability_pair_and_lowers_resultlessly() {
+        let input = final_dispatch_fixture(
+            r#"ability.handle_dispatch %ev, %tr, %handler, %tr2, %handler2 {ability_refs = [core.ability_ref() {name = @State}, core.ability_ref() {name = @Console}]} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+        );
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, &input);
+        resolve_evidence_dispatch(&mut ctx, module).unwrap();
+        let resolved = print_module(&ctx, module.op());
+        assert_eq!(resolved.matches("effect.extend").count(), 2);
+        assert_eq!(resolved.matches("func.call").count(), 1);
+        assert!(resolved.contains("__tribute_next_tag"));
+        assert!(resolved.contains("ability.handle_dispatch"));
+        let mut extensions = Vec::new();
+        let _ = walk_op::<()>(&ctx, module.op(), &mut |op| {
+            if effect::Extend::from_op(&ctx, op).is_ok() {
+                extensions.push(op);
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        assert_eq!(extensions.len(), 2);
+        assert_eq!(
+            ctx.op_operands(extensions[0])[1],
+            ctx.op_operands(extensions[1])[1],
+            "all abilities in one delimiter must share one runtime prompt tag"
+        );
+        crate::lower_handle_dispatch::lower_handle_dispatch(&mut ctx, module).unwrap();
+        let lowered = print_module(&ctx, module.op());
+        assert!(!lowered.contains("ability."));
+        assert!(!lowered.contains("__tribute_cps_control"));
+        assert!(lowered.contains("func.unreachable"));
+
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &lowered);
+    }
+
+    #[test]
+    fn malformed_final_handle_dispatches_fail_before_mutation() {
+        let malformed = [
+            (
+                r#"%result = ability.handle_dispatch %ev {ability_refs = []} : core.i32 {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "must be resultless",
+            ),
+            (
+                r#"ability.handle_dispatch {ability_refs = []} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "requires an evidence operand",
+            ),
+            (
+                r#"ability.handle_dispatch %ev, %tr {ability_refs = []} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "must form exact pairs",
+            ),
+            (
+                r#"ability.handle_dispatch %ev {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "requires an ability_refs list",
+            ),
+            (
+                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = []} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "cardinality",
+            ),
+            (
+                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = [1]} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "entry must be a type",
+            ),
+            (
+                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = [core.i32]} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "core.ability_ref type",
+            ),
+            (
+                r#"ability.handle_dispatch %prompt {ability_refs = []} {
+      ^body(%inner: core.i32):
+        func.unreachable
+    }"#,
+                "must have the evidence type",
+            ),
+            (
+                r#"ability.handle_dispatch %ev {ability_refs = []} {
+    }"#,
+                "exactly one block",
+            ),
+            (
+                r#"ability.handle_dispatch %ev {ability_refs = []} {
+      ^first(%inner: !evidence):
+        func.unreachable
+      ^second:
+        func.unreachable
+    }"#,
+                "exactly one block",
+            ),
+            (
+                r#"ability.handle_dispatch %ev {ability_refs = []} {
+      ^body:
+        func.unreachable
+    }"#,
+                "one evidence argument",
+            ),
+            (
+                r#"ability.handle_dispatch %ev {ability_refs = []} {
+      ^body(%inner: !evidence):
+    }"#,
+                "must end in a proper tail transfer",
+            ),
+            (
+                r#"ability.handle_dispatch %ev {ability_refs = []} {
+      ^body(%inner: !evidence):
+        func.return
+    }"#,
+                "proper tail transfer",
+            ),
+        ];
+        for (operation, expected) in malformed {
+            let input = final_dispatch_fixture(operation);
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, &input);
+            let before = print_module(&ctx, module.op());
+            let error = resolve_evidence_dispatch(&mut ctx, module).unwrap_err();
+            assert!(error.to_string().contains(expected), "{error}");
+            assert!(error.to_string().contains("textual-ir:0:0"), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
+    fn structured_final_delimiter_is_a_valid_proper_tail_body() {
+        let input = final_dispatch_fixture(
+            r#"ability.handle_dispatch %ev {ability_refs = []} {
+      ^body(%inner: !evidence):
+        %choice = arith.const {value = 0} : core.i32
+        scf.switch %choice {
+          scf.default {
+            func.unreachable
+          }
+        }
+    }"#,
+        );
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, &input);
+        validate_final_handle_dispatches(&ctx, module).unwrap();
     }
 
     // Note: CPS-specific evidence resolution (ability.evidence_lookup,

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -152,32 +152,7 @@ fn final_handle_dispatch_shape(
             "final ability.handle_dispatch body must end in a proper tail transfer".into(),
         ));
     };
-    let terminator_data = ctx.op(terminator);
-    let proper_tail = (terminator_data.dialect == Symbol::new("func")
-        && matches!(
-            terminator_data
-                .name
-                .with_str(|name| name.to_owned())
-                .as_str(),
-            "tail_call" | "tail_call_indirect" | "unreachable"
-        ))
-        || (terminator_data.dialect == Symbol::new("ability")
-            && matches!(
-                terminator_data
-                    .name
-                    .with_str(|name| name.to_owned())
-                    .as_str(),
-                "perform" | "handle_dispatch"
-            ))
-        || (terminator_data.dialect == Symbol::new("scf")
-            && matches!(
-                terminator_data
-                    .name
-                    .with_str(|name| name.to_owned())
-                    .as_str(),
-                "if" | "switch"
-            ));
-    if !proper_tail {
+    if !trunk_ir::validation::is_proper_tail_terminator(ctx, terminator) {
         return Err(error(
             "final ability.handle_dispatch body must end in a proper tail transfer".into(),
         ));

--- a/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_call_to_effect_dispatch_tail.snap
+++ b/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_call_to_effect_dispatch_tail.snap
@@ -1,12 +1,16 @@
 ---
 source: crates/tribute-passes/src/lower_ability_perform.rs
+assertion_line: 438
 expression: ir_text
 ---
 core.module @test {
+  !__tribute_ability_payload_7dc9fb1b = adt.struct() {fields = [[@arg0, tribute_rt.anyref]], name = @__tribute_ability_payload_7dc9fb1b}
+
   func.func @test_fn(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> tribute_rt.anyref {
       %1 = arith.const {value = 1} : tribute_rt.anyref
-      %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
-      %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
-      func.return %3
+      %2 = adt.struct_new %1 {type = !__tribute_ability_payload_7dc9fb1b} : !__tribute_ability_payload_7dc9fb1b
+      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      %4 = effect.dispatch_tail %0, %3 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
+      func.return %4
   }
 }

--- a/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_basic.snap
+++ b/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_basic.snap
@@ -1,13 +1,17 @@
 ---
 source: crates/tribute-passes/src/lower_ability_perform.rs
+assertion_line: 387
 expression: ir_text
 ---
 core.module @test {
+  !__tribute_ability_payload_7590c57e = adt.struct() {fields = [], name = @__tribute_ability_payload_7590c57e}
+
   func.func @test_fn(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> tribute_rt.anyref {
       %1 = arith.const {value = 0} : tribute_rt.anyref
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
-      %4 = effect.dispatch_cps %0, %3, %2 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      func.return %4
+      %2 = adt.struct_new {type = !__tribute_ability_payload_7590c57e} : !__tribute_ability_payload_7590c57e
+      %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      %4 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
+      %5 = effect.dispatch_cps %0, %4, %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      func.return %5
   }
 }

--- a/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_with_args.snap
+++ b/crates/tribute-passes/src/snapshots/tribute_passes__lower_ability_perform__tests__lower_perform_with_args.snap
@@ -1,14 +1,18 @@
 ---
 source: crates/tribute-passes/src/lower_ability_perform.rs
+assertion_line: 413
 expression: ir_text
 ---
 core.module @test {
+  !__tribute_ability_payload_50641714 = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_50641714}
+
   func.func @test_fn(%0: core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})) -> tribute_rt.anyref {
       %1 = arith.const {value = 42} : core.i32
       %2 = arith.const {value = 0} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-      %5 = effect.dispatch_cps %0, %4, %3 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      func.return %5
+      %3 = adt.struct_new %1 {type = !__tribute_ability_payload_50641714} : !__tribute_ability_payload_50641714
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %5 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      %6 = effect.dispatch_cps %0, %5, %4 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      func.return %6
   }
 }

--- a/crates/tribute-passes/src/tail_resumptive.rs
+++ b/crates/tribute-passes/src/tail_resumptive.rs
@@ -207,7 +207,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v
@@ -241,7 +241,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v
@@ -278,7 +278,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v
@@ -318,7 +318,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v
@@ -354,7 +354,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v
@@ -395,7 +395,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v
@@ -440,7 +440,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v
@@ -481,7 +481,7 @@ mod tests {
   func.func @test_fn() -> core.ptr {
     %yr = arith.const {value = 0} : core.ptr
     %hf = arith.const {value = 0} : core.ptr
-    %1 = ability.handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
+    %1 = ability.legacy_handle_dispatch %yr, %hf {tag = 1, result_type = core.ptr} : core.ptr {
       ability.done {
         ^bb0(%v: core.ptr):
           scf.yield %v

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -270,7 +270,11 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
                 ),
             });
         }
-        let expected = if general { 2 } else { 1 };
+        let expected = if general {
+            CallingConvention::Cps as i64
+        } else {
+            CallingConvention::EvidenceDirect as i64
+        };
         let trunk_ir::ValueDef::OpResult(def, _) = ctx.value_def(value) else {
             failures.push(BoundaryFailure {
                 op: Some(owner),
@@ -315,20 +319,22 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
 }
 
 fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
-    let mut signatures = HashMap::new();
     fn collect(
         ctx: &IrContext,
         op: OpRef,
         signatures: &mut HashMap<Symbol, (TypeRef, Option<i64>)>,
     ) {
+        let data = ctx.op(op);
+        if data.dialect == Symbol::new("core") && data.name == Symbol::new("module") {
+            return;
+        }
         if func::Func::matches(ctx, op)
             && let (Some(symbol), Some(ty)) = (
-                ctx.op(op).attributes.get_symbol("sym_name"),
-                ctx.op(op).attributes.get_type("type"),
+                data.attributes.get_symbol("sym_name"),
+                data.attributes.get_type("type"),
             )
         {
-            let convention = ctx
-                .op(op)
+            let convention = data
                 .attributes
                 .get_i64(CALLING_CONVENTION_ATTR)
                 .ok()
@@ -343,9 +349,7 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
             }
         }
     }
-    collect(ctx, module.op(), &mut signatures);
 
-    let mut failures = Vec::new();
     fn visit(
         ctx: &IrContext,
         op: OpRef,
@@ -353,6 +357,10 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
         failures: &mut Vec<BoundaryFailure>,
     ) {
         let data = ctx.op(op);
+        if data.dialect == Symbol::new("core") && data.name == Symbol::new("module") {
+            verify_module(ctx, op, failures);
+            return;
+        }
         let op_convention = data
             .attributes
             .get_i64(CALLING_CONVENTION_ATTR)
@@ -476,7 +484,115 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
             }
         }
     }
-    visit(ctx, module.op(), &signatures, &mut failures);
+
+    fn verify_module(ctx: &IrContext, module_op: OpRef, failures: &mut Vec<BoundaryFailure>) {
+        let mut signatures = HashMap::new();
+        let regions = ctx.op(module_op).regions.to_vec();
+        for region in regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for op in ctx.block(block).ops.iter().copied() {
+                    collect(ctx, op, &mut signatures);
+                }
+            }
+        }
+        for region in regions {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for op in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, op, &signatures, failures);
+                }
+            }
+        }
+    }
+
+    let mut failures = Vec::new();
+    verify_module(ctx, module.op(), &mut failures);
+    failures
+}
+
+fn verify_source_conversion_shapes(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
+    fn failure(ctx: &IrContext, op: OpRef, message: impl Into<String>) -> BoundaryFailure {
+        BoundaryFailure {
+            op: Some(op),
+            location: Some(ctx.op(op).location),
+            message: message.into(),
+        }
+    }
+
+    fn visit(ctx: &IrContext, op: OpRef, failures: &mut Vec<BoundaryFailure>) {
+        let data = ctx.op(op);
+        if !data.successors.is_empty() {
+            failures.push(failure(
+                ctx,
+                op,
+                "tribute-control-pre-cps is structured and forbids block successors",
+            ));
+        }
+        if data.dialect == Symbol::new("scf") && data.name == Symbol::new("switch") {
+            if ctx.op_operands(op).len() != 1
+                || !ctx.op_result_types(op).is_empty()
+                || data.regions.len() != 1
+            {
+                failures.push(failure(
+                    ctx,
+                    op,
+                    "scf.switch requires one discriminant, no results, and one body region",
+                ));
+            } else {
+                let blocks = &ctx.region(data.regions[0]).blocks;
+                if let [body] = blocks.as_slice() {
+                    for arm in ctx.block(*body).ops.iter().copied() {
+                        let arm_data = ctx.op(arm);
+                        let is_case = arm_data.dialect == Symbol::new("scf")
+                            && arm_data.name == Symbol::new("case");
+                        let is_default = arm_data.dialect == Symbol::new("scf")
+                            && arm_data.name == Symbol::new("default");
+                        if !is_case && !is_default {
+                            failures.push(failure(
+                                ctx,
+                                arm,
+                                "scf.switch body may contain only scf.case and scf.default",
+                            ));
+                            continue;
+                        }
+                        if is_case && !arm_data.attributes.contains_key("value") {
+                            failures.push(failure(ctx, arm, "scf.case requires a value attribute"));
+                        }
+                        if let [region] = arm_data.regions.as_slice() {
+                            if ctx.region(*region).blocks.len() != 1 {
+                                failures.push(failure(
+                                    ctx,
+                                    arm,
+                                    "scf switch arm region requires exactly one block",
+                                ));
+                            }
+                        } else {
+                            failures.push(failure(
+                                ctx,
+                                arm,
+                                "scf switch arm requires exactly one region",
+                            ));
+                        }
+                    }
+                } else {
+                    failures.push(failure(
+                        ctx,
+                        op,
+                        "scf.switch body region requires exactly one block",
+                    ));
+                }
+            }
+        }
+        for region in data.regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child, failures);
+                }
+            }
+        }
+    }
+
+    let mut failures = Vec::new();
+    visit(ctx, module.op(), &mut failures);
     failures
 }
 
@@ -516,6 +632,7 @@ pub fn verify_tribute_control_pre_cps(
         );
     }
     failures.extend(verify_type_boundary(ctx, module, TypeBoundary::Pre));
+    failures.extend(verify_source_conversion_shapes(ctx, module));
     failures.extend(
         trunk_ir::validation::validate_all(ctx, module)
             .errors
@@ -621,7 +738,8 @@ struct HandlerArmInfo {
 struct Converter<'a> {
     ctx: &'a mut IrContext,
     module_block: BlockRef,
-    funcs: HashMap<Symbol, CallableInfo>,
+    funcs_by_module: HashMap<OpRef, HashMap<Symbol, CallableInfo>>,
+    current_module: OpRef,
     converted_types: HashMap<TypeRef, TypeRef>,
     helper_index: u32,
 }
@@ -639,15 +757,37 @@ impl<'a> Converter<'a> {
     fn new(
         ctx: &'a mut IrContext,
         module_block: BlockRef,
-        funcs: HashMap<Symbol, CallableInfo>,
+        funcs_by_module: HashMap<OpRef, HashMap<Symbol, CallableInfo>>,
+        current_module: OpRef,
     ) -> Self {
         Self {
             ctx,
             module_block,
-            funcs,
+            funcs_by_module,
+            current_module,
             converted_types: HashMap::new(),
             helper_index: 0,
         }
+    }
+
+    fn current_func(&self, symbol: Symbol) -> Option<CallableInfo> {
+        self.funcs_by_module
+            .get(&self.current_module)
+            .and_then(|funcs| funcs.get(&symbol))
+            .cloned()
+    }
+
+    fn malformed_source(
+        &self,
+        source: OpRef,
+        message: impl Into<String>,
+    ) -> TributeControlToCpsError {
+        TributeControlToCpsError::one(
+            PRE_CPS_BOUNDARY,
+            Some(source),
+            Some(self.ctx.op(source).location),
+            message,
+        )
     }
 
     fn never_type(&mut self) -> TypeRef {
@@ -862,6 +1002,12 @@ impl<'a> Converter<'a> {
         let attrs = data.attributes.clone();
         let regions = data.regions.to_vec();
         let successors = data.successors.to_vec();
+        if !successors.is_empty() {
+            return Err(self.malformed_source(
+                source,
+                "plain operation cloning does not support block successors",
+            ));
+        }
 
         let mut builder = OperationDataBuilder::new(location, dialect, name);
         for operand in operands {
@@ -876,14 +1022,15 @@ impl<'a> Converter<'a> {
         }
         for region in regions {
             let converted = if dialect == Symbol::new("core") && name == Symbol::new("module") {
-                self.clone_module_region(region)?
+                let previous_module = self.current_module;
+                self.current_module = source;
+                let converted = self.clone_module_region(region);
+                self.current_module = previous_module;
+                converted?
             } else {
                 self.clone_plain_region(region, mapping)?
             };
             builder = builder.region(converted);
-        }
-        for successor in successors {
-            builder = builder.successor(successor);
         }
         let data = builder.build(self.ctx);
         let cloned = self.ctx.create_op(data);
@@ -1219,13 +1366,10 @@ impl<'a> Converter<'a> {
             )?;
             let converted_region = self.single_block_region(case_location, converted_block);
             let converted = if is_case {
-                scf::case(
-                    self.ctx,
-                    case_location,
-                    case_value.unwrap(),
-                    converted_region,
-                )
-                .op_ref()
+                let Some(case_value) = case_value else {
+                    return Err(self.malformed_source(case, "scf.case requires a value attribute"));
+                };
+                scf::case(self.ctx, case_location, case_value, converted_region).op_ref()
             } else {
                 scf::default(self.ctx, case_location, converted_region).op_ref()
             };
@@ -1453,13 +1597,19 @@ impl<'a> Converter<'a> {
             .op(source)
             .attributes
             .get_symbol("func_ref")
-            .unwrap();
-        let target = self.funcs.get(&target_symbol).cloned().unwrap();
+            .expect("pre-CPS validation checked func_ref target");
+        let target = self
+            .current_func(target_symbol)
+            .expect("pre-CPS validation resolved func_ref target in this module");
         let result_logical_ty = self.ctx.op_result_types(source)[0];
-        let result_callable =
-            tribute_control::Callable::from_type_ref(self.ctx, result_logical_ty).unwrap();
-        let result_convention = convert_convention(
-            tribute_control::callable_convention(self.ctx, result_logical_ty).unwrap(),
+        let result_callable = tribute_control::Callable::from_type_ref(self.ctx, result_logical_ty)
+            .expect("pre-CPS validation checked func_ref result type");
+        let result_convention = tribute_control::callable_convention(self.ctx, result_logical_ty)
+            .map(convert_convention)
+            .expect("pre-CPS validation checked func_ref convention");
+        debug_assert!(
+            !target.convention.needs_done_k() || result_convention.needs_done_k(),
+            "pre-CPS validation rejects a weaker func_ref result convention"
         );
         let result = self.convert_type(result_callable.result(self.ctx));
         let source_params: Vec<_> = result_callable
@@ -1484,6 +1634,8 @@ impl<'a> Converter<'a> {
         let block = self.make_block(location, &physical_params);
         let args = self.ctx.block_args(block).to_vec();
         let evidence_offset = usize::from(result_convention.needs_evidence());
+        // The environment is interposed immediately after optional evidence,
+        // so a present done continuation is the following slot.
         let done_offset = evidence_offset + 1;
         let source_offset = usize::from(result_convention.needs_evidence())
             + 1
@@ -1859,22 +2011,26 @@ impl<'a> Converter<'a> {
             .map(|arg| mapping.get(arg).copied().unwrap_or(*arg))
             .collect();
         let never = self.never_type();
+        let ability_ref = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_type("ability_ref")
+            .expect("pre-CPS validation checked perform ability");
+        let op_name = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_symbol("op_name")
+            .expect("pre-CPS validation checked perform operation");
         let perform = ability::perform(
             self.ctx,
             location,
             continuation,
             args,
             never,
-            self.ctx
-                .op(source)
-                .attributes
-                .get_type("ability_ref")
-                .unwrap(),
-            self.ctx
-                .op(source)
-                .attributes
-                .get_symbol("op_name")
-                .unwrap(),
+            ability_ref,
+            op_name,
         );
         self.ctx.push_op(block, perform.op_ref());
         Ok(())
@@ -2206,7 +2362,12 @@ impl<'a> Converter<'a> {
         };
         self.ctx.push_op(block, after_handle_op);
 
-        let handlers_region = self.ctx.op(source).regions[2];
+        let regions = self.ctx.op(source).regions.to_vec();
+        let [body_source, completion_source, handlers_region] = regions.as_slice() else {
+            unreachable!("pre-CPS validation checked handle regions");
+        };
+        let (body_source, completion_source, handlers_region) =
+            (*body_source, *completion_source, *handlers_region);
         let handlers_block = self.ctx.region(handlers_region).blocks[0];
         let mut handler_arms = Vec::new();
         let source_handlers = self.ctx.block(handlers_block).ops.to_vec();
@@ -2249,7 +2410,6 @@ impl<'a> Converter<'a> {
             root_exit_k: Some(after_handle),
             answer_type: handle_answer,
         };
-        let completion_source = self.ctx.op(source).regions[1];
         let (completion_op, completion_k) = self.build_completion_continuation(
             completion_source,
             after_handle,
@@ -2262,7 +2422,6 @@ impl<'a> Converter<'a> {
             exit_k: Some(completion_k),
             ..body_flow_base
         };
-        let body_source = self.ctx.op(source).regions[0];
         let source_body_block = self.ctx.region(body_source).blocks[0];
         self.convert_sequence(
             self.ctx.block(source_body_block).ops.to_vec(),
@@ -2359,9 +2518,15 @@ impl<'a> Converter<'a> {
                     index += 1;
                 }
                 "call" => {
-                    let target_symbol =
-                        self.ctx.op(source).attributes.get_symbol("callee").unwrap();
-                    let target = self.funcs.get(&target_symbol).cloned().unwrap();
+                    let target_symbol = self
+                        .ctx
+                        .op(source)
+                        .attributes
+                        .get_symbol("callee")
+                        .expect("pre-CPS validation checked direct callee");
+                    let target = self
+                        .current_func(target_symbol)
+                        .expect("pre-CPS validation resolved direct callee in this module");
                     if target.convention == CallingConvention::Cps {
                         if flow.convention != CallingConvention::Cps {
                             return Err(TributeControlToCpsError::one(
@@ -2407,9 +2572,9 @@ impl<'a> Converter<'a> {
                 "call_indirect" => {
                     let source_callee = self.ctx.op_operands(source)[0];
                     let logical_type = self.ctx.value_ty(source_callee);
-                    let convention = convert_convention(
-                        tribute_control::callable_convention(self.ctx, logical_type).unwrap(),
-                    );
+                    let convention = tribute_control::callable_convention(self.ctx, logical_type)
+                        .map(convert_convention)
+                        .expect("pre-CPS validation checked indirect callee convention");
                     let callee = mapping
                         .get(&source_callee)
                         .copied()
@@ -2473,7 +2638,7 @@ impl<'a> Converter<'a> {
                         .op(source)
                         .attributes
                         .get_symbol("operation_kind")
-                        .unwrap();
+                        .expect("pre-CPS validation checked operation kind");
                     if kind == Symbol::new("fn") {
                         let evidence = self.current_evidence(source, flow)?;
                         let _ = evidence;
@@ -2484,21 +2649,25 @@ impl<'a> Converter<'a> {
                             .map(|arg| mapping.get(arg).copied().unwrap_or(*arg))
                             .collect();
                         let result_type = self.convert_type(self.ctx.op_result_types(source)[0]);
+                        let ability_ref = self
+                            .ctx
+                            .op(source)
+                            .attributes
+                            .get_type("ability_ref")
+                            .expect("pre-CPS validation checked perform ability");
+                        let op_name = self
+                            .ctx
+                            .op(source)
+                            .attributes
+                            .get_symbol("op_name")
+                            .expect("pre-CPS validation checked perform operation");
                         let call = ability::call(
                             self.ctx,
                             location,
                             args,
                             result_type,
-                            self.ctx
-                                .op(source)
-                                .attributes
-                                .get_type("ability_ref")
-                                .unwrap(),
-                            self.ctx
-                                .op(source)
-                                .attributes
-                                .get_symbol("op_name")
-                                .unwrap(),
+                            ability_ref,
+                            op_name,
                         );
                         self.ctx.push_op(block, call.op_ref());
                         mapping.insert(self.ctx.op_result(source, 0), call.result(self.ctx));
@@ -2543,9 +2712,16 @@ impl<'a> Converter<'a> {
             .op(source)
             .attributes
             .get_symbol("sym_name")
-            .unwrap();
-        let logical_type = self.ctx.op(source).attributes.get_type("type").unwrap();
-        let info = self.funcs.get(&symbol).cloned().unwrap();
+            .expect("pre-CPS validation checked function symbol");
+        let logical_type = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_type("type")
+            .expect("pre-CPS validation checked function type");
+        let info = self
+            .current_func(symbol)
+            .expect("validated function is present in its module callable graph");
         let physical_type = self.physical_function_type(logical_type);
         if self.ctx.op(source).regions.is_empty() {
             let mut builder =
@@ -2664,38 +2840,84 @@ fn ordered_external_values(ctx: &IrContext, region: RegionRef) -> Vec<ValueRef> 
 fn collect_callable_graph(
     ctx: &IrContext,
     module: Module,
-) -> Result<HashMap<Symbol, CallableInfo>, TributeControlToCpsError> {
-    let mut funcs = HashMap::new();
-    fn visit(ctx: &IrContext, region: RegionRef, funcs: &mut HashMap<Symbol, CallableInfo>) {
+) -> HashMap<OpRef, HashMap<Symbol, CallableInfo>> {
+    fn collect_scope(
+        ctx: &IrContext,
+        region: RegionRef,
+        funcs: &mut HashMap<Symbol, CallableInfo>,
+        nested_modules: &mut Vec<OpRef>,
+    ) {
         for block in ctx.region(region).blocks.iter().copied() {
             for op in ctx.block(block).ops.iter().copied() {
+                let data = ctx.op(op);
+                if data.dialect == Symbol::new("core") && data.name == Symbol::new("module") {
+                    nested_modules.push(op);
+                    continue;
+                }
                 if tribute_control::Func::matches(ctx, op) {
-                    let symbol = ctx.op(op).attributes.get_symbol("sym_name").unwrap();
-                    let logical_type = ctx.op(op).attributes.get_type("type").unwrap();
-                    let callable =
-                        tribute_control::Callable::from_type_ref(ctx, logical_type).unwrap();
+                    let symbol = data
+                        .attributes
+                        .get_symbol("sym_name")
+                        .expect("pre-CPS validation checked function symbol");
+                    let logical_type = data
+                        .attributes
+                        .get_type("type")
+                        .expect("pre-CPS validation checked function type");
+                    let callable = tribute_control::Callable::from_type_ref(ctx, logical_type)
+                        .expect("pre-CPS validation checked callable type");
+                    let convention = tribute_control::callable_convention(ctx, logical_type)
+                        .expect("pre-CPS validation checked callable convention");
                     funcs.insert(
                         symbol,
                         CallableInfo {
                             symbol,
-                            convention: convert_convention(
-                                tribute_control::callable_convention(ctx, logical_type).unwrap(),
-                            ),
+                            convention: convert_convention(convention),
                             source_result: callable.result(ctx),
                             source_params: callable.params(ctx).to_vec(),
                         },
                     );
                 }
-                for nested in ctx.op(op).regions.iter().copied() {
-                    visit(ctx, nested, funcs);
+                for nested in data.regions.iter().copied() {
+                    collect_scope(ctx, nested, funcs, nested_modules);
                 }
             }
         }
     }
-    if let Some(body) = module.body(ctx) {
-        visit(ctx, body, &mut funcs);
+
+    fn visit_module(
+        ctx: &IrContext,
+        module_op: OpRef,
+        funcs_by_module: &mut HashMap<OpRef, HashMap<Symbol, CallableInfo>>,
+    ) {
+        let mut funcs = HashMap::new();
+        let mut nested_modules = Vec::new();
+        for region in ctx.op(module_op).regions.iter().copied() {
+            collect_scope(ctx, region, &mut funcs, &mut nested_modules);
+        }
+        funcs_by_module.insert(module_op, funcs);
+        for nested in nested_modules {
+            visit_module(ctx, nested, funcs_by_module);
+        }
     }
-    Ok(funcs)
+
+    let mut funcs_by_module = HashMap::new();
+    visit_module(ctx, module.op(), &mut funcs_by_module);
+    funcs_by_module
+}
+
+fn verify_candidate_or_restore_aliases(
+    ctx: &mut IrContext,
+    candidate: Module,
+    source_aliases: &[(Symbol, TypeRef)],
+) -> Result<(), TributeControlToCpsError> {
+    if let Err(error) = verify_tribute_control_post_cps(ctx, candidate) {
+        for (name, ty) in source_aliases {
+            ctx.register_type_alias(*name, *ty);
+        }
+        ctx.remove_op(candidate.op());
+        return Err(error);
+    }
+    Ok(())
 }
 
 /// Atomically convert the complete logical callable/control graph.
@@ -2708,7 +2930,7 @@ pub fn tribute_control_to_cps(
     declarations: &[tribute_control::OperationDeclaration],
 ) -> Result<(), TributeControlToCpsError> {
     verify_tribute_control_pre_cps(ctx, module, declarations)?;
-    let funcs = collect_callable_graph(ctx, module)?;
+    let funcs_by_module = collect_callable_graph(ctx, module);
     let source_region = module.body(ctx).ok_or_else(|| {
         TributeControlToCpsError::one(
             PRE_CPS_BOUNDARY,
@@ -2736,7 +2958,7 @@ pub fn tribute_control_to_cps(
         parent_region: None,
     });
     {
-        let mut converter = Converter::new(ctx, new_block, funcs);
+        let mut converter = Converter::new(ctx, new_block, funcs_by_module, module.op());
         let mut mapping = HashMap::new();
         let source_ops = converter.ctx.block(source_blocks[0]).ops.to_vec();
         for source in source_ops {
@@ -2772,18 +2994,23 @@ pub fn tribute_control_to_cps(
     for (name, ty) in &converted_aliases {
         ctx.register_type_alias(*name, *ty);
     }
-    if let Err(error) = verify_tribute_control_post_cps(ctx, candidate) {
+    verify_candidate_or_restore_aliases(ctx, candidate, &source_aliases)?;
+
+    ctx.detach_region(new_region);
+    ctx.remove_op(candidate.op());
+    ctx.detach_region(source_region);
+    ctx.op_mut(module.op()).regions.push(new_region);
+    ctx.region_mut(new_region).parent_op = Some(module.op());
+    if let Err(error) = verify_tribute_control_post_cps(ctx, module) {
+        ctx.detach_region(new_region);
+        ctx.op_mut(module.op()).regions.push(source_region);
+        ctx.region_mut(source_region).parent_op = Some(module.op());
         for (name, ty) in &source_aliases {
             ctx.register_type_alias(*name, *ty);
         }
         return Err(error);
     }
-
-    ctx.detach_region(new_region);
-    ctx.detach_region(source_region);
-    ctx.op_mut(module.op()).regions.push(new_region);
-    ctx.region_mut(new_region).parent_op = Some(module.op());
-    verify_tribute_control_post_cps(ctx, module)
+    Ok(())
 }
 
 /// Pass-manager wrapper carrying the verified source operation declarations.
@@ -2946,6 +3173,41 @@ mod tests {
     }
 
     #[test]
+    fn nested_modules_resolve_same_named_callables_in_their_own_scope() {
+        let input = r#"core.module @outer {
+  tribute_control.func @same(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @outer_call(%value: core.i32) -> core.i32 convention(direct) {
+    %result = tribute_control.call %value {callee = @same} : core.i32
+    tribute_control.return %result
+  }
+  core.module @inner {
+    tribute_control.func @same(%value: core.i1) -> core.i1 convention(evidence_direct) {
+      tribute_control.return %value
+    }
+    tribute_control.func @inner_call(%value: core.i1) -> core.i1 convention(evidence_direct) {
+      %result = tribute_control.call %value {callee = @same} : core.i1
+      tribute_control.return %result
+    }
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        verify_tribute_control_post_cps(&ctx, module).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert_eq!(printed.matches("func.func @same").count(), 2, "{printed}");
+        assert!(printed.contains("func.func @outer_call"), "{printed}");
+        assert!(printed.contains("func.func @inner_call"), "{printed}");
+        assert!(printed.contains("tribute.calling_convention = 0"));
+        assert!(printed.contains("tribute.calling_convention = 1"));
+
+        let mut reparsed = IrContext::new();
+        let reparsed_module = parse_test_module(&mut reparsed, &printed);
+        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+    }
+
+    #[test]
     fn textual_nested_attribute_types_convert_atomically() {
         let input = r#"core.module @test {
   !callback = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
@@ -2980,6 +3242,218 @@ mod tests {
         assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
         assert!(error.to_string().contains("func.call"));
         assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn malformed_lookup_inputs_fail_before_conversion_and_remain_unchanged() {
+        let malformed = [
+            (
+                r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(direct) {
+    %result = tribute_control.call %value : core.i32
+    tribute_control.return %result
+  }
+}"#,
+                "requires 'callee' attribute",
+            ),
+            (
+                r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(direct) {
+    %result = tribute_control.call %value {callee = @missing} : core.i32
+    tribute_control.return %result
+  }
+}"#,
+                "unresolved callee @missing",
+            ),
+            (
+                r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(direct) {
+    %result = tribute_control.call_indirect %value, %value : core.i32
+    tribute_control.return %result
+  }
+}"#,
+                "callee operand must have tribute_control.callable type",
+            ),
+            (
+                r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(cps) {
+    %result = tribute_control.perform %value : core.i32
+    tribute_control.return %result
+  }
+}"#,
+                "requires 'ability_ref' attribute",
+            ),
+            (
+                r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(cps) {
+    %result = tribute_control.handle : core.i32
+    tribute_control.return %result
+  }
+}"#,
+                "expects 3 region(s)",
+            ),
+        ];
+        for (input, expected) in malformed {
+            let (mut ctx, module) = parse(input);
+            let before = print_module(&ctx, module.op());
+            let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+            assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+            assert!(error.to_string().contains(expected), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
+    fn source_successors_fail_before_conversion_and_leave_ir_unchanged() {
+        let input = r#"core.module @test {
+  ^entry:
+    scf.br [^exit]
+  ^exit:
+}"#;
+        let (mut ctx, module) = parse(input);
+        let before = print_module(&ctx, module.op());
+        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+        assert!(
+            error.to_string().contains("forbids block successors"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn malformed_switch_case_fails_before_conversion_and_is_atomic() {
+        let input = r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(cps) {
+    scf.switch %value {
+      scf.case {
+        %identity = tribute_control.lambda(%nested: core.i32) -> core.i32 convention(direct) captures [] {
+          tribute_control.return %nested
+        }
+        scf.yield
+      }
+    }
+    tribute_control.return %value
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let before = print_module(&ctx, module.op());
+        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+        assert!(
+            error.to_string().contains("scf.case requires a value"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn source_shape_validation_rejects_every_malformed_switch_component() {
+        let malformed = [
+            (
+                r#"core.module @test {
+  %value = arith.const {value = 0} : core.i32
+  scf.switch {
+    scf.default {
+      scf.yield
+    }
+  }
+}"#,
+                "one discriminant, no results, and one body region",
+            ),
+            (
+                r#"core.module @test {
+  %value = arith.const {value = 0} : core.i32
+  %result = scf.switch %value : core.i32 {
+    scf.default {
+      scf.yield
+    }
+  }
+}"#,
+                "one discriminant, no results, and one body region",
+            ),
+            (
+                r#"core.module @test {
+  %value = arith.const {value = 0} : core.i32
+  scf.switch %value {
+    ^first:
+      scf.default {
+        scf.yield
+      }
+    ^second:
+  }
+}"#,
+                "body region requires exactly one block",
+            ),
+            (
+                r#"core.module @test {
+  %value = arith.const {value = 0} : core.i32
+  scf.switch %value {
+    %invalid = arith.const {value = 1} : core.i32
+  }
+}"#,
+                "body may contain only scf.case and scf.default",
+            ),
+            (
+                r#"core.module @test {
+  %value = arith.const {value = 0} : core.i32
+  scf.switch %value {
+    scf.case {value = 0}
+  }
+}"#,
+                "arm requires exactly one region",
+            ),
+            (
+                r#"core.module @test {
+  %value = arith.const {value = 0} : core.i32
+  scf.switch %value {
+    scf.default {
+      ^first:
+        scf.yield
+      ^second:
+    }
+  }
+}"#,
+                "arm region requires exactly one block",
+            ),
+        ];
+
+        for (input, expected) in malformed {
+            let (ctx, module) = parse(input);
+            let failures = verify_source_conversion_shapes(&ctx, module);
+            assert!(
+                failures
+                    .iter()
+                    .any(|failure| failure.message.contains(expected)),
+                "{failures:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn post_candidate_failure_restores_alias_maps_and_canonical_ir() {
+        let input = r#"core.module @candidate {
+  !callback = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  func.func @broken(%value: core.i32) -> core.i32 {
+    func.return %value
+  }
+}"#;
+        let (mut ctx, candidate) = parse(input);
+        let before = print_module(&ctx, candidate.op());
+        let source_aliases = ctx.type_aliases().to_vec();
+        let (alias_name, source_type) = source_aliases[0];
+        let converted_type = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        ctx.register_type_alias(alias_name, converted_type);
+
+        let error =
+            verify_candidate_or_restore_aliases(&mut ctx, candidate, &source_aliases).unwrap_err();
+        assert_eq!(error.boundary, POST_CPS_BOUNDARY);
+        assert_eq!(ctx.type_alias_by_name(alias_name), Some(source_type));
+        assert_eq!(ctx.type_alias_by_type(source_type), Some(alias_name));
+        assert_eq!(ctx.type_alias_by_type(converted_type), None);
+        assert_eq!(print_module(&ctx, candidate.op()), before);
     }
 
     #[test]
@@ -3285,6 +3759,45 @@ mod tests {
             i32_type,
         )];
         tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        let mut consumed_get = None;
+        let mut consumed_set = None;
+        fn find_one_shot_state_ops(
+            ctx: &IrContext,
+            op: OpRef,
+            consumed_get: &mut Option<ValueRef>,
+            consumed_set: &mut Option<ValueRef>,
+        ) {
+            let is_one_shot_type = |ty: TypeRef| {
+                ctx.types
+                    .get(ty)
+                    .attrs
+                    .get_symbol("name")
+                    .is_some_and(|name| {
+                        name.with_str(|text| text.starts_with("__tribute_one_shot_state"))
+                    })
+            };
+            if let Ok(get) = adt::StructGet::from_op(ctx, op)
+                && is_one_shot_type(get.r#type(ctx))
+            {
+                *consumed_get = Some(get.r#ref(ctx));
+            }
+            if let Ok(set) = adt::StructSet::from_op(ctx, op)
+                && is_one_shot_type(set.r#type(ctx))
+            {
+                assert!(ctx.op_results(op).is_empty(), "struct_set mutates in place");
+                *consumed_set = Some(set.r#ref(ctx));
+            }
+            for region in ctx.op(op).regions.iter().copied() {
+                for block in ctx.region(region).blocks.iter().copied() {
+                    for child in ctx.block(block).ops.iter().copied() {
+                        find_one_shot_state_ops(ctx, child, consumed_get, consumed_set);
+                    }
+                }
+            }
+        }
+        find_one_shot_state_ops(&ctx, module.op(), &mut consumed_get, &mut consumed_set);
+        assert_eq!(consumed_get, consumed_set);
+        assert!(consumed_get.is_some(), "one-shot state was not emitted");
         let printed = print_module(&ctx, module.op());
         assert_eq!(printed.matches("ability.handle_dispatch").count(), 1);
         assert!(!printed.contains("effect."));
@@ -3461,6 +3974,70 @@ mod tests {
         assert!(!printed.contains("tribute_control.func "));
         assert!(!printed.contains("tribute_control.func_ref "));
         assert!(!printed.contains("tribute_control.call_indirect "));
+    }
+
+    #[test]
+    fn func_ref_adapters_cover_every_legal_convention_strengthening() {
+        let input = r#"core.module @test {
+  !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !evidence = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 1}
+  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  tribute_control.func @direct(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @evidence(%value: core.i32) -> core.i32 convention(evidence_direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @cps(%value: core.i32) -> core.i32 convention(cps) {
+    tribute_control.return %value
+  }
+  tribute_control.func @refs(%value: core.i32) -> core.i32 convention(cps) {
+    %direct_direct = tribute_control.func_ref {func_ref = @direct} : !direct
+    %direct_evidence = tribute_control.func_ref {func_ref = @direct} : !evidence
+    %direct_cps = tribute_control.func_ref {func_ref = @direct} : !cps
+    %evidence_evidence = tribute_control.func_ref {func_ref = @evidence} : !evidence
+    %evidence_cps = tribute_control.func_ref {func_ref = @evidence} : !cps
+    %cps_cps = tribute_control.func_ref {func_ref = @cps} : !cps
+    tribute_control.return %value
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        verify_tribute_control_post_cps(&ctx, module).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert_eq!(
+            printed
+                .matches("func.func @__tribute_func_ref_adapter")
+                .count(),
+            6,
+            "{printed}"
+        );
+        assert!(!printed.contains("tribute_control."));
+    }
+
+    #[test]
+    fn weaker_func_ref_adapter_is_rejected_before_mutation() {
+        let input = r#"core.module @test {
+  !evidence = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 1}
+  tribute_control.func @cps(%value: core.i32) -> core.i32 convention(cps) {
+    tribute_control.return %value
+  }
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(evidence_direct) {
+    %callee = tribute_control.func_ref {func_ref = @cps} : !evidence
+    tribute_control.return %value
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let before = print_module(&ctx, module.op());
+        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+        assert!(
+            error
+                .to_string()
+                .contains("result convention must be at least as strong"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -1,0 +1,3662 @@
+//! Atomic legalization of verified `tribute_control` callable/control IR.
+//!
+//! The pass deliberately stops at the physical `func`/`closure` and logical
+//! `ability` surface. It does not run closure extraction, evidence lowering,
+//! or target-specific conversion.
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::fmt;
+
+use tribute_core::{
+    CALLING_CONVENTION_ATTR, CallableAbi, CallingConvention, set_calling_convention,
+};
+use tribute_ir::dialect::{ability, closure, tribute_control, tribute_rt};
+use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
+use trunk_ir::dialect::{adt, arith, core, func, scf};
+use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::pass::{Pass, PassRunResult};
+use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
+use trunk_ir::rewrite::{ConversionMode, ConversionTarget, Module};
+use trunk_ir::types::{Attribute, AttributeMap, Location, TypeDataBuilder};
+use trunk_ir::{OperationDataBuilder, Symbol};
+
+pub const PRE_CPS_BOUNDARY: &str = "tribute-control-pre-cps";
+pub const POST_CPS_BOUNDARY: &str = "tribute-control-post-cps";
+
+/// One source-located failure at a named callable/control boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BoundaryFailure {
+    pub op: Option<OpRef>,
+    pub location: Option<Location>,
+    pub message: String,
+}
+
+/// Failure returned without claiming that the requested named boundary holds.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TributeControlToCpsError {
+    pub boundary: &'static str,
+    pub failures: Vec<BoundaryFailure>,
+}
+
+impl TributeControlToCpsError {
+    fn one(
+        boundary: &'static str,
+        op: Option<OpRef>,
+        location: Option<Location>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            boundary,
+            failures: vec![BoundaryFailure {
+                op,
+                location,
+                message: message.into(),
+            }],
+        }
+    }
+}
+
+impl fmt::Display for TributeControlToCpsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "{} failed with {} error(s):",
+            self.boundary,
+            self.failures.len()
+        )?;
+        for failure in &self.failures {
+            if let Some(op) = failure.op {
+                write!(f, "  - {op}: ")?;
+            } else {
+                write!(f, "  - ")?;
+            }
+            writeln!(f, "{}", failure.message)?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for TributeControlToCpsError {}
+
+/// Full frontend-side operation target for verified direct-style control IR.
+pub fn tribute_control_pre_cps_target() -> ConversionTarget {
+    ConversionTarget::new()
+        .legal_dialect("core")
+        .legal_dialect("tribute_control")
+        .legal_dialect("scf")
+        .legal_dialect("arith")
+        .legal_dialect("adt")
+        .legal_dialect("list")
+        .legal_dialect("tribute_rt")
+        .legal_dialect("tribute_io")
+}
+
+/// Partial post-legalization target. Unknown operations belong to later passes.
+pub fn tribute_control_post_cps_target() -> ConversionTarget {
+    ConversionTarget::new().illegal_dialect("tribute_control")
+}
+
+#[derive(Clone, Copy)]
+enum TypeBoundary {
+    Pre,
+    Post,
+}
+
+fn type_is(ctx: &IrContext, ty: TypeRef, dialect: &str, name: &str) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::from_dynamic(dialect) && data.name == Symbol::from_dynamic(name)
+}
+
+fn walk_attribute_types(
+    ctx: &IrContext,
+    attribute: &Attribute,
+    boundary: TypeBoundary,
+    seen: &mut HashSet<TypeRef>,
+    errors: &mut Vec<String>,
+) {
+    match attribute {
+        Attribute::Type(ty) => walk_type(ctx, *ty, boundary, seen, errors),
+        Attribute::List(values) => {
+            for value in values {
+                walk_attribute_types(ctx, value, boundary, seen, errors);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn walk_type(
+    ctx: &IrContext,
+    ty: TypeRef,
+    boundary: TypeBoundary,
+    seen: &mut HashSet<TypeRef>,
+    errors: &mut Vec<String>,
+) {
+    if !seen.insert(ty) {
+        return;
+    }
+    let data = ctx.types.get(ty);
+    let forbidden = match boundary {
+        TypeBoundary::Pre => {
+            type_is(ctx, ty, "core", "func")
+                || type_is(ctx, ty, "closure", "closure")
+                || data.dialect == Symbol::new("ability")
+                || data.dialect == Symbol::new("effect")
+        }
+        TypeBoundary::Post => data.dialect == Symbol::new("tribute_control"),
+    };
+    if forbidden {
+        errors.push(format!(
+            "forbidden type {ty} is reachable at the named boundary"
+        ));
+    }
+    for param in data.params.iter().copied() {
+        walk_type(ctx, param, boundary, seen, errors);
+    }
+    for attribute in data.attrs.values() {
+        walk_attribute_types(ctx, attribute, boundary, seen, errors);
+    }
+}
+
+fn check_op_types(
+    ctx: &IrContext,
+    op: OpRef,
+    boundary: TypeBoundary,
+    failures: &mut Vec<BoundaryFailure>,
+) {
+    let mut errors = Vec::new();
+    let mut seen = HashSet::new();
+    for operand in ctx.op_operands(op) {
+        walk_type(
+            ctx,
+            ctx.value_ty(*operand),
+            boundary,
+            &mut seen,
+            &mut errors,
+        );
+    }
+    for ty in ctx.op_result_types(op) {
+        walk_type(ctx, *ty, boundary, &mut seen, &mut errors);
+    }
+    for attribute in ctx.op(op).attributes.values() {
+        walk_attribute_types(ctx, attribute, boundary, &mut seen, &mut errors);
+    }
+    for region in ctx.op(op).regions.iter().copied() {
+        for block in ctx.region(region).blocks.iter().copied() {
+            for arg in ctx.block_args(block) {
+                walk_type(ctx, ctx.value_ty(*arg), boundary, &mut seen, &mut errors);
+            }
+            for child in ctx.block(block).ops.iter().copied() {
+                check_op_types(ctx, child, boundary, failures);
+            }
+        }
+    }
+    failures.extend(errors.into_iter().map(|message| BoundaryFailure {
+        op: Some(op),
+        location: Some(ctx.op(op).location),
+        message,
+    }));
+}
+
+fn verify_type_boundary(
+    ctx: &IrContext,
+    module: Module,
+    boundary: TypeBoundary,
+) -> Vec<BoundaryFailure> {
+    let mut failures = Vec::new();
+    check_op_types(ctx, module.op(), boundary, &mut failures);
+    let mut seen = HashSet::new();
+    let mut alias_errors = Vec::new();
+    for (_, ty) in ctx.type_aliases() {
+        walk_type(ctx, *ty, boundary, &mut seen, &mut alias_errors);
+    }
+    failures.extend(alias_errors.into_iter().map(|message| BoundaryFailure {
+        op: Some(module.op()),
+        location: Some(ctx.op(module.op()).location),
+        message: format!("type alias contains {message}"),
+    }));
+    failures
+}
+
+fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
+    fn check_dispatcher(
+        ctx: &IrContext,
+        owner: OpRef,
+        value: ValueRef,
+        evidence: TypeRef,
+        general: bool,
+        failures: &mut Vec<BoundaryFailure>,
+    ) {
+        let closure_ty = ctx.types.get(ctx.value_ty(value));
+        let valid = if closure_ty.dialect == Symbol::new("closure")
+            && closure_ty.name == Symbol::new("closure")
+            && closure_ty.params.len() == 1
+        {
+            let func_ty = ctx.types.get(closure_ty.params[0]);
+            let params = &func_ty.params;
+            if general {
+                func_ty.dialect == Symbol::new("core")
+                    && func_ty.name == Symbol::new("func")
+                    && params.len() == 5
+                    && type_is(ctx, params[0], "core", "never")
+                    && params[1] == evidence
+                    && type_is(ctx, params[2], "tribute_rt", "anyref")
+                    && type_is(ctx, params[3], "core", "i32")
+                    && type_is(ctx, params[4], "tribute_rt", "anyref")
+            } else {
+                func_ty.dialect == Symbol::new("core")
+                    && func_ty.name == Symbol::new("func")
+                    && params.len() == 4
+                    && type_is(ctx, params[0], "tribute_rt", "anyref")
+                    && params[1] == evidence
+                    && type_is(ctx, params[2], "core", "i32")
+                    && type_is(ctx, params[3], "tribute_rt", "anyref")
+            }
+        } else {
+            false
+        };
+        if !valid {
+            failures.push(BoundaryFailure {
+                op: Some(owner),
+                location: Some(ctx.op(owner).location),
+                message: format!(
+                    "{} dispatcher has the wrong typed closure ABI",
+                    if general {
+                        "general"
+                    } else {
+                        "tail-resumptive"
+                    }
+                ),
+            });
+        }
+        let expected = if general { 2 } else { 1 };
+        let trunk_ir::ValueDef::OpResult(def, _) = ctx.value_def(value) else {
+            failures.push(BoundaryFailure {
+                op: Some(owner),
+                location: Some(ctx.op(owner).location),
+                message: "dispatcher must be a physical closure result with exact calling convention metadata"
+                    .into(),
+            });
+            return;
+        };
+        if ctx.op(def).attributes.get_i64(CALLING_CONVENTION_ATTR) != Ok(Some(expected)) {
+            failures.push(BoundaryFailure {
+                op: Some(def),
+                location: Some(ctx.op(def).location),
+                message: format!("dispatcher must preserve calling convention metadata {expected}"),
+            });
+        }
+    }
+
+    fn visit(ctx: &IrContext, op: OpRef, failures: &mut Vec<BoundaryFailure>) {
+        if ability::HandleDispatch::matches(ctx, op) {
+            let operands = ctx.op_operands(op);
+            if let Some((evidence, dispatchers)) = operands.split_first() {
+                let evidence_ty = ctx.value_ty(*evidence);
+                for pair in dispatchers.chunks_exact(2) {
+                    check_dispatcher(ctx, op, pair[0], evidence_ty, false, failures);
+                    check_dispatcher(ctx, op, pair[1], evidence_ty, true, failures);
+                }
+            }
+        }
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child, failures);
+                }
+            }
+        }
+    }
+
+    let mut failures = Vec::new();
+    visit(ctx, module.op(), &mut failures);
+    failures
+}
+
+fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
+    let mut signatures = HashMap::new();
+    fn collect(
+        ctx: &IrContext,
+        op: OpRef,
+        signatures: &mut HashMap<Symbol, (TypeRef, Option<i64>)>,
+    ) {
+        if func::Func::matches(ctx, op)
+            && let (Some(symbol), Some(ty)) = (
+                ctx.op(op).attributes.get_symbol("sym_name"),
+                ctx.op(op).attributes.get_type("type"),
+            )
+        {
+            let convention = ctx
+                .op(op)
+                .attributes
+                .get_i64(CALLING_CONVENTION_ATTR)
+                .ok()
+                .flatten();
+            signatures.insert(symbol, (ty, convention));
+        }
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    collect(ctx, child, signatures);
+                }
+            }
+        }
+    }
+    collect(ctx, module.op(), &mut signatures);
+
+    let mut failures = Vec::new();
+    fn visit(
+        ctx: &IrContext,
+        op: OpRef,
+        signatures: &HashMap<Symbol, (TypeRef, Option<i64>)>,
+        failures: &mut Vec<BoundaryFailure>,
+    ) {
+        let data = ctx.op(op);
+        let op_convention = data
+            .attributes
+            .get_i64(CALLING_CONVENTION_ATTR)
+            .ok()
+            .flatten();
+        let requires_convention = (data.dialect == Symbol::new("func")
+            && matches!(
+                data.name.with_str(|name| name.to_owned()).as_str(),
+                "func" | "call" | "call_indirect" | "tail_call" | "tail_call_indirect"
+            ))
+            || (data.dialect == Symbol::new("closure")
+                && matches!(
+                    data.name.with_str(|name| name.to_owned()).as_str(),
+                    "lambda" | "new"
+                ));
+        if requires_convention && !matches!(op_convention, Some(0..=2)) {
+            failures.push(BoundaryFailure {
+                op: Some(op),
+                location: Some(data.location),
+                message: format!(
+                    "{}.{} must carry exact Direct, EvidenceDirect, or Cps metadata",
+                    data.dialect, data.name
+                ),
+            });
+        }
+        if data.dialect == Symbol::new("func") && data.name == Symbol::new("tail_call") {
+            let Some(callee) = data.attributes.get_symbol("callee") else {
+                failures.push(BoundaryFailure {
+                    op: Some(op),
+                    location: Some(data.location),
+                    message: "func.tail_call requires a resolved callee symbol".into(),
+                });
+                return;
+            };
+            let Some((func_ty, convention)) = signatures.get(&callee) else {
+                failures.push(BoundaryFailure {
+                    op: Some(op),
+                    location: Some(data.location),
+                    message: format!("func.tail_call references unresolved callee @{callee}"),
+                });
+                return;
+            };
+            let ty = ctx.types.get(*func_ty);
+            let valid_never = ty.dialect == Symbol::new("core")
+                && ty.name == Symbol::new("func")
+                && ty
+                    .params
+                    .first()
+                    .is_some_and(|result| type_is(ctx, *result, "core", "never"));
+            if !valid_never {
+                failures.push(BoundaryFailure {
+                    op: Some(op),
+                    location: Some(data.location),
+                    message: "func.tail_call target must have core.never result".into(),
+                });
+            }
+            let expected = ty.params.get(1..).unwrap_or_default();
+            let operands = ctx.op_operands(op);
+            if operands.len() != expected.len()
+                || operands
+                    .iter()
+                    .zip(expected)
+                    .any(|(value, ty)| ctx.value_ty(*value) != *ty)
+            {
+                failures.push(BoundaryFailure {
+                    op: Some(op),
+                    location: Some(data.location),
+                    message: "func.tail_call operands do not match the target signature".into(),
+                });
+            }
+            if *convention != Some(CallingConvention::Cps as i64)
+                || op_convention != Some(CallingConvention::Cps as i64)
+            {
+                failures.push(BoundaryFailure {
+                    op: Some(op),
+                    location: Some(data.location),
+                    message: "func.tail_call must preserve exact Cps metadata".into(),
+                });
+            }
+        } else if data.dialect == Symbol::new("func")
+            && data.name == Symbol::new("tail_call_indirect")
+            && op_convention != Some(CallingConvention::Cps as i64)
+        {
+            failures.push(BoundaryFailure {
+                op: Some(op),
+                location: Some(data.location),
+                message: "func.tail_call_indirect must carry exact Cps metadata".into(),
+            });
+        } else if data.dialect == Symbol::new("func") && data.name == Symbol::new("call") {
+            let callee = data.attributes.get_symbol("callee");
+            if let Some(callee) = callee {
+                match signatures.get(&callee) {
+                    Some((_, target_convention)) if *target_convention == op_convention => {}
+                    Some(_) => failures.push(BoundaryFailure {
+                        op: Some(op),
+                        location: Some(data.location),
+                        message: "func.call metadata does not match its target".into(),
+                    }),
+                    None => failures.push(BoundaryFailure {
+                        op: Some(op),
+                        location: Some(data.location),
+                        message: format!("func.call references unresolved callee @{callee}"),
+                    }),
+                }
+            }
+        } else if data.dialect == Symbol::new("func")
+            && data.name == Symbol::new("call_indirect")
+            && op_convention == Some(CallingConvention::Cps as i64)
+        {
+            failures.push(BoundaryFailure {
+                op: Some(op),
+                location: Some(data.location),
+                message: "dynamic Cps transfers must use func.tail_call_indirect".into(),
+            });
+        }
+        for region in data.regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child, signatures, failures);
+                }
+            }
+        }
+    }
+    visit(ctx, module.op(), &signatures, &mut failures);
+    failures
+}
+
+/// Verify the complete named pre-CPS boundary.
+pub fn verify_tribute_control_pre_cps(
+    ctx: &IrContext,
+    module: Module,
+    declarations: &[tribute_control::OperationDeclaration],
+) -> Result<(), TributeControlToCpsError> {
+    let mut failures = Vec::new();
+    let validation = tribute_control::validate(ctx, module, declarations);
+    failures.extend(validation.errors.into_iter().map(|error| BoundaryFailure {
+        op: error.op,
+        location: error.location,
+        message: error.message,
+    }));
+
+    if let Some(body) = module.body(ctx) {
+        failures.extend(
+            tribute_control_pre_cps_target()
+                .verify_mode(ctx, body, ConversionMode::Full)
+                .into_iter()
+                .map(|illegal| BoundaryFailure {
+                    op: Some(illegal.op),
+                    location: Some(ctx.op(illegal.op).location),
+                    message: format!(
+                        "{} operation {}.{} is not legal",
+                        match illegal.legality {
+                            trunk_ir::rewrite::LegalityCheck::Illegal => "illegal",
+                            trunk_ir::rewrite::LegalityCheck::Unknown => "unknown",
+                            trunk_ir::rewrite::LegalityCheck::Legal => "unexpected legal",
+                        },
+                        ctx.op(illegal.op).dialect,
+                        ctx.op(illegal.op).name
+                    ),
+                }),
+        );
+    }
+    failures.extend(verify_type_boundary(ctx, module, TypeBoundary::Pre));
+    failures.extend(
+        trunk_ir::validation::validate_all(ctx, module)
+            .errors
+            .into_iter()
+            .map(|error| BoundaryFailure {
+                op: None,
+                location: None,
+                message: error.to_string(),
+            }),
+    );
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(TributeControlToCpsError {
+            boundary: PRE_CPS_BOUNDARY,
+            failures,
+        })
+    }
+}
+
+/// Verify the complete named post-CPS boundary.
+pub fn verify_tribute_control_post_cps(
+    ctx: &IrContext,
+    module: Module,
+) -> Result<(), TributeControlToCpsError> {
+    let mut failures = Vec::new();
+    if let Some(body) = module.body(ctx) {
+        failures.extend(
+            tribute_control_post_cps_target()
+                .verify_mode(ctx, body, ConversionMode::Partial)
+                .into_iter()
+                .map(|illegal| BoundaryFailure {
+                    op: Some(illegal.op),
+                    location: Some(ctx.op(illegal.op).location),
+                    message: format!(
+                        "residual {}.{} operation",
+                        ctx.op(illegal.op).dialect,
+                        ctx.op(illegal.op).name
+                    ),
+                }),
+        );
+    }
+    failures.extend(verify_type_boundary(ctx, module, TypeBoundary::Post));
+    if let Err(error) = crate::resolve_evidence::validate_final_handle_dispatches(ctx, module) {
+        let op = error.op();
+        failures.push(BoundaryFailure {
+            op: Some(op),
+            location: Some(ctx.op(op).location),
+            message: error.to_string(),
+        });
+    }
+    failures.extend(verify_final_handle_dispatch_types(ctx, module));
+    failures.extend(verify_physical_callable_graph(ctx, module));
+    failures.extend(
+        trunk_ir::validation::validate_all(ctx, module)
+            .errors
+            .into_iter()
+            .map(|error| BoundaryFailure {
+                op: None,
+                location: None,
+                message: error.to_string(),
+            }),
+    );
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(TributeControlToCpsError {
+            boundary: POST_CPS_BOUNDARY,
+            failures,
+        })
+    }
+}
+
+fn convert_convention(convention: tribute_control::CallingConvention) -> CallingConvention {
+    match convention {
+        tribute_control::CallingConvention::Direct => CallingConvention::Direct,
+        tribute_control::CallingConvention::EvidenceDirect => CallingConvention::EvidenceDirect,
+        tribute_control::CallingConvention::Cps => CallingConvention::Cps,
+    }
+}
+
+#[derive(Clone)]
+struct CallableInfo {
+    symbol: Symbol,
+    convention: CallingConvention,
+    source_result: TypeRef,
+    source_params: Vec<TypeRef>,
+}
+
+#[derive(Clone)]
+struct HandlerArmInfo {
+    op: OpRef,
+    value: ValueRef,
+    ability_ref: TypeRef,
+    op_name: Symbol,
+    kind: Symbol,
+    operation_result: TypeRef,
+    params: Vec<TypeRef>,
+    has_resume_token: bool,
+}
+
+struct Converter<'a> {
+    ctx: &'a mut IrContext,
+    module_block: BlockRef,
+    funcs: HashMap<Symbol, CallableInfo>,
+    converted_types: HashMap<TypeRef, TypeRef>,
+    helper_index: u32,
+}
+
+#[derive(Clone)]
+struct Flow {
+    convention: CallingConvention,
+    evidence: Option<ValueRef>,
+    exit_k: Option<ValueRef>,
+    root_exit_k: Option<ValueRef>,
+    answer_type: TypeRef,
+}
+
+impl<'a> Converter<'a> {
+    fn new(
+        ctx: &'a mut IrContext,
+        module_block: BlockRef,
+        funcs: HashMap<Symbol, CallableInfo>,
+    ) -> Self {
+        Self {
+            ctx,
+            module_block,
+            funcs,
+            converted_types: HashMap::new(),
+            helper_index: 0,
+        }
+    }
+
+    fn never_type(&mut self) -> TypeRef {
+        core::never(self.ctx).as_type_ref()
+    }
+
+    fn evidence_type(&mut self) -> TypeRef {
+        ability::evidence_adt_type_ref(self.ctx)
+    }
+
+    fn anyref_type(&mut self) -> TypeRef {
+        tribute_rt::anyref(self.ctx).as_type_ref()
+    }
+
+    fn done_k_type(&mut self, answer: TypeRef) -> TypeRef {
+        let never = self.never_type();
+        let function = core::func(self.ctx, never, [answer]).as_type_ref();
+        closure::closure(self.ctx, function).as_type_ref()
+    }
+
+    fn resumption_type(&mut self, input: TypeRef, answer: TypeRef) -> TypeRef {
+        let never = self.never_type();
+        let done_k = self.done_k_type(answer);
+        let function = core::func(self.ctx, never, [done_k, input]).as_type_ref();
+        closure::closure(self.ctx, function).as_type_ref()
+    }
+
+    fn convert_attribute(&mut self, attribute: &Attribute) -> Attribute {
+        match attribute {
+            Attribute::Type(ty) => Attribute::Type(self.convert_type(*ty)),
+            Attribute::List(values) => Attribute::List(
+                values
+                    .iter()
+                    .map(|value| self.convert_attribute(value))
+                    .collect(),
+            ),
+            value => value.clone(),
+        }
+    }
+
+    fn convert_attrs(&mut self, attrs: &AttributeMap) -> Vec<(Symbol, Attribute)> {
+        attrs
+            .iter()
+            .map(|(key, value)| (*key, self.convert_attribute(value)))
+            .collect()
+    }
+
+    fn convert_type(&mut self, ty: TypeRef) -> TypeRef {
+        if let Some(converted) = self.converted_types.get(&ty) {
+            return *converted;
+        }
+        if let Some(callable) = tribute_control::Callable::from_type_ref(self.ctx, ty) {
+            let convention = convert_convention(
+                tribute_control::callable_convention(self.ctx, ty)
+                    .expect("pre-CPS validation checked callable convention"),
+            );
+            let result = self.convert_type(callable.result(self.ctx));
+            let source_params = callable.params(self.ctx).to_vec();
+            let params: Vec<_> = source_params
+                .into_iter()
+                .map(|param| self.convert_type(param))
+                .collect();
+            let abi = CallableAbi::new(convention, params, result);
+            let evidence = self.evidence_type();
+            let done_k = self.done_k_type(result);
+            let lowered_params = abi.lowered_params(evidence, done_k);
+            let lowered_result = if convention == CallingConvention::Cps {
+                self.never_type()
+            } else {
+                result
+            };
+            let function = core::func(self.ctx, lowered_result, lowered_params).as_type_ref();
+            let converted = closure::closure(self.ctx, function).as_type_ref();
+            self.converted_types.insert(ty, converted);
+            return converted;
+        }
+        let data = self.ctx.types.get(ty).clone();
+        if data.dialect == Symbol::new("tribute_control")
+            && data.name == Symbol::new("resume_token")
+            && data.params.len() == 2
+        {
+            let input = self.convert_type(data.params[0]);
+            let answer = self.convert_type(data.params[1]);
+            let converted = self.resumption_type(input, answer);
+            self.converted_types.insert(ty, converted);
+            return converted;
+        }
+
+        let params: Vec<_> = data
+            .params
+            .iter()
+            .copied()
+            .map(|param| self.convert_type(param))
+            .collect();
+        let attrs: Vec<_> = data
+            .attrs
+            .iter()
+            .map(|(key, value)| (*key, self.convert_attribute(value)))
+            .collect();
+        if params == data.params.as_slice()
+            && attrs
+                .iter()
+                .all(|(key, value)| data.attrs.get(key) == Some(value))
+        {
+            self.converted_types.insert(ty, ty);
+            return ty;
+        }
+        let mut builder = TypeDataBuilder::new(data.dialect, data.name).params(params);
+        for (key, value) in attrs {
+            builder = builder.attr(key, value);
+        }
+        let converted = self.ctx.types.intern(builder.build());
+        self.converted_types.insert(ty, converted);
+        converted
+    }
+
+    fn physical_function_type(&mut self, logical: TypeRef) -> TypeRef {
+        let callable = tribute_control::Callable::from_type_ref(self.ctx, logical)
+            .expect("pre-CPS validation checked function type");
+        let convention = convert_convention(
+            tribute_control::callable_convention(self.ctx, logical)
+                .expect("pre-CPS validation checked function convention"),
+        );
+        let result = self.convert_type(callable.result(self.ctx));
+        let source_params = callable.params(self.ctx).to_vec();
+        let params: Vec<_> = source_params
+            .into_iter()
+            .map(|param| self.convert_type(param))
+            .collect();
+        let evidence = self.evidence_type();
+        let done_k = self.done_k_type(result);
+        let abi = CallableAbi::new(convention, params, result);
+        let params = abi.lowered_params(evidence, done_k);
+        let result = if convention == CallingConvention::Cps {
+            self.never_type()
+        } else {
+            result
+        };
+        core::func(self.ctx, result, params).as_type_ref()
+    }
+
+    fn copy_extra_attrs(&mut self, source: OpRef, target: OpRef, excluded: &[&str]) {
+        let excluded: HashSet<Symbol> = excluded
+            .iter()
+            .map(|name| Symbol::from_dynamic(name))
+            .collect();
+        let attrs = self.convert_attrs(&self.ctx.op(source).attributes.clone());
+        for (key, value) in attrs {
+            if !excluded.contains(&key) {
+                self.ctx.op_mut(target).attributes.insert(key, value);
+            }
+        }
+    }
+
+    fn fresh_helper(&mut self, prefix: &str) -> Symbol {
+        let index = self.helper_index;
+        self.helper_index += 1;
+        Symbol::from_dynamic(&format!("__tribute_{prefix}_{index}"))
+    }
+
+    fn make_block(&mut self, location: Location, types: &[TypeRef]) -> BlockRef {
+        self.ctx.create_block(BlockData {
+            location,
+            args: types
+                .iter()
+                .copied()
+                .map(|ty| BlockArgData {
+                    ty,
+                    attrs: AttributeMap::new(),
+                })
+                .collect(),
+            ops: Default::default(),
+            parent_region: None,
+        })
+    }
+
+    fn single_block_region(&mut self, location: Location, block: BlockRef) -> RegionRef {
+        self.ctx.create_region(RegionData {
+            location,
+            blocks: trunk_ir::smallvec::smallvec![block],
+            parent_op: None,
+        })
+    }
+
+    fn clone_plain_op(
+        &mut self,
+        source: OpRef,
+        mapping: &mut HashMap<ValueRef, ValueRef>,
+    ) -> Result<OpRef, TributeControlToCpsError> {
+        let data = self.ctx.op(source);
+        if data.dialect == Symbol::new("tribute_control") {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(data.location),
+                format!(
+                    "unsupported tribute_control operation {} reached plain cloning",
+                    data.name
+                ),
+            ));
+        }
+        let location = data.location;
+        let dialect = data.dialect;
+        let name = data.name;
+        let operands: Vec<_> = self
+            .ctx
+            .op_operands(source)
+            .iter()
+            .map(|value| mapping.get(value).copied().unwrap_or(*value))
+            .collect();
+        let result_types: Vec<_> = self.ctx.op_result_types(source).to_vec();
+        let attrs = data.attributes.clone();
+        let regions = data.regions.to_vec();
+        let successors = data.successors.to_vec();
+
+        let mut builder = OperationDataBuilder::new(location, dialect, name);
+        for operand in operands {
+            builder = builder.operand(operand);
+        }
+        for ty in result_types {
+            let converted = self.convert_type(ty);
+            builder = builder.result(converted);
+        }
+        for (key, value) in self.convert_attrs(&attrs) {
+            builder = builder.attr(key, value);
+        }
+        for region in regions {
+            let converted = if dialect == Symbol::new("core") && name == Symbol::new("module") {
+                self.clone_module_region(region)?
+            } else {
+                self.clone_plain_region(region, mapping)?
+            };
+            builder = builder.region(converted);
+        }
+        for successor in successors {
+            builder = builder.successor(successor);
+        }
+        let data = builder.build(self.ctx);
+        let cloned = self.ctx.create_op(data);
+        for (old, new) in self
+            .ctx
+            .op_results(source)
+            .to_vec()
+            .into_iter()
+            .zip(self.ctx.op_results(cloned).to_vec())
+        {
+            mapping.insert(old, new);
+        }
+        Ok(cloned)
+    }
+
+    fn clone_module_region(
+        &mut self,
+        source: RegionRef,
+    ) -> Result<RegionRef, TributeControlToCpsError> {
+        let location = self.ctx.region(source).location;
+        let source_blocks = self.ctx.region(source).blocks.to_vec();
+        let mut blocks = Vec::with_capacity(source_blocks.len());
+        for source_block in source_blocks {
+            let logical_arg_types = self
+                .ctx
+                .block_args(source_block)
+                .iter()
+                .map(|arg| self.ctx.value_ty(*arg))
+                .collect::<Vec<_>>();
+            let source_arg_types = logical_arg_types
+                .into_iter()
+                .map(|ty| self.convert_type(ty))
+                .collect::<Vec<_>>();
+            let block = self.make_block(self.ctx.block(source_block).location, &source_arg_types);
+            let previous_module_block = self.module_block;
+            self.module_block = block;
+            let conversion = (|| {
+                let mut mapping = HashMap::new();
+                for (old, new) in self
+                    .ctx
+                    .block_args(source_block)
+                    .iter()
+                    .copied()
+                    .zip(self.ctx.block_args(block).iter().copied())
+                {
+                    mapping.insert(old, new);
+                }
+                let source_ops = self.ctx.block(source_block).ops.to_vec();
+                for source_op in source_ops {
+                    let converted = if tribute_control::Func::matches(self.ctx, source_op) {
+                        self.convert_func(source_op)?
+                    } else if self.ctx.op(source_op).dialect == Symbol::new("tribute_control") {
+                        return Err(TributeControlToCpsError::one(
+                            PRE_CPS_BOUNDARY,
+                            Some(source_op),
+                            Some(self.ctx.op(source_op).location),
+                            "only tribute_control.func may appear directly in a module block",
+                        ));
+                    } else {
+                        self.clone_plain_op(source_op, &mut mapping)?
+                    };
+                    self.ctx.push_op(block, converted);
+                }
+                Ok(())
+            })();
+            self.module_block = previous_module_block;
+            conversion?;
+            blocks.push(block);
+        }
+        Ok(self.ctx.create_region(RegionData {
+            location,
+            blocks: blocks.into(),
+            parent_op: None,
+        }))
+    }
+
+    fn clone_plain_region(
+        &mut self,
+        source: RegionRef,
+        mapping: &mut HashMap<ValueRef, ValueRef>,
+    ) -> Result<RegionRef, TributeControlToCpsError> {
+        let location = self.ctx.region(source).location;
+        let source_blocks = self.ctx.region(source).blocks.to_vec();
+        let mut blocks = Vec::with_capacity(source_blocks.len());
+        for source_block in source_blocks {
+            let source_arg_types: Vec<_> = self
+                .ctx
+                .block_args(source_block)
+                .iter()
+                .map(|arg| self.ctx.value_ty(*arg))
+                .collect();
+            let arg_types: Vec<_> = source_arg_types
+                .into_iter()
+                .map(|ty| self.convert_type(ty))
+                .collect();
+            let block = self.make_block(self.ctx.block(source_block).location, &arg_types);
+            for (old, new) in self
+                .ctx
+                .block_args(source_block)
+                .to_vec()
+                .into_iter()
+                .zip(self.ctx.block_args(block).to_vec())
+            {
+                mapping.insert(old, new);
+            }
+            let source_ops = self.ctx.block(source_block).ops.to_vec();
+            for op in source_ops {
+                let cloned = self.clone_plain_op(op, mapping)?;
+                self.ctx.push_op(block, cloned);
+            }
+            blocks.push(block);
+        }
+        Ok(self.ctx.create_region(RegionData {
+            location,
+            blocks: blocks.into(),
+            parent_op: None,
+        }))
+    }
+
+    fn contains_tribute_control(&self, op: OpRef) -> bool {
+        self.ctx.op(op).regions.iter().copied().any(|region| {
+            self.ctx.region(region).blocks.iter().copied().any(|block| {
+                self.ctx.block(block).ops.iter().copied().any(|child| {
+                    self.ctx.op(child).dialect == Symbol::new("tribute_control")
+                        || self.contains_tribute_control(child)
+                })
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn lower_structured_if(
+        &mut self,
+        source: OpRef,
+        source_ops: &[OpRef],
+        index: usize,
+        block: BlockRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        if flow.convention != CallingConvention::Cps || self.ctx.op_result_types(source).len() != 1
+        {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(self.ctx.op(source).location),
+                "effectful scf.if requires one result inside a CPS callable",
+            ));
+        }
+        let location = self.ctx.op(source).location;
+        let source_result = self.ctx.op_result(source, 0);
+        let source_result_type = self.ctx.op_result_types(source)[0];
+        let continuation = self.build_suffix_continuation(
+            source_ops,
+            index + 1,
+            source_result,
+            source_result_type,
+            mapping,
+            flow,
+            location,
+        )?;
+        let continuation_op = match self.ctx.value_def(continuation) {
+            trunk_ir::ValueDef::OpResult(op, _) => op,
+            _ => unreachable!("structured continuation is a closure.lambda"),
+        };
+        self.ctx.push_op(block, continuation_op);
+
+        let mut converted_regions = Vec::new();
+        let source_regions = self.ctx.op(source).regions.to_vec();
+        for source_region in source_regions {
+            let source_blocks = self.ctx.region(source_region).blocks.to_vec();
+            let [source_block] = source_blocks.as_slice() else {
+                return Err(TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    Some(source),
+                    Some(location),
+                    "effectful scf.if regions must contain one block",
+                ));
+            };
+            let source_arg_types = self
+                .ctx
+                .block_args(*source_block)
+                .iter()
+                .map(|arg| self.ctx.value_ty(*arg))
+                .collect::<Vec<_>>();
+            let arg_types = source_arg_types
+                .into_iter()
+                .map(|ty| self.convert_type(ty))
+                .collect::<Vec<_>>();
+            let converted_block =
+                self.make_block(self.ctx.block(*source_block).location, &arg_types);
+            let mut branch_mapping = mapping.clone();
+            for (old, new) in self
+                .ctx
+                .block_args(*source_block)
+                .iter()
+                .copied()
+                .zip(self.ctx.block_args(converted_block).iter().copied())
+            {
+                branch_mapping.insert(old, new);
+            }
+            let branch_flow = Flow {
+                exit_k: Some(continuation),
+                ..flow.clone()
+            };
+            self.convert_sequence(
+                self.ctx.block(*source_block).ops.to_vec(),
+                0,
+                converted_block,
+                &mut branch_mapping,
+                &branch_flow,
+            )?;
+            converted_regions.push(self.single_block_region(location, converted_block));
+        }
+        let [then_region, else_region] = converted_regions.as_slice() else {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(location),
+                "scf.if requires exactly two regions",
+            ));
+        };
+        let condition = self.ctx.op_operands(source)[0];
+        let condition = mapping.get(&condition).copied().unwrap_or(condition);
+        let never = self.never_type();
+        let lowered = scf::r#if(
+            self.ctx,
+            location,
+            condition,
+            never,
+            *then_region,
+            *else_region,
+        );
+        self.copy_extra_attrs(source, lowered.op_ref(), &[]);
+        self.ctx.push_op(block, lowered.op_ref());
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn lower_structured_switch(
+        &mut self,
+        source: OpRef,
+        source_ops: &[OpRef],
+        index: usize,
+        block: BlockRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        if flow.convention != CallingConvention::Cps || !self.ctx.op_result_types(source).is_empty()
+        {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(self.ctx.op(source).location),
+                "effectful scf.switch must be resultless inside a CPS callable",
+            ));
+        }
+        let location = self.ctx.op(source).location;
+        let continuation =
+            self.build_void_suffix_continuation(source_ops, index + 1, mapping, flow, location)?;
+        let continuation_op = match self.ctx.value_def(continuation) {
+            trunk_ir::ValueDef::OpResult(op, _) => op,
+            _ => unreachable!("structured continuation is a closure.lambda"),
+        };
+        self.ctx.push_op(block, continuation_op);
+
+        let [source_body] = self.ctx.op(source).regions.as_slice() else {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(location),
+                "scf.switch requires exactly one body region",
+            ));
+        };
+        let source_body_blocks = self.ctx.region(*source_body).blocks.to_vec();
+        let [source_body_block] = source_body_blocks.as_slice() else {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(location),
+                "scf.switch body requires exactly one block",
+            ));
+        };
+        let switch_block = self.make_block(location, &[]);
+        let source_cases = self.ctx.block(*source_body_block).ops.to_vec();
+        for case in source_cases {
+            let case_data = self.ctx.op(case);
+            let case_location = case_data.location;
+            let is_case =
+                case_data.dialect == Symbol::new("scf") && case_data.name == Symbol::new("case");
+            let is_default =
+                case_data.dialect == Symbol::new("scf") && case_data.name == Symbol::new("default");
+            if !is_case && !is_default {
+                return Err(TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    Some(case),
+                    Some(case_location),
+                    "scf.switch body may contain only scf.case and scf.default",
+                ));
+            }
+            let case_regions = case_data.regions.to_vec();
+            let case_value = case_data.attributes.get("value").cloned();
+            let [source_region] = case_regions.as_slice() else {
+                return Err(TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    Some(case),
+                    Some(case_location),
+                    "scf switch arm requires exactly one region",
+                ));
+            };
+            let source_case_blocks = self.ctx.region(*source_region).blocks.to_vec();
+            let [source_case_block] = source_case_blocks.as_slice() else {
+                return Err(TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    Some(case),
+                    Some(case_location),
+                    "scf switch arm requires exactly one block",
+                ));
+            };
+            let source_case_ops = self.ctx.block(*source_case_block).ops.to_vec();
+            let converted_block = self.make_block(case_location, &[]);
+            let mut case_mapping = mapping.clone();
+            let case_flow = Flow {
+                exit_k: Some(continuation),
+                ..flow.clone()
+            };
+            self.convert_sequence(
+                source_case_ops,
+                0,
+                converted_block,
+                &mut case_mapping,
+                &case_flow,
+            )?;
+            let converted_region = self.single_block_region(case_location, converted_block);
+            let converted = if is_case {
+                scf::case(
+                    self.ctx,
+                    case_location,
+                    case_value.unwrap(),
+                    converted_region,
+                )
+                .op_ref()
+            } else {
+                scf::default(self.ctx, case_location, converted_region).op_ref()
+            };
+            self.ctx.push_op(switch_block, converted);
+        }
+        let switch_region = self.single_block_region(location, switch_block);
+        let discriminant = self.ctx.op_operands(source)[0];
+        let discriminant = mapping.get(&discriminant).copied().unwrap_or(discriminant);
+        let lowered = scf::switch(self.ctx, location, discriminant, switch_region);
+        self.copy_extra_attrs(source, lowered.op_ref(), &[]);
+        self.ctx.push_op(block, lowered.op_ref());
+        Ok(())
+    }
+
+    fn emit_exit(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        value: ValueRef,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        if flow.convention == CallingConvention::Cps {
+            let exit_k = flow.exit_k.ok_or_else(|| {
+                TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    None,
+                    Some(location),
+                    "CPS region has no verified exit continuation",
+                )
+            })?;
+            let tail = func::tail_call_indirect(self.ctx, location, exit_k, [value]);
+            set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+            self.ctx.push_op(block, tail.op_ref());
+        } else {
+            let ret = func::r#return(self.ctx, location, [value]);
+            self.ctx.push_op(block, ret.op_ref());
+        }
+        Ok(())
+    }
+
+    fn emit_void_exit(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        let exit_k = flow.exit_k.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "structured region has no verified exit continuation",
+            )
+        })?;
+        let tail =
+            func::tail_call_indirect(self.ctx, location, exit_k, std::iter::empty::<ValueRef>());
+        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(block, tail.op_ref());
+        Ok(())
+    }
+
+    fn build_void_suffix_continuation(
+        &mut self,
+        source_ops: &[OpRef],
+        start: usize,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+        location: Location,
+    ) -> Result<ValueRef, TributeControlToCpsError> {
+        let block = self.make_block(location, &[]);
+        let mut suffix_mapping = mapping.clone();
+        self.convert_sequence(source_ops.to_vec(), start, block, &mut suffix_mapping, flow)?;
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let never = self.never_type();
+        let function = core::func(self.ctx, never, std::iter::empty::<TypeRef>()).as_type_ref();
+        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        Ok(lambda.result(self.ctx))
+    }
+
+    fn lower_lambda(
+        &mut self,
+        source: OpRef,
+        mapping: &mut HashMap<ValueRef, ValueRef>,
+    ) -> Result<OpRef, TributeControlToCpsError> {
+        let location = self.ctx.op(source).location;
+        let logical_ty = self.ctx.op_result_types(source)[0];
+        let callable = tribute_control::Callable::from_type_ref(self.ctx, logical_ty).unwrap();
+        let convention =
+            convert_convention(tribute_control::callable_convention(self.ctx, logical_ty).unwrap());
+        let source_result = callable.result(self.ctx);
+        let source_params = callable.params(self.ctx).to_vec();
+        let result = self.convert_type(source_result);
+        let source_param_types: Vec<_> = source_params
+            .iter()
+            .copied()
+            .map(|ty| self.convert_type(ty))
+            .collect();
+        let evidence = self.evidence_type();
+        let done_k = self.done_k_type(result);
+        let abi = CallableAbi::new(convention, source_param_types.clone(), result);
+        let params = abi.lowered_params(evidence, done_k);
+        let body_source = self.ctx.op(source).regions[0];
+        let entry_source = self.ctx.region(body_source).blocks[0];
+        let block = self.make_block(location, &params);
+        let mut body_mapping = mapping.clone();
+        let offset = abi.source_param_offset();
+        for (old, new) in self
+            .ctx
+            .block_args(entry_source)
+            .to_vec()
+            .into_iter()
+            .zip(self.ctx.block_args(block)[offset..].iter().copied())
+        {
+            body_mapping.insert(old, new);
+        }
+        let evidence_value = convention
+            .needs_evidence()
+            .then(|| self.ctx.block_args(block)[0]);
+        let exit_k = convention
+            .needs_done_k()
+            .then(|| self.ctx.block_args(block)[usize::from(convention.needs_evidence())]);
+        let flow = Flow {
+            convention,
+            evidence: evidence_value,
+            exit_k,
+            root_exit_k: exit_k,
+            answer_type: result,
+        };
+        self.convert_sequence(
+            self.ctx.block(entry_source).ops.to_vec(),
+            0,
+            block,
+            &mut body_mapping,
+            &flow,
+        )?;
+        let body = self.single_block_region(location, block);
+        let captures: Vec<_> = self
+            .ctx
+            .op_operands(source)
+            .iter()
+            .map(|capture| mapping.get(capture).copied().unwrap_or(*capture))
+            .collect();
+        let physical_ty = self.convert_type(logical_ty);
+        let lambda = closure::lambda(self.ctx, location, captures, physical_ty, body);
+        self.copy_extra_attrs(source, lambda.op_ref(), &[CALLING_CONVENTION_ATTR]);
+        set_calling_convention(self.ctx, lambda.op_ref(), convention);
+        Ok(lambda.op_ref())
+    }
+
+    fn current_evidence(
+        &self,
+        source: OpRef,
+        flow: &Flow,
+    ) -> Result<ValueRef, TributeControlToCpsError> {
+        flow.evidence.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(self.ctx.op(source).location),
+                "operation requires evidence but the enclosing callable convention is Direct",
+            )
+        })
+    }
+
+    fn lower_direct_call(
+        &mut self,
+        source: OpRef,
+        target: &CallableInfo,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<func::Call, TributeControlToCpsError> {
+        let location = self.ctx.op(source).location;
+        let mut args = Vec::new();
+        if target.convention.needs_evidence() {
+            args.push(self.current_evidence(source, flow)?);
+        }
+        args.extend(
+            self.ctx
+                .op_operands(source)
+                .iter()
+                .map(|value| mapping.get(value).copied().unwrap_or(*value)),
+        );
+        let result_ty = self.convert_type(target.source_result);
+        let call = func::call(self.ctx, location, args, result_ty, target.symbol);
+        set_calling_convention(self.ctx, call.op_ref(), target.convention);
+        Ok(call)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_suffix_continuation(
+        &mut self,
+        source_ops: &[OpRef],
+        start: usize,
+        source_result: ValueRef,
+        result_type: TypeRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+        location: Location,
+    ) -> Result<ValueRef, TributeControlToCpsError> {
+        let result_type = self.convert_type(result_type);
+        let block = self.make_block(location, &[result_type]);
+        let mut body_mapping = mapping.clone();
+        body_mapping.insert(source_result, self.ctx.block_args(block)[0]);
+        self.convert_sequence(source_ops.to_vec(), start, block, &mut body_mapping, flow)?;
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let never = self.never_type();
+        let function = core::func(self.ctx, never, [result_type]).as_type_ref();
+        let closure_ty = closure::closure(self.ctx, function).as_type_ref();
+        let lambda = closure::lambda(self.ctx, location, captures, closure_ty, region);
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        Ok(lambda.result(self.ctx))
+    }
+
+    fn lower_func_ref(
+        &mut self,
+        source: OpRef,
+    ) -> Result<(Vec<OpRef>, ValueRef), TributeControlToCpsError> {
+        let location = self.ctx.op(source).location;
+        let target_symbol = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_symbol("func_ref")
+            .unwrap();
+        let target = self.funcs.get(&target_symbol).cloned().unwrap();
+        let result_logical_ty = self.ctx.op_result_types(source)[0];
+        let result_callable =
+            tribute_control::Callable::from_type_ref(self.ctx, result_logical_ty).unwrap();
+        let result_convention = convert_convention(
+            tribute_control::callable_convention(self.ctx, result_logical_ty).unwrap(),
+        );
+        let result = self.convert_type(result_callable.result(self.ctx));
+        let source_params: Vec<_> = result_callable
+            .params(self.ctx)
+            .to_vec()
+            .into_iter()
+            .map(|ty| self.convert_type(ty))
+            .collect();
+        let evidence_ty = self.evidence_type();
+        let done_k_ty = self.done_k_type(result);
+        let abi = CallableAbi::new(result_convention, source_params.clone(), result);
+        let logical_params = abi.lowered_params(evidence_ty, done_k_ty);
+        let env_ty = self.anyref_type();
+        let physical_params = abi.interpose_environment(&logical_params, env_ty);
+        let physical_result = if result_convention == CallingConvention::Cps {
+            self.never_type()
+        } else {
+            result
+        };
+        let adapter_ty =
+            core::func(self.ctx, physical_result, physical_params.clone()).as_type_ref();
+        let block = self.make_block(location, &physical_params);
+        let args = self.ctx.block_args(block).to_vec();
+        let evidence_offset = usize::from(result_convention.needs_evidence());
+        let done_offset = evidence_offset + 1;
+        let source_offset = usize::from(result_convention.needs_evidence())
+            + 1
+            + usize::from(result_convention.needs_done_k());
+        let mut target_args = Vec::new();
+        if target.convention.needs_evidence() {
+            target_args.push(args[0]);
+        }
+        if target.convention.needs_done_k() {
+            target_args.push(args[done_offset]);
+        }
+        target_args.extend_from_slice(&args[source_offset..]);
+        if target.convention == CallingConvention::Cps {
+            let tail = func::tail_call(self.ctx, location, target_args, target.symbol);
+            set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+            self.ctx.push_op(block, tail.op_ref());
+        } else {
+            let target_result = self.convert_type(target.source_result);
+            let call = func::call(
+                self.ctx,
+                location,
+                target_args,
+                target_result,
+                target.symbol,
+            );
+            set_calling_convention(self.ctx, call.op_ref(), target.convention);
+            self.ctx.push_op(block, call.op_ref());
+            if result_convention == CallingConvention::Cps {
+                let done_k = args[done_offset];
+                let tail =
+                    func::tail_call_indirect(self.ctx, location, done_k, [call.result(self.ctx)]);
+                set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+                self.ctx.push_op(block, tail.op_ref());
+            } else {
+                let ret = func::r#return(self.ctx, location, [call.result(self.ctx)]);
+                self.ctx.push_op(block, ret.op_ref());
+            }
+        }
+        let region = self.single_block_region(location, block);
+        let adapter_symbol = self.fresh_helper("func_ref_adapter");
+        let adapter = func::func(self.ctx, location, adapter_symbol, adapter_ty, region);
+        set_calling_convention(self.ctx, adapter.op_ref(), result_convention);
+        self.ctx.push_op(self.module_block, adapter.op_ref());
+
+        let empty_env_ty = self.ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("struct"))
+                .attr(
+                    "name",
+                    Attribute::Symbol(Symbol::from_dynamic(&format!("{adapter_symbol}::env"))),
+                )
+                .attr("fields", Attribute::List(vec![]))
+                .build(),
+        );
+        let empty_env = adt::struct_new(
+            self.ctx,
+            location,
+            std::iter::empty::<ValueRef>(),
+            empty_env_ty,
+            empty_env_ty,
+        );
+        let closure_ty = self.convert_type(result_logical_ty);
+        let closure_new = closure::new(
+            self.ctx,
+            location,
+            empty_env.result(self.ctx),
+            closure_ty,
+            adapter_symbol,
+        );
+        set_calling_convention(self.ctx, closure_new.op_ref(), result_convention);
+        Ok((
+            vec![empty_env.op_ref(), closure_new.op_ref()],
+            closure_new.result(self.ctx),
+        ))
+    }
+
+    fn build_completion_continuation(
+        &mut self,
+        source_region: RegionRef,
+        final_k: ValueRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+        location: Location,
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
+        let source_block = self.ctx.region(source_region).blocks[0];
+        let source_arg = self.ctx.block_args(source_block)[0];
+        let arg_type = self.convert_type(self.ctx.value_ty(source_arg));
+        let block = self.make_block(location, &[arg_type]);
+        let mut body_mapping = mapping.clone();
+        body_mapping.insert(source_arg, self.ctx.block_args(block)[0]);
+        let completion_flow = Flow {
+            convention: CallingConvention::Cps,
+            evidence: flow.evidence,
+            exit_k: Some(final_k),
+            root_exit_k: Some(final_k),
+            answer_type: flow.answer_type,
+        };
+        self.convert_sequence(
+            self.ctx.block(source_block).ops.to_vec(),
+            0,
+            block,
+            &mut body_mapping,
+            &completion_flow,
+        )?;
+        let body = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, body);
+        let never = self.never_type();
+        let function = core::func(self.ctx, never, [arg_type]).as_type_ref();
+        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let lambda = closure::lambda(self.ctx, location, captures, closure_type, body);
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        Ok((lambda.op_ref(), lambda.result(self.ctx)))
+    }
+
+    fn rebind_generated_continuation(
+        &mut self,
+        value: ValueRef,
+        old_root: ValueRef,
+        new_root: ValueRef,
+        destination: BlockRef,
+        cache: &mut HashMap<ValueRef, ValueRef>,
+    ) -> Result<ValueRef, TributeControlToCpsError> {
+        if value == old_root {
+            return Ok(new_root);
+        }
+        if let Some(rebound) = cache.get(&value) {
+            return Ok(*rebound);
+        }
+        let trunk_ir::ValueDef::OpResult(def, _) = self.ctx.value_def(value) else {
+            return Ok(value);
+        };
+        if !closure::Lambda::matches(self.ctx, def) {
+            return Ok(value);
+        }
+        let mut mapping = HashMap::from([(old_root, new_root)]);
+        for capture in self.ctx.op_operands(def).to_vec() {
+            let rebound = self.rebind_generated_continuation(
+                capture,
+                old_root,
+                new_root,
+                destination,
+                cache,
+            )?;
+            mapping.insert(capture, rebound);
+        }
+        let rebound_op = self.clone_plain_op(def, &mut mapping)?;
+        self.ctx.push_op(destination, rebound_op);
+        let rebound = self.ctx.op_result(rebound_op, 0);
+        cache.insert(value, rebound);
+        Ok(rebound)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_raw_resumption(
+        &mut self,
+        source_ops: &[OpRef],
+        start: usize,
+        source_result: ValueRef,
+        input_type: TypeRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+        location: Location,
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
+        let input_type = self.convert_type(input_type);
+        let done_k_type = self.done_k_type(flow.answer_type);
+        let block = self.make_block(location, &[done_k_type, input_type]);
+        let resume_done = self.ctx.block_args(block)[0];
+        let resume_input = self.ctx.block_args(block)[1];
+        let mut body_mapping = mapping.clone();
+        body_mapping.insert(source_result, resume_input);
+        let mut suffix_flow = flow.clone();
+        let old_root = flow.root_exit_k.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "resumptive computation has no root continuation",
+            )
+        })?;
+        let current_exit = flow.exit_k.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "resumptive computation has no current continuation",
+            )
+        })?;
+        let rebound_exit = self.rebind_generated_continuation(
+            current_exit,
+            old_root,
+            resume_done,
+            block,
+            &mut HashMap::new(),
+        )?;
+        suffix_flow.exit_k = Some(rebound_exit);
+        suffix_flow.root_exit_k = Some(resume_done);
+        self.convert_sequence(
+            source_ops.to_vec(),
+            start,
+            block,
+            &mut body_mapping,
+            &suffix_flow,
+        )?;
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let closure_type = self.resumption_type(input_type, flow.answer_type);
+        let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        Ok((lambda.op_ref(), lambda.result(self.ctx)))
+    }
+
+    fn build_one_shot_wrapper(
+        &mut self,
+        raw_continuation: ValueRef,
+        input_type: TypeRef,
+        answer_type: TypeRef,
+        location: Location,
+    ) -> (Vec<OpRef>, ValueRef) {
+        let i1_type = self
+            .ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i1")).build());
+        let state_name = self.fresh_helper("one_shot_state");
+        let state_type = self.ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("struct"))
+                .attr("name", Attribute::Symbol(state_name))
+                .attr(
+                    "fields",
+                    Attribute::List(vec![Attribute::List(vec![
+                        Attribute::Symbol(Symbol::new("consumed")),
+                        Attribute::Type(i1_type),
+                    ])]),
+                )
+                .build(),
+        );
+        let not_consumed = arith::r#const(self.ctx, location, i1_type, Attribute::Int(0));
+        let state = adt::struct_new(
+            self.ctx,
+            location,
+            [not_consumed.result(self.ctx)],
+            state_type,
+            state_type,
+        );
+
+        let done_k_type = self.done_k_type(answer_type);
+        let block = self.make_block(location, &[done_k_type, input_type]);
+        let args = self.ctx.block_args(block).to_vec();
+        let consumed = adt::struct_get(
+            self.ctx,
+            location,
+            state.result(self.ctx),
+            i1_type,
+            state_type,
+            0,
+        );
+        self.ctx.push_op(block, consumed.op_ref());
+
+        let reject_block = self.make_block(location, &[]);
+        let unreachable = func::unreachable(self.ctx, location);
+        self.ctx.push_op(reject_block, unreachable.op_ref());
+        let reject_region = self.single_block_region(location, reject_block);
+
+        let enter_block = self.make_block(location, &[]);
+        let consumed_true = arith::r#const(self.ctx, location, i1_type, Attribute::Int(1));
+        self.ctx.push_op(enter_block, consumed_true.op_ref());
+        let mark = adt::struct_set(
+            self.ctx,
+            location,
+            state.result(self.ctx),
+            consumed_true.result(self.ctx),
+            state_type,
+            0,
+        );
+        self.ctx.push_op(enter_block, mark.op_ref());
+        let tail =
+            func::tail_call_indirect(self.ctx, location, raw_continuation, args.iter().copied());
+        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(enter_block, tail.op_ref());
+        let enter_region = self.single_block_region(location, enter_block);
+
+        let never = self.never_type();
+        let guard = scf::r#if(
+            self.ctx,
+            location,
+            consumed.result(self.ctx),
+            never,
+            reject_region,
+            enter_region,
+        );
+        self.ctx.push_op(block, guard.op_ref());
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let closure_type = self.resumption_type(input_type, answer_type);
+        let wrapper = closure::lambda(self.ctx, location, captures, closure_type, region);
+        set_calling_convention(self.ctx, wrapper.op_ref(), CallingConvention::Cps);
+        (
+            vec![not_consumed.op_ref(), state.op_ref(), wrapper.op_ref()],
+            wrapper.result(self.ctx),
+        )
+    }
+
+    fn build_reject_continuation(
+        &mut self,
+        input_type: TypeRef,
+        answer_type: TypeRef,
+        location: Location,
+    ) -> (OpRef, ValueRef) {
+        let input_type = self.convert_type(input_type);
+        let done_k_type = self.done_k_type(answer_type);
+        let block = self.make_block(location, &[done_k_type, input_type]);
+        let unreachable = func::unreachable(self.ctx, location);
+        self.ctx.push_op(block, unreachable.op_ref());
+        let region = self.single_block_region(location, block);
+        let closure_type = self.resumption_type(input_type, answer_type);
+        let lambda = closure::lambda(
+            self.ctx,
+            location,
+            std::iter::empty::<ValueRef>(),
+            closure_type,
+            region,
+        );
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        (lambda.op_ref(), lambda.result(self.ctx))
+    }
+
+    fn lower_general_perform(
+        &mut self,
+        source: OpRef,
+        source_ops: &[OpRef],
+        index: usize,
+        block: BlockRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        if flow.convention != CallingConvention::Cps {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(self.ctx.op(source).location),
+                "general operation appears in a non-CPS callable",
+            ));
+        }
+        let location = self.ctx.op(source).location;
+        let old_result = self.ctx.op_result(source, 0);
+        let input_type = self.ctx.op_result_types(source)[0];
+        let continuation = if type_is(self.ctx, input_type, "core", "never") {
+            let (op, value) =
+                self.build_reject_continuation(input_type, flow.answer_type, location);
+            self.ctx.push_op(block, op);
+            value
+        } else {
+            let (raw_op, raw) = self.build_raw_resumption(
+                source_ops,
+                index + 1,
+                old_result,
+                input_type,
+                mapping,
+                flow,
+                location,
+            )?;
+            self.ctx.push_op(block, raw_op);
+            let converted_input = self.convert_type(input_type);
+            let (ops, one_shot) =
+                self.build_one_shot_wrapper(raw, converted_input, flow.answer_type, location);
+            for op in ops {
+                self.ctx.push_op(block, op);
+            }
+            one_shot
+        };
+        let args: Vec<_> = self
+            .ctx
+            .op_operands(source)
+            .iter()
+            .map(|arg| mapping.get(arg).copied().unwrap_or(*arg))
+            .collect();
+        let never = self.never_type();
+        let perform = ability::perform(
+            self.ctx,
+            location,
+            continuation,
+            args,
+            never,
+            self.ctx
+                .op(source)
+                .attributes
+                .get_type("ability_ref")
+                .unwrap(),
+            self.ctx
+                .op(source)
+                .attributes
+                .get_symbol("op_name")
+                .unwrap(),
+        );
+        self.ctx.push_op(block, perform.op_ref());
+        Ok(())
+    }
+
+    fn lower_resume(
+        &mut self,
+        source: OpRef,
+        source_ops: &[OpRef],
+        index: usize,
+        block: BlockRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        if flow.convention != CallingConvention::Cps {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(self.ctx.op(source).location),
+                "resume appears outside a CPS handler arm",
+            ));
+        }
+        let location = self.ctx.op(source).location;
+        let token_source = self.ctx.op_operands(source)[0];
+        let value_source = self.ctx.op_operands(source)[1];
+        let token = mapping.get(&token_source).copied().unwrap_or(token_source);
+        let value = mapping.get(&value_source).copied().unwrap_or(value_source);
+        let old_result = self.ctx.op_result(source, 0);
+        let result_type = self.ctx.op_result_types(source)[0];
+        let suffix = self.build_suffix_continuation(
+            source_ops,
+            index + 1,
+            old_result,
+            result_type,
+            mapping,
+            flow,
+            location,
+        )?;
+        let suffix_op = match self.ctx.value_def(suffix) {
+            trunk_ir::ValueDef::OpResult(op, _) => op,
+            _ => unreachable!("suffix is produced by closure.lambda"),
+        };
+        self.ctx.push_op(block, suffix_op);
+        let tail = func::tail_call_indirect(self.ctx, location, token, [suffix, value]);
+        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(block, tail.op_ref());
+        Ok(())
+    }
+
+    fn lower_handler_arm(
+        &mut self,
+        source: OpRef,
+        outer_mapping: &HashMap<ValueRef, ValueRef>,
+        handle_exit: ValueRef,
+        handle_answer: TypeRef,
+    ) -> Result<HandlerArmInfo, TributeControlToCpsError> {
+        let location = self.ctx.op(source).location;
+        let ability_ref = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_type("ability_ref")
+            .unwrap();
+        let op_name = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_symbol("op_name")
+            .unwrap();
+        let kind = self.ctx.op(source).attributes.get_symbol("kind").unwrap();
+        let operation_result = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_type("operation_result_type")
+            .unwrap();
+        let source_region = self.ctx.op(source).regions[0];
+        let source_block = self.ctx.region(source_region).blocks[0];
+        let source_args = self.ctx.block_args(source_block).to_vec();
+        let has_resume_token = source_args.last().is_some_and(|arg| {
+            type_is(
+                self.ctx,
+                self.ctx.value_ty(*arg),
+                "tribute_control",
+                "resume_token",
+            )
+        });
+        let evidence_type = self.evidence_type();
+        let converted_args: Vec<_> = source_args
+            .iter()
+            .map(|arg| self.convert_type(self.ctx.value_ty(*arg)))
+            .collect();
+        let mut params = vec![evidence_type];
+        params.extend_from_slice(&converted_args);
+        let block = self.make_block(location, &params);
+        let mut mapping = outer_mapping.clone();
+        for (old, new) in source_args
+            .into_iter()
+            .zip(self.ctx.block_args(block)[1..].iter().copied())
+        {
+            mapping.insert(old, new);
+        }
+        let evidence = self.ctx.block_args(block)[0];
+        let convention = if kind == Symbol::new("fn") {
+            CallingConvention::EvidenceDirect
+        } else {
+            CallingConvention::Cps
+        };
+        let flow = Flow {
+            convention,
+            evidence: Some(evidence),
+            exit_k: (convention == CallingConvention::Cps).then_some(handle_exit),
+            root_exit_k: (convention == CallingConvention::Cps).then_some(handle_exit),
+            answer_type: handle_answer,
+        };
+        self.convert_sequence(
+            self.ctx.block(source_block).ops.to_vec(),
+            0,
+            block,
+            &mut mapping,
+            &flow,
+        )?;
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let result = if convention == CallingConvention::Cps {
+            self.never_type()
+        } else {
+            self.convert_type(operation_result)
+        };
+        let function = core::func(self.ctx, result, params).as_type_ref();
+        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
+        set_calling_convention(self.ctx, lambda.op_ref(), convention);
+        Ok(HandlerArmInfo {
+            op: lambda.op_ref(),
+            value: lambda.result(self.ctx),
+            ability_ref,
+            op_name,
+            kind,
+            operation_result: self.convert_type(operation_result),
+            params: converted_args,
+            has_resume_token,
+        })
+    }
+
+    fn unpack_handler_payload(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        payload: ValueRef,
+        arm: &HandlerArmInfo,
+    ) -> Vec<ValueRef> {
+        let value_params = if arm.has_resume_token {
+            &arm.params[..arm.params.len() - 1]
+        } else {
+            arm.params.as_slice()
+        };
+        let payload_type = ability::operation_payload_type_ref(
+            self.ctx,
+            arm.ability_ref,
+            arm.op_name,
+            value_params.iter().copied(),
+        );
+        let cast = core::unrealized_conversion_cast(self.ctx, location, payload, payload_type);
+        self.ctx.push_op(block, cast.op_ref());
+        value_params
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(index, ty)| {
+                let get = adt::struct_get(
+                    self.ctx,
+                    location,
+                    cast.result(self.ctx),
+                    ty,
+                    payload_type,
+                    index as u32,
+                );
+                self.ctx.push_op(block, get.op_ref());
+                get.result(self.ctx)
+            })
+            .collect()
+    }
+
+    fn build_handler_dispatcher(
+        &mut self,
+        location: Location,
+        arms: &[HandlerArmInfo],
+        general: bool,
+    ) -> (OpRef, ValueRef) {
+        let evidence_type = self.evidence_type();
+        let anyref = self.anyref_type();
+        let i32_type = self
+            .ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let params = if general {
+            vec![evidence_type, anyref, i32_type, anyref]
+        } else {
+            vec![evidence_type, i32_type, anyref]
+        };
+        let result = if general { self.never_type() } else { anyref };
+        let block = self.make_block(location, &params);
+        let args = self.ctx.block_args(block).to_vec();
+        let evidence = args[0];
+        let (continuation, op_idx, payload) = if general {
+            (Some(args[1]), args[2], args[3])
+        } else {
+            (None, args[1], args[2])
+        };
+
+        let switch_block = self.make_block(location, &[]);
+        let selected: Vec<_> = arms
+            .iter()
+            .filter(|arm| (arm.kind == Symbol::new("op")) == general)
+            .collect();
+        for arm in selected {
+            let case_block = self.make_block(location, &[]);
+            let mut call_args = vec![evidence];
+            call_args.extend(self.unpack_handler_payload(case_block, location, payload, arm));
+            if arm.has_resume_token {
+                let token_type = *arm.params.last().unwrap();
+                let token = core::unrealized_conversion_cast(
+                    self.ctx,
+                    location,
+                    continuation.expect("general dispatcher has a continuation"),
+                    token_type,
+                );
+                self.ctx.push_op(case_block, token.op_ref());
+                call_args.push(token.result(self.ctx));
+            }
+            if general {
+                let tail = func::tail_call_indirect(self.ctx, location, arm.value, call_args);
+                set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+                self.ctx.push_op(case_block, tail.op_ref());
+            } else {
+                let call = func::call_indirect(
+                    self.ctx,
+                    location,
+                    arm.value,
+                    call_args,
+                    arm.operation_result,
+                );
+                set_calling_convention(self.ctx, call.op_ref(), CallingConvention::EvidenceDirect);
+                self.ctx.push_op(case_block, call.op_ref());
+                let erased = core::unrealized_conversion_cast(
+                    self.ctx,
+                    location,
+                    call.result(self.ctx),
+                    anyref,
+                );
+                self.ctx.push_op(case_block, erased.op_ref());
+                let ret = func::r#return(self.ctx, location, [erased.result(self.ctx)]);
+                self.ctx.push_op(case_block, ret.op_ref());
+            }
+            let case_region = self.single_block_region(location, case_block);
+            let op_index = ability::compute_op_idx(
+                self.ctx.types.get(arm.ability_ref).attrs.get_symbol("name"),
+                Some(arm.op_name),
+            );
+            let case = scf::case(
+                self.ctx,
+                location,
+                Attribute::Int(op_index as i128),
+                case_region,
+            );
+            self.ctx.push_op(switch_block, case.op_ref());
+        }
+        let reject_block = self.make_block(location, &[]);
+        let unreachable = func::unreachable(self.ctx, location);
+        self.ctx.push_op(reject_block, unreachable.op_ref());
+        let reject_region = self.single_block_region(location, reject_block);
+        let default = scf::default(self.ctx, location, reject_region);
+        self.ctx.push_op(switch_block, default.op_ref());
+        let switch_region = self.single_block_region(location, switch_block);
+        let switch = scf::switch(self.ctx, location, op_idx, switch_region);
+        self.ctx.push_op(block, switch.op_ref());
+
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let function = core::func(self.ctx, result, params).as_type_ref();
+        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
+        set_calling_convention(
+            self.ctx,
+            lambda.op_ref(),
+            if general {
+                CallingConvention::Cps
+            } else {
+                CallingConvention::EvidenceDirect
+            },
+        );
+        (lambda.op_ref(), lambda.result(self.ctx))
+    }
+
+    fn lower_handle(
+        &mut self,
+        source: OpRef,
+        source_ops: &[OpRef],
+        index: usize,
+        block: BlockRef,
+        mapping: &HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        if flow.convention != CallingConvention::Cps {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(self.ctx.op(source).location),
+                "handle appears in a non-CPS callable",
+            ));
+        }
+        let location = self.ctx.op(source).location;
+        let handle_result_source = self.ctx.op_result(source, 0);
+        let handle_answer_source = self.ctx.op_result_types(source)[0];
+        let handle_answer = self.convert_type(handle_answer_source);
+        let after_handle = self.build_suffix_continuation(
+            source_ops,
+            index + 1,
+            handle_result_source,
+            handle_answer_source,
+            mapping,
+            flow,
+            location,
+        )?;
+        let after_handle_op = match self.ctx.value_def(after_handle) {
+            trunk_ir::ValueDef::OpResult(op, _) => op,
+            _ => unreachable!("handle continuation is produced by closure.lambda"),
+        };
+        self.ctx.push_op(block, after_handle_op);
+
+        let handlers_region = self.ctx.op(source).regions[2];
+        let handlers_block = self.ctx.region(handlers_region).blocks[0];
+        let mut handler_arms = Vec::new();
+        let source_handlers = self.ctx.block(handlers_block).ops.to_vec();
+        for handler in source_handlers {
+            let arm = self.lower_handler_arm(handler, mapping, after_handle, handle_answer)?;
+            self.ctx.push_op(block, arm.op);
+            handler_arms.push(arm);
+        }
+
+        let mut ability_refs = Vec::new();
+        for arm in &handler_arms {
+            if !ability_refs.contains(&arm.ability_ref) {
+                ability_refs.push(arm.ability_ref);
+            }
+        }
+        let mut dispatchers = Vec::new();
+        for ability_ref in ability_refs.iter().copied() {
+            let ability_arms = handler_arms
+                .iter()
+                .filter(|arm| arm.ability_ref == ability_ref)
+                .cloned()
+                .collect::<Vec<_>>();
+            let (tr_op, tr_value) = self.build_handler_dispatcher(location, &ability_arms, false);
+            self.ctx.push_op(block, tr_op);
+            dispatchers.push(tr_value);
+            let (handler_op, handler_value) =
+                self.build_handler_dispatcher(location, &ability_arms, true);
+            self.ctx.push_op(block, handler_op);
+            dispatchers.push(handler_value);
+        }
+
+        let evidence_type = self.evidence_type();
+        let body_block = self.make_block(location, &[evidence_type]);
+        let extended_evidence = self.ctx.block_args(body_block)[0];
+        let mut body_mapping = mapping.clone();
+        let body_flow_base = Flow {
+            convention: CallingConvention::Cps,
+            evidence: Some(extended_evidence),
+            exit_k: Some(after_handle),
+            root_exit_k: Some(after_handle),
+            answer_type: handle_answer,
+        };
+        let completion_source = self.ctx.op(source).regions[1];
+        let (completion_op, completion_k) = self.build_completion_continuation(
+            completion_source,
+            after_handle,
+            &body_mapping,
+            &body_flow_base,
+            location,
+        )?;
+        self.ctx.push_op(body_block, completion_op);
+        let body_flow = Flow {
+            exit_k: Some(completion_k),
+            ..body_flow_base
+        };
+        let body_source = self.ctx.op(source).regions[0];
+        let source_body_block = self.ctx.region(body_source).blocks[0];
+        self.convert_sequence(
+            self.ctx.block(source_body_block).ops.to_vec(),
+            0,
+            body_block,
+            &mut body_mapping,
+            &body_flow,
+        )?;
+        let body_region = self.single_block_region(location, body_block);
+        let current_evidence = self.current_evidence(source, flow)?;
+        let dispatch = ability::handle_dispatch(
+            self.ctx,
+            location,
+            current_evidence,
+            dispatchers,
+            Attribute::List(ability_refs.into_iter().map(Attribute::Type).collect()),
+            body_region,
+        );
+        self.ctx.push_op(block, dispatch.op_ref());
+        Ok(())
+    }
+
+    fn convert_sequence(
+        &mut self,
+        source_ops: Vec<OpRef>,
+        mut index: usize,
+        block: BlockRef,
+        mapping: &mut HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        while index < source_ops.len() {
+            let source = source_ops[index];
+            let location = self.ctx.op(source).location;
+            let dialect = self.ctx.op(source).dialect;
+            let name = self.ctx.op(source).name;
+            if dialect == Symbol::new("scf") && name == Symbol::new("yield") {
+                let values = self.ctx.op_operands(source);
+                if values.is_empty() {
+                    self.emit_void_exit(block, location, flow)?;
+                    return Ok(());
+                }
+                if values.len() != 1 {
+                    return Err(TributeControlToCpsError::one(
+                        POST_CPS_BOUNDARY,
+                        Some(source),
+                        Some(location),
+                        "CPS structured exit requires exactly one scf.yield value",
+                    ));
+                }
+                let value = mapping.get(&values[0]).copied().unwrap_or(values[0]);
+                self.emit_exit(block, location, value, flow)?;
+                return Ok(());
+            }
+            if dialect == Symbol::new("scf")
+                && name == Symbol::new("switch")
+                && self.contains_tribute_control(source)
+            {
+                self.lower_structured_switch(source, &source_ops, index, block, mapping, flow)?;
+                return Ok(());
+            }
+            if dialect == Symbol::new("scf")
+                && name == Symbol::new("if")
+                && self.contains_tribute_control(source)
+            {
+                self.lower_structured_if(source, &source_ops, index, block, mapping, flow)?;
+                return Ok(());
+            }
+            if dialect != Symbol::new("tribute_control") {
+                let cloned = self.clone_plain_op(source, mapping)?;
+                self.ctx.push_op(block, cloned);
+                index += 1;
+                continue;
+            }
+
+            match name.with_str(|value| value.to_owned()).as_str() {
+                "return" | "yield" => {
+                    let value = self.ctx.op_operands(source)[0];
+                    let value = mapping.get(&value).copied().unwrap_or(value);
+                    self.emit_exit(block, location, value, flow)?;
+                    return Ok(());
+                }
+                "lambda" => {
+                    let lambda = self.lower_lambda(source, mapping)?;
+                    self.ctx.push_op(block, lambda);
+                    mapping.insert(self.ctx.op_result(source, 0), self.ctx.op_result(lambda, 0));
+                    index += 1;
+                }
+                "func_ref" => {
+                    let (ops, value) = self.lower_func_ref(source)?;
+                    for op in ops {
+                        self.ctx.push_op(block, op);
+                    }
+                    mapping.insert(self.ctx.op_result(source, 0), value);
+                    index += 1;
+                }
+                "call" => {
+                    let target_symbol =
+                        self.ctx.op(source).attributes.get_symbol("callee").unwrap();
+                    let target = self.funcs.get(&target_symbol).cloned().unwrap();
+                    if target.convention == CallingConvention::Cps {
+                        if flow.convention != CallingConvention::Cps {
+                            return Err(TributeControlToCpsError::one(
+                                POST_CPS_BOUNDARY,
+                                Some(source),
+                                Some(location),
+                                "a non-CPS callable cannot call a CPS target",
+                            ));
+                        }
+                        let old_result = self.ctx.op_result(source, 0);
+                        let result_type = self.ctx.op_result_types(source)[0];
+                        let continuation = self.build_suffix_continuation(
+                            &source_ops,
+                            index + 1,
+                            old_result,
+                            result_type,
+                            mapping,
+                            flow,
+                            location,
+                        )?;
+                        let continuation_op = match self.ctx.value_def(continuation) {
+                            trunk_ir::ValueDef::OpResult(op, _) => op,
+                            _ => unreachable!("continuation is produced by closure.lambda"),
+                        };
+                        self.ctx.push_op(block, continuation_op);
+                        let mut args = vec![self.current_evidence(source, flow)?, continuation];
+                        args.extend(
+                            self.ctx
+                                .op_operands(source)
+                                .iter()
+                                .map(|arg| mapping.get(arg).copied().unwrap_or(*arg)),
+                        );
+                        let tail = func::tail_call(self.ctx, location, args, target_symbol);
+                        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+                        self.ctx.push_op(block, tail.op_ref());
+                        return Ok(());
+                    }
+                    let call = self.lower_direct_call(source, &target, mapping, flow)?;
+                    self.ctx.push_op(block, call.op_ref());
+                    mapping.insert(self.ctx.op_result(source, 0), call.result(self.ctx));
+                    index += 1;
+                }
+                "call_indirect" => {
+                    let source_callee = self.ctx.op_operands(source)[0];
+                    let logical_type = self.ctx.value_ty(source_callee);
+                    let convention = convert_convention(
+                        tribute_control::callable_convention(self.ctx, logical_type).unwrap(),
+                    );
+                    let callee = mapping
+                        .get(&source_callee)
+                        .copied()
+                        .unwrap_or(source_callee);
+                    let source_args = self.ctx.op_operands(source)[1..].to_vec();
+                    if convention == CallingConvention::Cps {
+                        if flow.convention != CallingConvention::Cps {
+                            return Err(TributeControlToCpsError::one(
+                                POST_CPS_BOUNDARY,
+                                Some(source),
+                                Some(location),
+                                "a non-CPS callable cannot make a CPS indirect call",
+                            ));
+                        }
+                        let old_result = self.ctx.op_result(source, 0);
+                        let result_type = self.ctx.op_result_types(source)[0];
+                        let continuation = self.build_suffix_continuation(
+                            &source_ops,
+                            index + 1,
+                            old_result,
+                            result_type,
+                            mapping,
+                            flow,
+                            location,
+                        )?;
+                        let continuation_op = match self.ctx.value_def(continuation) {
+                            trunk_ir::ValueDef::OpResult(op, _) => op,
+                            _ => unreachable!("continuation is produced by closure.lambda"),
+                        };
+                        self.ctx.push_op(block, continuation_op);
+                        let mut args = vec![self.current_evidence(source, flow)?, continuation];
+                        args.extend(
+                            source_args
+                                .iter()
+                                .map(|arg| mapping.get(arg).copied().unwrap_or(*arg)),
+                        );
+                        let tail = func::tail_call_indirect(self.ctx, location, callee, args);
+                        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+                        self.ctx.push_op(block, tail.op_ref());
+                        return Ok(());
+                    }
+                    let mut args = Vec::new();
+                    if convention.needs_evidence() {
+                        args.push(self.current_evidence(source, flow)?);
+                    }
+                    args.extend(
+                        source_args
+                            .iter()
+                            .map(|arg| mapping.get(arg).copied().unwrap_or(*arg)),
+                    );
+                    let result_type = self.convert_type(self.ctx.op_result_types(source)[0]);
+                    let call = func::call_indirect(self.ctx, location, callee, args, result_type);
+                    set_calling_convention(self.ctx, call.op_ref(), convention);
+                    self.ctx.push_op(block, call.op_ref());
+                    mapping.insert(self.ctx.op_result(source, 0), call.result(self.ctx));
+                    index += 1;
+                }
+                "perform" => {
+                    let kind = self
+                        .ctx
+                        .op(source)
+                        .attributes
+                        .get_symbol("operation_kind")
+                        .unwrap();
+                    if kind == Symbol::new("fn") {
+                        let evidence = self.current_evidence(source, flow)?;
+                        let _ = evidence;
+                        let args: Vec<_> = self
+                            .ctx
+                            .op_operands(source)
+                            .iter()
+                            .map(|arg| mapping.get(arg).copied().unwrap_or(*arg))
+                            .collect();
+                        let result_type = self.convert_type(self.ctx.op_result_types(source)[0]);
+                        let call = ability::call(
+                            self.ctx,
+                            location,
+                            args,
+                            result_type,
+                            self.ctx
+                                .op(source)
+                                .attributes
+                                .get_type("ability_ref")
+                                .unwrap(),
+                            self.ctx
+                                .op(source)
+                                .attributes
+                                .get_symbol("op_name")
+                                .unwrap(),
+                        );
+                        self.ctx.push_op(block, call.op_ref());
+                        mapping.insert(self.ctx.op_result(source, 0), call.result(self.ctx));
+                        index += 1;
+                    } else {
+                        self.lower_general_perform(
+                            source,
+                            &source_ops,
+                            index,
+                            block,
+                            mapping,
+                            flow,
+                        )?;
+                        return Ok(());
+                    }
+                }
+                "resume" => {
+                    self.lower_resume(source, &source_ops, index, block, mapping, flow)?;
+                    return Ok(());
+                }
+                "handle" => {
+                    self.lower_handle(source, &source_ops, index, block, mapping, flow)?;
+                    return Ok(());
+                }
+                other => {
+                    return Err(TributeControlToCpsError::one(
+                        POST_CPS_BOUNDARY,
+                        Some(source),
+                        Some(location),
+                        format!("unsupported tribute_control operation '{other}'"),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn convert_func(&mut self, source: OpRef) -> Result<OpRef, TributeControlToCpsError> {
+        let location = self.ctx.op(source).location;
+        let symbol = self
+            .ctx
+            .op(source)
+            .attributes
+            .get_symbol("sym_name")
+            .unwrap();
+        let logical_type = self.ctx.op(source).attributes.get_type("type").unwrap();
+        let info = self.funcs.get(&symbol).cloned().unwrap();
+        let physical_type = self.physical_function_type(logical_type);
+        if self.ctx.op(source).regions.is_empty() {
+            let mut builder =
+                OperationDataBuilder::new(location, Symbol::new("func"), Symbol::new("func"))
+                    .attr("sym_name", Attribute::Symbol(symbol))
+                    .attr("type", Attribute::Type(physical_type));
+            for (key, value) in self.convert_attrs(&self.ctx.op(source).attributes.clone()) {
+                if key != Symbol::new("sym_name") && key != Symbol::new("type") {
+                    builder = builder.attr(key, value);
+                }
+            }
+            let data = builder.build(self.ctx);
+            let declaration = self.ctx.create_op(data);
+            set_calling_convention(self.ctx, declaration, info.convention);
+            return Ok(declaration);
+        }
+
+        let source_region = self.ctx.op(source).regions[0];
+        let source_block = self.ctx.region(source_region).blocks[0];
+        let source_result = self.convert_type(info.source_result);
+        let source_params: Vec<_> = info
+            .source_params
+            .iter()
+            .copied()
+            .map(|ty| self.convert_type(ty))
+            .collect();
+        let abi = CallableAbi::new(info.convention, source_params, source_result);
+        let evidence_ty = self.evidence_type();
+        let done_k_ty = self.done_k_type(source_result);
+        let params = abi.lowered_params(evidence_ty, done_k_ty);
+        let block = self.make_block(location, &params);
+        let mut mapping = HashMap::new();
+        for (old, new) in self.ctx.block_args(source_block).to_vec().into_iter().zip(
+            self.ctx.block_args(block)[abi.source_param_offset()..]
+                .iter()
+                .copied(),
+        ) {
+            mapping.insert(old, new);
+        }
+        let evidence = info
+            .convention
+            .needs_evidence()
+            .then(|| self.ctx.block_args(block)[0]);
+        let exit_k = info
+            .convention
+            .needs_done_k()
+            .then(|| self.ctx.block_args(block)[usize::from(info.convention.needs_evidence())]);
+        let flow = Flow {
+            convention: info.convention,
+            evidence,
+            exit_k,
+            root_exit_k: exit_k,
+            answer_type: source_result,
+        };
+        self.convert_sequence(
+            self.ctx.block(source_block).ops.to_vec(),
+            0,
+            block,
+            &mut mapping,
+            &flow,
+        )?;
+        let region = self.single_block_region(location, block);
+        let function = func::func(self.ctx, location, symbol, physical_type, region);
+        self.copy_extra_attrs(
+            source,
+            function.op_ref(),
+            &["sym_name", "type", CALLING_CONVENTION_ATTR],
+        );
+        set_calling_convention(self.ctx, function.op_ref(), info.convention);
+        Ok(function.op_ref())
+    }
+}
+
+fn collect_defined_values(ctx: &IrContext, region: RegionRef, defined: &mut HashSet<ValueRef>) {
+    for block in ctx.region(region).blocks.iter().copied() {
+        defined.extend(ctx.block_args(block).iter().copied());
+        for op in ctx.block(block).ops.iter().copied() {
+            defined.extend(ctx.op_results(op).iter().copied());
+            for nested in ctx.op(op).regions.iter().copied() {
+                collect_defined_values(ctx, nested, defined);
+            }
+        }
+    }
+}
+
+fn collect_external_in_order(
+    ctx: &IrContext,
+    region: RegionRef,
+    defined: &HashSet<ValueRef>,
+    seen: &mut HashSet<ValueRef>,
+    external: &mut Vec<ValueRef>,
+) {
+    for block in ctx.region(region).blocks.iter().copied() {
+        for op in ctx.block(block).ops.iter().copied() {
+            for operand in ctx.op_operands(op).iter().copied() {
+                if !defined.contains(&operand) && seen.insert(operand) {
+                    external.push(operand);
+                }
+            }
+            for nested in ctx.op(op).regions.iter().copied() {
+                collect_external_in_order(ctx, nested, defined, seen, external);
+            }
+        }
+    }
+}
+
+fn ordered_external_values(ctx: &IrContext, region: RegionRef) -> Vec<ValueRef> {
+    let mut defined = HashSet::new();
+    collect_defined_values(ctx, region, &mut defined);
+    let mut seen = HashSet::new();
+    let mut external = Vec::new();
+    collect_external_in_order(ctx, region, &defined, &mut seen, &mut external);
+    external
+}
+
+fn collect_callable_graph(
+    ctx: &IrContext,
+    module: Module,
+) -> Result<HashMap<Symbol, CallableInfo>, TributeControlToCpsError> {
+    let mut funcs = HashMap::new();
+    fn visit(ctx: &IrContext, region: RegionRef, funcs: &mut HashMap<Symbol, CallableInfo>) {
+        for block in ctx.region(region).blocks.iter().copied() {
+            for op in ctx.block(block).ops.iter().copied() {
+                if tribute_control::Func::matches(ctx, op) {
+                    let symbol = ctx.op(op).attributes.get_symbol("sym_name").unwrap();
+                    let logical_type = ctx.op(op).attributes.get_type("type").unwrap();
+                    let callable =
+                        tribute_control::Callable::from_type_ref(ctx, logical_type).unwrap();
+                    funcs.insert(
+                        symbol,
+                        CallableInfo {
+                            symbol,
+                            convention: convert_convention(
+                                tribute_control::callable_convention(ctx, logical_type).unwrap(),
+                            ),
+                            source_result: callable.result(ctx),
+                            source_params: callable.params(ctx).to_vec(),
+                        },
+                    );
+                }
+                for nested in ctx.op(op).regions.iter().copied() {
+                    visit(ctx, nested, funcs);
+                }
+            }
+        }
+    }
+    if let Some(body) = module.body(ctx) {
+        visit(ctx, body, &mut funcs);
+    }
+    Ok(funcs)
+}
+
+/// Atomically convert the complete logical callable/control graph.
+///
+/// The existing module region is not detached until a separately built module
+/// has passed the post-CPS operation and recursive type boundary.
+pub fn tribute_control_to_cps(
+    ctx: &mut IrContext,
+    module: Module,
+    declarations: &[tribute_control::OperationDeclaration],
+) -> Result<(), TributeControlToCpsError> {
+    verify_tribute_control_pre_cps(ctx, module, declarations)?;
+    let funcs = collect_callable_graph(ctx, module)?;
+    let source_region = module.body(ctx).ok_or_else(|| {
+        TributeControlToCpsError::one(
+            PRE_CPS_BOUNDARY,
+            Some(module.op()),
+            Some(ctx.op(module.op()).location),
+            "core.module has no body region",
+        )
+    })?;
+    let source_blocks = ctx.region(source_region).blocks.to_vec();
+    if source_blocks.len() != 1 {
+        return Err(TributeControlToCpsError::one(
+            PRE_CPS_BOUNDARY,
+            Some(module.op()),
+            Some(ctx.op(module.op()).location),
+            "tribute_control_to_cps currently requires a single module block",
+        ));
+    }
+    let module_location = ctx.op(module.op()).location;
+    let source_aliases = ctx.type_aliases().to_vec();
+    let mut converted_aliases = Vec::with_capacity(source_aliases.len());
+    let new_block = ctx.create_block(BlockData {
+        location: ctx.block(source_blocks[0]).location,
+        args: vec![],
+        ops: Default::default(),
+        parent_region: None,
+    });
+    {
+        let mut converter = Converter::new(ctx, new_block, funcs);
+        let mut mapping = HashMap::new();
+        let source_ops = converter.ctx.block(source_blocks[0]).ops.to_vec();
+        for source in source_ops {
+            if tribute_control::Func::matches(converter.ctx, source) {
+                let function = converter.convert_func(source)?;
+                converter.ctx.push_op(new_block, function);
+            } else if converter.ctx.op(source).dialect == Symbol::new("tribute_control") {
+                return Err(TributeControlToCpsError::one(
+                    PRE_CPS_BOUNDARY,
+                    Some(source),
+                    Some(converter.ctx.op(source).location),
+                    "only tribute_control.func may appear directly in a module block",
+                ));
+            } else {
+                let cloned = converter.clone_plain_op(source, &mut mapping)?;
+                converter.ctx.push_op(new_block, cloned);
+            }
+        }
+        converted_aliases.extend(
+            source_aliases
+                .iter()
+                .map(|(name, ty)| (*name, converter.convert_type(*ty))),
+        );
+    }
+    let new_region = ctx.create_region(RegionData {
+        location: ctx.region(source_region).location,
+        blocks: trunk_ir::smallvec::smallvec![new_block],
+        parent_op: None,
+    });
+    let temp_symbol = Symbol::new("__tribute_control_to_cps_candidate");
+    let temp_module = core::module(ctx, module_location, temp_symbol, new_region);
+    let candidate: Module = temp_module.into();
+    for (name, ty) in &converted_aliases {
+        ctx.register_type_alias(*name, *ty);
+    }
+    if let Err(error) = verify_tribute_control_post_cps(ctx, candidate) {
+        for (name, ty) in &source_aliases {
+            ctx.register_type_alias(*name, *ty);
+        }
+        return Err(error);
+    }
+
+    ctx.detach_region(new_region);
+    ctx.detach_region(source_region);
+    ctx.op_mut(module.op()).regions.push(new_region);
+    ctx.region_mut(new_region).parent_op = Some(module.op());
+    verify_tribute_control_post_cps(ctx, module)
+}
+
+/// Pass-manager wrapper carrying the verified source operation declarations.
+pub struct TributeControlToCps {
+    declarations: Vec<tribute_control::OperationDeclaration>,
+}
+
+impl TributeControlToCps {
+    pub fn new(
+        declarations: impl IntoIterator<Item = tribute_control::OperationDeclaration>,
+    ) -> Self {
+        Self {
+            declarations: declarations.into_iter().collect(),
+        }
+    }
+}
+
+impl Pass for TributeControlToCps {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "tribute-control-to-cps"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
+        tribute_control_to_cps(ctx, target.into(), &self.declarations)
+            .map_err(|error| Box::new(error) as _)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    fn parse(input: &str) -> (IrContext, Module) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        (ctx, module)
+    }
+
+    #[test]
+    fn textual_callable_graph_converts_and_reparses() {
+        let input = r#"core.module @test {
+  tribute_control.func @decl(%left: core.i32, %right: core.i32) -> core.i32 convention(direct)
+  tribute_control.func @identity(%value: core.i32) -> core.i32 convention(evidence_direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @cps_identity(%value: core.i32) -> core.i32 convention(cps) {
+    tribute_control.return %value
+  }
+  tribute_control.func @outer(%first: core.i32) -> core.i32 convention(direct) {
+    %captured = tribute_control.lambda(%value: core.i32) -> core.i32 convention(direct) captures [%first] {
+      tribute_control.return %first
+    }
+    tribute_control.return %first
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        verify_tribute_control_post_cps(&ctx, module).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(!printed.contains("tribute_control.func "));
+        assert!(!printed.contains("tribute_control.func_ref "));
+        assert!(!printed.contains("tribute_control.call_indirect "));
+        assert!(printed.contains("func.func @decl"));
+        assert!(printed.contains("closure.lambda"));
+        assert!(printed.contains("func.tail_call_indirect"));
+        assert!(printed.contains("tribute.calling_convention = 2"));
+
+        let mut reparsed = IrContext::new();
+        let reparsed_module = parse_test_module(&mut reparsed, &printed);
+        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+    }
+
+    #[test]
+    fn pass_wrapper_runs_the_verified_conversion() {
+        let input = r#"core.module @test {
+  tribute_control.func @identity(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let target = core::Module::from_op(&ctx, module.op()).unwrap();
+        let mut pass = TributeControlToCps::new([]);
+        assert_eq!(pass.name(), "tribute-control-to-cps");
+        pass.run(&mut ctx, target).unwrap();
+        verify_tribute_control_post_cps(&ctx, module).unwrap();
+    }
+
+    #[test]
+    fn textual_direct_evidence_and_cps_transfers_preserve_exact_abis() {
+        let input = r#"core.module @test {
+  !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !evidence = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 1}
+  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  tribute_control.func @direct(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @evidence(%value: core.i32) -> core.i32 convention(evidence_direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @cps(%value: core.i32) -> core.i32 convention(cps) {
+    tribute_control.return %value
+  }
+  tribute_control.func @exercise(%value: core.i32) -> core.i32 convention(cps) {
+    %direct_result = tribute_control.call %value {callee = @direct} : core.i32
+    %evidence_result = tribute_control.call %direct_result {callee = @evidence} : core.i32
+    %direct_ref = tribute_control.func_ref {func_ref = @direct} : !direct
+    %direct_indirect = tribute_control.call_indirect %direct_ref, %evidence_result : core.i32
+    %evidence_ref = tribute_control.func_ref {func_ref = @evidence} : !evidence
+    %evidence_indirect = tribute_control.call_indirect %evidence_ref, %direct_indirect : core.i32
+    %cps_ref = tribute_control.func_ref {func_ref = @cps} : !cps
+    %cps_indirect = tribute_control.call_indirect %cps_ref, %evidence_indirect : core.i32
+    tribute_control.return %cps_indirect
+  }
+  tribute_control.func @known_cps(%value: core.i32) -> core.i32 convention(cps) {
+    %result = tribute_control.call %value {callee = @cps} : core.i32
+    tribute_control.return %result
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("func.call "));
+        assert!(printed.contains("func.call_indirect"));
+        assert!(printed.contains("func.tail_call "));
+        assert!(printed.contains("func.tail_call_indirect"));
+        assert!(printed.contains("tribute.calling_convention = 0"));
+        assert!(printed.contains("tribute.calling_convention = 1"));
+        assert!(printed.contains("tribute.calling_convention = 2"));
+        assert!(!printed.contains("tribute_control."), "{printed}");
+
+        let mut reparsed = IrContext::new();
+        let reparsed_module = parse_test_module(&mut reparsed, &printed);
+        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+    }
+
+    #[test]
+    fn nested_textual_module_converts_its_callable_graph_atomically() {
+        let input = r#"core.module @outer {
+  core.module @inner {
+    tribute_control.func @nested(%value: core.i32) -> core.i32 convention(cps) {
+      tribute_control.return %value
+    }
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("core.module @inner"));
+        assert!(printed.contains("func.func @nested"));
+        assert!(printed.contains("func.tail_call_indirect"));
+        assert!(!printed.contains("tribute_control."));
+
+        let mut reparsed = IrContext::new();
+        let reparsed_module = parse_test_module(&mut reparsed, &printed);
+        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+    }
+
+    #[test]
+    fn textual_nested_attribute_types_convert_atomically() {
+        let input = r#"core.module @test {
+  !callback = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !record = adt.struct() {fields = [[@callback, !callback]], name = @CallbackRecord}
+  tribute_control.func @identity(%value: !record) -> !record convention(direct) {
+    tribute_control.return %value
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("name = @CallbackRecord"));
+        assert!(printed.contains("closure.closure(core.func(core.i32, core.i32))"));
+        assert!(!printed.contains("tribute_control."));
+
+        let mut reparsed = IrContext::new();
+        let reparsed_module = parse_test_module(&mut reparsed, &printed);
+        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+    }
+
+    #[test]
+    fn malformed_pre_boundary_is_atomic() {
+        let input = r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(direct) {
+    %illegal = func.call %value {callee = @broken} : core.i32
+    tribute_control.return %illegal
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let before = print_module(&ctx, module.op());
+        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+        assert!(error.to_string().contains("func.call"));
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn named_boundaries_report_local_and_core_validation_errors() {
+        let local_input = r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return
+  }
+}"#;
+        let (ctx, module) = parse(local_input);
+        let error = verify_tribute_control_pre_cps(&ctx, module, &[]).unwrap_err();
+        assert!(error.to_string().contains("expects 1 operand"), "{error}");
+
+        let core_input = r#"core.module @test {
+  tribute_control.func @broken(%value: core.i32) -> core.i32 convention(direct) {
+    func.tail_call_indirect
+    tribute_control.return %value
+  }
+}"#;
+        let (ctx, module) = parse(core_input);
+        let error = verify_tribute_control_pre_cps(&ctx, module, &[]).unwrap_err();
+        assert!(error.to_string().contains("requires a callee"), "{error}");
+
+        let post_input = r#"core.module @test {
+  func.func @broken() -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect
+  }
+}"#;
+        let (ctx, module) = parse(post_input);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        assert!(error.to_string().contains("requires a callee"), "{error}");
+
+        let malformed_delimiter = r#"core.module @test {
+  !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  func.func @broken() -> core.never attributes {tribute.calling_convention = 2} {
+    ability.handle_dispatch {ability_refs = []} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }
+  }
+}"#;
+        let (ctx, module) = parse(malformed_delimiter);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        assert!(error.to_string().contains("requires an evidence operand"));
+    }
+
+    #[test]
+    fn post_boundary_rejects_recursively_nested_control_types() {
+        let input = r#"core.module @test {
+  !nested = core.tuple(closure.closure(core.func(core.i32, tribute_control.resume_token(core.i32, core.i32))))
+}"#;
+        let (ctx, module) = parse(input);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        assert!(error.to_string().contains("forbidden type"), "{error}");
+    }
+
+    #[test]
+    fn post_boundary_rejects_malformed_physical_callable_transfers() {
+        let malformed = [
+            (
+                r#"core.module @test {
+  func.func @callee(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {tribute.calling_convention = 2}
+  }
+}"#,
+                "requires a resolved callee symbol",
+            ),
+            (
+                r#"core.module @test {
+  func.func @callee(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @callee}
+  }
+}"#,
+                "func.tail_call must carry exact Direct, EvidenceDirect, or Cps metadata",
+            ),
+            (
+                r#"core.module @test {
+  func.func @caller(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @missing, tribute.calling_convention = 2}
+  }
+}"#,
+                "unresolved callee @missing",
+            ),
+            (
+                r#"core.module @test {
+  func.func @callee(%value: core.i64) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @callee, tribute.calling_convention = 2}
+  }
+}"#,
+                "operands do not match the target signature",
+            ),
+            (
+                r#"core.module @test {
+  func.func @callee(%value: core.i32) -> core.i32 attributes {tribute.calling_convention = 2} {
+    func.return %value
+  }
+  func.func @caller(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @callee, tribute.calling_convention = 2}
+  }
+}"#,
+                "target must have core.never result",
+            ),
+            (
+                r#"core.module @test {
+  func.func @callee(%value: core.i32) -> core.never attributes {tribute.calling_convention = 1} {
+    func.unreachable
+  }
+  func.func @caller(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @callee, tribute.calling_convention = 2}
+  }
+}"#,
+                "must preserve exact Cps metadata",
+            ),
+            (
+                r#"core.module @test {
+  func.func @caller(%callee: closure.closure(core.func(core.never, core.i32)), %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %value
+  }
+}"#,
+                "tail_call_indirect must carry exact Cps metadata",
+            ),
+            (
+                r#"core.module @test {
+  func.func @callee(%value: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+    func.return %value
+  }
+  func.func @caller(%value: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+    %result = func.call %value {callee = @callee, tribute.calling_convention = 1} : core.i32
+    func.return %result
+  }
+}"#,
+                "func.call metadata does not match its target",
+            ),
+            (
+                r#"core.module @test {
+  func.func @caller(%value: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+    %result = func.call %value {callee = @missing, tribute.calling_convention = 0} : core.i32
+    func.return %result
+  }
+}"#,
+                "func.call references unresolved callee @missing",
+            ),
+            (
+                r#"core.module @test {
+  func.func @caller(%callee: closure.closure(core.func(core.never, core.i32)), %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    %result = func.call_indirect %callee, %value {tribute.calling_convention = 2} : core.never
+    func.unreachable
+  }
+}"#,
+                "dynamic Cps transfers must use func.tail_call_indirect",
+            ),
+        ];
+        for (input, expected) in malformed {
+            let (ctx, module) = parse(input);
+            let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn post_boundary_rejects_nonphysical_dispatchers_and_residual_control_ops() {
+        let dispatcher_input = r#"core.module @test {
+  !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !tr = closure.closure(core.func(tribute_rt.anyref, !evidence, core.i32, tribute_rt.anyref))
+  !general = closure.closure(core.func(core.never, !evidence, tribute_rt.anyref, core.i32, tribute_rt.anyref))
+  func.func @caller(%ev: !evidence, %tr: !tr, %general: !general) -> core.never attributes {tribute.calling_convention = 2} {
+    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }
+  }
+}"#;
+        let (ctx, module) = parse(dispatcher_input);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("dispatcher must be a physical closure result"),
+            "{error}"
+        );
+
+        let wrong_abi_input = r#"core.module @test {
+  !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  func.func @caller(%ev: !evidence) -> core.never attributes {tribute.calling_convention = 2} {
+    %tr = closure.lambda(%inner: !evidence) -> tribute_rt.anyref {tribute.calling_convention = 1} {
+      func.unreachable
+    }
+    %general = closure.lambda(%inner: !evidence) -> core.never {tribute.calling_convention = 2} {
+      func.unreachable
+    }
+    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }
+  }
+}"#;
+        let (ctx, module) = parse(wrong_abi_input);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        let text = error.to_string();
+        assert!(
+            text.contains("tail-resumptive dispatcher has the wrong"),
+            "{text}"
+        );
+        assert!(text.contains("general dispatcher has the wrong"), "{text}");
+
+        let wrong_metadata_input = r#"core.module @test {
+  !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  func.func @caller(%ev: !evidence) -> core.never attributes {tribute.calling_convention = 2} {
+    %tr = closure.lambda(%inner: !evidence, %op_idx: core.i32, %payload: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 0} {
+      func.unreachable
+    }
+    %general = closure.lambda(%inner: !evidence, %continuation: tribute_rt.anyref, %op_idx: core.i32, %payload: tribute_rt.anyref) -> core.never {tribute.calling_convention = 1} {
+      func.unreachable
+    }
+    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }
+  }
+}"#;
+        let (ctx, module) = parse(wrong_metadata_input);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        let text = error.to_string();
+        assert!(text.contains("calling convention metadata 1"), "{text}");
+        assert!(text.contains("calling convention metadata 2"), "{text}");
+
+        let residual_input = r#"core.module @test {
+  tribute_control.func @residual(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+}"#;
+        let (ctx, module) = parse(residual_input);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        assert!(error.to_string().contains("residual tribute_control.func"));
+    }
+
+    #[test]
+    fn conversion_error_display_handles_diagnostics_without_an_operation() {
+        let error =
+            TributeControlToCpsError::one(PRE_CPS_BOUNDARY, None, None, "synthetic failure");
+        let text = error.to_string();
+        assert!(text.contains("1 error(s)"));
+        assert!(text.contains("  - synthetic failure"));
+    }
+
+    #[test]
+    fn textual_resumptive_handle_emits_one_resultless_delimiter() {
+        let input = r#"core.module @test {
+  tribute_control.func @run(%input: core.i32) -> core.i32 convention(cps) {
+    %handled = tribute_control.handle : core.i32 {
+      %performed = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @State}, op_name = @get, operation_kind = @op} : core.i32
+      tribute_control.yield %performed
+    } {
+      ^completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @State}, kind = @op, op_name = @get, operation_result_type = core.i32} {
+        ^arm(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+          %resumed = tribute_control.resume %token, %argument : core.i32
+          tribute_control.yield %resumed
+      }
+    }
+    tribute_control.return %handled
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let mut ability_ref = None;
+        fn find_ability(ctx: &IrContext, region: RegionRef, found: &mut Option<TypeRef>) {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for op in ctx.block(block).ops.iter().copied() {
+                    if tribute_control::Handler::matches(ctx, op) {
+                        *found = ctx.op(op).attributes.get_type("ability_ref");
+                    }
+                    for nested in ctx.op(op).regions.iter().copied() {
+                        find_ability(ctx, nested, found);
+                    }
+                }
+            }
+        }
+        find_ability(&ctx, module.body(&ctx).unwrap(), &mut ability_ref);
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let declarations = [tribute_control::OperationDeclaration::new(
+            ability_ref.unwrap(),
+            Symbol::new("get"),
+            Symbol::new("op"),
+            vec![i32_type],
+            i32_type,
+        )];
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert_eq!(printed.matches("ability.handle_dispatch").count(), 1);
+        assert!(!printed.contains("effect."));
+        assert!(printed.contains("ability_refs = [core.ability_ref"));
+        assert!(printed.contains("func.tail_call_indirect"));
+        assert!(printed.contains("adt.struct_set"));
+        assert!(!printed.contains("tribute_control."));
+        assert!(!printed.contains("handler_metadata"));
+        assert!(!printed.contains("adt.ref_null"));
+        assert!(!printed.contains("__tribute_cps_control"));
+    }
+
+    #[test]
+    fn multiple_arms_for_one_ability_emit_one_dispatcher_pair() {
+        let input = r#"core.module @test {
+  tribute_control.func @run(%input: core.i32) -> core.i32 convention(cps) {
+    %handled = tribute_control.handle : core.i32 {
+      %performed = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @State}, op_name = @get, operation_kind = @op} : core.i32
+      tribute_control.yield %performed
+    } {
+      ^completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @State}, kind = @op, op_name = @get, operation_result_type = core.i32} {
+        ^get(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+          %resumed = tribute_control.resume %token, %argument : core.i32
+          tribute_control.yield %resumed
+      }
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @State}, kind = @op, op_name = @set, operation_result_type = core.i32} {
+        ^set(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+          %fallback = arith.const {value = 9} : core.i32
+          tribute_control.yield %fallback
+      }
+    }
+    tribute_control.return %handled
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let ability_ref = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("ability_ref"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let declarations = [
+            tribute_control::OperationDeclaration::new(
+                ability_ref,
+                Symbol::new("get"),
+                Symbol::new("op"),
+                [i32_type],
+                i32_type,
+            ),
+            tribute_control::OperationDeclaration::new(
+                ability_ref,
+                Symbol::new("set"),
+                Symbol::new("op"),
+                [i32_type],
+                i32_type,
+            ),
+        ];
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+
+        let mut delimiters = Vec::new();
+        fn collect_delimiters(ctx: &IrContext, op: OpRef, found: &mut Vec<OpRef>) {
+            if ability::HandleDispatch::matches(ctx, op) {
+                found.push(op);
+            }
+            for region in ctx.op(op).regions.iter().copied() {
+                for block in ctx.region(region).blocks.iter().copied() {
+                    for child in ctx.block(block).ops.iter().copied() {
+                        collect_delimiters(ctx, child, found);
+                    }
+                }
+            }
+        }
+        collect_delimiters(&ctx, module.op(), &mut delimiters);
+        let [delimiter] = delimiters.as_slice() else {
+            panic!("expected one final delimiter");
+        };
+        assert_eq!(ctx.op_operands(*delimiter).len(), 3);
+        let Some(Attribute::List(ability_refs)) = ctx.op(*delimiter).attributes.get("ability_refs")
+        else {
+            panic!("final delimiter must have ability_refs");
+        };
+        assert_eq!(ability_refs.len(), 1);
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("value = 9"));
+        assert!(printed.contains("func.tail_call_indirect"));
+        assert!(!printed.contains("effect."));
+    }
+
+    #[test]
+    fn textual_scf_branch_captures_only_the_selected_suffix() {
+        let input = r#"core.module @test {
+  tribute_control.func @branch(%input: core.i32) -> core.i32 convention(cps) {
+    %condition = arith.const {value = true} : core.i1
+    %selected = scf.if %condition : core.i32 {
+      %performed = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @State}, op_name = @get, operation_kind = @op} : core.i32
+      scf.yield %performed
+    } {
+      %fallback = arith.const {value = 7} : core.i32
+      scf.yield %fallback
+    }
+    %one = arith.const {value = 1} : core.i32
+    %sum = arith.addi %selected, %one : core.i32
+    tribute_control.return %sum
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let ability_ref = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("ability_ref"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let declarations = [tribute_control::OperationDeclaration::new(
+            ability_ref,
+            Symbol::new("get"),
+            Symbol::new("op"),
+            vec![i32_type],
+            i32_type,
+        )];
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("scf.if"));
+        assert!(printed.contains(" : core.never"));
+        assert!(printed.contains("ability.perform"));
+        assert!(printed.contains("func.tail_call_indirect"));
+        assert!(printed.contains("arith.addi"));
+        assert!(!printed.contains("tribute_control."));
+    }
+
+    #[test]
+    fn stronger_func_ref_builds_a_cps_adapter_without_a_null_environment() {
+        let input = r#"core.module @test {
+  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @run(%value: core.i32) -> core.i32 convention(cps) {
+    %callee = tribute_control.func_ref {func_ref = @id} : !cps
+    %result = tribute_control.call_indirect %callee, %value : core.i32
+    tribute_control.return %result
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("__tribute_func_ref_adapter"));
+        assert!(printed.contains("closure.new"));
+        assert!(printed.contains("func.tail_call_indirect"));
+        assert!(printed.contains("tribute.calling_convention = 2"));
+        assert!(!printed.contains("adt.ref_null"));
+        assert!(!printed.contains("tribute_control.func "));
+        assert!(!printed.contains("tribute_control.func_ref "));
+        assert!(!printed.contains("tribute_control.call_indirect "));
+    }
+
+    #[test]
+    fn nested_textual_handles_keep_distinct_delimiters() {
+        let input = r#"core.module @test {
+  tribute_control.func @nested(%input: core.i32) -> core.i32 convention(cps) {
+    %outer = tribute_control.handle : core.i32 {
+      %inner = tribute_control.handle : core.i32 {
+        tribute_control.yield %input
+      } {
+        ^inner_completion(%value: core.i32):
+          tribute_control.yield %value
+      } {
+        ^inner_handlers:
+      }
+      tribute_control.yield %inner
+    } {
+      ^outer_completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      ^outer_handlers:
+    }
+    tribute_control.return %outer
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert_eq!(printed.matches("ability.handle_dispatch").count(), 2);
+        assert!(!printed.contains("effect."));
+        assert!(printed.matches("func.tail_call_indirect").count() >= 3);
+        assert!(!printed.contains("__tribute_cps_control"));
+    }
+
+    #[test]
+    fn op_to_never_uses_a_typed_zero_capture_reject_continuation() {
+        let input = r#"core.module @test {
+  tribute_control.func @abortable(%input: core.i32) -> core.i32 convention(cps) {
+    %handled = tribute_control.handle : core.i32 {
+      %never = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @Abort}, op_name = @abort, operation_kind = @op} : core.never
+      %unreachable_suffix = arith.const {value = 99} : core.i32
+      tribute_control.yield %unreachable_suffix
+    } {
+      ^completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @Abort}, kind = @op, op_name = @abort, operation_result_type = core.never} {
+        ^arm(%argument: core.i32):
+          %fallback = arith.const {value = 7} : core.i32
+          tribute_control.yield %fallback
+      }
+    }
+    tribute_control.return %handled
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let ability_ref = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("ability_ref"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let never_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("never"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let declarations = [tribute_control::OperationDeclaration::new(
+            ability_ref,
+            Symbol::new("abort"),
+            Symbol::new("op"),
+            vec![i32_type],
+            never_type,
+        )];
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("ability.perform"));
+        assert!(printed.contains("func.unreachable"));
+        assert!(!printed.contains("value = 99"));
+        assert!(!printed.contains("@consumed"));
+        assert!(!printed.contains("adt.struct_set"));
+        assert!(!printed.contains("adt.ref_null"));
+    }
+
+    #[test]
+    fn fn_operation_stays_evidence_direct_without_continuation_capture() {
+        let input = r#"core.module @test {
+  tribute_control.func @read(%input: core.i32) -> core.i32 convention(cps) {
+    %handled = tribute_control.handle : core.i32 {
+      %value = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @Reader}, op_name = @read, operation_kind = @fn} : core.i32
+      tribute_control.yield %value
+    } {
+      ^completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @Reader}, kind = @fn, op_name = @read, operation_result_type = core.i32} {
+        ^arm(%argument: core.i32):
+          tribute_control.yield %argument
+      }
+    }
+    tribute_control.return %handled
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let ability_ref = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("ability_ref"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let declarations = [tribute_control::OperationDeclaration::new(
+            ability_ref,
+            Symbol::new("read"),
+            Symbol::new("fn"),
+            vec![i32_type],
+            i32_type,
+        )];
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("ability.call"));
+        assert!(!printed.contains("ability.perform"));
+        assert!(!printed.contains("@consumed"));
+        assert!(!printed.contains("adt.struct_set"));
+        assert!(printed.contains("tribute.calling_convention = 1"));
+    }
+
+    #[test]
+    fn textual_scf_switch_reenters_the_shared_suffix() {
+        let input = r#"core.module @test {
+  tribute_control.func @switching(%input: core.i32) -> core.i32 convention(cps) {
+    %choice = arith.const {value = 0} : core.i32
+    scf.switch %choice {
+      scf.case {value = 0} {
+        %performed = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @State}, op_name = @get, operation_kind = @op} : core.i32
+        scf.yield
+      }
+      scf.default {
+        scf.yield
+      }
+    }
+    tribute_control.return %input
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let ability_ref = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("ability_ref"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let declarations = [tribute_control::OperationDeclaration::new(
+            ability_ref,
+            Symbol::new("get"),
+            Symbol::new("op"),
+            vec![i32_type],
+            i32_type,
+        )];
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("scf.switch"));
+        assert!(printed.contains("scf.case"));
+        assert!(printed.contains("ability.perform"));
+        assert!(printed.matches("func.tail_call_indirect").count() >= 2);
+        assert!(!printed.contains("tribute_control."));
+    }
+}

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -20,6 +20,8 @@ mod func {
     #[attr(callee: Symbol)]
     fn tail_call(#[rest] args: ()) {}
 
+    fn tail_call_indirect(callee: (), #[rest] args: ()) {}
+
     fn r#return(#[rest] values: ()) {}
 
     #[attr(func_ref: Symbol)]

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -325,10 +325,87 @@ pub fn validate_operation_verifiers(ctx: &IrContext, module: Module) -> Validati
     walk::walk_region::<std::convert::Infallible>(ctx, body, &mut |op| {
         validate_arith_cmpf_predicate(ctx, op, &mut errors);
         validate_scf_if_structure(ctx, op, &mut errors);
+        validate_func_tail_call_indirect(ctx, op, &mut errors);
         std::ops::ControlFlow::Continue(walk::WalkAction::Advance)
     });
 
     ValidationResult { errors }
+}
+
+fn validate_func_tail_call_indirect(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
+    let data = ctx.op(op);
+    if data.dialect != Symbol::new("func") || data.name != Symbol::new("tail_call_indirect") {
+        return;
+    }
+    if !ctx.op_results(op).is_empty() {
+        errors.push(operation_verifier_error(ctx, op, "must be resultless"));
+    }
+    let Some((&callee, args)) = ctx.op_operands(op).split_first() else {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "requires a callee operand",
+        ));
+        return;
+    };
+    let callee_ty = ctx.types.get(ctx.value_ty(callee));
+    let func_ty = if callee_ty.dialect == Symbol::new("closure")
+        && callee_ty.name == Symbol::new("closure")
+    {
+        let [func_ty] = callee_ty.params.as_slice() else {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                "callee closure type must contain exactly one function type",
+            ));
+            return;
+        };
+        *func_ty
+    } else {
+        ctx.value_ty(callee)
+    };
+    let func_ty = ctx.types.get(func_ty);
+    if func_ty.dialect != Symbol::new("core")
+        || func_ty.name != Symbol::new("func")
+        || func_ty.params.is_empty()
+    {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "callee must have core.func or closure.closure<core.func> type",
+        ));
+        return;
+    }
+    let return_ty = ctx.types.get(func_ty.params[0]);
+    if return_ty.dialect != Symbol::new("core") || return_ty.name != Symbol::new("never") {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "callee function result must be core.never",
+        ));
+    }
+    let expected = &func_ty.params[1..];
+    if args.len() != expected.len() {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            format!(
+                "passes {} argument(s), but callee expects {}",
+                args.len(),
+                expected.len()
+            ),
+        ));
+        return;
+    }
+    for (index, (arg, expected)) in args.iter().zip(expected).enumerate() {
+        if ctx.value_ty(*arg) != *expected {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("argument #{index} type does not match the callee parameter"),
+            ));
+        }
+    }
 }
 
 /// Validate operation-level semantic constraints that are independent of
@@ -455,6 +532,31 @@ fn validate_scf_if_structure(ctx: &IrContext, op: OpRef, errors: &mut Vec<Valida
 
         let yield_data = ctx.op(yield_op);
         if yield_data.dialect != Symbol::new("scf") || yield_data.name != Symbol::new("yield") {
+            let never_result = match ctx.op_result_types(op) {
+                [ty] => {
+                    let ty = ctx.types.get(*ty);
+                    ty.dialect == Symbol::new("core") && ty.name == Symbol::new("never")
+                }
+                _ => false,
+            };
+            let proper_tail = (yield_data.dialect == Symbol::new("func")
+                && matches!(
+                    yield_data.name.with_str(|name| name.to_owned()).as_str(),
+                    "tail_call" | "tail_call_indirect" | "unreachable"
+                ))
+                || (yield_data.dialect == Symbol::new("ability")
+                    && matches!(
+                        yield_data.name.with_str(|name| name.to_owned()).as_str(),
+                        "perform" | "handle_dispatch"
+                    ))
+                || (yield_data.dialect == Symbol::new("scf")
+                    && matches!(
+                        yield_data.name.with_str(|name| name.to_owned()).as_str(),
+                        "if" | "switch"
+                    ));
+            if never_result && proper_tail {
+                continue;
+            }
             errors.push(operation_verifier_error(
                 ctx,
                 op,
@@ -1451,6 +1553,119 @@ mod tests {
     // ========================================================================
     // Call arity validation tests (textual IR)
     // ========================================================================
+
+    #[test]
+    fn tail_call_indirect_typed_cps_transfer_passes() {
+        let input = r#"core.module @test {
+  func.func @main(%k: closure.closure(core.func(core.never, core.i32)), %value: core.i32) -> core.never {
+    func.tail_call_indirect %k, %value
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn tail_call_indirect_rejects_non_cps_result_and_bad_arguments() {
+        let input = r#"core.module @test {
+  func.func @main(%k: closure.closure(core.func(core.i32, core.i32)), %value: core.bool) -> core.never {
+    func.tail_call_indirect %k, %value
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let result = validate_operation_verifiers(&ctx, module);
+        let text = result.to_string();
+        assert!(text.contains("result must be core.never"), "{text}");
+        assert!(text.contains("argument #0 type"), "{text}");
+    }
+
+    #[test]
+    fn tail_call_indirect_rejects_every_malformed_callable_shape() {
+        let input = r#"core.module @test {
+  func.func @result(%k: closure.closure(core.func(core.never))) -> core.never {
+    %bad = func.tail_call_indirect %k : core.i32
+    func.unreachable
+  }
+  func.func @missing() -> core.never {
+    func.tail_call_indirect
+  }
+  func.func @bad_closure(%k: closure.closure()) -> core.never {
+    func.tail_call_indirect %k
+  }
+  func.func @not_callable(%value: core.i32) -> core.never {
+    func.tail_call_indirect %value
+  }
+  func.func @direct_function(%k: core.func(core.never)) -> core.never {
+    func.tail_call_indirect %k
+  }
+  func.func @arity(%k: closure.closure(core.func(core.never, core.i32))) -> core.never {
+    func.tail_call_indirect %k
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let result = validate_operation_verifiers(&ctx, module);
+        let text = result.to_string();
+        assert!(text.contains("must be resultless"), "{text}");
+        assert!(text.contains("requires a callee operand"), "{text}");
+        assert!(
+            text.contains("closure type must contain exactly one function type"),
+            "{text}"
+        );
+        assert!(text.contains("callee must have core.func"), "{text}");
+        assert!(text.contains("passes 0 argument(s)"), "{text}");
+        assert_eq!(result.errors.len(), 5, "{text}");
+    }
+
+    #[test]
+    fn scf_never_regions_accept_every_proper_tail_surface() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1) -> core.never {
+    %outer = scf.if %cond : core.never {
+      ability.perform
+    } {
+      %nested = scf.if %cond : core.never {
+        func.unreachable
+      } {
+        ability.handle_dispatch
+      }
+    }
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn resultless_scf_regions_still_require_yield() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1) {
+    scf.if %cond {
+      func.unreachable
+    } {
+      func.unreachable
+    }
+    func.return
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let result = validate_operation_verifiers(&ctx, module);
+        let text = result.to_string();
+        assert!(
+            text.contains("then_region must terminate with scf.yield"),
+            "{text}"
+        );
+        assert!(
+            text.contains("else_region must terminate with scf.yield"),
+            "{text}"
+        );
+    }
 
     #[test]
     fn call_arity_mismatch_too_few_args() {

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -481,6 +481,27 @@ fn is_allowed_cmpf_predicate(predicate: Symbol) -> bool {
         || predicate == Symbol::new(SUPPORTED_CMPF_PREDICATES[5])
 }
 
+/// Return whether `op` is a resultless transfer that may terminate a
+/// structured `core.never` region without an `scf.yield`.
+pub fn is_proper_tail_terminator(ctx: &IrContext, op: OpRef) -> bool {
+    let data = ctx.op(op);
+    (data.dialect == Symbol::new("func")
+        && matches!(
+            data.name.with_str(|name| name.to_owned()).as_str(),
+            "tail_call" | "tail_call_indirect" | "unreachable"
+        ))
+        || (data.dialect == Symbol::new("ability")
+            && matches!(
+                data.name.with_str(|name| name.to_owned()).as_str(),
+                "perform" | "handle_dispatch"
+            ))
+        || (data.dialect == Symbol::new("scf")
+            && matches!(
+                data.name.with_str(|name| name.to_owned()).as_str(),
+                "if" | "switch"
+            ))
+}
+
 fn validate_scf_if_structure(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
     let data = ctx.op(op);
     if data.dialect != Symbol::new("scf") || data.name != Symbol::new("if") {
@@ -539,22 +560,7 @@ fn validate_scf_if_structure(ctx: &IrContext, op: OpRef, errors: &mut Vec<Valida
                 }
                 _ => false,
             };
-            let proper_tail = (yield_data.dialect == Symbol::new("func")
-                && matches!(
-                    yield_data.name.with_str(|name| name.to_owned()).as_str(),
-                    "tail_call" | "tail_call_indirect" | "unreachable"
-                ))
-                || (yield_data.dialect == Symbol::new("ability")
-                    && matches!(
-                        yield_data.name.with_str(|name| name.to_owned()).as_str(),
-                        "perform" | "handle_dispatch"
-                    ))
-                || (yield_data.dialect == Symbol::new("scf")
-                    && matches!(
-                        yield_data.name.with_str(|name| name.to_owned()).as_str(),
-                        "if" | "switch"
-                    ));
-            if never_result && proper_tail {
+            if never_result && is_proper_tail_terminator(ctx, yield_op) {
                 continue;
             }
             errors.push(operation_verifier_error(
@@ -1583,7 +1589,7 @@ mod tests {
     }
 
     #[test]
-    fn tail_call_indirect_rejects_every_malformed_callable_shape() {
+    fn tail_call_indirect_rejects_malformed_shapes_and_accepts_bare_function() {
         let input = r#"core.module @test {
   func.func @result(%k: closure.closure(core.func(core.never))) -> core.never {
     %bad = func.tail_call_indirect %k : core.i32

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1574,6 +1574,56 @@ mod tests {
             .expect("attached db")
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn native_one_shot_wrapper_traps_on_second_invocation() {
+        let input = r#"core.module @one_shot {
+  !state = adt.struct() {fields = [[@consumed, core.i1]], name = @OneShotState}
+
+  func.func @one_shot_wrapper(%state: !state, %value: core.i32) -> core.i32 attributes {tribute.calling_convention = 0} {
+    %consumed = adt.struct_get %state {field = 0, type = !state} : core.i1
+    %answer = scf.if %consumed : core.i32 {
+      func.unreachable
+    } {
+      %consumed_true = arith.const {value = 1} : core.i1
+      adt.struct_set %state, %consumed_true {field = 0, type = !state}
+      scf.yield %value
+    }
+    func.return %answer
+  }
+
+  func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
+    %not_consumed = arith.const {value = 0} : core.i1
+    %state = adt.struct_new %not_consumed {type = !state} : !state
+    %input = arith.const {value = 7} : core.i32
+    %first = func.call %state, %input {callee = @one_shot_wrapper, tribute.calling_convention = 0} : core.i32
+    %second = func.call %state, %first {callee = @one_shot_wrapper, tribute.calling_convention = 0} : core.i32
+    func.return %second
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(&mut ctx, input);
+
+        let object = compile_module_to_native(
+            &mut ctx,
+            module,
+            false,
+            NativeOptimizationOptions::production(),
+        )
+        .expect("one-shot wrapper must compile to native code");
+        let temp = tempfile::tempdir().expect("temporary executable directory");
+        let executable = temp.path().join("one-shot-wrapper");
+        link_native_binary(&object, &executable).expect("one-shot wrapper must link");
+
+        let status = std::process::Command::new(executable)
+            .status()
+            .expect("one-shot wrapper executable must start");
+        assert!(
+            !status.success(),
+            "the second invocation of the same wrapper must trap"
+        );
+    }
+
     #[cfg(debug_assertions)]
     #[test]
     fn debug_use_chain_verifier_reports_offending_pass() {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1577,6 +1577,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn native_one_shot_wrapper_traps_on_second_invocation() {
+        use std::os::unix::process::ExitStatusExt;
+
         let input = r#"core.module @one_shot {
   !state = adt.struct() {fields = [[@consumed, core.i1]], name = @OneShotState}
 
@@ -1595,7 +1597,7 @@ mod tests {
   func.func @main() -> core.i32 attributes {tribute.calling_convention = 0} {
     %not_consumed = arith.const {value = 0} : core.i1
     %state = adt.struct_new %not_consumed {type = !state} : !state
-    %input = arith.const {value = 7} : core.i32
+    %input = arith.const {value = 0} : core.i32
     %first = func.call %state, %input {callee = @one_shot_wrapper, tribute.calling_convention = 0} : core.i32
     %second = func.call %state, %first {callee = @one_shot_wrapper, tribute.calling_convention = 0} : core.i32
     func.return %second
@@ -1619,8 +1621,8 @@ mod tests {
             .status()
             .expect("one-shot wrapper executable must start");
         assert!(
-            !status.success(),
-            "the second invocation of the same wrapper must trap"
+            status.signal().is_some(),
+            "the second invocation of the same wrapper must terminate by signal, got {status}"
         );
     }
 


### PR DESCRIPTION
Closes #823

## Summary

- Add `tribute_control_to_cps`, an atomic whole-graph conversion before closure extraction.
- Lower callable and structured control operations to physical callable IR with proper-tail CPS transfers and no residual `tribute_control` operations or types.
- Add resultless `ability.handle_dispatch` and verified `func.tail_call_indirect` support while preserving calling conventions, evaluation order, symbols, and source locations.

## Compatibility

The existing frontend carrier path is temporarily routed through three explicitly named shims until #826 removes it:

- `ability.legacy_perform`
- `ability.legacy_call`
- `ability.legacy_handle_dispatch`

The final `ability.handle_dispatch` remains resultless. Pipeline composition and native/Wasm target lowering are unchanged.

## Validation

Formatting, linting, focused and workspace tests, and canonical native/Wasm/invalid examples pass.