### PR TITLE
Compose source-logical pipeline across targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-tribute",
+ "tribute-core",
  "tribute-front",
  "tribute-ir",
  "tribute-passes",
@@ -1547,6 +1548,7 @@ dependencies = [
  "tribute-core",
  "tribute-ir",
  "trunk-ir",
+ "trunk-ir-cranelift-backend",
  "trunk-ir-wasm-backend",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ insta.workspace = true
 itertools.workspace = true
 salsa-test-macros = { path = "crates/salsa-test-macros" }
 serde.workspace = true
+tribute-core.workspace = true
 
 [profile.dev]
 debug = "line-tables-only"

--- a/crates/tribute-core/src/callable_abi.rs
+++ b/crates/tribute-core/src/callable_abi.rs
@@ -2,6 +2,30 @@
 
 use crate::CallingConvention;
 
+/// Locate the closure environment in an already-lowered physical parameter
+/// list. Evidence is recognized only by exact leading-type equality.
+pub fn physical_environment_index<T: PartialEq>(params: &[T], evidence: &T) -> usize {
+    usize::from(params.first() == Some(evidence))
+}
+
+/// Interpose a closure environment into an already-lowered physical ABI.
+///
+/// Source CPS lambdas begin with exact evidence, while generated
+/// continuations and `done_k` targets do not. Convention metadata alone
+/// describes semantic role and must not be used to invent hidden parameters.
+pub fn interpose_physical_environment<T: Copy + PartialEq>(
+    params: &[T],
+    evidence: &T,
+    environment: T,
+) -> Vec<T> {
+    let index = physical_environment_index(params, evidence);
+    let mut physical = Vec::with_capacity(params.len() + 1);
+    physical.extend_from_slice(&params[..index]);
+    physical.push(environment);
+    physical.extend_from_slice(&params[index..]);
+    physical
+}
+
 /// A source callable paired with its selected calling convention.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CallableAbi<T> {
@@ -40,6 +64,28 @@ impl<T: Copy> CallableAbi<T> {
         params
     }
 
+    /// Parameter types for the result-indexed CPS ABI.
+    ///
+    /// This is the production logical layout. The older two-hidden-operand
+    /// helper remains solely for the explicitly isolated legacy frontend
+    /// compatibility path until it is removed.
+    pub fn lowered_params_with_dispatch(&self, evidence: T, done: T, dispatch: T) -> Vec<T> {
+        let mut params = Vec::with_capacity(
+            self.source_params.len()
+                + usize::from(self.convention.needs_evidence())
+                + usize::from(self.convention.needs_done_k()) * 2,
+        );
+        if self.convention.needs_evidence() {
+            params.push(evidence);
+        }
+        if self.convention.needs_done_k() {
+            params.push(done);
+            params.push(dispatch);
+        }
+        params.extend_from_slice(&self.source_params);
+        params
+    }
+
     /// Result type for the current compatibility representation.
     ///
     /// Logical CPS does not directly return a source result. Until true
@@ -57,15 +103,22 @@ impl<T: Copy> CallableAbi<T> {
         usize::from(self.convention.needs_evidence()) + usize::from(self.convention.needs_done_k())
     }
 
+    /// Source-parameter offset for [`Self::lowered_params_with_dispatch`].
+    pub fn source_param_offset_with_dispatch(&self) -> usize {
+        usize::from(self.convention.needs_evidence())
+            + usize::from(self.convention.needs_done_k()) * 2
+    }
+
     /// Interpose the physical closure environment in convention order.
     ///
     /// Direct: `env, source...`
     /// EvidenceDirect: `evidence, env, source...`
     /// Cps: `evidence, env, done_k, source...`
     pub fn interpose_environment(&self, logical_params: &[T], environment: T) -> Vec<T> {
-        debug_assert_eq!(
-            logical_params.len(),
-            self.lowered_params(environment, environment).len(),
+        let legacy_len = self.lowered_params(environment, environment).len();
+        let dispatch_len = legacy_len + usize::from(self.convention.needs_done_k());
+        debug_assert!(
+            logical_params.len() == legacy_len || logical_params.len() == dispatch_len,
             "logical parameter count must match the selected convention",
         );
         let env_index = usize::from(self.convention.needs_evidence());
@@ -124,6 +177,32 @@ mod tests {
         assert_eq!(
             cps.interpose_environment(&["ev", "control", "arg"], "env"),
             ["ev", "env", "control", "arg"]
+        );
+    }
+
+    #[test]
+    fn cps_dispatch_is_a_second_hidden_operand() {
+        let cps = abi(CallingConvention::Cps);
+        assert_eq!(
+            cps.lowered_params_with_dispatch("ev", "done", "dispatch"),
+            ["ev", "done", "dispatch", "arg"]
+        );
+        assert_eq!(cps.source_param_offset_with_dispatch(), 3);
+    }
+
+    #[test]
+    fn physical_environment_uses_only_an_exact_leading_evidence_type() {
+        assert_eq!(
+            interpose_physical_environment(&["evidence", "done", "arg"], &"evidence", "env"),
+            ["evidence", "env", "done", "arg"]
+        );
+        assert_eq!(
+            interpose_physical_environment(&["answer"], &"evidence", "env"),
+            ["env", "answer"]
+        );
+        assert_eq!(
+            interpose_physical_environment(&[], &"evidence", "env"),
+            ["env"]
         );
     }
 }

--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -2,10 +2,22 @@
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::refs::OpRef;
-use trunk_ir::types::Attribute;
+use trunk_ir::dialect::core;
+use trunk_ir::refs::{OpRef, TypeRef};
+use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
+/// Exact physical callable contract carried across closure lowering when an
+/// indirect callee becomes an untyped table/function pointer.
+pub const INDIRECT_CALL_SIGNATURE_ATTR: &str =
+    trunk_ir::dialect::func::INDIRECT_CALL_SIGNATURE_ATTR;
+/// Exact logical closure type retained on a lowered runtime closure value.
+/// This is value provenance, not a target ABI signature: consumers must use
+/// it only when the value is the result of the annotated closure packing op.
+pub const CLOSURE_CALLABLE_TYPE_ATTR: &str = "tribute.closure_callable_type";
+pub const ROOT_EXPORT_CONVENTION_ATTR: &str = "tribute.root_export_convention";
+pub const ROOT_SOURCE_RESULT_ATTR: &str = "tribute.root_source_result";
+pub const CPS_PARENT_RESULT_ATTR: &str = "tribute.cps_parent_result";
 
 /// The ABI strength required to call a function.
 ///
@@ -75,9 +87,285 @@ pub fn get_calling_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConve
     code.try_into().ok()
 }
 
+/// Attach the exact callable type for an indirect call or proper-tail transfer.
+/// The type includes the physical closure environment parameter when present.
+pub fn set_indirect_call_signature(ctx: &mut IrContext, op: OpRef, signature: TypeRef) {
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
+        Attribute::Type(signature),
+    );
+}
+
+/// Read the exact callable type preserved for an indirect transfer.
+pub fn get_indirect_call_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
+    ctx.op(op).attributes.get_type(INDIRECT_CALL_SIGNATURE_ATTR)
+}
+
+/// Preserve the typed closure occurrence while lowering it to `_closure`.
+pub fn set_closure_callable_type(ctx: &mut IrContext, op: OpRef, closure: TypeRef) {
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR),
+        Attribute::Type(closure),
+    );
+}
+
+/// Read the exact typed closure provenance from a lowered closure value.
+pub fn get_closure_callable_type(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
+    ctx.op(op).attributes.get_type(CLOSURE_CALLABLE_TYPE_ATTR)
+}
+
+/// Result-indexed CPS completion target `Done<R>`.
+pub fn cps_done_type(ctx: &mut IrContext, result: TypeRef) -> TypeRef {
+    let never = core::never(ctx).as_type_ref();
+    let function = core::func(ctx, never, [result]).as_type_ref();
+    physical_closure_type(ctx, function, CallingConvention::Cps)
+}
+
+/// Make the nominal reference for one private immutable `Flow<R>` pack.
+/// The paired struct layout may recursively use this reference.
+pub fn cps_parent_ref_type(ctx: &mut IrContext, name: Symbol, result: TypeRef) -> TypeRef {
+    ctx.types.intern(
+        TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("typeref"))
+            .attr("name", Attribute::Symbol(name))
+            .attr(CPS_PARENT_RESULT_ATTR, Attribute::Type(result))
+            .build(),
+    )
+}
+
+/// Make the exact layout for [`cps_parent_ref_type`].
+pub fn cps_parent_layout_type(
+    ctx: &mut IrContext,
+    name: Symbol,
+    result: TypeRef,
+    done: TypeRef,
+    dispatch: TypeRef,
+) -> TypeRef {
+    ctx.types.intern(
+        TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("struct"))
+            .attr("name", Attribute::Symbol(name))
+            .attr(CPS_PARENT_RESULT_ATTR, Attribute::Type(result))
+            .attr(
+                "fields",
+                Attribute::List(vec![
+                    Attribute::List(vec![
+                        Attribute::Symbol(Symbol::new("done")),
+                        Attribute::Type(done),
+                    ]),
+                    Attribute::List(vec![
+                        Attribute::Symbol(Symbol::new("dispatch")),
+                        Attribute::Type(dispatch),
+                    ]),
+                ]),
+            )
+            .build(),
+    )
+}
+
+pub fn cps_parent_result_type(ctx: &IrContext, parent: TypeRef) -> Option<TypeRef> {
+    let data = ctx.types.get(parent);
+    (data.dialect == Symbol::new("adt") && data.name == Symbol::new("typeref"))
+        .then(|| data.attrs.get_type(CPS_PARENT_RESULT_ATTR))
+        .flatten()
+}
+
+/// Whether `parent` has one exact nominal immutable layout for `dispatch`.
+///
+/// The result tag on a typeref alone is insufficient provenance: its matching
+/// struct layout must own the same nominal identity and carry the canonical
+/// `done` and `dispatch` fields.
+pub fn has_canonical_cps_parent_layout(
+    ctx: &IrContext,
+    parent: TypeRef,
+    dispatch: TypeRef,
+) -> bool {
+    let Some(result) = cps_parent_result_type(ctx, parent) else {
+        return false;
+    };
+    let Some(name) = ctx.types.get(parent).attrs.get_symbol("name") else {
+        return false;
+    };
+
+    let is_never = |ty| {
+        let data = ctx.types.get(ty);
+        data.dialect == Symbol::new("core") && data.name == Symbol::new("never")
+    };
+    let is_done = |ty| {
+        let Some(function) = cps_closure_function_type(ctx, ty) else {
+            return false;
+        };
+        let params = &ctx.types.get(function).params;
+        params.len() == 2 && is_never(params[0]) && params[1] == result
+    };
+    let mut matching_name = 0;
+    let mut canonical = 0;
+    for (_, data) in ctx.types.iter() {
+        if data.dialect != Symbol::new("adt")
+            || data.name != Symbol::new("struct")
+            || data.attrs.get_symbol("name") != Some(name)
+        {
+            continue;
+        }
+        matching_name += 1;
+        let Some(Attribute::List(fields)) = data.attrs.get("fields") else {
+            continue;
+        };
+        let [Attribute::List(done), Attribute::List(actual_dispatch)] = fields.as_slice() else {
+            continue;
+        };
+        let [Attribute::Symbol(done_name), Attribute::Type(done_type)] = done.as_slice() else {
+            continue;
+        };
+        let [
+            Attribute::Symbol(dispatch_name),
+            Attribute::Type(dispatch_type),
+        ] = actual_dispatch.as_slice()
+        else {
+            continue;
+        };
+        if data.attrs.get_type(CPS_PARENT_RESULT_ATTR) == Some(result)
+            && *done_name == Symbol::new("done")
+            && is_done(*done_type)
+            && *dispatch_name == Symbol::new("dispatch")
+            && *dispatch_type == dispatch
+        {
+            canonical += 1;
+        }
+    }
+    matching_name == 1 && canonical == 1
+}
+
+/// Strict suffix continuation
+/// `Completion<X, R> = (Evidence, Parent<R>, X) -> never`.
+pub fn cps_completion_type(
+    ctx: &mut IrContext,
+    evidence: TypeRef,
+    value: TypeRef,
+    parent: TypeRef,
+) -> TypeRef {
+    let never = core::never(ctx).as_type_ref();
+    let function = core::func(ctx, never, [evidence, parent, value]).as_type_ref();
+    physical_closure_type(ctx, function, CallingConvention::Cps)
+}
+
+/// Exact operation resumption
+/// `ResumeExact<I, R> = (Evidence, Parent<R>, I) -> never`.
+pub fn cps_resume_exact_type(
+    ctx: &mut IrContext,
+    evidence: TypeRef,
+    input: TypeRef,
+    parent: TypeRef,
+) -> TypeRef {
+    cps_completion_type(ctx, evidence, input, parent)
+}
+
+/// Erased-input resumption
+/// `Resume<R> = (Evidence, Parent<R>, anyref) -> never`.
+pub fn cps_resume_type(
+    ctx: &mut IrContext,
+    evidence: TypeRef,
+    parent: TypeRef,
+    anyref: TypeRef,
+) -> TypeRef {
+    cps_completion_type(ctx, evidence, anyref, parent)
+}
+
+/// Result-indexed general-operation dispatcher.
+pub fn cps_dispatch_type(
+    ctx: &mut IrContext,
+    evidence: TypeRef,
+    parent: TypeRef,
+    anyref: TypeRef,
+    i32_type: TypeRef,
+) -> TypeRef {
+    let never = core::never(ctx).as_type_ref();
+    let resume = cps_resume_type(ctx, evidence, parent, anyref);
+    let function = core::func(
+        ctx,
+        never,
+        [evidence, resume, i32_type, i32_type, i32_type, anyref],
+    )
+    .as_type_ref();
+    physical_closure_type(ctx, function, CallingConvention::Cps)
+}
+
+/// Return the underlying exact `core.func` only for a convention-proven CPS
+/// closure. Callers must reject absent provenance rather than infer it from
+/// structural shape.
+pub fn cps_closure_function_type(ctx: &IrContext, closure: TypeRef) -> Option<TypeRef> {
+    (get_physical_closure_convention(ctx, closure) == Some(CallingConvention::Cps))
+        .then(|| ctx.types.get(closure).params.first().copied())
+        .flatten()
+        .filter(|function| {
+            let data = ctx.types.get(*function);
+            data.dialect == Symbol::new("core") && data.name == Symbol::new("func")
+        })
+}
+
+/// Build a physical closure type that preserves its exact callable
+/// convention on the outer `closure.closure` occurrence.
+pub fn physical_closure_type(
+    ctx: &mut IrContext,
+    function: TypeRef,
+    convention: CallingConvention,
+) -> TypeRef {
+    ctx.types.intern(
+        TypeDataBuilder::new(Symbol::new("closure"), Symbol::new("closure"))
+            .param(function)
+            .attr(CALLING_CONVENTION_ATTR, Attribute::Int(convention as i128))
+            .build(),
+    )
+}
+
+/// Read exact convention provenance from a physical outer closure type.
+pub fn get_physical_closure_convention(
+    ctx: &IrContext,
+    closure: TypeRef,
+) -> Option<CallingConvention> {
+    let data = ctx.types.get(closure);
+    if data.dialect != Symbol::new("closure") || data.name != Symbol::new("closure") {
+        return None;
+    }
+    let code = data.attrs.get_u8(CALLING_CONVENTION_ATTR).ok()??;
+    code.try_into().ok()
+}
+
+/// Preserve the checker-selected Direct/EvidenceDirect convention for the
+/// exact root entry while its physical worker is promoted to CPS.
+pub fn set_root_export_convention(ctx: &mut IrContext, op: OpRef, convention: CallingConvention) {
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(ROOT_EXPORT_CONVENTION_ATTR),
+        Attribute::Int(convention as i128),
+    );
+}
+
+/// Read the checker-selected convention for the exact root export.
+pub fn get_root_export_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConvention> {
+    let code = ctx
+        .op(op)
+        .attributes
+        .get_u8(ROOT_EXPORT_CONVENTION_ATTR)
+        .ok()??;
+    code.try_into().ok()
+}
+
+/// Preserve the exact source result type of the root export while its worker
+/// is promoted to the physical CPS ABI.
+pub fn set_root_source_result(ctx: &mut IrContext, op: OpRef, result: trunk_ir::TypeRef) {
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(ROOT_SOURCE_RESULT_ATTR),
+        Attribute::Type(result),
+    );
+}
+
+/// Read the preserved source result type of the exact root export.
+pub fn get_root_source_result(ctx: &IrContext, op: OpRef) -> Option<trunk_ir::TypeRef> {
+    ctx.op(op).attributes.get_type(ROOT_SOURCE_RESULT_ATTR)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trunk_ir::types::TypeDataBuilder;
 
     #[test]
     fn integer_codes_round_trip() {
@@ -87,5 +375,93 @@ mod tests {
         }
 
         assert_eq!(CallingConvention::try_from(3), Err(3));
+    }
+
+    #[test]
+    fn physical_closure_convention_is_type_identity() {
+        let mut ctx = IrContext::new();
+        let never = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("never")).build());
+        let function = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                .param(never)
+                .build(),
+        );
+        let direct = physical_closure_type(&mut ctx, function, CallingConvention::Direct);
+        let cps = physical_closure_type(&mut ctx, function, CallingConvention::Cps);
+
+        assert_ne!(direct, cps);
+        assert_eq!(
+            get_physical_closure_convention(&ctx, direct),
+            Some(CallingConvention::Direct)
+        );
+        assert_eq!(
+            get_physical_closure_convention(&ctx, cps),
+            Some(CallingConvention::Cps)
+        );
+    }
+
+    #[test]
+    fn result_indexed_cps_types_preserve_all_boundary_types() {
+        let mut ctx = IrContext::new();
+        let evidence = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("ability"), Symbol::new("evidence")).build());
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let anyref = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("tribute_rt"), Symbol::new("anyref")).build());
+        let parent = cps_parent_ref_type(&mut ctx, Symbol::new("ParentI32"), i32_ty);
+        let done = cps_done_type(&mut ctx, i32_ty);
+        let dispatch = cps_dispatch_type(&mut ctx, evidence, parent, anyref, i32_ty);
+        let layout =
+            cps_parent_layout_type(&mut ctx, Symbol::new("ParentI32"), i32_ty, done, dispatch);
+        let completion = cps_completion_type(&mut ctx, evidence, i32_ty, parent);
+        let resume_exact = cps_resume_exact_type(&mut ctx, evidence, i32_ty, parent);
+        let resume = cps_resume_type(&mut ctx, evidence, parent, anyref);
+        let never = core::never(&mut ctx).as_type_ref();
+
+        assert_eq!(cps_parent_result_type(&ctx, parent), Some(i32_ty));
+        assert_eq!(
+            ctx.types.get(layout).attrs.get_type(CPS_PARENT_RESULT_ATTR),
+            Some(i32_ty)
+        );
+        assert_eq!(
+            ctx.types.get(layout).attrs.get("fields"),
+            Some(&Attribute::List(vec![
+                Attribute::List(vec![
+                    Attribute::Symbol(Symbol::new("done")),
+                    Attribute::Type(done)
+                ]),
+                Attribute::List(vec![
+                    Attribute::Symbol(Symbol::new("dispatch")),
+                    Attribute::Type(dispatch),
+                ]),
+            ]))
+        );
+
+        for (closure, expected) in [
+            (completion, vec![never, evidence, parent, i32_ty]),
+            (resume_exact, vec![never, evidence, parent, i32_ty]),
+            (resume, vec![never, evidence, parent, anyref]),
+            (
+                dispatch,
+                vec![never, evidence, resume, i32_ty, i32_ty, i32_ty, anyref],
+            ),
+        ] {
+            let function = cps_closure_function_type(&ctx, closure).unwrap();
+            assert_eq!(
+                ctx.types.get(function).params.as_slice(),
+                expected.as_slice()
+            );
+        }
+        assert_ne!(parent, anyref);
+        assert_ne!(
+            completion,
+            cps_completion_type(&mut ctx, evidence, anyref, parent)
+        );
     }
 }

--- a/crates/tribute-core/src/lib.rs
+++ b/crates/tribute-core/src/lib.rs
@@ -5,9 +5,17 @@ pub mod diagnostic;
 pub mod fmt;
 pub mod target;
 
-pub use callable_abi::CallableAbi;
+pub use callable_abi::{CallableAbi, interpose_physical_environment, physical_environment_index};
 pub use calling_convention::{
-    CALLING_CONVENTION_ATTR, CallingConvention, get_calling_convention, set_calling_convention,
+    CALLING_CONVENTION_ATTR, CLOSURE_CALLABLE_TYPE_ATTR, CPS_PARENT_RESULT_ATTR, CallingConvention,
+    INDIRECT_CALL_SIGNATURE_ATTR, ROOT_EXPORT_CONVENTION_ATTR, ROOT_SOURCE_RESULT_ATTR,
+    cps_closure_function_type, cps_completion_type, cps_dispatch_type, cps_done_type,
+    cps_parent_layout_type, cps_parent_ref_type, cps_parent_result_type, cps_resume_exact_type,
+    cps_resume_type, get_calling_convention, get_closure_callable_type,
+    get_indirect_call_signature, get_physical_closure_convention, get_root_export_convention,
+    get_root_source_result, has_canonical_cps_parent_layout, physical_closure_type,
+    set_calling_convention, set_closure_callable_type, set_indirect_call_signature,
+    set_root_export_convention, set_root_source_result,
 };
 pub use diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 pub use target::*;

--- a/crates/tribute-front/src/ast/types.rs
+++ b/crates/tribute-front/src/ast/types.rs
@@ -86,6 +86,13 @@ pub enum TypeKind<'db> {
     /// Index 0 refers to the innermost binder, following De Bruijn convention.
     BoundVar { index: u32 },
 
+    /// Type variable quantified by a local `let` binding.
+    ///
+    /// Unlike [`Self::BoundVar`], this retains the binding node that owns the
+    /// quantifier. It is valid only in typed bodies and semantic metadata;
+    /// function `TypeScheme`s never contain it.
+    LocalBoundVar { scope: NodeId, index: u32 },
+
     /// Unification variable (unknown during inference).
     ///
     /// These are created during type checking and resolved by unification.
@@ -230,6 +237,7 @@ impl fmt::Display for TypeKind<'_> {
                 write!(f, "#({elems})")
             }
             Self::BoundVar { index } => write!(f, "_{}", index),
+            Self::LocalBoundVar { index, .. } => write!(f, "_local{}", index),
             Self::UniVar { .. } => f.write_str("_"),
             Self::App { ctor, args } => {
                 let args = args

--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -108,6 +108,9 @@ pub struct IrLoweringCtx<'db> {
     logical_generated_signatures: HashMap<Symbol, LogicalGeneratedSignature>,
     /// Source declarations collected before logical lowering begins.
     logical_source_functions: HashSet<Symbol>,
+    /// Source extern declarations, retained separately so a monomorphized
+    /// intrinsic call can use its base ABI declaration.
+    logical_source_externs: HashSet<Symbol>,
     /// Extern declarations synthesized for referenced prelude functions.
     logical_emitted_externs: HashSet<Symbol>,
     /// Ability-level calling-convention requirements.
@@ -189,6 +192,7 @@ impl<'db> IrLoweringCtx<'db> {
             function_types,
             logical_generated_signatures: HashMap::new(),
             logical_source_functions: HashSet::new(),
+            logical_source_externs: HashSet::new(),
             logical_emitted_externs: HashSet::new(),
             ability_conventions,
             definition_conventions: HashMap::new(),
@@ -353,6 +357,22 @@ impl<'db> IrLoweringCtx<'db> {
         self.logical_source_functions.contains(&name)
     }
 
+    pub(crate) fn register_logical_source_extern(&mut self, name: Symbol) {
+        self.logical_source_externs.insert(name);
+    }
+
+    pub(crate) fn has_logical_source_extern_base(&self, name: Symbol) -> bool {
+        if self.logical_source_externs.contains(&name) {
+            return true;
+        }
+        name.with_str(|text| {
+            text.split_once('$').is_some_and(|(base, _)| {
+                self.logical_source_externs
+                    .contains(&Symbol::from_dynamic(base))
+            })
+        })
+    }
+
     /// Returns true exactly once for each prelude declaration that must be
     /// materialized in the logical module.
     pub(crate) fn mark_logical_extern_emitted(&mut self, name: Symbol) -> bool {
@@ -478,6 +498,22 @@ impl<'db> IrLoweringCtx<'db> {
         prefix.push_str("::");
         name.with_str(|s| prefix.push_str(s));
         Symbol::from_dynamic(&prefix)
+    }
+
+    /// Resolve a declaration's one canonical emitted identity.
+    ///
+    /// Source declarations use simple names and inherit the current nested
+    /// module. Synthetic monomorphized declarations already contain their
+    /// source-qualified path and must remain unchanged.
+    pub fn canonical_declaration_name(&self, name: Symbol) -> Symbol {
+        let mut prefix = self
+            .module_path
+            .iter()
+            .skip(1)
+            .map(Symbol::to_string)
+            .collect::<Vec<_>>()
+            .join("::");
+        crate::canonical_declaration_symbol(&mut prefix, name)
     }
 
     /// Generate a unique lambda name qualified with module path.
@@ -624,7 +660,7 @@ impl<'db> IrLoweringCtx<'db> {
                 // Legacy frontend CPS has no logical bottom representation.
                 self.anyref_type(ir)
             }
-            TypeKind::BoundVar { .. } => {
+            TypeKind::BoundVar { .. } | TypeKind::LocalBoundVar { .. } => {
                 // Quantified type variable in TypeScheme body → type-erased any
                 self.anyref_type(ir)
             }
@@ -660,7 +696,9 @@ impl<'db> IrLoweringCtx<'db> {
             TypeKind::Bytes => self.bytes_type(ir),
             TypeKind::Nil | TypeKind::Error => self.nil_type(ir),
             TypeKind::Never => core::never(ir).as_type_ref(),
-            TypeKind::BoundVar { .. } | TypeKind::UniVar { .. } => self.anyref_type(ir),
+            TypeKind::BoundVar { .. }
+            | TypeKind::LocalBoundVar { .. }
+            | TypeKind::UniVar { .. } => self.anyref_type(ir),
             TypeKind::Named { name, .. }
                 if self.get_type(*name).is_some()
                     || self.logical_nominal_declarations.contains(name) =>
@@ -746,6 +784,9 @@ impl<'db> IrLoweringCtx<'db> {
             TypeKind::Never => "never".into(),
             TypeKind::Error => "error".into(),
             TypeKind::BoundVar { index } => logical_key("bound", [index.to_string()]),
+            TypeKind::LocalBoundVar { scope, index } => {
+                logical_key("local_bound", [scope.raw().to_string(), index.to_string()])
+            }
             TypeKind::UniVar { id } => self.logical_univar_key(*id),
             TypeKind::Named { id, name, args } => {
                 let mut parts = vec![self.logical_nominal_key(*id, *name)];
@@ -1367,6 +1408,14 @@ mod tests {
         assert_eq!(
             ctx.qualify_name(Symbol::new("run")),
             Symbol::new("Nested::run")
+        );
+        assert_eq!(
+            ctx.canonical_declaration_name(Symbol::new("run")),
+            Symbol::new("Nested::run")
+        );
+        assert_eq!(
+            ctx.canonical_declaration_name(Symbol::new("Nested::run$Int")),
+            Symbol::new("Nested::run$Int")
         );
         ctx.exit_module();
 

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -136,7 +136,7 @@ pub(super) fn prescan_struct_fields<'db>(
 /// does not by itself require the definition's worker to use CPS. Concrete
 /// residual effects still contribute their ability-level requirements.
 /// Explicit annotations use the convention derived from their closed row.
-fn prescan_definition_conventions<'db>(
+pub(super) fn prescan_definition_conventions<'db>(
     ctx: &mut IrLoweringCtx<'db>,
     decls: &[Decl<TypedRef<'db>>],
     prefix: &mut String,
@@ -144,7 +144,7 @@ fn prescan_definition_conventions<'db>(
     for decl in decls {
         match decl {
             Decl::Function(func_decl) => {
-                let qualified = crate::qualified_symbol(prefix, func_decl.name);
+                let qualified = crate::canonical_declaration_symbol(prefix, func_decl.name);
                 let scheme = ctx
                     .lookup_function_type(qualified)
                     .or_else(|| ctx.lookup_function_type(func_decl.name));
@@ -190,7 +190,7 @@ fn prescan_definition_conventions<'db>(
 /// body invokes an open-effect callback or a named worker promoted in a prior
 /// pass.  Re-evaluate every body against the current definition map until no
 /// worker changes; conventions only ever strengthen to Cps.
-fn promote_definition_conventions_to_fixed_point<'db>(
+pub(super) fn promote_definition_conventions_to_fixed_point<'db>(
     ctx: &mut IrLoweringCtx<'db>,
     decls: &[Decl<TypedRef<'db>>],
     prefix: &mut String,
@@ -204,6 +204,58 @@ fn promote_definition_conventions_to_fixed_point<'db>(
     }
 }
 
+/// Promote source-logical workers until every handler and transitive CPS call
+/// is represented by a CPS worker convention.
+///
+/// The target-owned root ABI wrapper is constructed after shared legalization,
+/// so root `main` is intentionally not exempt at this boundary.
+pub(super) fn promote_logical_definition_conventions_to_fixed_point<'db>(
+    ctx: &mut IrLoweringCtx<'db>,
+    decls: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+) {
+    loop {
+        let mut changed = false;
+        promote_logical_definition_conventions_pass(ctx, decls, prefix, &mut changed);
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn promote_logical_definition_conventions_pass<'db>(
+    ctx: &mut IrLoweringCtx<'db>,
+    decls: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+    changed: &mut bool,
+) {
+    for decl in decls {
+        match decl {
+            Decl::Function(function) => {
+                let qualified = crate::canonical_declaration_symbol(prefix, function.name);
+                let Some(convention) = ctx.function_calling_convention(qualified) else {
+                    continue;
+                };
+                if convention != CallingConvention::Cps
+                    && expr::logical_evaluation_control_class(ctx, &function.body)
+                        == expr::EvaluationControlClass::Cps
+                {
+                    ctx.register_definition_convention(qualified, CallingConvention::Cps);
+                    *changed = true;
+                }
+            }
+            Decl::Module(module) => {
+                if let Some(body) = &module.body {
+                    let saved = crate::push_prefix(prefix, module.name);
+                    promote_logical_definition_conventions_pass(ctx, body, prefix, changed);
+                    prefix.truncate(saved);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 fn promote_definition_conventions_pass<'db>(
     ctx: &mut IrLoweringCtx<'db>,
     decls: &[Decl<TypedRef<'db>>],
@@ -213,7 +265,7 @@ fn promote_definition_conventions_pass<'db>(
     for decl in decls {
         match decl {
             Decl::Function(func_decl) => {
-                let qualified = crate::qualified_symbol(prefix, func_decl.name);
+                let qualified = crate::canonical_declaration_symbol(prefix, func_decl.name);
                 let Some(convention) = ctx.function_calling_convention(qualified) else {
                     continue;
                 };
@@ -267,6 +319,8 @@ impl<'db> TypedModule<'db> {
             perform_operations: _,
             lambda_signatures: _,
             exhaustive_cases: _,
+            call_callee_types: _,
+            specialized_call_callee_nodes: _,
         } = self;
         let module_location = span_map.get_or_default(ast.id);
         let location = Location::new(path, module_location);

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -914,6 +914,18 @@ pub(super) fn evaluation_control_class<'db>(
     evaluation_control_class_with_handle_propagation(ctx, expr, false)
 }
 
+/// Classify a source-logical worker before shared CPS legalization.
+///
+/// Unlike the temporary legacy physical route, the logical boundary does not
+/// own a private handler carrier. A handled computation therefore remains a
+/// CPS evaluation until the shared legalizer constructs its continuations.
+pub(super) fn logical_evaluation_control_class<'db>(
+    ctx: &super::super::context::IrLoweringCtx<'db>,
+    expr: &Expr<TypedRef<'db>>,
+) -> EvaluationControlClass {
+    evaluation_control_class_with_handle_propagation(ctx, expr, true)
+}
+
 /// Classify evaluation with an explicit nested-handle propagation policy.
 ///
 /// Source convention selection treats handles as source delimiters. Ambient

--- a/crates/tribute-front/src/ast_to_ir/lower/logical.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/logical.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 
 use salsa::Accumulator;
 use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
+use tribute_core::{set_root_export_convention, set_root_source_result};
 use tribute_ir::dialect::{
     list,
     tribute_control::{self, OperationDeclaration},
@@ -44,6 +45,8 @@ struct Declarations<'db> {
     >,
     lambda_signatures:
         std::collections::HashMap<crate::ast::NodeId, crate::typeck::LambdaSignature<'db>>,
+    call_callee_types: std::collections::HashMap<crate::ast::NodeId, crate::ast::Type<'db>>,
+    specialized_call_callee_nodes: std::collections::HashSet<crate::ast::NodeId>,
     exhaustive_cases: std::collections::HashSet<crate::ast::NodeId>,
 }
 
@@ -136,6 +139,8 @@ pub(super) fn lower_module<'db>(
         function_types,
         constructor_types,
         node_types,
+        call_callee_types,
+        specialized_call_callee_nodes,
         ability_conventions,
         ability_definitions,
         handler_operations,
@@ -168,8 +173,16 @@ pub(super) fn lower_module<'db>(
         handler_operations,
         perform_operations,
         lambda_signatures,
+        call_callee_types,
+        specialized_call_callee_nodes,
         exhaustive_cases,
     };
+    super::decl::prescan_definition_conventions(&mut ctx, &ast.decls, &mut String::new());
+    super::decl::promote_logical_definition_conventions_to_fixed_point(
+        &mut ctx,
+        &ast.decls,
+        &mut String::new(),
+    );
     let mut well_known_type_prescan = super::decl::WellKnownTypePrescan::new(well_known_types);
     collect_logical_nominal_identities(&mut ctx, &ast.decls, &mut String::new());
     prescan_logical_nominal_layouts(
@@ -280,8 +293,14 @@ fn prescan_logical_nominal_layouts<'db>(
                     .variants
                     .iter()
                     .map(|variant| {
-                        let variant_ctor =
-                            CtorId::new(ctx.db, crate::qualified_symbol(prefix, variant.name));
+                        let variant_ctor = if enumeration.id.variant().is_some() {
+                            CtorId::new(
+                                ctx.db,
+                                Symbol::from_dynamic(&format!("{qualified}${}", variant.name)),
+                            )
+                        } else {
+                            CtorId::new(ctx.db, crate::qualified_symbol(prefix, variant.name))
+                        };
                         let fields = constructor_fields(
                             ctx,
                             constructors,
@@ -456,10 +475,12 @@ fn prescan_source_functions<'db>(
     for declaration in declarations {
         match declaration {
             Decl::Function(function) => {
-                ctx.register_logical_source_function(ctx.qualify_name(function.name));
+                ctx.register_logical_source_function(ctx.canonical_declaration_name(function.name));
             }
             Decl::ExternFunction(function) => {
-                ctx.register_logical_source_function(ctx.qualify_name(function.name));
+                let name = ctx.canonical_declaration_name(function.name);
+                ctx.register_logical_source_function(name);
+                ctx.register_logical_source_extern(name);
             }
             Decl::Module(module) => {
                 if let Some(body) = &module.body {
@@ -540,21 +561,17 @@ fn function_signature<'db>(
     ir: &mut IrContext,
     function: &FuncDecl<TypedRef<'db>>,
 ) -> FuncSignature {
-    let qualified = ctx.qualify_name(function.name);
-    let signature = if qualified == function.name {
-        FuncSignature::lookup_logical(ctx, ir, function.name)
-    } else {
-        // Nested declarations are exported under their qualified identity; a
-        // short-name lookup can silently select an unrelated root declaration.
-        FuncSignature::lookup_logical(ctx, ir, qualified)
-            .or_else(|| FuncSignature::lookup_logical(ctx, ir, function.name))
-    };
-    signature.unwrap_or_else(|| {
+    let qualified = ctx.canonical_declaration_name(function.name);
+    let mut signature = FuncSignature::lookup_logical(ctx, ir, qualified).unwrap_or_else(|| {
         panic!(
             "missing typechecked signature for function {}",
             function.name
         )
-    })
+    });
+    signature.convention = ctx
+        .function_calling_convention(qualified)
+        .unwrap_or(signature.convention);
+    signature
 }
 
 fn lower_function<'db>(
@@ -565,6 +582,13 @@ fn lower_function<'db>(
     declarations: &mut Declarations<'db>,
 ) {
     let location = ctx.location(function.id);
+    let qualified_name = ctx.canonical_declaration_name(function.name);
+    let root_export_convention = crate::is_root_main(function.name, ctx.module_path().len() == 1)
+        .then(|| {
+            FuncSignature::lookup_logical(ctx, ir, qualified_name)
+                .expect("root main has a typechecked logical signature")
+                .convention
+        });
     let signature = function_signature(ctx, ir, &function);
     let callable = callable_type(
         ir,
@@ -594,12 +618,16 @@ fn lower_function<'db>(
                 scope.bind(id, parameter.name, ir.block_arg(entry, index as u32));
             }
         }
-        let value = lower_expr(
+        let Some(value) = lower_expr(
             &mut IrBuilder::new(&mut scope, ir, entry),
             function.body,
             declarations,
-        )
-        .expect("typechecked source expression failed logical IR lowering");
+        ) else {
+            // Type checking has emitted the source diagnostic.  Do not invent
+            // an invalid logical value or publish a partial function body
+            // during error recovery.
+            return;
+        };
         let value = IrBuilder::new(&mut scope, ir, entry).cast_if_needed(
             location,
             value,
@@ -614,10 +642,17 @@ fn lower_function<'db>(
         blocks: trunk_ir::smallvec::smallvec![entry],
         parent_op: None,
     });
-    let name = ctx.qualify_name(function.name);
-    let function = tribute_control::func_declaration(ir, location, name, callable);
+    let function = tribute_control::func_declaration(ir, location, qualified_name, callable);
     ir.op_mut(function.op_ref()).regions.push(body);
     ir.region_mut(body).parent_op = Some(function.op_ref());
+    if let Some(convention) = root_export_convention {
+        assert!(
+            convention != CallingConvention::Cps,
+            "typechecked root export convention must be Direct or EvidenceDirect"
+        );
+        set_root_export_convention(ir, function.op_ref(), convention);
+        set_root_source_result(ir, function.op_ref(), signature.return_type);
+    }
     ir.push_op(top, function.op_ref());
 }
 
@@ -628,26 +663,21 @@ fn lower_extern<'db>(
     decl: ExternFuncDecl,
 ) {
     let location = ctx.location(decl.id);
-    let qualified = ctx.qualify_name(decl.name);
-    let signature = if qualified == decl.name {
-        FuncSignature::lookup_logical(ctx, ir, decl.name)
-    } else {
-        FuncSignature::lookup_logical(ctx, ir, qualified)
-            .or_else(|| FuncSignature::lookup_logical(ctx, ir, decl.name))
-    }
-    .unwrap_or_else(|| {
+    let qualified = ctx.canonical_declaration_name(decl.name);
+    let mut signature = FuncSignature::lookup_logical(ctx, ir, qualified).unwrap_or_else(|| {
         panic!(
             "missing typechecked signature for extern function {}",
             decl.name
         )
     });
+    signature.convention = CallingConvention::Direct;
     let callable = callable_type(
         ir,
         signature.return_type,
         signature.param_types,
         signature.convention,
     );
-    let name = ctx.qualify_name(decl.name);
+    let name = ctx.canonical_declaration_name(decl.name);
     let function = tribute_control::func_declaration(ir, location, name, callable);
     ir.op_mut(function.op_ref())
         .attributes
@@ -662,6 +692,7 @@ fn ensure_prelude_declaration(
     signature: &FuncSignature,
 ) {
     if builder.ctx.is_logical_source_function(name)
+        || builder.ctx.has_logical_source_extern_base(name)
         || builder
             .ctx
             .lookup_logical_generated_signature(name)
@@ -1005,7 +1036,22 @@ fn lower_expr<'db>(
         }
         ExprKind::Resume { arg, local_id } => {
             let token = builder.ctx.lookup_resume(local_id?)?;
+            let declared_input_ty =
+                tribute_control::resume_token_parts(builder.ir, builder.ir.value_ty(token))
+                    .map(|(input, _)| input)
+                    .unwrap_or_else(|| {
+                        panic!("missing exact declared input type for resume token")
+                    });
+            let source_input_ty = expr_type(builder, &arg);
+            assert_eq!(
+                source_input_ty, declared_input_ty,
+                "typechecked resume input disagrees with its exact operation declaration"
+            );
             let value = lower_expr(builder, arg, declarations)?;
+            // Literal and erased ADT values use their source representation at
+            // this boundary.  The resume token, derived from the operation
+            // declaration, is the exact authority for restoring that type.
+            let value = builder.cast_if_needed(location, value, declared_input_ty);
             let result_ty = builder
                 .ctx
                 .get_node_type(expr.id)
@@ -1137,8 +1183,25 @@ fn lower_record<'db>(
     // values in declaration layout order.
     let mut values = HashMap::new();
     for (name, field) in fields {
-        if !field_order.contains(&name) || values.contains_key(&name) {
-            panic!("typechecked record has an invalid field layout");
+        if !field_order.contains(&name) {
+            Diagnostic::new(
+                format!("unknown field `{name}` for struct `{struct_name}`"),
+                location.span,
+                DiagnosticSeverity::Error,
+                CompilationPhase::Lowering,
+            )
+            .accumulate(builder.db());
+            return None;
+        }
+        if values.contains_key(&name) {
+            Diagnostic::new(
+                format!("duplicate field `{name}`"),
+                location.span,
+                DiagnosticSeverity::Error,
+                CompilationPhase::Lowering,
+            )
+            .accumulate(builder.db());
+            return None;
         }
         values.insert(name, lower_expr(builder, field, declarations)?);
     }
@@ -1147,8 +1210,16 @@ fn lower_record<'db>(
         if let Some(value) = values.get(name) {
             ordered.push(*value);
         } else {
-            let base =
-                spread.unwrap_or_else(|| panic!("typechecked record is missing field {name}"));
+            let Some(base) = spread else {
+                Diagnostic::new(
+                    format!("missing field: {name}"),
+                    location.span,
+                    DiagnosticSeverity::Error,
+                    CompilationPhase::Lowering,
+                )
+                .accumulate(builder.db());
+                return None;
+            };
             // The layout owns concrete field types.  `struct_get` needs a
             // result type, obtained from the matching getter expression type
             // only after normal typechecking; use layout metadata directly.
@@ -1194,10 +1265,10 @@ fn lower_case_chain<'db>(
     declarations: &mut Declarations<'db>,
 ) -> Option<ValueRef> {
     match arms {
-        // Typechecking has proved this path unreachable (for example the
-        // false branch after exhaustive Bool literal arms).  The arena has no
-        // source-logical unreachable producer, so keep it as an isolated
-        // polymorphic conversion value rather than introducing `func.*`.
+        // A finalized checker proof reaches an empty residual only through
+        // `build_case_else_region`, which has the structured-region context
+        // needed to emit logical bottom. Other empty chains remain ordinary
+        // diagnosed recovery.
         [] => Some(unreachable_case_value(builder, location, result_ty)),
         [last] if exhaustive && last.guard.is_none() => {
             let mut scope = builder.ctx.scope();
@@ -1394,6 +1465,15 @@ fn build_case_else_region<'db>(
         ops: Default::default(),
         parent_region: None,
     });
+    if arms.is_empty() && exhaustive {
+        let unreachable = tribute_control::unreachable(ir, location);
+        ir.push_op(block, unreachable.op_ref());
+        return Some(ir.create_region(RegionData {
+            location,
+            blocks: trunk_ir::smallvec::smallvec![block],
+            parent_op: None,
+        }));
+    }
     let value = lower_case_chain(
         &mut IrBuilder::new(ctx, ir, block),
         location,
@@ -1468,6 +1548,7 @@ fn lower_call<'db>(
     args: Vec<Expr<TypedRef<'db>>>,
     declarations: &mut Declarations<'db>,
 ) -> Option<ValueRef> {
+    let callee_id = callee.id;
     // A resolved variable callee is atomic. Any other callee expression is a
     // strict child and must be evaluated before the argument list.
     let indirect_callee = if matches!(&*callee.kind, ExprKind::Var(_)) {
@@ -1502,6 +1583,9 @@ fn lower_call<'db>(
                         semantic,
                     },
                 );
+                for (value, parameter_ty) in values.iter_mut().zip(&declaration.parameter_types) {
+                    *value = builder.cast_if_needed(location, *value, *parameter_ty);
+                }
                 let perform = op(builder.ir, builder.block, location, "perform", |builder| {
                     builder
                         .operands(values)
@@ -1531,7 +1615,27 @@ fn lower_call<'db>(
                     return Some(value);
                 }
                 let name = id.qualified(builder.ctx.db);
-                let signature = FuncSignature::lookup_logical(builder.ctx, builder.ir, name)
+                let signature = declarations
+                    .specialized_call_callee_nodes
+                    .contains(&callee_id)
+                    .then(|| {
+                        declarations
+                            .call_callee_types
+                            .get(&callee_id)
+                            .copied()
+                            .unwrap_or_else(|| {
+                                panic!("missing exact specialized call-callee metadata for {name}")
+                            })
+                    })
+                    .map(|callee_type| {
+                        FuncSignature::from_logical_type(builder.ctx, builder.ir, callee_type)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "typechecked call-callee metadata is not a callable for {name}"
+                                )
+                            })
+                    })
+                    .or_else(|| FuncSignature::lookup_logical(builder.ctx, builder.ir, name))
                     .unwrap_or_else(|| panic!("missing logical signature for call {name}"));
                 ensure_prelude_declaration(builder, location, name, &signature);
                 if values.len() != signature.param_types.len() {

--- a/crates/tribute-front/src/ast_to_ir/lower/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/mod.rs
@@ -12,9 +12,11 @@ mod logical;
 
 use salsa::Accumulator;
 use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
+use tribute_ir::dialect::tribute_control;
 use trunk_ir::Symbol;
-use trunk_ir::context::IrContext;
+use trunk_ir::context::{BlockArgData, BlockData, IrContext, OperationDataBuilder, RegionData};
 use trunk_ir::dialect::{arith, core};
+use trunk_ir::ops::DialectType;
 use trunk_ir::refs::{BlockRef, TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, Location};
 
@@ -34,6 +36,24 @@ pub(super) struct FuncSignature {
 }
 
 impl FuncSignature {
+    pub fn from_logical_type<'db>(
+        ctx: &IrLoweringCtx<'db>,
+        ir: &mut IrContext,
+        ty: crate::ast::Type<'db>,
+    ) -> Option<Self> {
+        match ty.kind(ctx.db) {
+            TypeKind::Func { params, result, .. } => Some(Self {
+                param_types: params
+                    .iter()
+                    .map(|parameter| ctx.convert_logical_type(ir, *parameter))
+                    .collect(),
+                return_type: ctx.convert_logical_type(ir, *result),
+                convention: ctx.calling_convention_for_type(ty)?,
+            }),
+            _ => None,
+        }
+    }
+
     /// Look up a function's TypeScheme by name and extract its IR-level signature.
     ///
     /// Returns `None` if the function has no TypeScheme or non-Func body type.
@@ -64,17 +84,7 @@ impl FuncSignature {
         }
         let scheme = *ctx.lookup_function_type(name)?;
         let body = scheme.body(ctx.db);
-        match body.kind(ctx.db) {
-            TypeKind::Func { params, result, .. } => Some(Self {
-                param_types: params
-                    .iter()
-                    .map(|ty| ctx.convert_logical_type(ir, *ty))
-                    .collect(),
-                return_type: ctx.convert_logical_type(ir, *result),
-                convention: ctx.calling_convention_for_type(body)?,
-            }),
-            _ => None,
-        }
+        Self::from_logical_type(ctx, ir, body)
     }
 }
 
@@ -152,6 +162,10 @@ impl<'a, 'db> IrBuilder<'a, 'db> {
             return value;
         }
 
+        if let Some(adapter) = self.callable_strengthening_adapter(location, value, target_ty) {
+            return adapter;
+        }
+
         // Skip cast for closure → func conversions
         if self.ctx.is_closure_type(self.ir, value_ty) && self.ctx.is_func_type(self.ir, target_ty)
         {
@@ -171,6 +185,82 @@ impl<'a, 'db> IrBuilder<'a, 'db> {
         let cast_op = core::unrealized_conversion_cast(self.ir, location, value, target_ty);
         self.ir.push_op(self.block, cast_op.op_ref());
         cast_op.result(self.ir)
+    }
+
+    /// Build the explicit source-logical Direct-to-Cps wrapper for an otherwise
+    /// identical callable signature. This is structural source IR, not an
+    /// unrealized control conversion: the wrapper calls the original closure
+    /// normally and returns through the Cps callable body.
+    fn callable_strengthening_adapter(
+        &mut self,
+        location: Location,
+        value: ValueRef,
+        target_ty: TypeRef,
+    ) -> Option<ValueRef> {
+        let source_ty = self.ir.value_ty(value);
+        let source = tribute_control::Callable::from_type_ref(self.ir, source_ty)?;
+        let target = tribute_control::Callable::from_type_ref(self.ir, target_ty)?;
+        let source_convention = tribute_control::callable_convention(self.ir, source_ty)?;
+        let target_convention = tribute_control::callable_convention(self.ir, target_ty)?;
+        if source_convention != tribute_control::CallingConvention::Direct
+            || target_convention != tribute_control::CallingConvention::Cps
+            || source.result(self.ir) != target.result(self.ir)
+            || source.params(self.ir) != target.params(self.ir)
+        {
+            return None;
+        }
+
+        let entry = self.ir.create_block(BlockData {
+            location,
+            args: target
+                .params(self.ir)
+                .iter()
+                .map(|ty| BlockArgData {
+                    ty: *ty,
+                    attrs: Default::default(),
+                })
+                .collect(),
+            ops: Default::default(),
+            parent_region: None,
+        });
+        let args = self.ir.block_args(entry).to_vec();
+        let call = OperationDataBuilder::new(
+            location,
+            Symbol::new("tribute_control"),
+            Symbol::new("call_indirect"),
+        )
+        .operand(value)
+        .operands(args)
+        .result(target.result(self.ir))
+        .build(self.ir);
+        let call = self.ir.create_op(call);
+        self.ir.push_op(entry, call);
+        let return_op = OperationDataBuilder::new(
+            location,
+            Symbol::new("tribute_control"),
+            Symbol::new("return"),
+        )
+        .operand(self.ir.op_result(call, 0))
+        .build(self.ir);
+        let return_op = self.ir.create_op(return_op);
+        self.ir.push_op(entry, return_op);
+        let region = self.ir.create_region(RegionData {
+            location,
+            blocks: trunk_ir::smallvec::smallvec![entry],
+            parent_op: None,
+        });
+        let lambda = OperationDataBuilder::new(
+            location,
+            Symbol::new("tribute_control"),
+            Symbol::new("lambda"),
+        )
+        .operand(value)
+        .result(target_ty)
+        .region(region)
+        .build(self.ir);
+        let lambda = self.ir.create_op(lambda);
+        self.ir.push_op(self.block, lambda);
+        Some(self.ir.op_result(lambda, 0))
     }
 }
 

--- a/crates/tribute-front/src/ast_to_ir/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/mod.rs
@@ -101,6 +101,10 @@ pub struct TypedModule<'db> {
     pub function_types: HashMap<Symbol, TypeScheme<'db>>,
     pub constructor_types: HashMap<crate::ast::CtorId<'db>, TypeScheme<'db>>,
     pub node_types: HashMap<NodeId, Type<'db>>,
+    /// Exact instantiated callable types for direct source calls.
+    pub call_callee_types: HashMap<NodeId, Type<'db>>,
+    /// Exact call sites whose callee metadata was specialized by monomorphization.
+    pub specialized_call_callee_nodes: std::collections::HashSet<NodeId>,
     pub ability_conventions: HashMap<AbilityId<'db>, CallingConvention>,
     pub ability_definitions: HashMap<AbilityId<'db>, crate::typeck::AbilityInfo<'db>>,
     pub handler_operations: HashMap<NodeId, crate::typeck::InstantiatedHandlerOperation<'db>>,

--- a/crates/tribute-front/src/lib.rs
+++ b/crates/tribute-front/src/lib.rs
@@ -48,6 +48,19 @@ pub fn qualified_symbol(prefix: &mut String, name: Symbol) -> Symbol {
     }
 }
 
+/// Resolve a declaration's canonical emitted identity.
+///
+/// Simple source names inherit the current module prefix. Synthetic
+/// monomorphized names already contain their qualified source path and must
+/// remain exact so prescan, convention analysis, lookup, and emission agree.
+pub fn canonical_declaration_symbol(prefix: &mut String, name: Symbol) -> Symbol {
+    if name.with_str(|text| text.contains("::")) {
+        name
+    } else {
+        qualified_symbol(prefix, name)
+    }
+}
+
 /// Build a qualified symbol from parsed path segments.
 pub fn qualified_path_symbol(path: &[Symbol]) -> Option<Symbol> {
     let (&name, prefix) = path.split_last()?;
@@ -71,4 +84,23 @@ pub fn push_prefix(prefix: &mut String, name: Symbol) -> usize {
 /// Whether a declaration is the exact root program entrypoint.
 pub(crate) fn is_root_main(name: Symbol, is_root_module: bool) -> bool {
     is_root_module && name == Symbol::new("main")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_declaration_identity_qualifies_only_simple_source_names() {
+        let mut nested = "Nested".to_string();
+        assert_eq!(
+            canonical_declaration_symbol(&mut nested, Symbol::new("run")),
+            Symbol::new("Nested::run")
+        );
+        assert_eq!(
+            canonical_declaration_symbol(&mut nested, Symbol::new("Nested::run$I32")),
+            Symbol::new("Nested::run$I32")
+        );
+        assert_eq!(nested, "Nested");
+    }
 }

--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -14,8 +14,9 @@ pub fn collect_instantiations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
     function_types: &[(trunk_ir::Symbol, TypeScheme<'db>)],
+    call_callee_types: &HashMap<crate::ast::NodeId, Type<'db>>,
 ) -> HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>> {
-    let mut collector = InstantiationCollector::new(db, function_types);
+    let mut collector = InstantiationCollector::new(db, function_types, call_callee_types);
     collector.visit_module(module);
     collector.instantiations
 }
@@ -66,11 +67,13 @@ fn extract_recursive<'db>(
             TypeKind::Func {
                 params: sp,
                 result: sr,
+                effect: se,
                 ..
             },
             TypeKind::Func {
                 params: cp,
                 result: cr,
+                effect: ce,
                 ..
             },
         ) => {
@@ -83,6 +86,7 @@ fn extract_recursive<'db>(
                 }
             }
             extract_recursive(db, *sr, *cr, type_args)
+                && extract_effect_args(db, *se, *ce, type_args)
         }
         (
             TypeKind::Named {
@@ -118,16 +122,42 @@ fn extract_recursive<'db>(
     }
 }
 
-struct InstantiationCollector<'db> {
+fn extract_effect_args<'db>(
+    db: &'db dyn salsa::Database,
+    scheme: crate::ast::EffectRow<'db>,
+    concrete: crate::ast::EffectRow<'db>,
+    type_args: &mut [Option<Type<'db>>],
+) -> bool {
+    let scheme_effects = scheme.effects(db);
+    let concrete_effects = concrete.effects(db);
+    if concrete_effects.len() < scheme_effects.len()
+        || (scheme.rest(db).is_none()
+            && (scheme_effects.len() != concrete_effects.len() || concrete.rest(db).is_some()))
+    {
+        return false;
+    }
+    scheme_effects.iter().zip(concrete_effects).all(|(s, c)| {
+        s.ability_id == c.ability_id
+            && s.args.len() == c.args.len()
+            && s.args
+                .iter()
+                .zip(&c.args)
+                .all(|(s, c)| extract_recursive(db, *s, *c, type_args))
+    })
+}
+
+struct InstantiationCollector<'a, 'db> {
     db: &'db dyn salsa::Database,
     schemes: HashMap<FuncDefId<'db>, TypeScheme<'db>>,
     instantiations: HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    call_callee_types: &'a HashMap<crate::ast::NodeId, Type<'db>>,
 }
 
-impl<'db> InstantiationCollector<'db> {
+impl<'a, 'db> InstantiationCollector<'a, 'db> {
     fn new(
         db: &'db dyn salsa::Database,
         function_types: &[(trunk_ir::Symbol, TypeScheme<'db>)],
+        call_callee_types: &'a HashMap<crate::ast::NodeId, Type<'db>>,
     ) -> Self {
         let schemes = function_types
             .iter()
@@ -138,19 +168,29 @@ impl<'db> InstantiationCollector<'db> {
             db,
             schemes,
             instantiations: HashMap::new(),
+            call_callee_types,
         }
     }
 
-    fn try_record(&mut self, typed_ref: &TypedRef<'db>) {
+    fn try_record(&mut self, node: crate::ast::NodeId, typed_ref: &TypedRef<'db>) {
         let ResolvedRef::Function { id } = &typed_ref.resolved else {
             return;
         };
         let Some(scheme) = self.schemes.get(id) else {
             return;
         };
-        let Some(type_args) = extract_type_args(self.db, *scheme, typed_ref.ty) else {
+        let Some(concrete) = self.call_callee_types.get(&node).copied() else {
             return;
         };
+        let Some(type_args) = extract_type_args(self.db, *scheme, concrete) else {
+            return;
+        };
+        if !type_args
+            .iter()
+            .all(|type_arg| is_concrete_type(self.db, *type_arg))
+        {
+            return;
+        }
         self.instantiations
             .entry(*id)
             .or_default()
@@ -180,7 +220,7 @@ impl<'db> InstantiationCollector<'db> {
     fn visit_expr(&mut self, expr: &Expr<TypedRef<'db>>) {
         match expr.kind.as_ref() {
             ExprKind::Var(typed_ref) => {
-                self.try_record(typed_ref);
+                self.try_record(expr.id, typed_ref);
             }
             ExprKind::Call { callee, args } => {
                 self.visit_expr(callee);
@@ -273,9 +313,18 @@ impl<'db> InstantiationCollector<'db> {
 pub fn collect_type_instantiations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
+    type_definitions: &HashMap<trunk_ir::Symbol, TypeScheme<'db>>,
+    node_types: &HashMap<crate::ast::NodeId, Type<'db>>,
+    function_types: &[(trunk_ir::Symbol, TypeScheme<'db>)],
 ) -> HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>> {
-    let generic_types = collect_generic_type_ids(db, module);
+    let generic_types = collect_generic_type_ids(db, module, type_definitions);
     let mut result: HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>> = HashMap::new();
+    for &ty in node_types.values() {
+        collect_from_type(db, ty, &generic_types, &mut result);
+    }
+    for (_, scheme) in function_types {
+        collect_from_type(db, scheme.body(db), &generic_types, &mut result);
+    }
 
     let mut visitor = TypeInstantiationVisitor {
         db,
@@ -290,10 +339,11 @@ pub fn collect_type_instantiations<'db>(
 fn collect_generic_type_ids<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
+    type_definitions: &HashMap<trunk_ir::Symbol, TypeScheme<'db>>,
 ) -> HashSet<TypeDefId<'db>> {
     let mut ids = HashSet::new();
     let mut prefix = String::new();
-    collect_generic_type_ids_inner(db, &module.decls, &mut prefix, &mut ids);
+    collect_generic_type_ids_inner(db, &module.decls, &mut prefix, type_definitions, &mut ids);
     ids
 }
 
@@ -301,27 +351,51 @@ fn collect_generic_type_ids_inner<'db>(
     db: &'db dyn salsa::Database,
     decls: &[Decl<TypedRef<'db>>],
     prefix: &mut String,
+    type_definitions: &HashMap<trunk_ir::Symbol, TypeScheme<'db>>,
     ids: &mut HashSet<TypeDefId<'db>>,
 ) {
     for decl in decls {
         match decl {
             Decl::Struct(s) if !s.type_params.is_empty() => {
                 let qualified = crate::qualified_symbol(prefix, s.name);
-                ids.insert(TypeDefId::source(db, qualified, s.id));
+                let scheme = type_definitions
+                    .get(&qualified)
+                    .expect("generic struct must have an exact nominal definition scheme");
+                ids.insert(
+                    nominal_result_id(db, scheme.body(db))
+                        .expect("generic struct definition must contain a nominal type"),
+                );
             }
             Decl::Enum(e) if !e.type_params.is_empty() => {
                 let qualified = crate::qualified_symbol(prefix, e.name);
-                ids.insert(TypeDefId::source(db, qualified, e.id));
+                let scheme = type_definitions
+                    .get(&qualified)
+                    .expect("generic enum must have an exact nominal definition scheme");
+                ids.insert(
+                    nominal_result_id(db, scheme.body(db))
+                        .expect("generic enum definition must contain a nominal type"),
+                );
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
                     let saved = crate::push_prefix(prefix, m.name);
-                    collect_generic_type_ids_inner(db, body, prefix, ids);
+                    collect_generic_type_ids_inner(db, body, prefix, type_definitions, ids);
                     prefix.truncate(saved);
                 }
             }
             _ => {}
         }
+    }
+}
+
+fn nominal_result_id<'db>(db: &'db dyn salsa::Database, ty: Type<'db>) -> Option<TypeDefId<'db>> {
+    let result = match ty.kind(db) {
+        TypeKind::Func { result, .. } => *result,
+        _ => ty,
+    };
+    match result.kind(db) {
+        TypeKind::Named { id, .. } => Some(*id),
+        _ => None,
     }
 }
 
@@ -334,7 +408,10 @@ fn collect_from_type<'db>(
 ) {
     match ty.kind(db) {
         TypeKind::Named { id, args, .. } => {
-            if !args.is_empty() && generic_types.contains(id) {
+            if !args.is_empty()
+                && generic_types.contains(id)
+                && args.iter().all(|arg| is_concrete_type(db, *arg))
+            {
                 result.entry(*id).or_default().insert(args.clone());
             }
             // Recurse into type arguments (e.g., List(Option(Int)) → collect Option(Int))
@@ -345,12 +422,18 @@ fn collect_from_type<'db>(
         TypeKind::Func {
             params,
             result: ret,
+            effect,
             ..
         } => {
             for p in params {
                 collect_from_type(db, *p, generic_types, result);
             }
             collect_from_type(db, *ret, generic_types, result);
+            for ability in effect.effects(db) {
+                for argument in &ability.args {
+                    collect_from_type(db, *argument, generic_types, result);
+                }
+            }
         }
         TypeKind::Tuple(elems) => {
             for e in elems {
@@ -371,6 +454,41 @@ fn collect_from_type<'db>(
         }
         // Primitives and variables: no nested Named types
         _ => {}
+    }
+}
+
+fn is_concrete_type(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+    match ty.kind(db) {
+        TypeKind::Named { args, .. } | TypeKind::Tuple(args) => {
+            args.iter().all(|arg| is_concrete_type(db, *arg))
+        }
+        TypeKind::Func {
+            params,
+            result,
+            effect,
+            ..
+        } => {
+            params.iter().all(|param| is_concrete_type(db, *param))
+                && is_concrete_type(db, *result)
+                && effect
+                    .effects(db)
+                    .iter()
+                    .all(|entry| entry.args.iter().all(|arg| is_concrete_type(db, *arg)))
+        }
+        TypeKind::App { .. }
+        | TypeKind::Continuation { .. }
+        | TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
+        | TypeKind::UniVar { .. }
+        | TypeKind::Error => false,
+        TypeKind::Int
+        | TypeKind::Nat
+        | TypeKind::Float
+        | TypeKind::Bool
+        | TypeKind::Bytes
+        | TypeKind::Rune
+        | TypeKind::Nil
+        | TypeKind::Never => true,
     }
 }
 
@@ -498,7 +616,10 @@ impl<'a, 'db> TypeInstantiationVisitor<'a, 'db> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{EffectRow, TypeParam, TypeScheme};
+    use crate::ast::{
+        AbilityId, Effect, EffectRow, EffectVar, EnumDecl, NodeId, TypeParam, TypeParamDecl,
+        TypeScheme,
+    };
 
     use super::*;
 
@@ -621,6 +742,292 @@ mod tests {
 
         let result = extract_type_args(&db, scheme, concrete);
         assert_eq!(result, Some(vec![int]));
+    }
+
+    #[test]
+    fn test_extract_param_present_only_in_ordered_effect_row() {
+        let db = TestDb::default();
+        let state = AbilityId::source(&db, trunk_ir::Symbol::new("State"));
+        let audit = AbilityId::source(&db, trunk_ir::Symbol::new("Audit"));
+        let bv0 = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let nil = Type::new(&db, TypeKind::Nil);
+        let scheme_effect = EffectRow::new(
+            &db,
+            vec![
+                Effect {
+                    ability_id: state,
+                    args: vec![bv0],
+                },
+                Effect {
+                    ability_id: audit,
+                    args: vec![],
+                },
+            ],
+            None,
+        );
+        let scheme = make_scheme(
+            &db,
+            1,
+            Type::new(
+                &db,
+                TypeKind::Func {
+                    params: vec![],
+                    result: nil,
+                    effect: scheme_effect,
+                    minimum_convention: crate::ast::CallingConvention::Direct,
+                },
+            ),
+        );
+
+        let int = Type::new(&db, TypeKind::Int);
+        let concrete_effect = EffectRow::new(
+            &db,
+            vec![
+                Effect {
+                    ability_id: state,
+                    args: vec![int],
+                },
+                Effect {
+                    ability_id: audit,
+                    args: vec![],
+                },
+            ],
+            None,
+        );
+        let concrete = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: nil,
+                effect: concrete_effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+        assert_eq!(extract_type_args(&db, scheme, concrete), Some(vec![int]));
+
+        let reversed = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: nil,
+                effect: EffectRow::new(
+                    &db,
+                    vec![
+                        Effect {
+                            ability_id: audit,
+                            args: vec![],
+                        },
+                        Effect {
+                            ability_id: state,
+                            args: vec![int],
+                        },
+                    ],
+                    None,
+                ),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+        assert_eq!(extract_type_args(&db, scheme, reversed), None);
+    }
+
+    #[test]
+    fn test_extract_open_effect_row_accepts_ordered_concrete_suffix() {
+        let db = TestDb::default();
+        let state = AbilityId::source(&db, trunk_ir::Symbol::new("State"));
+        let audit = AbilityId::source(&db, trunk_ir::Symbol::new("Audit"));
+        let trace = AbilityId::source(&db, trunk_ir::Symbol::new("Trace"));
+        let scheme_tail = EffectVar { id: 10 };
+        let concrete_tail = EffectVar { id: 20 };
+        let bound = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let nil = Type::new(&db, TypeKind::Nil);
+        let scheme = TypeScheme::new(
+            &db,
+            vec![TypeParam::anonymous()],
+            vec![scheme_tail],
+            Type::new(
+                &db,
+                TypeKind::Func {
+                    params: vec![],
+                    result: nil,
+                    effect: EffectRow::new(
+                        &db,
+                        vec![
+                            Effect {
+                                ability_id: state,
+                                args: vec![bound],
+                            },
+                            Effect {
+                                ability_id: audit,
+                                args: vec![],
+                            },
+                        ],
+                        Some(scheme_tail),
+                    ),
+                    minimum_convention: crate::ast::CallingConvention::Direct,
+                },
+            ),
+        );
+        let int = Type::new(&db, TypeKind::Int);
+        let concrete = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: nil,
+                effect: EffectRow::new(
+                    &db,
+                    vec![
+                        Effect {
+                            ability_id: state,
+                            args: vec![int],
+                        },
+                        Effect {
+                            ability_id: audit,
+                            args: vec![],
+                        },
+                        Effect {
+                            ability_id: trace,
+                            args: vec![],
+                        },
+                    ],
+                    Some(concrete_tail),
+                ),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+
+        assert_eq!(extract_type_args(&db, scheme, concrete), Some(vec![int]));
+    }
+
+    #[test]
+    fn test_extract_open_effect_row_rejects_wrong_ordered_prefix() {
+        let db = TestDb::default();
+        let state = AbilityId::source(&db, trunk_ir::Symbol::new("State"));
+        let audit = AbilityId::source(&db, trunk_ir::Symbol::new("Audit"));
+        let scheme_tail = EffectVar { id: 30 };
+        let bound = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let nil = Type::new(&db, TypeKind::Nil);
+        let scheme = TypeScheme::new(
+            &db,
+            vec![TypeParam::anonymous()],
+            vec![scheme_tail],
+            Type::new(
+                &db,
+                TypeKind::Func {
+                    params: vec![],
+                    result: nil,
+                    effect: EffectRow::new(
+                        &db,
+                        vec![
+                            Effect {
+                                ability_id: state,
+                                args: vec![bound],
+                            },
+                            Effect {
+                                ability_id: audit,
+                                args: vec![],
+                            },
+                        ],
+                        Some(scheme_tail),
+                    ),
+                    minimum_convention: crate::ast::CallingConvention::Direct,
+                },
+            ),
+        );
+        let int = Type::new(&db, TypeKind::Int);
+        let reordered = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: nil,
+                effect: EffectRow::new(
+                    &db,
+                    vec![
+                        Effect {
+                            ability_id: audit,
+                            args: vec![],
+                        },
+                        Effect {
+                            ability_id: state,
+                            args: vec![int],
+                        },
+                    ],
+                    Some(EffectVar { id: 31 }),
+                ),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+
+        assert_eq!(extract_type_args(&db, scheme, reordered), None);
+    }
+
+    #[test]
+    fn test_extract_closed_effect_row_rejects_extra_effects_and_open_tail() {
+        let db = TestDb::default();
+        let state = AbilityId::source(&db, trunk_ir::Symbol::new("State"));
+        let audit = AbilityId::source(&db, trunk_ir::Symbol::new("Audit"));
+        let bound = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let nil = Type::new(&db, TypeKind::Nil);
+        let scheme = make_scheme(
+            &db,
+            1,
+            Type::new(
+                &db,
+                TypeKind::Func {
+                    params: vec![],
+                    result: nil,
+                    effect: EffectRow::single(
+                        &db,
+                        Effect {
+                            ability_id: state,
+                            args: vec![bound],
+                        },
+                    ),
+                    minimum_convention: crate::ast::CallingConvention::Direct,
+                },
+            ),
+        );
+        let int = Type::new(&db, TypeKind::Int);
+        let extra_effect = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: nil,
+                effect: EffectRow::new(
+                    &db,
+                    vec![
+                        Effect {
+                            ability_id: state,
+                            args: vec![int],
+                        },
+                        Effect {
+                            ability_id: audit,
+                            args: vec![],
+                        },
+                    ],
+                    None,
+                ),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+        let open_tail = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: nil,
+                effect: EffectRow::new(
+                    &db,
+                    vec![Effect {
+                        ability_id: state,
+                        args: vec![int],
+                    }],
+                    Some(EffectVar { id: 40 }),
+                ),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+
+        assert_eq!(extract_type_args(&db, scheme, extra_effect), None);
+        assert_eq!(extract_type_args(&db, scheme, open_tail), None);
     }
 
     #[test]
@@ -752,6 +1159,140 @@ mod tests {
         assert_eq!(result.len(), 1);
         let option_insts = result.get(&option_id).unwrap();
         assert!(option_insts.contains(&vec![int]));
+    }
+
+    #[test]
+    fn test_collect_empty_generic_enum_uses_exact_definition_identity() {
+        let db = TestDb::default();
+        let declaration = NodeId::from_raw(1);
+        let name = trunk_ir::Symbol::new("Empty");
+        let id = TypeDefId::source(&db, name, declaration);
+        let bound = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let generic = Type::new(
+            &db,
+            TypeKind::Named {
+                id,
+                name,
+                args: vec![bound],
+            },
+        );
+        let module = Module::<TypedRef<'_>>::new(
+            NodeId::from_raw(2),
+            None,
+            vec![Decl::Enum(EnumDecl {
+                id: declaration,
+                is_pub: false,
+                name,
+                type_params: vec![TypeParamDecl {
+                    id: NodeId::from_raw(3),
+                    name: trunk_ir::Symbol::new("a"),
+                    bounds: vec![],
+                }],
+                variants: vec![],
+            })],
+        );
+        let definitions = HashMap::from([(name, make_scheme(&db, 1, generic))]);
+        let int = Type::new(&db, TypeKind::Int);
+        let empty_int = Type::new(
+            &db,
+            TypeKind::Named {
+                id,
+                name,
+                args: vec![int],
+            },
+        );
+        let signature = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![empty_int],
+                result: Type::new(&db, TypeKind::Nil),
+                effect: pure_effect(&db),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+        let function_types = vec![(
+            trunk_ir::Symbol::new("consume_empty"),
+            TypeScheme::mono(&db, signature),
+        )];
+
+        let instantiations = collect_type_instantiations(
+            &db,
+            &module,
+            &definitions,
+            &HashMap::new(),
+            &function_types,
+        );
+        assert_eq!(instantiations.get(&id), Some(&HashSet::from([vec![int]])));
+    }
+
+    #[test]
+    fn test_collect_nominal_instantiation_present_only_in_function_effect() {
+        let db = TestDb::default();
+        let declaration = NodeId::from_raw(10);
+        let name = trunk_ir::Symbol::new("Token");
+        let id = TypeDefId::source(&db, name, declaration);
+        let bound = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let generic = Type::new(
+            &db,
+            TypeKind::Named {
+                id,
+                name,
+                args: vec![bound],
+            },
+        );
+        let module = Module::<TypedRef<'_>>::new(
+            NodeId::from_raw(11),
+            None,
+            vec![Decl::Enum(EnumDecl {
+                id: declaration,
+                is_pub: false,
+                name,
+                type_params: vec![TypeParamDecl {
+                    id: NodeId::from_raw(12),
+                    name: trunk_ir::Symbol::new("a"),
+                    bounds: vec![],
+                }],
+                variants: vec![],
+            })],
+        );
+        let definitions = HashMap::from([(name, make_scheme(&db, 1, generic))]);
+        let int = Type::new(&db, TypeKind::Int);
+        let token_int = Type::new(
+            &db,
+            TypeKind::Named {
+                id,
+                name,
+                args: vec![int],
+            },
+        );
+        let signature = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![],
+                result: Type::new(&db, TypeKind::Nil),
+                effect: EffectRow::new(
+                    &db,
+                    vec![Effect {
+                        ability_id: AbilityId::source(&db, trunk_ir::Symbol::new("Witness")),
+                        args: vec![token_int],
+                    }],
+                    None,
+                ),
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        );
+
+        let instantiations = collect_type_instantiations(
+            &db,
+            &module,
+            &definitions,
+            &HashMap::new(),
+            &[(
+                trunk_ir::Symbol::new("effect_only"),
+                TypeScheme::mono(&db, signature),
+            )],
+        );
+        assert_eq!(instantiations.get(&id), Some(&HashSet::from([vec![int]])));
     }
 
     #[test]

--- a/crates/tribute-front/src/monomorphize/mangle.rs
+++ b/crates/tribute-front/src/monomorphize/mangle.rs
@@ -79,6 +79,9 @@ fn write_type_mangled(
             f.write_str("$1")
         }
         TypeKind::BoundVar { index } => write!(f, "T{index}"),
+        TypeKind::LocalBoundVar { .. } => {
+            panic!("mangle_name requires function-scoped concrete types")
+        }
         TypeKind::UniVar { .. } | TypeKind::App { .. } | TypeKind::Continuation { .. } => {
             panic!("mangle_name requires fully-resolved concrete types");
         }

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -3,17 +3,63 @@ pub mod mangle;
 mod rewrite;
 pub mod specialize;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use salsa::Accumulator;
+use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
+use trunk_ir::Span;
 use trunk_ir::Symbol;
 
-use crate::ast::{Decl, FuncDefId, Module, Type, TypeScheme, TypedRef};
+use crate::ast::{
+    AbilityId, CallingConvention, CtorId, Decl, FuncDefId, Module, NodeId, Type, TypeScheme,
+    TypedRef,
+};
+use crate::typeck::subst::substitute_bound_vars;
+use crate::typeck::{
+    AbilityInfo, InstantiatedHandlerOperation, InstantiatedPerformOperation, LambdaSignature,
+};
 
-/// Result of monomorphization: updated module + function types.
+/// Exact semantic metadata consumed by typed AST lowering.
+///
+/// Monomorphization owns this bundle because both function cloning and later
+/// nominal type rewriting change the identities used as lookup keys.
+pub struct MonomorphizeMetadata<'db> {
+    pub constructor_types: HashMap<CtorId<'db>, TypeScheme<'db>>,
+    pub type_definitions: HashMap<Symbol, TypeScheme<'db>>,
+    pub node_types: HashMap<NodeId, Type<'db>>,
+    pub call_callee_types: HashMap<NodeId, Type<'db>>,
+    /// Call-callee metadata entries rewritten to a concrete specialization.
+    pub specialized_call_callee_nodes: HashSet<NodeId>,
+    pub ability_conventions: HashMap<AbilityId<'db>, CallingConvention>,
+    pub ability_definitions: HashMap<AbilityId<'db>, AbilityInfo<'db>>,
+    pub handler_operations: HashMap<NodeId, InstantiatedHandlerOperation<'db>>,
+    pub perform_operations: HashMap<NodeId, InstantiatedPerformOperation<'db>>,
+    pub lambda_signatures: HashMap<NodeId, LambdaSignature<'db>>,
+    pub exhaustive_cases: HashSet<NodeId>,
+}
+
+/// Result of monomorphization: updated module and its exact semantic tables.
 pub struct MonomorphizeResult<'db> {
     pub module: Module<TypedRef<'db>>,
     pub function_types: Vec<(Symbol, TypeScheme<'db>)>,
+    pub metadata: MonomorphizeMetadata<'db>,
 }
+
+/// Internal guardrails for deterministic specialization expansion.
+///
+/// The production values keep recursive generic discovery bounded while the
+/// private test entry point can exercise the diagnostic without constructing a
+/// production-sized specialization graph.
+#[derive(Clone, Copy)]
+struct SpecializationLimits {
+    rounds: usize,
+    instantiations: usize,
+}
+
+const PRODUCTION_SPECIALIZATION_LIMITS: SpecializationLimits = SpecializationLimits {
+    rounds: 64,
+    instantiations: 2048,
+};
 
 /// Run monomorphization on a typed module.
 ///
@@ -26,59 +72,146 @@ pub fn monomorphize_functions<'db>(
     db: &'db dyn salsa::Database,
     module: Module<TypedRef<'db>>,
     function_types: HashMap<Symbol, TypeScheme<'db>>,
+    metadata: MonomorphizeMetadata<'db>,
 ) -> MonomorphizeResult<'db> {
-    let fn_types_vec: Vec<(Symbol, TypeScheme<'db>)> =
+    monomorphize_functions_with_limits(
+        db,
+        module,
+        function_types,
+        metadata,
+        PRODUCTION_SPECIALIZATION_LIMITS,
+    )
+}
+
+fn monomorphize_functions_with_limits<'db>(
+    db: &'db dyn salsa::Database,
+    module: Module<TypedRef<'db>>,
+    function_types: HashMap<Symbol, TypeScheme<'db>>,
+    mut metadata: MonomorphizeMetadata<'db>,
+    limits: SpecializationLimits,
+) -> MonomorphizeResult<'db> {
+    let source_function_types: Vec<(Symbol, TypeScheme<'db>)> =
         function_types.iter().map(|(k, v)| (*k, *v)).collect();
 
     // === Function monomorphization ===
+    // A specialization can expose concrete generic calls that were abstract in
+    // its source declaration. Iterate over newly created bodies until no such
+    // call remains. The original generic declarations are deliberately kept.
+    let mut module = module;
+    let mut function_types = source_function_types.clone();
+    let mut instantiations = HashMap::new();
+    let mut exceeded_limit = false;
 
-    // Step 1: Collect function instantiations
-    let func_instantiations = collect::collect_instantiations(db, &module, &fn_types_vec);
+    for _ in 0..limits.rounds {
+        let discovered = collect::collect_instantiations(
+            db,
+            &module,
+            &source_function_types,
+            &metadata.call_callee_types,
+        );
+        let new_instantiations = retain_new_instantiations(&mut instantiations, discovered);
+        if new_instantiations.is_empty() {
+            break;
+        }
+        if instantiation_count(&instantiations) > limits.instantiations {
+            exceeded_limit = true;
+            break;
+        }
 
-    let module = if !func_instantiations.is_empty() {
-        // Step 2: Generate specialized functions
-        let (specialized_decls, specialized_fn_types) =
-            specialize::generate_specializations(db, &module, &func_instantiations, &fn_types_vec);
-
-        // Build rewrite map
-        let rewrite_map = build_rewrite_map(db, &func_instantiations, &fn_types_vec);
-
-        // Step 3: Rewrite call sites in the module
-        let rewritten_module = rewrite::rewrite_module(db, module, &fn_types_vec, &rewrite_map);
-
-        // Step 4: Rewrite call sites inside specialized function bodies
-        let specialized_decls: Vec<Decl<TypedRef<'db>>> =
-            specialized_decls.into_iter().map(Decl::Function).collect();
-        let rewritten_specialized =
-            rewrite::rewrite_decls(db, specialized_decls, &fn_types_vec, &rewrite_map);
-
-        // Step 5: Append specialized functions to module
-        let mut decls = rewritten_module.decls;
+        let (specialized_decls, specialized_fn_types, specializations) =
+            specialize::generate_specializations(
+                db,
+                &module,
+                &new_instantiations,
+                &source_function_types,
+            );
+        specialize_node_metadata(db, &mut metadata, &specializations);
+        let specialized_extern_types = specialize::generate_extern_specialization_types(
+            db,
+            &module,
+            &new_instantiations,
+            &source_function_types,
+        );
+        let rewrite_map = build_rewrite_map(db, &instantiations, &source_function_types);
+        module = rewrite::rewrite_module(
+            db,
+            module,
+            &function_types,
+            &rewrite_map,
+            &mut metadata.call_callee_types,
+            &mut metadata.specialized_call_callee_nodes,
+        );
+        let rewritten_specialized = rewrite::rewrite_decls(
+            db,
+            specialized_decls.into_iter().map(Decl::Function).collect(),
+            &function_types,
+            &rewrite_map,
+            &mut metadata.call_callee_types,
+            &mut metadata.specialized_call_callee_nodes,
+        );
+        let mut decls = module.decls;
         decls.extend(rewritten_specialized);
+        module = Module::new(module.id, module.name, decls);
+        function_types.extend(specialized_fn_types);
+        function_types.extend(specialized_extern_types);
+    }
 
-        // Update function types for downstream
-        let mut all_fn_types = fn_types_vec;
-        all_fn_types.extend(specialized_fn_types);
+    if exceeded_limit
+        || !retain_new_instantiations(
+            &mut instantiations,
+            collect::collect_instantiations(
+                db,
+                &module,
+                &source_function_types,
+                &metadata.call_callee_types,
+            ),
+        )
+        .is_empty()
+    {
+        Diagnostic::new(
+            "generic specialization exceeded the deterministic expansion limit",
+            Span::default(),
+            DiagnosticSeverity::Error,
+            CompilationPhase::Lowering,
+        )
+        .accumulate(db);
+    }
 
-        // Return intermediate result with updated fn_types
-        let module = Module::new(rewritten_module.id, rewritten_module.name, decls);
-        (module, all_fn_types)
-    } else {
-        (module, fn_types_vec)
-    };
-
-    let (module, fn_types_vec) = module;
+    let fn_types_vec = function_types;
 
     // === Type monomorphization (struct/enum) ===
 
-    let type_instantiations = collect::collect_type_instantiations(db, &module);
+    // Function cloning creates variant NodeIds. Materialize their exact, substituted
+    // semantic metadata before collecting nominal instantiations so types that only
+    // occur in a specialized body or parameter are not lost.
+    let type_instantiations = collect::collect_type_instantiations(
+        db,
+        &module,
+        &metadata.type_definitions,
+        &metadata.node_types,
+        &fn_types_vec,
+    );
+    let constructor_specializations = specialize::generate_constructor_specializations(
+        db,
+        &module,
+        &type_instantiations,
+        &metadata.type_definitions,
+    );
 
-    let module = if !type_instantiations.is_empty() {
+    let (module, type_rewrite_map) = if !type_instantiations.is_empty() {
         // Generate specialized struct/enum declarations
-        let specialized_structs =
-            specialize::generate_struct_specializations(db, &module, &type_instantiations);
-        let specialized_enums =
-            specialize::generate_enum_specializations(db, &module, &type_instantiations);
+        let specialized_structs = specialize::generate_struct_specializations(
+            db,
+            &module,
+            &type_instantiations,
+            &metadata.type_definitions,
+        );
+        let specialized_enums = specialize::generate_enum_specializations(
+            db,
+            &module,
+            &type_instantiations,
+            &metadata.type_definitions,
+        );
 
         // Build type rewrite map and rewrite Named types throughout the module
         let type_rewrite_map = rewrite::build_type_rewrite_map(db, &type_instantiations);
@@ -89,15 +222,297 @@ pub fn monomorphize_functions<'db>(
         decls.extend(specialized_structs.into_iter().map(Decl::Struct));
         decls.extend(specialized_enums.into_iter().map(Decl::Enum));
 
-        Module::new(rewritten_module.id, rewritten_module.name, decls)
+        (
+            Module::new(rewritten_module.id, rewritten_module.name, decls),
+            type_rewrite_map,
+        )
     } else {
-        module
+        (module, rewrite::TypeRewriteMap::new())
     };
+
+    rewrite_semantic_types(
+        db,
+        &mut metadata,
+        &constructor_specializations,
+        &type_rewrite_map,
+    );
+    let function_types = fn_types_vec
+        .into_iter()
+        .map(|(name, scheme)| (name, rewrite_scheme(db, scheme, &type_rewrite_map)))
+        .collect();
 
     MonomorphizeResult {
         module,
-        function_types: fn_types_vec,
+        function_types,
+        metadata,
     }
+}
+
+fn retain_new_instantiations<'db>(
+    known: &mut HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    discovered: HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
+) -> HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>> {
+    let mut new = HashMap::new();
+    for (function, args) in discovered {
+        let known_args = known.entry(function).or_default();
+        for args in args {
+            if known_args.insert(args.clone()) {
+                new.entry(function)
+                    .or_insert_with(HashSet::new)
+                    .insert(args);
+            }
+        }
+    }
+    new
+}
+
+fn instantiation_count(instantiations: &HashMap<FuncDefId<'_>, HashSet<Vec<Type<'_>>>>) -> usize {
+    instantiations.values().map(HashSet::len).sum()
+}
+
+fn specialize_node_metadata<'db>(
+    db: &'db dyn salsa::Database,
+    metadata: &mut MonomorphizeMetadata<'db>,
+    specializations: &[specialize::FunctionSpecialization<'db>],
+) {
+    let source_node_types = metadata.node_types.clone();
+    let source_call_callee_types = metadata.call_callee_types.clone();
+    let source_handlers = metadata.handler_operations.clone();
+    let source_performs = metadata.perform_operations.clone();
+    let source_lambdas = metadata.lambda_signatures.clone();
+    let source_exhaustive = metadata.exhaustive_cases.clone();
+
+    for specialization in specializations {
+        for &origin in &specialization.node_origins {
+            let specialized = origin.with_variant(specialization.variant);
+            if let Some(&ty) = source_node_types.get(&origin) {
+                metadata.node_types.insert(
+                    specialized,
+                    substitute_type(db, ty, &specialization.type_args),
+                );
+            }
+            if let Some(&ty) = source_call_callee_types.get(&origin) {
+                metadata.call_callee_types.insert(
+                    specialized,
+                    substitute_type(db, ty, &specialization.type_args),
+                );
+            }
+            if let Some(operation) = source_handlers.get(&origin) {
+                metadata.handler_operations.insert(
+                    specialized,
+                    substitute_handler_operation(db, operation, &specialization.type_args),
+                );
+            }
+            if let Some(operation) = source_performs.get(&origin) {
+                metadata.perform_operations.insert(
+                    specialized,
+                    substitute_perform_operation(db, operation, &specialization.type_args),
+                );
+            }
+            if let Some(signature) = source_lambdas.get(&origin) {
+                metadata.lambda_signatures.insert(
+                    specialized,
+                    LambdaSignature {
+                        function_type: substitute_type(
+                            db,
+                            signature.function_type,
+                            &specialization.type_args,
+                        ),
+                        body_is_effect_free: signature.body_is_effect_free,
+                        contains_control_transfer: signature.contains_control_transfer,
+                        lexical_convention: signature.lexical_convention,
+                        convention: signature.convention,
+                    },
+                );
+            }
+            if source_exhaustive.contains(&origin) {
+                metadata.exhaustive_cases.insert(specialized);
+            }
+        }
+    }
+}
+
+fn rewrite_semantic_types<'db>(
+    db: &'db dyn salsa::Database,
+    metadata: &mut MonomorphizeMetadata<'db>,
+    constructor_specializations: &[specialize::ConstructorSpecialization<'db>],
+    type_rewrite_map: &rewrite::TypeRewriteMap<'db>,
+) {
+    let source_constructors = metadata.constructor_types.clone();
+    for (&constructor, &scheme) in &source_constructors {
+        metadata
+            .constructor_types
+            .insert(constructor, rewrite_scheme(db, scheme, type_rewrite_map));
+    }
+    for specialization in constructor_specializations {
+        let scheme = source_constructors
+            .get(&specialization.source)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing source constructor scheme for exact specialization `{}`",
+                    specialization.source.qualified(db)
+                )
+            });
+        metadata.constructor_types.insert(
+            specialization.specialized,
+            specialize_scheme(db, *scheme, &specialization.type_args, type_rewrite_map),
+        );
+    }
+    for scheme in metadata.type_definitions.values_mut() {
+        *scheme = rewrite_scheme(db, *scheme, type_rewrite_map);
+    }
+
+    for ty in metadata.node_types.values_mut() {
+        *ty = rewrite::rewrite_type(db, *ty, type_rewrite_map);
+    }
+    for ty in metadata.call_callee_types.values_mut() {
+        *ty = rewrite::rewrite_type(db, *ty, type_rewrite_map);
+    }
+    for operation in metadata.handler_operations.values_mut() {
+        rewrite_handler_operation(db, operation, type_rewrite_map);
+    }
+    for operation in metadata.perform_operations.values_mut() {
+        rewrite_perform_operation(db, operation, type_rewrite_map);
+    }
+    for signature in metadata.lambda_signatures.values_mut() {
+        signature.function_type =
+            rewrite::rewrite_type(db, signature.function_type, type_rewrite_map);
+    }
+    for ability in metadata.ability_definitions.values_mut() {
+        for operation in ability.operations.values_mut() {
+            operation.param_types = operation
+                .param_types
+                .iter()
+                .map(|ty| rewrite::rewrite_type(db, *ty, type_rewrite_map))
+                .collect();
+            operation.return_type =
+                rewrite::rewrite_type(db, operation.return_type, type_rewrite_map);
+        }
+    }
+}
+
+fn substitute_type<'db>(
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    arguments: &[Type<'db>],
+) -> Type<'db> {
+    substitute_bound_vars(db, ty, arguments).unwrap_or_else(|index, max| {
+        panic!(
+            "BoundVar index out of range in semantic metadata specialization: \
+             index={index}, subst.len()={max}"
+        )
+    })
+}
+
+fn substitute_handler_operation<'db>(
+    db: &'db dyn salsa::Database,
+    operation: &InstantiatedHandlerOperation<'db>,
+    arguments: &[Type<'db>],
+) -> InstantiatedHandlerOperation<'db> {
+    InstantiatedHandlerOperation {
+        ability: operation.ability,
+        ability_args: operation
+            .ability_args
+            .iter()
+            .map(|ty| substitute_type(db, *ty, arguments))
+            .collect(),
+        kind: operation.kind,
+        params: operation
+            .params
+            .iter()
+            .map(|ty| substitute_type(db, *ty, arguments))
+            .collect(),
+        result: substitute_type(db, operation.result, arguments),
+    }
+}
+
+fn substitute_perform_operation<'db>(
+    db: &'db dyn salsa::Database,
+    operation: &InstantiatedPerformOperation<'db>,
+    arguments: &[Type<'db>],
+) -> InstantiatedPerformOperation<'db> {
+    InstantiatedPerformOperation {
+        ability: operation.ability,
+        ability_args: operation
+            .ability_args
+            .iter()
+            .map(|ty| substitute_type(db, *ty, arguments))
+            .collect(),
+        kind: operation.kind,
+        params: operation
+            .params
+            .iter()
+            .map(|ty| substitute_type(db, *ty, arguments))
+            .collect(),
+        result: substitute_type(db, operation.result, arguments),
+    }
+}
+
+fn rewrite_handler_operation<'db>(
+    db: &'db dyn salsa::Database,
+    operation: &mut InstantiatedHandlerOperation<'db>,
+    type_rewrite_map: &rewrite::TypeRewriteMap<'db>,
+) {
+    operation.ability_args = operation
+        .ability_args
+        .iter()
+        .map(|ty| rewrite::rewrite_type(db, *ty, type_rewrite_map))
+        .collect();
+    operation.params = operation
+        .params
+        .iter()
+        .map(|ty| rewrite::rewrite_type(db, *ty, type_rewrite_map))
+        .collect();
+    operation.result = rewrite::rewrite_type(db, operation.result, type_rewrite_map);
+}
+
+fn rewrite_perform_operation<'db>(
+    db: &'db dyn salsa::Database,
+    operation: &mut InstantiatedPerformOperation<'db>,
+    type_rewrite_map: &rewrite::TypeRewriteMap<'db>,
+) {
+    operation.ability_args = operation
+        .ability_args
+        .iter()
+        .map(|ty| rewrite::rewrite_type(db, *ty, type_rewrite_map))
+        .collect();
+    operation.params = operation
+        .params
+        .iter()
+        .map(|ty| rewrite::rewrite_type(db, *ty, type_rewrite_map))
+        .collect();
+    operation.result = rewrite::rewrite_type(db, operation.result, type_rewrite_map);
+}
+
+fn rewrite_scheme<'db>(
+    db: &'db dyn salsa::Database,
+    scheme: TypeScheme<'db>,
+    type_rewrite_map: &rewrite::TypeRewriteMap<'db>,
+) -> TypeScheme<'db> {
+    TypeScheme::new(
+        db,
+        scheme.type_params(db).clone(),
+        scheme.effect_params(db).clone(),
+        rewrite::rewrite_type(db, scheme.body(db), type_rewrite_map),
+    )
+}
+
+fn specialize_scheme<'db>(
+    db: &'db dyn salsa::Database,
+    scheme: TypeScheme<'db>,
+    arguments: &[Type<'db>],
+    type_rewrite_map: &rewrite::TypeRewriteMap<'db>,
+) -> TypeScheme<'db> {
+    TypeScheme::new(
+        db,
+        vec![],
+        scheme.effect_params(db).clone(),
+        rewrite::rewrite_type(
+            db,
+            substitute_type(db, scheme.body(db), arguments),
+            type_rewrite_map,
+        ),
+    )
 }
 
 /// Build a map from (original FuncDefId, concrete callee type) → mangled Symbol
@@ -128,4 +543,87 @@ fn build_rewrite_map<'db>(
     }
 
     rewrite_map
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use salsa_test_macros::salsa_test;
+    use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
+
+    use super::*;
+    use crate::SourceCst;
+
+    /// Runs the real typed frontend inputs through monomorphization with a
+    /// deliberately tiny private budget. Keeping this query tracked makes the
+    /// lowering diagnostic observable through Salsa's accumulator.
+    #[salsa::tracked]
+    fn monomorphize_with_tiny_limit(db: &dyn salsa::Database, source: SourceCst) {
+        let parsed = crate::query::parsed_ast(db, source).expect("fixture must parse");
+        let ast = parsed.module(db).clone();
+        let span_map = parsed.span_map(db).clone();
+        let environment = crate::resolve::build_env(db, &ast);
+        let resolved = crate::resolve::resolve_with_env(db, ast, environment, span_map);
+        let output = crate::typeck::typecheck_module(db, resolved, parsed.span_map(db).clone());
+        let module = crate::tdnr::resolve_tdnr(db, output.module(db).clone(), std::iter::empty());
+        let nominal_types = output.nominal_types(db);
+        let expression_types = output.expression_types(db);
+        let metadata = MonomorphizeMetadata {
+            constructor_types: nominal_types.constructor_types.iter().copied().collect(),
+            type_definitions: nominal_types.type_definitions.iter().copied().collect(),
+            node_types: expression_types.node_types.iter().copied().collect(),
+            call_callee_types: expression_types.call_callee_types.iter().copied().collect(),
+            specialized_call_callee_nodes: Default::default(),
+            ability_conventions: output.ability_conventions(db).iter().copied().collect(),
+            ability_definitions: crate::typeck::ability_definitions_from_schemas(
+                output.ability_definitions(db),
+            ),
+            handler_operations: output.handler_operations(db).iter().cloned().collect(),
+            perform_operations: output.perform_operations(db).iter().cloned().collect(),
+            lambda_signatures: output.lambda_signatures(db).iter().cloned().collect(),
+            exhaustive_cases: output.exhaustive_cases(db).iter().copied().collect(),
+        };
+        let function_types: HashMap<_, _> = output.function_types(db).iter().copied().collect();
+
+        let _ = monomorphize_functions_with_limits(
+            db,
+            module,
+            function_types,
+            metadata,
+            SpecializationLimits {
+                rounds: 4,
+                instantiations: 1,
+            },
+        );
+    }
+
+    #[salsa_test]
+    fn specialization_limit_is_a_tracked_lowering_error(db: &salsa::DatabaseImpl) {
+        let source = SourceCst::from_source_str(
+            db,
+            "specialization_limit.trb",
+            r#"
+fn identity(value: a) -> a { value }
+
+fn use_nat() -> Nat { identity(1) }
+
+fn main() -> Bool { identity(true) }
+"#,
+        );
+
+        monomorphize_with_tiny_limit(db, source);
+        let diagnostics: Vec<_> =
+            monomorphize_with_tiny_limit::accumulated::<Diagnostic>(db, source)
+                .into_iter()
+                .filter(|diagnostic| {
+                    diagnostic.phase == CompilationPhase::Lowering
+                        && diagnostic.inner.severity == DiagnosticSeverity::Error
+                        && diagnostic.inner.message
+                            == "generic specialization exceeded the deterministic expansion limit"
+                })
+                .collect();
+
+        assert_eq!(diagnostics.len(), 1, "the limit must reject compilation");
+    }
 }

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -6,16 +6,18 @@
 
 use std::collections::{HashMap, HashSet};
 
+use tribute_ir::ModulePathExt;
 use trunk_ir::Symbol;
 
 use crate::ast::{
-    Arm, CtorId, Decl, Expr, ExprKind, FieldPattern, FuncDefId, HandlerArm, HandlerKind, Module,
-    ModuleDecl, Pattern, PatternKind, ResolvedRef, Stmt, Type, TypeDefId, TypeKind, TypeScheme,
-    TypedRef,
+    Arm, CtorId, Decl, Effect, EffectRow, Expr, ExprKind, FieldPattern, FuncDefId, HandlerArm,
+    HandlerKind, Module, ModuleDecl, Pattern, PatternKind, ResolvedRef, Stmt, Type, TypeDefId,
+    TypeKind, TypeScheme, TypedRef,
 };
 
 use super::collect::extract_type_args;
 use super::mangle::mangle_type_name;
+use crate::typeck::subst::substitute_bound_vars;
 
 /// Rewrite map: original FuncDefId → list of (type_args, mangled_name) pairs.
 pub type RewriteMap<'db> = HashMap<FuncDefId<'db>, Vec<(Vec<Type<'db>>, Symbol)>>;
@@ -29,8 +31,16 @@ pub fn rewrite_module<'db>(
     module: Module<TypedRef<'db>>,
     function_types: &[(Symbol, TypeScheme<'db>)],
     rewrite_map: &RewriteMap<'db>,
+    call_callee_types: &mut HashMap<crate::ast::NodeId, Type<'db>>,
+    specialized_call_callee_nodes: &mut HashSet<crate::ast::NodeId>,
 ) -> Module<TypedRef<'db>> {
-    let mut rewriter = make_rewriter(db, function_types, rewrite_map);
+    let mut rewriter = make_rewriter(
+        db,
+        function_types,
+        rewrite_map,
+        call_callee_types,
+        specialized_call_callee_nodes,
+    );
     let decls = module
         .decls
         .into_iter()
@@ -45,8 +55,16 @@ pub fn rewrite_decls<'db>(
     decls: Vec<Decl<TypedRef<'db>>>,
     function_types: &[(Symbol, TypeScheme<'db>)],
     rewrite_map: &RewriteMap<'db>,
+    call_callee_types: &mut HashMap<crate::ast::NodeId, Type<'db>>,
+    specialized_call_callee_nodes: &mut HashSet<crate::ast::NodeId>,
 ) -> Vec<Decl<TypedRef<'db>>> {
-    let mut rewriter = make_rewriter(db, function_types, rewrite_map);
+    let mut rewriter = make_rewriter(
+        db,
+        function_types,
+        rewrite_map,
+        call_callee_types,
+        specialized_call_callee_nodes,
+    );
     decls
         .into_iter()
         .map(|d| rewriter.rewrite_decl(d))
@@ -57,12 +75,16 @@ fn make_rewriter<'a, 'db>(
     db: &'db dyn salsa::Database,
     function_types: &[(Symbol, TypeScheme<'db>)],
     rewrite_map: &'a RewriteMap<'db>,
+    call_callee_types: &'a mut HashMap<crate::ast::NodeId, Type<'db>>,
+    specialized_call_callee_nodes: &'a mut HashSet<crate::ast::NodeId>,
 ) -> CallSiteRewriter<'a, 'db> {
     let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
     CallSiteRewriter {
         db,
         scheme_map,
         rewrite_map,
+        call_callee_types,
+        specialized_call_callee_nodes,
     }
 }
 
@@ -70,17 +92,24 @@ struct CallSiteRewriter<'a, 'db> {
     db: &'db dyn salsa::Database,
     scheme_map: HashMap<Symbol, TypeScheme<'db>>,
     rewrite_map: &'a RewriteMap<'db>,
+    call_callee_types: &'a mut HashMap<crate::ast::NodeId, Type<'db>>,
+    specialized_call_callee_nodes: &'a mut HashSet<crate::ast::NodeId>,
 }
 
 impl<'a, 'db> CallSiteRewriter<'a, 'db> {
-    fn try_rewrite_ref(&self, typed_ref: &TypedRef<'db>) -> Option<TypedRef<'db>> {
+    fn try_rewrite_ref(
+        &mut self,
+        node: crate::ast::NodeId,
+        typed_ref: &TypedRef<'db>,
+    ) -> Option<TypedRef<'db>> {
         let ResolvedRef::Function { id } = &typed_ref.resolved else {
             return None;
         };
         let entries = self.rewrite_map.get(id)?;
         let qualified = id.qualified(self.db);
         let scheme = self.scheme_map.get(&qualified)?;
-        let type_args = extract_type_args(self.db, *scheme, typed_ref.ty)?;
+        let concrete = self.call_callee_types.get(&node).copied()?;
+        let type_args = extract_type_args(self.db, *scheme, concrete)?;
 
         // Find the matching mangled name
         let mangled = entries.iter().find_map(|(args, name)| {
@@ -91,15 +120,24 @@ impl<'a, 'db> CallSiteRewriter<'a, 'db> {
             }
         })?;
 
+        let specialized_type = substitute_bound_vars(self.db, scheme.body(self.db), &type_args)
+            .unwrap_or_else(|index, max| {
+                panic!(
+                    "BoundVar index out of range in specialization of {}: index={}, subst.len()={}",
+                    qualified, index, max
+                )
+            });
+        self.call_callee_types.insert(node, specialized_type);
+        self.specialized_call_callee_nodes.insert(node);
         let specialized_id = FuncDefId::new(self.db, mangled);
         Some(TypedRef::new(
             ResolvedRef::Function { id: specialized_id },
-            typed_ref.ty,
+            specialized_type,
         ))
     }
 
-    fn rewrite_typed_ref(&self, tr: TypedRef<'db>) -> TypedRef<'db> {
-        self.try_rewrite_ref(&tr).unwrap_or(tr)
+    fn rewrite_typed_ref(&mut self, node: crate::ast::NodeId, tr: TypedRef<'db>) -> TypedRef<'db> {
+        self.try_rewrite_ref(node, &tr).unwrap_or(tr)
     }
 
     fn rewrite_decl(&mut self, decl: Decl<TypedRef<'db>>) -> Decl<TypedRef<'db>> {
@@ -125,7 +163,7 @@ impl<'a, 'db> CallSiteRewriter<'a, 'db> {
 
     fn rewrite_expr(&mut self, expr: Expr<TypedRef<'db>>) -> Expr<TypedRef<'db>> {
         let kind = match *expr.kind {
-            ExprKind::Var(tr) => ExprKind::Var(self.rewrite_typed_ref(tr)),
+            ExprKind::Var(tr) => ExprKind::Var(self.rewrite_typed_ref(expr.id, tr)),
             ExprKind::Call { callee, args } => ExprKind::Call {
                 callee: self.rewrite_expr(callee),
                 args: args.into_iter().map(|a| self.rewrite_expr(a)).collect(),
@@ -353,7 +391,8 @@ pub fn rewrite_type<'db>(
         } => {
             let new_params: Vec<_> = params.iter().map(|p| rewrite_type(db, *p, map)).collect();
             let new_result = rewrite_type(db, *result, map);
-            if new_params == *params && new_result == *result {
+            let new_effect = rewrite_effect_row(db, *effect, map);
+            if new_params == *params && new_result == *result && new_effect == *effect {
                 return ty;
             }
             Type::new(
@@ -361,7 +400,7 @@ pub fn rewrite_type<'db>(
                 TypeKind::Func {
                     params: new_params,
                     result: new_result,
-                    effect: *effect,
+                    effect: new_effect,
                     minimum_convention: *minimum_convention,
                 },
             )
@@ -394,7 +433,8 @@ pub fn rewrite_type<'db>(
         } => {
             let new_arg = rewrite_type(db, *arg, map);
             let new_result = rewrite_type(db, *result, map);
-            if new_arg == *arg && new_result == *result {
+            let new_effect = rewrite_effect_row(db, *effect, map);
+            if new_arg == *arg && new_result == *result && new_effect == *effect {
                 return ty;
             }
             Type::new(
@@ -402,7 +442,7 @@ pub fn rewrite_type<'db>(
                 TypeKind::Continuation {
                     arg: new_arg,
                     result: new_result,
-                    effect: *effect,
+                    effect: new_effect,
                 },
             )
         }
@@ -416,8 +456,33 @@ pub fn rewrite_type<'db>(
         | TypeKind::Nil
         | TypeKind::Never
         | TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
         | TypeKind::UniVar { .. }
         | TypeKind::Error => ty,
+    }
+}
+
+fn rewrite_effect_row<'db>(
+    db: &'db dyn salsa::Database,
+    effect: EffectRow<'db>,
+    map: &TypeRewriteMap<'db>,
+) -> EffectRow<'db> {
+    let rewritten: Vec<_> = effect
+        .effects(db)
+        .iter()
+        .map(|entry| Effect {
+            ability_id: entry.ability_id,
+            args: entry
+                .args
+                .iter()
+                .map(|arg| rewrite_type(db, *arg, map))
+                .collect(),
+        })
+        .collect();
+    if rewritten == *effect.effects(db) {
+        effect
+    } else {
+        EffectRow::new(db, rewritten, effect.rest(db))
     }
 }
 
@@ -455,7 +520,7 @@ fn rewrite_typed_ref_type<'db>(
 
 fn find_mangled_for_ctor<'db>(
     db: &'db dyn salsa::Database,
-    _ctor_id: CtorId<'db>,
+    ctor_id: CtorId<'db>,
     ty: Type<'db>,
     map: &TypeRewriteMap<'db>,
 ) -> Option<Symbol> {
@@ -470,7 +535,14 @@ fn find_mangled_for_ctor<'db>(
             let entries = map.get(id)?;
             // Match against the original args stored in the map.
             let (_, mangled) = entries.iter().find(|(ta, _)| ta == args)?;
-            Some(*mangled)
+            if ctor_id.qualified(db) == id.qualified(db) {
+                Some(*mangled)
+            } else {
+                Some(Symbol::from_dynamic(&format!(
+                    "{mangled}${}",
+                    ctor_id.qualified(db).last_segment()
+                )))
+            }
         }
         _ => None,
     }

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -2,31 +2,43 @@ use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::num::NonZero;
 
+use tribute_ir::ModulePathExt;
 use trunk_ir::Symbol;
 
 use crate::ast::{
     Arm, Decl, EnumDecl, Expr, ExprKind, FieldDecl, FieldPattern, FuncDecl, FuncDefId, HandlerArm,
-    HandlerKind, Module, NodeId, Pattern, PatternKind, Stmt, StructDecl, Type, TypeAnnotation,
-    TypeAnnotationKind, TypeDefId, TypeKind, TypeScheme, TypedRef, VariantDecl,
+    HandlerKind, Module, NodeId, Param, ParamDecl, Pattern, PatternKind, Stmt, StructDecl, Type,
+    TypeAnnotation, TypeAnnotationKind, TypeDefId, TypeKind, TypeScheme, TypedRef, VariantDecl,
 };
 use crate::typeck::subst::substitute_bound_vars;
 
 use super::mangle::{mangle_name, mangle_type_name};
 
+type GeneratedFunctionSpecializations<'db> = (
+    Vec<FuncDecl<TypedRef<'db>>>,
+    Vec<(Symbol, TypeScheme<'db>)>,
+    Vec<FunctionSpecialization<'db>>,
+);
+
 /// Generate specialized copies of generic functions for each instantiation.
 ///
 /// Returns a list of new specialized `FuncDecl`s and their corresponding
 /// `(Symbol, TypeScheme)` entries for `function_types`.
-pub fn generate_specializations<'db>(
+pub(crate) fn generate_specializations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
     instantiations: &HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
     function_types: &[(Symbol, TypeScheme<'db>)],
-) -> (Vec<FuncDecl<TypedRef<'db>>>, Vec<(Symbol, TypeScheme<'db>)>) {
+) -> GeneratedFunctionSpecializations<'db> {
     let func_decls = collect_func_decls(module);
     let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
 
-    let mut entries: Vec<(Symbol, FuncDecl<TypedRef<'db>>, TypeScheme<'db>)> = Vec::new();
+    let mut entries: Vec<(
+        Symbol,
+        FuncDecl<TypedRef<'db>>,
+        TypeScheme<'db>,
+        FunctionSpecialization<'db>,
+    )> = Vec::new();
 
     for (func_id, type_arg_sets) in instantiations {
         let qualified = func_id.qualified(db);
@@ -40,20 +52,17 @@ pub fn generate_specializations<'db>(
         for type_args in type_arg_sets {
             let mangled = mangle_name(db, qualified, type_args);
             let specialized = specialize_func_decl(db, func, type_args, mangled);
-            let specialized_scheme = TypeScheme::new(
-                db,
-                vec![],
-                scheme.effect_params(db).clone(),
-                substitute_bound_vars(db, scheme.body(db), type_args).unwrap_or_else(
-                    |index, max| {
-                        panic!(
-                            "BoundVar index out of range in specialization of {}: index={}, subst.len()={}",
-                            qualified, index, max
-                        )
-                    },
-                ),
-            );
-            entries.push((mangled, specialized, specialized_scheme));
+            let specialized_scheme = specialize_function_scheme(db, qualified, *scheme, type_args);
+            entries.push((
+                mangled,
+                specialized,
+                specialized_scheme,
+                FunctionSpecialization {
+                    type_args: type_args.clone(),
+                    variant: type_args_variant(type_args),
+                    node_origins: collect_semantic_node_ids(func),
+                },
+            ));
         }
     }
 
@@ -62,12 +71,75 @@ pub fn generate_specializations<'db>(
 
     let mut new_decls = Vec::with_capacity(entries.len());
     let mut new_function_types = Vec::with_capacity(entries.len());
-    for (name, decl, scheme) in entries {
+    let mut specializations = Vec::with_capacity(entries.len());
+    for (name, decl, scheme, specialization) in entries {
         new_decls.push(decl);
         new_function_types.push((name, scheme));
+        specializations.push(specialization);
     }
 
-    (new_decls, new_function_types)
+    (new_decls, new_function_types, specializations)
+}
+
+#[derive(Clone)]
+pub(crate) struct FunctionSpecialization<'db> {
+    pub type_args: Vec<Type<'db>>,
+    pub variant: NonZero<u64>,
+    pub node_origins: HashSet<NodeId>,
+}
+
+/// Generate exact semantic signatures for rewritten generic extern calls.
+///
+/// The source ABI declaration intentionally remains at its unmangled base
+/// symbol. Target-specific intrinsic lowering authorizes specialized call
+/// names through that base declaration, so this function must not synthesize
+/// declarations for names the runtime does not export.
+pub fn generate_extern_specialization_types<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+    instantiations: &HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    function_types: &[(Symbol, TypeScheme<'db>)],
+) -> Vec<(Symbol, TypeScheme<'db>)> {
+    let externs = collect_extern_names(module);
+    let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
+    let mut entries = Vec::new();
+
+    for (func_id, type_arg_sets) in instantiations {
+        let qualified = func_id.qualified(db);
+        if !externs.contains(&qualified) {
+            continue;
+        }
+        let Some(scheme) = scheme_map.get(&qualified) else {
+            continue;
+        };
+        for type_args in type_arg_sets {
+            let mangled = mangle_name(db, qualified, type_args);
+            let specialized_scheme = specialize_function_scheme(db, qualified, *scheme, type_args);
+            entries.push((mangled, specialized_scheme));
+        }
+    }
+
+    entries.sort_by_key(|entry| entry.0);
+    entries
+}
+
+fn specialize_function_scheme<'db>(
+    db: &'db dyn salsa::Database,
+    qualified: Symbol,
+    scheme: TypeScheme<'db>,
+    type_args: &[Type<'db>],
+) -> TypeScheme<'db> {
+    TypeScheme::new(
+        db,
+        vec![],
+        scheme.effect_params(db).clone(),
+        substitute_bound_vars(db, scheme.body(db), type_args).unwrap_or_else(|index, max| {
+            panic!(
+                "BoundVar index out of range in specialization of {}: index={}, subst.len()={}",
+                qualified, index, max
+            )
+        }),
+    )
 }
 
 // ============================================================================
@@ -79,8 +151,9 @@ pub fn generate_struct_specializations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
     instantiations: &HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    type_definitions: &HashMap<Symbol, TypeScheme<'db>>,
 ) -> Vec<StructDecl> {
-    let struct_decls = collect_struct_decls(db, module);
+    let struct_decls = collect_struct_decls(db, module, type_definitions);
     let mut entries: Vec<(Symbol, StructDecl)> = Vec::new();
 
     for (id, type_arg_sets) in instantiations {
@@ -107,8 +180,9 @@ pub fn generate_enum_specializations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
     instantiations: &HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    type_definitions: &HashMap<Symbol, TypeScheme<'db>>,
 ) -> Vec<EnumDecl> {
-    let enum_decls = collect_enum_decls(db, module);
+    let enum_decls = collect_enum_decls(db, module, type_definitions);
     let mut entries: Vec<(Symbol, EnumDecl)> = Vec::new();
 
     for (id, type_arg_sets) in instantiations {
@@ -128,6 +202,56 @@ pub fn generate_enum_specializations<'db>(
 
     entries.sort_by_key(|e| e.0);
     entries.into_iter().map(|(_, decl)| decl).collect()
+}
+
+#[derive(Clone)]
+pub(crate) struct ConstructorSpecialization<'db> {
+    pub source: crate::ast::CtorId<'db>,
+    pub specialized: crate::ast::CtorId<'db>,
+    pub type_args: Vec<Type<'db>>,
+}
+
+pub(crate) fn generate_constructor_specializations<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+    instantiations: &HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    type_definitions: &HashMap<Symbol, TypeScheme<'db>>,
+) -> Vec<ConstructorSpecialization<'db>> {
+    let structs = collect_struct_decls(db, module, type_definitions);
+    let enums = collect_enum_decls(db, module, type_definitions);
+    let mut result = Vec::new();
+
+    for (owner, argument_sets) in instantiations {
+        for type_args in argument_sets {
+            let mangled_owner = mangle_type_name(db, *owner, owner.qualified(db), type_args);
+            if structs.contains_key(owner) {
+                result.push(ConstructorSpecialization {
+                    source: crate::ast::CtorId::new(db, owner.qualified(db)),
+                    specialized: crate::ast::CtorId::new(db, mangled_owner),
+                    type_args: type_args.clone(),
+                });
+                continue;
+            }
+            let Some(enumeration) = enums.get(owner) else {
+                continue;
+            };
+            for variant in &enumeration.variants {
+                let source = owner
+                    .qualified(db)
+                    .parent_path()
+                    .map_or(variant.name, |prefix| prefix.join_path(variant.name));
+                let specialized =
+                    Symbol::from_dynamic(&format!("{mangled_owner}${}", variant.name));
+                result.push(ConstructorSpecialization {
+                    source: crate::ast::CtorId::new(db, source),
+                    specialized: crate::ast::CtorId::new(db, specialized),
+                    type_args: type_args.clone(),
+                });
+            }
+        }
+    }
+    result.sort_by_key(|entry| entry.specialized.qualified(db));
+    result
 }
 
 fn specialize_struct_decl<'db>(
@@ -151,7 +275,7 @@ fn specialize_struct_decl<'db>(
                 id: f.id.with_variant(variant),
                 is_pub: f.is_pub,
                 name: f.name,
-                ty: substitute_annotation(db, &f.ty, &param_names, type_args),
+                ty: substitute_annotation(db, &f.ty, &param_names, type_args, variant),
             })
             .collect(),
     }
@@ -184,7 +308,7 @@ fn specialize_enum_decl<'db>(
                         id: f.id.with_variant(variant),
                         is_pub: f.is_pub,
                         name: f.name,
-                        ty: substitute_annotation(db, &f.ty, &param_names, type_args),
+                        ty: substitute_annotation(db, &f.ty, &param_names, type_args, variant),
                     })
                     .collect(),
             })
@@ -201,6 +325,7 @@ fn substitute_annotation<'db>(
     ann: &TypeAnnotation,
     param_names: &[Symbol],
     type_args: &[Type<'db>],
+    variant: NonZero<u64>,
 ) -> TypeAnnotation {
     let kind = match &ann.kind {
         TypeAnnotationKind::Named(name) => {
@@ -208,15 +333,21 @@ fn substitute_annotation<'db>(
             if let Some(idx) = param_names.iter().position(|p| p == name)
                 && let Some(ty) = type_args.get(idx)
             {
-                return type_to_annotation(db, *ty, ann.id);
+                return type_to_annotation(db, *ty, ann.id.with_variant(variant));
             }
             ann.kind.clone()
         }
         TypeAnnotationKind::App { ctor, args } => TypeAnnotationKind::App {
-            ctor: Box::new(substitute_annotation(db, ctor, param_names, type_args)),
+            ctor: Box::new(substitute_annotation(
+                db,
+                ctor,
+                param_names,
+                type_args,
+                variant,
+            )),
             args: args
                 .iter()
-                .map(|a| substitute_annotation(db, a, param_names, type_args))
+                .map(|a| substitute_annotation(db, a, param_names, type_args, variant))
                 .collect(),
         },
         TypeAnnotationKind::Func {
@@ -226,22 +357,34 @@ fn substitute_annotation<'db>(
         } => TypeAnnotationKind::Func {
             params: params
                 .iter()
-                .map(|p| substitute_annotation(db, p, param_names, type_args))
+                .map(|p| substitute_annotation(db, p, param_names, type_args, variant))
                 .collect(),
-            result: Box::new(substitute_annotation(db, result, param_names, type_args)),
-            abilities: abilities.clone(),
+            result: Box::new(substitute_annotation(
+                db,
+                result,
+                param_names,
+                type_args,
+                variant,
+            )),
+            abilities: abilities
+                .iter()
+                .map(|ability| substitute_annotation(db, ability, param_names, type_args, variant))
+                .collect(),
         },
         TypeAnnotationKind::Tuple(elems) => TypeAnnotationKind::Tuple(
             elems
                 .iter()
-                .map(|e| substitute_annotation(db, e, param_names, type_args))
+                .map(|e| substitute_annotation(db, e, param_names, type_args, variant))
                 .collect(),
         ),
         TypeAnnotationKind::Path(_) | TypeAnnotationKind::Infer | TypeAnnotationKind::Error => {
             ann.kind.clone()
         }
     };
-    TypeAnnotation { id: ann.id, kind }
+    TypeAnnotation {
+        id: ann.id.with_variant(variant),
+        kind,
+    }
 }
 
 /// Convert a semantic Type to a TypeAnnotation.
@@ -338,10 +481,11 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
 fn collect_struct_decls<'a, 'db>(
     db: &'db dyn salsa::Database,
     module: &'a Module<TypedRef<'db>>,
+    type_definitions: &HashMap<Symbol, TypeScheme<'db>>,
 ) -> HashMap<TypeDefId<'db>, &'a StructDecl> {
     let mut map = HashMap::new();
     let mut prefix = String::new();
-    collect_struct_decls_inner(db, &module.decls, &mut prefix, &mut map);
+    collect_struct_decls_inner(db, &module.decls, &mut prefix, type_definitions, &mut map);
     map
 }
 
@@ -349,18 +493,23 @@ fn collect_struct_decls_inner<'a, 'db>(
     db: &'db dyn salsa::Database,
     decls: &'a [Decl<TypedRef<'db>>],
     prefix: &mut String,
+    type_definitions: &HashMap<Symbol, TypeScheme<'db>>,
     map: &mut HashMap<TypeDefId<'db>, &'a StructDecl>,
 ) {
     for decl in decls {
         match decl {
             Decl::Struct(s) => {
                 let qualified = crate::qualified_symbol(prefix, s.name);
-                map.insert(TypeDefId::source(db, qualified, s.id), s);
+                if let Some(scheme) = type_definitions.get(&qualified)
+                    && let Some(owner) = nominal_result_id(db, scheme.body(db))
+                {
+                    map.insert(owner, s);
+                }
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
                     let len = crate::push_prefix(prefix, m.name);
-                    collect_struct_decls_inner(db, body, prefix, map);
+                    collect_struct_decls_inner(db, body, prefix, type_definitions, map);
                     prefix.truncate(len);
                 }
             }
@@ -372,10 +521,11 @@ fn collect_struct_decls_inner<'a, 'db>(
 fn collect_enum_decls<'a, 'db>(
     db: &'db dyn salsa::Database,
     module: &'a Module<TypedRef<'db>>,
+    type_definitions: &HashMap<Symbol, TypeScheme<'db>>,
 ) -> HashMap<TypeDefId<'db>, &'a EnumDecl> {
     let mut map = HashMap::new();
     let mut prefix = String::new();
-    collect_enum_decls_inner(db, &module.decls, &mut prefix, &mut map);
+    collect_enum_decls_inner(db, &module.decls, &mut prefix, type_definitions, &mut map);
     map
 }
 
@@ -383,23 +533,39 @@ fn collect_enum_decls_inner<'a, 'db>(
     db: &'db dyn salsa::Database,
     decls: &'a [Decl<TypedRef<'db>>],
     prefix: &mut String,
+    type_definitions: &HashMap<Symbol, TypeScheme<'db>>,
     map: &mut HashMap<TypeDefId<'db>, &'a EnumDecl>,
 ) {
     for decl in decls {
         match decl {
             Decl::Enum(e) => {
                 let qualified = crate::qualified_symbol(prefix, e.name);
-                map.insert(TypeDefId::source(db, qualified, e.id), e);
+                if let Some(scheme) = type_definitions.get(&qualified)
+                    && let Some(owner) = nominal_result_id(db, scheme.body(db))
+                {
+                    map.insert(owner, e);
+                }
             }
             Decl::Module(m) => {
                 if let Some(body) = &m.body {
                     let len = crate::push_prefix(prefix, m.name);
-                    collect_enum_decls_inner(db, body, prefix, map);
+                    collect_enum_decls_inner(db, body, prefix, type_definitions, map);
                     prefix.truncate(len);
                 }
             }
             _ => {}
         }
+    }
+}
+
+fn nominal_result_id<'db>(db: &'db dyn salsa::Database, ty: Type<'db>) -> Option<TypeDefId<'db>> {
+    let result = match ty.kind(db) {
+        TypeKind::Func { result, .. } => *result,
+        _ => ty,
+    };
+    match result.kind(db) {
+        TypeKind::Named { id, .. } => Some(*id),
+        _ => None,
     }
 }
 
@@ -439,6 +605,35 @@ fn collect_func_decls_inner<'a, 'db>(
     }
 }
 
+fn collect_extern_names<'db>(module: &Module<TypedRef<'db>>) -> HashSet<Symbol> {
+    let mut names = HashSet::new();
+    let mut prefix = String::new();
+    collect_extern_names_inner(&module.decls, &mut prefix, &mut names);
+    names
+}
+
+fn collect_extern_names_inner<'db>(
+    decls: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+    names: &mut HashSet<Symbol>,
+) {
+    for decl in decls {
+        match decl {
+            Decl::ExternFunction(function) => {
+                names.insert(crate::qualified_symbol(prefix, function.name));
+            }
+            Decl::Module(module) => {
+                if let Some(body) = &module.body {
+                    let len = crate::push_prefix(prefix, module.name);
+                    collect_extern_names_inner(body, prefix, names);
+                    prefix.truncate(len);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Compute a NonZero<u64> variant hash from concrete type arguments.
 ///
 /// This is used to give specialized AST nodes unique NodeIds that
@@ -458,15 +653,36 @@ fn specialize_func_decl<'db>(
     mangled_name: Symbol,
 ) -> FuncDecl<TypedRef<'db>> {
     let variant = type_args_variant(type_args);
+    let param_names: Vec<Symbol> = func.type_params.iter().map(|param| param.name).collect();
     FuncDecl {
         id: func.id.with_variant(variant),
         is_pub: false,
         name: mangled_name,
         type_params: vec![],
-        params: func.params.clone(),
-        return_ty: func.return_ty.clone(),
-        effects: func.effects.clone(),
-        body: substitute_expr(db, func.body.clone(), type_args, variant),
+        params: func
+            .params
+            .iter()
+            .map(|param| ParamDecl {
+                id: param.id.with_variant(variant),
+                name: param.name,
+                ty: param
+                    .ty
+                    .as_ref()
+                    .map(|ty| substitute_annotation(db, ty, &param_names, type_args, variant)),
+                local_id: param.local_id,
+            })
+            .collect(),
+        return_ty: func
+            .return_ty
+            .as_ref()
+            .map(|ty| substitute_annotation(db, ty, &param_names, type_args, variant)),
+        effects: func.effects.as_ref().map(|effects| {
+            effects
+                .iter()
+                .map(|effect| substitute_annotation(db, effect, &param_names, type_args, variant))
+                .collect()
+        }),
+        body: substitute_expr(db, func.body.clone(), &param_names, type_args, variant),
     }
 }
 
@@ -500,52 +716,56 @@ fn subst_typed_ref<'db>(
 fn substitute_expr<'db>(
     db: &'db dyn salsa::Database,
     expr: Expr<TypedRef<'db>>,
+    param_names: &[Symbol],
     type_args: &[Type<'db>],
     variant: NonZero<u64>,
 ) -> Expr<TypedRef<'db>> {
     let kind = match *expr.kind {
         ExprKind::Var(tr) => ExprKind::Var(subst_typed_ref(db, tr, type_args)),
         ExprKind::Call { callee, args } => ExprKind::Call {
-            callee: substitute_expr(db, callee, type_args, variant),
+            callee: substitute_expr(db, callee, param_names, type_args, variant),
             args: args
                 .into_iter()
-                .map(|a| substitute_expr(db, a, type_args, variant))
+                .map(|a| substitute_expr(db, a, param_names, type_args, variant))
                 .collect(),
         },
         ExprKind::Block { stmts, value } => ExprKind::Block {
             stmts: stmts
                 .into_iter()
-                .map(|s| substitute_stmt(db, s, type_args, variant))
+                .map(|s| substitute_stmt(db, s, param_names, type_args, variant))
                 .collect(),
-            value: substitute_expr(db, value, type_args, variant),
+            value: substitute_expr(db, value, param_names, type_args, variant),
         },
         ExprKind::Case { scrutinee, arms } => ExprKind::Case {
-            scrutinee: substitute_expr(db, scrutinee, type_args, variant),
+            scrutinee: substitute_expr(db, scrutinee, param_names, type_args, variant),
             arms: arms
                 .into_iter()
-                .map(|a| substitute_arm(db, a, type_args, variant))
+                .map(|a| substitute_arm(db, a, param_names, type_args, variant))
                 .collect(),
         },
         ExprKind::Lambda { params, body } => ExprKind::Lambda {
-            params,
-            body: substitute_expr(db, body, type_args, variant),
+            params: params
+                .into_iter()
+                .map(|param| substitute_lambda_param(db, param, param_names, type_args, variant))
+                .collect(),
+            body: substitute_expr(db, body, param_names, type_args, variant),
         },
         ExprKind::Handle { body, handlers } => ExprKind::Handle {
-            body: substitute_expr(db, body, type_args, variant),
+            body: substitute_expr(db, body, param_names, type_args, variant),
             handlers: handlers
                 .into_iter()
-                .map(|h| substitute_handler_arm(db, h, type_args, variant))
+                .map(|h| substitute_handler_arm(db, h, param_names, type_args, variant))
                 .collect(),
         },
         ExprKind::Resume { arg, local_id } => ExprKind::Resume {
-            arg: substitute_expr(db, arg, type_args, variant),
+            arg: substitute_expr(db, arg, param_names, type_args, variant),
             local_id,
         },
         ExprKind::Cons { ctor, args } => ExprKind::Cons {
             ctor: subst_typed_ref(db, ctor, type_args),
             args: args
                 .into_iter()
-                .map(|a| substitute_expr(db, a, type_args, variant))
+                .map(|a| substitute_expr(db, a, param_names, type_args, variant))
                 .collect(),
         },
         ExprKind::Record {
@@ -556,35 +776,40 @@ fn substitute_expr<'db>(
             type_name: subst_typed_ref(db, type_name, type_args),
             fields: fields
                 .into_iter()
-                .map(|(name, e)| (name, substitute_expr(db, e, type_args, variant)))
+                .map(|(name, e)| {
+                    (
+                        name,
+                        substitute_expr(db, e, param_names, type_args, variant),
+                    )
+                })
                 .collect(),
-            spread: spread.map(|s| substitute_expr(db, s, type_args, variant)),
+            spread: spread.map(|s| substitute_expr(db, s, param_names, type_args, variant)),
         },
         ExprKind::MethodCall {
             receiver,
             method,
             args,
         } => ExprKind::MethodCall {
-            receiver: substitute_expr(db, receiver, type_args, variant),
+            receiver: substitute_expr(db, receiver, param_names, type_args, variant),
             method,
             args: args
                 .into_iter()
-                .map(|a| substitute_expr(db, a, type_args, variant))
+                .map(|a| substitute_expr(db, a, param_names, type_args, variant))
                 .collect(),
         },
         ExprKind::BinOp { op, lhs, rhs } => ExprKind::BinOp {
             op,
-            lhs: substitute_expr(db, lhs, type_args, variant),
-            rhs: substitute_expr(db, rhs, type_args, variant),
+            lhs: substitute_expr(db, lhs, param_names, type_args, variant),
+            rhs: substitute_expr(db, rhs, param_names, type_args, variant),
         },
         ExprKind::Tuple(es) => ExprKind::Tuple(
             es.into_iter()
-                .map(|e| substitute_expr(db, e, type_args, variant))
+                .map(|e| substitute_expr(db, e, param_names, type_args, variant))
                 .collect(),
         ),
         ExprKind::List(es) => ExprKind::List(
             es.into_iter()
-                .map(|e| substitute_expr(db, e, type_args, variant))
+                .map(|e| substitute_expr(db, e, param_names, type_args, variant))
                 .collect(),
         ),
         // Leaf nodes — no types to substitute
@@ -604,6 +829,7 @@ fn substitute_expr<'db>(
 fn substitute_stmt<'db>(
     db: &'db dyn salsa::Database,
     stmt: Stmt<TypedRef<'db>>,
+    param_names: &[Symbol],
     type_args: &[Type<'db>],
     variant: NonZero<u64>,
 ) -> Stmt<TypedRef<'db>> {
@@ -616,12 +842,14 @@ fn substitute_stmt<'db>(
         } => Stmt::Let {
             id: id.with_variant(variant),
             pattern: substitute_pattern(db, pattern, type_args, variant),
-            ty,
-            value: substitute_expr(db, value, type_args, variant),
+            ty: ty.as_ref().map(|annotation| {
+                substitute_annotation(db, annotation, param_names, type_args, variant)
+            }),
+            value: substitute_expr(db, value, param_names, type_args, variant),
         },
         Stmt::Expr { id, expr } => Stmt::Expr {
             id: id.with_variant(variant),
-            expr: substitute_expr(db, expr, type_args, variant),
+            expr: substitute_expr(db, expr, param_names, type_args, variant),
         },
     }
 }
@@ -629,6 +857,7 @@ fn substitute_stmt<'db>(
 fn substitute_arm<'db>(
     db: &'db dyn salsa::Database,
     arm: Arm<TypedRef<'db>>,
+    param_names: &[Symbol],
     type_args: &[Type<'db>],
     variant: NonZero<u64>,
 ) -> Arm<TypedRef<'db>> {
@@ -637,14 +866,15 @@ fn substitute_arm<'db>(
         pattern: substitute_pattern(db, arm.pattern, type_args, variant),
         guard: arm
             .guard
-            .map(|g| substitute_expr(db, g, type_args, variant)),
-        body: substitute_expr(db, arm.body, type_args, variant),
+            .map(|g| substitute_expr(db, g, param_names, type_args, variant)),
+        body: substitute_expr(db, arm.body, param_names, type_args, variant),
     }
 }
 
 fn substitute_handler_arm<'db>(
     db: &'db dyn salsa::Database,
     arm: HandlerArm<TypedRef<'db>>,
+    param_names: &[Symbol],
     type_args: &[Type<'db>],
     variant: NonZero<u64>,
 ) -> HandlerArm<TypedRef<'db>> {
@@ -682,7 +912,24 @@ fn substitute_handler_arm<'db>(
     HandlerArm {
         id: arm.id.with_variant(variant),
         kind,
-        body: substitute_expr(db, arm.body, type_args, variant),
+        body: substitute_expr(db, arm.body, param_names, type_args, variant),
+    }
+}
+
+fn substitute_lambda_param<'db>(
+    db: &'db dyn salsa::Database,
+    param: Param,
+    param_names: &[Symbol],
+    type_args: &[Type<'db>],
+    variant: NonZero<u64>,
+) -> Param {
+    Param {
+        id: param.id.with_variant(variant),
+        name: param.name,
+        ty: param.ty.as_ref().map(|annotation| {
+            substitute_annotation(db, annotation, param_names, type_args, variant)
+        }),
+        local_id: param.local_id,
     }
 }
 
@@ -758,6 +1005,197 @@ fn substitute_pattern<'db>(
     Pattern::new(pattern.id.with_variant(variant), kind)
 }
 
+fn collect_semantic_node_ids<'db>(func: &FuncDecl<TypedRef<'db>>) -> HashSet<NodeId> {
+    let mut ids = HashSet::new();
+    ids.insert(func.id);
+    for param in &func.params {
+        ids.insert(param.id);
+        if let Some(annotation) = &param.ty {
+            collect_annotation_ids(annotation, &mut ids);
+        }
+    }
+    if let Some(annotation) = &func.return_ty {
+        collect_annotation_ids(annotation, &mut ids);
+    }
+    if let Some(effects) = &func.effects {
+        for effect in effects {
+            collect_annotation_ids(effect, &mut ids);
+        }
+    }
+    collect_expr_ids(&func.body, &mut ids);
+    ids
+}
+
+fn collect_annotation_ids(annotation: &TypeAnnotation, ids: &mut HashSet<NodeId>) {
+    ids.insert(annotation.id);
+    match &annotation.kind {
+        TypeAnnotationKind::App { ctor, args } => {
+            collect_annotation_ids(ctor, ids);
+            for arg in args {
+                collect_annotation_ids(arg, ids);
+            }
+        }
+        TypeAnnotationKind::Func {
+            params,
+            result,
+            abilities,
+        } => {
+            for param in params {
+                collect_annotation_ids(param, ids);
+            }
+            collect_annotation_ids(result, ids);
+            for ability in abilities {
+                collect_annotation_ids(ability, ids);
+            }
+        }
+        TypeAnnotationKind::Tuple(elements) => {
+            for element in elements {
+                collect_annotation_ids(element, ids);
+            }
+        }
+        TypeAnnotationKind::Named(_)
+        | TypeAnnotationKind::Path(_)
+        | TypeAnnotationKind::Infer
+        | TypeAnnotationKind::Error => {}
+    }
+}
+
+fn collect_expr_ids<'db>(expr: &Expr<TypedRef<'db>>, ids: &mut HashSet<NodeId>) {
+    ids.insert(expr.id);
+    match expr.kind.as_ref() {
+        ExprKind::Call { callee, args } => {
+            collect_expr_ids(callee, ids);
+            for arg in args {
+                collect_expr_ids(arg, ids);
+            }
+        }
+        ExprKind::Block { stmts, value } => {
+            for stmt in stmts {
+                match stmt {
+                    Stmt::Let {
+                        id,
+                        pattern,
+                        ty,
+                        value,
+                    } => {
+                        ids.insert(*id);
+                        collect_pattern_ids(pattern, ids);
+                        if let Some(annotation) = ty {
+                            collect_annotation_ids(annotation, ids);
+                        }
+                        collect_expr_ids(value, ids);
+                    }
+                    Stmt::Expr { id, expr } => {
+                        ids.insert(*id);
+                        collect_expr_ids(expr, ids);
+                    }
+                }
+            }
+            collect_expr_ids(value, ids);
+        }
+        ExprKind::Case { scrutinee, arms } => {
+            collect_expr_ids(scrutinee, ids);
+            for arm in arms {
+                ids.insert(arm.id);
+                collect_pattern_ids(&arm.pattern, ids);
+                if let Some(guard) = &arm.guard {
+                    collect_expr_ids(guard, ids);
+                }
+                collect_expr_ids(&arm.body, ids);
+            }
+        }
+        ExprKind::Lambda { params, body } => {
+            for param in params {
+                ids.insert(param.id);
+                if let Some(annotation) = &param.ty {
+                    collect_annotation_ids(annotation, ids);
+                }
+            }
+            collect_expr_ids(body, ids);
+        }
+        ExprKind::Handle { body, handlers } => {
+            collect_expr_ids(body, ids);
+            for handler in handlers {
+                ids.insert(handler.id);
+                match &handler.kind {
+                    HandlerKind::Do { binding } => collect_pattern_ids(binding, ids),
+                    HandlerKind::Fn { params, .. } | HandlerKind::Op { params, .. } => {
+                        for param in params {
+                            collect_pattern_ids(param, ids);
+                        }
+                    }
+                }
+                collect_expr_ids(&handler.body, ids);
+            }
+        }
+        ExprKind::Resume { arg, .. } => collect_expr_ids(arg, ids),
+        ExprKind::Cons { args, .. } | ExprKind::Tuple(args) | ExprKind::List(args) => {
+            for arg in args {
+                collect_expr_ids(arg, ids);
+            }
+        }
+        ExprKind::Record { fields, spread, .. } => {
+            for (_, value) in fields {
+                collect_expr_ids(value, ids);
+            }
+            if let Some(spread) = spread {
+                collect_expr_ids(spread, ids);
+            }
+        }
+        ExprKind::MethodCall { receiver, args, .. } => {
+            collect_expr_ids(receiver, ids);
+            for arg in args {
+                collect_expr_ids(arg, ids);
+            }
+        }
+        ExprKind::BinOp { lhs, rhs, .. } => {
+            collect_expr_ids(lhs, ids);
+            collect_expr_ids(rhs, ids);
+        }
+        ExprKind::Var(_)
+        | ExprKind::NatLit(_)
+        | ExprKind::IntLit(_)
+        | ExprKind::FloatLit(_)
+        | ExprKind::StringLit(_)
+        | ExprKind::BytesLit(_)
+        | ExprKind::BoolLit(_)
+        | ExprKind::RuneLit(_)
+        | ExprKind::Nil
+        | ExprKind::Error => {}
+    }
+}
+
+fn collect_pattern_ids<'db>(pattern: &Pattern<TypedRef<'db>>, ids: &mut HashSet<NodeId>) {
+    ids.insert(pattern.id);
+    match pattern.kind.as_ref() {
+        PatternKind::Variant { fields, .. }
+        | PatternKind::Tuple(fields)
+        | PatternKind::List(fields) => {
+            for field in fields {
+                collect_pattern_ids(field, ids);
+            }
+        }
+        PatternKind::Record { fields, .. } => {
+            for field in fields {
+                ids.insert(field.id);
+                if let Some(pattern) = &field.pattern {
+                    collect_pattern_ids(pattern, ids);
+                }
+            }
+        }
+        PatternKind::ListRest { head, .. } => {
+            for element in head {
+                collect_pattern_ids(element, ids);
+            }
+        }
+        PatternKind::As { pattern, .. } => collect_pattern_ids(pattern, ids),
+        PatternKind::Wildcard
+        | PatternKind::Bind { .. }
+        | PatternKind::Literal(_)
+        | PatternKind::Error => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ast::{EffectRow, NodeId, ResolvedRef, TypeKind, TypeParam};
@@ -810,7 +1248,7 @@ mod tests {
         );
         let expr = Expr::new(node_id(1), ExprKind::Var(tr));
         let variant = type_args_variant(&[int]);
-        let result = substitute_expr(&db, expr, &[int], variant);
+        let result = substitute_expr(&db, expr, &[], &[int], variant);
 
         // NodeId should have the variant applied
         assert!(result.id.variant().is_some());
@@ -868,6 +1306,129 @@ mod tests {
     }
 
     #[test]
+    fn specialized_annotation_ids_and_metadata_origins_agree() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let named_a = |id| TypeAnnotation {
+            id: node_id(id),
+            kind: TypeAnnotationKind::Named(Symbol::new("a")),
+        };
+        let let_annotation = TypeAnnotation {
+            id: node_id(22),
+            kind: TypeAnnotationKind::Func {
+                params: vec![],
+                result: Box::new(TypeAnnotation {
+                    id: node_id(23),
+                    kind: TypeAnnotationKind::Named(Symbol::new("Nil")),
+                }),
+                abilities: vec![TypeAnnotation {
+                    id: node_id(24),
+                    kind: TypeAnnotationKind::App {
+                        ctor: Box::new(TypeAnnotation {
+                            id: node_id(25),
+                            kind: TypeAnnotationKind::Named(Symbol::new("State")),
+                        }),
+                        args: vec![named_a(26)],
+                    },
+                }],
+            },
+        };
+        let lambda = Expr::new(
+            node_id(10),
+            ExprKind::Lambda {
+                params: vec![Param {
+                    id: node_id(11),
+                    name: Symbol::new("value"),
+                    ty: Some(named_a(12)),
+                    local_id: Some(crate::ast::LocalId::new(1)),
+                }],
+                body: Expr::new(node_id(13), ExprKind::Nil),
+            },
+        );
+        let func = FuncDecl {
+            id: node_id(1),
+            is_pub: false,
+            name: Symbol::new("annotated"),
+            type_params: vec![crate::ast::TypeParamDecl {
+                id: node_id(2),
+                name: Symbol::new("a"),
+                bounds: vec![],
+            }],
+            params: vec![ParamDecl {
+                id: node_id(3),
+                name: Symbol::new("input"),
+                ty: Some(named_a(4)),
+                local_id: Some(crate::ast::LocalId::new(0)),
+            }],
+            return_ty: Some(TypeAnnotation {
+                id: node_id(5),
+                kind: TypeAnnotationKind::Named(Symbol::new("Nil")),
+            }),
+            effects: None,
+            body: Expr::new(
+                node_id(30),
+                ExprKind::Block {
+                    stmts: vec![Stmt::Let {
+                        id: node_id(20),
+                        pattern: Pattern::new(
+                            node_id(21),
+                            PatternKind::Bind {
+                                name: Symbol::new("f"),
+                                local_id: Some(crate::ast::LocalId::new(2)),
+                            },
+                        ),
+                        ty: Some(let_annotation),
+                        value: lambda,
+                    }],
+                    value: Expr::new(node_id(31), ExprKind::Nil),
+                },
+            ),
+        };
+
+        let origins = collect_semantic_node_ids(&func);
+        for id in [4, 12, 22, 23, 24, 25, 26] {
+            assert!(
+                origins.contains(&node_id(id)),
+                "missing metadata origin {id}"
+            );
+        }
+
+        let variant = type_args_variant(&[int]);
+        let specialized = specialize_func_decl(&db, &func, &[int], Symbol::new("annotated$Int"));
+        assert_eq!(
+            specialized.params[0].ty.as_ref().unwrap().id,
+            node_id(4).with_variant(variant)
+        );
+        let ExprKind::Block { stmts, .. } = specialized.body.kind.as_ref() else {
+            panic!("expected block body");
+        };
+        let Stmt::Let { ty, value, .. } = &stmts[0] else {
+            panic!("expected let statement");
+        };
+        let annotation = ty.as_ref().expect("specialized let annotation");
+        assert_eq!(annotation.id, node_id(22).with_variant(variant));
+        let TypeAnnotationKind::Func { abilities, .. } = &annotation.kind else {
+            panic!("expected nested function annotation");
+        };
+        let TypeAnnotationKind::App { args, .. } = &abilities[0].kind else {
+            panic!("expected parameterized ability annotation");
+        };
+        assert!(
+            matches!(args[0].kind, TypeAnnotationKind::Named(name) if name == Symbol::new("Int"))
+        );
+        assert_eq!(args[0].id, node_id(26).with_variant(variant));
+
+        let ExprKind::Lambda { params, .. } = value.kind.as_ref() else {
+            panic!("expected lambda value");
+        };
+        assert_eq!(params[0].id, node_id(11).with_variant(variant));
+        assert_eq!(
+            params[0].ty.as_ref().unwrap().id,
+            node_id(12).with_variant(variant)
+        );
+    }
+
+    #[test]
     fn test_generate_specializations_produces_correct_count() {
         let db = TestDb::default();
         let bv0 = Type::new(&db, TypeKind::BoundVar { index: 0 });
@@ -921,11 +1482,12 @@ mod tests {
         let mut instantiations = HashMap::new();
         instantiations.insert(func_id, type_arg_sets);
 
-        let (new_decls, new_fn_types) =
+        let (new_decls, new_fn_types, specializations) =
             generate_specializations(&db, &module, &instantiations, &function_types);
 
         assert_eq!(new_decls.len(), 2);
         assert_eq!(new_fn_types.len(), 2);
+        assert_eq!(specializations.len(), 2);
 
         // Verify names are mangled
         let names: HashSet<String> = new_decls.iter().map(|d| d.name.to_string()).collect();
@@ -1260,7 +1822,13 @@ mod tests {
             id: node_id(1),
             kind: TypeAnnotationKind::Named(Symbol::new("a")),
         };
-        let result = substitute_annotation(&db, &ann, &[Symbol::new("a")], &[int]);
+        let result = substitute_annotation(
+            &db,
+            &ann,
+            &[Symbol::new("a")],
+            &[int],
+            type_args_variant(&[int]),
+        );
         match &result.kind {
             TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Int"),
             other => panic!("expected Named(Int), got {:?}", other),
@@ -1275,7 +1843,13 @@ mod tests {
             id: node_id(1),
             kind: TypeAnnotationKind::Named(Symbol::new("Text")),
         };
-        let result = substitute_annotation(&db, &ann, &[Symbol::new("a")], &[int]);
+        let result = substitute_annotation(
+            &db,
+            &ann,
+            &[Symbol::new("a")],
+            &[int],
+            type_args_variant(&[int]),
+        );
         match &result.kind {
             TypeAnnotationKind::Named(name) => assert_eq!(name.to_string(), "Text"),
             other => panic!("expected Named(Text), got {:?}", other),

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -73,6 +73,7 @@ fn type_contains_univar<'db>(db: &'db dyn salsa::Database, ty: Type<'db>) -> boo
         | TypeKind::Nil
         | TypeKind::Never
         | TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
         | TypeKind::Error => false,
     }
 }
@@ -89,6 +90,25 @@ fn effect_row_contains_univar<'db>(db: &'db dyn salsa::Database, row: EffectRow<
     false
 }
 
+/// Resolve only the constraints known while a lambda body was evaluated.
+/// Contextual callback-row equations are deliberately added after this probe:
+/// they describe the slot receiving the closure, not effects evaluated by the
+/// closure value itself.
+fn lexical_lambda_body_is_pure<'db>(
+    ctx: &FunctionInferenceContext<'_, 'db>,
+    effects: &[EffectRow<'db>],
+) -> bool {
+    let mut solver = TypeSolver::new(ctx.db());
+    solver.solve(ctx.constraints_snapshot()).is_ok_and(|()| {
+        effects.iter().all(|effect| {
+            solver
+                .row_subst()
+                .apply(ctx.db(), *effect)
+                .is_pure(ctx.db())
+        })
+    })
+}
+
 impl<'db> TypeChecker<'db> {
     // =========================================================================
     // Expression checking
@@ -101,6 +121,7 @@ impl<'db> TypeChecker<'db> {
         expr: Expr<ResolvedRef<'db>>,
         mode: Mode<'db>,
     ) -> Expr<TypedRef<'db>> {
+        let inferred_before_conversion = ctx.get_node_type(expr.id);
         let ty = match &*expr.kind {
             ExprKind::NatLit(_) => ctx.nat_type(),
             ExprKind::IntLit(_) => ctx.int_type(),
@@ -114,6 +135,7 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
+                ctx.record_call_callee_type(callee.id, callee_ty);
                 // Conversion re-visits the callee. Keep this one ability-op
                 // inference instance connected to that visit through dedicated
                 // semantic state, never through the concrete node-type table.
@@ -161,6 +183,7 @@ impl<'db> TypeChecker<'db> {
             }
             ExprKind::Cons { ctor, args } => {
                 let ctor_ty = self.infer_var_with_ctx(ctx, ctor);
+                ctx.record_reference_type(expr.id, ctor_ty);
                 if args.is_empty() {
                     // Unit constructor (e.g., None) - just return the constructor type
                     ctor_ty
@@ -180,6 +203,7 @@ impl<'db> TypeChecker<'db> {
             } => {
                 // Get the struct constructor type and extract return type
                 let ctor_ty = self.infer_var_with_ctx(ctx, type_name);
+                ctx.record_reference_type(expr.id, ctor_ty);
                 let struct_ty = if let TypeKind::Func { result, .. } = ctor_ty.kind(self.db()) {
                     // Constructor has function type: fn(fields...) -> StructType
                     *result
@@ -353,6 +377,7 @@ impl<'db> TypeChecker<'db> {
                 // lambda's effect to include State(s).
                 let fresh_effect = ctx.fresh_effect_row();
                 ctx.set_current_effect(fresh_effect);
+                ctx.begin_lexical_lambda_effects();
 
                 // Use a new scope for lambda parameters so they don't leak out
                 ctx.push_scope();
@@ -369,6 +394,8 @@ impl<'db> TypeChecker<'db> {
 
                 // The lambda's effect is what accumulated during body inference
                 let inferred_effect = ctx.current_effect();
+                let (lexical_effects, contains_control_transfer) = ctx.end_lexical_lambda_effects();
+                let body_is_effect_free = lexical_lambda_body_is_pure(ctx, &lexical_effects);
 
                 ctx.pop_scope();
 
@@ -402,10 +429,14 @@ impl<'db> TypeChecker<'db> {
                     lambda_effect,
                     minimum_convention,
                 );
+                ctx.record_inferred_lambda_type(expr.id, lambda_type);
                 ctx.record_lambda_signature(
                     expr.id,
                     crate::typeck::LambdaSignature {
                         function_type: lambda_type,
+                        body_is_effect_free,
+                        contains_control_transfer,
+                        lexical_convention: crate::ast::CallingConvention::Direct,
                         convention: minimum_convention,
                     },
                 );
@@ -526,6 +557,7 @@ impl<'db> TypeChecker<'db> {
                 ctx.canonical_list_type(elem_ty)
             }
             ExprKind::Resume { arg, local_id } => {
+                ctx.record_lexical_lambda_control_transfer();
                 let arg_ty = self.infer_expr_type_with_ctx(ctx, arg);
                 if let Some(lid) = local_id
                     && let Some(cont_ty) = ctx.lookup_local(*lid)
@@ -542,6 +574,17 @@ impl<'db> TypeChecker<'db> {
                 }
             }
             ExprKind::Error => ctx.error_type(),
+        };
+
+        // The initial inference pass owns expression-level solver variables.
+        // Conversion may recheck an expression to construct TypedRefs, but it
+        // must use that exact instance rather than export a detached second
+        // set of body-local variables.
+        let ty = if let Some(inferred) = inferred_before_conversion {
+            ctx.constrain_eq(ty, inferred);
+            inferred
+        } else {
+            ty
         };
 
         // Check mode: constrain inferred type to match expected type.
@@ -574,18 +617,6 @@ impl<'db> TypeChecker<'db> {
             }
         }
 
-        // If a type was already recorded for this node (e.g., by infer_expr_type_with_ctx),
-        // add a constraint to ensure consistency. This handles cases like Lambda where
-        // type inference may occur twice (once in infer_* and once in check_*).
-        if let ExprKind::Lambda { .. } = &*expr.kind
-            && let Some(inferred_lambda_type) = ctx.get_inferred_lambda_type(expr.id)
-        {
-            ctx.constrain_eq(ty, inferred_lambda_type);
-        }
-        if let Some(existing_ty) = ctx.get_node_type(expr.id) {
-            ctx.constrain_eq(ty, existing_ty);
-        }
-
         let lambda_signature_type = if matches!(&*expr.kind, ExprKind::Lambda { .. }) {
             match &mode {
                 Mode::Check(expected)
@@ -593,7 +624,7 @@ impl<'db> TypeChecker<'db> {
                 {
                     *expected
                 }
-                _ => ty,
+                _ => ctx.get_inferred_lambda_type(expr.id).unwrap_or(ty),
             }
         } else {
             ty
@@ -603,10 +634,18 @@ impl<'db> TypeChecker<'db> {
                 minimum_convention, ..
             } = lambda_signature_type.kind(self.db())
         {
+            let body_is_effect_free = ctx
+                .lambda_signature(expr.id)
+                .is_some_and(|signature| signature.body_is_effect_free);
             ctx.record_checked_lambda_signature(
                 expr.id,
                 crate::typeck::LambdaSignature {
                     function_type: lambda_signature_type,
+                    body_is_effect_free,
+                    contains_control_transfer: ctx
+                        .lambda_signature(expr.id)
+                        .is_some_and(|signature| signature.contains_control_transfer),
+                    lexical_convention: crate::ast::CallingConvention::Direct,
                     convention: *minimum_convention,
                 },
             );
@@ -626,7 +665,15 @@ impl<'db> TypeChecker<'db> {
         ctx: &mut FunctionInferenceContext<'_, 'db>,
         expr: &Expr<ResolvedRef<'db>>,
     ) -> Type<'db> {
-        match &*expr.kind {
+        // The structural conversion walk revisits expressions after the first
+        // inference walk has established their exact solver instance. Reusing
+        // that instance keeps locally generalized binder provenance attached
+        // to constructor and call arguments instead of allocating detached
+        // conversion-only UniVars.
+        if let Some(ty) = ctx.get_node_type(expr.id) {
+            return ty;
+        }
+        let ty = match &*expr.kind {
             ExprKind::NatLit(_) => ctx.nat_type(),
             ExprKind::IntLit(_) => ctx.int_type(),
             ExprKind::FloatLit(_) => ctx.float_type(),
@@ -638,6 +685,7 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
+                ctx.record_call_callee_type(callee.id, callee_ty);
                 if matches!(&*callee.kind, ExprKind::Var(ResolvedRef::AbilityOp { .. })) {
                     ctx.record_ability_op_callee_type(callee.id, callee_ty);
                 }
@@ -762,6 +810,7 @@ impl<'db> TypeChecker<'db> {
                 let outer_effect = ctx.current_effect();
                 let fresh_effect = ctx.fresh_effect_row();
                 ctx.set_current_effect(fresh_effect);
+                ctx.begin_lexical_lambda_effects();
 
                 ctx.push_scope();
                 for (param, ty) in params.iter().zip(param_types.iter()) {
@@ -773,12 +822,30 @@ impl<'db> TypeChecker<'db> {
 
                 let body_ty = self.infer_expr_type_with_ctx(ctx, body);
                 let inferred_effect = ctx.current_effect();
+                let (lexical_effects, contains_control_transfer) = ctx.end_lexical_lambda_effects();
+                let body_is_effect_free = lexical_lambda_body_is_pure(ctx, &lexical_effects);
 
                 ctx.pop_scope();
                 ctx.set_current_effect(outer_effect);
 
                 let lambda_type = ctx.func_type(param_types, body_ty, inferred_effect);
                 ctx.record_inferred_lambda_type(expr.id, lambda_type);
+                // Preserve the lexical body-effect observation from the first
+                // inference walk.  A later contextual check reuses this
+                // lambda instance and may equate its open row with an
+                // effectful callback slot; that contextual equation must not
+                // make an otherwise pure closure value CPS, but it also must
+                // not hide an effect already performed by the body.
+                ctx.record_lambda_signature(
+                    expr.id,
+                    crate::typeck::LambdaSignature {
+                        function_type: lambda_type,
+                        body_is_effect_free,
+                        contains_control_transfer,
+                        lexical_convention: crate::ast::CallingConvention::Direct,
+                        convention: crate::ast::CallingConvention::Direct,
+                    },
+                );
                 lambda_type
             }
             ExprKind::Tuple(elems) => {
@@ -797,7 +864,9 @@ impl<'db> TypeChecker<'db> {
                 ctx.canonical_list_type(elem_ty)
             }
             _ => ctx.fresh_type_var(),
-        }
+        };
+        ctx.record_node_type(expr.id, ty);
+        ty
     }
 
     /// Infer the type of a variable reference.
@@ -814,8 +883,12 @@ impl<'db> TypeChecker<'db> {
                 } else {
                     ctx.lookup_local(*id)
                 };
-                let by_name = ctx.lookup_local_by_name(*name);
-                by_id.or(by_name).unwrap_or_else(|| ctx.fresh_type_var())
+                if let Some(ty) = by_id {
+                    ty
+                } else {
+                    ctx.lookup_local_by_name(*name)
+                        .unwrap_or_else(|| ctx.fresh_type_var())
+                }
             }
             ResolvedRef::Function { id } => ctx
                 .instantiate_function(*id)
@@ -947,6 +1020,7 @@ impl<'db> TypeChecker<'db> {
                 // effect row is already the handler body's effect row (assigned in
                 // convert_handler_arm_with_ctx), so it's already accounted for in the
                 // enclosing handle expression's effect propagation.
+                ctx.record_lexical_lambda_control_transfer();
                 ctx.constrain_eq_at(
                     callee_ty,
                     expected_cont_ty,
@@ -1162,14 +1236,30 @@ impl<'db> TypeChecker<'db> {
             ExprKind::BytesLit(b) => ExprKind::BytesLit(b),
             ExprKind::Nil => ExprKind::Nil,
             ExprKind::RuneLit(r) => ExprKind::RuneLit(r),
-            ExprKind::Var(resolved) => ExprKind::Var(self.convert_ref_with_ctx(ctx, resolved)),
+            ExprKind::Var(resolved) => {
+                ExprKind::Var(self.convert_ref_with_ctx(ctx, Some(expr_id), resolved))
+            }
             ExprKind::Call { callee, args } => {
                 let inferred_ability_op_callee = ctx.get_ability_op_callee_type(callee.id);
-                // First, process callee so its type gets recorded
-                let converted_callee = self.check_expr_with_ctx(ctx, callee, Mode::Infer);
+                let inferred_callee = ctx.get_call_callee_type(callee.id);
+                // A direct reference was already instantiated while inferring
+                // this call. Reuse that exact instance instead of revisiting
+                // the reference and allocating an unrelated local-scheme
+                // UniVar during conversion.
+                let Expr {
+                    id: callee_id,
+                    kind: callee_kind,
+                } = callee;
+                let converted_callee = match *callee_kind {
+                    ExprKind::Var(resolved) => Expr::new(
+                        callee_id,
+                        ExprKind::Var(self.convert_ref_with_ctx(ctx, Some(callee_id), resolved)),
+                    ),
+                    kind => self.check_expr_with_ctx(ctx, Expr::new(callee_id, kind), Mode::Infer),
+                };
 
                 // Now get callee's type (recorded during check_expr_with_ctx)
-                let callee_ty = ctx.get_node_type(converted_callee.id);
+                let callee_ty = inferred_callee.or_else(|| ctx.get_node_type(converted_callee.id));
 
                 if let (Some(inferred), Some(converted)) = (inferred_ability_op_callee, callee_ty) {
                     ctx.constrain_eq(inferred, converted);
@@ -1212,7 +1302,7 @@ impl<'db> TypeChecker<'db> {
                 }
             }
             ExprKind::Cons { ctor, args } => ExprKind::Cons {
-                ctor: self.convert_ref_with_ctx(ctx, ctor),
+                ctor: self.convert_ref_with_ctx(ctx, Some(expr_id), ctor),
                 args: args
                     .into_iter()
                     .map(|a| self.check_expr_with_ctx(ctx, a, Mode::Infer))
@@ -1223,7 +1313,7 @@ impl<'db> TypeChecker<'db> {
                 fields,
                 spread,
             } => ExprKind::Record {
-                type_name: self.convert_ref_with_ctx(ctx, type_name),
+                type_name: self.convert_ref_with_ctx(ctx, Some(expr_id), type_name),
                 fields: fields
                     .into_iter()
                     .map(|(name, expr)| (name, self.check_expr_with_ctx(ctx, expr, Mode::Infer)))
@@ -1310,10 +1400,16 @@ impl<'db> TypeChecker<'db> {
                     })
                     .collect();
 
-                // Check exhaustiveness
-                if self.check_exhaustiveness(scrutinee_ty, &converted_arms, scrutinee_expr.id) {
-                    ctx.record_exhaustive_case(expr_id);
-                }
+                // The local solver owns the concrete scrutinee type.  Record
+                // this compact case snapshot now and classify it only after
+                // substitution, rather than treating an inference UniVar as
+                // non-exhaustive here.
+                ctx.record_pending_exhaustiveness_case(
+                    expr_id,
+                    scrutinee_expr.id,
+                    scrutinee_ty,
+                    converted_arms.clone(),
+                );
 
                 ExprKind::Case {
                     scrutinee: scrutinee_expr,
@@ -1321,31 +1417,30 @@ impl<'db> TypeChecker<'db> {
                 }
             }
             ExprKind::Lambda { params, body } => {
-                // Save and restore effect context for lambda body,
-                // just like in the infer phase. This prevents lambda
-                // body effects from leaking into the enclosing scope.
-                let outer_effect = ctx.current_effect();
-                let fresh_effect = ctx.fresh_effect_row();
-                ctx.set_current_effect(fresh_effect);
+                // Reuse the lambda instance created during inference.  Creating
+                // a second set of parameter/result UniVars while converting the
+                // typed body leaves body-local polymorphism outside the local
+                // generalization that bound the original lambda value.
+                let inferred = ctx
+                    .get_inferred_lambda_type(expr_id)
+                    .expect("lambda conversion must follow lambda inference");
+                let (param_types, lambda_effect) = match inferred.kind(self.db()) {
+                    TypeKind::Func { params, effect, .. } => (params.clone(), *effect),
+                    _ => unreachable!("inferred lambda type must be a function"),
+                };
 
-                // Bind lambda parameters so that references to them in the body
-                // resolve to their concrete types (not fresh UniVars). Without this,
-                // TDNR cannot determine receiver types for method calls inside lambdas.
-                let param_types: Vec<Type<'db>> = params
-                    .iter()
-                    .map(|p| match &p.ty {
-                        Some(ann) => self.annotation_to_type_with_ctx(ctx, ann),
-                        None => ctx.fresh_type_var(),
-                    })
-                    .collect();
+                // Reuse the solved latent row while materializing the typed
+                // body. Its contextual constraints must not revise the
+                // lexical evaluation-effect observation recorded by the first
+                // inference walk above.
+                let outer_effect = ctx.current_effect();
+                ctx.set_current_effect(lambda_effect);
+                ctx.begin_lexical_lambda_effects();
+
+                // Bind the exact inferred parameter types so references in the
+                // converted body use the same local-generalized instance.
                 ctx.push_scope();
                 for (param, ty) in params.iter().zip(param_types.iter()) {
-                    tracing::debug!(
-                        "convert Lambda: binding param '{}' (local_id={:?}) to {:?}",
-                        param.name,
-                        param.local_id,
-                        ty.kind(self.db())
-                    );
                     if let Some(local_id) = param.local_id {
                         ctx.bind_local(local_id, *ty);
                     }
@@ -1353,6 +1448,8 @@ impl<'db> TypeChecker<'db> {
                 }
 
                 let converted_body = self.check_expr_with_ctx(ctx, body, Mode::Infer);
+                let (_, contains_control_transfer) = ctx.end_lexical_lambda_effects();
+                ctx.record_converted_lambda_control_transfer(expr_id, contains_control_transfer);
 
                 ctx.pop_scope();
                 ctx.set_current_effect(outer_effect);
@@ -1382,10 +1479,13 @@ impl<'db> TypeChecker<'db> {
                         .collect(),
                 }
             }
-            ExprKind::Resume { arg, local_id } => ExprKind::Resume {
-                arg: self.check_expr_with_ctx(ctx, arg, Mode::Infer),
-                local_id,
-            },
+            ExprKind::Resume { arg, local_id } => {
+                ctx.record_lexical_lambda_control_transfer();
+                ExprKind::Resume {
+                    arg: self.check_expr_with_ctx(ctx, arg, Mode::Infer),
+                    local_id,
+                }
+            }
             ExprKind::Tuple(elements) => ExprKind::Tuple(
                 elements
                     .into_iter()
@@ -1406,9 +1506,18 @@ impl<'db> TypeChecker<'db> {
     fn convert_ref_with_ctx(
         &self,
         ctx: &mut FunctionInferenceContext<'_, 'db>,
+        node_id: Option<NodeId>,
         resolved: ResolvedRef<'db>,
     ) -> TypedRef<'db> {
-        let ty = self.infer_var_with_ctx(ctx, &resolved);
+        // A direct call has already selected one exact callee instantiation in
+        // the inference pass. Reusing it prevents conversion from creating an
+        // unrelated raw UniVar for a locally generalized function reference.
+        let ty = node_id
+            .and_then(|node| {
+                ctx.get_reference_type(node)
+                    .or_else(|| ctx.get_call_callee_type(node))
+            })
+            .unwrap_or_else(|| self.infer_var_with_ctx(ctx, &resolved));
         TypedRef { resolved, ty }
     }
 
@@ -1443,6 +1552,7 @@ impl<'db> TypeChecker<'db> {
                 self.generalize_and_bind_pattern_with_ctx(
                     ctx,
                     pattern,
+                    Some(value),
                     value_ty,
                     evaluation_effect,
                 );
@@ -1489,6 +1599,7 @@ impl<'db> TypeChecker<'db> {
                 self.generalize_and_bind_pattern_with_ctx(
                     ctx,
                     &pattern,
+                    None,
                     value_ty,
                     evaluation_effect,
                 );
@@ -1516,6 +1627,7 @@ impl<'db> TypeChecker<'db> {
         &self,
         ctx: &mut FunctionInferenceContext<'_, 'db>,
         pattern: &Pattern<ResolvedRef<'db>>,
+        value: Option<&Expr<ResolvedRef<'db>>>,
         value_ty: Type<'db>,
         evaluation_effect: EffectRow<'db>,
     ) {
@@ -1530,6 +1642,10 @@ impl<'db> TypeChecker<'db> {
         let should_generalize = row_subst
             .apply(self.db(), evaluation_effect)
             .is_pure(self.db());
+
+        if should_generalize && let Some(value) = value {
+            self.record_generalized_lambda_owners(ctx, pattern, value);
+        }
 
         let mut environment_type_vars = Vec::new();
         let mut environment_effect_vars = Vec::new();
@@ -1564,14 +1680,16 @@ impl<'db> TypeChecker<'db> {
             &mut bindings,
         );
 
-        for (name, local_id, binding_ty) in bindings {
+        for (name, local_id, binding_scope, binding_ty) in bindings {
             let scheme = if should_generalize {
-                let (generalized, type_params) = type_subst.generalize_excluding(
-                    self.db(),
-                    binding_ty,
-                    &row_subst,
-                    &environment_type_vars,
-                );
+                let (generalized, type_params, mapping) = type_subst
+                    .generalize_excluding_with_mapping(
+                        self.db(),
+                        binding_ty,
+                        &row_subst,
+                        &environment_type_vars,
+                    );
+                ctx.record_local_generalization(binding_scope, mapping);
                 let effect_params: Vec<_> = collect_effect_vars(self.db(), generalized)
                     .into_iter()
                     .filter(|var| !environment_effect_vars.contains(var))
@@ -1581,9 +1699,9 @@ impl<'db> TypeChecker<'db> {
                 TypeScheme::mono(self.db(), binding_ty)
             };
             if let Some(local_id) = local_id {
-                ctx.bind_local_scheme(local_id, scheme);
+                ctx.bind_local_scheme_with_owner(local_id, scheme, binding_scope);
             }
-            ctx.bind_local_scheme_by_name(name, scheme);
+            ctx.bind_local_scheme_by_name_with_owner(name, scheme, binding_scope);
         }
     }
 
@@ -1594,12 +1712,12 @@ impl<'db> TypeChecker<'db> {
         ty: Type<'db>,
         type_subst: &TypeSubst<'db>,
         row_subst: &RowSubst<'db>,
-        bindings: &mut Vec<(Symbol, Option<LocalId>, Type<'db>)>,
+        bindings: &mut Vec<(Symbol, Option<LocalId>, NodeId, Type<'db>)>,
     ) {
         let resolve = |ty| type_subst.apply_with_rows(self.db(), ty, row_subst);
         match &*pattern.kind {
             PatternKind::Bind { name, local_id } => {
-                bindings.push((*name, *local_id, resolve(ty)));
+                bindings.push((*name, *local_id, pattern.id, resolve(ty)));
             }
             PatternKind::Tuple(patterns)
             | PatternKind::Variant {
@@ -1631,7 +1749,7 @@ impl<'db> TypeChecker<'db> {
                             ctx, pattern, field_ty, type_subst, row_subst, bindings,
                         );
                     } else {
-                        bindings.push((field.name, None, field_ty));
+                        bindings.push((field.name, None, field.id, field_ty));
                     }
                 }
             }
@@ -1650,7 +1768,7 @@ impl<'db> TypeChecker<'db> {
                     );
                 }
                 if let Some(name) = rest {
-                    bindings.push((*name, *rest_local_id, resolve(ty)));
+                    bindings.push((*name, *rest_local_id, pattern.id, resolve(ty)));
                 }
             }
             PatternKind::As {
@@ -1659,7 +1777,7 @@ impl<'db> TypeChecker<'db> {
                 local_id,
             } => {
                 let resolved_ty = resolve(ty);
-                bindings.push((*name, *local_id, resolved_ty));
+                bindings.push((*name, *local_id, pattern.id, resolved_ty));
                 self.collect_pattern_bindings_with_ctx(
                     ctx,
                     pattern,
@@ -1670,6 +1788,34 @@ impl<'db> TypeChecker<'db> {
                 );
             }
             PatternKind::Wildcard | PatternKind::Literal(_) | PatternKind::Error => {}
+        }
+    }
+
+    fn record_generalized_lambda_owners(
+        &self,
+        ctx: &mut FunctionInferenceContext<'_, 'db>,
+        pattern: &Pattern<ResolvedRef<'db>>,
+        value: &Expr<ResolvedRef<'db>>,
+    ) {
+        match (&*pattern.kind, &*value.kind) {
+            (PatternKind::Bind { .. }, ExprKind::Lambda { .. }) => {
+                ctx.record_local_generalized_lambda(value.id, pattern.id);
+            }
+            (PatternKind::Tuple(patterns), ExprKind::Tuple(values))
+            | (PatternKind::List(patterns), ExprKind::List(values)) => {
+                for (pattern, value) in patterns.iter().zip(values) {
+                    self.record_generalized_lambda_owners(ctx, pattern, value);
+                }
+            }
+            (PatternKind::Variant { fields, .. }, ExprKind::Cons { args, .. }) => {
+                for (pattern, value) in fields.iter().zip(args) {
+                    self.record_generalized_lambda_owners(ctx, pattern, value);
+                }
+            }
+            (PatternKind::As { pattern, .. }, _) => {
+                self.record_generalized_lambda_owners(ctx, pattern, value);
+            }
+            _ => {}
         }
     }
 
@@ -1691,6 +1837,7 @@ impl<'db> TypeChecker<'db> {
             },
             PatternKind::Variant { ctor, fields } => {
                 let ctor_ty = self.infer_var_with_ctx(ctx, ctor);
+                ctx.record_reference_type(pattern.id, ctor_ty);
                 ctx.record_node_type(pattern.id, ctor_ty);
 
                 match ctor_ty.kind(self.db()) {
@@ -1729,7 +1876,9 @@ impl<'db> TypeChecker<'db> {
             }
             PatternKind::Record { type_name, .. } => {
                 if let Some(type_ref) = type_name {
-                    self.infer_var_with_ctx(ctx, type_ref)
+                    let ty = self.infer_var_with_ctx(ctx, type_ref);
+                    ctx.record_reference_type(pattern.id, ty);
+                    ty
                 } else {
                     ctx.fresh_type_var()
                 }
@@ -1845,7 +1994,7 @@ impl<'db> TypeChecker<'db> {
             PatternKind::Bind { name, local_id } => PatternKind::Bind { name, local_id },
             PatternKind::Literal(lit) => PatternKind::Literal(lit),
             PatternKind::Variant { ctor, fields } => PatternKind::Variant {
-                ctor: self.convert_ref_with_ctx(ctx, ctor),
+                ctor: self.convert_ref_with_ctx(ctx, Some(pattern.id), ctor),
                 fields: fields
                     .into_iter()
                     .map(|p| self.convert_pattern_with_ctx(ctx, p))
@@ -1856,7 +2005,7 @@ impl<'db> TypeChecker<'db> {
                 fields,
                 rest,
             } => PatternKind::Record {
-                type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, t)),
+                type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, Some(pattern.id), t)),
                 fields: fields
                     .into_iter()
                     .map(|f| self.convert_field_pattern_with_ctx(ctx, f))
@@ -2015,7 +2164,7 @@ impl<'db> TypeChecker<'db> {
                     .collect();
 
                 PatternKind::Record {
-                    type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, t)),
+                    type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, None, t)),
                     fields: converted_fields,
                     rest,
                 }
@@ -2094,14 +2243,14 @@ impl<'db> TypeChecker<'db> {
         arm: HandlerArm<ResolvedRef<'db>>,
         handle_ctx: &super::super::func_context::HandleContext<'db>,
     ) -> HandlerArm<TypedRef<'db>> {
-        let kind = match arm.kind {
+        let (kind, body_ty) = match arm.kind {
             HandlerKind::Do { binding } => {
                 let pattern_ty = self.infer_pattern_type_with_ctx(ctx, &binding);
                 ctx.constrain_eq(pattern_ty, handle_ctx.body_ty);
                 self.bind_pattern_vars_with_ctx(ctx, &binding, handle_ctx.body_ty);
                 let binding =
                     self.convert_pattern_with_expected_ctx(ctx, binding, handle_ctx.body_ty);
-                HandlerKind::Do { binding }
+                (HandlerKind::Do { binding }, handle_ctx.answer_ty)
             }
             HandlerKind::Fn {
                 ability,
@@ -2119,15 +2268,19 @@ impl<'db> TypeChecker<'db> {
                         handle_ctx,
                     },
                 );
+                let result_ty = operation.result;
                 ctx.record_handler_operation(arm.id, operation);
-                HandlerKind::Fn {
-                    ability: self.convert_ref_with_ctx(ctx, ability),
-                    op,
-                    params: params
-                        .into_iter()
-                        .map(|p| self.convert_pattern_with_ctx(ctx, p))
-                        .collect(),
-                }
+                (
+                    HandlerKind::Fn {
+                        ability: self.convert_ref_with_ctx(ctx, None, ability),
+                        op,
+                        params: params
+                            .into_iter()
+                            .map(|p| self.convert_pattern_with_ctx(ctx, p))
+                            .collect(),
+                    },
+                    result_ty,
+                )
             }
             HandlerKind::Op {
                 ability,
@@ -2172,21 +2325,27 @@ impl<'db> TypeChecker<'db> {
                     }
                 }
 
-                HandlerKind::Op {
-                    ability: self.convert_ref_with_ctx(ctx, ability),
-                    op,
-                    params: params
-                        .into_iter()
-                        .map(|p| self.convert_pattern_with_ctx(ctx, p))
-                        .collect(),
-                    resume_local_id,
-                }
+                (
+                    HandlerKind::Op {
+                        ability: self.convert_ref_with_ctx(ctx, None, ability),
+                        op,
+                        params: params
+                            .into_iter()
+                            .map(|p| self.convert_pattern_with_ctx(ctx, p))
+                            .collect(),
+                        resume_local_id,
+                    },
+                    handle_ctx.answer_ty,
+                )
             }
         };
         HandlerArm {
             id: arm.id,
             kind,
-            body: self.check_expr_with_ctx(ctx, arm.body, Mode::Infer),
+            // `fn` arms return the direct operation answer, allowing the
+            // handled computation to continue normally. `do` and resumptive
+            // `op` arms produce the enclosing handle answer.
+            body: self.check_expr_with_ctx(ctx, arm.body, Mode::Check(body_ty)),
         }
     }
 
@@ -2462,7 +2621,7 @@ impl<'db> TypeChecker<'db> {
     /// - If the last arm has a wildcard or bind pattern, it's exhaustive
     /// - If matching an enum, all variants must be covered
     /// - Otherwise, emit a warning for patterns we can't fully analyze
-    fn check_exhaustiveness(
+    pub(super) fn check_exhaustiveness(
         &self,
         scrutinee_ty: Type<'db>,
         arms: &[Arm<TypedRef<'db>>],

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -128,10 +128,14 @@ impl<'db> TypeChecker<'db> {
         let constraints = ctx.take_constraints();
         // Take node_types now while ctx is still alive, before we need mutable self access
         let func_node_types = ctx.take_node_types();
+        let func_call_callee_types = ctx.take_call_callee_types();
         let func_handler_operations = ctx.take_handler_operations();
         let func_perform_operations = ctx.take_perform_operations();
         let func_lambda_signatures = ctx.take_lambda_signatures();
-        let func_exhaustive_cases = ctx.take_exhaustive_cases();
+        let func_local_generalizations = ctx.take_local_generalizations();
+        let func_local_generalized_bindings = ctx.take_local_generalized_bindings();
+        let func_local_generalized_lambdas = ctx.take_local_generalized_lambdas();
+        let pending_exhaustiveness_cases = ctx.take_pending_exhaustiveness_cases();
         // Save the accumulated effect row from the body before dropping ctx
         let body_effect_row = ctx.current_effect();
         // Take deferred methods for post-solve resolution
@@ -159,31 +163,6 @@ impl<'db> TypeChecker<'db> {
         // 5. Apply substitution and generalization
         let type_subst = solver.type_subst();
         let row_subst = solver.row_subst();
-
-        // First, collect ALL unresolved UniVars from the function type, body, and deferred
-        // method callee types. This ensures that UniVars created during body type checking
-        // or post-solve deferred method resolution are included in the generalization mapping.
-        let mut all_univars = Vec::new();
-        type_subst.collect_univars_from_type(
-            self.db(),
-            instantiated_func_ty,
-            row_subst,
-            &mut all_univars,
-        );
-        self.collect_univars_from_body(&body, type_subst, row_subst, &mut all_univars);
-        self.collect_univars_from_deferred_resolutions(
-            &deferred_resolutions,
-            type_subst,
-            row_subst,
-            &mut all_univars,
-        );
-
-        // Create a comprehensive mapping from all UniVars to BoundVars
-        let var_to_index: HashMap<UniVarId<'db>, u32> = all_univars
-            .into_iter()
-            .enumerate()
-            .map(|(i, id)| (id, i as u32))
-            .collect();
 
         // Only the exact root `main` is an entrypoint. Its omitted effect
         // annotation is closed over the effects actually performed by its body:
@@ -236,6 +215,24 @@ impl<'db> TypeChecker<'db> {
 
         // Apply substitution and generalization to the function type.
         let substituted_ty = type_subst.apply_with_rows(self.db(), inferred_func_ty, row_subst);
+
+        // A function scheme quantifies only type variables exposed by its
+        // callable interface. Local inference artifacts must remain local:
+        // quantifying them creates phantom scheme parameters that no call site
+        // can instantiate, which in turn erases exact higher-order CPS types.
+        let mut interface_univars = Vec::new();
+        type_subst.collect_univars_from_type(
+            self.db(),
+            substituted_ty,
+            row_subst,
+            &mut interface_univars,
+        );
+        let mut var_to_index: HashMap<UniVarId<'db>, u32> = interface_univars
+            .iter()
+            .enumerate()
+            .map(|(index, id)| (*id, index as u32))
+            .collect();
+        type_subst.propagate_bound_var_aliases(self.db(), &mut var_to_index);
 
         // Validate that root `main` returns Nil.
         if is_root_main
@@ -338,8 +335,8 @@ impl<'db> TypeChecker<'db> {
         let generalized =
             type_subst.apply_generalization(self.db(), substituted_ty, row_subst, &var_to_index);
 
-        // Create type params for all generalized UniVars
-        let type_params: Vec<crate::ast::TypeParam> = (0..var_to_index.len())
+        // Create type parameters only for generalized interface variables.
+        let type_params: Vec<crate::ast::TypeParam> = (0..interface_univars.len())
             .map(|_| crate::ast::TypeParam::anonymous())
             .collect();
 
@@ -347,6 +344,145 @@ impl<'db> TypeChecker<'db> {
         let new_scheme = TypeScheme::new(self.db(), type_params, effect_params, generalized);
         // Update the function's type scheme with the generalized version
         self.env.register_function(func_id, new_scheme);
+
+        // Local generalization happens against a solved constraint snapshot.
+        // The function-wide solve may have subsequently compressed its UniVar
+        // representative, so record both the lexical variable and its final
+        // unresolved representative before materializing typed references.
+        let mut resolved_local_generalizations = func_local_generalizations.clone();
+        for (var, binding) in func_local_generalizations {
+            let original = Type::new(self.db(), TypeKind::UniVar { id: var });
+            let resolved = type_subst.apply_with_rows(self.db(), original, row_subst);
+            let mut representatives = Vec::new();
+            type_subst.collect_univars_from_type(
+                self.db(),
+                resolved,
+                row_subst,
+                &mut representatives,
+            );
+            for representative in representatives {
+                resolved_local_generalizations
+                    .entry(representative)
+                    .or_insert(binding);
+            }
+        }
+        // Conversion can revisit a value with a compressed representative.
+        // Recover only from the exact binding pattern that introduced the
+        // scheme; sibling tuple/record bindings deliberately do not share a
+        // scope or index space.
+        for (scope, _) in func_local_generalized_bindings {
+            let Some(binding_ty) = func_node_types
+                .iter()
+                .find_map(|(node, ty)| (*node == scope).then_some(*ty))
+            else {
+                continue;
+            };
+            let mut representatives = Vec::new();
+            type_subst.collect_univars_from_type(
+                self.db(),
+                binding_ty,
+                row_subst,
+                &mut representatives,
+            );
+            for (index, representative) in representatives.into_iter().enumerate() {
+                resolved_local_generalizations
+                    .entry(representative)
+                    .or_insert((scope, index as u32));
+            }
+        }
+        for (lambda, scope) in func_local_generalized_lambdas {
+            let Some(signature) = func_lambda_signatures.get(&lambda) else {
+                continue;
+            };
+            let mut representatives = Vec::new();
+            type_subst.collect_univars_from_type(
+                self.db(),
+                signature.function_type,
+                row_subst,
+                &mut representatives,
+            );
+            for (index, representative) in representatives.into_iter().enumerate() {
+                resolved_local_generalizations
+                    .entry(representative)
+                    .or_insert((scope, index as u32));
+            }
+        }
+        type_subst
+            .propagate_local_generalization_aliases(self.db(), &mut resolved_local_generalizations);
+        self.local_generalizations = resolved_local_generalizations;
+
+        // Finalization is the last point at which solver variables are allowed
+        // to exist.  A body-only variable which is neither part of the
+        // callable interface nor a recorded local scheme is ambiguous source
+        // typing, not a lowering representation.  Diagnose it here and
+        // materialize typed Error recovery consistently in the body and every
+        // exported semantic table below.
+        self.unresolved_body_univars = if self.finalization_audit_enabled {
+            collect_finalization_univars(
+                self.db(),
+                type_subst,
+                row_subst,
+                &body,
+                &func_node_types,
+                &func_call_callee_types,
+                &func_handler_operations,
+                &func_perform_operations,
+                &func_lambda_signatures,
+                &deferred_resolutions,
+            )
+            .into_iter()
+            .filter(|id| {
+                !var_to_index.contains_key(id) && !self.local_generalizations.contains_key(id)
+            })
+            .collect()
+        } else {
+            HashSet::new()
+        };
+        if !self.unresolved_body_univars.is_empty() {
+            Diagnostic::new(
+                format!(
+                    "cannot infer a concrete type for {} body-local expression{}",
+                    self.unresolved_body_univars.len(),
+                    if self.unresolved_body_univars.len() == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
+                ),
+                self.get_span(func.id),
+                DiagnosticSeverity::Error,
+                CompilationPhase::TypeChecking,
+            )
+            .accumulate(self.db());
+        }
+
+        // Exhaustiveness is a property of the finalized scrutinee type.  The
+        // pending record avoids a second body traversal while preserving the
+        // original scrutinee span for the established diagnostics.
+        for pending in pending_exhaustiveness_cases {
+            let scrutinee_type = self.apply_subst_to_type(
+                pending.scrutinee_type,
+                type_subst,
+                row_subst,
+                &var_to_index,
+            );
+            let arms = pending
+                .arms
+                .into_iter()
+                .map(|arm| {
+                    self.apply_subst_to_arm(
+                        arm,
+                        type_subst,
+                        row_subst,
+                        &var_to_index,
+                        &deferred_resolutions,
+                    )
+                })
+                .collect_vec();
+            if self.check_exhaustiveness(scrutinee_type, &arms, pending.diagnostic_span) {
+                self.exhaustive_cases.push(pending.case);
+            }
+        }
 
         // 6. Apply substitution and generalization to all TypedRef types in the body
         let body = self.apply_subst_to_body(
@@ -357,12 +493,17 @@ impl<'db> TypeChecker<'db> {
             &deferred_resolutions,
         );
 
-        // 7. Collect node types from this function's context and apply substitution.
-        // These entries describe concrete expression storage for lowering; the
-        // source-logical operation metadata is carried separately on TypedRef.
+        // 7. Apply the same interface generalization to every semantic table
+        // consumed by monomorphization/lowering. Keeping call metadata as raw
+        // UniVars would make a specialized recursive call appear unresolved
+        // even though the corresponding TypedRef carries BoundVars.
         for (node_id, ty) in func_node_types {
-            let substituted = type_subst.apply_with_rows(self.db(), ty, row_subst);
+            let substituted = self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index);
             self.node_types.insert(node_id, substituted);
+        }
+        for (callee_id, ty) in func_call_callee_types {
+            let substituted = self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index);
+            self.call_callee_types.insert(callee_id, substituted);
         }
         for (arm_id, operation) in func_handler_operations {
             self.handler_operations.insert(
@@ -372,15 +513,24 @@ impl<'db> TypeChecker<'db> {
                     ability_args: operation
                         .ability_args
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
                     kind: operation.kind,
                     params: operation
                         .params
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
-                    result: type_subst.apply_with_rows(self.db(), operation.result, row_subst),
+                    result: self.apply_subst_to_type(
+                        operation.result,
+                        type_subst,
+                        row_subst,
+                        &var_to_index,
+                    ),
                 },
             );
         }
@@ -392,15 +542,24 @@ impl<'db> TypeChecker<'db> {
                     ability_args: operation
                         .ability_args
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
                     kind: operation.kind,
                     params: operation
                         .params
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
-                    result: type_subst.apply_with_rows(self.db(), operation.result, row_subst),
+                    result: self.apply_subst_to_type(
+                        operation.result,
+                        type_subst,
+                        row_subst,
+                        &var_to_index,
+                    ),
                 },
             );
         }
@@ -410,23 +569,37 @@ impl<'db> TypeChecker<'db> {
             .into_iter()
             .collect::<HashMap<_, _>>();
         for (lambda_id, signature) in func_lambda_signatures {
-            let function_type =
-                type_subst.apply_with_rows(self.db(), signature.function_type, row_subst);
-            let convention = crate::ast::calling_convention_for_function_type(
-                self.db(),
-                function_type,
-                &ability_conventions,
-            )
-            .expect("lambda semantic signature must remain a function type");
+            let function_type = self.apply_subst_to_type(
+                signature.function_type,
+                type_subst,
+                row_subst,
+                &var_to_index,
+            );
+            let convention = if signature.contains_control_transfer {
+                crate::ast::CallingConvention::Cps
+            } else if signature.body_is_effect_free {
+                signature.lexical_convention
+            } else {
+                crate::ast::calling_convention_for_function_type(
+                    self.db(),
+                    function_type,
+                    &ability_conventions,
+                )
+                .expect("lambda semantic signature must remain a function type")
+            };
             self.lambda_signatures.insert(
                 lambda_id,
                 crate::typeck::LambdaSignature {
                     function_type,
+                    body_is_effect_free: signature.body_is_effect_free,
+                    contains_control_transfer: signature.contains_control_transfer,
+                    lexical_convention: signature.lexical_convention,
                     convention,
                 },
             );
         }
-        self.exhaustive_cases.extend(func_exhaustive_cases);
+        self.local_generalizations.clear();
+        self.unresolved_body_univars.clear();
 
         FuncDecl {
             id: func.id,
@@ -932,8 +1105,17 @@ impl<'db> TypeChecker<'db> {
     ) -> Type<'db> {
         // First apply the substitution to resolve UniVars
         let substituted = type_subst.apply_with_rows(self.db(), ty, row_subst);
-        // Then apply the generalization mapping to convert remaining UniVars to BoundVars
-        type_subst.apply_generalization(self.db(), substituted, row_subst, var_to_index)
+        // Then apply the enclosing function and local-let mappings. The latter
+        // are deliberately scope-tagged so they cannot become function scheme
+        // parameters during specialization.
+        type_subst.apply_generalization_with_local_vars(
+            self.db(),
+            substituted,
+            row_subst,
+            var_to_index,
+            &self.local_generalizations,
+            &self.unresolved_body_univars,
+        )
     }
 
     /// Apply substitution to a statement.
@@ -1156,224 +1338,262 @@ impl<'db> TypeChecker<'db> {
                 .map(|p| self.apply_subst_to_pattern(p, type_subst, row_subst, var_to_index)),
         }
     }
+}
 
-    // =========================================================================
-    // UniVar collection from body
-    // =========================================================================
-
-    /// Collect all unresolved UniVars from the body expression.
-    fn collect_univars_from_body(
-        &self,
-        body: &Expr<TypedRef<'db>>,
-        type_subst: &TypeSubst<'db>,
-        row_subst: &RowSubst<'db>,
-        out: &mut Vec<UniVarId<'db>>,
-    ) {
-        self.collect_univars_from_expr_kind(&body.kind, type_subst, row_subst, out);
+/// Collect every solver variable that could otherwise escape one function's
+/// finalization boundary.  The typed tree is walked separately from the
+/// semantic tables because constructors, record names, case patterns and
+/// handler ability references carry `TypedRef`s outside ordinary expressions.
+#[allow(clippy::too_many_arguments)] // The audited output surfaces are explicit by design.
+fn collect_finalization_univars<'db>(
+    db: &'db dyn salsa::Database,
+    type_subst: &TypeSubst<'db>,
+    row_subst: &RowSubst<'db>,
+    body: &Expr<TypedRef<'db>>,
+    node_types: &HashMap<crate::ast::NodeId, Type<'db>>,
+    call_callee_types: &HashMap<crate::ast::NodeId, Type<'db>>,
+    handler_operations: &HashMap<
+        crate::ast::NodeId,
+        crate::typeck::InstantiatedHandlerOperation<'db>,
+    >,
+    perform_operations: &HashMap<
+        crate::ast::NodeId,
+        crate::typeck::InstantiatedPerformOperation<'db>,
+    >,
+    lambda_signatures: &HashMap<crate::ast::NodeId, crate::typeck::LambdaSignature<'db>>,
+    deferred_resolutions: &HashMap<crate::ast::NodeId, (FuncDefId<'db>, Type<'db>)>,
+) -> Vec<UniVarId<'db>> {
+    let mut out = Vec::new();
+    collect_expr_univars(db, type_subst, row_subst, body, &mut out);
+    for ty in node_types.values().chain(call_callee_types.values()) {
+        collect_type_univars(type_subst, db, *ty, row_subst, &mut out);
     }
-
-    fn collect_univars_from_deferred_resolutions(
-        &self,
-        deferred_resolutions: &HashMap<crate::ast::NodeId, (FuncDefId<'db>, Type<'db>)>,
-        type_subst: &TypeSubst<'db>,
-        row_subst: &RowSubst<'db>,
-        out: &mut Vec<UniVarId<'db>>,
-    ) {
-        let mut node_ids: Vec<_> = deferred_resolutions.keys().copied().collect();
-        node_ids.sort();
-        for node_id in node_ids {
-            let (_, callee_ty) = deferred_resolutions[&node_id];
-            type_subst.collect_univars_from_type(self.db(), callee_ty, row_subst, out);
+    for operation in handler_operations.values() {
+        for ty in operation
+            .ability_args
+            .iter()
+            .chain(operation.params.iter())
+            .chain(std::iter::once(&operation.result))
+        {
+            collect_type_univars(type_subst, db, *ty, row_subst, &mut out);
         }
     }
+    for operation in perform_operations.values() {
+        for ty in operation
+            .ability_args
+            .iter()
+            .chain(operation.params.iter())
+            .chain(std::iter::once(&operation.result))
+        {
+            collect_type_univars(type_subst, db, *ty, row_subst, &mut out);
+        }
+    }
+    for signature in lambda_signatures.values() {
+        collect_type_univars(type_subst, db, signature.function_type, row_subst, &mut out);
+    }
+    for (_, ty) in deferred_resolutions.values() {
+        collect_type_univars(type_subst, db, *ty, row_subst, &mut out);
+    }
+    out
+}
 
-    fn collect_univars_from_expr_kind(
-        &self,
-        kind: &ExprKind<TypedRef<'db>>,
-        type_subst: &TypeSubst<'db>,
-        row_subst: &RowSubst<'db>,
-        out: &mut Vec<UniVarId<'db>>,
-    ) {
-        match kind {
-            ExprKind::NatLit(_)
-            | ExprKind::IntLit(_)
-            | ExprKind::FloatLit(_)
-            | ExprKind::BoolLit(_)
-            | ExprKind::StringLit(_)
-            | ExprKind::BytesLit(_)
-            | ExprKind::Nil
-            | ExprKind::RuneLit(_)
-            | ExprKind::Error => {}
+fn collect_type_univars<'db>(
+    type_subst: &TypeSubst<'db>,
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    row_subst: &RowSubst<'db>,
+    out: &mut Vec<UniVarId<'db>>,
+) {
+    type_subst.collect_univars_from_type(db, ty, row_subst, out);
+}
 
-            ExprKind::Var(typed_ref) => {
-                type_subst.collect_univars_from_type(self.db(), typed_ref.ty, row_subst, out);
+fn collect_typed_ref_univars<'db>(
+    db: &'db dyn salsa::Database,
+    type_subst: &TypeSubst<'db>,
+    row_subst: &RowSubst<'db>,
+    typed_ref: &TypedRef<'db>,
+    out: &mut Vec<UniVarId<'db>>,
+) {
+    collect_type_univars(type_subst, db, typed_ref.ty, row_subst, out);
+}
+
+fn collect_expr_univars<'db>(
+    db: &'db dyn salsa::Database,
+    type_subst: &TypeSubst<'db>,
+    row_subst: &RowSubst<'db>,
+    expr: &Expr<TypedRef<'db>>,
+    out: &mut Vec<UniVarId<'db>>,
+) {
+    match &*expr.kind {
+        ExprKind::Var(typed_ref) => {
+            collect_typed_ref_univars(db, type_subst, row_subst, typed_ref, out);
+        }
+        ExprKind::Call { callee, args } => {
+            collect_expr_univars(db, type_subst, row_subst, callee, out);
+            for arg in args {
+                collect_expr_univars(db, type_subst, row_subst, arg, out);
             }
-            ExprKind::Call { callee, args } => {
-                self.collect_univars_from_body(callee, type_subst, row_subst, out);
-                for arg in args {
-                    self.collect_univars_from_body(arg, type_subst, row_subst, out);
-                }
+        }
+        ExprKind::Cons { ctor, args } => {
+            collect_typed_ref_univars(db, type_subst, row_subst, ctor, out);
+            for arg in args {
+                collect_expr_univars(db, type_subst, row_subst, arg, out);
             }
-            ExprKind::Cons { ctor, args } => {
-                type_subst.collect_univars_from_type(self.db(), ctor.ty, row_subst, out);
-                for arg in args {
-                    self.collect_univars_from_body(arg, type_subst, row_subst, out);
-                }
+        }
+        ExprKind::Record {
+            type_name,
+            fields,
+            spread,
+        } => {
+            collect_typed_ref_univars(db, type_subst, row_subst, type_name, out);
+            for (_, field) in fields {
+                collect_expr_univars(db, type_subst, row_subst, field, out);
             }
-            ExprKind::Record {
-                type_name,
-                fields,
-                spread,
-            } => {
-                type_subst.collect_univars_from_type(self.db(), type_name.ty, row_subst, out);
-                for (_, expr) in fields {
-                    self.collect_univars_from_body(expr, type_subst, row_subst, out);
-                }
-                if let Some(e) = spread {
-                    self.collect_univars_from_body(e, type_subst, row_subst, out);
-                }
+            if let Some(spread) = spread {
+                collect_expr_univars(db, type_subst, row_subst, spread, out);
             }
-            ExprKind::MethodCall { receiver, args, .. } => {
-                self.collect_univars_from_body(receiver, type_subst, row_subst, out);
-                for arg in args {
-                    self.collect_univars_from_body(arg, type_subst, row_subst, out);
-                }
+        }
+        ExprKind::MethodCall { receiver, args, .. } => {
+            collect_expr_univars(db, type_subst, row_subst, receiver, out);
+            for arg in args {
+                collect_expr_univars(db, type_subst, row_subst, arg, out);
             }
-            ExprKind::BinOp { lhs, rhs, .. } => {
-                self.collect_univars_from_body(lhs, type_subst, row_subst, out);
-                self.collect_univars_from_body(rhs, type_subst, row_subst, out);
-            }
-            ExprKind::Block { stmts, value } => {
-                for stmt in stmts {
-                    self.collect_univars_from_stmt(stmt, type_subst, row_subst, out);
-                }
-                self.collect_univars_from_body(value, type_subst, row_subst, out);
-            }
-            ExprKind::Case { scrutinee, arms } => {
-                self.collect_univars_from_body(scrutinee, type_subst, row_subst, out);
-                for arm in arms {
-                    self.collect_univars_from_pattern(&arm.pattern, type_subst, row_subst, out);
-                    if let Some(g) = &arm.guard {
-                        self.collect_univars_from_body(g, type_subst, row_subst, out);
+        }
+        ExprKind::Block { stmts, value } => {
+            for stmt in stmts {
+                match stmt {
+                    Stmt::Let { pattern, value, .. } => {
+                        collect_pattern_univars(db, type_subst, row_subst, pattern, out);
+                        collect_expr_univars(db, type_subst, row_subst, value, out);
                     }
-                    self.collect_univars_from_body(&arm.body, type_subst, row_subst, out);
-                }
-            }
-            ExprKind::Lambda { body, .. } => {
-                self.collect_univars_from_body(body, type_subst, row_subst, out);
-            }
-            ExprKind::Handle { body, handlers } => {
-                self.collect_univars_from_body(body, type_subst, row_subst, out);
-                for handler in handlers {
-                    match &handler.kind {
-                        HandlerKind::Do { binding } => {
-                            self.collect_univars_from_pattern(binding, type_subst, row_subst, out);
-                        }
-                        HandlerKind::Fn {
-                            ability, params, ..
-                        }
-                        | HandlerKind::Op {
-                            ability, params, ..
-                        } => {
-                            type_subst.collect_univars_from_type(
-                                self.db(),
-                                ability.ty,
-                                row_subst,
-                                out,
-                            );
-                            for p in params {
-                                self.collect_univars_from_pattern(p, type_subst, row_subst, out);
-                            }
-                        }
-                    }
-                    self.collect_univars_from_body(&handler.body, type_subst, row_subst, out);
-                }
-            }
-            ExprKind::Resume { arg, .. } => {
-                self.collect_univars_from_body(arg, type_subst, row_subst, out);
-            }
-            ExprKind::Tuple(elems) | ExprKind::List(elems) => {
-                for elem in elems {
-                    self.collect_univars_from_body(elem, type_subst, row_subst, out);
-                }
-            }
-        }
-    }
-
-    fn collect_univars_from_stmt(
-        &self,
-        stmt: &Stmt<TypedRef<'db>>,
-        type_subst: &TypeSubst<'db>,
-        row_subst: &RowSubst<'db>,
-        out: &mut Vec<UniVarId<'db>>,
-    ) {
-        match stmt {
-            Stmt::Let { pattern, value, .. } => {
-                self.collect_univars_from_pattern(pattern, type_subst, row_subst, out);
-                self.collect_univars_from_body(value, type_subst, row_subst, out);
-            }
-            Stmt::Expr { expr, .. } => {
-                self.collect_univars_from_body(expr, type_subst, row_subst, out);
-            }
-        }
-    }
-
-    fn collect_univars_from_pattern(
-        &self,
-        pattern: &Pattern<TypedRef<'db>>,
-        type_subst: &TypeSubst<'db>,
-        row_subst: &RowSubst<'db>,
-        out: &mut Vec<UniVarId<'db>>,
-    ) {
-        match &*pattern.kind {
-            PatternKind::Wildcard
-            | PatternKind::Bind { .. }
-            | PatternKind::Literal(_)
-            | PatternKind::Error => {}
-            PatternKind::Variant { ctor, fields } => {
-                type_subst.collect_univars_from_type(self.db(), ctor.ty, row_subst, out);
-                for f in fields {
-                    self.collect_univars_from_pattern(f, type_subst, row_subst, out);
-                }
-            }
-            PatternKind::Record {
-                type_name, fields, ..
-            } => {
-                if let Some(t) = type_name {
-                    type_subst.collect_univars_from_type(self.db(), t.ty, row_subst, out);
-                }
-                for f in fields {
-                    if let Some(p) = &f.pattern {
-                        self.collect_univars_from_pattern(p, type_subst, row_subst, out);
+                    Stmt::Expr { expr, .. } => {
+                        collect_expr_univars(db, type_subst, row_subst, expr, out);
                     }
                 }
             }
-            PatternKind::Tuple(pats) | PatternKind::List(pats) => {
-                for p in pats {
-                    self.collect_univars_from_pattern(p, type_subst, row_subst, out);
+            collect_expr_univars(db, type_subst, row_subst, value, out);
+        }
+        ExprKind::Case { scrutinee, arms } => {
+            collect_expr_univars(db, type_subst, row_subst, scrutinee, out);
+            for arm in arms {
+                collect_pattern_univars(db, type_subst, row_subst, &arm.pattern, out);
+                if let Some(guard) = &arm.guard {
+                    collect_expr_univars(db, type_subst, row_subst, guard, out);
                 }
-            }
-            PatternKind::ListRest { head, .. } => {
-                for p in head {
-                    self.collect_univars_from_pattern(p, type_subst, row_subst, out);
-                }
-            }
-            PatternKind::As { pattern, .. } => {
-                self.collect_univars_from_pattern(pattern, type_subst, row_subst, out);
+                collect_expr_univars(db, type_subst, row_subst, &arm.body, out);
             }
         }
+        ExprKind::Lambda { body, .. } => {
+            collect_expr_univars(db, type_subst, row_subst, body, out);
+        }
+        ExprKind::Handle { body, handlers } => {
+            collect_expr_univars(db, type_subst, row_subst, body, out);
+            for handler in handlers {
+                collect_handler_univars(db, type_subst, row_subst, handler, out);
+            }
+        }
+        ExprKind::Resume { arg, .. } => {
+            collect_expr_univars(db, type_subst, row_subst, arg, out);
+        }
+        ExprKind::Tuple(elements) | ExprKind::List(elements) => {
+            for element in elements {
+                collect_expr_univars(db, type_subst, row_subst, element, out);
+            }
+        }
+        ExprKind::BinOp { lhs, rhs, .. } => {
+            collect_expr_univars(db, type_subst, row_subst, lhs, out);
+            collect_expr_univars(db, type_subst, row_subst, rhs, out);
+        }
+        ExprKind::NatLit(_)
+        | ExprKind::IntLit(_)
+        | ExprKind::FloatLit(_)
+        | ExprKind::BoolLit(_)
+        | ExprKind::StringLit(_)
+        | ExprKind::BytesLit(_)
+        | ExprKind::Nil
+        | ExprKind::RuneLit(_)
+        | ExprKind::Error => {}
+    }
+}
+
+fn collect_handler_univars<'db>(
+    db: &'db dyn salsa::Database,
+    type_subst: &TypeSubst<'db>,
+    row_subst: &RowSubst<'db>,
+    handler: &HandlerArm<TypedRef<'db>>,
+    out: &mut Vec<UniVarId<'db>>,
+) {
+    match &handler.kind {
+        HandlerKind::Do { binding } => {
+            collect_pattern_univars(db, type_subst, row_subst, binding, out);
+        }
+        HandlerKind::Fn {
+            ability, params, ..
+        }
+        | HandlerKind::Op {
+            ability, params, ..
+        } => {
+            collect_typed_ref_univars(db, type_subst, row_subst, ability, out);
+            for param in params {
+                collect_pattern_univars(db, type_subst, row_subst, param, out);
+            }
+        }
+    }
+    collect_expr_univars(db, type_subst, row_subst, &handler.body, out);
+}
+
+fn collect_pattern_univars<'db>(
+    db: &'db dyn salsa::Database,
+    type_subst: &TypeSubst<'db>,
+    row_subst: &RowSubst<'db>,
+    pattern: &Pattern<TypedRef<'db>>,
+    out: &mut Vec<UniVarId<'db>>,
+) {
+    match &*pattern.kind {
+        PatternKind::Variant { ctor, fields } => {
+            collect_typed_ref_univars(db, type_subst, row_subst, ctor, out);
+            for field in fields {
+                collect_pattern_univars(db, type_subst, row_subst, field, out);
+            }
+        }
+        PatternKind::Record {
+            type_name, fields, ..
+        } => {
+            if let Some(type_name) = type_name {
+                collect_typed_ref_univars(db, type_subst, row_subst, type_name, out);
+            }
+            for field in fields {
+                if let Some(pattern) = &field.pattern {
+                    collect_pattern_univars(db, type_subst, row_subst, pattern, out);
+                }
+            }
+        }
+        PatternKind::Tuple(patterns) | PatternKind::List(patterns) => {
+            for pattern in patterns {
+                collect_pattern_univars(db, type_subst, row_subst, pattern, out);
+            }
+        }
+        PatternKind::ListRest { head, .. } => {
+            for pattern in head {
+                collect_pattern_univars(db, type_subst, row_subst, pattern, out);
+            }
+        }
+        PatternKind::As { pattern, .. } => {
+            collect_pattern_univars(db, type_subst, row_subst, pattern, out);
+        }
+        PatternKind::Wildcard
+        | PatternKind::Bind { .. }
+        | PatternKind::Literal(_)
+        | PatternKind::Error => {}
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use salsa_test_macros::salsa_test;
     use trunk_ir::Symbol;
 
-    use crate::ast::{EffectRow, NodeId, SpanMap, Type, TypeDefId, TypeKind};
-    use crate::typeck::{TypeChecker, TypeSolver};
+    use crate::ast::{NodeId, Type, TypeDefId, TypeKind};
 
     use super::super::super::solver::SolveError;
     use super::{ConstraintOriginKind, format_solve_error, solve_error_context};
@@ -1430,69 +1650,5 @@ mod tests {
             ),
             "canonical compiler-owned type `List(Int)` is distinct from source-declared type `List(Int)`"
         );
-    }
-
-    #[salsa_test]
-    fn collect_deferred_resolution_univars_includes_callee_type(db: &salsa::DatabaseImpl) {
-        let mut solver = TypeSolver::new(db);
-        let first_solver_var = solver.fresh_type_var(db);
-        let second_solver_var = solver.fresh_type_var(db);
-        let first_callee_ty = Type::new(
-            db,
-            TypeKind::Func {
-                params: vec![Type::new(db, TypeKind::Nat)],
-                result: first_solver_var,
-                effect: EffectRow::pure(db),
-                minimum_convention: crate::ast::CallingConvention::Direct,
-            },
-        );
-        let second_callee_ty = Type::new(
-            db,
-            TypeKind::Func {
-                params: vec![Type::new(db, TypeKind::Nat)],
-                result: second_solver_var,
-                effect: EffectRow::pure(db),
-                minimum_convention: crate::ast::CallingConvention::Direct,
-            },
-        );
-
-        let mut deferred_resolutions = HashMap::new();
-        deferred_resolutions.insert(
-            NodeId::from_raw(2),
-            (
-                crate::ast::FuncDefId::new(db, Symbol::new("Box::flat_map")),
-                second_callee_ty,
-            ),
-        );
-        deferred_resolutions.insert(
-            NodeId::from_raw(1),
-            (
-                crate::ast::FuncDefId::new(db, Symbol::new("Box::map")),
-                first_callee_ty,
-            ),
-        );
-
-        let checker = TypeChecker::new(db, SpanMap::default());
-        let mut collected = Vec::new();
-        checker.collect_univars_from_deferred_resolutions(
-            &deferred_resolutions,
-            solver.type_subst(),
-            solver.row_subst(),
-            &mut collected,
-        );
-
-        let TypeKind::UniVar {
-            id: first_solver_id,
-        } = first_solver_var.kind(db)
-        else {
-            panic!("fresh solver variable should be a UniVar");
-        };
-        let TypeKind::UniVar {
-            id: second_solver_id,
-        } = second_solver_var.kind(db)
-        else {
-            panic!("fresh solver variable should be a UniVar");
-        };
-        assert_eq!(collected, vec![*first_solver_id, *second_solver_id]);
     }
 }

--- a/crates/tribute-front/src/typeck/checker/mod.rs
+++ b/crates/tribute-front/src/typeck/checker/mod.rs
@@ -24,7 +24,7 @@ mod collect;
 mod expr;
 mod func_check;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use trunk_ir::{Span, Symbol};
 
@@ -47,8 +47,12 @@ pub struct ModuleCheckResult<'db> {
     /// Constructor type schemes retain exact nominal field types for logical
     /// layout construction.
     pub constructor_types: Vec<(crate::ast::CtorId<'db>, TypeScheme<'db>)>,
+    /// Exact nominal definition schemes keyed by resolved declaration name.
+    pub type_definitions: Vec<(trunk_ir::Symbol, TypeScheme<'db>)>,
     /// Node types for IR lowering (NodeId → monomorphic type).
     pub node_types: Vec<(NodeId, Type<'db>)>,
+    /// Exact, solved callee inference instances for call-site monomorphization.
+    pub call_callee_types: Vec<(NodeId, Type<'db>)>,
     /// Ability-level calling-convention requirements.
     pub ability_conventions: Vec<(crate::ast::AbilityId<'db>, CallingConvention)>,
     /// Exact semantic operation instances for handler arms.
@@ -93,11 +97,23 @@ pub struct TypeChecker<'db> {
     /// Accumulated node types from all functions.
     /// Collects NodeId → Type mappings during type checking.
     node_types: HashMap<NodeId, Type<'db>>,
+    call_callee_types: HashMap<NodeId, Type<'db>>,
     /// Exact handler operation instances collected from each checked function.
     handler_operations: HashMap<NodeId, crate::typeck::InstantiatedHandlerOperation<'db>>,
     perform_operations: HashMap<NodeId, crate::typeck::InstantiatedPerformOperation<'db>>,
     lambda_signatures: HashMap<NodeId, crate::typeck::LambdaSignature<'db>>,
     exhaustive_cases: Vec<NodeId>,
+    /// Local `let` quantifiers for the function currently being materialized.
+    /// These are kept separate from the exported function TypeScheme.
+    local_generalizations: HashMap<crate::ast::UniVarId<'db>, (NodeId, u32)>,
+    /// Unresolved body-only variables discovered by finalization. They become
+    /// typed `Error` recovery nodes after a diagnostic, never raw solver
+    /// variables in the exported typed AST or semantic metadata.
+    unresolved_body_univars: HashSet<crate::ast::UniVarId<'db>>,
+    /// Prelude checking exports declaration schemes only, not typed bodies or
+    /// body semantic tables. Its legacy implementation bodies therefore do
+    /// not participate in the user-facing typed-output finalization audit.
+    finalization_audit_enabled: bool,
     /// Source origins for concrete effects in each collected function signature.
     effect_annotation_origins: HashMap<FuncDefId<'db>, crate::ast::EffectAnnotationOrigins>,
 }
@@ -131,10 +147,14 @@ impl<'db> TypeChecker<'db> {
             prefix: String::new(),
             span_map,
             node_types: HashMap::new(),
+            call_callee_types: HashMap::new(),
             handler_operations: HashMap::new(),
             perform_operations: HashMap::new(),
             lambda_signatures: HashMap::new(),
             exhaustive_cases: Vec::new(),
+            local_generalizations: HashMap::new(),
+            unresolved_body_univars: HashSet::new(),
+            finalization_audit_enabled: true,
             effect_annotation_origins: HashMap::new(),
         }
     }
@@ -190,6 +210,7 @@ impl<'db> TypeChecker<'db> {
         module: Module<ResolvedRef<'db>>,
     ) -> ModuleCheckResult<'db> {
         self.collect_declarations(&module);
+        self.finalization_audit_enabled = false;
         let string_type = self.prelude_well_known_type(&module, StringType);
         self.env.set_prelude_string_type(string_type);
         self.check_collected_module(module)
@@ -228,6 +249,7 @@ impl<'db> TypeChecker<'db> {
         // Export the function types (already finalized during per-function checking)
         let function_types = self.env.export_function_types();
         let constructor_types = self.env.export_constructor_types();
+        let type_definitions = self.env.export_type_defs();
         let ability_conventions = self.env.export_ability_conventions();
         let ability_definitions = self.env.export_ability_defs();
         let well_known_types = self.env.well_known_types();
@@ -236,6 +258,8 @@ impl<'db> TypeChecker<'db> {
         // Sort by NodeId to ensure deterministic ordering for Salsa cache stability
         let mut node_types: Vec<(NodeId, Type<'db>)> = self.node_types.into_iter().collect();
         node_types.sort_by_key(|(id, _)| *id);
+        let mut call_callee_types: Vec<_> = self.call_callee_types.into_iter().collect();
+        call_callee_types.sort_by_key(|(id, _)| *id);
         let mut handler_operations: Vec<_> = self.handler_operations.into_iter().collect();
         handler_operations.sort_by_key(|(id, _)| *id);
         let mut perform_operations: Vec<_> = self.perform_operations.into_iter().collect();
@@ -252,7 +276,9 @@ impl<'db> TypeChecker<'db> {
             },
             function_types,
             constructor_types,
+            type_definitions,
             node_types,
+            call_callee_types,
             ability_conventions,
             handler_operations,
             perform_operations,
@@ -274,6 +300,7 @@ impl<'db> TypeChecker<'db> {
         // Phase 1: Collect type definitions and function signatures
         // Note: module_path starts empty - prelude functions use simple names internally.
         self.collect_declarations(&module);
+        self.finalization_audit_enabled = false;
         let string_type = self.prelude_well_known_type(&module, StringType);
         self.env.set_prelude_string_type(string_type);
 

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -15,8 +15,8 @@ use trunk_ir::Symbol;
 
 use super::{InstantiatedHandlerOperation, InstantiatedPerformOperation, LambdaSignature};
 use crate::ast::{
-    CtorId, Effect, EffectRow, EffectVar, FuncDefId, LocalId, NodeId, Type, TypeKind, TypeScheme,
-    UniVarId, UniVarSource,
+    Arm, CtorId, Effect, EffectRow, EffectVar, FuncDefId, LocalId, NodeId, Type, TypeKind,
+    TypeScheme, TypedRef, UniVarId, UniVarSource,
 };
 
 use super::constraint::{ConstraintOrigin, ConstraintOriginKind, ConstraintSet};
@@ -32,6 +32,16 @@ pub(crate) struct HandleContext<'db> {
     pub answer_ty: Type<'db>,
     pub body_ty: Type<'db>,
     pub body_effect: EffectRow<'db>,
+}
+
+/// A case whose coverage must be decided after this function's constraints
+/// have been solved.  Inference-time scrutinee types may still be UniVars, so
+/// classifying them while converting the expression would lose a valid proof.
+pub(crate) struct PendingExhaustivenessCase<'db> {
+    pub case: NodeId,
+    pub diagnostic_span: NodeId,
+    pub scrutinee_type: Type<'db>,
+    pub arms: Vec<Arm<TypedRef<'db>>>,
 }
 
 /// Function-level type inference context.
@@ -63,16 +73,39 @@ pub struct FunctionInferenceContext<'a, 'db> {
     /// Types of local variables (by LocalId), organized as a stack of scopes.
     /// The last element is the innermost (current) scope.
     local_scopes: Vec<HashMap<LocalId, TypeScheme<'db>>>,
+    local_scheme_owners: Vec<HashMap<LocalId, NodeId>>,
 
     /// Types of local variables by name, organized as a stack of scopes.
     /// The last element is the innermost (current) scope.
     name_scopes: Vec<HashMap<Symbol, TypeScheme<'db>>>,
+    name_scheme_owners: Vec<HashMap<Symbol, NodeId>>,
 
     /// Types of AST nodes (for TypedRef construction).
     node_types: HashMap<NodeId, Type<'db>>,
 
+    /// The inference instance selected for each call's callee expression.
+    /// Unlike `node_types`, this is recorded on the first call inference and
+    /// is not replaced when typed-expression conversion revisits the callee.
+    call_callee_types: HashMap<NodeId, Type<'db>>,
+
     /// Fully instantiated operation metadata for handler arms.
     handler_operations: HashMap<NodeId, InstantiatedHandlerOperation<'db>>,
+
+    /// Function-local quantifiers introduced by pure `let` generalization.
+    ///
+    /// These remain distinct from the enclosing function scheme's BoundVars
+    /// when the completed typed body is materialized.
+    local_generalizations: HashMap<UniVarId<'db>, (NodeId, u32)>,
+
+    /// Exact binding-pattern provenance for locally generalized schemes.
+    /// Final conversion can use the pattern's own type to recover a solver
+    /// representative without conflating sibling destructuring bindings.
+    local_generalized_bindings: Vec<(NodeId, HashMap<UniVarId<'db>, u32>)>,
+
+    /// Lambda value nodes aligned with a locally generalized binding pattern.
+    /// Conversion may revisit the lambda after binding; this exact source
+    /// provenance keeps that second instance in the binding's local scope.
+    local_generalized_lambdas: HashMap<NodeId, NodeId>,
 
     /// Exact instantiated metadata for ability-operation call expressions.
     perform_operations: HashMap<NodeId, InstantiatedPerformOperation<'db>>,
@@ -83,6 +116,12 @@ pub struct FunctionInferenceContext<'a, 'db> {
     /// concrete node-type table consumed by legacy lowering.
     ability_op_callee_types: HashMap<NodeId, Type<'db>>,
 
+    /// Exact first-pass types for syntax-level references without their own
+    /// expression node, such as constructors and nominal record references.
+    /// Conversion must reuse these instances instead of instantiating a fresh
+    /// declaration scheme after local generalization has fixed lexical owners.
+    reference_types: HashMap<NodeId, Type<'db>>,
+
     /// Inference-time lambda expression types. Call conversion revisits lambda
     /// children, so this keeps their call-constrained instance separate from
     /// the concrete node-type table used by legacy lowering.
@@ -91,8 +130,19 @@ pub struct FunctionInferenceContext<'a, 'db> {
     /// Source-logical callable signatures for lambda nodes.
     lambda_signatures: HashMap<NodeId, LambdaSignature<'db>>,
 
-    /// Case expressions whose typechecking coverage analysis proved exhaustive.
-    exhaustive_cases: Vec<NodeId>,
+    /// Effects evaluated by the innermost lambda body.  This is deliberately
+    /// separate from `current_effect`: a contextual callback-row constraint may
+    /// widen a lambda's latent effect row after its body has been checked, but
+    /// cannot make a pure closure value effectful.
+    lexical_lambda_effects: Vec<Vec<EffectRow<'db>>>,
+
+    /// Continuation transfers observed while checking each nested lambda body.
+    /// This must not be inferred from the lambda's contextually widened row.
+    lexical_lambda_control_transfers: Vec<bool>,
+
+    /// Cases awaiting the function-local solver result before coverage is
+    /// classified and diagnostics are emitted.
+    pending_exhaustiveness_cases: Vec<PendingExhaustivenessCase<'db>>,
 
     /// Generated constraints for this function.
     constraints: ConstraintSet<'db>,
@@ -156,14 +206,23 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             func_id,
             // Start with one scope (the function's top-level scope)
             local_scopes: vec![HashMap::new()],
+            local_scheme_owners: vec![HashMap::new()],
             name_scopes: vec![HashMap::new()],
+            name_scheme_owners: vec![HashMap::new()],
             node_types: HashMap::new(),
+            call_callee_types: HashMap::new(),
             handler_operations: HashMap::new(),
+            local_generalizations: HashMap::new(),
+            local_generalized_bindings: Vec::new(),
+            local_generalized_lambdas: HashMap::new(),
             perform_operations: HashMap::new(),
             ability_op_callee_types: HashMap::new(),
+            reference_types: HashMap::new(),
             inferred_lambda_types: HashMap::new(),
             lambda_signatures: HashMap::new(),
-            exhaustive_cases: Vec::new(),
+            lexical_lambda_effects: Vec::new(),
+            lexical_lambda_control_transfers: Vec::new(),
+            pending_exhaustiveness_cases: Vec::new(),
             constraints: ConstraintSet::new(),
             next_type_var: 0,
             // Start from 1 to avoid collision with EffectVar { id: 0 } placeholder
@@ -225,7 +284,9 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     /// Push a new scope. Call this when entering a lambda body or case arm.
     pub fn push_scope(&mut self) {
         self.local_scopes.push(HashMap::new());
+        self.local_scheme_owners.push(HashMap::new());
         self.name_scopes.push(HashMap::new());
+        self.name_scheme_owners.push(HashMap::new());
     }
 
     /// Pop the current scope. Call this when exiting a lambda body or case arm.
@@ -233,7 +294,9 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         // Never pop the last scope (function's top-level scope)
         if self.local_scopes.len() > 1 {
             self.local_scopes.pop();
+            self.local_scheme_owners.pop();
             self.name_scopes.pop();
+            self.name_scheme_owners.pop();
         }
     }
 
@@ -264,15 +327,36 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         if let Some(scope) = self.local_scopes.last_mut() {
             scope.insert(local, scheme);
         }
+        if let Some(owners) = self.local_scheme_owners.last_mut() {
+            owners.remove(&local);
+        }
+    }
+
+    pub fn bind_local_scheme_with_owner(
+        &mut self,
+        local: LocalId,
+        scheme: TypeScheme<'db>,
+        owner: NodeId,
+    ) {
+        if let Some(scope) = self.local_scopes.last_mut() {
+            scope.insert(local, scheme);
+        }
+        if let Some(owners) = self.local_scheme_owners.last_mut() {
+            owners.insert(local, owner);
+        }
     }
 
     /// Look up the type of a local variable.
     ///
     /// Searches from innermost to outermost scope.
     pub fn lookup_local(&mut self, local: LocalId) -> Option<Type<'db>> {
-        for scope in self.local_scopes.iter().rev() {
-            if let Some(scheme) = scope.get(&local).copied() {
-                return Some(self.instantiate_scheme(scheme));
+        for index in (0..self.local_scopes.len()).rev() {
+            if let Some(scheme) = self.local_scopes[index].get(&local).copied() {
+                let owner = self.local_scheme_owners[index].get(&local).copied();
+                return Some(match owner {
+                    Some(owner) => self.instantiate_local_scheme(scheme, owner),
+                    None => self.instantiate_scheme(scheme),
+                });
             }
         }
         None
@@ -288,15 +372,36 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         if let Some(scope) = self.name_scopes.last_mut() {
             scope.insert(name, scheme);
         }
+        if let Some(owners) = self.name_scheme_owners.last_mut() {
+            owners.remove(&name);
+        }
+    }
+
+    pub fn bind_local_scheme_by_name_with_owner(
+        &mut self,
+        name: Symbol,
+        scheme: TypeScheme<'db>,
+        owner: NodeId,
+    ) {
+        if let Some(scope) = self.name_scopes.last_mut() {
+            scope.insert(name, scheme);
+        }
+        if let Some(owners) = self.name_scheme_owners.last_mut() {
+            owners.insert(name, owner);
+        }
     }
 
     /// Look up a local variable by name.
     ///
     /// Searches from innermost to outermost scope.
     pub fn lookup_local_by_name(&mut self, name: Symbol) -> Option<Type<'db>> {
-        for scope in self.name_scopes.iter().rev() {
-            if let Some(scheme) = scope.get(&name).copied() {
-                return Some(self.instantiate_scheme(scheme));
+        for index in (0..self.name_scopes.len()).rev() {
+            if let Some(scheme) = self.name_scopes[index].get(&name).copied() {
+                let owner = self.name_scheme_owners[index].get(&name).copied();
+                return Some(match owner {
+                    Some(owner) => self.instantiate_local_scheme(scheme, owner),
+                    None => self.instantiate_scheme(scheme),
+                });
             }
         }
         None
@@ -349,6 +454,18 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         std::mem::take(&mut self.node_types)
     }
 
+    pub fn record_call_callee_type(&mut self, callee: NodeId, ty: Type<'db>) {
+        self.call_callee_types.entry(callee).or_insert(ty);
+    }
+
+    pub fn take_call_callee_types(&mut self) -> HashMap<NodeId, Type<'db>> {
+        std::mem::take(&mut self.call_callee_types)
+    }
+
+    pub fn get_call_callee_type(&self, callee: NodeId) -> Option<Type<'db>> {
+        self.call_callee_types.get(&callee).copied()
+    }
+
     /// Record the exact semantic operation selected for a handler arm.
     pub fn record_handler_operation(
         &mut self,
@@ -363,6 +480,46 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         &mut self,
     ) -> HashMap<NodeId, InstantiatedHandlerOperation<'db>> {
         std::mem::take(&mut self.handler_operations)
+    }
+
+    /// Record the variable-to-local-scheme mapping produced for one pure
+    /// binding. `scope` is the exact binding-pattern node, not the enclosing
+    /// destructuring pattern: every local quantifier therefore has a unique
+    /// lexical owner even when each component scheme starts indexing at zero.
+    pub fn record_local_generalization(
+        &mut self,
+        scope: NodeId,
+        mapping: HashMap<UniVarId<'db>, u32>,
+    ) {
+        if !mapping.is_empty() {
+            self.local_generalized_bindings
+                .push((scope, mapping.clone()));
+        }
+        for (var, index) in mapping {
+            self.local_generalizations
+                .entry(var)
+                .or_insert((scope, index));
+        }
+    }
+
+    pub fn take_local_generalizations(&mut self) -> HashMap<UniVarId<'db>, (NodeId, u32)> {
+        std::mem::take(&mut self.local_generalizations)
+    }
+
+    pub fn take_local_generalized_bindings(
+        &mut self,
+    ) -> Vec<(NodeId, HashMap<UniVarId<'db>, u32>)> {
+        std::mem::take(&mut self.local_generalized_bindings)
+    }
+
+    pub fn record_local_generalized_lambda(&mut self, lambda: NodeId, scope: NodeId) {
+        self.local_generalized_lambdas
+            .entry(lambda)
+            .or_insert(scope);
+    }
+
+    pub fn take_local_generalized_lambdas(&mut self) -> HashMap<NodeId, NodeId> {
+        std::mem::take(&mut self.local_generalized_lambdas)
     }
 
     pub fn record_perform_operation(
@@ -390,7 +547,19 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         self.ability_op_callee_types.get(&callee).copied()
     }
 
+    pub fn record_reference_type(&mut self, node: NodeId, ty: Type<'db>) {
+        self.reference_types.entry(node).or_insert(ty);
+    }
+
+    pub fn get_reference_type(&self, node: NodeId) -> Option<Type<'db>> {
+        self.reference_types.get(&node).copied()
+    }
+
     pub fn record_inferred_lambda_type(&mut self, lambda: NodeId, ty: Type<'db>) {
+        // The first inference establishes the lambda value's lexical scheme.
+        // Conversion may revisit the expression to construct the typed body,
+        // but must constrain against this instance rather than replace it with
+        // unrelated fresh variables.
         self.inferred_lambda_types.entry(lambda).or_insert(ty);
     }
 
@@ -402,14 +571,23 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         self.lambda_signatures.entry(lambda).or_insert(signature);
     }
 
+    pub fn lambda_signature(&self, lambda: NodeId) -> Option<&LambdaSignature<'db>> {
+        self.lambda_signatures.get(&lambda)
+    }
+
     /// Replace an inference-time lambda seed with the contextual function
     /// type used while checking the expression.  The latter is authoritative:
     /// it carries the expected polymorphic result/effect slots before solving.
     pub fn record_checked_lambda_signature(
         &mut self,
         lambda: NodeId,
-        signature: LambdaSignature<'db>,
+        mut signature: LambdaSignature<'db>,
     ) {
+        if let Some(inferred) = self.lambda_signatures.get(&lambda) {
+            signature.body_is_effect_free = inferred.body_is_effect_free;
+            signature.contains_control_transfer = inferred.contains_control_transfer;
+            signature.lexical_convention = inferred.lexical_convention;
+        }
         self.lambda_signatures.insert(lambda, signature);
     }
 
@@ -417,14 +595,26 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
         std::mem::take(&mut self.lambda_signatures)
     }
 
-    pub fn record_exhaustive_case(&mut self, case: NodeId) {
-        if !self.exhaustive_cases.contains(&case) {
-            self.exhaustive_cases.push(case);
-        }
+    pub fn record_pending_exhaustiveness_case(
+        &mut self,
+        case: NodeId,
+        diagnostic_span: NodeId,
+        scrutinee_type: Type<'db>,
+        arms: Vec<Arm<TypedRef<'db>>>,
+    ) {
+        self.pending_exhaustiveness_cases
+            .push(PendingExhaustivenessCase {
+                case,
+                diagnostic_span,
+                scrutinee_type,
+                arms,
+            });
     }
 
-    pub fn take_exhaustive_cases(&mut self) -> Vec<NodeId> {
-        std::mem::take(&mut self.exhaustive_cases)
+    pub(crate) fn take_pending_exhaustiveness_cases(
+        &mut self,
+    ) -> Vec<PendingExhaustivenessCase<'db>> {
+        std::mem::take(&mut self.pending_exhaustiveness_cases)
     }
 
     // =========================================================================
@@ -476,6 +666,33 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             self.substitute_bound_vars(scheme.body(self.db), &fresh_vars)
         };
 
+        let quantified_rows = scheme.effect_params(self.db);
+        let db = self.db;
+        subst::freshen_effect_vars(db, instantiated, quantified_rows, || self.fresh_row_var())
+    }
+
+    /// Instantiate a locally generalized scheme and retain the exact lexical
+    /// quantifier owner for each fresh type variable.  The variables remain
+    /// ordinary inference variables during checking; finalization uses this
+    /// provenance only if a typed reference still needs the local scheme.
+    fn instantiate_local_scheme(&mut self, scheme: TypeScheme<'db>, owner: NodeId) -> Type<'db> {
+        let params = scheme.type_params(self.db);
+        let instantiated = if params.is_empty() {
+            scheme.body(self.db)
+        } else {
+            let fresh_vars: Vec<Type<'db>> = (0..params.len())
+                .map(|index| {
+                    let ty = self.fresh_type_var();
+                    if let TypeKind::UniVar { id } = ty.kind(self.db) {
+                        self.local_generalizations
+                            .entry(*id)
+                            .or_insert((owner, index as u32));
+                    }
+                    ty
+                })
+                .collect();
+            self.substitute_bound_vars(scheme.body(self.db), &fresh_vars)
+        };
         let quantified_rows = scheme.effect_params(self.db);
         let db = self.db;
         subst::freshen_effect_vars(db, instantiated, quantified_rows, || self.fresh_row_var())
@@ -607,6 +824,11 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     }
 
     fn merge_effect_with_origin(&mut self, effect: EffectRow<'db>, origin: Option<NodeId>) {
+        if !effect.is_pure(self.db)
+            && let Some(effects) = self.lexical_lambda_effects.last_mut()
+        {
+            effects.push(effect);
+        }
         let db = self.db;
         let current = self.current_effect;
 
@@ -705,6 +927,57 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
                     merge_effects_with_unification(self, current.effects(db), effect.effects(db));
                 self.current_effect = EffectRow::new(db, effects, Some(e3));
             }
+        }
+    }
+
+    /// Begin collecting the effects evaluated directly by one lambda body.
+    pub fn begin_lexical_lambda_effects(&mut self) {
+        self.lexical_lambda_effects.push(Vec::new());
+        self.lexical_lambda_control_transfers.push(false);
+    }
+
+    /// Finish the innermost lambda-body effect capture.
+    pub fn end_lexical_lambda_effects(&mut self) -> (Vec<EffectRow<'db>>, bool) {
+        let effects = self
+            .lexical_lambda_effects
+            .pop()
+            .expect("lambda effect capture must be balanced");
+        let control_transfer = self
+            .lexical_lambda_control_transfers
+            .pop()
+            .expect("lambda control-transfer capture must be balanced");
+        (effects, control_transfer)
+    }
+
+    /// A continuation invocation transfers control even though its effect row
+    /// is accounted for by the enclosing handler.  It cannot make the lambda
+    /// value an ordinary Direct closure.
+    pub fn record_lexical_lambda_control_transfer(&mut self) {
+        if let Some(control_transfer) = self.lexical_lambda_control_transfers.last_mut() {
+            *control_transfer = true;
+        }
+        if !self.lexical_lambda_effects.is_empty() {
+            let effect = EffectRow::open(self.db, self.fresh_row_var());
+            self.lexical_lambda_effects
+                .last_mut()
+                .expect("nonempty lambda effect capture")
+                .push(effect);
+        }
+    }
+
+    /// Typed-expression conversion can encounter a continuation call after
+    /// the first inference walk has seeded the lambda signature.  Preserve
+    /// that exact control fact without revisiting body-effect purity under the
+    /// contextual latent row.
+    pub fn record_converted_lambda_control_transfer(
+        &mut self,
+        lambda: NodeId,
+        contains_control_transfer: bool,
+    ) {
+        if contains_control_transfer
+            && let Some(signature) = self.lambda_signatures.get_mut(&lambda)
+        {
+            signature.contains_control_transfer = true;
         }
     }
 

--- a/crates/tribute-front/src/typeck/mod.rs
+++ b/crates/tribute-front/src/typeck/mod.rs
@@ -81,6 +81,19 @@ pub struct LambdaSignature<'db> {
     /// The solved full source function type.  Retaining its effect row avoids
     /// confusing the ABI lower bound with the selected convention.
     pub function_type: Type<'db>,
+    /// Whether the lambda body introduced no effect beyond its fresh lexical
+    /// accumulator. Contextual effect-row unification may widen the semantic
+    /// function type, but must not turn a pure closure value into CPS.
+    pub body_is_effect_free: bool,
+    /// Whether checking the lambda body observed a continuation transfer.
+    /// This is control, not an ordinary effect-row observation, and therefore
+    /// remains Cps even when a contextual row is otherwise empty.
+    pub contains_control_transfer: bool,
+    /// The convention justified by evaluating this lambda body before its
+    /// callable type is unified with a contextual callback slot.  A pure
+    /// Direct closure can later be strengthened structurally for a CPS slot,
+    /// but contextual widening must not rewrite the closure itself to CPS.
+    pub lexical_convention: CallingConvention,
     pub convention: CallingConvention,
 }
 
@@ -188,6 +201,18 @@ impl WellKnownTypes<'_> {
 /// both can be derived from a single type checking invocation.
 /// Also stores the SpanMap so that downstream stages (e.g., ast_to_ir)
 /// can look up source spans without a separate plumbing path.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub struct NominalTypeMetadata<'db> {
+    pub constructor_types: Vec<(CtorId<'db>, TypeScheme<'db>)>,
+    pub type_definitions: Vec<(Symbol, TypeScheme<'db>)>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub struct ExpressionTypeMetadata<'db> {
+    pub node_types: Vec<(NodeId, Type<'db>)>,
+    pub call_callee_types: Vec<(NodeId, Type<'db>)>,
+}
+
 #[salsa::tracked]
 pub struct TypeCheckOutput<'db> {
     /// The type-checked AST module.
@@ -197,16 +222,16 @@ pub struct TypeCheckOutput<'db> {
     /// Stored as Vec<(Symbol, TypeScheme)> because FuncDefId doesn't implement Ord.
     #[returns(ref)]
     pub function_types: Vec<(Symbol, TypeScheme<'db>)>,
-    /// Constructor schemes used to build logical nominal layouts without
-    /// reinterpreting source annotations.
+    /// Exact constructor and nominal definition schemes. Definition scheme
+    /// bodies carry the authoritative `TypeDefId`, including empty enums.
     #[returns(ref)]
-    pub constructor_types: Vec<(CtorId<'db>, TypeScheme<'db>)>,
+    pub nominal_types: NominalTypeMetadata<'db>,
     /// Node types collected during type checking.
     /// Maps NodeId to its inferred type (after substitution but before generalization).
     /// Used by IR lowering to get lambda effect types.
     /// Stored as Vec for Salsa compatibility (HashMap doesn't implement Hash).
     #[returns(ref)]
-    pub node_types: Vec<(NodeId, Type<'db>)>,
+    pub expression_types: ExpressionTypeMetadata<'db>,
     /// Ability-level calling-convention requirements.
     #[returns(ref)]
     pub ability_conventions: Vec<(AbilityId<'db>, CallingConvention)>,
@@ -295,8 +320,14 @@ pub fn typecheck_module<'db>(
         db,
         result.module,
         result.function_types,
-        result.constructor_types,
-        result.node_types,
+        NominalTypeMetadata {
+            constructor_types: result.constructor_types,
+            type_definitions: result.type_definitions,
+        },
+        ExpressionTypeMetadata {
+            node_types: result.node_types,
+            call_callee_types: result.call_callee_types,
+        },
         result.ability_conventions,
         ability_schemas(&result.ability_definitions),
         result.handler_operations,

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -2,12 +2,12 @@
 //!
 //! Solves type constraints using union-find based unification.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use trunk_ir::smallvec::SmallVec;
 
 use crate::ast::{
-    Effect, EffectRow, EffectVar, Type, TypeKind, TypeParam, UniVarId, UniVarSource,
+    Effect, EffectRow, EffectVar, NodeId, Type, TypeKind, TypeParam, UniVarId, UniVarSource,
     collect_effect_vars,
 };
 
@@ -154,6 +154,58 @@ impl<'db> TypeSubst<'db> {
         self.map.get(&var).copied()
     }
 
+    /// Extend lexical local-generalization provenance across direct solver
+    /// aliases.  Unification may orient an equality from a fresh conversion
+    /// variable to an already-owned local variable; both spellings denote the
+    /// same quantifier at finalization.
+    pub fn propagate_local_generalization_aliases(
+        &self,
+        db: &'db dyn salsa::Database,
+        local_vars: &mut HashMap<UniVarId<'db>, (NodeId, u32)>,
+    ) {
+        loop {
+            let mut changed = false;
+            for (alias, ty) in &self.map {
+                let TypeKind::UniVar { id } = ty.kind(db) else {
+                    continue;
+                };
+                if let Some(owner) = local_vars.get(id).copied()
+                    && local_vars.insert(*alias, owner).is_none()
+                {
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// Extend a function-interface generalization map across direct solver
+    /// aliases created while the body is converted after signature inference.
+    pub fn propagate_bound_var_aliases(
+        &self,
+        db: &'db dyn salsa::Database,
+        bound_vars: &mut HashMap<UniVarId<'db>, u32>,
+    ) {
+        loop {
+            let mut changed = false;
+            for (alias, ty) in &self.map {
+                let TypeKind::UniVar { id } = ty.kind(db) else {
+                    continue;
+                };
+                if let Some(index) = bound_vars.get(id).copied()
+                    && bound_vars.insert(*alias, index).is_none()
+                {
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
     /// Apply the substitution to a type.
     ///
     /// Note: This delegates to `apply_with_rows` with an empty row substitution.
@@ -286,7 +338,8 @@ impl<'db> TypeSubst<'db> {
             .collect();
 
         // Pass 2: replace UniVars with BoundVars
-        let generalized = self.replace_univars_with_bound(db, ty, row_subst, &var_to_index);
+        let generalized =
+            self.replace_univars_with_bound(db, ty, row_subst, &var_to_index, None, None);
 
         // Build type params (anonymous — names not tracked through UniVar)
         let type_params: Vec<TypeParam> = univars.iter().map(|_| TypeParam::anonymous()).collect();
@@ -302,6 +355,20 @@ impl<'db> TypeSubst<'db> {
         row_subst: &RowSubst<'db>,
         excluded: &[UniVarId<'db>],
     ) -> (Type<'db>, Vec<TypeParam>) {
+        let (generalized, type_params, _) =
+            self.generalize_excluding_with_mapping(db, ty, row_subst, excluded);
+        (generalized, type_params)
+    }
+
+    /// Generalize unresolved variables except those free in the environment,
+    /// retaining the exact variable-to-local-scheme mapping.
+    pub fn generalize_excluding_with_mapping(
+        &self,
+        db: &'db dyn salsa::Database,
+        ty: Type<'db>,
+        row_subst: &RowSubst<'db>,
+        excluded: &[UniVarId<'db>],
+    ) -> (Type<'db>, Vec<TypeParam>, HashMap<UniVarId<'db>, u32>) {
         let mut univars = Vec::new();
         self.collect_unresolved_univars(db, ty, row_subst, &mut univars);
         univars.retain(|id| !excluded.contains(id));
@@ -311,9 +378,10 @@ impl<'db> TypeSubst<'db> {
             .enumerate()
             .map(|(index, &id)| (id, index as u32))
             .collect();
-        let generalized = self.replace_univars_with_bound(db, ty, row_subst, &var_to_index);
+        let generalized =
+            self.replace_univars_with_bound(db, ty, row_subst, &var_to_index, None, None);
         let type_params = univars.iter().map(|_| TypeParam::anonymous()).collect();
-        (generalized, type_params)
+        (generalized, type_params, var_to_index)
     }
 
     /// Generalize a type and return the UniVar → BoundVar index mapping.
@@ -342,7 +410,8 @@ impl<'db> TypeSubst<'db> {
             .collect();
 
         // Pass 2: replace UniVars with BoundVars
-        let generalized = self.replace_univars_with_bound(db, ty, row_subst, &var_to_index);
+        let generalized =
+            self.replace_univars_with_bound(db, ty, row_subst, &var_to_index, None, None);
 
         // Build type params (anonymous — names not tracked through UniVar)
         let type_params: Vec<TypeParam> = univars.iter().map(|_| TypeParam::anonymous()).collect();
@@ -361,7 +430,31 @@ impl<'db> TypeSubst<'db> {
         row_subst: &RowSubst<'db>,
         var_to_index: &HashMap<UniVarId<'db>, u32>,
     ) -> Type<'db> {
-        self.replace_univars_with_bound(db, ty, row_subst, var_to_index)
+        self.replace_univars_with_bound(db, ty, row_subst, var_to_index, None, None)
+    }
+
+    /// Apply function-interface and local-let generalization mappings.
+    ///
+    /// Local quantifiers are deliberately distinct from function scheme
+    /// parameters so a body-only variable cannot become a phantom callable
+    /// parameter during later monomorphization.
+    pub fn apply_generalization_with_local_vars(
+        &self,
+        db: &'db dyn salsa::Database,
+        ty: Type<'db>,
+        row_subst: &RowSubst<'db>,
+        var_to_index: &HashMap<UniVarId<'db>, u32>,
+        local_vars: &HashMap<UniVarId<'db>, (NodeId, u32)>,
+        unresolved_body_vars: &HashSet<UniVarId<'db>>,
+    ) -> Type<'db> {
+        self.replace_univars_with_bound(
+            db,
+            ty,
+            row_subst,
+            var_to_index,
+            Some(local_vars),
+            Some(unresolved_body_vars),
+        )
     }
 
     /// Collect unresolved UniVarIds from a type in appearance (left-to-right) order.
@@ -458,6 +551,8 @@ impl<'db> TypeSubst<'db> {
         ty: Type<'db>,
         row_subst: &RowSubst<'db>,
         var_to_index: &HashMap<UniVarId<'db>, u32>,
+        local_vars: Option<&HashMap<UniVarId<'db>, (NodeId, u32)>>,
+        unresolved_body_vars: Option<&HashSet<UniVarId<'db>>>,
     ) -> Type<'db> {
         match ty.kind(db) {
             TypeKind::UniVar { id } => {
@@ -467,8 +562,19 @@ impl<'db> TypeSubst<'db> {
                 // we want to generalize X (which is in the mapping), not Y (which may not be).
                 if let Some(&index) = var_to_index.get(id) {
                     Type::new(db, TypeKind::BoundVar { index })
+                } else if let Some(&(scope, index)) = local_vars.and_then(|vars| vars.get(id)) {
+                    Type::new(db, TypeKind::LocalBoundVar { scope, index })
+                } else if unresolved_body_vars.is_some_and(|vars| vars.contains(id)) {
+                    Type::new(db, TypeKind::Error)
                 } else if let Some(subst_ty) = self.get(*id) {
-                    self.replace_univars_with_bound(db, subst_ty, row_subst, var_to_index)
+                    self.replace_univars_with_bound(
+                        db,
+                        subst_ty,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                        unresolved_body_vars,
+                    )
                 } else {
                     ty
                 }
@@ -476,7 +582,16 @@ impl<'db> TypeSubst<'db> {
             TypeKind::Named { id, name, args } => {
                 let new_args: Vec<_> = args
                     .iter()
-                    .map(|a| self.replace_univars_with_bound(db, *a, row_subst, var_to_index))
+                    .map(|a| {
+                        self.replace_univars_with_bound(
+                            db,
+                            *a,
+                            row_subst,
+                            var_to_index,
+                            local_vars,
+                            unresolved_body_vars,
+                        )
+                    })
                     .collect();
                 Type::new(
                     db,
@@ -495,13 +610,35 @@ impl<'db> TypeSubst<'db> {
             } => {
                 let new_params: Vec<_> = params
                     .iter()
-                    .map(|p| self.replace_univars_with_bound(db, *p, row_subst, var_to_index))
+                    .map(|p| {
+                        self.replace_univars_with_bound(
+                            db,
+                            *p,
+                            row_subst,
+                            var_to_index,
+                            local_vars,
+                            unresolved_body_vars,
+                        )
+                    })
                     .collect();
-                let new_result =
-                    self.replace_univars_with_bound(db, *result, row_subst, var_to_index);
+                let new_result = self.replace_univars_with_bound(
+                    db,
+                    *result,
+                    row_subst,
+                    var_to_index,
+                    local_vars,
+                    unresolved_body_vars,
+                );
                 let applied_row = row_subst.apply(db, *effect);
                 let new_effect = map_effect_row_type_args(db, applied_row, |a| {
-                    self.replace_univars_with_bound(db, a, row_subst, var_to_index)
+                    self.replace_univars_with_bound(
+                        db,
+                        a,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                        unresolved_body_vars,
+                    )
                 });
                 Type::new(
                     db,
@@ -516,15 +653,40 @@ impl<'db> TypeSubst<'db> {
             TypeKind::Tuple(elems) => {
                 let new_elems: Vec<_> = elems
                     .iter()
-                    .map(|e| self.replace_univars_with_bound(db, *e, row_subst, var_to_index))
+                    .map(|e| {
+                        self.replace_univars_with_bound(
+                            db,
+                            *e,
+                            row_subst,
+                            var_to_index,
+                            local_vars,
+                            unresolved_body_vars,
+                        )
+                    })
                     .collect();
                 Type::new(db, TypeKind::Tuple(new_elems))
             }
             TypeKind::App { ctor, args } => {
-                let new_ctor = self.replace_univars_with_bound(db, *ctor, row_subst, var_to_index);
+                let new_ctor = self.replace_univars_with_bound(
+                    db,
+                    *ctor,
+                    row_subst,
+                    var_to_index,
+                    local_vars,
+                    unresolved_body_vars,
+                );
                 let new_args: Vec<_> = args
                     .iter()
-                    .map(|a| self.replace_univars_with_bound(db, *a, row_subst, var_to_index))
+                    .map(|a| {
+                        self.replace_univars_with_bound(
+                            db,
+                            *a,
+                            row_subst,
+                            var_to_index,
+                            local_vars,
+                            unresolved_body_vars,
+                        )
+                    })
                     .collect();
                 Type::new(
                     db,
@@ -539,12 +701,32 @@ impl<'db> TypeSubst<'db> {
                 result,
                 effect,
             } => {
-                let new_arg = self.replace_univars_with_bound(db, *arg, row_subst, var_to_index);
-                let new_result =
-                    self.replace_univars_with_bound(db, *result, row_subst, var_to_index);
+                let new_arg = self.replace_univars_with_bound(
+                    db,
+                    *arg,
+                    row_subst,
+                    var_to_index,
+                    local_vars,
+                    unresolved_body_vars,
+                );
+                let new_result = self.replace_univars_with_bound(
+                    db,
+                    *result,
+                    row_subst,
+                    var_to_index,
+                    local_vars,
+                    unresolved_body_vars,
+                );
                 let applied_row = row_subst.apply(db, *effect);
                 let new_effect = map_effect_row_type_args(db, applied_row, |a| {
-                    self.replace_univars_with_bound(db, a, row_subst, var_to_index)
+                    self.replace_univars_with_bound(
+                        db,
+                        a,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                        unresolved_body_vars,
+                    )
                 });
                 Type::new(
                     db,

--- a/crates/tribute-front/src/typeck/subst.rs
+++ b/crates/tribute-front/src/typeck/subst.rs
@@ -397,6 +397,7 @@ fn freshen_effect_vars_inner<'db>(
             },
         ),
         TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
         | TypeKind::UniVar { .. }
         | TypeKind::Int
         | TypeKind::Nat

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -100,6 +100,8 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
     let constructor_types: std::collections::HashMap<_, _> =
         result.constructor_types.into_iter().collect();
     let node_types_map: std::collections::HashMap<_, _> = result.node_types.into_iter().collect();
+    let call_callee_types: std::collections::HashMap<_, _> =
+        result.call_callee_types.into_iter().collect();
     let ability_conventions: std::collections::HashMap<_, _> =
         result.ability_conventions.into_iter().collect();
     let ability_definitions: std::collections::HashMap<_, _> =
@@ -115,6 +117,8 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
         function_types: function_types_map,
         constructor_types,
         node_types: node_types_map,
+        call_callee_types,
+        specialized_call_callee_nodes: Default::default(),
         ability_conventions,
         ability_definitions,
         handler_operations,

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -261,6 +261,68 @@ fn logical_root_main_preserves_pure_and_io_conventions(db: &salsa::DatabaseImpl)
     );
 }
 
+/// The comparison result starts as an inference variable.  Exhaustiveness is
+/// decided only after solving it to Bool, so source-logical lowering selects
+/// the final arm without manufacturing a Nil conversion for an empty else.
+#[salsa_test]
+fn inferred_case_scrutinee_is_classified_after_solving(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "inferred_exhaustive_case.trb",
+        r#"
+fn select(value: Nat) -> Nat {
+    case value == 0 {
+        True -> 1
+        False -> 2
+    }
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir = run_ast_pipeline_with_ir(db, source);
+    let select = checked_logical_function(&ir, "select");
+    assert!(
+        select.contains("scf.if"),
+        "expected structured case lowering:\n{select}"
+    );
+    assert!(
+        !select.contains("core.unrealized_conversion_cast"),
+        "a solved exhaustive Bool case must not manufacture a Nil cast:\n{select}"
+    );
+}
+
+#[salsa_test]
+fn finalized_exhaustive_guarded_residual_uses_logical_bottom(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "guarded_exhaustive_case.trb",
+        r#"
+fn select(value: Bool) -> Int {
+    case value {
+        True -> 1
+        False -> 2
+        True if value -> 3
+    }
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir = run_ast_pipeline_with_ir(db, source);
+    let select = checked_logical_function(&ir, "select");
+    assert!(
+        select.contains("tribute_control.unreachable"),
+        "the finalized guarded residual must terminate logically:\n{select}"
+    );
+    assert!(
+        !select.contains("core.unrealized_conversion_cast"),
+        "a proven logical residual must not manufacture a Nil cast:\n{select}"
+    );
+}
+
 #[salsa_test]
 fn nested_main_is_not_a_root_convention_special_case(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -670,23 +732,30 @@ fn main() {
         pure_header.contains("convention(direct)"),
         "pure worker must remain Direct:\n{pure_header}"
     );
-    for name in ["apply_closed", "main"] {
-        let header = ir_text
-            .lines()
-            .find(|line| {
-                line.trim_start()
-                    .starts_with(&format!("tribute_control.func @{name}("))
-            })
-            .unwrap_or_else(|| panic!("missing lowered worker {name}"));
-        assert!(
-            header.contains("convention(direct)"),
-            "{name} must stay Direct:\n{header}"
-        );
-    }
+    let apply_closed_header = ir_text
+        .lines()
+        .find(|line| {
+            line.trim_start()
+                .starts_with("tribute_control.func @apply_closed(")
+        })
+        .expect("missing lowered apply_closed worker");
+    assert!(
+        apply_closed_header.contains("convention(direct)"),
+        "apply_closed must stay Direct:\n{apply_closed_header}"
+    );
+    let main_header = ir_text
+        .lines()
+        .find(|line| line.trim_start().starts_with("tribute_control.func @main("))
+        .expect("missing lowered root main");
+    assert!(
+        main_header.contains("convention(cps)")
+            && main_header.contains("tribute.root_export_convention = 0"),
+        "open-callback root must use a Cps worker while preserving its Direct export contract:\n{main_header}"
+    );
 }
 
-/// An `Io` root keeps its EvidenceDirect ABI while the frontend delimiter
-/// closes the CPS implementation convention of an open callback worker.
+/// An `Io` root preserves EvidenceDirect only as its external export contract;
+/// its worker promotes to Cps when open callback evaluation requires it.
 #[salsa_test]
 fn test_open_callback_evidence_root_main_stays_evidence_direct(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -710,8 +779,9 @@ fn main() ->{std::io::Io} Nil {
         .find(|line| line.trim_start().starts_with("tribute_control.func @main("))
         .expect("missing lowered root main");
     assert!(
-        main_header.contains("convention(evidence_direct)"),
-        "Io root main must remain EvidenceDirect, not Cps:\n{main_header}"
+        main_header.contains("convention(cps)")
+            && main_header.contains("tribute.root_export_convention = 1"),
+        "Io root must use a Cps worker while preserving its EvidenceDirect export contract:\n{main_header}"
     );
 }
 
@@ -811,6 +881,73 @@ fn main() { }
     assert!(
         !ir.contains("tribute_control.call {callee = @\"Nested::apply\"}"),
         "lowering must not reinterpret the local as the nested function:\n{ir}"
+    );
+}
+
+/// Monomorphized nested declarations already carry their source-qualified
+/// identity. Convention prescan and fixed-point promotion must use that same
+/// identity rather than qualifying it a second time. A same-short-name root
+/// declaration ensures lookup cannot silently fall back to the wrong worker.
+#[salsa_test]
+fn nested_generic_worker_uses_one_canonical_declaration_identity(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "nested_generic_identity.trb",
+        r#"
+struct Box(a) { value: a }
+
+fn unwrap(value: Box(a)) ->{} a { value.value }
+
+mod Nested {
+    struct Box(a) { value: a }
+
+    fn unwrap(value: Box(a)) ->{} a { value.value }
+
+    fn use_nested() ->{} Int {
+        unwrap(Box { value: +41 })
+    }
+}
+
+fn main() {
+    let _root = unwrap(Box { value: +1 })
+    let _nested = Nested::use_nested()
+}
+"#,
+    );
+
+    let ir = run_ast_pipeline_with_ir(db, source);
+    assert_logical_boundary(&ir);
+    assert!(
+        !ir.contains("Nested::Nested::"),
+        "an already-qualified synthetic declaration must never be qualified twice:\n{ir}"
+    );
+
+    let nested_specializations: Vec<_> = ir
+        .lines()
+        .filter(|line| {
+            line.trim_start()
+                .starts_with("tribute_control.func @\"Nested::Box::value\"")
+        })
+        .collect();
+    assert_eq!(
+        nested_specializations.len(),
+        1,
+        "the nested specialization must have one exact declaration:\n{ir}"
+    );
+    assert!(
+        nested_specializations[0].contains("convention(direct)"),
+        "the concrete-pure nested worker must remain Direct:\n{}",
+        nested_specializations[0]
+    );
+    assert!(
+        ir.lines().any(|line| line
+            .trim_start()
+            .starts_with("tribute_control.func @\"Box::value\"")),
+        "the same-short-name root specialization must remain distinct:\n{ir}"
+    );
+    assert!(
+        logical_function(&ir, "Nested::unwrap").contains("callee = @\"Nested::Box::value\""),
+        "the nested caller must target the exact qualified synthetic declaration:\n{ir}"
     );
 }
 

--- a/crates/tribute-front/tests/int_text.rs
+++ b/crates/tribute-front/tests/int_text.rs
@@ -92,8 +92,25 @@ fn public_logical_output_declarations_inner(db: &dyn salsa::Database, source: So
         ast: typed,
         span_map: checked.span_map(db).clone(),
         function_types: checked.function_types(db).iter().cloned().collect(),
-        constructor_types: checked.constructor_types(db).iter().cloned().collect(),
-        node_types: checked.node_types(db).iter().cloned().collect(),
+        constructor_types: checked
+            .nominal_types(db)
+            .constructor_types
+            .iter()
+            .cloned()
+            .collect(),
+        node_types: checked
+            .expression_types(db)
+            .node_types
+            .iter()
+            .cloned()
+            .collect(),
+        call_callee_types: checked
+            .expression_types(db)
+            .call_callee_types
+            .iter()
+            .cloned()
+            .collect(),
+        specialized_call_callee_nodes: Default::default(),
         ability_conventions: checked.ability_conventions(db).iter().cloned().collect(),
         ability_definitions: tribute_front::typeck::ability_definitions_from_schemas(
             checked.ability_definitions(db),

--- a/crates/tribute-front/tests/lambda_effect_type.rs
+++ b/crates/tribute-front/tests/lambda_effect_type.rs
@@ -56,6 +56,39 @@ fn main() -> Int {
     assert_snapshot!(ir_text);
 }
 
+/// A pure body remains Direct even when root promotion makes the receiving
+/// callback slot Cps; lowering inserts an explicit logical wrapper instead of
+/// a control callable conversion cast.
+#[salsa_test]
+fn test_pure_lambda_contextualized_to_cps_slot_stays_direct(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn apply(f: fn(Int) -> Int, x: Int) -> Int { f(x) }
+
+fn main() -> Int {
+    apply(fn(n) { n + 1 }, 41)
+}
+"#,
+    );
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    let main = ir_text
+        .split("tribute_control.func @main")
+        .nth(1)
+        .expect("fixture must lower main");
+    assert!(
+        main.matches("tribute_control.lambda(").count() == 2
+            && main.contains("convention(direct)")
+            && main.matches("convention(cps)").count() >= 2,
+        "the pure closure and its structural Cps wrapper must remain distinct:\n{main}"
+    );
+    assert!(
+        !main.contains("core.unrealized_conversion_cast"),
+        "the Direct-to-Cps boundary must not use a control callable cast:\n{main}"
+    );
+}
+
 // ========================================================================
 // Effectful Lambda Tests - Effect Type Expected
 // ========================================================================

--- a/crates/tribute-front/tests/let_generalization.rs
+++ b/crates/tribute-front/tests/let_generalization.rs
@@ -1,6 +1,9 @@
 use salsa_test_macros::salsa_test;
 use tribute_core::{CompilationPhase, Diagnostic, DiagnosticSeverity};
-use tribute_front::SourceCst;
+use tribute_front::{
+    SourceCst,
+    ast::{Decl, Expr, ExprKind, HandlerKind, Pattern, PatternKind, Stmt, Type, TypeKind},
+};
 
 fn phase_errors(
     db: &dyn salsa::Database,
@@ -21,6 +24,353 @@ fn type_errors(db: &dyn salsa::Database, source: SourceCst) -> Vec<String> {
     phase_errors(db, source, CompilationPhase::TypeChecking)
 }
 
+fn type_contains_univar(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+    match ty.kind(db) {
+        TypeKind::UniVar { .. } => true,
+        TypeKind::Named { args, .. } => args.iter().any(|arg| type_contains_univar(db, *arg)),
+        TypeKind::Func {
+            params,
+            result,
+            effect,
+            ..
+        } => {
+            params.iter().any(|param| type_contains_univar(db, *param))
+                || type_contains_univar(db, *result)
+                || effect
+                    .effects(db)
+                    .iter()
+                    .flat_map(|entry| entry.args.iter())
+                    .any(|arg| type_contains_univar(db, *arg))
+        }
+        TypeKind::Tuple(elements) => elements
+            .iter()
+            .any(|element| type_contains_univar(db, *element)),
+        TypeKind::App { ctor, args } => {
+            type_contains_univar(db, *ctor) || args.iter().any(|arg| type_contains_univar(db, *arg))
+        }
+        TypeKind::Continuation {
+            arg,
+            result,
+            effect,
+        } => {
+            type_contains_univar(db, *arg)
+                || type_contains_univar(db, *result)
+                || effect
+                    .effects(db)
+                    .iter()
+                    .flat_map(|entry| entry.args.iter())
+                    .any(|entry| type_contains_univar(db, *entry))
+        }
+        _ => false,
+    }
+}
+
+fn collect_local_bound_scopes(
+    db: &dyn salsa::Database,
+    ty: Type<'_>,
+    scopes: &mut Vec<tribute_front::ast::NodeId>,
+) {
+    let mut bounds = Vec::new();
+    collect_local_bounds(db, ty, &mut bounds);
+    scopes.extend(bounds.into_iter().map(|(scope, _)| scope));
+}
+
+fn collect_local_bounds(
+    db: &dyn salsa::Database,
+    ty: Type<'_>,
+    bounds: &mut Vec<(tribute_front::ast::NodeId, u32)>,
+) {
+    match ty.kind(db) {
+        TypeKind::LocalBoundVar { scope, index } => bounds.push((*scope, *index)),
+        TypeKind::Named { args, .. } => {
+            for arg in args {
+                collect_local_bounds(db, *arg, bounds);
+            }
+        }
+        TypeKind::Func {
+            params,
+            result,
+            effect,
+            ..
+        } => {
+            for param in params {
+                collect_local_bounds(db, *param, bounds);
+            }
+            collect_local_bounds(db, *result, bounds);
+            for entry in effect.effects(db) {
+                for arg in &entry.args {
+                    collect_local_bounds(db, *arg, bounds);
+                }
+            }
+        }
+        TypeKind::Tuple(elements) => {
+            for element in elements {
+                collect_local_bounds(db, *element, bounds);
+            }
+        }
+        TypeKind::App { ctor, args } => {
+            collect_local_bounds(db, *ctor, bounds);
+            for arg in args {
+                collect_local_bounds(db, *arg, bounds);
+            }
+        }
+        TypeKind::Continuation {
+            arg,
+            result,
+            effect,
+        } => {
+            collect_local_bounds(db, *arg, bounds);
+            collect_local_bounds(db, *result, bounds);
+            for entry in effect.effects(db) {
+                for arg in &entry.args {
+                    collect_local_bounds(db, *arg, bounds);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_typed_refs_resolved(
+    db: &dyn salsa::Database,
+    expr: &Expr<tribute_front::ast::TypedRef<'_>>,
+) {
+    match &*expr.kind {
+        ExprKind::Var(reference) => assert!(
+            !type_contains_univar(db, reference.ty),
+            "typed reference leaked a raw UniVar: {}",
+            reference.ty
+        ),
+        ExprKind::Cons { ctor, args } => {
+            assert!(!type_contains_univar(db, ctor.ty));
+            for arg in args {
+                assert_typed_refs_resolved(db, arg);
+            }
+        }
+        ExprKind::Record {
+            type_name,
+            fields,
+            spread,
+        } => {
+            assert!(!type_contains_univar(db, type_name.ty));
+            for (_, value) in fields {
+                assert_typed_refs_resolved(db, value);
+            }
+            if let Some(spread) = spread {
+                assert_typed_refs_resolved(db, spread);
+            }
+        }
+        ExprKind::MethodCall { receiver, args, .. } => {
+            assert_typed_refs_resolved(db, receiver);
+            for arg in args {
+                assert_typed_refs_resolved(db, arg);
+            }
+        }
+        ExprKind::Call { callee, args } => {
+            assert_typed_refs_resolved(db, callee);
+            for arg in args {
+                assert_typed_refs_resolved(db, arg);
+            }
+        }
+        ExprKind::Block { stmts, value } => {
+            for stmt in stmts {
+                match stmt {
+                    Stmt::Let { pattern, value, .. } => {
+                        assert_pattern_refs_resolved(db, pattern);
+                        assert_typed_refs_resolved(db, value);
+                    }
+                    Stmt::Expr { expr: value, .. } => {
+                        assert_typed_refs_resolved(db, value);
+                    }
+                }
+            }
+            assert_typed_refs_resolved(db, value);
+        }
+        ExprKind::Lambda { body, .. } => assert_typed_refs_resolved(db, body),
+        ExprKind::Case { scrutinee, arms } => {
+            assert_typed_refs_resolved(db, scrutinee);
+            for arm in arms {
+                assert_pattern_refs_resolved(db, &arm.pattern);
+                if let Some(guard) = &arm.guard {
+                    assert_typed_refs_resolved(db, guard);
+                }
+                assert_typed_refs_resolved(db, &arm.body);
+            }
+        }
+        ExprKind::Handle { body, handlers } => {
+            assert_typed_refs_resolved(db, body);
+            for handler in handlers {
+                match &handler.kind {
+                    HandlerKind::Do { binding } => assert_pattern_refs_resolved(db, binding),
+                    HandlerKind::Fn {
+                        ability, params, ..
+                    }
+                    | HandlerKind::Op {
+                        ability, params, ..
+                    } => {
+                        assert!(!type_contains_univar(db, ability.ty));
+                        for param in params {
+                            assert_pattern_refs_resolved(db, param);
+                        }
+                    }
+                }
+                assert_typed_refs_resolved(db, &handler.body);
+            }
+        }
+        ExprKind::Resume { arg, .. } => assert_typed_refs_resolved(db, arg),
+        ExprKind::Tuple(values) | ExprKind::List(values) => {
+            for value in values {
+                assert_typed_refs_resolved(db, value);
+            }
+        }
+        ExprKind::BinOp { lhs, rhs, .. } => {
+            assert_typed_refs_resolved(db, lhs);
+            assert_typed_refs_resolved(db, rhs);
+        }
+        _ => {}
+    }
+}
+
+fn assert_pattern_refs_resolved(
+    db: &dyn salsa::Database,
+    pattern: &Pattern<tribute_front::ast::TypedRef<'_>>,
+) {
+    match &*pattern.kind {
+        PatternKind::Variant { ctor, fields } => {
+            assert!(!type_contains_univar(db, ctor.ty));
+            for field in fields {
+                assert_pattern_refs_resolved(db, field);
+            }
+        }
+        PatternKind::Record {
+            type_name, fields, ..
+        } => {
+            if let Some(type_name) = type_name {
+                assert!(!type_contains_univar(db, type_name.ty));
+            }
+            for field in fields {
+                if let Some(pattern) = &field.pattern {
+                    assert_pattern_refs_resolved(db, pattern);
+                }
+            }
+        }
+        PatternKind::Tuple(patterns) | PatternKind::List(patterns) => {
+            for pattern in patterns {
+                assert_pattern_refs_resolved(db, pattern);
+            }
+        }
+        PatternKind::ListRest { head, .. } => {
+            for pattern in head {
+                assert_pattern_refs_resolved(db, pattern);
+            }
+        }
+        PatternKind::As { pattern, .. } => assert_pattern_refs_resolved(db, pattern),
+        PatternKind::Wildcard
+        | PatternKind::Bind { .. }
+        | PatternKind::Literal(_)
+        | PatternKind::Error => {}
+    }
+}
+
+#[salsa_test]
+fn local_generalization_stays_scoped(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Signal {
+    fn tick(value: Nat) -> Nil
+}
+
+fn local_identity_and_handler() -> Nil {
+    let identity = fn(value) value
+    handle Signal::tick(identity(1)) {
+        do result { result }
+        fn Signal::tick(value) { Nil }
+    }
+}
+"#,
+    );
+
+    let errors = type_errors(db, source);
+    assert!(errors.is_empty(), "unexpected type errors: {errors:#?}");
+
+    let output = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    let scheme = output
+        .function_types(db)
+        .iter()
+        .find(|(name, _)| name == "local_identity_and_handler")
+        .map(|(_, scheme)| *scheme)
+        .expect("function scheme should be present");
+    assert!(
+        scheme.type_params(db).is_empty(),
+        "a body-local identity must not add a function scheme parameter"
+    );
+    assert!(!type_contains_univar(db, scheme.body(db)));
+
+    let metadata = output.expression_types(db);
+    for (node, ty) in &metadata.node_types {
+        assert!(
+            !type_contains_univar(db, *ty),
+            "node type {node:?} leaked raw UniVar: {:?}",
+            ty.kind(db)
+        );
+    }
+    for (_, ty) in &metadata.call_callee_types {
+        assert!(
+            !type_contains_univar(db, *ty),
+            "callee type leaked raw UniVar: {ty}"
+        );
+    }
+    for (_, operation) in output.handler_operations(db) {
+        for ty in operation
+            .ability_args
+            .iter()
+            .chain(operation.params.iter())
+            .chain([&operation.result])
+        {
+            assert!(
+                !type_contains_univar(db, *ty),
+                "handler metadata leaked raw UniVar: {ty}"
+            );
+        }
+    }
+    for (_, operation) in output.perform_operations(db) {
+        for ty in operation
+            .ability_args
+            .iter()
+            .chain(operation.params.iter())
+            .chain([&operation.result])
+        {
+            assert!(
+                !type_contains_univar(db, *ty),
+                "perform metadata leaked raw UniVar: {ty}"
+            );
+        }
+    }
+    for (_, signature) in output.lambda_signatures(db) {
+        assert!(
+            !type_contains_univar(db, signature.function_type),
+            "lambda metadata leaked raw UniVar: {}",
+            signature.function_type
+        );
+    }
+
+    let function = output
+        .module(db)
+        .decls
+        .iter()
+        .find_map(|decl| match decl {
+            Decl::Function(function) if function.name == "local_identity_and_handler" => {
+                Some(function)
+            }
+            _ => None,
+        })
+        .expect("typed function should be present");
+    assert_typed_refs_resolved(db, &function.body);
+}
+
 #[salsa_test]
 fn pure_local_identity_is_polymorphic(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -29,13 +379,121 @@ fn pure_local_identity_is_polymorphic(db: &salsa::DatabaseImpl) {
         r#"
 fn pair() -> #(Nat, Bool) {
     let identity = fn(value) value
-    #(identity(1), identity(true))
+    #(identity(1), identity(True))
+}
+
+"#,
+    );
+
+    let errors = type_errors(db, source);
+    assert!(errors.is_empty(), "unexpected type errors: {errors:#?}");
+}
+
+#[salsa_test]
+fn tuple_local_generalizations_have_distinct_lexical_owners(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn pair() -> #(Nat, Bool) {
+    let #(left, right) = #(fn(value) value, fn(value) value)
+    #(left(1), right(True))
 }
 "#,
     );
 
     let errors = type_errors(db, source);
     assert!(errors.is_empty(), "unexpected type errors: {errors:#?}");
+
+    let output = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    let mut scopes = Vec::new();
+    for (_, signature) in output.lambda_signatures(db) {
+        collect_local_bound_scopes(db, signature.function_type, &mut scopes);
+    }
+    scopes.sort_by_key(|scope| scope.raw());
+    scopes.dedup();
+    assert_eq!(
+        scopes.len(),
+        2,
+        "independent destructured local schemes must retain distinct owners: {scopes:?}"
+    );
+}
+
+#[salsa_test]
+fn unresolved_body_only_variable_is_diagnosed_and_recovered(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn ambiguous() -> Nil {
+    let identity = fn(value) value
+    identity(1)
+    []
+    Nil
+}
+"#,
+    );
+
+    let errors = type_errors(db, source);
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.contains("cannot infer a concrete type for")),
+        "expected a body-local ambiguity diagnostic, got: {errors:#?}"
+    );
+
+    let output = tribute_front::query::type_check_output(db, source)
+        .expect("error recovery should still produce typed output");
+    let function = output
+        .module(db)
+        .decls
+        .iter()
+        .find_map(|decl| match decl {
+            Decl::Function(function) if function.name == "ambiguous" => Some(function),
+            _ => None,
+        })
+        .expect("recovered typed function should be present");
+    assert_typed_refs_resolved(db, &function.body);
+    for (_, signature) in output.lambda_signatures(db) {
+        assert!(
+            !type_contains_univar(db, signature.function_type),
+            "recovered lambda metadata leaked raw UniVar: {}",
+            signature.function_type
+        );
+    }
+}
+
+#[salsa_test]
+fn multi_parameter_local_scheme_preserves_distinct_indices(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn pairs() -> #(#(Nat, Bool), #(Bool, Nat)) {
+    let pair = fn(left, right) #(left, right)
+    #(pair(1, True), pair(True, 1))
+}
+"#,
+    );
+
+    let errors = type_errors(db, source);
+    assert!(errors.is_empty(), "unexpected type errors: {errors:#?}");
+
+    let output = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    let mut bounds = Vec::new();
+    for (_, signature) in output.lambda_signatures(db) {
+        collect_local_bounds(db, signature.function_type, &mut bounds);
+    }
+    bounds.sort_by_key(|(scope, index)| (scope.raw(), *index));
+    bounds.dedup();
+    assert!(
+        bounds
+            .windows(2)
+            .any(|pair| pair[0].0 == pair[1].0 && pair[0].1 != pair[1].1),
+        "a multi-parameter local scheme must retain its distinct bound indices: {bounds:?}"
+    );
 }
 
 #[salsa_test]
@@ -50,7 +508,7 @@ enum Wrapped(a) {
 
 fn pair() -> #(Nat, Bool) {
     let Wrapped(identity) = Wrapped(fn(value) value)
-    #(identity(1), identity(true))
+    #(identity(1), identity(True))
 }
 "#,
     );
@@ -67,7 +525,7 @@ fn as_pattern_alias_preserves_polymorphism(db: &salsa::DatabaseImpl) {
         r#"
 fn pair() -> #(Nat, Bool) {
     let _ as identity = fn(value) value
-    #(identity(1), identity(true))
+    #(identity(1), identity(True))
 }
 "#,
     );

--- a/crates/tribute-front/tests/snapshots/block_scope__block_let_binding_accessible_inside.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__block_let_binding_accessible_inside.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 42} : core.i32
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/block_scope__block_with_case_pattern_binding.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__block_with_case_pattern_binding.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Option = adt.enum() {name = @Option, variants = [[@Some, [tribute_rt.anyref]], [@None, []]]}
 
-  tribute_control.func @example(%0: adt.typeref() {name = @Option}) -> core.i32 convention(cps) {
+  tribute_control.func @example(%0: adt.typeref() {name = @Option}) -> core.i32 convention(direct) {
       %1 = adt.variant_is %0 {tag = @Some, type = !Option} : core.i1
       %2 = scf.if %1 : core.i1 {
           %3 = adt.variant_cast %0 {tag = @Some, type = !Option} : !Option

--- a/crates/tribute-front/tests/snapshots/block_scope__nested_blocks_separate_scopes.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__nested_blocks_separate_scopes.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       tribute_control.return %1

--- a/crates/tribute-front/tests/snapshots/block_scope__outer_scope_accessible_in_inner_block.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__outer_scope_accessible_in_inner_block.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 10} : core.i32
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/block_scope__sequential_blocks_independent_scopes.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__sequential_blocks_independent_scopes.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       tribute_control.return %0

--- a/crates/tribute-front/tests/snapshots/case_type__case_bool_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_bool_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @invert(%0: core.i1) -> core.i1 convention(cps) {
+  tribute_control.func @invert(%0: core.i1) -> core.i1 convention(direct) {
       %1 = arith.const {value = true} : core.i1
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i1 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_enum_variant.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_enum_variant.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Option = adt.enum() {name = @Option, variants = [[@Some, [tribute_rt.anyref]], [@None, []]]}
 
-  tribute_control.func @unwrap_or(%0: adt.typeref() {name = @Option}, %1: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @unwrap_or(%0: adt.typeref() {name = @Option}, %1: core.i32) -> core.i32 convention(direct) {
       %2 = adt.variant_is %0 {tag = @Some, type = !Option} : core.i1
       %3 = scf.if %2 : core.i1 {
           %4 = adt.variant_cast %0 {tag = @Some, type = !Option} : !Option

--- a/crates/tribute-front/tests/snapshots/case_type__case_int_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_int_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @sign(%0: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @sign(%0: core.i32) -> core.i32 convention(direct) {
       %1 = arith.const {value = -1} : core.i32
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_nat_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_nat_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @classify(%0: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @classify(%0: core.i32) -> core.i32 convention(direct) {
       %1 = arith.const {value = 0} : core.i32
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_nested.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_nested.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @nested(%0: core.i32, %1: core.i1) -> core.i32 convention(cps) {
+  tribute_control.func @nested(%0: core.i32, %1: core.i1) -> core.i32 convention(direct) {
       %2 = arith.const {value = 0} : core.i32
       %3 = arith.cmpi %0, %2 {predicate = @eq} : core.i1
       %4 = scf.if %3 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_result_type_unification.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_result_type_unification.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @to_nat(%0: core.i1) -> core.i32 convention(cps) {
+  tribute_control.func @to_nat(%0: core.i1) -> core.i32 convention(direct) {
       %1 = arith.const {value = true} : core.i1
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
@@ -15,7 +15,7 @@ core.module @test {
       %2 = arith.addi %0, %1 : core.i32
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.nil convention(direct) {
+  tribute_control.func @main() -> core.nil convention(direct) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
       %0 = arith.const {value = unit} : core.nil
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_func_has_evidence_param.snap
@@ -7,7 +7,7 @@ core.module @test {
       %0 = tribute_control.perform {ability_ref = core.ability_ref() {name = @Foo}, op_name = @bar, operation_kind = @op} : core.i32
       tribute_control.return %0
   }
-  tribute_control.func @main() -> core.nil convention(direct) {
+  tribute_control.func @main() -> core.nil convention(direct) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
       %0 = arith.const {value = unit} : core.nil
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
@@ -7,7 +7,7 @@ core.module @test {
       %0 = tribute_control.perform {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask, operation_kind = @op} : core.i32
       tribute_control.return %0
   }
-  tribute_control.func @main() -> core.nil convention(direct) {
+  tribute_control.func @main() -> core.nil convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
       %0 = tribute_control.handle : core.i32 {
           %1 = tribute_control.call {callee = @use_ask} : core.i32
           tribute_control.yield %1

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_false.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_false.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @no() -> core.i1 convention(cps) {
+  tribute_control.func @no() -> core.i1 convention(direct) {
       %0 = arith.const {value = false} : core.i1
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_true.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_true.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @yes() -> core.i1 convention(cps) {
+  tribute_control.func @yes() -> core.i1 convention(direct) {
       %0 = arith.const {value = true} : core.i1
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @logic(%0: core.i1, %1: core.i1) -> core.i1 convention(cps) {
+  tribute_control.func @logic(%0: core.i1, %1: core.i1) -> core.i1 convention(direct) {
       %2 = scf.if %0 : core.i1 {
           %3 = arith.const {value = true} : core.i1
           scf.yield %3

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bytes_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bytes_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @data() -> core.bytes convention(cps) {
+  tribute_control.func @data() -> core.bytes convention(direct) {
       %0 = adt.bytes_const {value = b"payload"} : core.bytes
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
@@ -13,7 +13,7 @@ core.module @test {
   tribute_control.func @"Float::<="(%arg0: core.f64, %arg1: core.f64) -> core.i1 convention(direct)
   tribute_control.func @"Float::>"(%arg0: core.f64, %arg1: core.f64) -> core.i1 convention(direct)
   tribute_control.func @"Float::>="(%arg0: core.f64, %arg1: core.f64) -> core.i1 convention(direct)
-  tribute_control.func @comparisons(%0: core.f64, %1: core.f64) -> !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool_1 convention(cps) {
+  tribute_control.func @comparisons(%0: core.f64, %1: core.f64) -> !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool_1 convention(direct) {
       %2 = tribute_control.call %0, %1 {callee = @"Float::=="} : core.i1
       %3 = tribute_control.call %0, %1 {callee = @"Float::!="} : core.i1
       %4 = tribute_control.call %0, %1 {callee = @"Float::<"} : core.i1

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @pi() -> core.f64 convention(cps) {
+  tribute_control.func @pi() -> core.f64 convention(direct) {
       %0 = arith.const {value = 3.14} : core.f64
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
@@ -3,13 +3,11 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
-
-  tribute_control.func @id(%0: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @id(%0: core.i32) -> core.i32 convention(direct) {
       tribute_control.return %0
   }
   tribute_control.func @test_ref() -> core.i32 convention(cps) {
-      %0 = tribute_control.func_ref {func_ref = @id} : !t0
+      %0 = tribute_control.func_ref {func_ref = @id} : tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
       %1 = arith.const {value = 1} : core.i32
       %2 = tribute_control.call_indirect %0, %1 : core.i32
       tribute_control.return %2

--- a/crates/tribute-front/tests/snapshots/expr_coverage__list_literals_use_shared_sequence_ops.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__list_literals_use_shared_sequence_ops.snap
@@ -3,13 +3,13 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
+  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 0}
 
-  tribute_control.func @empty() -> tribute_rt.anyref convention(cps) {
+  tribute_control.func @empty() -> tribute_rt.anyref convention(direct) {
       %0 = list.empty {element_type = tribute_rt.anyref} : tribute_rt.anyref
       tribute_control.return %0
   }
-  tribute_control.func @numbers() -> tribute_rt.anyref convention(cps) {
+  tribute_control.func @numbers() -> tribute_rt.anyref convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32

--- a/crates/tribute-front/tests/snapshots/expr_coverage__list_sequence_patterns_use_shared_observation_ops.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__list_sequence_patterns_use_shared_observation_ops.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @observe(%0: tribute_rt.anyref) -> core.i32 convention(cps) {
+  tribute_control.func @observe(%0: tribute_rt.anyref) -> core.i32 convention(direct) {
       %1 = list.is_empty %0 {element_type = core.i32} : core.i1
       %2 = scf.if %1 : core.i32 {
           %3 = arith.const {value = 0} : core.i32

--- a/crates/tribute-front/tests/snapshots/expr_coverage__nil_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__nil_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @nothing() -> core.nil convention(cps) {
+  tribute_control.func @nothing() -> core.nil convention(direct) {
       %0 = arith.const {value = unit} : core.nil
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__rune_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__rune_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @letter() -> core.i32 convention(cps) {
+  tribute_control.func @letter() -> core.i32 convention(direct) {
       %0 = arith.const {value = 97} : core.i32
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__string_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__string_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @greeting() -> tribute_rt.anyref convention(cps) {
+  tribute_control.func @greeting() -> tribute_rt.anyref convention(direct) {
       %0 = adt.string_const {value = "hello"} : tribute_rt.anyref
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__tuple_construction.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__tuple_construction.snap
@@ -6,7 +6,7 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_4_bool = adt.struct() {fields = [[@0, core.i32], [@1, core.i1]], name = @__logical_tuple_tuple_3_1_2_3_nat_4_bool}
   !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_4_bool}
 
-  tribute_control.func @pair() -> !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1 convention(cps) {
+  tribute_control.func @pair() -> !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1 convention(direct) {
       %0 = arith.const {value = 42} : core.i32
       %1 = arith.const {value = true} : core.i1
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_4_bool} : !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -5,7 +5,8 @@ expression: ir_text
 core.module @test {
   !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
   !t1 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
-  !t2 = core.ability_ref(tribute_rt.anyref) {name = @State}
+  !t2 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 0}
+  !t3 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
   tribute_control.func @counter() -> core.i32 convention(cps) {
       %0 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
@@ -22,29 +23,37 @@ core.module @test {
         ^bb2(%4: tribute_rt.anyref):
           tribute_control.yield %4
       } {
-          tribute_control.handler {ability_ref = !t2, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
+          tribute_control.handler {ability_ref = !t3, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
             ^bb4(%5: tribute_control.resume_token(tribute_rt.anyref, tribute_rt.anyref)):
-              %6 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%1, %5] {
+              %6 = tribute_control.lambda() -> tribute_rt.anyref convention(direct) captures [%1, %5] {
                   %7 = tribute_control.resume %5, %1 : tribute_rt.anyref
                   tribute_control.return %7
               }
-              %8 = tribute_control.call %6, %1 {callee = @run_state} : tribute_rt.anyref
-              tribute_control.yield %8
-          }
-          tribute_control.handler {ability_ref = !t2, kind = @op, op_name = @set, operation_result_type = core.nil} {
-            ^bb6(%9: tribute_rt.anyref, %10: tribute_control.resume_token(core.nil, tribute_rt.anyref)):
-              %11 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%10] {
-                  %12 = arith.const {value = unit} : core.nil
-                  %13 = tribute_control.resume %10, %12 : tribute_rt.anyref
-                  tribute_control.return %13
+              %8 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%6] {
+                  %9 = tribute_control.call_indirect %6 : tribute_rt.anyref
+                  tribute_control.return %9
               }
-              %14 = tribute_control.call %11, %9 {callee = @run_state} : tribute_rt.anyref
-              tribute_control.yield %14
+              %10 = tribute_control.call %8, %1 {callee = @run_state} : tribute_rt.anyref
+              tribute_control.yield %10
+          }
+          tribute_control.handler {ability_ref = !t3, kind = @op, op_name = @set, operation_result_type = core.nil} {
+            ^bb7(%11: tribute_rt.anyref, %12: tribute_control.resume_token(core.nil, tribute_rt.anyref)):
+              %13 = tribute_control.lambda() -> tribute_rt.anyref convention(direct) captures [%12] {
+                  %14 = arith.const {value = unit} : core.nil
+                  %15 = tribute_control.resume %12, %14 : tribute_rt.anyref
+                  tribute_control.return %15
+              }
+              %16 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%13] {
+                  %17 = tribute_control.call_indirect %13 : tribute_rt.anyref
+                  tribute_control.return %17
+              }
+              %18 = tribute_control.call %16, %11 {callee = @run_state} : tribute_rt.anyref
+              tribute_control.yield %18
           }
       }
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.call {callee = @counter} : core.i32
           %2 = tribute_control.call {callee = @counter} : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
@@ -28,14 +28,12 @@ core.module @test {
       }
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
-          %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
-          %3 = core.unrealized_conversion_cast %2 : core.i32
-          tribute_control.return %3
+          tribute_control.return %1
       }
-      %4 = tribute_control.call %0 {callee = @run_with_state} : core.i32
-      tribute_control.return %4
+      %2 = tribute_control.call %0 {callee = @run_with_state} : core.i32
+      tribute_control.return %2
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -35,7 +35,7 @@ core.module @test {
       }
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.call {callee = @counter} : core.i32
           tribute_control.return %1

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
@@ -28,7 +28,7 @@ core.module @test {
       }
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
           %2 = arith.const {value = 1} : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
@@ -4,7 +4,8 @@ expression: ir_text
 ---
 core.module @test {
   !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
-  !t1 = core.ability_ref(tribute_rt.anyref) {name = @State}
+  !t1 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 0}
+  !t2 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
   tribute_control.func @run_state(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref convention(cps) {
       %2 = tribute_control.handle : tribute_rt.anyref {
@@ -14,29 +15,37 @@ core.module @test {
         ^bb2(%4: tribute_rt.anyref):
           tribute_control.yield %4
       } {
-          tribute_control.handler {ability_ref = !t1, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
+          tribute_control.handler {ability_ref = !t2, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
             ^bb4(%5: tribute_control.resume_token(tribute_rt.anyref, tribute_rt.anyref)):
-              %6 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%1, %5] {
+              %6 = tribute_control.lambda() -> tribute_rt.anyref convention(direct) captures [%1, %5] {
                   %7 = tribute_control.resume %5, %1 : tribute_rt.anyref
                   tribute_control.return %7
               }
-              %8 = tribute_control.call %6, %1 {callee = @run_state} : tribute_rt.anyref
-              tribute_control.yield %8
-          }
-          tribute_control.handler {ability_ref = !t1, kind = @op, op_name = @set, operation_result_type = core.nil} {
-            ^bb6(%9: tribute_rt.anyref, %10: tribute_control.resume_token(core.nil, tribute_rt.anyref)):
-              %11 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%10] {
-                  %12 = arith.const {value = unit} : core.nil
-                  %13 = tribute_control.resume %10, %12 : tribute_rt.anyref
-                  tribute_control.return %13
+              %8 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%6] {
+                  %9 = tribute_control.call_indirect %6 : tribute_rt.anyref
+                  tribute_control.return %9
               }
-              %14 = tribute_control.call %11, %9 {callee = @run_state} : tribute_rt.anyref
-              tribute_control.yield %14
+              %10 = tribute_control.call %8, %1 {callee = @run_state} : tribute_rt.anyref
+              tribute_control.yield %10
+          }
+          tribute_control.handler {ability_ref = !t2, kind = @op, op_name = @set, operation_result_type = core.nil} {
+            ^bb7(%11: tribute_rt.anyref, %12: tribute_control.resume_token(core.nil, tribute_rt.anyref)):
+              %13 = tribute_control.lambda() -> tribute_rt.anyref convention(direct) captures [%12] {
+                  %14 = arith.const {value = unit} : core.nil
+                  %15 = tribute_control.resume %12, %14 : tribute_rt.anyref
+                  tribute_control.return %15
+              }
+              %16 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%13] {
+                  %17 = tribute_control.call_indirect %13 : tribute_rt.anyref
+                  tribute_control.return %17
+              }
+              %18 = tribute_control.call %16, %11 {callee = @run_state} : tribute_rt.anyref
+              tribute_control.yield %18
           }
       }
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(direct) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = arith.const {value = 0} : core.i32
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -4,7 +4,9 @@ expression: ir_text
 ---
 core.module @test {
   !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
-  !t1 = core.ability_ref(tribute_rt.anyref) {name = @State}
+  !t1 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 0}
+  !t2 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t3 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
   tribute_control.func @with_state(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref convention(cps) {
       %2 = tribute_control.handle : tribute_rt.anyref {
@@ -14,40 +16,46 @@ core.module @test {
         ^bb2(%4: tribute_rt.anyref):
           tribute_control.yield %4
       } {
-          tribute_control.handler {ability_ref = !t1, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
+          tribute_control.handler {ability_ref = !t3, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
             ^bb4(%5: tribute_control.resume_token(tribute_rt.anyref, tribute_rt.anyref)):
-              %6 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%1, %5] {
+              %6 = tribute_control.lambda() -> tribute_rt.anyref convention(direct) captures [%1, %5] {
                   %7 = tribute_control.resume %5, %1 : tribute_rt.anyref
                   tribute_control.return %7
               }
-              %8 = tribute_control.call %6, %1 {callee = @with_state} : tribute_rt.anyref
-              tribute_control.yield %8
-          }
-          tribute_control.handler {ability_ref = !t1, kind = @op, op_name = @set, operation_result_type = core.nil} {
-            ^bb6(%9: tribute_rt.anyref, %10: tribute_control.resume_token(core.nil, tribute_rt.anyref)):
-              %11 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%10] {
-                  %12 = arith.const {value = unit} : core.nil
-                  %13 = tribute_control.resume %10, %12 : tribute_rt.anyref
-                  tribute_control.return %13
+              %8 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%6] {
+                  %9 = tribute_control.call_indirect %6 : tribute_rt.anyref
+                  tribute_control.return %9
               }
-              %14 = tribute_control.call %11, %9 {callee = @with_state} : tribute_rt.anyref
-              tribute_control.yield %14
+              %10 = tribute_control.call %8, %1 {callee = @with_state} : tribute_rt.anyref
+              tribute_control.yield %10
+          }
+          tribute_control.handler {ability_ref = !t3, kind = @op, op_name = @set, operation_result_type = core.nil} {
+            ^bb7(%11: tribute_rt.anyref, %12: tribute_control.resume_token(core.nil, tribute_rt.anyref)):
+              %13 = tribute_control.lambda() -> tribute_rt.anyref convention(direct) captures [%12] {
+                  %14 = arith.const {value = unit} : core.nil
+                  %15 = tribute_control.resume %12, %14 : tribute_rt.anyref
+                  tribute_control.return %15
+              }
+              %16 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%13] {
+                  %17 = tribute_control.call_indirect %13 : tribute_rt.anyref
+                  tribute_control.return %17
+              }
+              %18 = tribute_control.call %16, %11 {callee = @with_state} : tribute_rt.anyref
+              tribute_control.yield %18
           }
       }
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
-          %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
-          %3 = core.unrealized_conversion_cast %2 : core.i32
-          tribute_control.return %3
+          tribute_control.return %1
       }
-      %4 = arith.const {value = 42} : core.i32
-      %5 = core.unrealized_conversion_cast %0 : !t0
-      %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %7 = tribute_control.call %5, %6 {callee = @with_state} : tribute_rt.anyref
-      %8 = core.unrealized_conversion_cast %7 : core.i32
-      tribute_control.return %8
+      %2 = arith.const {value = 42} : core.i32
+      %3 = core.unrealized_conversion_cast %0 : !t0
+      %4 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
+      %5 = tribute_control.call %3, %4 {callee = @with_state} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %5 : core.i32
+      tribute_control.return %6
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
@@ -27,18 +27,16 @@ core.module @test {
       %1 = tribute_control.call_indirect %0 : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
               %2 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
-              %3 = core.unrealized_conversion_cast %2 : tribute_rt.anyref
-              %4 = core.unrealized_conversion_cast %3 : core.i32
-              tribute_control.return %4
+              tribute_control.return %2
           }
-          %5 = tribute_control.call %1 {callee = @run_with_state} : core.i32
-          tribute_control.return %5
+          %3 = tribute_control.call %1 {callee = @run_with_state} : core.i32
+          tribute_control.return %3
       }
-      %6 = tribute_control.call %0 {callee = @apply_thunk} : core.i32
-      tribute_control.return %6
+      %4 = tribute_control.call %0 {callee = @apply_thunk} : core.i32
+      tribute_control.return %4
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
@@ -9,14 +9,18 @@ core.module @test {
       %2 = tribute_control.call_indirect %0, %1 : core.i32
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
-      %0 = tribute_control.lambda(%1: core.i32) -> core.i32 convention(cps) captures [] {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
+      %0 = tribute_control.lambda(%1: core.i32) -> core.i32 convention(direct) captures [] {
           %2 = arith.const {value = 1} : core.i32
           %3 = arith.addi %1, %2 : core.i32
           tribute_control.return %3
       }
       %4 = arith.const {value = 41} : core.i32
-      %5 = tribute_control.call %0, %4 {callee = @apply} : core.i32
-      tribute_control.return %5
+      %5 = tribute_control.lambda(%6: core.i32) -> core.i32 convention(cps) captures [%0] {
+          %7 = tribute_control.call_indirect %0, %6 : core.i32
+          tribute_control.return %7
+      }
+      %8 = tribute_control.call %5, %4 {callee = @apply} : core.i32
+      tribute_control.return %8
   }
 }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
@@ -9,14 +9,18 @@ core.module @test {
       %2 = tribute_control.call_indirect %0, %1 : core.i32
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = arith.const {value = 10} : core.i32
-      %1 = tribute_control.lambda(%2: core.i32) -> core.i32 convention(cps) captures [%0] {
+      %1 = tribute_control.lambda(%2: core.i32) -> core.i32 convention(direct) captures [%0] {
           %3 = arith.addi %2, %0 : core.i32
           tribute_control.return %3
       }
       %4 = arith.const {value = 32} : core.i32
-      %5 = tribute_control.call %1, %4 {callee = @apply} : core.i32
-      tribute_control.return %5
+      %5 = tribute_control.lambda(%6: core.i32) -> core.i32 convention(cps) captures [%1] {
+          %7 = tribute_control.call_indirect %1, %6 : core.i32
+          tribute_control.return %7
+      }
+      %8 = tribute_control.call %5, %4 {callee = @apply} : core.i32
+      tribute_control.return %8
   }
 }

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Point} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @make_point() -> !Point_1 convention(cps) {
+  tribute_control.func @make_point() -> !Point_1 convention(direct) {
       %0 = arith.const {value = 10} : core.i32
       %1 = arith.const {value = 20} : core.i32
       %2 = adt.struct_new %0, %1 {type = !Point} : !Point_1

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Pair} : tribute_rt.anyref
       tribute_control.return %1
   }
-  tribute_control.func @make_pair() -> !Pair_1 convention(cps) {
+  tribute_control.func @make_pair() -> !Pair_1 convention(direct) {
       %0 = arith.const {value = 42} : core.i32
       %1 = arith.const {value = true} : core.i1
       %2 = adt.struct_new %0, %1 {type = !Pair} : !Pair_1

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Point} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @update_x(%0: !Point_1) -> !Point_1 convention(cps) {
+  tribute_control.func @update_x(%0: !Point_1) -> !Point_1 convention(direct) {
       %1 = arith.const {value = 100} : core.i32
       %2 = adt.struct_get %0 {field = 1, type = !Point} : core.i32
       %3 = adt.struct_new %1, %2 {type = !Point} : !Point_1

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Point_1} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @replace_all(%0: !Point) -> !Point convention(cps) {
+  tribute_control.func @replace_all(%0: !Point) -> !Point convention(direct) {
       %1 = arith.const {value = 1} : core.i32
       %2 = arith.const {value = 2} : core.i32
       %3 = adt.struct_new %1, %2 {type = !Point_1} : !Point

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Config} : core.i1
       tribute_control.return %1
   }
-  tribute_control.func @copy_config(%0: !Config_1) -> !Config_1 convention(cps) {
+  tribute_control.func @copy_config(%0: !Config_1) -> !Config_1 convention(direct) {
       %1 = adt.struct_get %0 {field = 0, type = !Config} : core.i1
       %2 = adt.struct_get %0 {field = 1, type = !Config} : core.i1
       %3 = adt.struct_new %1, %2 {type = !Config} : !Config_1

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
@@ -6,7 +6,7 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32]], name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
 
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_from_function.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_from_function.snap
@@ -6,11 +6,11 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32]], name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
 
-  tribute_control.func @make_pair(%0: core.i32, %1: core.i32) -> !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 convention(cps) {
+  tribute_control.func @make_pair(%0: core.i32, %1: core.i32) -> !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 convention(direct) {
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1
       tribute_control.return %2
   }
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 10} : core.i32
       %1 = arith.const {value = 20} : core.i32
       %2 = tribute_control.call %0, %1 {callee = @make_pair} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
@@ -8,7 +8,7 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1]], name = @__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat}
 
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
@@ -6,7 +6,7 @@ core.module @test {
   !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32], [@2, core.i32]], name = @__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat}
   !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat}
 
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
@@ -4,9 +4,9 @@ expression: ir_text
 ---
 core.module @test {
   !Triple = adt.typeref() {name = @Triple}
+  !t0 = tribute_control.callable(core.i32, !Triple) {tribute.calling_convention = 0}
   !Triple_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32], [@z, core.i32]], name = @Triple}
   !Pair = adt.typeref() {name = @Pair}
-  !t0 = tribute_control.callable(core.i32, !Triple) {tribute.calling_convention = 0}
   !t1 = tribute_control.callable(core.i32, !Pair) {tribute.calling_convention = 0}
   !Pair_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32]], name = @Pair}
 
@@ -30,13 +30,13 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 2, type = !Triple_1} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(cps) {
+  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(direct) {
       %2 = tribute_control.call %0 {callee = @"Pair::x"} : core.i32
       %3 = tribute_control.call %0 {callee = @"Pair::y"} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple_1} : !Triple
       tribute_control.return %4
   }
-  tribute_control.func @"Triple::sum"(%0: !Triple) -> core.i32 convention(cps) {
+  tribute_control.func @"Triple::sum"(%0: !Triple) -> core.i32 convention(direct) {
       %1 = tribute_control.call %0 {callee = @"Triple::x"} : core.i32
       %2 = tribute_control.call %0 {callee = @"Triple::y"} : core.i32
       %3 = arith.addi %1, %2 : core.i32
@@ -44,7 +44,7 @@ core.module @test {
       %5 = arith.addi %3, %4 : core.i32
       tribute_control.return %5
   }
-  tribute_control.func @test(%0: !Pair) -> core.i32 convention(cps) {
+  tribute_control.func @test(%0: !Pair) -> core.i32 convention(direct) {
       %1 = arith.const {value = 3} : core.i32
       %2 = tribute_control.call %0, %1 {callee = @"Pair::extend"} : !Triple
       %3 = tribute_control.call %2 {callee = @"Triple::sum"} : core.i32

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
@@ -30,13 +30,13 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 2, type = !Triple_1} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(cps) {
+  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(direct) {
       %2 = tribute_control.call %0 {callee = @"Pair::x"} : core.i32
       %3 = tribute_control.call %0 {callee = @"Pair::y"} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple_1} : !Triple
       tribute_control.return %4
   }
-  tribute_control.func @test(%0: !Pair) -> !Triple convention(cps) {
+  tribute_control.func @test(%0: !Pair) -> !Triple convention(direct) {
       %1 = arith.const {value = 3} : core.i32
       %2 = tribute_control.call %0, %1 {callee = @"Pair::extend"} : !Triple
       tribute_control.return %2

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -20,19 +20,18 @@ mod ability {
         {}
     }
 
-    /// Perform an ability operation with an explicit continuation closure.
-    ///
-    /// The continuation closure captures the rest of the computation
-    /// after the effect point.
+    /// Perform a general ability operation through an exact result-indexed
+    /// dispatch and resumption pair.
     ///
     /// ```text
-    /// %yr = ability.perform %continuation, [%args...]
+    /// ability.perform %evidence, %dispatch, %resume, [%args...]
     ///   { ability_ref: @State, op_name: @get }
     /// ```
     ///
-    /// Lowered to: evidence lookup → ShiftInfo construction → YieldResult::Shift.
+    /// Both control closures retain their exact CPS types. Only source values
+    /// are packed for dispatch.
     #[attr(ability_ref: Type, op_name: Symbol)]
-    fn perform(continuation: (), #[rest] values: ()) -> result {}
+    fn perform(evidence: (), dispatch: (), resume: (), #[rest] values: ()) -> result {}
 
     /// Legacy frontend form using the carrier pipeline's null-or-single-value
     /// payload convention until the frontend/pipeline migration is complete.
@@ -82,15 +81,15 @@ mod ability {
     /// Resultless proper-tail handler delimiter emitted by
     /// `tribute_control_to_cps`.
     ///
-    /// `ability_refs` is ordered to match pairs in `dispatchers`. Each pair is
+    /// `prompt_tag` is the runtime-unique identity allocated for this exact
+    /// delimiter. `ability_refs` is ordered to match pairs in `dispatchers`. Each pair is
     /// `(tr_dispatch_fn, handler_dispatch)`, using typed reject closures when a
     /// handled ability has no operation of that kind. `resolve_evidence`
-    /// allocates one runtime-unique prompt identity for the delimiter and
-    /// shares it across every pair. The body entry block receives the extended
+    /// consumes that exact identity and shares it across every pair. The body entry block receives the extended
     /// evidence. Every body path ends in a proper tail transfer or
     /// `func.unreachable`.
     #[attr(ability_refs: any)]
-    fn handle_dispatch(evidence: (), #[rest] dispatchers: ()) {
+    fn handle_dispatch(evidence: (), prompt_tag: (), #[rest] dispatchers: ()) {
         #[region(body)]
         {}
     }

--- a/crates/tribute-ir/src/dialect/closure.rs
+++ b/crates/tribute-ir/src/dialect/closure.rs
@@ -234,11 +234,21 @@ fn parse_closure_lambda<'a>(
     };
 
     // closure.closure<core.func<...>>
+    //
+    // Physical closure.lambda operations carry their exact calling convention
+    // on both the operation and the outer closure type. The custom syntax
+    // prints the operation dictionary only, so reconstruct the durable type
+    // provenance from that exact attribute during parsing.
+    let closure_type_attrs = attributes
+        .iter()
+        .find(|(key, _)| *key == crate::dialect::tribute_control::CALLING_CONVENTION_ATTR)
+        .map(|(key, value)| vec![(*key, value.clone())])
+        .unwrap_or_default();
     let closure_raw_ty = RawType::Concrete {
         dialect: "closure",
         name: "closure",
         params: vec![func_raw_ty],
-        attrs: vec![],
+        attrs: closure_type_attrs,
     };
 
     Ok(RawOperation {
@@ -566,6 +576,35 @@ mod tests {
     func.return %0
   }
 }"#,
+        );
+    }
+
+    #[test]
+    fn test_lambda_parser_preserves_calling_convention_on_closure_type() {
+        let input = r#"core.module @test {
+  func.func @main() -> core.i32 {
+    %0 = closure.lambda(%1: core.i32) -> core.i32 {tribute.calling_convention = 2} {
+        func.return %1
+    }
+    func.return %0
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(&mut ctx, input);
+        let module_entry = ctx.region(module.body(&ctx).unwrap()).blocks[0];
+        let function =
+            trunk_ir::dialect::func::Func::from_op(&ctx, ctx.block(module_entry).ops[0]).unwrap();
+        let function_entry = ctx.region(function.body(&ctx)).blocks[0];
+        let lambda = super::Lambda::from_op(&ctx, ctx.block(function_entry).ops[0]).unwrap();
+        let closure_ty = ctx.value_ty(lambda.result(&ctx));
+
+        assert_eq!(
+            ctx.types
+                .get(closure_ty)
+                .attrs
+                .get_u8(crate::dialect::tribute_control::CALLING_CONVENTION_ATTR)
+                .unwrap(),
+            Some(2)
         );
     }
 

--- a/crates/tribute-ir/src/dialect/effect.rs
+++ b/crates/tribute-ir/src/dialect/effect.rs
@@ -30,10 +30,11 @@ mod effect {
 
     /// Dispatch a general CPS `op` ability operation.
     ///
-    /// `continuation` is the already-constructed continuation closure and
-    /// `payload` is the single packed operation argument value.
+    /// `dispatch` and `resume` retain exact result-indexed CPS closure types;
+    /// `payload` is the single packed source operation argument value. Dispatch
+    /// is a proper-tail transfer and therefore produces no control result.
     #[attr(ability_ref: Type, op_name: Symbol)]
-    fn dispatch_cps(evidence: (), continuation: (), payload: ()) -> result {}
+    fn dispatch_cps(evidence: (), dispatch: (), resume: (), payload: ()) {}
 }
 
 inventory::submit! { trunk_ir::op_interface::PureOps::register("effect", "extend") }
@@ -116,7 +117,8 @@ mod tests {
         let ability = ability_ref(&mut ctx, "Console");
         let evidence = const_i32(&mut ctx, loc, ptr_ty, 0);
         let payload = const_i32(&mut ctx, loc, anyref_ty, 1);
-        let continuation = const_i32(&mut ctx, loc, anyref_ty, 2);
+        let dispatch = const_i32(&mut ctx, loc, anyref_ty, 2);
+        let resume = const_i32(&mut ctx, loc, anyref_ty, 3);
 
         let tail = super::dispatch_tail(
             &mut ctx,
@@ -131,9 +133,9 @@ mod tests {
             &mut ctx,
             loc,
             evidence,
-            continuation,
+            dispatch,
+            resume,
             payload,
-            anyref_ty,
             ability,
             Symbol::new("get"),
         );
@@ -147,8 +149,10 @@ mod tests {
         assert_eq!(tail_wrapper.payload(&ctx), payload);
         assert_eq!(tail_wrapper.ability_ref(&ctx), ability);
         assert_eq!(tail_wrapper.op_name(&ctx), Symbol::new("print"));
-        assert_eq!(cps_wrapper.continuation(&ctx), continuation);
+        assert_eq!(cps_wrapper.dispatch(&ctx), dispatch);
+        assert_eq!(cps_wrapper.resume(&ctx), resume);
         assert_eq!(cps_wrapper.op_name(&ctx), Symbol::new("get"));
+        assert!(ctx.op_results(cps.op_ref()).is_empty());
 
         let tail_printed = print_op(&ctx, tail.op_ref());
         assert!(tail_printed.contains("effect.dispatch_tail"));

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -112,6 +112,8 @@ mod tribute_control {
     fn resume(resume_token: (), value: ()) -> result {}
 
     fn r#yield(value: ()) {}
+
+    fn unreachable() {}
 }
 
 /// Typed wrapper for `tribute_control.callable(Result, Params...)`.
@@ -177,7 +179,10 @@ pub fn callable_convention(ctx: &IrContext, ty: TypeRef) -> Option<CallingConven
         .and_then(|code| CallingConvention::try_from(code).ok())
 }
 
-fn resume_token_parts(ctx: &IrContext, ty: TypeRef) -> Option<(TypeRef, TypeRef)> {
+/// Return the exact source input and handler-answer types carried by a resume
+/// token.  Source lowering uses this provenance to materialize erased source
+/// data at the token's declared type; control continuations are never erased.
+pub fn resume_token_parts(ctx: &IrContext, ty: TypeRef) -> Option<(TypeRef, TypeRef)> {
     if !ResumeToken::matches(ctx, ty) {
         return None;
     }
@@ -1663,6 +1668,40 @@ fn validate_yield(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>)
     }
 }
 
+fn validate_unreachable(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
+    validate_arity(ctx, op, Some(0), Some(0), Some(0), errors);
+    validate_attr_keys(ctx, op, &[], false, errors);
+    let Some(block) = ctx.op(op).parent_block else {
+        push_op_error(
+            ctx,
+            op,
+            errors,
+            "must terminate an exhaustive scf.if region",
+        );
+        return;
+    };
+    if ctx.block(block).ops.last().copied() != Some(op) {
+        push_op_error(ctx, op, errors, "must be the final operation in its block");
+    }
+    let placed = parent_op(ctx, op).is_some_and(|owner| {
+        ctx.op(owner).dialect == Symbol::new("scf")
+            && ctx.op(owner).name == Symbol::new("if")
+            && ctx
+                .op(owner)
+                .regions
+                .iter()
+                .any(|&region| parent_region(ctx, op) == Some(region))
+    });
+    if !placed {
+        push_op_error(
+            ctx,
+            op,
+            errors,
+            "must terminate an exhaustive scf.if region",
+        );
+    }
+}
+
 fn validate_local_operation(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
     let data = ctx.op(op);
     if data.dialect != Symbol::new("tribute_control") {
@@ -1680,6 +1719,7 @@ fn validate_local_operation(ctx: &IrContext, op: OpRef, errors: &mut Vec<Validat
         "handler" => validate_handler(ctx, op, errors),
         "resume" => validate_resume(ctx, op, errors),
         "yield" => validate_yield(ctx, op, errors),
+        "unreachable" => validate_unreachable(ctx, op, errors),
         name => push_op_error(
             ctx,
             op,
@@ -1751,6 +1791,25 @@ fn same_source_signature(ctx: &IrContext, left: TypeRef, right: TypeRef) -> bool
     left_result == right_result && left_params == right_params
 }
 
+/// Return the unmangled base of a specialized direct-call symbol.
+///
+/// A nonempty `$...` suffix is required. This helper identifies only the
+/// spelling relation; callers must still prove that the base is an eligible
+/// body-less intrinsic declaration and must give exact symbols priority.
+pub fn specialized_intrinsic_base(symbol: Symbol) -> Option<Symbol> {
+    symbol.with_str(|text| {
+        text.split_once('$')
+            .filter(|(base, suffix)| !base.is_empty() && !suffix.is_empty())
+            .map(|(base, _)| Symbol::from_dynamic(base))
+    })
+}
+
+fn is_intrinsic_declaration(ctx: &IrContext, op: OpRef) -> bool {
+    is_control_op(ctx, op, "func")
+        && ctx.op(op).regions.is_empty()
+        && ctx.op(op).attributes.get_str("abi") == Some("intrinsic")
+}
+
 fn validate_symbol_uses(
     ctx: &IrContext,
     body: RegionRef,
@@ -1800,10 +1859,25 @@ fn validate_symbol_uses(
             let Some(symbol) = ctx.op(op).attributes.get_symbol("callee") else {
                 return;
             };
-            let Some(target) = funcs.get(&symbol).copied() else {
+            let exact_target = funcs.get(&symbol).copied();
+            let target = exact_target.or_else(|| {
+                let base = specialized_intrinsic_base(symbol)?;
+                funcs
+                    .get(&base)
+                    .copied()
+                    .filter(|target| is_intrinsic_declaration(ctx, *target))
+            });
+            let Some(target) = target else {
                 push_op_error(ctx, op, errors, format!("unresolved callee @{symbol}"));
                 return;
             };
+            // A specialized intrinsic call deliberately has no declaration at
+            // its mangled symbol. Its exact types were selected by the
+            // frontend and are carried on the call itself; the unmangled
+            // declaration authorizes only its ABI/lowering family.
+            if exact_target.is_none() {
+                return;
+            }
             let Some(target_ty) = ctx.op(target).attributes.get_type("type") else {
                 return;
             };
@@ -2852,6 +2926,42 @@ mod tests {
             assert!(printed.contains(expected), "missing {expected}\n{printed}");
         }
         assert!(printed.contains("tribute.calling_convention = 0"));
+    }
+
+    #[test]
+    fn logical_unreachable_round_trips_and_is_limited_to_a_structured_arm() {
+        let input = r#"core.module @test {
+  tribute_control.func @select(%condition: core.i1, %value: core.i32) -> core.i32 convention(direct) {
+    %selected = scf.if %condition : core.i32 {
+      scf.yield %value
+    } {
+      tribute_control.unreachable
+    }
+    tribute_control.return %selected
+  }
+}"#;
+        let (ctx, module) = parse_fixture(input);
+        let result = validate(&ctx, module, &[]);
+        assert!(result.is_ok(), "{result}");
+        let printed = assert_round_trip(&ctx, module);
+        assert!(printed.contains("tribute_control.unreachable"), "{printed}");
+    }
+
+    #[test]
+    fn logical_unreachable_outside_a_structured_arm_is_rejected_without_mutation() {
+        let input = r#"core.module @test {
+  tribute_control.func @bad() -> core.i32 convention(direct) {
+    tribute_control.unreachable
+  }
+}"#;
+        let (ctx, module) = parse_fixture(input);
+        let before = print_module(&ctx, module.op());
+        let result = validate(&ctx, module, &[]);
+        assert!(
+            messages(&result).contains("must terminate an exhaustive scf.if region"),
+            "{result}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/tribute-passes/Cargo.toml
+++ b/crates/tribute-passes/Cargo.toml
@@ -13,6 +13,7 @@ tracing.workspace = true
 tribute-core.workspace = true
 tribute-ir.workspace = true
 trunk-ir.workspace = true
+trunk-ir-cranelift-backend.workspace = true
 trunk-ir-wasm-backend.workspace = true
 
 [dev-dependencies]

--- a/crates/tribute-passes/src/backend_ready.rs
+++ b/crates/tribute-passes/src/backend_ready.rs
@@ -1,0 +1,1115 @@
+//! Tribute-specific final backend boundaries.
+//!
+//! Generic backend validators intentionally know nothing about Tribute's
+//! logical dialects or CPS ABI. This verifier runs immediately before emission
+//! and combines a full operation target with recursive type and convention
+//! checks.
+
+use std::collections::HashSet;
+use std::ops::ControlFlow;
+
+use tribute_core::{CALLING_CONVENTION_ATTR, CallingConvention, get_calling_convention};
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::dialect::core;
+use trunk_ir::ops::DialectType;
+use trunk_ir::refs::{OpRef, TypeRef};
+use trunk_ir::rewrite::Module;
+use trunk_ir::types::Attribute;
+use trunk_ir::walk::{WalkAction, walk_op};
+
+use crate::target_abi::{
+    ROOT_CPS_CALL_ATTR, ROOT_CPS_WORKER_ATTR, ROOT_DONE_K_ATTR, ROOT_WRAPPER_ATTR, TargetAbiError,
+};
+
+const CPS_MAIN_SYMBOL: &str = "__tribute_cps_main";
+const ROOT_DONE_K_SYMBOL: &str = "__tribute_root_done_k";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TributeBackend {
+    Native,
+    Wasm,
+}
+
+impl TributeBackend {
+    fn boundary(self) -> &'static str {
+        match self {
+            Self::Native => "tribute-backend-ready-native",
+            Self::Wasm => "tribute-backend-ready-wasm",
+        }
+    }
+
+    fn dialect(self) -> &'static str {
+        match self {
+            Self::Native => "clif",
+            Self::Wasm => "wasm",
+        }
+    }
+
+    fn function_name(self) -> &'static str {
+        "func"
+    }
+
+    fn call_name(self) -> &'static str {
+        "call"
+    }
+
+    fn return_name(self) -> &'static str {
+        "return"
+    }
+
+    fn tail_names(self) -> [&'static str; 2] {
+        ["return_call", "return_call_indirect"]
+    }
+}
+
+/// Verify the final Tribute backend boundary without mutating the module.
+pub fn verify_tribute_backend_ready(
+    ctx: &IrContext,
+    module: Module,
+    backend: TributeBackend,
+) -> Result<(), TargetAbiError> {
+    let operation_result = match backend {
+        TributeBackend::Native => trunk_ir_cranelift_backend::validate_clif_ir(ctx, module)
+            .map_err(|error| error.to_string()),
+        TributeBackend::Wasm => {
+            trunk_ir_wasm_backend::validate_wasm_ir(ctx, module).map_err(|error| error.to_string())
+        }
+    };
+    if let Err(error) = operation_result {
+        return Err(TargetAbiError::new(format!(
+            "{}: illegal or unknown operation(s): {error}",
+            backend.boundary(),
+        )));
+    }
+
+    let nil = ctx
+        .types
+        .iter()
+        .find_map(|(ty, data)| {
+            (data.dialect == Symbol::new("core") && data.name == Symbol::new("nil")).then_some(ty)
+        })
+        .ok_or_else(|| {
+            TargetAbiError::new(format!(
+                "{}: canonical core.nil type is not interned",
+                backend.boundary()
+            ))
+        })?;
+    let ops = collect_ops(ctx, module.op());
+    let mut verifier = RecursiveTypeVerifier::new(ctx, backend);
+
+    for (name, ty) in ctx.type_aliases() {
+        if *name == Symbol::new("__tribute_cps_control") {
+            return Err(TargetAbiError::new(format!(
+                "{}: private CPS control carrier alias remains",
+                backend.boundary()
+            )));
+        }
+        verifier.verify_metadata(*ty, "type alias")?;
+    }
+
+    for &op in &ops {
+        for &ty in ctx.op_result_types(op) {
+            verifier
+                .verify_result(ty, "operation result")
+                .map_err(|error| {
+                    TargetAbiError::new(format!(
+                        "{error} (at operation {}.{})",
+                        ctx.op(op).dialect,
+                        ctx.op(op).name
+                    ))
+                })?;
+        }
+        for &operand in ctx.op_operands(op) {
+            verifier
+                .verify_value(ctx.value_ty(operand), "operation operand")
+                .map_err(|error| {
+                    TargetAbiError::new(format!(
+                        "{error} (at operation {}.{})",
+                        ctx.op(op).dialect,
+                        ctx.op(op).name
+                    ))
+                })?;
+        }
+        for (key, attribute) in &ctx.op(op).attributes {
+            verifier
+                .verify_op_attribute(op, *key, attribute)
+                .map_err(|error| {
+                    TargetAbiError::new(format!(
+                        "{error} (at operation {}.{})",
+                        ctx.op(op).dialect,
+                        ctx.op(op).name
+                    ))
+                })?;
+        }
+        for &region in &ctx.op(op).regions {
+            for &block in &ctx.region(region).blocks {
+                for arg in &ctx.block(block).args {
+                    verifier.verify_value(arg.ty, "block argument")?;
+                    for attribute in arg.attrs.values() {
+                        verifier.verify_attribute(attribute, "block argument attribute")?;
+                    }
+                }
+            }
+        }
+    }
+
+    let mut root_workers = Vec::new();
+    let mut root_wrappers = Vec::new();
+    let mut root_done_functions = Vec::new();
+    let mut root_calls = Vec::new();
+    let mut reserved_worker_without_marker = false;
+    let mut reserved_done_without_marker = false;
+    let mut calls_to_reserved_worker = Vec::new();
+    for &op in &ops {
+        let data = ctx.op(op);
+        let is_backend_function = data.dialect == Symbol::new(backend.dialect())
+            && data.name == Symbol::new(backend.function_name());
+        let convention = checked_calling_convention(ctx, op, backend)?;
+        let is_root_done = exact_marker(ctx, op, ROOT_DONE_K_ATTR, backend)?;
+        let is_root_worker = exact_marker(ctx, op, ROOT_CPS_WORKER_ATTR, backend)?;
+        let is_root_wrapper = exact_marker(ctx, op, ROOT_WRAPPER_ATTR, backend)?;
+        let is_root_call = exact_marker(ctx, op, ROOT_CPS_CALL_ATTR, backend)?;
+        let symbol = data.attributes.get_symbol("sym_name");
+
+        if is_backend_function && symbol == Some(Symbol::new(CPS_MAIN_SYMBOL)) && !is_root_worker {
+            reserved_worker_without_marker = true;
+        }
+        if is_backend_function
+            && symbol == Some(Symbol::new("main"))
+            && convention == Some(CallingConvention::Cps)
+        {
+            return Err(TargetAbiError::new(format!(
+                "{}: unwrapped Cps root main remains",
+                backend.boundary()
+            )));
+        }
+        if is_backend_function && symbol == Some(Symbol::new(ROOT_DONE_K_SYMBOL)) && !is_root_done {
+            reserved_done_without_marker = true;
+        }
+        if reserved_done_without_marker {
+            return Err(TargetAbiError::new(format!(
+                "{}: reserved root done function is missing tribute.root_done_k",
+                backend.boundary()
+            )));
+        }
+        if data.dialect == Symbol::new(backend.dialect())
+            && data.name == Symbol::new(backend.call_name())
+            && data.attributes.get_symbol("callee") == Some(Symbol::new(CPS_MAIN_SYMBOL))
+        {
+            calls_to_reserved_worker.push(op);
+        }
+
+        if backend == TributeBackend::Wasm && is_backend_function && data.regions.is_empty() {
+            return Err(TargetAbiError::new(format!(
+                "{}: bodyless wasm.func `{}` must be lowered to wasm.import_func",
+                backend.boundary(),
+                data.attributes
+                    .get_symbol("sym_name")
+                    .map_or_else(|| "<unnamed>".to_owned(), |name| name.to_string())
+            )));
+        }
+
+        if is_root_done
+            && (!is_backend_function
+                || convention != Some(CallingConvention::Cps)
+                || data.attributes.get_symbol("sym_name") != Some(Symbol::new(ROOT_DONE_K_SYMBOL)))
+        {
+            return Err(TargetAbiError::new(format!(
+                "{}: tribute.root_done_k is valid only on the exact Cps root done function",
+                backend.boundary()
+            )));
+        }
+        if is_root_worker
+            && (!is_backend_function
+                || convention != Some(CallingConvention::Cps)
+                || symbol != Some(Symbol::new(CPS_MAIN_SYMBOL)))
+        {
+            return Err(TargetAbiError::new(format!(
+                "{}: tribute.root_cps_worker is valid only on the exact Cps root worker",
+                backend.boundary()
+            )));
+        }
+        if is_root_wrapper
+            && (!is_backend_function
+                || !matches!(
+                    convention,
+                    Some(CallingConvention::Direct | CallingConvention::EvidenceDirect)
+                ))
+        {
+            return Err(TargetAbiError::new(format!(
+                "{}: tribute.root_wrapper is valid only on an ordinary root wrapper",
+                backend.boundary()
+            )));
+        }
+
+        if is_backend_function && convention == Some(CallingConvention::Cps) {
+            let signature = data.attributes.get_type("type").ok_or_else(|| {
+                TargetAbiError::new(format!(
+                    "{}: Cps function has no signature",
+                    backend.boundary()
+                ))
+            })?;
+            let callable = core::Func::from_type_ref(ctx, signature).ok_or_else(|| {
+                TargetAbiError::new(format!(
+                    "{}: Cps function signature is not core.func",
+                    backend.boundary()
+                ))
+            })?;
+            if callable.r#return(ctx) != nil {
+                return Err(TargetAbiError::new(format!(
+                    "{}: Cps function result is not physically empty",
+                    backend.boundary()
+                )));
+            }
+            verify_cps_body(ctx, op, backend, is_root_done)?;
+        }
+
+        let is_tail = data.dialect == Symbol::new(backend.dialect())
+            && backend
+                .tail_names()
+                .iter()
+                .any(|name| data.name == Symbol::new(name));
+        if is_tail {
+            if !ctx.op_result_types(op).is_empty() {
+                return Err(TargetAbiError::new(format!(
+                    "{}: result-producing CPS transfer remains",
+                    backend.boundary()
+                )));
+            }
+            if convention != Some(CallingConvention::Cps) {
+                return Err(TargetAbiError::new(format!(
+                    "{}: proper-tail transfer lacks exact Cps convention",
+                    backend.boundary()
+                )));
+            }
+        }
+
+        if is_root_call {
+            if data.dialect != Symbol::new(backend.dialect())
+                || data.name != Symbol::new(backend.call_name())
+                || convention != Some(CallingConvention::Cps)
+                || ctx.op_result_types(op) != [nil]
+            {
+                return Err(TargetAbiError::new(format!(
+                    "{}: malformed tribute.root_cps_call exception",
+                    backend.boundary()
+                )));
+            }
+            root_calls.push(op);
+        } else if convention == Some(CallingConvention::Cps) && !is_backend_function && !is_tail {
+            return Err(TargetAbiError::new(format!(
+                "{}: non-tail Cps operation is not the exact root wrapper call",
+                backend.boundary()
+            )));
+        }
+
+        if is_root_worker {
+            root_workers.push(op);
+        }
+        if is_root_wrapper {
+            root_wrappers.push(op);
+        }
+        if is_root_done {
+            root_done_functions.push(op);
+        }
+    }
+
+    let bridge_present = !root_workers.is_empty()
+        || !root_wrappers.is_empty()
+        || !root_done_functions.is_empty()
+        || !root_calls.is_empty()
+        || reserved_worker_without_marker
+        || reserved_done_without_marker
+        || !calls_to_reserved_worker.is_empty();
+    if !bridge_present {
+        return Ok(());
+    }
+    if reserved_worker_without_marker {
+        return Err(TargetAbiError::new(format!(
+            "{}: reserved Cps root worker is missing tribute.root_cps_worker",
+            backend.boundary()
+        )));
+    }
+    if reserved_done_without_marker {
+        return Err(TargetAbiError::new(format!(
+            "{}: reserved root done function is missing tribute.root_done_k",
+            backend.boundary()
+        )));
+    }
+    if root_workers.len() != 1 {
+        return Err(TargetAbiError::new(format!(
+            "{}: root bridge requires exactly one marked Cps worker",
+            backend.boundary()
+        )));
+    }
+    if root_wrappers.len() != 1 {
+        return Err(TargetAbiError::new(format!(
+            "{}: root bridge requires exactly one marked ordinary wrapper",
+            backend.boundary()
+        )));
+    }
+    if root_done_functions.len() != 1 {
+        return Err(TargetAbiError::new(format!(
+            "{}: root bridge requires exactly one marked done function",
+            backend.boundary()
+        )));
+    }
+    if root_calls.len() != 1 {
+        return Err(TargetAbiError::new(format!(
+            "{}: root bridge requires exactly one marked ordinary root CPS call",
+            backend.boundary()
+        )));
+    }
+    let root_worker = root_workers[0];
+    let root_wrapper = root_wrappers[0];
+    let root_call = root_calls[0];
+    let worker_symbol = ctx
+        .op(root_worker)
+        .attributes
+        .get_symbol("sym_name")
+        .ok_or_else(|| {
+            TargetAbiError::new(format!(
+                "{}: marked Cps root worker has no symbol",
+                backend.boundary()
+            ))
+        })?;
+    if ctx.op(root_call).attributes.get_symbol("callee") != Some(worker_symbol) {
+        return Err(TargetAbiError::new(format!(
+            "{}: marked root CPS call does not target the marked Cps worker",
+            backend.boundary()
+        )));
+    }
+    if calls_to_reserved_worker.len() != 1 || calls_to_reserved_worker[0] != root_call {
+        return Err(TargetAbiError::new(format!(
+            "{}: root Cps worker must have exactly one marked ordinary wrapper call",
+            backend.boundary()
+        )));
+    }
+    let owner = enclosing_backend_function(ctx, root_call, backend).ok_or_else(|| {
+        TargetAbiError::new(format!(
+            "{}: root CPS call is not enclosed by a backend function",
+            backend.boundary()
+        ))
+    })?;
+    if owner != root_wrapper {
+        return Err(TargetAbiError::new(format!(
+            "{}: root CPS call is not owned by the marked ordinary wrapper",
+            backend.boundary()
+        )));
+    }
+    verify_root_wrapper_order(ctx, root_wrapper, root_call, backend)?;
+    Ok(())
+}
+
+fn verify_cps_body(
+    ctx: &IrContext,
+    function: OpRef,
+    backend: TributeBackend,
+    root_done: bool,
+) -> Result<(), TargetAbiError> {
+    let nested = collect_ops(ctx, function);
+    let ordinary_returns = nested
+        .iter()
+        .copied()
+        .filter(|&op| {
+            let data = ctx.op(op);
+            data.dialect == Symbol::new(backend.dialect())
+                && data.name == Symbol::new(backend.return_name())
+        })
+        .count();
+    if root_done {
+        if ordinary_returns != 1 {
+            return Err(TargetAbiError::new(format!(
+                "{}: root done function must contain exactly one terminal return",
+                backend.boundary()
+            )));
+        }
+    } else if ordinary_returns != 0 {
+        return Err(TargetAbiError::new(format!(
+            "{}: Cps body contains an ordinary return instead of a proper-tail transfer",
+            backend.boundary()
+        )));
+    }
+    Ok(())
+}
+
+fn checked_calling_convention(
+    ctx: &IrContext,
+    op: OpRef,
+    backend: TributeBackend,
+) -> Result<Option<CallingConvention>, TargetAbiError> {
+    if !ctx.op(op).attributes.contains_key(CALLING_CONVENTION_ATTR) {
+        return Ok(None);
+    }
+    get_calling_convention(ctx, op)
+        .ok_or_else(|| {
+            TargetAbiError::new(format!(
+                "{}: operation has an invalid tribute.calling_convention attribute",
+                backend.boundary()
+            ))
+        })
+        .map(Some)
+}
+
+fn exact_marker(
+    ctx: &IrContext,
+    op: OpRef,
+    marker: &str,
+    backend: TributeBackend,
+) -> Result<bool, TargetAbiError> {
+    if !ctx.op(op).attributes.contains_key(marker) {
+        return Ok(false);
+    }
+    if ctx.op(op).attributes.get_bool(marker) == Some(true) {
+        return Ok(true);
+    }
+    Err(TargetAbiError::new(format!(
+        "{}: `{marker}` marker must be exactly true",
+        backend.boundary()
+    )))
+}
+
+fn verify_root_wrapper_order(
+    ctx: &IrContext,
+    wrapper: OpRef,
+    root_call: OpRef,
+    backend: TributeBackend,
+) -> Result<(), TargetAbiError> {
+    let block = ctx.op(root_call).parent_block.ok_or_else(|| {
+        TargetAbiError::new(format!(
+            "{}: marked root CPS call has no containing block",
+            backend.boundary()
+        ))
+    })?;
+    let ops = &ctx.block(block).ops;
+    let call_index = ops.iter().position(|&op| op == root_call).ok_or_else(|| {
+        TargetAbiError::new(format!(
+            "{}: marked root CPS call is not attached to its containing block",
+            backend.boundary()
+        ))
+    })?;
+    let return_after_call = ops.iter().skip(call_index + 1).any(|&op| {
+        let data = ctx.op(op);
+        data.dialect == Symbol::new(backend.dialect())
+            && data.name == Symbol::new(backend.return_name())
+    });
+    if !return_after_call || enclosing_backend_function(ctx, root_call, backend) != Some(wrapper) {
+        return Err(TargetAbiError::new(format!(
+            "{}: root wrapper must resume after its ordinary CPS worker call",
+            backend.boundary()
+        )));
+    }
+    Ok(())
+}
+
+fn enclosing_backend_function(
+    ctx: &IrContext,
+    mut op: OpRef,
+    backend: TributeBackend,
+) -> Option<OpRef> {
+    while let Some(block) = ctx.op(op).parent_block {
+        let region = ctx.block(block).parent_region?;
+        let parent = ctx.region(region).parent_op?;
+        let data = ctx.op(parent);
+        if data.dialect == Symbol::new(backend.dialect())
+            && data.name == Symbol::new(backend.function_name())
+        {
+            return Some(parent);
+        }
+        op = parent;
+    }
+    None
+}
+
+fn collect_ops(ctx: &IrContext, root: OpRef) -> Vec<OpRef> {
+    let mut ops = Vec::new();
+    let _ = walk_op::<()>(ctx, root, &mut |op| {
+        ops.push(op);
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    ops
+}
+
+struct RecursiveTypeVerifier<'a> {
+    ctx: &'a IrContext,
+    backend: TributeBackend,
+    visited: HashSet<(TypeRef, TypeSurface)>,
+}
+
+/// A final backend type can be valid as nominal/layout metadata while being
+/// illegal in a runtime value slot. Keep the surfaces distinct so source
+/// aggregates cannot leak into the native emitter as SSA values.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+enum TypeSurface {
+    Value,
+    Result,
+    Metadata,
+    Signature,
+}
+
+impl<'a> RecursiveTypeVerifier<'a> {
+    fn new(ctx: &'a IrContext, backend: TributeBackend) -> Self {
+        Self {
+            ctx,
+            backend,
+            visited: HashSet::new(),
+        }
+    }
+
+    fn verify_value(&mut self, ty: TypeRef, surface: &str) -> Result<(), TargetAbiError> {
+        self.verify_on_surface(ty, TypeSurface::Value, surface)
+    }
+
+    fn verify_result(&mut self, ty: TypeRef, surface: &str) -> Result<(), TargetAbiError> {
+        self.verify_on_surface(ty, TypeSurface::Result, surface)
+    }
+
+    fn verify_metadata(&mut self, ty: TypeRef, surface: &str) -> Result<(), TargetAbiError> {
+        self.verify_on_surface(ty, TypeSurface::Metadata, surface)
+    }
+
+    fn verify_signature(&mut self, ty: TypeRef, surface: &str) -> Result<(), TargetAbiError> {
+        self.verify_on_surface(ty, TypeSurface::Signature, surface)
+    }
+
+    fn verify_on_surface(
+        &mut self,
+        ty: TypeRef,
+        type_surface: TypeSurface,
+        surface: &str,
+    ) -> Result<(), TargetAbiError> {
+        if !self.visited.insert((ty, type_surface)) {
+            return Ok(());
+        }
+        let data = self.ctx.types.get(ty);
+        let dialect = data.dialect;
+        let name = data.name;
+        if !is_legal_final_type(self.ctx, self.backend, type_surface, ty)
+            || data.attrs.get_symbol("name") == Some(Symbol::new("__tribute_cps_control"))
+        {
+            return Err(TargetAbiError::new(format!(
+                "{}: illegal type `{dialect}.{name}` remains in {surface}",
+                self.backend.boundary()
+            )));
+        }
+
+        if type_surface == TypeSurface::Signature {
+            if dialect != Symbol::new("core")
+                || name != Symbol::new("func")
+                || data.params.is_empty()
+            {
+                return Err(TargetAbiError::new(format!(
+                    "{}: `{dialect}.{name}` is not a callable signature in {surface}",
+                    self.backend.boundary()
+                )));
+            }
+            self.verify_result(data.params[0], "function result")?;
+            for &param in &data.params[1..] {
+                self.verify_value(param, "function parameter")?;
+            }
+        } else if type_surface != TypeSurface::Result || !is_core_type(dialect, name, "nil") {
+            for &param in &data.params {
+                self.verify_metadata(param, "nested type parameter")?;
+            }
+        }
+        for attribute in data.attrs.values() {
+            self.verify_attribute(attribute, "type attribute")?;
+        }
+        Ok(())
+    }
+
+    fn verify_op_attribute(
+        &mut self,
+        op: OpRef,
+        key: Symbol,
+        attribute: &Attribute,
+    ) -> Result<(), TargetAbiError> {
+        let data = self.ctx.op(op);
+        let is_function_signature = key == Symbol::new("type")
+            && data.dialect == Symbol::new(self.backend.dialect())
+            && data.name == Symbol::new(self.backend.function_name());
+        let is_indirect_signature = key == Symbol::new("sig")
+            && data.dialect == Symbol::new(self.backend.dialect())
+            && (data.name == Symbol::new("call_indirect")
+                || data.name == Symbol::new("return_call_indirect"));
+        if is_function_signature || is_indirect_signature {
+            let Attribute::Type(ty) = attribute else {
+                return Err(TargetAbiError::new(format!(
+                    "{}: callable signature attribute is not a type",
+                    self.backend.boundary()
+                )));
+            };
+            self.verify_signature(*ty, "callable signature")
+        } else {
+            self.verify_attribute(attribute, "operation attribute")
+        }
+    }
+
+    fn verify_attribute(
+        &mut self,
+        attribute: &Attribute,
+        surface: &str,
+    ) -> Result<(), TargetAbiError> {
+        match attribute {
+            Attribute::Type(ty) => self.verify_metadata(*ty, surface),
+            Attribute::List(values) => {
+                for value in values {
+                    self.verify_attribute(value, surface)?;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Target types are accepted positively and by use-site. The layout/alias
+/// graph retains named aggregate descriptions for target lowering, while SSA
+/// values are restricted to the selected emitter's value conversion.
+fn is_legal_final_type(
+    ctx: &IrContext,
+    backend: TributeBackend,
+    surface: TypeSurface,
+    ty: TypeRef,
+) -> bool {
+    let data = ctx.types.get(ty);
+    let dialect = data.dialect;
+    let name = data.name;
+    match surface {
+        TypeSurface::Value => is_target_value_type(ctx, backend, ty),
+        TypeSurface::Result => {
+            is_core_type(dialect, name, "nil") || is_target_value_type(ctx, backend, ty)
+        }
+        TypeSurface::Signature => is_core_type(dialect, name, "func"),
+        TypeSurface::Metadata => is_target_metadata_type(backend, dialect, name, data),
+    }
+}
+
+fn is_target_value_type(ctx: &IrContext, backend: TributeBackend, ty: TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    let dialect = data.dialect;
+    let name = data.name;
+    match backend {
+        // Exactly `translate_type`: aggregate and callable types remain
+        // layout/signature metadata, never Cranelift SSA values.
+        TributeBackend::Native => ["i1", "i8", "i16", "i32", "i64", "f32", "f64", "ptr"]
+            .iter()
+            .any(|candidate| is_core_type(dialect, name, candidate)),
+        // Mirrors `type_to_valtype`; core.nil is the Wasm null-reference unit
+        // representation, and only the concrete Bytes backing ref is a
+        // supported core.ref value in the Wasm ABI.
+        TributeBackend::Wasm => {
+            let core_value = [
+                "nil", "i1", "i32", "i64", "f32", "f64", "bytes", "ptr", "array", "func",
+            ]
+            .iter()
+            .any(|candidate| is_core_type(dialect, name, candidate));
+            let bytes_ref = dialect == Symbol::new("core")
+                && name == Symbol::new("ref")
+                && trunk_ir_wasm_backend::gc_types::concrete_wasm_ref_type(ctx, ty).is_some();
+            let adt_value = dialect == Symbol::new("adt")
+                && (["struct", "enum", "typeref", "variant_inst"]
+                    .iter()
+                    .any(|candidate| name == Symbol::new(candidate))
+                    || data.attrs.get_bool("is_variant") == Some(true));
+            let wasm_ref = dialect == Symbol::new("wasm")
+                && ["anyref", "i31ref", "structref", "arrayref", "funcref"]
+                    .iter()
+                    .any(|candidate| name == Symbol::new(candidate));
+            core_value || bytes_ref || adt_value || wasm_ref
+        }
+    }
+}
+
+fn is_target_metadata_type(
+    backend: TributeBackend,
+    dialect: Symbol,
+    name: Symbol,
+    data: &trunk_ir::types::TypeData,
+) -> bool {
+    let core = Symbol::new("core");
+    let adt = Symbol::new("adt");
+    let wasm = Symbol::new("wasm");
+    if dialect == core {
+        return [
+            "func", "nil", "i1", "i8", "i16", "i32", "i64", "f32", "f64", "ptr", "bytes", "ref",
+            "array",
+        ]
+        .iter()
+        .any(|candidate| name == Symbol::new(candidate));
+    }
+    if dialect == adt {
+        return ["struct", "enum", "typeref", "variant_inst"]
+            .iter()
+            .any(|candidate| name == Symbol::new(candidate))
+            || data.attrs.get_bool("is_variant") == Some(true);
+    }
+    backend == TributeBackend::Wasm
+        && dialect == wasm
+        && ["anyref", "i31ref", "structref", "arrayref", "funcref"]
+            .iter()
+            .any(|candidate| name == Symbol::new(candidate))
+}
+
+fn is_core_type(dialect: Symbol, name: Symbol, expected: &str) -> bool {
+    dialect == Symbol::new("core") && name == Symbol::from_dynamic(expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    type RootMutation = fn(&mut IrContext, OpRef, OpRef, OpRef, OpRef);
+    type RootBoundaryCase = (&'static str, RootMutation, &'static str);
+
+    fn root_bridge_fixture(dialect: &str, wrapper: &str) -> String {
+        format!(
+            r#"core.module @test {{
+  {dialect}.func @__tribute_cps_main() -> core.nil {{
+    {dialect}.return_call {{callee = @__tribute_root_done_k}}
+  }}
+  {dialect}.func @__tribute_root_done_k() -> core.nil {{
+    {dialect}.return
+  }}
+  {dialect}.func @{wrapper}() -> core.nil {{
+    %call = {dialect}.call {{callee = @__tribute_cps_main}} : core.nil
+    {dialect}.return
+  }}
+}}"#
+        )
+    }
+
+    fn marked_root_bridge(
+        dialect: &str,
+        wrapper: &str,
+    ) -> (IrContext, Module, OpRef, OpRef, OpRef, OpRef) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, &root_bridge_fixture(dialect, wrapper));
+        let mut worker = None;
+        let mut done = None;
+        let mut wrapper_op = None;
+        for op in module.ops(&ctx) {
+            let symbol = ctx.op(op).attributes.get_symbol("sym_name");
+            if symbol == Some(Symbol::new(CPS_MAIN_SYMBOL)) {
+                worker = Some(op);
+            } else if symbol == Some(Symbol::new(ROOT_DONE_K_SYMBOL)) {
+                done = Some(op);
+            } else if symbol == Some(Symbol::from_dynamic(wrapper)) {
+                wrapper_op = Some(op);
+            }
+        }
+        let worker = worker.expect("root worker");
+        let done = done.expect("root done");
+        let wrapper_op = wrapper_op.expect("root wrapper");
+        let root_call = collect_ops(&ctx, wrapper_op)
+            .into_iter()
+            .find(|&op| {
+                ctx.op(op).attributes.get_symbol("callee") == Some(Symbol::new(CPS_MAIN_SYMBOL))
+            })
+            .expect("root call");
+
+        for op in [worker, done] {
+            ctx.op_mut(op).attributes.insert(
+                Symbol::new(CALLING_CONVENTION_ATTR),
+                Attribute::Int(CallingConvention::Cps as i128),
+            );
+        }
+        ctx.op_mut(worker)
+            .attributes
+            .insert(Symbol::new(ROOT_CPS_WORKER_ATTR), Attribute::Bool(true));
+        ctx.op_mut(done)
+            .attributes
+            .insert(Symbol::new(ROOT_DONE_K_ATTR), Attribute::Bool(true));
+        ctx.op_mut(wrapper_op).attributes.insert(
+            Symbol::new(CALLING_CONVENTION_ATTR),
+            Attribute::Int(CallingConvention::Direct as i128),
+        );
+        ctx.op_mut(wrapper_op)
+            .attributes
+            .insert(Symbol::new(ROOT_WRAPPER_ATTR), Attribute::Bool(true));
+        ctx.op_mut(root_call).attributes.insert(
+            Symbol::new(CALLING_CONVENTION_ATTR),
+            Attribute::Int(CallingConvention::Cps as i128),
+        );
+        ctx.op_mut(root_call)
+            .attributes
+            .insert(Symbol::new(ROOT_CPS_CALL_ATTR), Attribute::Bool(true));
+        let worker_tail = collect_ops(&ctx, worker)
+            .into_iter()
+            .find(|&op| ctx.op(op).name == Symbol::new("return_call"))
+            .expect("worker tail transfer");
+        ctx.op_mut(worker_tail).attributes.insert(
+            Symbol::new(CALLING_CONVENTION_ATTR),
+            Attribute::Int(CallingConvention::Cps as i128),
+        );
+        (ctx, module, worker, done, wrapper_op, root_call)
+    }
+
+    #[test]
+    fn backend_ready_accepts_marked_root_bridge_after_native_rename_and_for_wasm() {
+        for (backend, dialect, wrapper) in [
+            (TributeBackend::Native, "clif", "_tribute_main"),
+            (TributeBackend::Wasm, "wasm", "main"),
+        ] {
+            let (ctx, module, ..) = marked_root_bridge(dialect, wrapper);
+            verify_tribute_backend_ready(&ctx, module, backend).unwrap();
+        }
+    }
+
+    #[test]
+    fn backend_ready_rejects_invalid_convention_and_root_marker_gaps_without_mutation() {
+        let cases: [RootBoundaryCase; 5] = [
+            (
+                "invalid convention",
+                |ctx, _worker, _done, wrapper, _call| {
+                    ctx.op_mut(wrapper)
+                        .attributes
+                        .insert(Symbol::new(CALLING_CONVENTION_ATTR), Attribute::Int(99));
+                },
+                "invalid tribute.calling_convention",
+            ),
+            (
+                "unwrapped worker",
+                |ctx, worker, _done, _wrapper, _call| {
+                    ctx.op_mut(worker).attributes.remove(ROOT_CPS_WORKER_ATTR);
+                },
+                "missing tribute.root_cps_worker",
+            ),
+            (
+                "unmarked root call",
+                |ctx, _worker, _done, _wrapper, call| {
+                    ctx.op_mut(call).attributes.remove(ROOT_CPS_CALL_ATTR);
+                    ctx.op_mut(call).attributes.remove(CALLING_CONVENTION_ATTR);
+                },
+                "exactly one marked ordinary root CPS call",
+            ),
+            (
+                "unmarked wrapper",
+                |ctx, _worker, _done, wrapper, _call| {
+                    ctx.op_mut(wrapper).attributes.remove(ROOT_WRAPPER_ATTR);
+                },
+                "exactly one marked ordinary wrapper",
+            ),
+            (
+                "unmarked done_k",
+                |ctx, _worker, done, _wrapper, _call| {
+                    ctx.op_mut(done).attributes.remove(ROOT_DONE_K_ATTR);
+                },
+                "missing tribute.root_done_k",
+            ),
+        ];
+
+        for (name, mutate, expected) in cases {
+            let (mut ctx, module, worker, done, wrapper, call) =
+                marked_root_bridge("clif", "_tribute_main");
+            mutate(&mut ctx, worker, done, wrapper, call);
+            let before = print_module(&ctx, module.op());
+            let error =
+                verify_tribute_backend_ready(&ctx, module, TributeBackend::Native).expect_err(name);
+            assert!(error.to_string().contains(expected), "{name}: {error}");
+            assert_eq!(print_module(&ctx, module.op()), before, "{name}");
+        }
+    }
+
+    #[test]
+    fn backend_ready_rejects_duplicate_marked_root_calls() {
+        let (mut ctx, module, _worker, _done, _wrapper, root_call) =
+            marked_root_bridge("wasm", "main");
+        let mut mapping = trunk_ir::IrMapping::new();
+        let duplicate = ctx.clone_op(root_call, &mut mapping);
+        let block = ctx.op(root_call).parent_block.unwrap();
+        ctx.push_op(block, duplicate);
+        let error = verify_tribute_backend_ready(&ctx, module, TributeBackend::Wasm).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("exactly one marked ordinary root CPS call"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn backend_ready_rejects_an_unwrapped_cps_main() {
+        let (mut ctx, module, worker, _done, _wrapper, _call) = marked_root_bridge("wasm", "main");
+        ctx.op_mut(worker).attributes.insert(
+            Symbol::new("sym_name"),
+            Attribute::Symbol(Symbol::new("main")),
+        );
+        ctx.op_mut(worker).attributes.remove(ROOT_CPS_WORKER_ATTR);
+        let before = print_module(&ctx, module.op());
+
+        let error = verify_tribute_backend_ready(&ctx, module, TributeBackend::Wasm).unwrap_err();
+
+        assert!(
+            error.to_string().contains("unwrapped Cps root main"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn backend_ready_rejects_unknown_top_level_nested_and_attribute_types() {
+        let cases = [
+            (
+                "top-level",
+                r#"!unknown = unknown.value()"#,
+                "unknown.value",
+            ),
+            (
+                "nested",
+                r#"!unknown = core.array(unknown.value())"#,
+                "unknown.value",
+            ),
+            (
+                "attribute",
+                r#"!unknown = adt.struct() {metadata = [unknown.value()], name = @Unknown}"#,
+                "unknown.value",
+            ),
+        ];
+        for (name, alias, expected) in cases {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    "core.module @test {{\n  {alias}\n  wasm.func @main() -> core.nil {{\n    wasm.return\n  }}\n}}"
+                ),
+            );
+            let before = print_module(&ctx, module.op());
+            let error = verify_tribute_backend_ready(&ctx, module, TributeBackend::Wasm)
+                .expect_err(name)
+                .to_string();
+            assert!(error.contains(expected), "{name}: {error}");
+            assert_eq!(print_module(&ctx, module.op()), before, "{name}");
+        }
+    }
+
+    #[test]
+    fn backend_ready_rejects_unknown_backend_operations() {
+        for (backend, dialect) in [
+            (TributeBackend::Native, "clif"),
+            (TributeBackend::Wasm, "wasm"),
+        ] {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    "core.module @test {{\n  {dialect}.func @main() -> core.nil {{\n    {dialect}.unknown\n    {dialect}.return\n  }}\n}}"
+                ),
+            );
+            let error = verify_tribute_backend_ready(&ctx, module, backend)
+                .expect_err(dialect)
+                .to_string();
+            assert!(error.contains(&format!("{dialect}.unknown")), "{error}");
+        }
+    }
+
+    #[test]
+    fn backend_ready_rejects_native_metadata_types_in_value_and_signature_slots() {
+        let cases = [
+            (
+                "bytes parameter",
+                r#"clif.func @main(%bytes: core.bytes) -> core.nil {
+    clif.return
+  }"#,
+            ),
+            (
+                "callable parameter",
+                r#"clif.func @main(%callback: core.func(core.nil, core.i32)) -> core.nil {
+    clif.return
+  }"#,
+            ),
+            (
+                "aggregate result",
+                r#"clif.func @main() -> adt.struct() {fields = [[@payload, core.i32]], name = @Box} {
+    clif.return
+  }"#,
+            ),
+        ];
+        for (name, function) in cases {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    r#"core.module @test {{
+  !layout = adt.struct() {{fields = [[@bytes, core.bytes]], name = @Layout}}
+  clif.func @void() -> core.nil {{
+    clif.return
+  }}
+  {function}
+}}"#,
+                ),
+            );
+            let before = print_module(&ctx, module.op());
+            let error = verify_tribute_backend_ready(&ctx, module, TributeBackend::Native)
+                .expect_err(name)
+                .to_string();
+            assert!(error.contains("illegal type"), "{name}: {error}");
+            assert_eq!(print_module(&ctx, module.op()), before, "{name}");
+        }
+    }
+
+    #[test]
+    fn backend_ready_keeps_native_layout_metadata_out_of_value_legality() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !layout = adt.struct() {fields = [[@bytes, core.bytes]], name = @Layout}
+  clif.func @main(%value: core.i32) -> core.nil {
+    clif.return
+  }
+}"#,
+        );
+        verify_tribute_backend_ready(&ctx, module, TributeBackend::Native).unwrap();
+    }
+
+    #[test]
+    fn backend_ready_derives_wasm_value_slots_from_emittable_valtypes() {
+        let cases = [
+            (
+                "narrow integer parameter",
+                r#"wasm.func @main(%byte: core.i8) -> core.nil {
+    wasm.return
+  }"#,
+            ),
+            (
+                "narrow integer result",
+                r#"wasm.func @main() -> core.i16 {
+    wasm.return
+  }"#,
+            ),
+        ];
+        for (name, function) in cases {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    "core.module @test {{\n  wasm.func @void() -> core.nil {{\n    wasm.return\n  }}\n  {function}\n}}"
+                ),
+            );
+            let before = print_module(&ctx, module.op());
+            let error = verify_tribute_backend_ready(&ctx, module, TributeBackend::Wasm)
+                .expect_err(name)
+                .to_string();
+            assert!(error.contains("illegal type"), "{name}: {error}");
+            assert_eq!(print_module(&ctx, module.op()), before, "{name}");
+        }
+    }
+
+    #[test]
+    fn backend_ready_accepts_wasm_nil_value_representation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @main(%unit: core.nil) -> core.nil {
+    wasm.return
+  }
+}"#,
+        );
+        verify_tribute_backend_ready(&ctx, module, TributeBackend::Wasm).unwrap();
+    }
+}

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -19,7 +19,10 @@
 //!
 //! Uses `RewritePattern` + `PatternApplicator` for declarative transformation.
 
-use tribute_core::{CallableAbi, get_calling_convention};
+use tribute_core::{
+    CPS_PARENT_RESULT_ATTR, get_calling_convention, get_closure_callable_type,
+    physical_environment_index, set_closure_callable_type, set_indirect_call_signature,
+};
 use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
@@ -51,12 +54,61 @@ pub fn closure_struct_type_ref(ctx: &mut IrContext) -> TypeRef {
 }
 
 /// Check if a TypeRef is an adt.struct with name "_closure".
-fn is_closure_struct_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
+/// Whether `ty` is the canonical runtime closure pair produced by this pass.
+/// Target ABI validation uses this exact projection when a preserved callable
+/// signature still names an abstract `closure.closure` parameter.
+pub(crate) fn is_closure_struct_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
     let data = ctx.types.get(ty);
     if data.dialect != Symbol::new("adt") || data.name != Symbol::new("struct") {
         return false;
     }
-    data.attrs.get_symbol("name") == Some(Symbol::new("_closure"))
+    let [table, environment] = data.params.as_slice() else {
+        return false;
+    };
+    let table = ctx.types.get(*table);
+    let environment = ctx.types.get(*environment);
+    data.attrs.len() == 1
+        && data.attrs.get_symbol("name") == Some(Symbol::new("_closure"))
+        && table.dialect == Symbol::new("core")
+        && table.name == Symbol::new("i32")
+        && environment.dialect == Symbol::new("tribute_rt")
+        && environment.name == Symbol::new("anyref")
+}
+
+/// Whether `op` is the canonical closure-lowering pack for `callable`.
+///
+/// This is the sole accepted bridge from a typed `closure.closure` value to
+/// its runtime `_closure` pair. In particular, an arbitrary `adt.struct_new`
+/// may not claim callable provenance through the temporary attribute.
+pub(crate) fn is_lowered_closure_pack(ctx: &IrContext, op: OpRef, callable: TypeRef) -> bool {
+    if get_closure_callable_type(ctx, op) != Some(callable)
+        || adt::StructNew::from_op(ctx, op).is_err()
+    {
+        return false;
+    }
+    let [result] = ctx.op_results(op) else {
+        return false;
+    };
+    let struct_ty = ctx.value_ty(*result);
+    if !is_closure_struct_type_ref(ctx, struct_ty)
+        || ctx.op(op).attributes.get_type("type") != Some(struct_ty)
+    {
+        return false;
+    }
+    let [funcref, _environment] = ctx.op_operands(op) else {
+        return false;
+    };
+    let trunk_ir::refs::ValueDef::OpResult(def, _) = ctx.value_def(*funcref) else {
+        return false;
+    };
+    if func::Constant::from_op(ctx, def).is_err() {
+        return false;
+    }
+    let Some(closure) = closure::Closure::from_type_ref(ctx, callable) else {
+        return false;
+    };
+    let function = closure.func_type(ctx);
+    ctx.value_ty(*funcref) == function
 }
 
 // ============================================================================
@@ -113,6 +165,13 @@ impl RewritePattern for UpdateFuncSignatureArena {
         // Build new func type
         let return_ty = new_params[0];
         let new_func_ty = core::func(ctx, return_ty, new_params[1..].iter().copied()).as_type_ref();
+        let extra_attrs: Vec<_> = ctx
+            .op(op)
+            .attributes
+            .iter()
+            .filter(|(name, _)| **name != Symbol::new("sym_name") && **name != Symbol::new("type"))
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
 
         // Rebuild the function with new type
         let func_name = func_op.sym_name(ctx);
@@ -126,6 +185,9 @@ impl RewritePattern for UpdateFuncSignatureArena {
         }
         ctx.detach_region(body);
         let new_op = func::func(ctx, loc, func_name, new_func_ty, body).op_ref();
+        for (name, value) in extra_attrs {
+            ctx.op_mut(new_op).attributes.insert(name, value);
+        }
         rewriter.replace_op(new_op);
         true
     }
@@ -166,6 +228,7 @@ impl RewritePattern for LowerClosureNewArena {
         // Generate: %closure = adt.struct_new(%funcref, %env) : closure_struct_type
         let struct_ty = closure_struct_type_ref(ctx);
         let struct_new_op = adt::struct_new(ctx, loc, vec![funcref, env], struct_ty, struct_ty);
+        set_closure_callable_type(ctx, struct_new_op.op_ref(), result_ty);
 
         rewriter.insert_op(constant_op.op_ref());
         rewriter.replace_op(struct_new_op.op_ref());
@@ -200,27 +263,7 @@ impl RewritePattern for LowerClosureCallArena {
         let callee = operands[0];
         let callee_ty = ctx.value_ty(callee);
 
-        // Determine if callee is a closure
-        let callee_is_closure = if closure::Closure::matches(ctx, callee_ty) {
-            true
-        } else if is_closure_struct_type_ref(ctx, callee_ty) {
-            // Already lowered closure struct
-            true
-        } else if core::Func::matches(ctx, callee_ty) {
-            // core.func in func.call_indirect is always a closure value.
-            // Direct function calls use func.call; call_indirect operates on
-            // closure values (block args, env captures, etc.).
-            true
-        } else {
-            // Fallback: check if result of closure.new
-            if let trunk_ir::refs::ValueDef::OpResult(def_op, _) = ctx.value_def(callee) {
-                closure::New::from_op(ctx, def_op).is_ok()
-            } else {
-                false
-            }
-        };
-
-        if !callee_is_closure {
+        if !is_closure_callee(ctx, callee) {
             return false;
         }
 
@@ -247,11 +290,8 @@ impl RewritePattern for LowerClosureCallArena {
         let env_op = closure::env(ctx, loc, callee, anyref_ty);
         let env = ctx.op_result(env_op.op_ref(), 0);
 
-        let new_args = if let Some(convention) = get_calling_convention(ctx, op) {
-            let hidden =
-                usize::from(convention.needs_evidence()) + usize::from(convention.needs_done_k());
-            let abi = CallableAbi::new(convention, args[hidden..].iter().copied(), env);
-            abi.interpose_environment(&args, env)
+        let new_args = if get_calling_convention(ctx, op).is_some() {
+            interpose_environment_for_physical_args(ctx, &args, env)
         } else {
             // Compatibility for hand-written legacy IR without metadata.
             let evidence = if let Some(evidence) = self.legacy_evidence {
@@ -266,7 +306,14 @@ impl RewritePattern for LowerClosureCallArena {
             legacy.extend_from_slice(&args);
             legacy
         };
+        let attrs_to_preserve = ctx.op(op).attributes.clone();
         let new_call = func::call_indirect(ctx, loc, table_idx, new_args, callee_return_ty);
+        ctx.op_mut(new_call.op_ref())
+            .attributes
+            .extend(attrs_to_preserve);
+        if let Some(signature) = physical_indirect_signature(ctx, callee) {
+            set_indirect_call_signature(ctx, new_call.op_ref(), signature);
+        }
 
         rewriter.insert_op(table_idx_op.op_ref());
         rewriter.insert_op(env_op.op_ref());
@@ -287,6 +334,117 @@ impl RewritePattern for LowerClosureCallArena {
     fn name(&self) -> &'static str {
         "LowerClosureCallArena"
     }
+}
+
+/// Lower a resultless closure-valued proper-tail transfer.
+struct LowerClosureTailCallArena;
+
+impl RewritePattern for LowerClosureTailCallArena {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if func::TailCallIndirect::from_op(ctx, op).is_err() || !ctx.op_result_types(op).is_empty()
+        {
+            return false;
+        }
+        let operands = ctx.op_operands(op);
+        let Some((&callee, args)) = operands.split_first() else {
+            return false;
+        };
+        if !is_closure_callee(ctx, callee) {
+            return false;
+        }
+
+        let loc = ctx.op(op).location;
+        let args = args.to_vec();
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+        let table_idx_op = closure::func(ctx, loc, callee, i32_ty);
+        let env_op = closure::env(ctx, loc, callee, anyref_ty);
+        let new_args = interpose_environment_for_physical_args(ctx, &args, env_op.result(ctx));
+        let attrs_to_preserve = ctx.op(op).attributes.clone();
+        let new_tail = func::tail_call_indirect(ctx, loc, table_idx_op.result(ctx), new_args);
+        ctx.op_mut(new_tail.op_ref())
+            .attributes
+            .extend(attrs_to_preserve);
+        if let Some(signature) = physical_indirect_signature(ctx, callee) {
+            set_indirect_call_signature(ctx, new_tail.op_ref(), signature);
+        }
+
+        rewriter.insert_op(table_idx_op.op_ref());
+        rewriter.insert_op(env_op.op_ref());
+        rewriter.replace_op(new_tail.op_ref());
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "LowerClosureTailCallArena"
+    }
+}
+
+fn is_closure_callee(ctx: &IrContext, callee: ValueRef) -> bool {
+    let callee_ty = ctx.value_ty(callee);
+    closure::Closure::matches(ctx, callee_ty)
+        || is_closure_struct_type_ref(ctx, callee_ty)
+        || core::Func::matches(ctx, callee_ty)
+        || matches!(
+            ctx.value_def(callee),
+            trunk_ir::refs::ValueDef::OpResult(def_op, _)
+                if closure::New::from_op(ctx, def_op).is_ok()
+        )
+}
+
+fn interpose_environment_for_physical_args(
+    ctx: &mut IrContext,
+    args: &[ValueRef],
+    environment: ValueRef,
+) -> Vec<ValueRef> {
+    let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
+    let arg_types: Vec<_> = args.iter().map(|&arg| ctx.value_ty(arg)).collect();
+    let index = physical_environment_index(&arg_types, &evidence_ty);
+    let mut physical = Vec::with_capacity(args.len() + 1);
+    physical.extend_from_slice(&args[..index]);
+    physical.push(environment);
+    physical.extend_from_slice(&args[index..]);
+    physical
+}
+
+/// Preserve the exact callable ABI when closure lowering erases the typed
+/// `closure.closure` callee into a table/function pointer plus environment.
+fn physical_indirect_signature(ctx: &mut IrContext, callee: ValueRef) -> Option<TypeRef> {
+    // `PrepareClosureLowering` normally turns callable values into
+    // `closure.closure`.  Generated continuations can still carry a bare
+    // `core.func` at this point; this pattern lowers both forms through the
+    // same runtime closure pair, so retain the corresponding exact physical
+    // signature in either case rather than leaving a raw table pointer
+    // unproven for later target ABI projection.
+    let callee_ty = ctx.value_ty(callee);
+    let callable_ty = closure::Closure::from_type_ref(ctx, callee_ty)
+        .map(|closure| closure.func_type(ctx))
+        .or_else(|| core::Func::from_type_ref(ctx, callee_ty).map(|_| callee_ty))
+        .or_else(|| {
+            let trunk_ir::refs::ValueDef::OpResult(pack, _) = ctx.value_def(callee) else {
+                return None;
+            };
+            let closure_ty = get_closure_callable_type(ctx, pack)?;
+            let closure = closure::Closure::from_type_ref(ctx, closure_ty)?;
+            is_lowered_closure_pack(ctx, pack, closure_ty).then_some(closure.func_type(ctx))
+        })?;
+    let callable = core::Func::from_type_ref(ctx, callable_ty)?;
+    let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
+    let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+    let params = callable.params(ctx);
+    let environment_index = physical_environment_index(params, &evidence_ty);
+    let mut physical_params = Vec::with_capacity(params.len() + 1);
+    physical_params.extend_from_slice(&params[..environment_index]);
+    physical_params.push(anyref_ty);
+    physical_params.extend_from_slice(&params[environment_index..]);
+    Some(core::func(ctx, callable.r#return(ctx), physical_params).as_type_ref())
 }
 
 /// Lower `closure.func` to `adt.struct_get` field 0.
@@ -398,9 +556,29 @@ pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) {
 /// remains module-scoped because function signatures are interprocedural
 /// contracts.
 pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
+    retire_parent_layout_aliases(ctx);
     let applicator =
         PatternApplicator::new(TypeConverter::new()).add_pattern(UpdateFuncSignatureArena);
     applicator.apply_partial(ctx, module);
+}
+
+/// Parent layouts are aliases only at the post-CPS textual boundary: they let
+/// a reparsed boundary validate the exact nominal layout.  The layout itself
+/// is interned and referenced by every generated `adt.struct_new/get`, so it
+/// remains available to target layout consumers after the alias is retired.
+/// Keeping the logical alias beyond closure lowering would make an otherwise
+/// unreachable `closure.closure` field look like a residual target type.
+fn retire_parent_layout_aliases(ctx: &mut IrContext) {
+    let aliases = ctx.type_aliases().to_vec();
+    for (name, ty) in aliases {
+        let data = ctx.types.get(ty);
+        if data.dialect == Symbol::new("adt")
+            && data.name == Symbol::new("struct")
+            && data.attrs.contains_key(CPS_PARENT_RESULT_ATTR)
+        {
+            ctx.remove_type_alias(name);
+        }
+    }
 }
 
 /// Lower closure operations in one function body.
@@ -408,6 +586,9 @@ pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
 /// Closure calls already carry convention-specific hidden operands. This pass
 /// only interposes the physical closure environment.
 pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
+    if ctx.op(func_op.op_ref()).regions.is_empty() {
+        return;
+    }
     let legacy_evidence = evidence_param_for_func(ctx, func_op);
     let applicator = PatternApplicator::new(TypeConverter::new())
         .with_target(
@@ -416,6 +597,7 @@ pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
                 .recursive_legal_op("func", "func"),
         )
         .add_pattern(LowerClosureCallArena { legacy_evidence })
+        .add_pattern(LowerClosureTailCallArena)
         .add_pattern(LowerClosureNewArena)
         .add_pattern(LowerClosureFuncArena)
         .add_pattern(LowerClosureEnvArena);
@@ -554,6 +736,17 @@ mod tests {
         ctx.block_args(entry)[0]
     }
 
+    fn tail_call_indirect_operands(ctx: &IrContext, func_op: func::Func) -> Vec<Vec<ValueRef>> {
+        let mut calls = Vec::new();
+        let _ = walk_op::<()>(ctx, func_op.op_ref(), &mut |op| {
+            if func::TailCallIndirect::from_op(ctx, op).is_ok() {
+                calls.push(ctx.op_operands(op).to_vec());
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        calls
+    }
+
     fn nested_closure_test_module(ctx: &mut IrContext) -> Module {
         let ev_ty = evidence_type_str();
         parse_test_module(
@@ -602,6 +795,50 @@ mod tests {
             ir.contains("closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))"),
             "function-typed params should be prepared as closure params:\n{ir}"
         );
+    }
+
+    #[test]
+    fn prepare_pass_retires_parent_layout_aliases_without_losing_layout() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = core.i32}
+  !done = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !resume = closure.closure(core.func(core.never, !parent, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !dispatch = closure.closure(core.func(core.never, !resume, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !parent_layout = adt.struct() {fields = [[@done, !done], [@dispatch, !dispatch]], name = @Parent, tribute.cps_parent_result = core.i32}
+}"#,
+        );
+
+        let parent_layout = ctx
+            .type_alias_by_name(Symbol::new("parent_layout"))
+            .expect("test should start with a registered Parent layout alias");
+
+        prepare_closure_lowering(&mut ctx, module);
+
+        assert_eq!(
+            ctx.type_alias_by_name(Symbol::new("parent_layout")),
+            None,
+            "logical Parent layout aliases must not leak abstract closures into target validation"
+        );
+        let parent_data = ctx.types.get(parent_layout);
+        let result = parent_data
+            .attrs
+            .get_type(CPS_PARENT_RESULT_ATTR)
+            .expect("Parent layout must retain its result provenance");
+        assert_eq!(
+            (ctx.types.get(result).dialect, ctx.types.get(result).name),
+            (Symbol::new("core"), Symbol::new("i32")),
+            "physicalization must retain exact Parent result provenance"
+        );
+        let fields = trunk_ir::adt_layout::get_struct_fields(&ctx, parent_layout)
+            .expect("interned Parent layout must remain available to target layout consumers");
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].0, Symbol::new("done"));
+        assert_eq!(fields[1].0, Symbol::new("dispatch"));
+        assert_eq!(ctx.types.get(fields[0].1).dialect, Symbol::new("closure"));
+        assert_eq!(ctx.types.get(fields[1].1).dialect, Symbol::new("closure"));
     }
 
     #[test]
@@ -690,6 +927,159 @@ mod tests {
             inner_calls[0][1],
             entry_evidence_arg(&ctx, inner),
             "nested function pass should use the nested function's own evidence argument"
+        );
+    }
+
+    #[test]
+    fn generated_continuation_tail_interposes_env_before_answer() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !done = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  func.func @generated(%done: !done, %answer: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      func.tail_call_indirect %done, %answer {tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let generated = func_by_name(&ctx, module, "generated");
+        let entry = ctx.region(generated.body(&ctx)).blocks[0];
+        let answer = ctx.block_args(entry)[1];
+
+        lower_closures_in_func(&mut ctx, generated);
+
+        let tails = tail_call_indirect_operands(&ctx, generated);
+        assert_eq!(tails.len(), 1);
+        assert_eq!(tails[0].len(), 3, "table index, env, answer");
+        assert_eq!(tails[0][2], answer);
+        let tail = ctx.value_def(tails[0][0]);
+        assert!(matches!(tail, trunk_ir::refs::ValueDef::OpResult(_, 0)));
+    }
+
+    #[test]
+    fn bare_function_tail_keeps_exact_raw_pointer_signature() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @generated(%done: core.func(core.never, core.nil), %answer: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %done, %answer {tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let generated = func_by_name(&ctx, module, "generated");
+
+        lower_closures_in_func(&mut ctx, generated);
+
+        let block = ctx.region(generated.body(&ctx)).blocks[0];
+        let tail = ctx
+            .block(block)
+            .ops
+            .iter()
+            .copied()
+            .find(|&op| func::TailCallIndirect::from_op(&ctx, op).is_ok())
+            .expect("lowered function tail should remain present");
+        let signature = tribute_core::get_indirect_call_signature(&ctx, tail)
+            .expect("raw table-pointer tail must retain the exact physical callable signature");
+        let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
+        let anyref_ty = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let nil_ty = core::nil(&mut ctx).as_type_ref();
+        assert_eq!(callable.params(&ctx), [anyref_ty, nil_ty]);
+    }
+
+    #[test]
+    fn canonical_packed_closure_tail_keeps_exact_raw_pointer_signature() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !done = closure.closure(core.func(core.never, core.nil)) {tribute.calling_convention = 2}
+  !raw = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  func.func @done(%answer: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @generated(%answer: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+    %fun = func.constant {func_ref = @done} : core.func(core.never, core.nil)
+    %env = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+    %closure = adt.struct_new %fun, %env {tribute.closure_callable_type = !done, type = !raw} : !raw
+    func.tail_call_indirect %closure, %answer {tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let generated = func_by_name(&ctx, module, "generated");
+
+        lower_closures_in_func(&mut ctx, generated);
+
+        let block = ctx.region(generated.body(&ctx)).blocks[0];
+        let tail = ctx
+            .block(block)
+            .ops
+            .iter()
+            .copied()
+            .find(|&op| func::TailCallIndirect::from_op(&ctx, op).is_ok())
+            .expect("lowered packed closure tail should remain present");
+        let signature = tribute_core::get_indirect_call_signature(&ctx, tail)
+            .expect("canonical packed closure must retain its exact raw-pointer signature");
+        let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
+        let anyref_ty = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let nil_ty = core::nil(&mut ctx).as_type_ref();
+        assert_eq!(callable.params(&ctx), [anyref_ty, nil_ty]);
+    }
+
+    #[test]
+    fn source_cps_tail_interposes_env_after_exact_evidence() {
+        let ev_ty = evidence_type_str();
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  !done = closure.closure(core.func(core.never, core.i32)) {{tribute.calling_convention = 2}}
+  !source = closure.closure(core.func(core.never, {ev_ty}, !done, core.i32)) {{tribute.calling_convention = 2}}
+  func.func @source_caller(%callee: !source, %evidence: {ev_ty}, %done: !done, %value: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
+      func.tail_call_indirect %callee, %evidence, %done, %value {{tribute.calling_convention = 2}}
+  }}
+}}"#
+            ),
+        );
+        let caller = func_by_name(&ctx, module, "source_caller");
+        let entry = ctx.region(caller.body(&ctx)).blocks[0];
+        let entry_args = ctx.block_args(entry).to_vec();
+
+        lower_closures_in_func(&mut ctx, caller);
+
+        let tails = tail_call_indirect_operands(&ctx, caller);
+        assert_eq!(tails.len(), 1);
+        assert_eq!(tails[0].len(), 5, "table index, evidence, env, done, value");
+        assert_eq!(tails[0][1], entry_args[1]);
+        assert_eq!(tails[0][3], entry_args[2]);
+        assert_eq!(tails[0][4], entry_args[3]);
+        let tail_op = match ctx.value_def(tails[0][0]) {
+            trunk_ir::refs::ValueDef::OpResult(op, _) => ctx
+                .block(ctx.op(op).parent_block.unwrap())
+                .ops
+                .iter()
+                .copied()
+                .find(|&candidate| func::TailCallIndirect::from_op(&ctx, candidate).is_ok())
+                .unwrap(),
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            get_calling_convention(&ctx, tail_op),
+            Some(tribute_core::CallingConvention::Cps)
+        );
+        let signature = tribute_core::get_indirect_call_signature(&ctx, tail_op)
+            .expect("closure lowering must preserve the exact raw-pointer callable signature");
+        let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
+        let anyref_ty = tribute_rt::anyref(&mut ctx).as_type_ref();
+        assert_eq!(
+            callable.params(&ctx),
+            [
+                ctx.value_ty(entry_args[1]),
+                anyref_ty,
+                ctx.value_ty(entry_args[2]),
+                ctx.value_ty(entry_args[3]),
+            ]
         );
     }
 }

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -295,9 +295,12 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
             parent_op: None,
         });
 
-        // Detach old body region before replacing
-        let old_body = func_op.body(ctx);
-        ctx.detach_region(old_body);
+        // Logical externs remain body-less declarations. The temporary legacy
+        // route materializes an unreachable body, so accept either shape while
+        // replacing the declaration with the same concrete implementation.
+        if let Some(old_body) = ctx.op(op).regions.first().copied() {
+            ctx.detach_region(old_body);
+        }
 
         let new_func = func::func(ctx, loc, sym_name, func_ty, body).op_ref();
         // Do NOT copy the "intrinsic" abi — this is now a real function

--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod diagnostic;
 
 // === TrunkIR passes ===
+pub mod backend_ready;
 pub mod boxing;
 pub mod closure_lower;
 pub mod evidence;
@@ -24,6 +25,7 @@ pub mod lower_handle_dispatch;
 pub mod native;
 pub mod resolve_evidence;
 pub mod tail_resumptive;
+pub mod target_abi;
 pub mod tribute_control_to_cps;
 pub mod type_converter;
 pub mod wasm;

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -11,27 +11,32 @@
 //! // Output:
 //! %payload = pack %args into the canonical operation product
 //! %cont = cast %continuation to anyref
-//! %result = effect.dispatch_cps %evidence, %cont, %payload
+//! effect.dispatch_cps %evidence, %cont, %payload
 //!   { ability_ref: @State, op_name: @get }
-//! func.return %result
 //! ```
 //!
 //! The explicitly named legacy operations retain the old null-or-single-value
 //! carrier payload ABI until the frontend/pipeline migration is complete. Uses
-//! `PatternApplicator` for declarative op-level rewriting. This is an
-//! intermediate best-effort pass: the final `ability-lowered` boundary is
-//! established by `LowerHandleDispatch` after evidence resolution.
+//! `PatternApplicator` for declarative op-level rewriting. The function pass
+//! validates every final `ability.perform` candidate before mutation; the
+//! final `ability-lowered` dialect boundary is established by
+//! `LowerHandleDispatch` after evidence resolution.
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{adt, core, func};
 use trunk_ir::ops::DialectOp;
-use trunk_ir::pass::{Pass, PassRunResult};
-use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
+use trunk_ir::pass::{Pass, PassRunResult, VerifyError};
+use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
-    PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter, erase_op,
+    PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter,
 };
+use trunk_ir::walk::{WalkAction, walk_op};
 
+use tribute_core::{
+    CLOSURE_CALLABLE_TYPE_ATTR, cps_closure_function_type, get_closure_callable_type,
+    has_canonical_cps_parent_layout,
+};
 use tribute_ir::dialect::ability;
 use tribute_ir::dialect::effect;
 use tribute_ir::dialect::tribute_rt;
@@ -73,12 +78,179 @@ impl Pass for LowerAbilityPerform {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        if ctx.op(target.op_ref()).regions.is_empty() {
+            return Ok(());
+        }
+        prevalidate_final_performs(ctx, target)?;
         lower_ability_perform(ctx, target);
+        let mut residual = None;
+        let _ = walk_op::<()>(ctx, target.op_ref(), &mut |op| {
+            if ability::Perform::from_op(ctx, op).is_ok() {
+                let reason = explain_invalid_final_perform(ctx, op)
+                    .unwrap_or("lowering pattern rejected a prevalidated final perform");
+                residual = Some(format!("residual ability.perform: {reason}"));
+                return std::ops::ControlFlow::Break(());
+            }
+            std::ops::ControlFlow::Continue(WalkAction::Advance)
+        });
+        if let Some(message) = residual {
+            return Err(Box::new(VerifyError { message }));
+        }
+        consume_closure_callable_provenance(ctx, target);
         Ok(())
     }
 }
 
-/// Pattern: `ability.perform` → `effect.dispatch_cps` + return.
+fn prevalidate_final_performs(ctx: &IrContext, target: func::Func) -> PassRunResult {
+    let mut invalid = None;
+    let _ = walk_op::<()>(ctx, target.op_ref(), &mut |op| {
+        if let Some(callable) = get_closure_callable_type(ctx, op)
+            && !crate::closure_lower::is_lowered_closure_pack(ctx, op, callable)
+        {
+            invalid = Some(
+                "invalid temporary closure callable provenance on a non-canonical closure pack"
+                    .to_owned(),
+            );
+            return std::ops::ControlFlow::Break(());
+        }
+        if ability::Perform::from_op(ctx, op).is_ok()
+            && let Some(reason) = explain_invalid_final_perform(ctx, op)
+        {
+            invalid = Some(format!("invalid final ability.perform: {reason}"));
+            return std::ops::ControlFlow::Break(());
+        }
+        std::ops::ControlFlow::Continue(WalkAction::Advance)
+    });
+    match invalid {
+        Some(message) => Err(Box::new(VerifyError { message })),
+        None => Ok(()),
+    }
+}
+
+/// Remove the proof-only closure type after every final perform in this
+/// function has lowered successfully. The marker must not reach backend-ready
+/// IR, where it would retain an abstract closure type in an attribute.
+fn consume_closure_callable_provenance(ctx: &mut IrContext, target: func::Func) {
+    let mut packs = Vec::new();
+    let _ = walk_op::<()>(ctx, target.op_ref(), &mut |op| {
+        if get_closure_callable_type(ctx, op).is_some() {
+            packs.push(op);
+        }
+        std::ops::ControlFlow::Continue(WalkAction::Advance)
+    });
+    for pack in packs {
+        ctx.op_mut(pack)
+            .attributes
+            .remove(Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR));
+    }
+}
+
+#[derive(Clone)]
+struct FinalPerformShape {
+    evidence: ValueRef,
+    dispatch: ValueRef,
+    resume: ValueRef,
+    values: Vec<ValueRef>,
+}
+
+/// Validate the complete final `ability.perform` ABI before either the pass
+/// wrapper or the local rewrite pattern mutates IR. The exact callback types
+/// are proof-bearing control values; raw `anyref` never substitutes for them.
+fn validate_final_perform_shape(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<FinalPerformShape, &'static str> {
+    let operands = ctx.op_operands(op);
+    if operands.len() < 3 {
+        return Err("missing explicit dynamic evidence, dispatch, or resume operand");
+    }
+    let evidence = operands[0];
+    if !ability::is_evidence_type_ref(ctx, ctx.value_ty(evidence)) {
+        return Err("dynamic evidence operand has the wrong exact type");
+    }
+    let dispatch = operands[1];
+    let Some(dispatch_closure) = proven_callback_closure_type(ctx, dispatch) else {
+        return Err("dispatch operand is not a convention-proven CPS closure");
+    };
+    let Some(dispatch_function) = cps_closure_function_type(ctx, dispatch_closure) else {
+        return Err("dispatch operand is not a convention-proven CPS closure");
+    };
+    let dispatch_params = &ctx.types.get(dispatch_function).params;
+    if dispatch_params.len() != 7
+        || !is_type(ctx, dispatch_params[0], "core", "never")
+        || dispatch_params[1] != ctx.value_ty(evidence)
+        || !is_type(ctx, dispatch_params[3], "core", "i32")
+        || !is_type(ctx, dispatch_params[4], "core", "i32")
+        || !is_type(ctx, dispatch_params[5], "core", "i32")
+        || !is_type(ctx, dispatch_params[6], "tribute_rt", "anyref")
+    {
+        return Err("dispatch operand does not have the exact Dispatch<R> ABI");
+    }
+    let expected_resume = dispatch_params[2];
+    let resume = operands[2];
+    if proven_callback_closure_type(ctx, resume) != Some(expected_resume) {
+        return Err("resume operand does not match Dispatch<R>'s exact Resume<R> type");
+    }
+    let Some(resume_function) = cps_closure_function_type(ctx, expected_resume) else {
+        return Err("Dispatch<R> does not name a convention-proven Resume<R> closure");
+    };
+    let resume_params = &ctx.types.get(resume_function).params;
+    if resume_params.len() != 4
+        || !is_type(ctx, resume_params[0], "core", "never")
+        || resume_params[1] != ctx.value_ty(evidence)
+        || !has_canonical_cps_parent_layout(ctx, resume_params[2], dispatch_closure)
+        || !is_type(ctx, resume_params[3], "tribute_rt", "anyref")
+    {
+        return Err("Dispatch<R> names a malformed Resume<R> callback");
+    }
+    let [result] = ctx.op_results(op) else {
+        return Err("expected exactly one core.never marker result");
+    };
+    let result_type = ctx.types.get(ctx.value_ty(*result));
+    if result_type.dialect != Symbol::new("core") || result_type.name != Symbol::new("never") {
+        return Err("marker result is not core.never");
+    }
+    if ctx.has_uses(*result) {
+        return Err("core.never marker result is used");
+    }
+    let Some(block) = ctx.op(op).parent_block else {
+        return Err("operation has no parent block");
+    };
+    if ctx.block(block).ops.last().copied() != Some(op) {
+        return Err("operation is not in proper-tail position");
+    }
+    Ok(FinalPerformShape {
+        evidence,
+        dispatch,
+        resume,
+        values: operands[3..].to_vec(),
+    })
+}
+
+fn proven_callback_closure_type(ctx: &IrContext, value: ValueRef) -> Option<TypeRef> {
+    let value_type = ctx.value_ty(value);
+    if cps_closure_function_type(ctx, value_type).is_some() {
+        return Some(value_type);
+    }
+    let trunk_ir::ValueDef::OpResult(def, _) = ctx.value_def(value) else {
+        return None;
+    };
+    let closure_type = get_closure_callable_type(ctx, def)?;
+    crate::closure_lower::is_lowered_closure_pack(ctx, def, closure_type)
+        .then_some(closure_type)
+        .filter(|closure| cps_closure_function_type(ctx, *closure).is_some())
+}
+
+fn is_type(ctx: &IrContext, ty: TypeRef, dialect: &'static str, name: &'static str) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::new(dialect) && data.name == Symbol::new(name)
+}
+
+fn explain_invalid_final_perform(ctx: &IrContext, op: OpRef) -> Option<&'static str> {
+    validate_final_perform_shape(ctx, op).err()
+}
+
+/// Pattern: `ability.perform` → resultless `effect.dispatch_cps`.
 struct LowerPerformPattern {
     types: CommonTypes,
 }
@@ -90,11 +262,14 @@ impl RewritePattern for LowerPerformPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let legacy = if ability::Perform::from_op(ctx, op).is_ok() {
-            false
-        } else if ability::LegacyPerform::from_op(ctx, op).is_ok() {
-            true
-        } else {
+        if ability::Perform::from_op(ctx, op).is_err() {
+            // The explicitly named carrier form remains on the legacy path
+            // until its dedicated cleanup; the final effect ABI has no
+            // result-producing overload.
+            return false;
+        }
+
+        let Ok(shape) = validate_final_perform_shape(ctx, op) else {
             return false;
         };
 
@@ -102,103 +277,31 @@ impl RewritePattern for LowerPerformPattern {
         let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
         let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
 
-        // Operands: [continuation, ...values]
-        let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
-        let continuation_val = operands[0];
-        let value_operands = &operands[1..];
-
         let t = &self.types;
 
-        // Find evidence parameter from enclosing func's entry block.
-        let evidence_val = find_evidence_from_op(ctx, op);
-
-        // === 1. Find evidence ===
-        let Some(evidence_val) = evidence_val else {
-            // Missing evidence means the frontend detected unhandled effects
-            // and emitted a diagnostic. Skip this op gracefully.
-            return false;
-        };
-
         // === 2. Build the canonical payload product. ===
-        let shift_value_val = if legacy {
-            pack_legacy_payload(ctx, rewriter, location, value_operands, t.anyref)
-        } else {
-            pack_payload(
-                ctx,
-                rewriter,
-                location,
-                ability_ref_type,
-                op_name_sym,
-                value_operands,
-                t.anyref,
-            )
-        };
+        let shift_value_val = pack_payload(
+            ctx,
+            rewriter,
+            location,
+            ability_ref_type,
+            op_name_sym,
+            &shape.values,
+            t.anyref,
+        );
 
-        // === 3. Cast continuation closure to anyref ===
-        let cont_anyref =
-            core::unrealized_conversion_cast(ctx, location, continuation_val, t.anyref);
-        rewriter.insert_op(cont_anyref.op_ref());
-
-        // === 4. Dispatch through target-independent effect ABI ===
-        let dispatch_op = effect::dispatch_cps(
+        let dispatch = effect::dispatch_cps(
             ctx,
             location,
-            evidence_val,
-            cont_anyref.result(ctx),
+            shape.evidence,
+            shape.dispatch,
+            shape.resume,
             shift_value_val,
-            t.anyref,
             ability_ref_type,
             op_name_sym,
         );
-        rewriter.insert_op(dispatch_op.op_ref());
-
-        // === 5. Return the dispatch result (cast to function return type) ===
-        let block = ctx.op(op).parent_block.unwrap();
-        if is_in_func_body(ctx, block) {
-            let result_val = dispatch_op.result(ctx);
-            let func_ret_ty = find_enclosing_func_return_type(ctx, block);
-            let ret_op = if let Some(ret_ty) = func_ret_ty {
-                if is_nil_type(ctx, ret_ty) {
-                    // Nil return type = void in Cranelift; return with no args.
-                    func::r#return(ctx, location, std::iter::empty::<ValueRef>())
-                } else if ret_ty != t.anyref {
-                    let cast = core::unrealized_conversion_cast(ctx, location, result_val, ret_ty);
-                    rewriter.insert_op(cast.op_ref());
-                    func::r#return(ctx, location, [cast.result(ctx)])
-                } else {
-                    func::r#return(ctx, location, [result_val])
-                }
-            } else {
-                func::r#return(ctx, location, [result_val])
-            };
-            rewriter.insert_op(ret_op.op_ref());
-        }
-
-        // Erase perform op, mapping its result to the dispatch result.
-        rewriter.erase_op(vec![dispatch_op.result(ctx)]);
-
-        // Remove dead code after the perform op in the same block.
-        // Only do this when we inserted a func.return terminator (i.e., in
-        // func body); in other regions (scf.if, etc.) the existing terminator
-        // (scf.yield) must be preserved.
-        if is_in_func_body(ctx, block) {
-            let dead_ops: Vec<OpRef> = {
-                let ops = &ctx.block(block).ops;
-                let Some(idx) = ops.iter().position(|&o| o == op) else {
-                    return true;
-                };
-                ops[idx + 1..].to_vec()
-            };
-            // Erase unreachable ops after the perform in reverse order
-            // (consumer before producer) so `erase_op`'s result-use check never
-            // trips on a later dead op still consuming an earlier one. Unlike
-            // the previous detach-only loop, this also clears the dead ops'
-            // operand use-chains (#710).
-            for dead_op in dead_ops.into_iter().rev() {
-                erase_op(ctx, dead_op);
-            }
-        }
-
+        rewriter.insert_op(dispatch.op_ref());
+        rewriter.erase_op_with_unused_results();
         true
     }
 }
@@ -226,6 +329,7 @@ impl RewritePattern for LowerCallPattern {
         let location = ctx.op(op).location;
         let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
         let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
+        let source_result_ty = ctx.op_result_types(op)[0];
 
         // Operands: [...values]
         let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
@@ -270,8 +374,26 @@ impl RewritePattern for LowerCallPattern {
         );
         rewriter.insert_op(dispatch_op.op_ref());
 
-        // === 4. Erase ability.call, mapping its result to the dispatch result ===
-        rewriter.erase_op(vec![dispatch_op.result(ctx)]);
+        // === 4. Restore the source result after the erased effect ABI. ===
+        // `effect.dispatch_tail` always returns the runtime-erased `anyref`
+        // produced by the handler dispatcher. The source `ability.call`
+        // result remains its exact declared type, so preserve the conversion
+        // boundary explicitly for target materialization.
+        let replacement = if source_result_ty == t.anyref {
+            dispatch_op.result(ctx)
+        } else {
+            let cast = core::unrealized_conversion_cast(
+                ctx,
+                location,
+                dispatch_op.result(ctx),
+                source_result_ty,
+            );
+            let result = cast.result(ctx);
+            rewriter.insert_op(cast.op_ref());
+            result
+        };
+
+        rewriter.erase_op(vec![replacement]);
 
         true
     }
@@ -334,37 +456,6 @@ fn pack_legacy_payload(
     }
 }
 
-/// Check if a TypeRef is `core.nil` (void return type in Cranelift).
-fn is_nil_type(ctx: &IrContext, ty: trunk_ir::TypeRef) -> bool {
-    let td = ctx.types.get(ty);
-    td.dialect == Symbol::new("core") && td.name == Symbol::new("nil")
-}
-
-/// Find the return type of the enclosing `func.func`.
-fn find_enclosing_func_return_type(ctx: &IrContext, block: BlockRef) -> Option<trunk_ir::TypeRef> {
-    let region = ctx.block(block).parent_region?;
-    let parent_op = ctx.region(region).parent_op?;
-    let func_op = func::Func::from_op(ctx, parent_op).ok()?;
-    let func_ty = func_op.r#type(ctx);
-    let td = ctx.types.get(func_ty);
-    if td.dialect == Symbol::new("core") && td.name == Symbol::new("func") {
-        td.params.first().copied()
-    } else {
-        None
-    }
-}
-
-/// Check if a block belongs directly to a `func.func` body region.
-fn is_in_func_body(ctx: &IrContext, block: BlockRef) -> bool {
-    let Some(region) = ctx.block(block).parent_region else {
-        return false;
-    };
-    let Some(parent_op) = ctx.region(region).parent_op else {
-        return false;
-    };
-    func::Func::matches(ctx, parent_op)
-}
-
 /// Find the evidence parameter by walking up from the op to its enclosing func.
 fn find_evidence_from_op(ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
     let mut current_op = op;
@@ -372,17 +463,88 @@ fn find_evidence_from_op(ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
         let block = ctx.op(current_op).parent_block?;
         let region = ctx.block(block).parent_region?;
         let parent = ctx.region(region).parent_op?;
+        if let Ok(handle) = ability::HandleDispatch::from_op(ctx, parent) {
+            // A final delimiter owns an exact dynamically extended evidence
+            // value in its body entry block. A perform lexically inside that
+            // body must look up its prompt through that value, rather than
+            // through the enclosing function's outer evidence parameter.
+            // Handler arms are lowered into separate closures, so they do not
+            // satisfy this exact body-region provenance check.
+            if region == handle.body(ctx) {
+                let [evidence] = ctx.block_args(block) else {
+                    return None;
+                };
+                return ability::is_evidence_type_ref(ctx, ctx.value_ty(*evidence))
+                    .then_some(*evidence);
+            }
+        }
         if func::Func::matches(ctx, parent) {
             // Found the enclosing func — check entry block args.
             let func_body = func::Func::from_op(ctx, parent).ok()?.body(ctx);
             let entry = ctx.region(func_body).blocks[0];
-            return ctx
+            if let Some(evidence) = ctx
                 .block_args(entry)
                 .iter()
                 .find(|&&arg| ability::is_evidence_type_ref(ctx, ctx.value_ty(arg)))
-                .copied();
+                .copied()
+            {
+                return Some(evidence);
+            }
+            return captured_evidence_from_closure_environment(ctx, entry);
         }
         current_op = parent;
+    }
+}
+
+/// Recover evidence only from the canonical leading closure-environment
+/// extraction sequence produced by `lower_closure_lambda`.
+///
+/// The environment is the exact entry argument named `__env`; its first
+/// operation is an `adt.ref_cast`, followed immediately by the capture
+/// `adt.struct_get`s. Restricting lookup to that prefix proves provenance and
+/// dominance and rejects unrelated evidence-producing operations later in the
+/// entry block.
+fn captured_evidence_from_closure_environment(
+    ctx: &IrContext,
+    entry: trunk_ir::refs::BlockRef,
+) -> Option<ValueRef> {
+    let env_indices = ctx
+        .block(entry)
+        .args
+        .iter()
+        .enumerate()
+        .filter_map(|(index, arg)| {
+            (arg.attrs.get_symbol("bind_name") == Some(Symbol::new("__env"))).then_some(index)
+        })
+        .collect::<Vec<_>>();
+    let [env_index] = env_indices.as_slice() else {
+        return None;
+    };
+    let env_arg = ctx.block_arg(entry, *env_index as u32);
+
+    let mut ops = ctx.block(entry).ops.iter().copied();
+    let cast = adt::RefCast::from_op(ctx, ops.next()?).ok()?;
+    if cast.r#ref(ctx) != env_arg {
+        return None;
+    }
+    let cast_result = cast.result(ctx);
+
+    let mut candidates = Vec::new();
+    for op in ops {
+        let Ok(get) = adt::StructGet::from_op(ctx, op) else {
+            break;
+        };
+        if get.r#ref(ctx) != cast_result {
+            break;
+        }
+        let result = get.result(ctx);
+        if ability::is_evidence_type_ref(ctx, ctx.value_ty(result)) {
+            candidates.push(result);
+        }
+    }
+    match candidates.as_slice() {
+        [evidence] => Some(*evidence),
+        _ => None,
     }
 }
 
@@ -404,20 +566,31 @@ mod tests {
         "core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})"
     }
 
+    fn control_type_decls(ev_ty: &str) -> String {
+        format!(
+            "  !parent = adt.typeref() {{name = @Parent, tribute.cps_parent_result = core.i32}}\n  \
+             !done = closure.closure(core.func(core.never, core.i32)) {{tribute.calling_convention = 2}}\n  \
+             !resume = closure.closure(core.func(core.never, {ev_ty}, !parent, tribute_rt.anyref)) \
+             {{tribute.calling_convention = 2}}\n  \
+             !dispatch = closure.closure(core.func(core.never, {ev_ty}, !resume, core.i32, core.i32, core.i32, tribute_rt.anyref)) \
+             {{tribute.calling_convention = 2}}\n  \
+             !parent_layout = adt.struct() {{fields = [[@done, !done], [@dispatch, !dispatch]], name = @Parent, tribute.cps_parent_result = core.i32}}\n"
+        )
+    }
+
     #[test]
     fn test_lower_perform_basic() {
         let mut ctx = IrContext::new();
         init_common_types(&mut ctx);
         let ev_ty = evidence_type_str();
+        let control = control_type_decls(ev_ty);
 
         let module = parse_test_module(
             &mut ctx,
             &format!(
                 r#"core.module @test {{
-  func.func @test_fn(%ev: {ev_ty}) -> tribute_rt.anyref {{
-    %k = arith.const {{value = 0}} : tribute_rt.anyref
-    %yr = ability.perform %k {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : tribute_rt.anyref
-    func.return %yr
+{control}  func.func @test_fn(%ev: {ev_ty}, %dispatch: !dispatch, %resume: !resume) -> core.never {{
+    %never = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
   }}
 }}"#
             ),
@@ -426,7 +599,11 @@ mod tests {
         lower_ability_perform(&mut ctx, module);
 
         let ir_text = print_module(&ctx, module.op());
-        assert_snapshot!(ir_text);
+        assert!(!ir_text.contains("ability.perform"), "{ir_text}");
+        assert!(ir_text.contains("effect.dispatch_cps"), "{ir_text}");
+        assert!(!ir_text.contains("func.return"), "{ir_text}");
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &ir_text);
     }
 
     #[test]
@@ -434,16 +611,15 @@ mod tests {
         let mut ctx = IrContext::new();
         init_common_types(&mut ctx);
         let ev_ty = evidence_type_str();
+        let control = control_type_decls(ev_ty);
 
         let module = parse_test_module(
             &mut ctx,
             &format!(
                 r#"core.module @test {{
-  func.func @test_fn(%ev: {ev_ty}) -> tribute_rt.anyref {{
+{control}  func.func @test_fn(%ev: {ev_ty}, %dispatch: !dispatch, %resume: !resume) -> core.never {{
     %val = arith.const {{value = 42}} : core.i32
-    %k = arith.const {{value = 0}} : tribute_rt.anyref
-    %yr = ability.perform %k, %val {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}} : tribute_rt.anyref
-    func.return %yr
+    %never = ability.perform %ev, %dispatch, %resume, %val {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}} : core.never
   }}
 }}"#
             ),
@@ -452,7 +628,45 @@ mod tests {
         lower_ability_perform(&mut ctx, module);
 
         let ir_text = print_module(&ctx, module.op());
-        assert_snapshot!(ir_text);
+        assert!(!ir_text.contains("ability.perform"), "{ir_text}");
+        assert!(ir_text.contains("effect.dispatch_cps"), "{ir_text}");
+        assert!(ir_text.contains("@arg0"), "{ir_text}");
+    }
+
+    #[test]
+    fn perform_in_final_handle_body_uses_dynamic_body_evidence() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  func.func @run(%outer: {ev_ty}) -> core.never {{
+    %prompt = arith.const {{value = 7}} : core.i32
+    ability.handle_dispatch %outer, %prompt {{ability_refs = []}} {{
+      ^body(%dynamic: {ev_ty}):
+        %dispatch = arith.const {{value = 0}} : tribute_rt.anyref
+        %resume = arith.const {{value = 0}} : tribute_rt.anyref
+        %never = ability.perform %dynamic, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+    }}
+  }}
+}}"#
+            ),
+        );
+        let run = module
+            .ops(&ctx)
+            .iter()
+            .find_map(|op| func::Func::from_op(&ctx, *op).ok())
+            .expect("run function");
+        let entry = ctx.region(run.body(&ctx)).blocks[0];
+        let handle = ctx.block(entry).ops[1];
+        let handle = ability::HandleDispatch::from_op(&ctx, handle).expect("delimiter");
+        let body = ctx.region(handle.body(&ctx)).blocks[0];
+        let dynamic = ctx.block_arg(body, 0);
+        let perform = ctx.block(body).ops[2];
+
+        assert_eq!(find_evidence_from_op(&ctx, perform), Some(dynamic));
     }
 
     #[test]
@@ -481,6 +695,36 @@ mod tests {
     }
 
     #[test]
+    fn tail_dispatch_restores_the_exact_source_result_after_erasure() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  func.func @call_nat(%ev: {ev_ty}) -> core.i32 {{
+    %result = ability.call {{ability_ref = core.ability_ref() {{name = @Ask}}, op_name = @ask}} : core.i32
+    func.return %result
+  }}
+}}"#
+            ),
+        );
+
+        lower_ability_perform(&mut ctx, module);
+
+        let ir = print_module(&ctx, module.op());
+        assert!(!ir.contains("ability.call"), "{ir}");
+        assert!(ir.contains("effect.dispatch_tail"), "{ir}");
+        assert!(
+            ir.contains("core.unrealized_conversion_cast") && ir.contains(": core.i32"),
+            "the erased handler result must be restored to the source Nat type:\n{ir}"
+        );
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &ir);
+    }
+
+    #[test]
     fn legacy_operations_keep_the_carrier_payload_abi() {
         let mut ctx = IrContext::new();
         init_common_types(&mut ctx);
@@ -505,12 +749,254 @@ mod tests {
         lower_ability_perform(&mut ctx, module);
 
         let ir = print_module(&ctx, module.op());
-        assert!(!ir.contains("ability.legacy_"));
+        assert!(ir.contains("ability.legacy_perform"));
+        assert!(!ir.contains("ability.legacy_call"));
         assert!(!ir.contains("__tribute_ability_payload_"));
-        assert!(ir.contains("adt.ref_null"));
-        assert_eq!(ir.matches("effect.dispatch_").count(), 2);
+        assert_eq!(ir.matches("effect.dispatch_").count(), 1);
+        assert_eq!(ir.matches("effect.dispatch_tail").count(), 1);
+        assert!(ir.contains("core.unrealized_conversion_cast %"));
+        assert!(!ir.contains("effect.legacy"));
         let mut reparsed = IrContext::new();
         parse_test_module(&mut reparsed, &ir);
+    }
+
+    #[test]
+    fn explicit_dynamic_evidence_is_used_without_environment_provenance_scan() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let control = control_type_decls(ev_ty);
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  !env = adt.struct() {{fields = [[@value, core.i32]], name = @env}}
+{control}  func.func @run(%__env: tribute_rt.anyref, %dispatch: !dispatch, %resume: !resume) -> core.never {{
+    %env_cast = adt.ref_cast %__env {{type = !env}} : !env
+    %captured_value = adt.struct_get %env_cast {{field = 0, type = !env}} : core.i32
+    %unrelated = adt.ref_null {{type = {ev_ty}}} : {ev_ty}
+    %never = ability.perform %unrelated, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+            ),
+        );
+        let run = module
+            .ops(&ctx)
+            .iter()
+            .find_map(|op| func::Func::from_op(&ctx, *op).ok())
+            .expect("run function");
+        let entry = ctx.region(run.body(&ctx)).blocks[0];
+        let env_arg = ctx.block_arg(entry, 0);
+        assert_eq!(
+            ctx.block(entry).args[0].attrs.get_symbol("bind_name"),
+            Some(Symbol::new("__env"))
+        );
+        let entry_ops = ctx.block(entry).ops.clone();
+        let env_cast = adt::RefCast::from_op(&ctx, entry_ops[0]).expect("leading environment cast");
+        assert_eq!(env_cast.r#ref(&ctx), env_arg);
+        let captured_value =
+            adt::StructGet::from_op(&ctx, entry_ops[1]).expect("leading environment field");
+        assert_eq!(captured_value.r#ref(&ctx), env_cast.result(&ctx));
+        assert!(!ability::is_evidence_type_ref(
+            &ctx,
+            ctx.value_ty(captured_value.result(&ctx))
+        ));
+        let unrelated =
+            adt::RefNull::from_op(&ctx, entry_ops[2]).expect("later unrelated evidence producer");
+        assert!(ability::is_evidence_type_ref(
+            &ctx,
+            ctx.value_ty(unrelated.result(&ctx))
+        ));
+        lower_ability_perform(&mut ctx, module);
+
+        let after = print_module(&ctx, module.op());
+        assert!(!after.contains("ability.perform"), "{after}");
+        assert!(after.contains("effect.dispatch_cps"), "{after}");
+    }
+
+    #[test]
+    fn prevalidation_preserves_mixed_valid_and_invalid_function() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let control = control_type_decls(ev_ty);
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+{control}  func.func @run(%ev: {ev_ty}, %dispatch: !dispatch, %resume: !resume, %condition: core.i1) -> core.never {{
+    %never = scf.if %condition : core.never {{
+      %valid = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+    }} {{
+      %invalid = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+      func.unreachable
+    }}
+  }}
+}}"#
+            ),
+        );
+        let run = module
+            .ops(&ctx)
+            .iter()
+            .find_map(|op| func::Func::from_op(&ctx, *op).ok())
+            .expect("run function");
+        let before = print_module(&ctx, module.op());
+
+        let error = LowerAbilityPerform.run(&mut ctx, run).unwrap_err();
+
+        assert!(error.to_string().contains("not in proper-tail position"));
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn final_perform_prevalidation_rejects_unproven_control_values_without_mutation() {
+        let ev_ty = evidence_type_str();
+        let control = control_type_decls(ev_ty);
+        let cases = [
+            (
+                format!(
+                    r#"core.module @test {{
+{control}  func.func @run(%wrong: core.i32, %dispatch: !dispatch, %resume: !resume) -> core.never {{
+    %never = ability.perform %wrong, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+                ),
+                "dynamic evidence operand has the wrong exact type",
+            ),
+            (
+                format!(
+                    r#"core.module @test {{
+{control}  func.func @run(%ev: {ev_ty}, %dispatch: tribute_rt.anyref, %resume: !resume) -> core.never {{
+    %never = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+                ),
+                "dispatch operand is not a convention-proven CPS closure",
+            ),
+            (
+                format!(
+                    r#"core.module @test {{
+{control}  func.func @run(%ev: {ev_ty}, %dispatch: !dispatch, %resume: tribute_rt.anyref) -> core.never {{
+    %never = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+                ),
+                "resume operand does not match Dispatch<R>'s exact Resume<R> type",
+            ),
+            (
+                format!(
+                    r#"core.module @test {{
+{control}  !other_parent = adt.typeref() {{name = @Other, tribute.cps_parent_result = core.i64}}
+  !other_resume = closure.closure(core.func(core.never, {ev_ty}, !other_parent, tribute_rt.anyref)) {{tribute.calling_convention = 2}}
+  func.func @run(%ev: {ev_ty}, %dispatch: !dispatch, %resume: !other_resume) -> core.never {{
+    %never = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+                ),
+                "resume operand does not match Dispatch<R>'s exact Resume<R> type",
+            ),
+            (
+                format!(
+                    r#"core.module @test {{
+{control}  !missing_layout_parent = adt.typeref() {{name = @MissingLayout, tribute.cps_parent_result = core.i32}}
+  !missing_layout_resume = closure.closure(core.func(core.never, {ev_ty}, !missing_layout_parent, tribute_rt.anyref)) {{tribute.calling_convention = 2}}
+  !missing_layout_dispatch = closure.closure(core.func(core.never, {ev_ty}, !missing_layout_resume, core.i32, core.i32, core.i32, tribute_rt.anyref)) {{tribute.calling_convention = 2}}
+  func.func @run(%ev: {ev_ty}, %dispatch: !missing_layout_dispatch, %resume: !missing_layout_resume) -> core.never {{
+    %never = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+                ),
+                "Dispatch<R> names a malformed Resume<R> callback",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let mut ctx = IrContext::new();
+            init_common_types(&mut ctx);
+            let module = parse_test_module(&mut ctx, &input);
+            let run = module
+                .ops(&ctx)
+                .iter()
+                .find_map(|op| func::Func::from_op(&ctx, *op).ok())
+                .expect("run function");
+            let before = print_module(&ctx, module.op());
+            let error = LowerAbilityPerform.run(&mut ctx, run).unwrap_err();
+            assert!(error.to_string().contains(expected), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
+    fn final_perform_consumes_canonical_closure_pack_provenance() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let control = control_type_decls(ev_ty);
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+{control}  !closure = adt.struct(core.i32, tribute_rt.anyref) {{name = @_closure}}
+  func.func @resume_impl(%ev: {ev_ty}, %parent: !parent, %input: tribute_rt.anyref) -> core.never {{
+    func.unreachable
+  }}
+  func.func @run(%ev: {ev_ty}, %dispatch: !dispatch, %env: tribute_rt.anyref) -> core.never {{
+    %resume_fn = func.constant @resume_impl : core.func(core.never, {ev_ty}, !parent, tribute_rt.anyref)
+    %resume = adt.struct_new %resume_fn, %env {{type = !closure, tribute.closure_callable_type = !resume}} : !closure
+    %never = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+            ),
+        );
+        let run = module
+            .ops(&ctx)
+            .iter()
+            .filter_map(|op| func::Func::from_op(&ctx, *op).ok())
+            .find(|func_op| func_op.sym_name(&ctx) == Symbol::new("run"))
+            .expect("run function");
+
+        LowerAbilityPerform.run(&mut ctx, run).unwrap();
+
+        let ir = print_module(&ctx, module.op());
+        assert!(!ir.contains("ability.perform"), "{ir}");
+        assert!(!ir.contains(CLOSURE_CALLABLE_TYPE_ATTR), "{ir}");
+    }
+
+    #[test]
+    fn final_perform_rejects_spoofed_closure_pack_provenance_without_mutation() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let control = control_type_decls(ev_ty);
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+{control}  !closure = adt.struct(core.i32, tribute_rt.anyref) {{name = @_closure}}
+  func.func @run(%ev: {ev_ty}, %dispatch: !dispatch, %env: tribute_rt.anyref) -> core.never {{
+    %not_a_function = arith.const {{value = 0}} : core.i32
+    %resume = adt.struct_new %not_a_function, %env {{type = !closure, tribute.closure_callable_type = !resume}} : !closure
+    %never = ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : core.never
+  }}
+}}"#
+            ),
+        );
+        let run = module
+            .ops(&ctx)
+            .iter()
+            .find_map(|op| func::Func::from_op(&ctx, *op).ok())
+            .expect("run function");
+        let before = print_module(&ctx, module.op());
+
+        let error = LowerAbilityPerform.run(&mut ctx, run).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid temporary closure callable provenance"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]
@@ -522,10 +1008,10 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @test_fn() -> tribute_rt.anyref {
-    %k = arith.const {value = 0} : tribute_rt.anyref
-    %yr = ability.perform %k {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-    func.return %yr
+  func.func @test_fn() -> core.never {
+    %dispatch = arith.const {value = 0} : tribute_rt.anyref
+    %resume = arith.const {value = 0} : tribute_rt.anyref
+    %never = ability.perform %dispatch, %resume {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : core.never
   }
 }"#,
         );

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -25,7 +25,9 @@
 use std::collections::HashMap;
 
 use tribute_core::{
-    CallableAbi, CallingConvention, get_calling_convention, set_calling_convention,
+    CallingConvention, get_calling_convention, get_physical_closure_convention,
+    interpose_physical_environment, physical_closure_type, physical_environment_index,
+    set_calling_convention,
 };
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
@@ -166,6 +168,7 @@ fn lower_single_lambda(
 
     // === Build the lifted function ===
     let evidence_ty = ability::evidence_adt_type_ref(ctx);
+    let has_evidence_param = physical_environment_index(&orig_param_types, &evidence_ty) == 1;
     let implicit_evidence = convention
         .is_none()
         .then(|| nearest_physical_evidence_arg(ctx, lambda_ref, evidence_ty))
@@ -181,6 +184,7 @@ fn lower_single_lambda(
             env_struct_ty,
             orig_param_types: &orig_param_types,
             convention,
+            has_evidence_param,
             evidence_ty,
             implicit_evidence,
             anyref_ty,
@@ -189,15 +193,8 @@ fn lower_single_lambda(
 
     // Source lambdas carry explicit convention metadata. Synthetic legacy
     // continuations still use the compatibility ABI `(evidence, env, args...)`.
-    let all_param_tys = if let Some(convention) = convention {
-        let source_offset =
-            usize::from(convention.needs_evidence()) + usize::from(convention.needs_done_k());
-        let abi = CallableAbi::new(
-            convention,
-            orig_param_types[source_offset..].iter().copied(),
-            func_result_ty,
-        );
-        abi.interpose_environment(&orig_param_types, anyref_ty)
+    let all_param_tys = if convention.is_some() {
+        interpose_physical_environment(&orig_param_types, &evidence_ty, anyref_ty)
     } else {
         let mut params = Vec::with_capacity(orig_param_types.len() + 2);
         params.push(ability::evidence_adt_type_ref(ctx));
@@ -234,7 +231,18 @@ fn lower_single_lambda(
     // Create closure.new replacing the lambda.
     let closure_func_ty =
         core::func(ctx, func_result_ty, orig_param_types.iter().copied()).as_type_ref();
-    let closure_ty = closure::closure(ctx, closure_func_ty).as_type_ref();
+    if let Some(type_convention) = get_physical_closure_convention(ctx, result_ty) {
+        assert_eq!(
+            Some(type_convention),
+            convention,
+            "closure.lambda operation/type convention mismatch"
+        );
+    }
+    let closure_ty = if let Some(convention) = convention {
+        physical_closure_type(ctx, closure_func_ty, convention)
+    } else {
+        closure::closure(ctx, closure_func_ty).as_type_ref()
+    };
     let closure_new_op = closure::new(ctx, location, closure_env, closure_ty, lifted_name);
     if let Some(convention) = convention {
         set_calling_convention(ctx, closure_new_op.op_ref(), convention);
@@ -263,6 +271,7 @@ struct LiftBodyParams<'a> {
     env_struct_ty: Option<TypeRef>,
     orig_param_types: &'a [TypeRef],
     convention: Option<CallingConvention>,
+    has_evidence_param: bool,
     evidence_ty: TypeRef,
     implicit_evidence: Option<ValueRef>,
     anyref_ty: TypeRef,
@@ -281,6 +290,7 @@ fn build_lifted_body(
     let env_struct_ty = params.env_struct_ty;
     let orig_param_types = params.orig_param_types;
     let convention = params.convention;
+    let has_evidence_param = params.has_evidence_param;
     let evidence_ty = params.evidence_ty;
     let implicit_evidence = params.implicit_evidence;
     let anyref_ty = params.anyref_ty;
@@ -293,7 +303,7 @@ fn build_lifted_body(
     // --- Pass 1: Create new entry block with the physical closure ABI. ---
     let mut new_entry_args = Vec::new();
     match convention {
-        Some(convention) if convention.needs_evidence() => {
+        Some(_) if has_evidence_param => {
             new_entry_args.push(BlockArgData {
                 ty: orig_param_types[0],
                 attrs: ctx.block(orig_entry).args[0].attrs.clone(),
@@ -311,7 +321,7 @@ fn build_lifted_body(
         ty: anyref_ty,
         attrs: make_bind_name_attrs("__env"),
     });
-    let source_start = usize::from(convention.is_some_and(CallingConvention::needs_evidence));
+    let source_start = usize::from(has_evidence_param);
     for (i, &param_ty) in orig_param_types.iter().enumerate().skip(source_start) {
         new_entry_args.push(BlockArgData {
             ty: param_ty,
@@ -332,7 +342,7 @@ fn build_lifted_body(
     for i in 0..orig_param_count {
         let old_arg = ctx.block_arg(orig_entry, i as u32);
         let new_index = match convention {
-            Some(convention) if convention.needs_evidence() && i == 0 => 0,
+            Some(_) if has_evidence_param && i == 0 => 0,
             Some(_) => i + 1,
             None => i + 2,
         };
@@ -350,7 +360,7 @@ fn build_lifted_body(
     }
 
     // Insert env extraction ops at the start of the new entry block.
-    let env_index = u32::from(convention.is_none_or(CallingConvention::needs_evidence));
+    let env_index = u32::from(convention.is_none() || has_evidence_param);
     let raw_env_val = ctx.block_arg(new_entry, env_index);
     if let Some(env_ty) = env_struct_ty {
         let cast_op = adt::ref_cast(ctx, location, raw_env_val, env_ty, env_ty);

--- a/crates/tribute-passes/src/lower_handle_dispatch.rs
+++ b/crates/tribute-passes/src/lower_handle_dispatch.rs
@@ -70,6 +70,9 @@ impl Pass for LowerHandleDispatch {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        if ctx.op(target.op_ref()).regions.is_empty() {
+            return Ok(());
+        }
         lower_handle_dispatch(ctx, target).map_err(Into::into)
     }
 }

--- a/crates/tribute-passes/src/native/adt_rc_header.rs
+++ b/crates/tribute-passes/src/native/adt_rc_header.rs
@@ -17,7 +17,10 @@ use std::collections::HashMap;
 
 use tribute_ir::dialect::tribute_rt::{RC_HEADER_SIZE, REFCOUNT_OFFSET, RTTI_IDX_OFFSET};
 use trunk_ir::Symbol;
-use trunk_ir::adt_layout::{compute_enum_layout, compute_struct_layout, find_variant_layout};
+use trunk_ir::adt_layout::{
+    compute_enum_layout, compute_struct_layout, find_variant_layout, get_struct_fields,
+    type_size_align,
+};
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::adt;
 use trunk_ir::dialect::clif;
@@ -174,7 +177,14 @@ impl RewritePattern for StructNewPattern {
             fields.len(),
             layout.field_offsets.len(),
         );
-        for (i, &field_val) in fields.iter().enumerate() {
+        let Some(field_types) = get_struct_fields(ctx, struct_ty) else {
+            panic!("adt_rc_header: struct_new type has no fields metadata");
+        };
+        for (i, (&field_val, (_, field_ty))) in fields.iter().zip(field_types.iter()).enumerate() {
+            let native_ty = tc.convert_type_or_identity(ctx, *field_ty);
+            if type_size_align(ctx, native_ty).0 == 0 {
+                continue;
+            }
             let offset = layout.field_offsets[i] as i32;
             let store_op = clif::store(ctx, loc, field_val, payload_val, offset);
             ops.push(store_op.op_ref());
@@ -466,5 +476,22 @@ mod tests {
         let unit_ty = crate::native::rtti::make_struct_type(&mut ctx, &[]);
         let output = build_and_lower(&mut ctx, loc, unit_ty, &[]);
         insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn root_completion_cell_lowers_through_native_rc_header() {
+        let (mut ctx, loc) = test_ctx();
+        let nil_ty = core::nil(&mut ctx).as_type_ref();
+        let completion_cell = crate::target_abi::root_completion_cell_type(&mut ctx, nil_ty);
+
+        let output = build_and_lower(&mut ctx, loc, completion_cell, &[nil_ty]);
+
+        assert!(!output.contains("adt.struct_new"), "{output}");
+        assert!(output.contains("clif.call"), "{output}");
+        assert_eq!(
+            output.matches("clif.store").count(),
+            2,
+            "the Nil completion field has no native storage: {output}"
+        );
     }
 }

--- a/crates/tribute-passes/src/native/calling_convention.rs
+++ b/crates/tribute-passes/src/native/calling_convention.rs
@@ -1,0 +1,355 @@
+//! Project Tribute callable conventions onto the generic Cranelift ABI.
+//!
+//! The generic Cranelift backend consumes only `clif.calling_convention`.
+//! This boundary is the last place that understands the proven Tribute CPS
+//! convention, so it validates that every proper-tail transfer has an exact
+//! CPS target before attaching generic backend metadata.
+
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+
+use tribute_core::{CALLING_CONVENTION_ATTR, CallingConvention, get_calling_convention};
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::dialect::{clif, core, func};
+use trunk_ir::ops::DialectOp;
+use trunk_ir::refs::OpRef;
+use trunk_ir::rewrite::Module;
+use trunk_ir::types::Attribute;
+use trunk_ir::walk::{WalkAction, walk_op};
+
+use crate::target_abi::TargetAbiError;
+
+#[derive(Clone, Copy)]
+struct FunctionConvention {
+    convention: CallingConvention,
+    imported: bool,
+}
+
+/// Validate Tribute's final callable conventions and attach generic Cranelift
+/// ABI metadata without exposing Tribute-specific attributes to the backend.
+///
+/// Direct calls use the callee declaration's Cranelift signature.  Indirect
+/// calls carry their signature convention explicitly because no declaration is
+/// available once a closure has become a function pointer.
+pub fn project_to_clif(ctx: &mut IrContext, module: Module) -> Result<(), TargetAbiError> {
+    let ops = collect_ops(ctx, module.op());
+    let mut functions = HashMap::new();
+    let mut function_ops = Vec::new();
+    let mut indirect_ops = Vec::new();
+    let mut direct_tail_ops = Vec::new();
+
+    for &op in &ops {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            continue;
+        };
+        let imported = ctx.op(op).attributes.contains_key("abi");
+        let convention = checked_convention(ctx, op)?.unwrap_or(CallingConvention::Direct);
+        if imported && convention == CallingConvention::Cps {
+            return Err(TargetAbiError::new(format!(
+                "native calling convention: imported function `{}` cannot use the CPS Tail ABI",
+                function.sym_name(ctx)
+            )));
+        }
+        let scope = symbol_scope(ctx, op)?;
+        if functions
+            .insert(
+                (scope, function.sym_name(ctx)),
+                FunctionConvention {
+                    convention,
+                    imported,
+                },
+            )
+            .is_some()
+        {
+            return Err(TargetAbiError::new(format!(
+                "native calling convention: duplicate function symbol `{}` in one module scope",
+                function.sym_name(ctx)
+            )));
+        }
+        function_ops.push((op, convention));
+    }
+
+    for &op in &ops {
+        if func::TailCall::from_op(ctx, op).is_ok() {
+            let convention = require_cps_transfer(ctx, op, "direct proper-tail transfer")?;
+            debug_assert_eq!(convention, CallingConvention::Cps);
+            let callee = ctx.op(op).attributes.get_symbol("callee").ok_or_else(|| {
+                TargetAbiError::new(
+                    "native calling convention: direct proper-tail transfer has no callee",
+                )
+            })?;
+            let scope = symbol_scope(ctx, op)?;
+            let target = functions.get(&(scope, callee)).ok_or_else(|| {
+                TargetAbiError::new(format!(
+                    "native calling convention: direct proper-tail transfer targets unknown `{callee}`"
+                ))
+            })?;
+            if target.imported || target.convention != CallingConvention::Cps {
+                return Err(TargetAbiError::new(format!(
+                    "native calling convention: direct proper-tail transfer target `{callee}` is not a proven CPS worker"
+                )));
+            }
+            direct_tail_ops.push(op);
+            continue;
+        }
+
+        if func::TailCallIndirect::from_op(ctx, op).is_ok() {
+            require_cps_transfer(ctx, op, "indirect proper-tail transfer")?;
+            if !ctx.op_result_types(op).is_empty() {
+                return Err(TargetAbiError::new(
+                    "native calling convention: indirect proper-tail transfer must have no results",
+                ));
+            }
+            indirect_ops.push((op, CallingConvention::Cps));
+            continue;
+        }
+
+        if func::CallIndirect::from_op(ctx, op).is_ok() {
+            let convention = checked_convention(ctx, op)?.unwrap_or(CallingConvention::Direct);
+            if convention == CallingConvention::Cps {
+                return Err(TargetAbiError::new(
+                    "native calling convention: CPS indirect call must be a proper-tail transfer",
+                ));
+            }
+            indirect_ops.push((op, convention));
+            continue;
+        }
+
+        if func::Call::from_op(ctx, op).is_ok() {
+            // A direct call's FuncRef refers to the separately declared callee
+            // signature.  Still reject malformed source metadata here rather
+            // than allowing it to disappear during generic lowering.
+            let _ = checked_convention(ctx, op)?;
+        }
+    }
+
+    // Apply only after every function and transfer was validated.
+    for (op, convention) in function_ops {
+        set_clif_convention(ctx, op, convention);
+    }
+    for op in direct_tail_ops {
+        set_clif_convention(ctx, op, CallingConvention::Cps);
+    }
+    for (op, convention) in indirect_ops {
+        set_clif_convention(ctx, op, convention);
+    }
+    Ok(())
+}
+
+fn require_cps_transfer(
+    ctx: &IrContext,
+    op: OpRef,
+    transfer: &str,
+) -> Result<CallingConvention, TargetAbiError> {
+    let convention = checked_convention(ctx, op)?.ok_or_else(|| {
+        TargetAbiError::new(format!(
+            "native calling convention: {transfer} lacks Tribute convention provenance"
+        ))
+    })?;
+    if convention != CallingConvention::Cps {
+        return Err(TargetAbiError::new(format!(
+            "native calling convention: {transfer} must use the proven CPS convention"
+        )));
+    }
+    Ok(convention)
+}
+
+fn checked_convention(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<Option<CallingConvention>, TargetAbiError> {
+    if !ctx.op(op).attributes.contains_key(CALLING_CONVENTION_ATTR) {
+        return Ok(None);
+    }
+    get_calling_convention(ctx, op).ok_or_else(|| {
+        TargetAbiError::new(
+            "native calling convention: operation has an invalid tribute.calling_convention attribute",
+        )
+    }).map(Some)
+}
+
+fn set_clif_convention(ctx: &mut IrContext, op: OpRef, convention: CallingConvention) {
+    let value = match convention {
+        CallingConvention::Cps => clif::CALLING_CONVENTION_TAIL,
+        CallingConvention::Direct | CallingConvention::EvidenceDirect => {
+            clif::CALLING_CONVENTION_PLATFORM
+        }
+    };
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(clif::CALLING_CONVENTION_ATTR),
+        Attribute::Symbol(Symbol::new(value)),
+    );
+}
+
+fn collect_ops(ctx: &IrContext, root: OpRef) -> Vec<OpRef> {
+    let mut ops = Vec::new();
+    let _ = walk_op::<()>(ctx, root, &mut |op| {
+        ops.push(op);
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    ops
+}
+
+fn symbol_scope(ctx: &IrContext, op: OpRef) -> Result<OpRef, TargetAbiError> {
+    let mut current = Some(op);
+    while let Some(candidate) = current {
+        if core::Module::from_op(ctx, candidate).is_ok() {
+            return Ok(candidate);
+        }
+        current = ctx.op(candidate).parent_block.and_then(|block| {
+            let region = ctx.block(block).parent_region?;
+            ctx.region(region).parent_op
+        });
+    }
+    Err(TargetAbiError::new(
+        "native calling convention: operation has no owning core.module symbol scope",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    fn clif_convention(ctx: &IrContext, op: OpRef) -> Option<Symbol> {
+        ctx.op(op)
+            .attributes
+            .get_symbol(clif::CALLING_CONVENTION_ATTR)
+    }
+
+    fn function(ctx: &IrContext, module: Module, name: &str) -> OpRef {
+        let symbol = Symbol::from_dynamic(name);
+        module
+            .ops(ctx)
+            .into_iter()
+            .find(|&op| {
+                func::Func::from_op(ctx, op).is_ok_and(|function| function.sym_name(ctx) == symbol)
+            })
+            .unwrap_or_else(|| panic!("missing function `{name}`"))
+    }
+
+    #[test]
+    fn projects_tail_only_for_proven_cps_workers_and_transfers() {
+        let input = r#"core.module @test {
+  !cps = closure.closure(core.func(core.nil, core.i32)) {tribute.calling_convention = 2}
+  func.func @direct(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 0} {
+    %result = func.call_indirect %value, %value {tribute.calling_convention = 0} : core.i32
+    func.return
+  }
+  func.func @worker(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @done, tribute.calling_convention = 2}
+  }
+  func.func @done(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.return
+  }
+  func.func @indirect(%callee: !cps, %value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %value {tribute.calling_convention = 2}
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        project_to_clif(&mut ctx, module).unwrap();
+        let output = print_module(&ctx, module.op());
+        assert_eq!(
+            clif_convention(&ctx, function(&ctx, module, "direct")),
+            Some(Symbol::new(clif::CALLING_CONVENTION_PLATFORM))
+        );
+        assert_eq!(
+            clif_convention(&ctx, function(&ctx, module, "worker")),
+            Some(Symbol::new(clif::CALLING_CONVENTION_TAIL))
+        );
+        let tail_ops: Vec<_> = collect_ops(&ctx, module.op())
+            .into_iter()
+            .filter(|&op| {
+                func::TailCall::from_op(&ctx, op).is_ok()
+                    || func::TailCallIndirect::from_op(&ctx, op).is_ok()
+            })
+            .collect();
+        assert_eq!(tail_ops.len(), 2);
+        assert!(tail_ops.iter().all(|&op| {
+            clif_convention(&ctx, op) == Some(Symbol::new(clif::CALLING_CONVENTION_TAIL))
+        }));
+        assert!(output.contains("func.call_indirect %0, %0 {"));
+        assert!(output.contains("clif.calling_convention = @platform"));
+    }
+
+    #[test]
+    fn rejects_unproven_tail_transfer_without_mutating() {
+        let input = r#"core.module @test {
+  func.func @worker() -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call {callee = @worker}
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+        let error = project_to_clif(&mut ctx, module).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("lacks Tribute convention provenance")
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn rejects_malformed_convention_without_mutating() {
+        let input = r#"core.module @test {
+  func.func @worker() -> core.nil attributes {tribute.calling_convention = 99} {
+    func.return
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+        let error = project_to_clif(&mut ctx, module).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("invalid tribute.calling_convention")
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn preserves_root_markers_while_projecting_worker_and_wrapper_abis() {
+        let input = r#"core.module @test {
+  func.func @__tribute_cps_main() -> core.nil attributes {tribute.calling_convention = 2, tribute.root_cps_worker = true} {
+    func.tail_call {callee = @__tribute_root_done_k, tribute.calling_convention = 2}
+  }
+  func.func @__tribute_root_done_k() -> core.nil attributes {tribute.calling_convention = 2, tribute.root_done_k = true} {
+    func.return
+  }
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0, tribute.root_wrapper = true} {
+    func.call {callee = @__tribute_cps_main, tribute.calling_convention = 2, tribute.root_cps_call = true} : core.nil
+    func.return
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        project_to_clif(&mut ctx, module).unwrap();
+
+        let worker = function(&ctx, module, "__tribute_cps_main");
+        let done = function(&ctx, module, "__tribute_root_done_k");
+        let wrapper = function(&ctx, module, "main");
+        assert_eq!(
+            clif_convention(&ctx, worker),
+            Some(Symbol::new(clif::CALLING_CONVENTION_TAIL))
+        );
+        assert_eq!(
+            clif_convention(&ctx, done),
+            Some(Symbol::new(clif::CALLING_CONVENTION_TAIL))
+        );
+        assert_eq!(
+            clif_convention(&ctx, wrapper),
+            Some(Symbol::new(clif::CALLING_CONVENTION_PLATFORM))
+        );
+        let root_call = collect_ops(&ctx, wrapper)
+            .into_iter()
+            .find(|&op| ctx.op(op).attributes.contains_key("tribute.root_cps_call"))
+            .expect("root wrapper must retain its marked ordinary worker call");
+        assert!(clif_convention(&ctx, root_call).is_none());
+    }
+}

--- a/crates/tribute-passes/src/native/entrypoint.rs
+++ b/crates/tribute-passes/src/native/entrypoint.rs
@@ -147,6 +147,12 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
 /// Rewrites `callee` attributes (on func.call / func.tail_call) and
 /// `func_ref` attributes (on func.constant).
 fn rewrite_symbol_refs(ctx: &mut IrContext, op: OpRef, old_sym: Symbol, new_sym: Symbol) {
+    // A nested core.module owns an independent symbol scope. Its local @main
+    // references must not be rewritten while adapting the immediate root.
+    if core::Module::from_op(ctx, op).is_ok() {
+        return;
+    }
+
     // Rewrite callee attribute
     let callee_key = Symbol::new("callee");
     let func_ref_key = Symbol::new("func_ref");
@@ -309,11 +315,13 @@ fn build_entrypoint(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::target_abi::ROOT_WRAPPER_ATTR;
     use trunk_ir::Span;
     use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
     use trunk_ir::dialect::arith;
     use trunk_ir::dialect::func;
     use trunk_ir::ops::DialectOp;
+    use trunk_ir::parser::parse_test_module;
     use trunk_ir::rewrite::Module;
     use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 
@@ -467,6 +475,98 @@ mod tests {
             3,
             "Expected exactly 3 functions, got: {:?}",
             names
+        );
+    }
+
+    #[test]
+    fn entrypoint_preserves_root_wrapper_identity_across_native_rename() {
+        let (mut ctx, loc) = test_ctx();
+        let module = make_main_module(&mut ctx, loc);
+        let original = module
+            .ops(&ctx)
+            .into_iter()
+            .find(|&op| {
+                func::Func::from_op(&ctx, op)
+                    .is_ok_and(|function| function.sym_name(&ctx) == Symbol::new("main"))
+            })
+            .expect("source root wrapper");
+        ctx.op_mut(original)
+            .attributes
+            .insert(Symbol::new(ROOT_WRAPPER_ATTR), Attribute::Bool(true));
+
+        generate_native_entrypoint(&mut ctx, module, false);
+
+        let renamed = module
+            .ops(&ctx)
+            .into_iter()
+            .find(|&op| {
+                func::Func::from_op(&ctx, op)
+                    .is_ok_and(|function| function.sym_name(&ctx) == Symbol::new("_tribute_main"))
+            })
+            .expect("renamed root wrapper");
+        assert_eq!(
+            ctx.op(renamed).attributes.get_bool(ROOT_WRAPPER_ATTR),
+            Some(true)
+        );
+        let c_entrypoint = module
+            .ops(&ctx)
+            .into_iter()
+            .find(|&op| {
+                func::Func::from_op(&ctx, op)
+                    .is_ok_and(|function| function.sym_name(&ctx) == Symbol::new("main"))
+            })
+            .expect("C entrypoint");
+        assert!(
+            !ctx.op(c_entrypoint)
+                .attributes
+                .contains_key(ROOT_WRAPPER_ATTR)
+        );
+    }
+
+    #[test]
+    fn entrypoint_does_not_rewrite_nested_local_main_references() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main() -> core.nil {
+    func.return
+  }
+  core.module @nested {
+    func.func @main() -> core.nil {
+      %local = func.call {callee = @main} : core.nil
+      func.return %local
+    }
+  }
+}"#,
+        );
+
+        generate_native_entrypoint(&mut ctx, module, false);
+
+        let nested = module
+            .ops(&ctx)
+            .into_iter()
+            .find(|&op| core::Module::from_op(&ctx, op).is_ok())
+            .expect("nested module");
+        let nested_body = core::Module::from_op(&ctx, nested).unwrap().body(&ctx);
+        let nested_function = ctx.block(ctx.region(nested_body).blocks[0]).ops[0];
+        let nested_call = ctx
+            .block(
+                ctx.region(
+                    func::Func::from_op(&ctx, nested_function)
+                        .unwrap()
+                        .body(&ctx),
+                )
+                .blocks[0],
+            )
+            .ops
+            .iter()
+            .copied()
+            .find(|&op| func::Call::from_op(&ctx, op).is_ok())
+            .expect("nested local main call");
+        assert_eq!(
+            ctx.op(nested_call).attributes.get_symbol("callee"),
+            Some(Symbol::new("main"))
         );
     }
 

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -24,6 +24,7 @@
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 
+use tribute_core::{CallingConvention, set_calling_convention};
 use tribute_ir::dialect::ability::{
     self, MarkerField, compute_op_idx, evidence_abi, evidence_runtime_symbols,
 };
@@ -63,6 +64,9 @@ pub fn lower_evidence_to_native_func(ctx: &mut IrContext, func_op: func::Func) {
 
 fn try_lower_evidence_to_native_func(ctx: &mut IrContext, func_op: func::Func) -> PassRunResult {
     if is_evidence_runtime_fn(func_op.sym_name(ctx)) {
+        return Ok(());
+    }
+    if ctx.op(func_op.op_ref()).regions.is_empty() {
         return Ok(());
     }
     lower_effect_abi_to_native(ctx, func_op)?;
@@ -463,9 +467,9 @@ impl RewritePattern for LowerEffectDispatchTailToNative {
             ],
             result_ty,
         );
-        let new_result = call.result(ctx);
+        let result = call.result(ctx);
         rewriter.insert_op(call.op_ref());
-        rewriter.erase_op(vec![new_result]);
+        rewriter.erase_op(vec![result]);
         true
     }
 }
@@ -484,7 +488,6 @@ impl RewritePattern for LowerEffectDispatchCpsToNative {
         };
 
         let loc = ctx.op(op).location;
-        let ptr_ty = core_ptr_type(ctx);
         let i32_ty = core_i32_type(ctx);
         let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
         let closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
@@ -494,59 +497,55 @@ impl RewritePattern for LowerEffectDispatchCpsToNative {
         let ability_id_val = ability_id_op.result(ctx);
         rewriter.insert_op(ability_id_op.op_ref());
 
-        let dispatch_closure = func::call(
-            ctx,
-            loc,
-            [dispatch_op.evidence(ctx), ability_id_val],
-            ptr_ty,
-            Symbol::new(evidence_abi::LOOKUP_HANDLER),
-        );
-        let dispatch_val = dispatch_closure.result(ctx);
-        rewriter.insert_op(dispatch_closure.op_ref());
-
-        // The native lookup ABI already returns the Marker prompt tag. Thread
-        // that dynamic owner into the general handler closure; it is compared
-        // only against a proven private Escape by shared lowering.
-        let owner_lookup = func::call(
+        let prompt = func::call(
             ctx,
             loc,
             [dispatch_op.evidence(ctx), ability_id_val],
             i32_ty,
             Symbol::new(evidence_abi::LOOKUP),
         );
-        let owner_tag = owner_lookup.result(ctx);
-        rewriter.insert_op(owner_lookup.op_ref());
+        let prompt_val = prompt.result(ctx);
+        rewriter.insert_op(prompt.op_ref());
 
         let op_idx_op = op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
         let op_idx_val = op_idx_op.result(ctx);
         rewriter.insert_op(op_idx_op.op_ref());
 
-        let fn_ptr_get = adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
+        let fn_ptr_get =
+            adt::struct_get(ctx, loc, dispatch_op.dispatch(ctx), i32_ty, closure_ty, 0);
         let fn_ptr = fn_ptr_get.result(ctx);
         rewriter.insert_op(fn_ptr_get.op_ref());
 
-        let env_get = adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
+        let env_get = adt::struct_get(
+            ctx,
+            loc,
+            dispatch_op.dispatch(ctx),
+            anyref_ty,
+            closure_ty,
+            1,
+        );
         let env_val = env_get.result(ctx);
         rewriter.insert_op(env_get.op_ref());
 
-        let result_ty = ctx.op_result_types(op)[0];
-        let call = func::call_indirect(
+        if !ctx.op_result_types(op).is_empty() {
+            return false;
+        }
+        let tail = func::tail_call_indirect(
             ctx,
             loc,
             fn_ptr,
             [
                 dispatch_op.evidence(ctx),
                 env_val,
-                dispatch_op.continuation(ctx),
-                owner_tag,
+                dispatch_op.resume(ctx),
+                prompt_val,
+                ability_id_val,
                 op_idx_val,
                 dispatch_op.payload(ctx),
             ],
-            result_ty,
         );
-        let new_result = call.result(ctx);
-        rewriter.insert_op(call.op_ref());
-        rewriter.erase_op(vec![new_result]);
+        set_calling_convention(ctx, tail.op_ref(), CallingConvention::Cps);
+        rewriter.replace_op(tail.op_ref());
         true
     }
 }
@@ -1033,5 +1032,48 @@ mod tests {
             entry_arg(&ctx, inner, 0),
             "nested native evidence lowering should pass the nested function's own evidence"
         );
+    }
+
+    #[test]
+    fn textual_dispatch_cps_uses_exact_resultless_handler_tail_abi() {
+        let input = r#"core.module @test {
+  func.func @run(%ev: core.ptr, %dispatch: tribute_rt.anyref, %resume: tribute_rt.anyref, %payload: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        lower_evidence_to_native(&mut ctx, module);
+
+        let run = func_by_name_recursive(&ctx, module, "run");
+        let entry = ctx.region(run.body(&ctx)).blocks[0];
+        let ops = ctx.block(entry).ops.to_vec();
+        let tails: Vec<_> = ops
+            .iter()
+            .copied()
+            .filter(|&op| func::TailCallIndirect::from_op(&ctx, op).is_ok())
+            .collect();
+        assert_eq!(tails.len(), 1);
+        let operands = ctx.op_operands(tails[0]);
+        assert_eq!(
+            operands.len(),
+            8,
+            "callee plus evidence, environment and five Dispatch arguments"
+        );
+        assert_eq!(operands[1], entry_arg(&ctx, run, 0));
+        assert_eq!(operands[3], entry_arg(&ctx, run, 2));
+        assert_eq!(operands[7], entry_arg(&ctx, run, 3));
+        assert_eq!(
+            tribute_core::get_calling_convention(&ctx, tails[0]),
+            Some(CallingConvention::Cps)
+        );
+
+        let direct_callees: Vec<_> = ops
+            .iter()
+            .copied()
+            .filter_map(|op| func::Call::from_op(&ctx, op).ok())
+            .map(|call| call.callee(&ctx))
+            .collect();
+        assert_eq!(direct_callees, [Symbol::new(evidence_abi::LOOKUP)]);
     }
 }

--- a/crates/tribute-passes/src/native/mod.rs
+++ b/crates/tribute-passes/src/native/mod.rs
@@ -14,6 +14,7 @@
 //! - `rc_lowering`: Lower `tribute_rt.retain`/`release` to inline `clif.*` ops
 
 pub mod adt_rc_header;
+pub mod calling_convention;
 pub mod const_to_native;
 pub mod entrypoint;
 pub mod evidence;

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -42,7 +42,9 @@ pub fn compute_and_attach(
     let mut definitions: HashMap<Symbol, Vec<OpRef>> = HashMap::new();
     for &op in &module_ops {
         ctx.op_mut(op).attributes.remove(PARAMETER_OWNERSHIP_ATTR);
-        if let Ok(function) = func::Func::from_op(ctx, op) {
+        if let Ok(function) = func::Func::from_op(ctx, op)
+            && !ctx.op(op).regions.is_empty()
+        {
             definitions
                 .entry(function.sym_name(ctx))
                 .or_default()
@@ -144,7 +146,8 @@ impl TrustedOwnershipSummaries {
                     return None;
                 }
                 let function = clif::Func::from_op(ctx, ops[0]).ok()?;
-                let parameters = entry_parameters(ctx, function.body(ctx));
+                let body = *ctx.op(function.op_ref()).regions.first()?;
+                let parameters = entry_parameters(ctx, body);
                 if parameters.len() != expected.len() {
                     return None;
                 }
@@ -198,8 +201,11 @@ impl TrustedOwnershipSummaries {
             let Ok(function) = clif::Func::from_op(ctx, op) else {
                 continue;
             };
+            let Some(&body) = ctx.op(function.op_ref()).regions.first() else {
+                continue;
+            };
             let symbol = function.sym_name(ctx);
-            let summary: Vec<_> = entry_parameters(ctx, function.body(ctx))
+            let summary: Vec<_> = entry_parameters(ctx, body)
                 .into_iter()
                 .map(|parameter| {
                     if is_anyref_value(ctx, parameter) {
@@ -254,7 +260,10 @@ fn collect_escaping_function_symbols(
         let Ok(function) = func::Func::from_op(ctx, op) else {
             continue;
         };
-        collect_escaping_function_symbols_in_region(ctx, function.body(ctx), functions, ineligible);
+        let Some(&body) = ctx.op(function.op_ref()).regions.first() else {
+            continue;
+        };
+        collect_escaping_function_symbols_in_region(ctx, body, functions, ineligible);
     }
 }
 
@@ -280,12 +289,9 @@ fn collect_escaping_function_symbols_in_region(
             }
 
             if let Ok(nested_function) = func::Func::from_op(ctx, op) {
-                collect_escaping_function_symbols_in_region(
-                    ctx,
-                    nested_function.body(ctx),
-                    functions,
-                    ineligible,
-                );
+                if let Some(&body) = ctx.op(nested_function.op_ref()).regions.first() {
+                    collect_escaping_function_symbols_in_region(ctx, body, functions, ineligible);
+                }
             } else {
                 for &nested in &ctx.op(op).regions {
                     collect_escaping_function_symbols_in_region(ctx, nested, functions, ineligible);
@@ -482,6 +488,69 @@ mod tests {
         assert_eq!(
             summaries.summaries.get(&Symbol::new("tail_target")),
             Some(&vec![ParameterOwnership::Owned])
+        );
+    }
+
+    #[test]
+    fn bodyless_clif_declaration_survives_ownership_and_rc_insertion() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @imported(%value: tribute_rt.anyref) -> core.i32 attributes {abi = "C"}
+  func.func @defined(%value: tribute_rt.anyref) -> core.i32 {
+    %result = clif.load %value {offset = 0} : core.i32
+    func.return %result
+  }
+}"#,
+        );
+
+        let trusted = compute_and_attach(&mut ctx, module, &TypeConverter::new());
+        let module_block = module.first_block(&ctx).expect("module body");
+        let body = module.body(&ctx).expect("module region");
+        lower_func_ops_to_clif(&mut ctx, body);
+        insert_rc_with_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            &trusted,
+        );
+
+        let declaration = clif::Func::from_op(&ctx, ctx.block(module_block).ops[0]).unwrap();
+        assert!(ctx.op(declaration.op_ref()).regions.is_empty());
+        assert!(
+            ctx.op(declaration.op_ref())
+                .attributes
+                .get_text("abi")
+                .is_some_and(|abi| abi == "C")
+        );
+        let declaration_type = ctx.types.get(declaration.r#type(&ctx));
+        assert_eq!(declaration_type.params.len(), 2);
+        assert_eq!(
+            ctx.types.get(declaration_type.params[0]).name,
+            Symbol::new("i32")
+        );
+        assert_eq!(
+            ctx.types.get(declaration_type.params[1]).name,
+            Symbol::new("ptr")
+        );
+
+        let defined = clif::Func::from_op(&ctx, ctx.block(module_block).ops[1]).unwrap();
+        assert!(
+            ctx.op(defined.op_ref())
+                .attributes
+                .contains_key(PARAMETER_OWNERSHIP_ATTR)
+        );
+        let body = *ctx
+            .op(defined.op_ref())
+            .regions
+            .first()
+            .expect("defined body");
+        let entry = ctx.region(body).blocks[0];
+        let parameter = ctx.block_args(entry)[0];
+        assert_eq!(
+            ctx.types.get(ctx.value_ty(parameter)).name,
+            Symbol::new("ptr")
         );
     }
 

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -85,6 +85,7 @@ fn is_terminator_op(ctx: &IrContext, op: OpRef) -> bool {
         || clif::Brif::matches(ctx, op)
         || clif::Trap::matches(ctx, op)
         || clif::ReturnCall::matches(ctx, op)
+        || clif::ReturnCallIndirect::matches(ctx, op)
         || clif::BrTable::matches(ctx, op)
 }
 
@@ -501,7 +502,9 @@ fn insert_rc_impl(
             if sym.with_str(|s| s.starts_with(super::rtti::RELEASE_FN_PREFIX)) {
                 continue;
             }
-            let body = func_op.body(ctx);
+            let Some(&body) = ctx.op(func_op.op_ref()).regions.first() else {
+                continue;
+            };
             let function_policy = if borrow_safe_functions.contains(&sym) {
                 borrowed_parameters
             } else {
@@ -535,6 +538,7 @@ fn borrow_safe_functions(ctx: &IrContext, module_ops: &[OpRef]) -> HashSet<Symbo
     for &op in module_ops {
         if let Ok(func_op) = clif::Func::from_op(ctx, op)
             && !ctx.op(op).attributes.contains_key("abi")
+            && !ctx.op(op).regions.is_empty()
         {
             candidates.insert(func_op.sym_name(ctx));
         }
@@ -542,8 +546,10 @@ fn borrow_safe_functions(ctx: &IrContext, module_ops: &[OpRef]) -> HashSet<Symbo
 
     let mut unsafe_callees = HashSet::new();
     for &op in module_ops {
-        if let Ok(func_op) = clif::Func::from_op(ctx, op) {
-            collect_borrow_unsafe_callees(ctx, func_op.body(ctx), &candidates, &mut unsafe_callees);
+        if let Ok(func_op) = clif::Func::from_op(ctx, op)
+            && let Some(&body) = ctx.op(func_op.op_ref()).regions.first()
+        {
+            collect_borrow_unsafe_callees(ctx, body, &candidates, &mut unsafe_callees);
         }
     }
     candidates.retain(|symbol| !unsafe_callees.contains(symbol));
@@ -604,8 +610,9 @@ fn lower_anyref_to_ptr(ctx: &mut IrContext, module: Module) {
                 );
             }
 
-            let body = func_op.body(ctx);
-            lower_anyref_in_region(ctx, body, ptr_ty);
+            if let Some(&body) = ctx.op(func_op.op_ref()).regions.first() {
+                lower_anyref_in_region(ctx, body, ptr_ty);
+            }
         }
     }
 }
@@ -1148,12 +1155,24 @@ fn insert_rc_in_block(
         }
     }
 
-    // Returned values
+    // Values transferred through a function exit. Proper-tail calls never
+    // return to this frame, so their reference operands must remain live for
+    // the callee exactly like an ordinary return value. Releasing a freshly
+    // boxed payload before `return_call_indirect` would otherwise hand the
+    // resumed continuation a freed allocation.
     let mut returned_values: HashSet<ValueRef> = HashSet::new();
-    if let Some(&last_op) = ops.last()
-        && clif::Return::matches(ctx, last_op)
-    {
-        for &operand in ctx.op_operands(last_op) {
+    if let Some(&last_op) = ops.last() {
+        let transfer_operands =
+            if clif::Return::matches(ctx, last_op) || clif::ReturnCall::matches(ctx, last_op) {
+                Some(ctx.op_operands(last_op))
+            } else if clif::ReturnCallIndirect::matches(ctx, last_op) {
+                // Operand zero is the raw function pointer; every remaining
+                // operand belongs to the exact indirect callee signature.
+                Some(&ctx.op_operands(last_op)[1..])
+            } else {
+                None
+            };
+        for &operand in transfer_operands.into_iter().flatten() {
             if ptr_values.contains(&operand) {
                 returned_values.insert(operand);
             }
@@ -1951,9 +1970,28 @@ mod tests {
             concat!(
                 "%1 = tribute_rt.retain %0 : core.ptr\n",
                 "tribute_rt.release %0 {alloc_size = 0}\n",
-                "%1 = tribute_rt.retain %0 : core.ptr\n",
-                "tribute_rt.release %0 {alloc_size = 0}"
+                "%1 = tribute_rt.retain %0 : core.ptr"
             ),
+        );
+    }
+
+    #[test]
+    fn indirect_tail_transfer_keeps_fresh_payload_live() {
+        let output = run_pass_with_policy(
+            r#"core.module @test {
+  clif.func @caller(%0: core.i64) -> core.nil {
+    %1 = clif.call %0 {callee = @__tribute_alloc} : tribute_rt.anyref
+    clif.return_call_indirect %0, %1 {sig = core.func(core.nil, tribute_rt.anyref)}
+  }
+}"#,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+        );
+        let tail = output
+            .find("clif.return_call_indirect")
+            .expect("tail transfer remains present");
+        assert!(
+            !output[..tail].contains("tribute_rt.release %1"),
+            "fresh payload must transfer to the indirect tail callee:\n{output}"
         );
     }
 

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -63,6 +63,7 @@ impl Error for ResolveEvidenceError {}
 
 struct FinalHandleDispatchShape {
     evidence: ValueRef,
+    prompt_tag: ValueRef,
     dispatcher_pairs: Vec<(TypeRef, ValueRef, ValueRef)>,
     body: RegionRef,
     body_evidence: ValueRef,
@@ -89,11 +90,22 @@ fn final_handle_dispatch_shape(
             "final ability.handle_dispatch must be resultless".into(),
         ));
     }
-    let Some((&evidence, dispatchers)) = operands.split_first() else {
+    let Some((&evidence, operands)) = operands.split_first() else {
         return Err(error(
             "final ability.handle_dispatch requires an evidence operand".into(),
         ));
     };
+    let Some((&prompt_tag, dispatchers)) = operands.split_first() else {
+        return Err(error(
+            "final ability.handle_dispatch requires an explicit prompt_tag operand".into(),
+        ));
+    };
+    let prompt_type = ctx.types.get(ctx.value_ty(prompt_tag));
+    if prompt_type.dialect != Symbol::new("core") || prompt_type.name != Symbol::new("i32") {
+        return Err(error(
+            "final ability.handle_dispatch prompt_tag must have core.i32 type".into(),
+        ));
+    }
     if !dispatchers.len().is_multiple_of(2) {
         return Err(error(
             "final ability.handle_dispatch dispatcher operands must form exact pairs".into(),
@@ -159,6 +171,7 @@ fn final_handle_dispatch_shape(
     }
     Ok(FinalHandleDispatchShape {
         evidence,
+        prompt_tag,
         dispatcher_pairs,
         body: *body,
         body_evidence: *body_evidence,
@@ -371,6 +384,9 @@ fn collect_handler_root_functions(
             if fns_with_evidence.contains(&func_name) {
                 continue;
             }
+            if ctx.op(op).regions.is_empty() {
+                continue;
+            }
             if region_contains_handle_dispatch(ctx, func_op.body(ctx)) {
                 handler_roots.insert(func_name);
             }
@@ -579,6 +595,9 @@ fn update_calls_to_newly_evidenced(
         if handler_root_fns.contains(&func_name) {
             continue;
         }
+        if ctx.op(func_op_ref).regions.is_empty() {
+            continue;
+        }
 
         let body = func_op.body(ctx);
         update_calls_in_region(ctx, body, newly_evidenced, evidence_ty, i32_ty);
@@ -675,6 +694,9 @@ fn transform_shifts_in_module(
         if !fns_with_evidence.contains(&func_name) {
             continue;
         }
+        if ctx.op(func_op_ref).regions.is_empty() {
+            continue;
+        }
 
         let body = func_op.body(ctx);
         let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
@@ -739,16 +761,26 @@ fn transform_shifts_in_block(
             let location = ctx.op(op).location;
             let shape = final_handle_dispatch_shape(ctx, op)?;
             let mut current_ev = shape.evidence;
-            let i32_ty = i32_type_ref(ctx);
-            let prompt = func::call(
-                ctx,
-                location,
-                std::iter::empty::<ValueRef>(),
-                i32_ty,
-                Symbol::new("__tribute_next_tag"),
-            );
-            let prompt_tag = prompt.result(ctx);
-            ctx.insert_op_before(block, op, prompt.op_ref());
+            let prompt_tag = match ctx.value_def(shape.prompt_tag) {
+                ValueDef::OpResult(owner_op, _)
+                    if effect::FreshPromptTag::from_op(ctx, owner_op).is_ok() =>
+                {
+                    let i32_ty = i32_type_ref(ctx);
+                    let prompt = func::call(
+                        ctx,
+                        location,
+                        std::iter::empty::<ValueRef>(),
+                        i32_ty,
+                        Symbol::new("__tribute_next_tag"),
+                    );
+                    let resolved = prompt.result(ctx);
+                    ctx.insert_op_before(block, op, prompt.op_ref());
+                    ctx.replace_all_uses(shape.prompt_tag, resolved);
+                    erase_op(ctx, owner_op);
+                    resolved
+                }
+                _ => shape.prompt_tag,
+            };
             let evidence_ty = ability::evidence_adt_type_ref(ctx);
             for (ability_ref, tr_dispatch, handler_dispatch) in shape.dispatcher_pairs {
                 let extend = effect::extend(
@@ -1184,7 +1216,7 @@ mod tests {
     #[test]
     fn final_handle_dispatch_extends_each_ability_pair_and_lowers_resultlessly() {
         let input = final_dispatch_fixture(
-            r#"ability.handle_dispatch %ev, %tr, %handler, %tr2, %handler2 {ability_refs = [core.ability_ref() {name = @State}, core.ability_ref() {name = @Console}]} {
+            r#"ability.handle_dispatch %ev, %prompt, %tr, %handler, %tr2, %handler2 {ability_refs = [core.ability_ref() {name = @State}, core.ability_ref() {name = @Console}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
@@ -1194,8 +1226,7 @@ mod tests {
         resolve_evidence_dispatch(&mut ctx, module).unwrap();
         let resolved = print_module(&ctx, module.op());
         assert_eq!(resolved.matches("effect.extend").count(), 2);
-        assert_eq!(resolved.matches("func.call").count(), 1);
-        assert!(resolved.contains("__tribute_next_tag"));
+        assert_eq!(resolved.matches("func.call").count(), 0);
         assert!(resolved.contains("ability.handle_dispatch"));
         let mut extensions = Vec::new();
         let _ = walk_op::<()>(&ctx, module.op(), &mut |op| {
@@ -1238,54 +1269,54 @@ mod tests {
                 "requires an evidence operand",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr {ability_refs = []} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "must form exact pairs",
             ),
             (
-                r#"ability.handle_dispatch %ev {
+                r#"ability.handle_dispatch %ev, %prompt {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "requires an ability_refs list",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr, %handler {ability_refs = []} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "cardinality",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = [1]} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr, %handler {ability_refs = [1]} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "entry must be a type",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = [core.i32]} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr, %handler {ability_refs = [core.i32]} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "core.ability_ref type",
             ),
             (
-                r#"ability.handle_dispatch %prompt {ability_refs = []} {
+                r#"ability.handle_dispatch %prompt, %prompt {ability_refs = []} {
       ^body(%inner: core.i32):
         func.unreachable
     }"#,
                 "must have the evidence type",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
     }"#,
                 "exactly one block",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^first(%inner: !evidence):
         func.unreachable
       ^second:
@@ -1294,20 +1325,20 @@ mod tests {
                 "exactly one block",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body:
         func.unreachable
     }"#,
                 "one evidence argument",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body(%inner: !evidence):
     }"#,
                 "must end in a proper tail transfer",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body(%inner: !evidence):
         func.return
     }"#,
@@ -1329,7 +1360,7 @@ mod tests {
     #[test]
     fn structured_final_delimiter_is_a_valid_proper_tail_body() {
         let input = final_dispatch_fixture(
-            r#"ability.handle_dispatch %ev {ability_refs = []} {
+            r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body(%inner: !evidence):
         %choice = arith.const {value = 0} : core.i32
         scf.switch %choice {

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -1,0 +1,2708 @@
+//! Target-owned physical CPS signatures and root entry bridge.
+//!
+//! Shared legalization deliberately keeps `core.never` as the logical bottom
+//! result of CPS callables. Native and Wasm call this module after shared
+//! closure/effect lowering to select the physical empty-result ABI and, when
+//! the exact root export was promoted to CPS, delimit it with an ordinary
+//! Direct/EvidenceDirect wrapper.
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::fmt;
+use std::ops::ControlFlow;
+
+use tribute_core::{
+    CALLING_CONVENTION_ATTR, CallingConvention, INDIRECT_CALL_SIGNATURE_ATTR,
+    ROOT_EXPORT_CONVENTION_ATTR, ROOT_SOURCE_RESULT_ATTR, get_calling_convention,
+    get_indirect_call_signature, get_physical_closure_convention, get_root_export_convention,
+    get_root_source_result, set_calling_convention,
+};
+use tribute_ir::dialect::{ability, closure, tribute_rt};
+use trunk_ir::Symbol;
+use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
+use trunk_ir::dialect::{adt, arith, core, func, scf};
+use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::refs::{BlockRef, OpRef, TypeRef};
+use trunk_ir::rewrite::Module;
+use trunk_ir::smallvec::smallvec;
+use trunk_ir::types::{Attribute, AttributeMap, TypeData};
+use trunk_ir::walk::{WalkAction, walk_op};
+
+pub const ROOT_CPS_CALL_ATTR: &str = "tribute.root_cps_call";
+pub const ROOT_DONE_K_ATTR: &str = "tribute.root_done_k";
+pub const ROOT_CPS_WORKER_ATTR: &str = "tribute.root_cps_worker";
+pub const ROOT_WRAPPER_ATTR: &str = "tribute.root_wrapper";
+
+const CPS_MAIN_SYMBOL: &str = "__tribute_cps_main";
+const ROOT_DONE_K_SYMBOL: &str = "__tribute_root_done_k";
+const ROOT_REJECT_DISPATCH_SYMBOL: &str = "__tribute_root_reject_dispatch";
+const ROOT_COMPLETION_CELL_NAME: &str = "__tribute_root_completion_cell";
+const ROOT_COMPLETION_CELL_VALUE_FIELD: &str = "value";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetAbiError {
+    message: String,
+}
+
+impl TargetAbiError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for TargetAbiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for TargetAbiError {}
+
+/// Build the root completion cell using the canonical `adt.struct` field
+/// metadata consumed by native and Wasm layout lowering.
+pub(crate) fn root_completion_cell_type(ctx: &mut IrContext, value_ty: TypeRef) -> TypeRef {
+    ctx.types.intern(TypeData {
+        dialect: Symbol::new("adt"),
+        name: Symbol::new("struct"),
+        params: smallvec![value_ty],
+        attrs: [
+            (
+                Symbol::new("name"),
+                Attribute::Symbol(Symbol::new(ROOT_COMPLETION_CELL_NAME)),
+            ),
+            (
+                Symbol::new("fields"),
+                Attribute::List(vec![Attribute::List(vec![
+                    Attribute::Symbol(Symbol::new(ROOT_COMPLETION_CELL_VALUE_FIELD)),
+                    Attribute::Type(value_ty),
+                ])]),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    })
+}
+
+/// Rewrite only logical CPS callable result slots from `core.never` to the
+/// target's physical empty-result marker (`core.nil`).
+///
+/// Selection is occurrence-specific: function signatures use their operation
+/// convention, physical closure types use their explicit outer type
+/// convention, and `func.constant` uses its exact target symbol. An untagged
+/// nested `core.func<core.never, ...>` is rejected instead of inferred.
+pub fn lower_cps_signatures_to_physical(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), TargetAbiError> {
+    let ops = collect_ops(ctx, module.op());
+    let never_ty = core::never(ctx).as_type_ref();
+    let nil_ty = core::nil(ctx).as_type_ref();
+    let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+
+    let mut functions = HashMap::new();
+    let mut function_conventions = HashMap::new();
+    for &op in &ops {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            continue;
+        };
+        let Some(convention) = get_calling_convention(ctx, op) else {
+            continue;
+        };
+        let signature = function.r#type(ctx);
+        let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
+            return Err(TargetAbiError::new(format!(
+                "target signature lowering: `{}` does not have a core.func signature",
+                function.sym_name(ctx)
+            )));
+        };
+        let environment_index = exact_environment_index(ctx, op, callable.params(ctx), anyref_ty)?;
+        let identity = FunctionIdentity {
+            signature,
+            convention,
+            environment_index,
+        };
+        function_conventions.insert(op, convention);
+        let scope = symbol_scope(ctx, op)?;
+        if functions
+            .insert((scope, function.sym_name(ctx)), identity)
+            .is_some()
+        {
+            return Err(TargetAbiError::new(format!(
+                "target signature lowering: duplicate function symbol `{}` in one module scope",
+                function.sym_name(ctx)
+            )));
+        }
+    }
+
+    // `tribute_control_to_cps` deliberately uses an unused `core.never`
+    // result to mark an SCF region whose branches end in proper-tail
+    // transfers. It is not a value at the target ABI. Validate that exact
+    // structural role before planning its physical empty result, so malformed
+    // source Never and unproven control flow cannot be erased by shape.
+    let structured_never_results =
+        validate_structured_never_results(ctx, &ops, never_ty, &function_conventions)?;
+
+    let blocks = collect_blocks(ctx, &ops);
+    let aliases = ctx.type_aliases().to_vec();
+    let mut converter = PhysicalTypeConverter::new(ctx, never_ty, nil_ty);
+    let mut plan = PhysicalizationPlan::default();
+
+    for (name, ty) in aliases {
+        let converted = converter.convert_nested(ty)?;
+        if converted != ty {
+            plan.type_aliases.push((name, converted));
+        }
+    }
+
+    for &op in &ops {
+        let function = func::Func::from_op(converter.ctx, op).ok();
+        if let Some(function) = function {
+            let signature = function.r#type(converter.ctx);
+            let converted = match get_calling_convention(converter.ctx, op) {
+                Some(convention) => converter.convert_callable(signature, convention)?,
+                None => converter.convert_unproven_callable(signature)?,
+            };
+            if converted != signature {
+                plan.op_attributes
+                    .push((op, Symbol::new("type"), Attribute::Type(converted)));
+            }
+        }
+
+        let result_types = converter.ctx.op_result_types(op).to_vec();
+        for (index, ty) in result_types.into_iter().enumerate() {
+            let converted = if structured_never_results.contains(&(op, index as u32)) {
+                nil_ty
+            } else if let Ok(constant) = func::Constant::from_op(converter.ctx, op) {
+                let target = constant.func_ref(converter.ctx);
+                let scope = symbol_scope(converter.ctx, op)?;
+                let identity = functions.get(&(scope, target)).ok_or_else(|| {
+                    TargetAbiError::new(format!(
+                        "target signature lowering: func.constant references unknown or \
+                         convention-less target `{target}` in its module scope"
+                    ))
+                })?;
+                validate_constant_signature(converter.ctx, target, ty, *identity, never_ty)?;
+                converter.convert_callable(ty, identity.convention)?
+            } else {
+                converter.convert_nested(ty)?
+            };
+            if converted != ty {
+                plan.op_results.push((op, index as u32, converted));
+            }
+        }
+
+        let attributes: Vec<_> = converter
+            .ctx
+            .op(op)
+            .attributes
+            .iter()
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
+        for (name, value) in attributes {
+            if function.is_some() && name == Symbol::new("type") {
+                continue;
+            }
+            let converted = if name == Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR) {
+                let Attribute::Type(signature) = &value else {
+                    return Err(TargetAbiError::new(
+                        "target signature lowering: indirect callable signature must be a type attribute",
+                    ));
+                };
+                let convention = get_calling_convention(converter.ctx, op).ok_or_else(|| {
+                    TargetAbiError::new(
+                        "target signature lowering: indirect callable signature has no valid calling convention",
+                    )
+                })?;
+                Attribute::Type(converter.convert_callable(*signature, convention)?)
+            } else {
+                converter.convert_attribute(value.clone())?
+            };
+            if converted != value {
+                plan.op_attributes.push((op, name, converted));
+            }
+        }
+    }
+
+    for block in blocks {
+        let args = converter.ctx.block(block).args.clone();
+        for (index, arg) in args.into_iter().enumerate() {
+            let converted = converter.convert_nested(arg.ty)?;
+            if converted != arg.ty {
+                plan.block_arg_types.push((block, index as u32, converted));
+            }
+            for (name, value) in arg.attrs {
+                let converted = converter.convert_attribute(value.clone())?;
+                if converted != value {
+                    plan.block_arg_attributes
+                        .push((block, index, name, converted));
+                }
+            }
+        }
+    }
+
+    drop(converter);
+    for (name, ty) in plan.type_aliases {
+        ctx.register_type_alias(name, ty);
+    }
+    for (op, index, ty) in plan.op_results {
+        ctx.set_op_result_type(op, index, ty);
+    }
+    for (op, name, value) in plan.op_attributes {
+        ctx.op_mut(op).attributes.insert(name, value);
+    }
+    for (block, index, ty) in plan.block_arg_types {
+        ctx.set_block_arg_type(block, index, ty);
+    }
+    for (block, index, name, value) in plan.block_arg_attributes {
+        ctx.block_mut(block).args[index].attrs.insert(name, value);
+    }
+
+    debug_assert!(collect_ops(ctx, module.op()).into_iter().all(|op| {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            return true;
+        };
+        get_calling_convention(ctx, op) != Some(CallingConvention::Cps)
+            || core::Func::from_type_ref(ctx, function.r#type(ctx))
+                .is_some_and(|signature| signature.r#return(ctx) == nil_ty)
+    }));
+    Ok(())
+}
+
+/// Project native-only zero-sized `core.nil` parameters out of callable ABIs.
+///
+/// Wasm deliberately represents `core.nil` as a nullable reference, so this
+/// pass is intentionally invoked only by the native pipeline.  It plans every
+/// affected declaration, definition, direct reference, and transfer before
+/// changing IR; a malformed exact signature therefore leaves the module
+/// untouched.
+pub fn lower_native_nil_abi(ctx: &mut IrContext, module: Module) -> Result<(), TargetAbiError> {
+    let nil_ty = core::nil(ctx).as_type_ref();
+    let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+    let ops = collect_ops(ctx, module.op());
+    let mut functions = HashMap::new();
+    let mut plan = NativeNilAbiPlan::default();
+
+    for &op in &ops {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            continue;
+        };
+        let signature = function.r#type(ctx);
+        let callable = core::Func::from_type_ref(ctx, signature).ok_or_else(|| {
+            TargetAbiError::new(format!(
+                "native Nil ABI: function `{}` does not have a core.func signature",
+                function.sym_name(ctx)
+            ))
+        })?;
+        let params = callable.params(ctx).to_vec();
+        let nil_params: Vec<_> = params
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &ty)| (ty == nil_ty).then_some(index))
+            .collect();
+        let identity = NativeNilFunctionIdentity {
+            signature,
+            environment_index: exact_environment_index(ctx, op, &params, anyref_ty)?,
+            nil_params: nil_params.clone(),
+        };
+        let scope = symbol_scope(ctx, op)?;
+        if functions
+            .insert((scope, function.sym_name(ctx)), identity)
+            .is_some()
+        {
+            return Err(TargetAbiError::new(format!(
+                "native Nil ABI: duplicate function symbol `{}` in one module scope",
+                function.sym_name(ctx)
+            )));
+        }
+
+        if nil_params.is_empty() {
+            continue;
+        }
+        if get_calling_convention(ctx, op).is_none() {
+            return Err(TargetAbiError::new(format!(
+                "native Nil ABI: function `{}` with core.nil parameter has no valid calling convention",
+                function.sym_name(ctx)
+            )));
+        }
+        if let Some(&region) = ctx.op(op).regions.first() {
+            let Some(&entry) = ctx.region(region).blocks.first() else {
+                return Err(TargetAbiError::new(format!(
+                    "native Nil ABI: function `{}` definition has no entry block",
+                    function.sym_name(ctx)
+                )));
+            };
+            let args = ctx.block_args(entry);
+            if args.len() != params.len()
+                || args
+                    .iter()
+                    .zip(&params)
+                    .any(|(&arg, &ty)| ctx.value_ty(arg) != ty)
+            {
+                return Err(TargetAbiError::new(format!(
+                    "native Nil ABI: function `{}` entry block does not match its exact signature",
+                    function.sym_name(ctx)
+                )));
+            }
+            plan.entry_nil_args.push((entry, nil_params));
+        }
+    }
+
+    for &op in &ops {
+        if let Ok(call) = func::Call::from_op(ctx, op) {
+            let target = call.callee(ctx);
+            let scope = symbol_scope(ctx, op)?;
+            let identity = functions.get(&(scope, target)).ok_or_else(|| {
+                TargetAbiError::new(format!(
+                    "native Nil ABI: func.call references unknown target `{target}`"
+                ))
+            })?;
+            if !identity.nil_params.is_empty() {
+                validate_direct_nil_transfer(ctx, op, identity, 0, target)?;
+                plan.transfer_nil_operands
+                    .push((op, identity.nil_params.clone()));
+            }
+        } else if let Ok(tail) = func::TailCall::from_op(ctx, op) {
+            let target = tail.callee(ctx);
+            let scope = symbol_scope(ctx, op)?;
+            let identity = functions.get(&(scope, target)).ok_or_else(|| {
+                TargetAbiError::new(format!(
+                    "native Nil ABI: func.tail_call references unknown target `{target}`"
+                ))
+            })?;
+            if !identity.nil_params.is_empty() {
+                validate_direct_nil_transfer(ctx, op, identity, 0, target)?;
+                plan.transfer_nil_operands
+                    .push((op, identity.nil_params.clone()));
+            }
+        } else if func::CallIndirect::from_op(ctx, op).is_ok()
+            || func::TailCallIndirect::from_op(ctx, op).is_ok()
+        {
+            let operands = ctx.op_operands(op);
+            let Some((_callee, args)) = operands.split_first() else {
+                return Err(TargetAbiError::new(
+                    "native Nil ABI: indirect transfer has no callee operand",
+                ));
+            };
+            if args.iter().any(|&arg| ctx.value_ty(arg) == nil_ty) {
+                let nil_args = validate_indirect_nil_transfer(ctx, op, nil_ty)?;
+                if !nil_args.is_empty() {
+                    plan.transfer_nil_operands.push((op, nil_args));
+                }
+            }
+        } else if let Ok(constant) = func::Constant::from_op(ctx, op) {
+            let target = constant.func_ref(ctx);
+            let scope = symbol_scope(ctx, op)?;
+            let identity = functions.get(&(scope, target)).ok_or_else(|| {
+                TargetAbiError::new(format!(
+                    "native Nil ABI: func.constant references unknown target `{target}`"
+                ))
+            })?;
+            if !identity.nil_params.is_empty() {
+                let actual = ctx.value_ty(constant.result(ctx));
+                validate_native_constant_signature(ctx, target, actual, identity.clone())?;
+            }
+        } else if func::Return::from_op(ctx, op).is_ok() {
+            let operands = ctx.op_operands(op);
+            if operands.is_empty() {
+                continue;
+            }
+            if !operands
+                .iter()
+                .any(|&operand| ctx.value_ty(operand) == nil_ty)
+            {
+                continue;
+            }
+            if operands.len() != 1 || ctx.value_ty(operands[0]) != nil_ty {
+                return Err(TargetAbiError::new(
+                    "native Nil ABI: core.nil return operand must be the sole return value",
+                ));
+            }
+            let function = enclosing_function(ctx, op).ok_or_else(|| {
+                TargetAbiError::new(
+                    "native Nil ABI: func.return with core.nil operand is outside a function",
+                )
+            })?;
+            let function = func::Func::from_op(ctx, function).map_err(|_| {
+                TargetAbiError::new(
+                    "native Nil ABI: func.return with core.nil operand has a malformed owner",
+                )
+            })?;
+            let signature = core::Func::from_type_ref(ctx, function.r#type(ctx)).ok_or_else(|| {
+                TargetAbiError::new(
+                    "native Nil ABI: func.return with core.nil operand has a malformed signature",
+                )
+            })?;
+            if signature.r#return(ctx) != nil_ty {
+                return Err(TargetAbiError::new(
+                    "native Nil ABI: core.nil return operand does not match its function result",
+                ));
+            }
+            plan.nil_return_operands.push(op);
+        }
+    }
+
+    // Final native IR must not retain Nil block arguments.  The only legal
+    // occurrences at this boundary are entry parameters whose exact callable
+    // signature is being projected above.
+    let entry_blocks: HashSet<_> = plan
+        .entry_nil_args
+        .iter()
+        .map(|(block, _)| *block)
+        .collect();
+    for block in collect_blocks(ctx, &ops) {
+        if entry_blocks.contains(&block) {
+            continue;
+        }
+        if ctx
+            .block_args(block)
+            .iter()
+            .any(|&arg| ctx.value_ty(arg) == nil_ty)
+        {
+            return Err(TargetAbiError::new(
+                "native Nil ABI: residual core.nil block argument is not an exact callable parameter",
+            ));
+        }
+    }
+
+    let aliases = ctx.type_aliases().to_vec();
+    let mut converter = NativeNilTypeConverter::new(ctx, nil_ty);
+    for (name, ty) in aliases {
+        let converted = converter.convert_type(ty)?;
+        if converted != ty {
+            plan.type_aliases.push((name, converted));
+        }
+    }
+    for &op in &ops {
+        let results = converter.ctx.op_result_types(op).to_vec();
+        for (index, ty) in results.into_iter().enumerate() {
+            let converted = converter.convert_type(ty)?;
+            if converted != ty {
+                plan.op_results.push((op, index as u32, converted));
+            }
+        }
+        let attributes: Vec<_> = converter
+            .ctx
+            .op(op)
+            .attributes
+            .iter()
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
+        for (name, value) in attributes {
+            let converted = converter.convert_attribute(value.clone())?;
+            if converted != value {
+                plan.op_attributes.push((op, name, converted));
+            }
+        }
+    }
+    for block in collect_blocks(converter.ctx, &ops) {
+        let args = converter.ctx.block(block).args.clone();
+        for (index, arg) in args.into_iter().enumerate() {
+            let converted = converter.convert_type(arg.ty)?;
+            if converted != arg.ty {
+                plan.block_arg_types.push((block, index as u32, converted));
+            }
+            for (name, value) in arg.attrs {
+                let converted = converter.convert_attribute(value.clone())?;
+                if converted != value {
+                    plan.block_arg_attributes
+                        .push((block, index, name, converted));
+                }
+            }
+        }
+    }
+    drop(converter);
+
+    for (name, ty) in plan.type_aliases {
+        ctx.register_type_alias(name, ty);
+    }
+    for (op, index, ty) in plan.op_results {
+        ctx.set_op_result_type(op, index, ty);
+    }
+    for (op, name, value) in plan.op_attributes {
+        ctx.op_mut(op).attributes.insert(name, value);
+    }
+    for (block, index, ty) in plan.block_arg_types {
+        ctx.set_block_arg_type(block, index, ty);
+    }
+    for (block, index, name, value) in plan.block_arg_attributes {
+        ctx.block_mut(block).args[index].attrs.insert(name, value);
+    }
+    for (op, mut indices) in plan.transfer_nil_operands {
+        indices.sort_unstable();
+        indices.dedup();
+        for index in indices.into_iter().rev() {
+            ctx.remove_op_operand(op, index as u32);
+        }
+    }
+    for op in plan.nil_return_operands {
+        ctx.remove_op_operand(op, 0);
+    }
+    for (block, mut indices) in plan.entry_nil_args {
+        indices.sort_unstable();
+        indices.dedup();
+        for index in indices.into_iter().rev() {
+            let value = ctx.block_args(block)[index];
+            let location = ctx.block(block).location;
+            let unit = arith::r#const(ctx, location, nil_ty, Attribute::Unit);
+            if let Some(&first) = ctx.block(block).ops.first() {
+                ctx.insert_op_before(block, first, unit.op_ref());
+            } else {
+                ctx.push_op(block, unit.op_ref());
+            }
+            ctx.replace_all_uses(value, unit.result(ctx));
+            debug_assert!(ctx.uses(value).is_empty());
+            ctx.remove_block_arg(block, index as u32);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone)]
+struct NativeNilFunctionIdentity {
+    signature: TypeRef,
+    environment_index: Option<usize>,
+    nil_params: Vec<usize>,
+}
+
+#[derive(Default)]
+struct NativeNilAbiPlan {
+    type_aliases: Vec<(Symbol, TypeRef)>,
+    op_results: Vec<(OpRef, u32, TypeRef)>,
+    op_attributes: Vec<(OpRef, Symbol, Attribute)>,
+    block_arg_types: Vec<(BlockRef, u32, TypeRef)>,
+    block_arg_attributes: Vec<(BlockRef, usize, Symbol, Attribute)>,
+    entry_nil_args: Vec<(BlockRef, Vec<usize>)>,
+    transfer_nil_operands: Vec<(OpRef, Vec<usize>)>,
+    nil_return_operands: Vec<OpRef>,
+}
+
+fn validate_direct_nil_transfer(
+    ctx: &IrContext,
+    op: OpRef,
+    identity: &NativeNilFunctionIdentity,
+    operand_offset: usize,
+    target: Symbol,
+) -> Result<(), TargetAbiError> {
+    let callable = core::Func::from_type_ref(ctx, identity.signature)
+        .expect("native Nil identity was prevalidated as core.func");
+    let operands = ctx.op_operands(op);
+    let expected = callable.params(ctx);
+    if operands.len() != expected.len() + operand_offset
+        || operands[operand_offset..]
+            .iter()
+            .zip(expected)
+            .any(|(&operand, &ty)| ctx.value_ty(operand) != ty)
+    {
+        return Err(TargetAbiError::new(format!(
+            "native Nil ABI: transfer to `{target}` does not match its exact pre-projection signature"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate an indirect transfer against the exact callable type carried by
+/// its callee value, then return only the argument operand indices that the
+/// native zero-size ABI may project. The callee remains at operand zero.
+fn validate_indirect_nil_transfer(
+    ctx: &IrContext,
+    op: OpRef,
+    nil_ty: TypeRef,
+) -> Result<Vec<usize>, TargetAbiError> {
+    if get_calling_convention(ctx, op).is_none() {
+        return Err(TargetAbiError::new(
+            "native Nil ABI: indirect transfer with core.nil argument has no valid calling convention",
+        ));
+    }
+    let operands = ctx.op_operands(op);
+    let Some((&callee, args)) = operands.split_first() else {
+        return Err(TargetAbiError::new(
+            "native Nil ABI: indirect transfer has no callee operand",
+        ));
+    };
+    let callable_ty = get_indirect_call_signature(ctx, op).or_else(|| {
+        let callee_ty = ctx.value_ty(callee);
+        core::Func::from_type_ref(ctx, callee_ty)
+            .map(|_| callee_ty)
+            .or_else(|| closure::Closure::from_type_ref(ctx, callee_ty).map(|closure| closure.func_type(ctx)))
+    }).ok_or_else(|| {
+        TargetAbiError::new(
+            "native Nil ABI: indirect transfer with core.nil argument has no exact callable signature provenance",
+        )
+    })?;
+    let callable = core::Func::from_type_ref(ctx, callable_ty).ok_or_else(|| {
+        TargetAbiError::new(
+            "native Nil ABI: indirect transfer closure does not contain an exact core.func type",
+        )
+    })?;
+    let expected = callable.params(ctx);
+    if args.len() != expected.len()
+        || args
+            .iter()
+            .zip(expected)
+            .any(|(&arg, &ty)| !matches_indirect_callable_parameter(ctx, ty, ctx.value_ty(arg)))
+    {
+        return Err(TargetAbiError::new(
+            "native Nil ABI: indirect transfer does not match its exact pre-projection callable signature",
+        ));
+    }
+    Ok(expected
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &ty)| (ty == nil_ty).then_some(index + 1))
+        .collect())
+}
+
+/// Closure lowering changes abstract closure values into the exact canonical
+/// `_closure { table_idx, env }` runtime pair. This is a representation
+/// projection, not a signature inference: the preserved callable type remains
+/// authoritative and every other type must match identically.
+fn matches_indirect_callable_parameter(
+    ctx: &IrContext,
+    expected: TypeRef,
+    actual: TypeRef,
+) -> bool {
+    expected == actual
+        || (closure::Closure::matches(ctx, expected)
+            && crate::closure_lower::is_closure_struct_type_ref(ctx, actual))
+}
+
+fn validate_native_constant_signature(
+    ctx: &mut IrContext,
+    target: Symbol,
+    actual: TypeRef,
+    identity: NativeNilFunctionIdentity,
+) -> Result<(), TargetAbiError> {
+    let definition = core::Func::from_type_ref(ctx, identity.signature)
+        .expect("native Nil identity was prevalidated as core.func");
+    let mut expected_params = definition.params(ctx).to_vec();
+    if let Some(index) = identity.environment_index {
+        expected_params.remove(index);
+    }
+    let expected = core::func(
+        ctx,
+        definition.r#return(ctx),
+        expected_params.iter().copied(),
+    )
+    .as_type_ref();
+    if actual != expected {
+        return Err(TargetAbiError::new(format!(
+            "native Nil ABI: func.constant @{target} does not match the exact environment-less signature of its target"
+        )));
+    }
+    Ok(())
+}
+
+struct NativeNilTypeConverter<'a> {
+    ctx: &'a mut IrContext,
+    nil_ty: TypeRef,
+    cache: HashMap<TypeRef, TypeRef>,
+}
+
+impl<'a> NativeNilTypeConverter<'a> {
+    fn new(ctx: &'a mut IrContext, nil_ty: TypeRef) -> Self {
+        Self {
+            ctx,
+            nil_ty,
+            cache: HashMap::new(),
+        }
+    }
+
+    fn convert_type(&mut self, ty: TypeRef) -> Result<TypeRef, TargetAbiError> {
+        if let Some(&converted) = self.cache.get(&ty) {
+            return Ok(converted);
+        }
+        let data = self.ctx.types.get(ty).clone();
+        let mut converted = data.clone();
+        if data.dialect == Symbol::new("core") && data.name == Symbol::new("func") {
+            if data.params.is_empty() {
+                return Err(TargetAbiError::new(
+                    "native Nil ABI: malformed core.func type",
+                ));
+            }
+            converted.params = smallvec![self.convert_type(data.params[0])?];
+            for &param in &data.params[1..] {
+                if param != self.nil_ty {
+                    converted.params.push(self.convert_type(param)?);
+                }
+            }
+        } else {
+            for param in &mut converted.params {
+                *param = self.convert_type(*param)?;
+            }
+        }
+        self.convert_type_attributes(&mut converted)?;
+        let result = if converted == data {
+            ty
+        } else {
+            self.ctx.types.intern(converted)
+        };
+        self.cache.insert(ty, result);
+        Ok(result)
+    }
+
+    fn convert_type_attributes(&mut self, data: &mut TypeData) -> Result<(), TargetAbiError> {
+        let attrs: Vec<_> = data
+            .attrs
+            .iter()
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
+        for (name, value) in attrs {
+            data.attrs.insert(name, self.convert_attribute(value)?);
+        }
+        Ok(())
+    }
+
+    fn convert_attribute(&mut self, attribute: Attribute) -> Result<Attribute, TargetAbiError> {
+        match attribute {
+            Attribute::Type(ty) => Ok(Attribute::Type(self.convert_type(ty)?)),
+            Attribute::List(values) => Ok(Attribute::List(
+                values
+                    .into_iter()
+                    .map(|value| self.convert_attribute(value))
+                    .collect::<Result<_, _>>()?,
+            )),
+            other => Ok(other),
+        }
+    }
+}
+
+/// Construct the target root delimiter after physical CPS signature lowering.
+///
+/// Direct roots remain ordinary. A promoted root worker is renamed and called
+/// once by a Direct/EvidenceDirect wrapper. Its terminal continuation stores
+/// the source result in a typed completion cell before returning through the
+/// target's empty result ABI.
+pub fn compose_root_entry_bridge(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), TargetAbiError> {
+    let Some(module_block) = module.first_block(ctx) else {
+        return Ok(());
+    };
+    let top_level_ops = ctx.block(module_block).ops.to_vec();
+    let roots: Vec<_> = top_level_ops
+        .iter()
+        .copied()
+        .filter(|&op| {
+            func::Func::from_op(ctx, op)
+                .is_ok_and(|function| function.sym_name(ctx) == Symbol::new("main"))
+        })
+        .collect();
+    if roots.len() > 1 {
+        return Err(TargetAbiError::new(
+            "target root bridge: multiple immediate root `main` definitions",
+        ));
+    }
+    let Some(&worker_op) = roots.first() else {
+        return Ok(());
+    };
+    let worker_convention = checked_calling_convention(ctx, worker_op)?;
+    let export_convention = checked_root_export_convention(ctx, worker_op)?;
+    let source_result = checked_root_source_result(ctx, worker_op)?;
+    if export_convention.is_some() != source_result.is_some() {
+        return Err(TargetAbiError::new(
+            "target root bridge: preserved root export convention and source result must either \
+             both be present or both be absent",
+        ));
+    }
+    let Some(worker_convention) = worker_convention else {
+        if export_convention.is_none() && source_result.is_none() {
+            return Ok(());
+        }
+        return Err(TargetAbiError::new(
+            "target root bridge: root main has no calling convention",
+        ));
+    };
+    if worker_convention != CallingConvention::Cps {
+        let Some(export_convention) = export_convention else {
+            return Ok(());
+        };
+        let Some(_source_result) = source_result else {
+            return Err(TargetAbiError::new(
+                "target root bridge: missing preserved root source result type",
+            ));
+        };
+        if worker_convention != export_convention {
+            return Err(TargetAbiError::new(
+                "target root bridge: unpromoted root convention does not match its preserved \
+                 export convention",
+            ));
+        }
+        remove_root_contract(ctx, worker_op);
+        return Ok(());
+    }
+
+    let export_convention = export_convention.ok_or_else(|| {
+        TargetAbiError::new(
+            "target root bridge: missing preserved root export convention for promoted Cps main",
+        )
+    })?;
+    if export_convention == CallingConvention::Cps {
+        return Err(TargetAbiError::new(
+            "target root bridge: the preserved root export convention must be Direct or \
+             EvidenceDirect",
+        ));
+    }
+    let source_result = source_result.ok_or_else(|| {
+        TargetAbiError::new(
+            "target root bridge: missing preserved root source result type for promoted Cps main",
+        )
+    })?;
+
+    let nil_ty = core::nil(ctx).as_type_ref();
+    if source_result != nil_ty {
+        return Err(TargetAbiError::new(
+            "target root bridge: current source main contract must return core.nil",
+        ));
+    }
+    let evidence_ty = ability::evidence_adt_type_ref(ctx);
+    let worker = func::Func::from_op(ctx, worker_op)
+        .map_err(|_| TargetAbiError::new("target root bridge: root main is not func.func"))?;
+    let worker_signature = core::Func::from_type_ref(ctx, worker.r#type(ctx))
+        .ok_or_else(|| TargetAbiError::new("target root bridge: main is not core.func"))?;
+    if worker_signature.r#return(ctx) != nil_ty {
+        return Err(TargetAbiError::new(
+            "target root bridge: Cps root must have a physically empty result",
+        ));
+    }
+    let worker_params = worker_signature.params(ctx);
+    if worker_params.len() != 3 || worker_params[0] != evidence_ty {
+        return Err(TargetAbiError::new(
+            "target root bridge: source main must have no parameters beyond physical evidence and \
+             done_k and dispatch",
+        ));
+    }
+    let done_k_ty = worker_params[1];
+    validate_root_done_k_type(ctx, done_k_ty, source_result, nil_ty)?;
+    let dispatch_ty = worker_params[2];
+    let dispatch_function = validate_root_dispatch_type(ctx, dispatch_ty, nil_ty)?;
+    if ctx.op(worker_op).regions.is_empty() {
+        return Err(TargetAbiError::new(
+            "target root bridge: root main must be a definition",
+        ));
+    }
+
+    let cps_main = Symbol::new(CPS_MAIN_SYMBOL);
+    let root_done_k = Symbol::new(ROOT_DONE_K_SYMBOL);
+    let root_reject_dispatch = Symbol::new(ROOT_REJECT_DISPATCH_SYMBOL);
+    for &op in &top_level_ops {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            continue;
+        };
+        let name = function.sym_name(ctx);
+        if name == cps_main || name == root_done_k || name == root_reject_dispatch {
+            return Err(TargetAbiError::new(format!(
+                "target root bridge: reserved symbol collision at `{name}`"
+            )));
+        }
+    }
+
+    let location = ctx.op(worker_op).location;
+    ctx.op_mut(worker_op)
+        .attributes
+        .insert(Symbol::new("sym_name"), Attribute::Symbol(cps_main));
+    ctx.op_mut(worker_op)
+        .attributes
+        .insert(Symbol::new(ROOT_CPS_WORKER_ATTR), Attribute::Bool(true));
+    remove_root_contract(ctx, worker_op);
+    for &op in &top_level_ops {
+        rewrite_symbol_refs(ctx, op, Symbol::new("main"), cps_main);
+    }
+
+    let cell_ty = root_completion_cell_type(ctx, source_result);
+    let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+    let done_callable_ty = core::func(ctx, nil_ty, [source_result]).as_type_ref();
+    let done_function_ty = core::func(ctx, nil_ty, [anyref_ty, source_result]).as_type_ref();
+
+    let done_entry = ctx.create_block(BlockData {
+        location,
+        args: vec![
+            BlockArgData {
+                ty: anyref_ty,
+                attrs: bind_name("__env"),
+            },
+            BlockArgData {
+                ty: source_result,
+                attrs: bind_name("__answer"),
+            },
+        ],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    let done_args = ctx.block_args(done_entry).to_vec();
+    let cell = adt::ref_cast(ctx, location, done_args[0], cell_ty, cell_ty);
+    ctx.push_op(done_entry, cell.op_ref());
+    let store = adt::struct_set(ctx, location, cell.result(ctx), done_args[1], cell_ty, 0);
+    ctx.push_op(done_entry, store.op_ref());
+    let done_nil = arith::r#const(ctx, location, nil_ty, Attribute::Unit);
+    ctx.push_op(done_entry, done_nil.op_ref());
+    let done_return = func::r#return(ctx, location, [done_nil.result(ctx)]);
+    ctx.push_op(done_entry, done_return.op_ref());
+    let done_region = ctx.create_region(RegionData {
+        location,
+        blocks: smallvec![done_entry],
+        parent_op: None,
+    });
+    let done_function = func::func(ctx, location, root_done_k, done_function_ty, done_region);
+    set_calling_convention(ctx, done_function.op_ref(), CallingConvention::Cps);
+    ctx.op_mut(done_function.op_ref())
+        .attributes
+        .insert(Symbol::new(ROOT_DONE_K_ATTR), Attribute::Bool(true));
+
+    let dispatch_params = core::Func::from_type_ref(ctx, dispatch_function)
+        .expect("validated root dispatch function remains core.func")
+        .params(ctx)
+        .to_vec();
+    let mut reject_params = Vec::with_capacity(dispatch_params.len() + 1);
+    reject_params.push(anyref_ty);
+    reject_params.extend(dispatch_params.iter().copied());
+    let reject_function_ty = core::func(ctx, nil_ty, reject_params.clone()).as_type_ref();
+    let reject_entry = ctx.create_block(BlockData {
+        location,
+        args: reject_params
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(index, ty)| BlockArgData {
+                ty,
+                attrs: if index == 0 {
+                    bind_name("__env")
+                } else {
+                    Default::default()
+                },
+            })
+            .collect(),
+        ops: smallvec![],
+        parent_region: None,
+    });
+    let reject = func::unreachable(ctx, location);
+    ctx.push_op(reject_entry, reject.op_ref());
+    let reject_region = ctx.create_region(RegionData {
+        location,
+        blocks: smallvec![reject_entry],
+        parent_op: None,
+    });
+    let reject_function = func::func(
+        ctx,
+        location,
+        root_reject_dispatch,
+        reject_function_ty,
+        reject_region,
+    );
+    set_calling_convention(ctx, reject_function.op_ref(), CallingConvention::Cps);
+
+    let wrapper_params = if export_convention == CallingConvention::EvidenceDirect {
+        vec![evidence_ty]
+    } else {
+        vec![]
+    };
+    let wrapper_entry = ctx.create_block(BlockData {
+        location,
+        args: wrapper_params
+            .iter()
+            .copied()
+            .map(|ty| BlockArgData {
+                ty,
+                attrs: bind_name("__evidence"),
+            })
+            .collect(),
+        ops: smallvec![],
+        parent_region: None,
+    });
+    let initial = arith::r#const(ctx, location, source_result, Attribute::Unit);
+    ctx.push_op(wrapper_entry, initial.op_ref());
+    let cell_new = adt::struct_new(ctx, location, [initial.result(ctx)], cell_ty, cell_ty);
+    ctx.push_op(wrapper_entry, cell_new.op_ref());
+    let erased_cell =
+        core::unrealized_conversion_cast(ctx, location, cell_new.result(ctx), anyref_ty);
+    ctx.push_op(wrapper_entry, erased_cell.op_ref());
+    let done_constant = func::constant(ctx, location, done_callable_ty, root_done_k);
+    ctx.push_op(wrapper_entry, done_constant.op_ref());
+    let closure_struct_ty = crate::closure_lower::closure_struct_type_ref(ctx);
+    let done_closure = adt::struct_new(
+        ctx,
+        location,
+        [done_constant.result(ctx), erased_cell.result(ctx)],
+        closure_struct_ty,
+        closure_struct_ty,
+    );
+    ctx.push_op(wrapper_entry, done_closure.op_ref());
+    let typed_done =
+        core::unrealized_conversion_cast(ctx, location, done_closure.result(ctx), done_k_ty);
+    ctx.push_op(wrapper_entry, typed_done.op_ref());
+    let reject_constant = func::constant(ctx, location, reject_function_ty, root_reject_dispatch);
+    ctx.push_op(wrapper_entry, reject_constant.op_ref());
+    let reject_closure = adt::struct_new(
+        ctx,
+        location,
+        [reject_constant.result(ctx), erased_cell.result(ctx)],
+        closure_struct_ty,
+        closure_struct_ty,
+    );
+    ctx.push_op(wrapper_entry, reject_closure.op_ref());
+    let typed_dispatch =
+        core::unrealized_conversion_cast(ctx, location, reject_closure.result(ctx), dispatch_ty);
+    ctx.push_op(wrapper_entry, typed_dispatch.op_ref());
+
+    let evidence = if export_convention == CallingConvention::EvidenceDirect {
+        ctx.block_args(wrapper_entry)[0]
+    } else {
+        let i32_ty = ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::new("i32"),
+            params: smallvec![],
+            attrs: AttributeMap::new(),
+        });
+        let zero = arith::r#const(ctx, location, i32_ty, Attribute::Int(0));
+        ctx.push_op(wrapper_entry, zero.op_ref());
+        let empty = adt::array_new(ctx, location, [zero.result(ctx)], evidence_ty, evidence_ty);
+        ctx.push_op(wrapper_entry, empty.op_ref());
+        empty.result(ctx)
+    };
+    let worker_call = func::call(
+        ctx,
+        location,
+        [evidence, typed_done.result(ctx), typed_dispatch.result(ctx)],
+        nil_ty,
+        cps_main,
+    );
+    set_calling_convention(ctx, worker_call.op_ref(), CallingConvention::Cps);
+    ctx.op_mut(worker_call.op_ref())
+        .attributes
+        .insert(Symbol::new(ROOT_CPS_CALL_ATTR), Attribute::Bool(true));
+    ctx.push_op(wrapper_entry, worker_call.op_ref());
+
+    let completed = adt::struct_get(
+        ctx,
+        location,
+        cell_new.result(ctx),
+        source_result,
+        cell_ty,
+        0,
+    );
+    ctx.push_op(wrapper_entry, completed.op_ref());
+    let wrapper_return = func::r#return(ctx, location, [completed.result(ctx)]);
+    ctx.push_op(wrapper_entry, wrapper_return.op_ref());
+    let wrapper_region = ctx.create_region(RegionData {
+        location,
+        blocks: smallvec![wrapper_entry],
+        parent_op: None,
+    });
+    let wrapper_ty = core::func(ctx, source_result, wrapper_params.iter().copied()).as_type_ref();
+    let wrapper = func::func(
+        ctx,
+        location,
+        Symbol::new("main"),
+        wrapper_ty,
+        wrapper_region,
+    );
+    set_calling_convention(ctx, wrapper.op_ref(), export_convention);
+    ctx.op_mut(wrapper.op_ref())
+        .attributes
+        .insert(Symbol::new(ROOT_WRAPPER_ATTR), Attribute::Bool(true));
+
+    ctx.push_op(module_block, done_function.op_ref());
+    ctx.push_op(module_block, reject_function.op_ref());
+    ctx.push_op(module_block, wrapper.op_ref());
+    Ok(())
+}
+
+fn exact_environment_index(
+    ctx: &IrContext,
+    function: OpRef,
+    signature_params: &[TypeRef],
+    anyref_ty: TypeRef,
+) -> Result<Option<usize>, TargetAbiError> {
+    let Some(&region) = ctx.op(function).regions.first() else {
+        return Ok(None);
+    };
+    let Some(&entry) = ctx.region(region).blocks.first() else {
+        return Ok(None);
+    };
+    if ctx.block(entry).args.len() != signature_params.len() {
+        return Err(TargetAbiError::new(
+            "target CPS signature lowering: function signature and entry block arity differ",
+        ));
+    }
+    let indices: Vec<_> = ctx
+        .block(entry)
+        .args
+        .iter()
+        .enumerate()
+        .filter_map(|(index, arg)| {
+            (arg.attrs.get_symbol("bind_name") == Some(Symbol::new("__env"))).then_some(index)
+        })
+        .collect();
+    match indices.as_slice() {
+        [] => Ok(None),
+        [index] => {
+            if signature_params[*index] != anyref_ty {
+                return Err(TargetAbiError::new(
+                    "target CPS signature lowering: `__env` must have exact tribute_rt.anyref type",
+                ));
+            }
+            Ok(Some(*index))
+        }
+        _ => Err(TargetAbiError::new(
+            "target CPS signature lowering: function has multiple `__env` parameters",
+        )),
+    }
+}
+
+/// Find `scf.if : core.never` markers that have the one CPS meaning which can
+/// be physicalized: every branch transfers control in tail position and the
+/// marker result is unused. Any other operation result of `core.never` reaches
+/// this boundary without enough provenance for an ABI rewrite, so reject it.
+fn validate_structured_never_results(
+    ctx: &IrContext,
+    ops: &[OpRef],
+    never_ty: TypeRef,
+    function_conventions: &HashMap<OpRef, CallingConvention>,
+) -> Result<HashSet<(OpRef, u32)>, TargetAbiError> {
+    let mut results = HashSet::new();
+    for &op in ops {
+        for (index, &ty) in ctx.op_result_types(op).iter().enumerate() {
+            if ty != never_ty {
+                continue;
+            }
+            if !scf::If::matches(ctx, op) || index != 0 || ctx.op_results(op).len() != 1 {
+                return Err(TargetAbiError::new(
+                    "target signature lowering: residual core.never operation result is not a \
+                     proven structured CPS tail marker",
+                ));
+            }
+            let function = enclosing_function(ctx, op).ok_or_else(|| {
+                TargetAbiError::new(
+                    "target signature lowering: structured core.never marker has no owning \
+                     callable",
+                )
+            })?;
+            if function_conventions.get(&function) != Some(&CallingConvention::Cps) {
+                return Err(TargetAbiError::new(
+                    "target signature lowering: structured core.never marker is not owned by a \
+                     proven Cps callable",
+                ));
+            }
+            let result = ctx.op_result(op, 0);
+            if ctx.has_uses(result) {
+                return Err(TargetAbiError::new(
+                    "target signature lowering: structured core.never marker result must be \
+                     unused",
+                ));
+            }
+            if !structured_if_ends_in_proper_tail(ctx, op, never_ty) {
+                return Err(TargetAbiError::new(format!(
+                    "target signature lowering: structured core.never marker must end every \
+                         branch in a proper-tail transfer or typed unreachable (branch endings: {})",
+                    structured_if_branch_endings(ctx, op)
+                )));
+            }
+            results.insert((op, index as u32));
+        }
+    }
+    Ok(results)
+}
+
+fn structured_if_branch_endings(ctx: &IrContext, op: OpRef) -> String {
+    let Ok(if_op) = scf::If::from_op(ctx, op) else {
+        return "<not scf.if>".to_owned();
+    };
+    [if_op.then_region(ctx), if_op.else_region(ctx)]
+        .into_iter()
+        .map(|region| {
+            let Some(block) = ctx.region(region).blocks.first().copied() else {
+                return "<empty region>".to_owned();
+            };
+            let ops = &ctx.block(block).ops;
+            let Some(op) = ops.last().copied() else {
+                return "<empty block>".to_owned();
+            };
+            let data = ctx.op(op);
+            let all_ops = ops
+                .iter()
+                .map(|&op| {
+                    let data = ctx.op(op);
+                    format!("{}.{}", data.dialect, data.name)
+                })
+                .collect::<Vec<_>>()
+                .join(" -> ");
+            format!("{}.{} [{}]", data.dialect, data.name, all_ops)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn enclosing_function(ctx: &IrContext, op: OpRef) -> Option<OpRef> {
+    let mut current = Some(op);
+    while let Some(candidate) = current {
+        if func::Func::from_op(ctx, candidate).is_ok() {
+            return Some(candidate);
+        }
+        if candidate != op && core::Module::from_op(ctx, candidate).is_ok() {
+            return None;
+        }
+        current = ctx.op(candidate).parent_block.and_then(|block| {
+            let region = ctx.block(block).parent_region?;
+            ctx.region(region).parent_op
+        });
+    }
+    None
+}
+
+fn structured_if_ends_in_proper_tail(ctx: &IrContext, op: OpRef, never_ty: TypeRef) -> bool {
+    let Ok(if_op) = scf::If::from_op(ctx, op) else {
+        return false;
+    };
+    [if_op.then_region(ctx), if_op.else_region(ctx)]
+        .into_iter()
+        .all(|region| region_ends_in_proper_tail(ctx, region, never_ty))
+}
+
+fn region_ends_in_proper_tail(
+    ctx: &IrContext,
+    region: trunk_ir::refs::RegionRef,
+    never_ty: TypeRef,
+) -> bool {
+    let [block] = ctx.region(region).blocks.as_slice() else {
+        return false;
+    };
+    let Some(&terminator) = ctx.block(*block).ops.last() else {
+        return false;
+    };
+    let data = ctx.op(terminator);
+    if data.dialect == Symbol::new("func")
+        && (data.name == Symbol::new("tail_call") || data.name == Symbol::new("tail_call_indirect"))
+    {
+        return get_calling_convention(ctx, terminator) == Some(CallingConvention::Cps);
+    }
+    if data.dialect == Symbol::new("effect") && data.name == Symbol::new("dispatch_cps") {
+        return ctx.op_result_types(terminator).is_empty();
+    }
+    // Handler dispatches may have a statically unreachable reject arm. It is
+    // a genuine non-returning exit, unlike an empty/fallthrough block, and
+    // carries no value through the physical control-flow edge.
+    if data.dialect == Symbol::new("func") && data.name == Symbol::new("unreachable") {
+        return true;
+    }
+    scf::If::matches(ctx, terminator)
+        && ctx.op_result_types(terminator) == [never_ty]
+        && !ctx.has_uses(ctx.op_result(terminator, 0))
+        && structured_if_ends_in_proper_tail(ctx, terminator, never_ty)
+        || (scf::Switch::matches(ctx, terminator)
+            && structured_switch_ends_in_proper_tail(ctx, terminator, never_ty))
+}
+
+/// A resultless `scf.switch` may terminate a proven `core.never` branch only
+/// when it is a complete dispatch whose every case/default region transfers
+/// control. This keeps structured source control explicit without admitting a
+/// fallthrough or an empty arm as a physical CPS exit.
+fn structured_switch_ends_in_proper_tail(ctx: &IrContext, op: OpRef, never_ty: TypeRef) -> bool {
+    let Ok(switch) = scf::Switch::from_op(ctx, op) else {
+        return false;
+    };
+    let [body] = ctx.op(switch.op_ref()).regions.as_slice() else {
+        return false;
+    };
+    let [block] = ctx.region(*body).blocks.as_slice() else {
+        return false;
+    };
+    let arms = ctx.block(*block).ops.as_slice();
+    !arms.is_empty()
+        && arms.iter().all(|&arm| {
+            let data = ctx.op(arm);
+            let is_arm = scf::Case::matches(ctx, arm) || scf::Default::matches(ctx, arm);
+            let [region] = data.regions.as_slice() else {
+                return false;
+            };
+            is_arm && region_ends_in_proper_tail(ctx, *region, never_ty)
+        })
+        && arms.iter().any(|&arm| scf::Default::matches(ctx, arm))
+}
+
+fn collect_ops(ctx: &IrContext, root: OpRef) -> Vec<OpRef> {
+    let mut ops = Vec::new();
+    let _ = walk_op::<()>(ctx, root, &mut |op| {
+        ops.push(op);
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    ops
+}
+
+fn collect_blocks(ctx: &IrContext, ops: &[OpRef]) -> Vec<BlockRef> {
+    let mut seen = HashSet::new();
+    let mut blocks = Vec::new();
+    for &op in ops {
+        for &region in &ctx.op(op).regions {
+            for &block in &ctx.region(region).blocks {
+                if seen.insert(block) {
+                    blocks.push(block);
+                }
+            }
+        }
+    }
+    blocks
+}
+
+/// Return the nearest owning `core.module` for an operation's symbol lookup.
+///
+/// `func.constant` names are module-local. The physicalizer traverses nested
+/// modules to rewrite their types too, so a bare symbol alone cannot identify
+/// a callable without conflating a nested local declaration with a root one.
+fn symbol_scope(ctx: &IrContext, op: OpRef) -> Result<OpRef, TargetAbiError> {
+    let mut current = Some(op);
+    while let Some(candidate) = current {
+        if core::Module::from_op(ctx, candidate).is_ok() {
+            return Ok(candidate);
+        }
+        current = ctx.op(candidate).parent_block.and_then(|block| {
+            let region = ctx.block(block).parent_region?;
+            ctx.region(region).parent_op
+        });
+    }
+    Err(TargetAbiError::new(
+        "target signature lowering: operation has no owning core.module symbol scope",
+    ))
+}
+
+#[derive(Clone, Copy)]
+struct FunctionIdentity {
+    signature: TypeRef,
+    convention: CallingConvention,
+    environment_index: Option<usize>,
+}
+
+#[derive(Default)]
+struct PhysicalizationPlan {
+    type_aliases: Vec<(Symbol, TypeRef)>,
+    op_results: Vec<(OpRef, u32, TypeRef)>,
+    op_attributes: Vec<(OpRef, Symbol, Attribute)>,
+    block_arg_types: Vec<(BlockRef, u32, TypeRef)>,
+    block_arg_attributes: Vec<(BlockRef, usize, Symbol, Attribute)>,
+}
+
+fn validate_constant_signature(
+    ctx: &mut IrContext,
+    target: Symbol,
+    actual: TypeRef,
+    identity: FunctionIdentity,
+    never_ty: TypeRef,
+) -> Result<(), TargetAbiError> {
+    let definition = core::Func::from_type_ref(ctx, identity.signature)
+        .expect("function identity was prevalidated as core.func");
+    let mut expected_params = definition.params(ctx).to_vec();
+    if let Some(index) = identity.environment_index {
+        expected_params.remove(index);
+    }
+    let expected_result = definition.r#return(ctx);
+    if identity.convention == CallingConvention::Cps && expected_result != never_ty {
+        return Err(TargetAbiError::new(format!(
+            "target signature lowering: Cps target `{target}` must have logical core.never result"
+        )));
+    }
+    let expected = core::func(ctx, expected_result, expected_params.iter().copied()).as_type_ref();
+    if actual != expected {
+        return Err(TargetAbiError::new(format!(
+            "target signature lowering: func.constant @{} does not match the exact \
+             environment-less signature of its target",
+            target
+        )));
+    }
+    Ok(())
+}
+
+struct PhysicalTypeConverter<'a> {
+    ctx: &'a mut IrContext,
+    never_ty: TypeRef,
+    nil_ty: TypeRef,
+    nested_cache: HashMap<TypeRef, TypeRef>,
+    callable_cache: HashMap<(TypeRef, CallingConvention), TypeRef>,
+}
+
+impl<'a> PhysicalTypeConverter<'a> {
+    fn new(ctx: &'a mut IrContext, never_ty: TypeRef, nil_ty: TypeRef) -> Self {
+        Self {
+            ctx,
+            never_ty,
+            nil_ty,
+            nested_cache: HashMap::new(),
+            callable_cache: HashMap::new(),
+        }
+    }
+
+    fn convert_unproven_callable(&mut self, ty: TypeRef) -> Result<TypeRef, TargetAbiError> {
+        let callable = core::Func::from_type_ref(self.ctx, ty).ok_or_else(|| {
+            TargetAbiError::new("target signature lowering: function type is not core.func")
+        })?;
+        if callable.r#return(self.ctx) == self.never_ty {
+            return Err(TargetAbiError::new(
+                "target signature lowering: core.never function has no explicit convention",
+            ));
+        }
+        self.convert_callable(ty, CallingConvention::Direct)
+    }
+
+    fn convert_callable(
+        &mut self,
+        ty: TypeRef,
+        convention: CallingConvention,
+    ) -> Result<TypeRef, TargetAbiError> {
+        if let Some(&converted) = self.callable_cache.get(&(ty, convention)) {
+            return Ok(converted);
+        }
+        let mut data = self.ctx.types.get(ty).clone();
+        if data.dialect != Symbol::new("core")
+            || data.name != Symbol::new("func")
+            || data.params.is_empty()
+        {
+            return Err(TargetAbiError::new(
+                "target signature lowering: proven callable is not a valid core.func",
+            ));
+        }
+        if convention == CallingConvention::Cps && data.params[0] != self.never_ty {
+            return Err(TargetAbiError::new(
+                "target signature lowering: Cps callable must have logical core.never result",
+            ));
+        }
+
+        let old_result = data.params[0];
+        data.params[0] = if convention == CallingConvention::Cps {
+            self.nil_ty
+        } else {
+            self.convert_nested(old_result)?
+        };
+        for index in 1..data.params.len() {
+            data.params[index] = self.convert_nested(data.params[index])?;
+        }
+        self.convert_type_attributes(&mut data)?;
+
+        let converted = if data == *self.ctx.types.get(ty) {
+            ty
+        } else {
+            self.ctx.types.intern(data)
+        };
+        self.callable_cache.insert((ty, convention), converted);
+        Ok(converted)
+    }
+
+    fn convert_nested(&mut self, ty: TypeRef) -> Result<TypeRef, TargetAbiError> {
+        if let Some(&converted) = self.nested_cache.get(&ty) {
+            return Ok(converted);
+        }
+        let data = self.ctx.types.get(ty).clone();
+        if data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure") {
+            if data.params.len() != 1 {
+                return Err(TargetAbiError::new(
+                    "target signature lowering: physical closure must contain one core.func",
+                ));
+            }
+            let inner = data.params[0];
+            let convention = get_physical_closure_convention(self.ctx, ty);
+            if convention.is_none()
+                && data
+                    .attrs
+                    .contains_key(tribute_core::CALLING_CONVENTION_ATTR)
+            {
+                return Err(TargetAbiError::new(
+                    "target signature lowering: physical closure has an invalid convention tag",
+                ));
+            }
+            let converted_inner = if let Some(convention) = convention {
+                self.convert_callable(inner, convention)?
+            } else {
+                let callable = core::Func::from_type_ref(self.ctx, inner).ok_or_else(|| {
+                    TargetAbiError::new(
+                        "target signature lowering: closure does not contain core.func",
+                    )
+                })?;
+                if callable.r#return(self.ctx) == self.never_ty {
+                    return Err(TargetAbiError::new(
+                        "target signature lowering: untagged nested core.func<core.never, ...>",
+                    ));
+                }
+                self.convert_callable(inner, CallingConvention::Direct)?
+            };
+            let mut converted_data = data.clone();
+            converted_data.params[0] = converted_inner;
+            self.convert_type_attributes(&mut converted_data)?;
+            let converted = if converted_data == data {
+                ty
+            } else {
+                self.ctx.types.intern(converted_data)
+            };
+            self.nested_cache.insert(ty, converted);
+            return Ok(converted);
+        }
+
+        if data.dialect == Symbol::new("core") && data.name == Symbol::new("func") {
+            let callable = core::Func::from_type_ref(self.ctx, ty)
+                .expect("core.func type was matched structurally");
+            if callable.r#return(self.ctx) == self.never_ty {
+                return Err(TargetAbiError::new(
+                    "target signature lowering: untagged nested core.func<core.never, ...>",
+                ));
+            }
+            let converted = self.convert_callable(ty, CallingConvention::Direct)?;
+            self.nested_cache.insert(ty, converted);
+            return Ok(converted);
+        }
+
+        let mut converted_data = data.clone();
+        for param in &mut converted_data.params {
+            *param = self.convert_nested(*param)?;
+        }
+        self.convert_type_attributes(&mut converted_data)?;
+        let converted = if converted_data == data {
+            ty
+        } else {
+            self.ctx.types.intern(converted_data)
+        };
+        self.nested_cache.insert(ty, converted);
+        Ok(converted)
+    }
+
+    fn convert_type_attributes(&mut self, data: &mut TypeData) -> Result<(), TargetAbiError> {
+        let attributes: Vec<_> = data
+            .attrs
+            .iter()
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
+        for (name, value) in attributes {
+            data.attrs.insert(name, self.convert_attribute(value)?);
+        }
+        Ok(())
+    }
+
+    fn convert_attribute(&mut self, attribute: Attribute) -> Result<Attribute, TargetAbiError> {
+        match attribute {
+            Attribute::Type(ty) => Ok(Attribute::Type(self.convert_nested(ty)?)),
+            Attribute::List(values) => Ok(Attribute::List(
+                values
+                    .into_iter()
+                    .map(|value| self.convert_attribute(value))
+                    .collect::<Result<_, _>>()?,
+            )),
+            other => Ok(other),
+        }
+    }
+}
+
+fn validate_root_done_k_type(
+    ctx: &IrContext,
+    done_k_ty: TypeRef,
+    source_result: TypeRef,
+    physical_result: TypeRef,
+) -> Result<(), TargetAbiError> {
+    if get_physical_closure_convention(ctx, done_k_ty) != Some(CallingConvention::Cps) {
+        return Err(TargetAbiError::new(
+            "target root bridge: done_k closure must carry exact Cps type provenance",
+        ));
+    }
+    let done_closure = closure::Closure::from_type_ref(ctx, done_k_ty).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: done_k parameter is not closure.closure")
+    })?;
+    let done_callable =
+        core::Func::from_type_ref(ctx, done_closure.func_type(ctx)).ok_or_else(|| {
+            TargetAbiError::new("target root bridge: done_k closure does not contain core.func")
+        })?;
+    if done_callable.r#return(ctx) != physical_result
+        || done_callable.params(ctx) != [source_result]
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: done_k must accept the exact source result and return physically \
+             empty",
+        ));
+    }
+    Ok(())
+}
+
+/// Validate the final root reject-dispatch contract without inferring it from
+/// argument shape. The root owns the only rejecting dispatcher; every other
+/// operation receives a captured, result-indexed dispatch closure.
+fn validate_root_dispatch_type(
+    ctx: &IrContext,
+    dispatch_ty: TypeRef,
+    physical_result: TypeRef,
+) -> Result<TypeRef, TargetAbiError> {
+    if get_physical_closure_convention(ctx, dispatch_ty) != Some(CallingConvention::Cps) {
+        return Err(TargetAbiError::new(
+            "target root bridge: dispatch closure must carry exact Cps type provenance",
+        ));
+    }
+    let closure = closure::Closure::from_type_ref(ctx, dispatch_ty).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: dispatch parameter is not closure.closure")
+    })?;
+    let function_ty = closure.func_type(ctx);
+    let callable = core::Func::from_type_ref(ctx, function_ty).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: dispatch closure does not contain core.func")
+    })?;
+    let params = callable.params(ctx);
+    let i32_ty = ctx
+        .types
+        .iter()
+        .find_map(|(ty, data)| {
+            (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32")).then_some(ty)
+        })
+        .ok_or_else(|| TargetAbiError::new("target root bridge: core.i32 type is unavailable"))?;
+    let payload_ty = ctx.types.get(params[5]);
+    if callable.r#return(ctx) != physical_result
+        || params.len() != 6
+        || !ability::is_evidence_type_ref(ctx, params[0])
+        || get_physical_closure_convention(ctx, params[1]) != Some(CallingConvention::Cps)
+        || params[2..5] != [i32_ty, i32_ty, i32_ty]
+        || payload_ty.dialect != Symbol::new("tribute_rt")
+        || payload_ty.name != Symbol::new("anyref")
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: dispatch must be Dispatch<R> with exact physical Cps result",
+        ));
+    }
+    Ok(function_ty)
+}
+
+fn checked_calling_convention(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<Option<CallingConvention>, TargetAbiError> {
+    if !ctx.op(op).attributes.contains_key(CALLING_CONVENTION_ATTR) {
+        return Ok(None);
+    }
+    get_calling_convention(ctx, op)
+        .ok_or_else(|| {
+            TargetAbiError::new(
+                "target root bridge: root main has an invalid tribute.calling_convention attribute",
+            )
+        })
+        .map(Some)
+}
+
+fn checked_root_export_convention(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<Option<CallingConvention>, TargetAbiError> {
+    if !ctx
+        .op(op)
+        .attributes
+        .contains_key(ROOT_EXPORT_CONVENTION_ATTR)
+    {
+        return Ok(None);
+    }
+    let convention = get_root_export_convention(ctx, op).ok_or_else(|| {
+        TargetAbiError::new(
+            "target root bridge: preserved root export convention attribute is malformed",
+        )
+    })?;
+    Ok(Some(convention))
+}
+
+fn checked_root_source_result(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<Option<TypeRef>, TargetAbiError> {
+    if !ctx.op(op).attributes.contains_key(ROOT_SOURCE_RESULT_ATTR) {
+        return Ok(None);
+    }
+    get_root_source_result(ctx, op)
+        .ok_or_else(|| {
+            TargetAbiError::new(
+                "target root bridge: preserved root source result attribute is malformed",
+            )
+        })
+        .map(Some)
+}
+
+fn bind_name(name: &str) -> AttributeMap {
+    [(
+        Symbol::new("bind_name"),
+        Attribute::Symbol(Symbol::from_dynamic(name)),
+    )]
+    .into_iter()
+    .collect()
+}
+
+fn remove_root_contract(ctx: &mut IrContext, op: OpRef) {
+    ctx.op_mut(op)
+        .attributes
+        .remove(ROOT_EXPORT_CONVENTION_ATTR);
+    ctx.op_mut(op).attributes.remove(ROOT_SOURCE_RESULT_ATTR);
+}
+
+fn rewrite_symbol_refs(ctx: &mut IrContext, op: OpRef, old: Symbol, new: Symbol) {
+    if core::Module::from_op(ctx, op).is_ok() {
+        return;
+    }
+    for key in [Symbol::new("callee"), Symbol::new("func_ref")] {
+        if ctx.op(op).attributes.get_symbol(key) == Some(old) {
+            ctx.op_mut(op)
+                .attributes
+                .insert(key, Attribute::Symbol(new));
+        }
+    }
+    let regions = ctx.op(op).regions.to_vec();
+    for region in regions {
+        let blocks = ctx.region(region).blocks.to_vec();
+        for block in blocks {
+            let ops = ctx.block(block).ops.to_vec();
+            for nested in ops {
+                rewrite_symbol_refs(ctx, nested, old, new);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    fn function_by_name(ctx: &IrContext, module: Module, name: &str) -> func::Func {
+        let name = Symbol::from_dynamic(name);
+        module
+            .ops(ctx)
+            .into_iter()
+            .find_map(|op| {
+                let function = func::Func::from_op(ctx, op).ok()?;
+                (function.sym_name(ctx) == name).then_some(function)
+            })
+            .unwrap_or_else(|| panic!("missing function `{name}`"))
+    }
+
+    #[test]
+    fn physicalizes_only_proven_cps_occurrences_with_identical_never_shapes() {
+        let input = r#"core.module @test {
+  !direct_closure = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 0}
+  !cps_closure = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+
+  func.func @holder(%direct: !direct_closure, %cps: !cps_closure) -> core.nil attributes {tribute.calling_convention = 0} {
+    func.unreachable
+  }
+
+  func.func @direct() -> core.never attributes {tribute.calling_convention = 0} {
+    func.unreachable
+  }
+
+  func.func @cps() -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let direct_before = function_by_name(&ctx, module, "direct").r#type(&ctx);
+        let cps_before = function_by_name(&ctx, module, "cps").r#type(&ctx);
+        assert_eq!(
+            direct_before, cps_before,
+            "fixture must share one structurally interned core.func type"
+        );
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+
+        let never = core::never(&mut ctx).as_type_ref();
+        let nil = core::nil(&mut ctx).as_type_ref();
+        let direct = function_by_name(&ctx, module, "direct");
+        let cps = function_by_name(&ctx, module, "cps");
+        assert_eq!(
+            core::Func::from_type_ref(&ctx, direct.r#type(&ctx))
+                .unwrap()
+                .r#return(&ctx),
+            never
+        );
+        assert_eq!(
+            core::Func::from_type_ref(&ctx, cps.r#type(&ctx))
+                .unwrap()
+                .r#return(&ctx),
+            nil
+        );
+
+        let direct_alias = ctx
+            .type_alias_by_name(Symbol::new("direct_closure"))
+            .unwrap();
+        let cps_alias = ctx.type_alias_by_name(Symbol::new("cps_closure")).unwrap();
+        let direct_inner = closure::Closure::from_type_ref(&ctx, direct_alias)
+            .unwrap()
+            .func_type(&ctx);
+        let cps_inner = closure::Closure::from_type_ref(&ctx, cps_alias)
+            .unwrap()
+            .func_type(&ctx);
+        assert_eq!(
+            core::Func::from_type_ref(&ctx, direct_inner)
+                .unwrap()
+                .r#return(&ctx),
+            never
+        );
+        assert_eq!(
+            core::Func::from_type_ref(&ctx, cps_inner)
+                .unwrap()
+                .r#return(&ctx),
+            nil
+        );
+    }
+
+    #[test]
+    fn untagged_nested_never_callable_fails_without_mutation() {
+        let input = r#"core.module @test {
+  !untagged = closure.closure(core.func(core.never, core.i32))
+
+  func.func @holder(%callee: !untagged) -> core.nil attributes {tribute.calling_convention = 0} {
+    func.unreachable
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("untagged nested core.func<core.never"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn physicalizes_proper_tail_structured_never_for_native_cfg_and_wasm_if() {
+        let input = r#"core.module @test {
+  func.func @done() -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @run(%condition: core.i1) -> core.never attributes {tribute.calling_convention = 2} {
+    %never = scf.if %condition : core.never {
+      func.tail_call {callee = @done, tribute.calling_convention = 2}
+    } {
+      func.tail_call {callee = @done, tribute.calling_convention = 2}
+    }
+  }
+}"#;
+
+        let mut native_ctx = IrContext::new();
+        let native_module = parse_test_module(&mut native_ctx, input);
+        lower_cps_signatures_to_physical(&mut native_ctx, native_module).unwrap();
+        let nil = core::nil(&mut native_ctx).as_type_ref();
+        let never = core::never(&mut native_ctx).as_type_ref();
+        let structured = collect_ops(&native_ctx, native_module.op())
+            .into_iter()
+            .find(|&op| scf::If::matches(&native_ctx, op))
+            .expect("structured tail marker");
+        assert_eq!(native_ctx.op_result_types(structured), [nil]);
+
+        trunk_ir::transforms::scf_to_cf::lower_scf_to_cf(&mut native_ctx, native_module);
+        let native_ir = print_module(&native_ctx, native_module.op());
+        assert!(!native_ir.contains("scf.if"), "{native_ir}");
+        assert!(!native_ir.contains("core.never"), "{native_ir}");
+        for block in collect_blocks(&native_ctx, &collect_ops(&native_ctx, native_module.op())) {
+            for arg in &native_ctx.block(block).args {
+                assert_ne!(arg.ty, never, "native CFG retained a core.never block arg");
+            }
+            for &op in &native_ctx.block(block).ops {
+                let data = native_ctx.op(op);
+                if data.dialect == Symbol::new("cf")
+                    && (data.name == Symbol::new("br") || data.name == Symbol::new("cond_br"))
+                {
+                    assert!(
+                        native_ctx
+                            .op_operands(op)
+                            .iter()
+                            .all(|&operand| native_ctx.value_ty(operand) != never),
+                        "native CFG edge retained a core.never operand: {native_ir}"
+                    );
+                }
+            }
+        }
+
+        let mut wasm_ctx = IrContext::new();
+        let wasm_module = parse_test_module(&mut wasm_ctx, input);
+        lower_cps_signatures_to_physical(&mut wasm_ctx, wasm_module).unwrap();
+        let wasm_tc = crate::wasm::type_converter::wasm_type_converter(&mut wasm_ctx);
+        trunk_ir_wasm_backend::passes::scf_to_wasm::lower(&mut wasm_ctx, wasm_module, wasm_tc);
+        let wasm_ir = print_module(&wasm_ctx, wasm_module.op());
+        assert!(wasm_ir.contains("wasm.if"), "{wasm_ir}");
+        assert!(!wasm_ir.contains("core.never"), "{wasm_ir}");
+        let wasm_if = collect_ops(&wasm_ctx, wasm_module.op())
+            .into_iter()
+            .find(|&op| {
+                let data = wasm_ctx.op(op);
+                data.dialect == Symbol::new("wasm") && data.name == Symbol::new("if")
+            })
+            .expect("physical wasm if");
+        assert_eq!(wasm_ctx.op_result_types(wasm_if), [nil]);
+    }
+
+    #[test]
+    fn malformed_structured_never_marker_fails_without_mutation() {
+        let input = r#"core.module @test {
+  func.func @run(%condition: core.i1) -> core.never attributes {tribute.calling_convention = 2} {
+    %never = scf.if %condition : core.never {
+      %unit = arith.const {value = unit} : core.nil
+    } {
+      %unit = arith.const {value = unit} : core.nil
+    }
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("must end every branch in a proper-tail transfer or typed unreachable"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn native_nil_abi_projects_interleaved_direct_indirect_and_constant_signatures() {
+        let input = r#"core.module @test {
+  !cps = closure.closure(core.func(core.nil, core.i32, core.nil, core.i64)) {tribute.calling_convention = 2}
+
+  func.func @callee(%head: core.i32, %unit: core.nil, %tail: core.i64) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @direct(%head: core.i32, %unit: core.nil, %tail: core.i64) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %head, %unit, %tail {callee = @callee, tribute.calling_convention = 2}
+  }
+  func.func @indirect(%callee: !cps, %head: core.i32, %unit: core.nil, %tail: core.i64) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %head, %unit, %tail {tribute.calling_convention = 2}
+  }
+  func.func @constant_user() -> core.nil attributes {tribute.calling_convention = 2} {
+    %reference = func.constant {func_ref = @callee} : core.func(core.nil, core.i32, core.nil, core.i64)
+    func.unreachable
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let nil = core::nil(&mut ctx).as_type_ref();
+        let i32_ty = ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::new("i32"),
+            params: smallvec![],
+            attrs: AttributeMap::new(),
+        });
+        let i64_ty = ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::new("i64"),
+            params: smallvec![],
+            attrs: AttributeMap::new(),
+        });
+
+        lower_native_nil_abi(&mut ctx, module).unwrap();
+
+        for name in ["callee", "direct"] {
+            let function = function_by_name(&ctx, module, name);
+            let callable = core::Func::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
+            assert_eq!(callable.params(&ctx), [i32_ty, i64_ty]);
+            let entry = ctx.region(function.body(&ctx)).blocks[0];
+            assert_eq!(
+                ctx.block_args(entry)
+                    .iter()
+                    .map(|&arg| ctx.value_ty(arg))
+                    .collect::<Vec<_>>(),
+                vec![i32_ty, i64_ty]
+            );
+        }
+
+        let indirect = function_by_name(&ctx, module, "indirect");
+        let indirect_entry = ctx.region(indirect.body(&ctx)).blocks[0];
+        let projected_callee_ty = ctx.value_ty(ctx.block_args(indirect_entry)[0]);
+        let projected_inner = closure::Closure::from_type_ref(&ctx, projected_callee_ty)
+            .unwrap()
+            .func_type(&ctx);
+        assert_eq!(
+            core::Func::from_type_ref(&ctx, projected_inner)
+                .unwrap()
+                .params(&ctx),
+            [i32_ty, i64_ty]
+        );
+        assert_eq!(
+            ctx.block_args(indirect_entry)
+                .iter()
+                .map(|&arg| ctx.value_ty(arg))
+                .collect::<Vec<_>>(),
+            vec![projected_callee_ty, i32_ty, i64_ty]
+        );
+        let indirect_tail = collect_ops(&ctx, indirect.op_ref())
+            .into_iter()
+            .find(|&op| func::TailCallIndirect::from_op(&ctx, op).is_ok())
+            .unwrap();
+        assert_eq!(
+            ctx.op_operands(indirect_tail)
+                .iter()
+                .map(|&value| ctx.value_ty(value))
+                .collect::<Vec<_>>(),
+            vec![projected_callee_ty, i32_ty, i64_ty]
+        );
+
+        let direct = function_by_name(&ctx, module, "direct");
+        let direct_tail = collect_ops(&ctx, direct.op_ref())
+            .into_iter()
+            .find(|&op| func::TailCall::from_op(&ctx, op).is_ok())
+            .unwrap();
+        assert_eq!(
+            ctx.op_operands(direct_tail)
+                .iter()
+                .map(|&value| ctx.value_ty(value))
+                .collect::<Vec<_>>(),
+            vec![i32_ty, i64_ty]
+        );
+
+        let constant_user = function_by_name(&ctx, module, "constant_user");
+        let constant = collect_ops(&ctx, constant_user.op_ref())
+            .into_iter()
+            .find(|&op| func::Constant::from_op(&ctx, op).is_ok())
+            .unwrap();
+        let constant_callable =
+            core::Func::from_type_ref(&ctx, ctx.op_result_types(constant)[0]).unwrap();
+        assert_eq!(constant_callable.params(&ctx), [i32_ty, i64_ty]);
+        assert!(
+            collect_blocks(&ctx, &collect_ops(&ctx, module.op()))
+                .into_iter()
+                .flat_map(|block| ctx.block_args(block))
+                .all(|&arg| ctx.value_ty(arg) != nil)
+        );
+    }
+
+    #[test]
+    fn native_nil_abi_rejects_mismatched_direct_transfer_without_mutation() {
+        let input = r#"core.module @test {
+  func.func @callee(%value: core.i32, %unit: core.nil) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @callee, tribute.calling_convention = 2}
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_native_nil_abi(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not match its exact pre-projection signature")
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn native_nil_abi_rejects_mismatched_nil_return_without_mutation() {
+        let input = r#"core.module @test {
+  func.func @bad() -> core.i32 attributes {tribute.calling_convention = 0} {
+    %unit = arith.const {value = unit} : core.nil
+    func.return %unit
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_native_nil_abi(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not match its function result")
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn native_nil_abi_rejects_multi_value_nil_return_without_mutation() {
+        let input = r#"core.module @test {
+  func.func @bad() -> core.nil attributes {tribute.calling_convention = 0} {
+    %unit = arith.const {value = unit} : core.nil
+    %value = arith.const {value = 1} : core.i32
+    func.return %unit, %value
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_native_nil_abi(&mut ctx, module).unwrap_err();
+
+        assert!(error.to_string().contains("must be the sole return value"));
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn native_nil_abi_rejects_mismatched_indirect_callable_without_mutation() {
+        let input = r#"core.module @test {
+  !expects_i32 = closure.closure(core.func(core.nil, core.i32)) {tribute.calling_convention = 2}
+
+  func.func @caller(%callee: !expects_i32, %unit: core.nil) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %unit {tribute.calling_convention = 2}
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_native_nil_abi(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not match its exact pre-projection callable signature")
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn native_nil_abi_uses_provenance_after_closure_lowering_erases_callee_type() {
+        let input = r#"core.module @test {
+  !done = closure.closure(core.func(core.never, core.nil)) {tribute.calling_convention = 2}
+
+  func.func @generated(%done: !done, %answer: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %done, %answer {tribute.calling_convention = 2}
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let generated = function_by_name(&ctx, module, "generated");
+
+        crate::closure_lower::lower_closures_in_func(&mut ctx, generated);
+        let raw_tail = collect_ops(&ctx, generated.op_ref())
+            .into_iter()
+            .find(|&op| func::TailCallIndirect::from_op(&ctx, op).is_ok())
+            .unwrap();
+        let raw_callee = ctx.op_operands(raw_tail)[0];
+        assert_eq!(
+            ctx.types.get(ctx.value_ty(raw_callee)).name,
+            Symbol::new("i32")
+        );
+        let raw_signature = get_indirect_call_signature(&ctx, raw_tail)
+            .expect("raw pointer transfer must retain its exact callable provenance");
+        let raw_callable = core::Func::from_type_ref(&ctx, raw_signature).unwrap();
+        let raw_params = raw_callable.params(&ctx).to_vec();
+        let nil = core::nil(&mut ctx).as_type_ref();
+        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
+        assert_eq!(raw_params, [anyref, nil]);
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        lower_native_nil_abi(&mut ctx, module).unwrap();
+
+        let tail = collect_ops(&ctx, generated.op_ref())
+            .into_iter()
+            .find(|&op| func::TailCallIndirect::from_op(&ctx, op).is_ok())
+            .unwrap();
+        assert_eq!(
+            ctx.op_operands(tail).len(),
+            2,
+            "raw callee plus environment only"
+        );
+        let signature = get_indirect_call_signature(&ctx, tail)
+            .expect("native lowering must preserve projected exact provenance for func-to-clif");
+        let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
+        assert_eq!(callable.params(&ctx), [anyref].as_slice());
+    }
+
+    #[test]
+    fn cps_root_bridge_uses_typed_completion_and_an_ordinary_wrapper_call() {
+        let input = r#"core.module @test {
+  tribute_control.func @main() -> core.nil convention(cps) {
+    %unit = arith.const {value = unit} : core.nil
+    tribute_control.return %unit
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        crate::tribute_control_to_cps::tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let logical_main = function_by_name(&ctx, module, "main");
+        let nil = core::nil(&mut ctx).as_type_ref();
+        tribute_core::set_root_export_convention(
+            &mut ctx,
+            logical_main.op_ref(),
+            CallingConvention::Direct,
+        );
+        tribute_core::set_root_source_result(&mut ctx, logical_main.op_ref(), nil);
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        compose_root_entry_bridge(&mut ctx, module).unwrap();
+
+        let wrapper = function_by_name(&ctx, module, "main");
+        let worker = function_by_name(&ctx, module, CPS_MAIN_SYMBOL);
+        let done_k = function_by_name(&ctx, module, ROOT_DONE_K_SYMBOL);
+        assert_eq!(
+            get_calling_convention(&ctx, wrapper.op_ref()),
+            Some(CallingConvention::Direct)
+        );
+        assert_eq!(
+            get_calling_convention(&ctx, worker.op_ref()),
+            Some(CallingConvention::Cps)
+        );
+        assert_eq!(
+            get_calling_convention(&ctx, done_k.op_ref()),
+            Some(CallingConvention::Cps)
+        );
+        for function in [worker, done_k] {
+            assert_eq!(
+                core::Func::from_type_ref(&ctx, function.r#type(&ctx))
+                    .unwrap()
+                    .r#return(&ctx),
+                nil
+            );
+        }
+        assert_eq!(
+            ctx.op(done_k.op_ref())
+                .attributes
+                .get_bool(ROOT_DONE_K_ATTR),
+            Some(true)
+        );
+        assert_eq!(
+            ctx.op(worker.op_ref())
+                .attributes
+                .get_bool(ROOT_CPS_WORKER_ATTR),
+            Some(true)
+        );
+        assert_eq!(
+            ctx.op(wrapper.op_ref())
+                .attributes
+                .get_bool(ROOT_WRAPPER_ATTR),
+            Some(true)
+        );
+
+        let wrapper_ops = collect_ops(&ctx, wrapper.op_ref());
+        let root_calls: Vec<_> = wrapper_ops
+            .iter()
+            .copied()
+            .filter(|&op| {
+                func::Call::from_op(&ctx, op).is_ok()
+                    && ctx.op(op).attributes.get_bool(ROOT_CPS_CALL_ATTR) == Some(true)
+            })
+            .collect();
+        assert_eq!(root_calls.len(), 1);
+        assert_eq!(
+            ctx.op(root_calls[0]).attributes.get_symbol("callee"),
+            Some(Symbol::new(CPS_MAIN_SYMBOL))
+        );
+        assert_eq!(ctx.op_result_types(root_calls[0]), [nil]);
+        assert!(
+            wrapper_ops
+                .iter()
+                .all(|&op| func::TailCall::from_op(&ctx, op).is_err())
+        );
+
+        let cell = wrapper_ops
+            .iter()
+            .find_map(|&op| {
+                let new = adt::StructNew::from_op(&ctx, op).ok()?;
+                let ty = new.r#type(&ctx);
+                (ctx.types.get(ty).attrs.get_symbol("name")
+                    == Some(Symbol::new(ROOT_COMPLETION_CELL_NAME)))
+                .then_some(ty)
+            })
+            .expect("root bridge must construct its completion cell");
+        assert_eq!(ctx.types.get(cell).params.as_slice(), [nil]);
+        assert_eq!(
+            trunk_ir::adt_layout::get_struct_fields(&ctx, cell),
+            Some(vec![(Symbol::new(ROOT_COMPLETION_CELL_VALUE_FIELD), nil)])
+        );
+        let (native_types, _) = crate::native::type_converter::native_type_converter(&mut ctx);
+        let layout = trunk_ir::adt_layout::compute_struct_layout(&ctx, cell, &native_types)
+            .expect("root completion cell must have a native struct layout");
+        assert_eq!(layout.field_offsets, vec![0]);
+        assert_eq!(layout.total_size, 0);
+        assert_eq!(layout.alignment, 1);
+        let root_call_index = wrapper_ops
+            .iter()
+            .position(|&op| op == root_calls[0])
+            .expect("root call must belong to the wrapper");
+        let completion_read_index = wrapper_ops
+            .iter()
+            .position(|&op| adt::StructGet::from_op(&ctx, op).is_ok())
+            .expect("shared root wrapper must read its typed completion cell");
+        assert!(
+            root_call_index < completion_read_index,
+            "the shared wrapper must read completion only after the worker call"
+        );
+        let wrapper_return = wrapper_ops
+            .iter()
+            .copied()
+            .find(|&op| func::Return::from_op(&ctx, op).is_ok())
+            .expect("root wrapper must return its completion value");
+        assert!(
+            ctx.op_operands(wrapper_return).len() == 1,
+            "the shared/Wasm wrapper must preserve the typed Nil completion value"
+        );
+        let done_ops = collect_ops(&ctx, done_k.op_ref());
+        assert!(
+            done_ops.iter().any(|&op| {
+                adt::StructSet::from_op(&ctx, op).is_ok()
+                    && ctx.op_operands(op).get(1).copied()
+                        == Some(ctx.block_args(ctx.region(done_k.body(&ctx)).blocks[0])[1])
+            }),
+            "root done_k must store its exact answer into the completion cell"
+        );
+        let printed = print_module(&ctx, module.op());
+        assert!(!printed.contains("__tribute_cps_control"), "{printed}");
+        assert!(!printed.contains("tribute_rt.unbox_int"), "{printed}");
+
+        lower_native_nil_abi(&mut ctx, module).unwrap();
+        let wrapper = function_by_name(&ctx, module, "main");
+        let native_wrapper_return = collect_ops(&ctx, wrapper.op_ref())
+            .into_iter()
+            .find(|&op| func::Return::from_op(&ctx, op).is_ok())
+            .expect("native wrapper must retain its return terminator");
+        assert!(
+            ctx.op_operands(native_wrapper_return).is_empty(),
+            "native Nil projection must remove only the return payload"
+        );
+        let native_completion_read = collect_ops(&ctx, wrapper.op_ref())
+            .into_iter()
+            .find(|&op| adt::StructGet::from_op(&ctx, op).is_ok())
+            .expect("native lowering retains the completion read until ADT lowering");
+        assert!(
+            !ctx.has_uses(ctx.op_results(native_completion_read)[0]),
+            "native Nil projection must leave the zero-sized completion read unused"
+        );
+        let done_k = function_by_name(&ctx, module, ROOT_DONE_K_SYMBOL);
+        let done_signature = core::Func::from_type_ref(&ctx, done_k.r#type(&ctx)).unwrap();
+        assert_eq!(done_signature.params(&ctx).len(), 1);
+        let done_entry = ctx.region(done_k.body(&ctx)).blocks[0];
+        assert_eq!(ctx.block_args(done_entry).len(), 1);
+        assert_eq!(
+            ctx.value_ty(ctx.block_args(done_entry)[0]),
+            tribute_rt::anyref(&mut ctx).as_type_ref()
+        );
+        assert!(
+            collect_blocks(&ctx, &collect_ops(&ctx, module.op()))
+                .into_iter()
+                .flat_map(|block| ctx.block_args(block))
+                .all(|&arg| ctx.value_ty(arg) != nil)
+        );
+    }
+
+    #[test]
+    fn promoted_evidence_direct_root_forwards_its_exact_evidence_argument() {
+        let input = r#"core.module @test {
+  tribute_control.func @main() -> core.nil convention(cps) {
+    %unit = arith.const {value = unit} : core.nil
+    tribute_control.return %unit
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        crate::tribute_control_to_cps::tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let logical_main = function_by_name(&ctx, module, "main");
+        let nil = core::nil(&mut ctx).as_type_ref();
+        tribute_core::set_root_export_convention(
+            &mut ctx,
+            logical_main.op_ref(),
+            CallingConvention::EvidenceDirect,
+        );
+        tribute_core::set_root_source_result(&mut ctx, logical_main.op_ref(), nil);
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        compose_root_entry_bridge(&mut ctx, module).unwrap();
+
+        let wrapper = function_by_name(&ctx, module, "main");
+        let wrapper_entry = ctx.region(wrapper.body(&ctx)).blocks[0];
+        let evidence = ctx.block_args(wrapper_entry)[0];
+        let wrapper_ops = collect_ops(&ctx, wrapper.op_ref());
+        let root_call = wrapper_ops
+            .iter()
+            .copied()
+            .find(|&op| ctx.op(op).attributes.get_bool(ROOT_CPS_CALL_ATTR) == Some(true))
+            .expect("promoted root wrapper must call its CPS worker");
+        assert_eq!(ctx.op_operands(root_call)[0], evidence);
+        let evidence_ty = ability::evidence_adt_type_ref(&mut ctx);
+        assert_eq!(ctx.value_ty(evidence), evidence_ty);
+        assert!(
+            wrapper_ops
+                .iter()
+                .all(|&op| adt::ArrayNew::from_op(&ctx, op).is_err()),
+            "EvidenceDirect wrapper must not synthesize empty evidence"
+        );
+    }
+
+    #[test]
+    fn unpromoted_roots_only_drop_the_temporary_export_contract() {
+        for (source_convention, export_convention) in [
+            ("direct", CallingConvention::Direct),
+            ("evidence_direct", CallingConvention::EvidenceDirect),
+        ] {
+            let input = format!(
+                r#"core.module @test {{
+  tribute_control.func @main() -> core.nil convention({source_convention}) {{
+    %unit = arith.const {{value = unit}} : core.nil
+    tribute_control.return %unit
+  }}
+}}"#
+            );
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, &input);
+            crate::tribute_control_to_cps::tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+            let main = function_by_name(&ctx, module, "main");
+            let nil = core::nil(&mut ctx).as_type_ref();
+            tribute_core::set_root_export_convention(&mut ctx, main.op_ref(), export_convention);
+            tribute_core::set_root_source_result(&mut ctx, main.op_ref(), nil);
+            let signature_before = main.r#type(&ctx);
+            let body_before = main.body(&ctx);
+            let body_ops_before = collect_ops(&ctx, main.op_ref());
+
+            lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+            compose_root_entry_bridge(&mut ctx, module).unwrap();
+
+            let main = function_by_name(&ctx, module, "main");
+            assert_eq!(main.r#type(&ctx), signature_before);
+            assert_eq!(
+                get_calling_convention(&ctx, main.op_ref()),
+                Some(export_convention)
+            );
+            assert_eq!(main.body(&ctx), body_before);
+            assert_eq!(collect_ops(&ctx, main.op_ref()), body_ops_before);
+            assert!(
+                !ctx.op(main.op_ref())
+                    .attributes
+                    .contains_key(ROOT_EXPORT_CONVENTION_ATTR)
+            );
+            assert!(
+                !ctx.op(main.op_ref())
+                    .attributes
+                    .contains_key(ROOT_SOURCE_RESULT_ATTR)
+            );
+            assert_eq!(
+                module
+                    .ops(&ctx)
+                    .into_iter()
+                    .filter(|&op| func::Func::from_op(&ctx, op).is_ok())
+                    .count(),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn incomplete_unpromoted_root_contract_is_rejected_without_mutation() {
+        enum IncompleteContract {
+            MissingExportConvention,
+            MissingSourceResult,
+        }
+
+        for incomplete in [
+            IncompleteContract::MissingExportConvention,
+            IncompleteContract::MissingSourceResult,
+        ] {
+            let input = r#"core.module @test {
+  tribute_control.func @main() -> core.nil convention(direct) {
+    %unit = arith.const {value = unit} : core.nil
+    tribute_control.return %unit
+  }
+}"#;
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, input);
+            crate::tribute_control_to_cps::tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+            let main = function_by_name(&ctx, module, "main");
+            let nil = core::nil(&mut ctx).as_type_ref();
+            match incomplete {
+                IncompleteContract::MissingExportConvention => {
+                    tribute_core::set_root_source_result(&mut ctx, main.op_ref(), nil);
+                }
+                IncompleteContract::MissingSourceResult => {
+                    tribute_core::set_root_export_convention(
+                        &mut ctx,
+                        main.op_ref(),
+                        CallingConvention::Direct,
+                    );
+                }
+            }
+            lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+            let before = print_module(&ctx, module.op());
+
+            let error = compose_root_entry_bridge(&mut ctx, module).unwrap_err();
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("must either both be present or both be absent"),
+                "{error}"
+            );
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
+    fn physicalization_and_root_bridge_keep_nested_main_scope_local() {
+        let input = r#"core.module @test {
+  tribute_control.func @main() -> core.nil convention(cps) {
+    %unit = arith.const {value = unit} : core.nil
+    tribute_control.return %unit
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        crate::tribute_control_to_cps::tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let main = function_by_name(&ctx, module, "main");
+        let nil = core::nil(&mut ctx).as_type_ref();
+        tribute_core::set_root_export_convention(
+            &mut ctx,
+            main.op_ref(),
+            CallingConvention::Direct,
+        );
+        tribute_core::set_root_source_result(&mut ctx, main.op_ref(), nil);
+
+        // Add this before physicalization: a recursive traversal must not
+        // conflate this local `@main` with the immediate root declaration.
+        let location = ctx.op(module.op()).location;
+        let nested_entry = ctx.create_block(BlockData {
+            location,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let nested_function_type = core::func(&mut ctx, nil, []).as_type_ref();
+        let local_constant = func::constant(
+            &mut ctx,
+            location,
+            nested_function_type,
+            Symbol::new("main"),
+        );
+        ctx.push_op(nested_entry, local_constant.op_ref());
+        let local_call = func::call(&mut ctx, location, [], nil, Symbol::new("main"));
+        let local_result = local_call.result(&ctx);
+        ctx.push_op(nested_entry, local_call.op_ref());
+        let local_return = func::r#return(&mut ctx, location, [local_result]);
+        ctx.push_op(nested_entry, local_return.op_ref());
+        let nested_function_region = ctx.create_region(RegionData {
+            location,
+            blocks: smallvec![nested_entry],
+            parent_op: None,
+        });
+        let nested_function = func::func(
+            &mut ctx,
+            location,
+            Symbol::new("main"),
+            nested_function_type,
+            nested_function_region,
+        );
+        set_calling_convention(
+            &mut ctx,
+            nested_function.op_ref(),
+            CallingConvention::Direct,
+        );
+        let nested_module_block = ctx.create_block(BlockData {
+            location,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        ctx.push_op(nested_module_block, nested_function.op_ref());
+        let nested_module_region = ctx.create_region(RegionData {
+            location,
+            blocks: smallvec![nested_module_block],
+            parent_op: None,
+        });
+        let nested_module = core::module(
+            &mut ctx,
+            location,
+            Symbol::new("nested"),
+            nested_module_region,
+        );
+        ctx.push_op(module.first_block(&ctx).unwrap(), nested_module.op_ref());
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        compose_root_entry_bridge(&mut ctx, module).unwrap();
+
+        assert_eq!(
+            function_by_name(&ctx, module, CPS_MAIN_SYMBOL).sym_name(&ctx),
+            Symbol::new(CPS_MAIN_SYMBOL)
+        );
+        assert_eq!(
+            function_by_name(&ctx, module, "main").sym_name(&ctx),
+            Symbol::new("main")
+        );
+
+        let nested = module
+            .ops(&ctx)
+            .into_iter()
+            .find(|&op| core::Module::from_op(&ctx, op).is_ok())
+            .expect("nested module");
+        let nested_call = collect_ops(&ctx, nested)
+            .into_iter()
+            .find(|&op| func::Call::from_op(&ctx, op).is_ok())
+            .expect("nested local main call");
+        let nested_constant = collect_ops(&ctx, nested)
+            .into_iter()
+            .find_map(|op| func::Constant::from_op(&ctx, op).ok())
+            .expect("nested local main constant");
+        assert_eq!(
+            ctx.op(nested_call).attributes.get_symbol("callee"),
+            Some(Symbol::new("main"))
+        );
+        assert_eq!(nested_constant.func_ref(&ctx), Symbol::new("main"));
+        assert_eq!(
+            ctx.op_result_types(nested_constant.op_ref()),
+            [nested_function_type]
+        );
+        assert!(collect_ops(&ctx, nested).into_iter().any(|op| {
+            func::Func::from_op(&ctx, op)
+                .is_ok_and(|function| function.sym_name(&ctx) == Symbol::new("main"))
+        }));
+    }
+
+    #[test]
+    fn promoted_cps_root_requires_complete_well_formed_export_contract_without_mutation() {
+        enum ContractCase {
+            Missing,
+            Malformed,
+            Inconsistent,
+        }
+
+        for case in [
+            ContractCase::Missing,
+            ContractCase::Malformed,
+            ContractCase::Inconsistent,
+        ] {
+            let input = r#"core.module @test {
+  tribute_control.func @main() -> core.nil convention(cps) {
+    %unit = arith.const {value = unit} : core.nil
+    tribute_control.return %unit
+  }
+}"#;
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, input);
+            crate::tribute_control_to_cps::tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+            let main = function_by_name(&ctx, module, "main");
+            let nil = core::nil(&mut ctx).as_type_ref();
+            match case {
+                ContractCase::Missing => {}
+                ContractCase::Malformed => {
+                    ctx.op_mut(main.op_ref())
+                        .attributes
+                        .insert(Symbol::new(ROOT_EXPORT_CONVENTION_ATTR), Attribute::Int(99));
+                    tribute_core::set_root_source_result(&mut ctx, main.op_ref(), nil);
+                }
+                ContractCase::Inconsistent => {
+                    tribute_core::set_root_export_convention(
+                        &mut ctx,
+                        main.op_ref(),
+                        CallingConvention::Direct,
+                    );
+                    let i32 = ctx.types.intern(TypeData {
+                        dialect: Symbol::new("core"),
+                        name: Symbol::new("i32"),
+                        params: smallvec![],
+                        attrs: AttributeMap::new(),
+                    });
+                    tribute_core::set_root_source_result(&mut ctx, main.op_ref(), i32);
+                }
+            }
+            lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+            let before = print_module(&ctx, module.op());
+
+            let error = compose_root_entry_bridge(&mut ctx, module).unwrap_err();
+
+            assert!(error.to_string().contains("target root bridge"), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+}

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -9,9 +9,12 @@ use std::error::Error;
 use std::fmt;
 
 use tribute_core::{
-    CALLING_CONVENTION_ATTR, CallableAbi, CallingConvention, set_calling_convention,
+    CALLING_CONVENTION_ATTR, CallableAbi, CallingConvention, cps_closure_function_type,
+    cps_completion_type, cps_dispatch_type, cps_done_type, cps_parent_layout_type,
+    cps_parent_ref_type, cps_resume_exact_type, cps_resume_type, get_calling_convention,
+    physical_closure_type, set_calling_convention,
 };
-use tribute_ir::dialect::{ability, closure, tribute_control, tribute_rt};
+use tribute_ir::dialect::{ability, closure, effect, tribute_control, tribute_rt};
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, arith, core, func, scf};
 use trunk_ir::ops::{DialectOp, DialectType};
@@ -219,6 +222,49 @@ fn verify_type_boundary(
     failures
 }
 
+/// Source-logical Cps callable identity is never representational data. A
+/// Direct-to-Cps adaptation must be an explicit `tribute_control.lambda`, not
+/// an unrealized conversion cast deferred to legalization.
+fn verify_pre_cps_control_casts(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
+    fn is_cps_callable(ctx: &IrContext, ty: TypeRef) -> bool {
+        tribute_control::Callable::from_type_ref(ctx, ty).is_some()
+            && tribute_control::callable_convention(ctx, ty)
+                == Some(tribute_control::CallingConvention::Cps)
+    }
+
+    fn visit(ctx: &IrContext, op: OpRef, failures: &mut Vec<BoundaryFailure>) {
+        let data = ctx.op(op);
+        if data.dialect == Symbol::new("core")
+            && data.name == Symbol::new("unrealized_conversion_cast")
+            && (ctx
+                .op_operands(op)
+                .iter()
+                .any(|value| is_cps_callable(ctx, ctx.value_ty(*value)))
+                || ctx
+                    .op_result_types(op)
+                    .iter()
+                    .any(|ty| is_cps_callable(ctx, *ty)))
+        {
+            failures.push(BoundaryFailure {
+                op: Some(op),
+                location: Some(data.location),
+                message: "CPS control callables may not cross unrealized conversion casts".into(),
+            });
+        }
+        for region in data.regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child, failures);
+                }
+            }
+        }
+    }
+
+    let mut failures = Vec::new();
+    visit(ctx, module.op(), &mut failures);
+    failures
+}
+
 fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
     fn check_dispatcher(
         ctx: &IrContext,
@@ -241,7 +287,7 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
                     && params.len() == 5
                     && type_is(ctx, params[0], "core", "never")
                     && params[1] == evidence
-                    && type_is(ctx, params[2], "tribute_rt", "anyref")
+                    && tribute_core::cps_parent_result_type(ctx, params[2]).is_some()
                     && type_is(ctx, params[3], "core", "i32")
                     && type_is(ctx, params[4], "tribute_rt", "anyref")
             } else {
@@ -296,7 +342,9 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
     fn visit(ctx: &IrContext, op: OpRef, failures: &mut Vec<BoundaryFailure>) {
         if ability::HandleDispatch::matches(ctx, op) {
             let operands = ctx.op_operands(op);
-            if let Some((evidence, dispatchers)) = operands.split_first() {
+            if let Some((evidence, operands)) = operands.split_first()
+                && let Some((_, dispatchers)) = operands.split_first()
+            {
                 let evidence_ty = ctx.value_ty(*evidence);
                 for pair in dispatchers.chunks_exact(2) {
                     check_dispatcher(ctx, op, pair[0], evidence_ty, false, failures);
@@ -318,11 +366,337 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
     failures
 }
 
+/// Verify the immutable, result-indexed `Parent<R>` control frame before
+/// closure lowering erases closure values into their target representation.
+///
+/// This is deliberately structural: a generated helper name is never used as
+/// provenance.  The tagged nominal reference, its ordered layout fields, and
+/// exact CPS closure signatures establish the only accepted control boundary.
+fn verify_parent_control_abi(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
+    fn cps_function(ctx: &IrContext, closure: TypeRef) -> Option<TypeRef> {
+        cps_closure_function_type(ctx, closure)
+    }
+
+    fn is_never(ctx: &IrContext, ty: TypeRef) -> bool {
+        type_is(ctx, ty, "core", "never")
+    }
+
+    fn is_anyref(ctx: &IrContext, ty: TypeRef) -> bool {
+        type_is(ctx, ty, "tribute_rt", "anyref")
+    }
+
+    fn is_i32(ctx: &IrContext, ty: TypeRef) -> bool {
+        type_is(ctx, ty, "core", "i32")
+    }
+
+    fn is_evidence(ctx: &IrContext, ty: TypeRef) -> bool {
+        ability::is_evidence_type_ref(ctx, ty)
+    }
+
+    fn is_done(ctx: &IrContext, ty: TypeRef, result: TypeRef) -> bool {
+        let Some(function) = cps_function(ctx, ty) else {
+            return false;
+        };
+        let data = ctx.types.get(function);
+        data.params.len() == 2 && is_never(ctx, data.params[0]) && data.params[1] == result
+    }
+
+    fn is_resume(ctx: &IrContext, ty: TypeRef, parent: TypeRef) -> bool {
+        let Some(function) = cps_function(ctx, ty) else {
+            return false;
+        };
+        let data = ctx.types.get(function);
+        data.params.len() == 4
+            && is_never(ctx, data.params[0])
+            && is_evidence(ctx, data.params[1])
+            && data.params[2] == parent
+            && is_anyref(ctx, data.params[3])
+    }
+
+    fn is_dispatch(ctx: &IrContext, ty: TypeRef, parent: TypeRef) -> bool {
+        let Some(function) = cps_function(ctx, ty) else {
+            return false;
+        };
+        let data = ctx.types.get(function);
+        data.params.len() == 7
+            && is_never(ctx, data.params[0])
+            && is_evidence(ctx, data.params[1])
+            && is_resume(ctx, data.params[2], parent)
+            && is_i32(ctx, data.params[3])
+            && is_i32(ctx, data.params[4])
+            && is_i32(ctx, data.params[5])
+            && is_anyref(ctx, data.params[6])
+    }
+
+    fn is_parent_layout(ctx: &IrContext, parent: TypeRef, layout: TypeRef) -> bool {
+        let Some(result) = tribute_core::cps_parent_result_type(ctx, parent) else {
+            return false;
+        };
+        let Some(name) = ctx.types.get(parent).attrs.get_symbol("name") else {
+            return false;
+        };
+        let data = ctx.types.get(layout);
+        if data.dialect != Symbol::new("adt")
+            || data.name != Symbol::new("struct")
+            || data.attrs.get_symbol("name") != Some(name)
+            || data.attrs.get_type(tribute_core::CPS_PARENT_RESULT_ATTR) != Some(result)
+        {
+            return false;
+        }
+        let Some(Attribute::List(fields)) = data.attrs.get("fields") else {
+            return false;
+        };
+        let [Attribute::List(done), Attribute::List(dispatch)] = fields.as_slice() else {
+            return false;
+        };
+        let [Attribute::Symbol(done_name), Attribute::Type(done_type)] = done.as_slice() else {
+            return false;
+        };
+        let [
+            Attribute::Symbol(dispatch_name),
+            Attribute::Type(dispatch_type),
+        ] = dispatch.as_slice()
+        else {
+            return false;
+        };
+        *done_name == Symbol::new("done")
+            && is_done(ctx, *done_type, result)
+            && *dispatch_name == Symbol::new("dispatch")
+            && is_dispatch(ctx, *dispatch_type, parent)
+    }
+
+    fn done_result(ctx: &IrContext, ty: TypeRef) -> Option<TypeRef> {
+        let function = cps_function(ctx, ty)?;
+        let data = ctx.types.get(function);
+        (data.params.len() == 2 && is_never(ctx, data.params[0])).then_some(data.params[1])
+    }
+
+    fn preflight_parent_types(
+        ctx: &IrContext,
+        module: Module,
+    ) -> (HashMap<TypeRef, TypeRef>, Vec<BoundaryFailure>) {
+        let parents: Vec<_> = ctx
+            .types
+            .iter()
+            .filter_map(|(ty, _)| tribute_core::cps_parent_result_type(ctx, ty).map(|_| ty))
+            .collect();
+        let mut layouts = HashMap::new();
+        let mut failures = Vec::new();
+        for parent in parents {
+            let result = tribute_core::cps_parent_result_type(ctx, parent)
+                .expect("parent list is filtered by result provenance");
+            let Some(name) = ctx.types.get(parent).attrs.get_symbol("name") else {
+                failures.push(BoundaryFailure {
+                    op: Some(module.op()),
+                    location: Some(ctx.op(module.op()).location),
+                    message: format!("Parent<{result}> is missing its nominal name provenance"),
+                });
+                continue;
+            };
+            let named_layouts: Vec<_> = ctx
+                .types
+                .iter()
+                .filter_map(|(candidate, data)| {
+                    (data.dialect == Symbol::new("adt")
+                        && data.name == Symbol::new("struct")
+                        && data.attrs.get_symbol("name") == Some(name))
+                    .then_some(candidate)
+                })
+                .collect();
+            let canonical: Vec<_> = named_layouts
+                .iter()
+                .copied()
+                .filter(|layout| is_parent_layout(ctx, parent, *layout))
+                .collect();
+            if named_layouts.len() != 1 || canonical.len() != 1 {
+                failures.push(BoundaryFailure {
+                    op: Some(module.op()),
+                    location: Some(ctx.op(module.op()).location),
+                    message: format!(
+                        "Parent<{result}> requires exactly one canonical immutable layout; found {} matching-name layout(s) and {} exact layout(s)",
+                        named_layouts.len(),
+                        canonical.len()
+                    ),
+                });
+                continue;
+            }
+            layouts.insert(parent, canonical[0]);
+        }
+
+        for (closure, _) in ctx.types.iter() {
+            let Some(function) = cps_function(ctx, closure) else {
+                continue;
+            };
+            let params = &ctx.types.get(function).params;
+            if params.len() == 3
+                && is_never(ctx, params[0])
+                && (done_result(ctx, params[1]).is_some()
+                    || tribute_core::cps_parent_result_type(ctx, params[1]).is_some())
+            {
+                failures.push(BoundaryFailure {
+                    op: Some(module.op()),
+                    location: Some(ctx.op(module.op()).location),
+                    message: "Completion and Resume closures must take explicit Evidence, Parent<R>, not an obsolete two-operand callback form".into(),
+                });
+            }
+        }
+        (layouts, failures)
+    }
+
+    fn parent_layout_field(ctx: &IrContext, layout: TypeRef, index: usize) -> Option<TypeRef> {
+        let Attribute::List(fields) = ctx.types.get(layout).attrs.get("fields")? else {
+            return None;
+        };
+        let Attribute::List(field) = fields.get(index)? else {
+            return None;
+        };
+        let Attribute::Type(ty) = field.get(1)? else {
+            return None;
+        };
+        Some(*ty)
+    }
+
+    fn is_control_value(ctx: &IrContext, ty: TypeRef) -> bool {
+        tribute_core::cps_parent_result_type(ctx, ty).is_some()
+            || cps_closure_function_type(ctx, ty).is_some()
+    }
+
+    fn failure(ctx: &IrContext, op: OpRef, message: impl Into<String>) -> BoundaryFailure {
+        BoundaryFailure {
+            op: Some(op),
+            location: Some(ctx.op(op).location),
+            message: message.into(),
+        }
+    }
+
+    fn visit(
+        ctx: &IrContext,
+        op: OpRef,
+        layouts: &HashMap<TypeRef, TypeRef>,
+        failures: &mut Vec<BoundaryFailure>,
+    ) {
+        let data = ctx.op(op);
+        let operands = ctx.op_operands(op);
+        let results = ctx.op_results(op);
+        if data.dialect == Symbol::new("adt") && data.name == Symbol::new("struct_new") {
+            if let [result_value] = results {
+                let parent = ctx.value_ty(*result_value);
+                if let Some(result) = tribute_core::cps_parent_result_type(ctx, parent) {
+                    let layout = layouts.get(&parent).copied();
+                    let expected_done =
+                        layout.and_then(|layout| parent_layout_field(ctx, layout, 0));
+                    let expected_dispatch =
+                        layout.and_then(|layout| parent_layout_field(ctx, layout, 1));
+                    if layout.is_none()
+                        || data.attributes.get_type("type") != layout
+                        || operands.len() != 2
+                        || operands.first().map(|value| ctx.value_ty(*value)) != expected_done
+                        || operands.get(1).map(|value| ctx.value_ty(*value)) != expected_dispatch
+                    {
+                        failures.push(failure(
+                            ctx,
+                            op,
+                            format!("Parent<{result}> must be packed with exact immutable done/dispatch fields"),
+                        ));
+                    }
+                }
+            }
+        } else if data.dialect == Symbol::new("adt") && data.name == Symbol::new("struct_get") {
+            if let Some(parent_value) = operands.first() {
+                let parent = ctx.value_ty(*parent_value);
+                if let Some(result) = tribute_core::cps_parent_result_type(ctx, parent) {
+                    let layout = layouts.get(&parent).copied();
+                    let field = data.attributes.get_u32("field").ok().flatten();
+                    let expected = layout.and_then(|layout| {
+                        field.and_then(|field| parent_layout_field(ctx, layout, field as usize))
+                    });
+                    if !matches!(field, Some(0 | 1))
+                        || data.attributes.get_type("type") != layout
+                        || results.first().map(|value| ctx.value_ty(*value)) != expected
+                    {
+                        failures.push(failure(
+                            ctx,
+                            op,
+                            format!("Parent<{result}> field access must use its exact done/dispatch layout"),
+                        ));
+                    }
+                }
+            }
+        } else if data.dialect == Symbol::new("adt") && data.name == Symbol::new("struct_set") {
+            if operands.first().is_some_and(|value| {
+                tribute_core::cps_parent_result_type(ctx, ctx.value_ty(*value)).is_some()
+            }) {
+                failures.push(failure(
+                    ctx,
+                    op,
+                    "Parent is immutable and may not be mutated",
+                ));
+            }
+        } else if data.dialect == Symbol::new("core")
+            && data.name == Symbol::new("unrealized_conversion_cast")
+        {
+            if operands
+                .first()
+                .is_some_and(|value| is_control_value(ctx, ctx.value_ty(*value)))
+                || results
+                    .first()
+                    .is_some_and(|value| is_control_value(ctx, ctx.value_ty(*value)))
+            {
+                failures.push(failure(
+                    ctx,
+                    op,
+                    "Parent and CPS control closures may not cross unrealized conversion casts",
+                ));
+            }
+        } else if data.dialect == Symbol::new("func")
+            && data.name == Symbol::new("tail_call_indirect")
+            && get_calling_convention(ctx, op) == Some(CallingConvention::Cps)
+        {
+            let Some(callee) = operands.first() else {
+                return;
+            };
+            let Some(function) = cps_closure_function_type(ctx, ctx.value_ty(*callee)) else {
+                failures.push(failure(
+                    ctx,
+                    op,
+                    "CPS indirect transfer requires an exact convention-proven closure callee",
+                ));
+                return;
+            };
+            let params = &ctx.types.get(function).params;
+            let operand_types: Vec<_> = operands[1..]
+                .iter()
+                .map(|value| ctx.value_ty(*value))
+                .collect();
+            if params.first().is_none_or(|result| !is_never(ctx, *result))
+                || params.get(1..) != Some(operand_types.as_slice())
+            {
+                failures.push(failure(
+                    ctx,
+                    op,
+                    "CPS indirect transfer operands do not match its exact control closure signature",
+                ));
+            }
+        }
+        for region in data.regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child, layouts, failures);
+                }
+            }
+        }
+    }
+
+    let (layouts, mut failures) = preflight_parent_types(ctx, module);
+    visit(ctx, module.op(), &layouts, &mut failures);
+    failures
+}
+
 fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<BoundaryFailure> {
     fn collect(
         ctx: &IrContext,
         op: OpRef,
-        signatures: &mut HashMap<Symbol, (TypeRef, Option<i64>)>,
+        signatures: &mut HashMap<Symbol, (TypeRef, Option<i64>, bool)>,
     ) {
         let data = ctx.op(op);
         if data.dialect == Symbol::new("core") && data.name == Symbol::new("module") {
@@ -339,7 +713,9 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
                 .get_i64(CALLING_CONVENTION_ATTR)
                 .ok()
                 .flatten();
-            signatures.insert(symbol, (ty, convention));
+            let intrinsic_declaration =
+                data.regions.is_empty() && data.attributes.get_str("abi") == Some("intrinsic");
+            signatures.insert(symbol, (ty, convention, intrinsic_declaration));
         }
         for region in ctx.op(op).regions.iter().copied() {
             for block in ctx.region(region).blocks.iter().copied() {
@@ -353,7 +729,7 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
     fn visit(
         ctx: &IrContext,
         op: OpRef,
-        signatures: &HashMap<Symbol, (TypeRef, Option<i64>)>,
+        signatures: &HashMap<Symbol, (TypeRef, Option<i64>, bool)>,
         failures: &mut Vec<BoundaryFailure>,
     ) {
         let data = ctx.op(op);
@@ -395,7 +771,7 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
                 });
                 return;
             };
-            let Some((func_ty, convention)) = signatures.get(&callee) else {
+            let Some((func_ty, convention, _)) = signatures.get(&callee) else {
                 failures.push(BoundaryFailure {
                     op: Some(op),
                     location: Some(data.location),
@@ -452,8 +828,13 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
         } else if data.dialect == Symbol::new("func") && data.name == Symbol::new("call") {
             let callee = data.attributes.get_symbol("callee");
             if let Some(callee) = callee {
-                match signatures.get(&callee) {
-                    Some((_, target_convention)) if *target_convention == op_convention => {}
+                let exact = signatures.get(&callee);
+                let target = exact.or_else(|| {
+                    let base = tribute_control::specialized_intrinsic_base(callee)?;
+                    signatures.get(&base).filter(|(_, _, intrinsic)| *intrinsic)
+                });
+                match target {
+                    Some((_, target_convention, _)) if *target_convention == op_convention => {}
                     Some(_) => failures.push(BoundaryFailure {
                         op: Some(op),
                         location: Some(data.location),
@@ -631,6 +1012,7 @@ pub fn verify_tribute_control_pre_cps(
                 }),
         );
     }
+    failures.extend(verify_pre_cps_control_casts(ctx, module));
     failures.extend(verify_type_boundary(ctx, module, TypeBoundary::Pre));
     failures.extend(verify_source_conversion_shapes(ctx, module));
     failures.extend(
@@ -686,6 +1068,7 @@ pub fn verify_tribute_control_post_cps(
         });
     }
     failures.extend(verify_final_handle_dispatch_types(ctx, module));
+    failures.extend(verify_parent_control_abi(ctx, module));
     failures.extend(verify_physical_callable_graph(ctx, module));
     failures.extend(
         trunk_ir::validation::validate_all(ctx, module)
@@ -721,6 +1104,15 @@ struct CallableInfo {
     convention: CallingConvention,
     source_result: TypeRef,
     source_params: Vec<TypeRef>,
+    intrinsic_declaration: bool,
+}
+
+#[derive(Clone, Copy)]
+struct ParentTypes {
+    reference: TypeRef,
+    layout: TypeRef,
+    done: TypeRef,
+    dispatch: TypeRef,
 }
 
 #[derive(Clone)]
@@ -733,6 +1125,35 @@ struct HandlerArmInfo {
     operation_result: TypeRef,
     params: Vec<TypeRef>,
     has_resume_token: bool,
+    parent_type: Option<TypeRef>,
+}
+
+/// Immutable recipe for rebuilding one exact handler token. Grouping these
+/// values makes it explicit that a token receives the dynamic Parent only at
+/// invocation; the factory metadata itself is never overwritten by re-entry.
+#[derive(Clone)]
+struct HandlerTokenFactory {
+    resume_body: ValueRef,
+    completion: ValueRef,
+    input_type: TypeRef,
+    body_type: TypeRef,
+    answer_type: TypeRef,
+    dispatch_factory: Symbol,
+    dispatch_factory_args: Vec<ValueRef>,
+}
+
+/// The exact dispatcher to install in a resumed `Parent<X>`.
+enum ResumeDispatchRebuild {
+    Adapter { factory: Symbol },
+    LocalFactory(LocalDispatchFactory),
+}
+
+/// Immutable inputs for rebuilding the lexical dispatcher after a foreign
+/// resumption. The dynamic Parent is supplied by `build_rebound_resume`; this
+/// recipe contains only the lexical factory and captures it needs to rebuild.
+struct LocalDispatchFactory {
+    factory: Symbol,
+    args: Vec<ValueRef>,
 }
 
 struct Converter<'a> {
@@ -741,16 +1162,32 @@ struct Converter<'a> {
     funcs_by_module: HashMap<OpRef, HashMap<Symbol, CallableInfo>>,
     current_module: OpRef,
     converted_types: HashMap<TypeRef, TypeRef>,
+    parents: HashMap<TypeRef, ParentTypes>,
+    parent_layout_aliases: Vec<(Symbol, TypeRef)>,
     helper_index: u32,
 }
 
 #[derive(Clone)]
 struct Flow {
     convention: CallingConvention,
+    /// Evidence used to evaluate the current lexical computation.
     evidence: Option<ValueRef>,
-    exit_k: Option<ValueRef>,
-    root_exit_k: Option<ValueRef>,
-    answer_type: TypeRef,
+    /// Evidence carried by an explicit callback context. A resumed suffix uses
+    /// this dynamic value when it performs again, while a handler arm may keep
+    /// evaluating under its outer lexical evidence.
+    resume_evidence: Option<ValueRef>,
+    done: Option<ValueRef>,
+    dispatch: Option<ValueRef>,
+    boundary_result: TypeRef,
+    /// A handler arm routes resumed suffixes through this completion using the
+    /// dynamic outer `Done` supplied to the suffix frame.
+    resume_after: Option<ValueRef>,
+    /// The enclosing `Done<O>` used to invoke a resumed arm suffix. This is
+    /// distinct from the arm's normal `Done<A>` exit.
+    resume_done: Option<ValueRef>,
+    /// Resultless structured control uses this exact zero-argument suffix.
+    void_done: Option<ValueRef>,
+    preserve_scf_yield: bool,
 }
 
 impl<'a> Converter<'a> {
@@ -766,6 +1203,8 @@ impl<'a> Converter<'a> {
             funcs_by_module,
             current_module,
             converted_types: HashMap::new(),
+            parents: HashMap::new(),
+            parent_layout_aliases: Vec::new(),
             helper_index: 0,
         }
     }
@@ -775,6 +1214,26 @@ impl<'a> Converter<'a> {
             .get(&self.current_module)
             .and_then(|funcs| funcs.get(&symbol))
             .cloned()
+    }
+
+    fn current_direct_call_target(&self, source: OpRef, symbol: Symbol) -> Option<CallableInfo> {
+        if let Some(exact) = self.current_func(symbol) {
+            return Some(exact);
+        }
+        let base = tribute_control::specialized_intrinsic_base(symbol)?;
+        let mut target = self.current_func(base)?;
+        if !target.intrinsic_declaration {
+            return None;
+        }
+        target.symbol = symbol;
+        target.source_result = *self.ctx.op_result_types(source).first()?;
+        target.source_params = self
+            .ctx
+            .op_operands(source)
+            .iter()
+            .map(|value| self.ctx.value_ty(*value))
+            .collect();
+        Some(target)
     }
 
     fn malformed_source(
@@ -802,17 +1261,124 @@ impl<'a> Converter<'a> {
         tribute_rt::anyref(self.ctx).as_type_ref()
     }
 
-    fn done_k_type(&mut self, answer: TypeRef) -> TypeRef {
-        let never = self.never_type();
-        let function = core::func(self.ctx, never, [answer]).as_type_ref();
-        closure::closure(self.ctx, function).as_type_ref()
+    fn i32_type(&mut self) -> TypeRef {
+        self.ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
     }
 
-    fn resumption_type(&mut self, input: TypeRef, answer: TypeRef) -> TypeRef {
-        let never = self.never_type();
-        let done_k = self.done_k_type(answer);
-        let function = core::func(self.ctx, never, [done_k, input]).as_type_ref();
-        closure::closure(self.ctx, function).as_type_ref()
+    fn done_k_type(&mut self, result: TypeRef) -> TypeRef {
+        cps_done_type(self.ctx, result)
+    }
+
+    fn completion_type(&mut self, value: TypeRef, boundary: TypeRef) -> TypeRef {
+        let evidence = self.evidence_type();
+        let parent = self.parent_types(boundary).reference;
+        cps_completion_type(self.ctx, evidence, value, parent)
+    }
+
+    fn resumption_type(&mut self, input: TypeRef, boundary: TypeRef) -> TypeRef {
+        let evidence = self.evidence_type();
+        let parent = self.parent_types(boundary).reference;
+        cps_resume_exact_type(self.ctx, evidence, input, parent)
+    }
+
+    fn erased_resumption_type(&mut self, boundary: TypeRef) -> TypeRef {
+        let evidence = self.evidence_type();
+        let anyref = self.anyref_type();
+        let parent = self.parent_types(boundary).reference;
+        cps_resume_type(self.ctx, evidence, parent, anyref)
+    }
+
+    fn dispatch_type(&mut self, boundary: TypeRef) -> TypeRef {
+        self.parent_types(boundary).dispatch
+    }
+
+    fn parent_types(&mut self, result: TypeRef) -> ParentTypes {
+        if let Some(parent) = self.parents.get(&result).copied() {
+            return parent;
+        }
+        let name = Symbol::from_dynamic(&format!("__tribute_parent_{result:?}"));
+        let reference = cps_parent_ref_type(self.ctx, name, result);
+        let done = self.done_k_type(result);
+        let evidence = self.evidence_type();
+        let anyref = self.anyref_type();
+        let i32 = self.i32_type();
+        let dispatch = cps_dispatch_type(self.ctx, evidence, reference, anyref, i32);
+        let layout = cps_parent_layout_type(self.ctx, name, result, done, dispatch);
+        self.parent_layout_aliases.push((name, layout));
+        let parent = ParentTypes {
+            reference,
+            layout,
+            done,
+            dispatch,
+        };
+        self.parents.insert(result, parent);
+        parent
+    }
+
+    fn pack_parent(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        result: TypeRef,
+        done: ValueRef,
+        dispatch: ValueRef,
+    ) -> ValueRef {
+        let parent = self.parent_types(result);
+        assert_eq!(
+            self.ctx.value_ty(done),
+            parent.done,
+            "Parent done type mismatch"
+        );
+        assert_eq!(
+            self.ctx.value_ty(dispatch),
+            parent.dispatch,
+            "Parent dispatch type mismatch"
+        );
+        let pack = adt::struct_new(
+            self.ctx,
+            location,
+            [done, dispatch],
+            parent.reference,
+            parent.layout,
+        );
+        self.ctx.push_op(block, pack.op_ref());
+        pack.result(self.ctx)
+    }
+
+    fn unpack_parent(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        result: TypeRef,
+        parent_value: ValueRef,
+    ) -> (ValueRef, ValueRef) {
+        let parent = self.parent_types(result);
+        assert_eq!(
+            self.ctx.value_ty(parent_value),
+            parent.reference,
+            "Parent provenance mismatch"
+        );
+        let done = adt::struct_get(
+            self.ctx,
+            location,
+            parent_value,
+            parent.done,
+            parent.layout,
+            0,
+        );
+        self.ctx.push_op(block, done.op_ref());
+        let dispatch = adt::struct_get(
+            self.ctx,
+            location,
+            parent_value,
+            parent.dispatch,
+            parent.layout,
+            1,
+        );
+        self.ctx.push_op(block, dispatch.op_ref());
+        (done.result(self.ctx), dispatch.result(self.ctx))
     }
 
     fn convert_attribute(&mut self, attribute: &Attribute) -> Attribute {
@@ -853,14 +1419,15 @@ impl<'a> Converter<'a> {
             let abi = CallableAbi::new(convention, params, result);
             let evidence = self.evidence_type();
             let done_k = self.done_k_type(result);
-            let lowered_params = abi.lowered_params(evidence, done_k);
+            let dispatch = self.dispatch_type(result);
+            let lowered_params = abi.lowered_params_with_dispatch(evidence, done_k, dispatch);
             let lowered_result = if convention == CallingConvention::Cps {
                 self.never_type()
             } else {
                 result
             };
             let function = core::func(self.ctx, lowered_result, lowered_params).as_type_ref();
-            let converted = closure::closure(self.ctx, function).as_type_ref();
+            let converted = physical_closure_type(self.ctx, function, convention);
             self.converted_types.insert(ty, converted);
             return converted;
         }
@@ -919,8 +1486,9 @@ impl<'a> Converter<'a> {
             .collect();
         let evidence = self.evidence_type();
         let done_k = self.done_k_type(result);
+        let dispatch = self.dispatch_type(result);
         let abi = CallableAbi::new(convention, params, result);
-        let params = abi.lowered_params(evidence, done_k);
+        let params = abi.lowered_params_with_dispatch(evidence, done_k, dispatch);
         let result = if convention == CallingConvention::Cps {
             self.never_type()
         } else {
@@ -1168,35 +1736,64 @@ impl<'a> Converter<'a> {
         source_ops: &[OpRef],
         index: usize,
         block: BlockRef,
-        mapping: &HashMap<ValueRef, ValueRef>,
+        mapping: &mut HashMap<ValueRef, ValueRef>,
         flow: &Flow,
     ) -> Result<(), TributeControlToCpsError> {
-        if flow.convention != CallingConvention::Cps || self.ctx.op_result_types(source).len() != 1
-        {
+        let result_types = self.ctx.op_result_types(source).to_vec();
+        if result_types.len() > 1 {
             return Err(TributeControlToCpsError::one(
                 POST_CPS_BOUNDARY,
                 Some(source),
                 Some(self.ctx.op(source).location),
-                "effectful scf.if requires one result inside a CPS callable",
+                "effectful scf.if requires zero or one result",
             ));
         }
+        if flow.convention != CallingConvention::Cps {
+            return self
+                .lower_direct_structured_if(source, source_ops, index, block, mapping, flow);
+        }
         let location = self.ctx.op(source).location;
-        let source_result = self.ctx.op_result(source, 0);
-        let source_result_type = self.ctx.op_result_types(source)[0];
-        let continuation = self.build_suffix_continuation(
-            source_ops,
-            index + 1,
-            source_result,
-            source_result_type,
-            mapping,
-            flow,
-            location,
-        )?;
-        let continuation_op = match self.ctx.value_def(continuation) {
-            trunk_ir::ValueDef::OpResult(op, _) => op,
-            _ => unreachable!("structured continuation is a closure.lambda"),
+        // `core.never` is the structured proper-tail marker, not an SSA value
+        // boundary. In particular, an `op -> Never` branch keeps the active
+        // `Flow<R>` so its rejecting `Resume<R>` matches `Dispatch<R>`.
+        let value_result_type = result_types
+            .first()
+            .copied()
+            .filter(|ty| !type_is(self.ctx, *ty, "core", "never"));
+        let is_tail_never_marker = value_result_type.is_none() && result_types.len() == 1;
+        let (branch_done, branch_dispatch) = if is_tail_never_marker {
+            (flow.done, flow.dispatch)
+        } else {
+            let continuation = if let Some(source_result_type) = value_result_type {
+                self.build_suffix_continuation(
+                    source_ops,
+                    index + 1,
+                    self.ctx.op_result(source, 0),
+                    source_result_type,
+                    mapping,
+                    flow,
+                    location,
+                )?
+            } else {
+                self.build_void_suffix_continuation(source_ops, index + 1, mapping, flow, location)?
+            };
+            let continuation_op = match self.ctx.value_def(continuation) {
+                trunk_ir::ValueDef::OpResult(op, _) => op,
+                _ => unreachable!("structured continuation is a closure.lambda"),
+            };
+            self.ctx.push_op(block, continuation_op);
+            if let Some(source_result_type) = value_result_type {
+                let value_type = self.convert_type(source_result_type);
+                let (ops, done, dispatch) =
+                    self.build_cps_call_adapters(value_type, continuation, flow, location)?;
+                for op in ops {
+                    self.ctx.push_op(block, op);
+                }
+                (Some(done), Some(dispatch))
+            } else {
+                (flow.done, flow.dispatch)
+            }
         };
-        self.ctx.push_op(block, continuation_op);
 
         let mut converted_regions = Vec::new();
         let source_regions = self.ctx.op(source).regions.to_vec();
@@ -1233,7 +1830,8 @@ impl<'a> Converter<'a> {
                 branch_mapping.insert(old, new);
             }
             let branch_flow = Flow {
-                exit_k: Some(continuation),
+                done: branch_done,
+                dispatch: branch_dispatch,
                 ..flow.clone()
             };
             self.convert_sequence(
@@ -1267,6 +1865,88 @@ impl<'a> Converter<'a> {
         self.copy_extra_attrs(source, lowered.op_ref(), &[]);
         self.ctx.push_op(block, lowered.op_ref());
         Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn lower_direct_structured_if(
+        &mut self,
+        source: OpRef,
+        source_ops: &[OpRef],
+        index: usize,
+        block: BlockRef,
+        mapping: &mut HashMap<ValueRef, ValueRef>,
+        flow: &Flow,
+    ) -> Result<(), TributeControlToCpsError> {
+        let location = self.ctx.op(source).location;
+        let mut converted_regions = Vec::new();
+        let source_regions = self.ctx.op(source).regions.clone();
+        for source_region in source_regions {
+            let source_blocks = self.ctx.region(source_region).blocks.to_vec();
+            let [source_block] = source_blocks.as_slice() else {
+                return Err(self
+                    .malformed_source(source, "effectful scf.if regions must contain one block"));
+            };
+            let source_arg_types = self
+                .ctx
+                .block_args(*source_block)
+                .iter()
+                .map(|arg| self.ctx.value_ty(*arg))
+                .collect::<Vec<_>>();
+            let arg_types = source_arg_types
+                .into_iter()
+                .map(|ty| self.convert_type(ty))
+                .collect::<Vec<_>>();
+            let converted_block =
+                self.make_block(self.ctx.block(*source_block).location, &arg_types);
+            let mut branch_mapping = mapping.clone();
+            for (old, new) in self
+                .ctx
+                .block_args(*source_block)
+                .iter()
+                .copied()
+                .zip(self.ctx.block_args(converted_block).iter().copied())
+            {
+                branch_mapping.insert(old, new);
+            }
+            let branch_flow = Flow {
+                preserve_scf_yield: true,
+                ..flow.clone()
+            };
+            self.convert_sequence(
+                self.ctx.block(*source_block).ops.to_vec(),
+                0,
+                converted_block,
+                &mut branch_mapping,
+                &branch_flow,
+            )?;
+            converted_regions.push(self.single_block_region(location, converted_block));
+        }
+        let [then_region, else_region] = converted_regions.as_slice() else {
+            return Err(self.malformed_source(source, "scf.if requires exactly two regions"));
+        };
+        let condition = self.ctx.op_operands(source)[0];
+        let condition = mapping.get(&condition).copied().unwrap_or(condition);
+        let mut builder =
+            OperationDataBuilder::new(location, Symbol::new("scf"), Symbol::new("if"))
+                .operand(condition);
+        for result_type in self.ctx.op_result_types(source).to_vec() {
+            builder = builder.result(self.convert_type(result_type));
+        }
+        builder = builder.region(*then_region).region(*else_region);
+        let data = builder.build(self.ctx);
+        let lowered = self.ctx.create_op(data);
+        self.copy_extra_attrs(source, lowered, &[]);
+        self.ctx.push_op(block, lowered);
+        for (old, new) in self
+            .ctx
+            .op_results(source)
+            .to_vec()
+            .into_iter()
+            .zip(self.ctx.op_results(lowered).to_vec())
+        {
+            mapping.insert(old, new);
+        }
+        self.convert_sequence(source_ops.to_vec(), index + 1, block, mapping, flow)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1354,7 +2034,8 @@ impl<'a> Converter<'a> {
             let converted_block = self.make_block(case_location, &[]);
             let mut case_mapping = mapping.clone();
             let case_flow = Flow {
-                exit_k: Some(continuation),
+                done: Some(continuation),
+                void_done: Some(continuation),
                 ..flow.clone()
             };
             self.convert_sequence(
@@ -1392,15 +2073,15 @@ impl<'a> Converter<'a> {
         flow: &Flow,
     ) -> Result<(), TributeControlToCpsError> {
         if flow.convention == CallingConvention::Cps {
-            let exit_k = flow.exit_k.ok_or_else(|| {
+            let done = flow.done.ok_or_else(|| {
                 TributeControlToCpsError::one(
                     POST_CPS_BOUNDARY,
                     None,
                     Some(location),
-                    "CPS region has no verified exit continuation",
+                    "CPS region has no verified Done boundary",
                 )
             })?;
-            let tail = func::tail_call_indirect(self.ctx, location, exit_k, [value]);
+            let tail = func::tail_call_indirect(self.ctx, location, done, [value]);
             set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
             self.ctx.push_op(block, tail.op_ref());
         } else {
@@ -1416,7 +2097,7 @@ impl<'a> Converter<'a> {
         location: Location,
         flow: &Flow,
     ) -> Result<(), TributeControlToCpsError> {
-        let exit_k = flow.exit_k.ok_or_else(|| {
+        let done = flow.done.ok_or_else(|| {
             TributeControlToCpsError::one(
                 POST_CPS_BOUNDARY,
                 None,
@@ -1425,7 +2106,7 @@ impl<'a> Converter<'a> {
             )
         })?;
         let tail =
-            func::tail_call_indirect(self.ctx, location, exit_k, std::iter::empty::<ValueRef>());
+            func::tail_call_indirect(self.ctx, location, done, std::iter::empty::<ValueRef>());
         set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
         self.ctx.push_op(block, tail.op_ref());
         Ok(())
@@ -1443,10 +2124,10 @@ impl<'a> Converter<'a> {
         let mut suffix_mapping = mapping.clone();
         self.convert_sequence(source_ops.to_vec(), start, block, &mut suffix_mapping, flow)?;
         let region = self.single_block_region(location, block);
-        let captures = ordered_external_values(self.ctx, region);
+        let captures = self.continuation_captures(region, flow);
         let never = self.never_type();
         let function = core::func(self.ctx, never, std::iter::empty::<TypeRef>()).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let closure_type = physical_closure_type(self.ctx, function, CallingConvention::Cps);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok(lambda.result(self.ctx))
@@ -1472,13 +2153,14 @@ impl<'a> Converter<'a> {
             .collect();
         let evidence = self.evidence_type();
         let done_k = self.done_k_type(result);
+        let dispatch = self.dispatch_type(result);
         let abi = CallableAbi::new(convention, source_param_types.clone(), result);
-        let params = abi.lowered_params(evidence, done_k);
+        let params = abi.lowered_params_with_dispatch(evidence, done_k, dispatch);
         let body_source = self.ctx.op(source).regions[0];
         let entry_source = self.ctx.region(body_source).blocks[0];
         let block = self.make_block(location, &params);
         let mut body_mapping = mapping.clone();
-        let offset = abi.source_param_offset();
+        let offset = abi.source_param_offset_with_dispatch();
         for (old, new) in self
             .ctx
             .block_args(entry_source)
@@ -1491,15 +2173,24 @@ impl<'a> Converter<'a> {
         let evidence_value = convention
             .needs_evidence()
             .then(|| self.ctx.block_args(block)[0]);
-        let exit_k = convention
+        let done_index = usize::from(convention.needs_evidence());
+        let done = convention
             .needs_done_k()
-            .then(|| self.ctx.block_args(block)[usize::from(convention.needs_evidence())]);
+            .then(|| self.ctx.block_args(block)[done_index]);
+        let dispatch = convention
+            .needs_done_k()
+            .then(|| self.ctx.block_args(block)[done_index + 1]);
         let flow = Flow {
             convention,
             evidence: evidence_value,
-            exit_k,
-            root_exit_k: exit_k,
-            answer_type: result,
+            resume_evidence: evidence_value,
+            done,
+            dispatch,
+            boundary_result: result,
+            resume_after: None,
+            resume_done: None,
+            void_done: None,
+            preserve_scf_yield: false,
         };
         self.convert_sequence(
             self.ctx.block(entry_source).ops.to_vec(),
@@ -1533,6 +2224,21 @@ impl<'a> Converter<'a> {
                 Some(source),
                 Some(self.ctx.op(source).location),
                 "operation requires evidence but the enclosing callable convention is Direct",
+            )
+        })
+    }
+
+    fn current_resume_evidence(
+        &self,
+        source: OpRef,
+        flow: &Flow,
+    ) -> Result<ValueRef, TributeControlToCpsError> {
+        flow.resume_evidence.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(self.ctx.op(source).location),
+                "CPS call has no verified dynamic evidence context",
             )
         })
     }
@@ -1573,18 +2279,315 @@ impl<'a> Converter<'a> {
         location: Location,
     ) -> Result<ValueRef, TributeControlToCpsError> {
         let result_type = self.convert_type(result_type);
-        let block = self.make_block(location, &[result_type]);
+        let evidence_type = self.evidence_type();
+        let parent_type = self.parent_types(flow.boundary_result).reference;
+        let block = self.make_block(location, &[evidence_type, parent_type, result_type]);
+        let context_evidence = self.ctx.block_args(block)[0];
+        let parent_value = self.ctx.block_args(block)[1];
+        let (parent_done, parent_dispatch) =
+            self.unpack_parent(block, location, flow.boundary_result, parent_value);
         let mut body_mapping = mapping.clone();
-        body_mapping.insert(source_result, self.ctx.block_args(block)[0]);
-        self.convert_sequence(source_ops.to_vec(), start, block, &mut body_mapping, flow)?;
+        body_mapping.insert(source_result, self.ctx.block_args(block)[2]);
+        let dynamic_done = if let Some(after) = flow.resume_after {
+            let (op, done) = self.build_done_adapter(
+                result_type,
+                after,
+                context_evidence,
+                parent_value,
+                location,
+            );
+            self.ctx.push_op(block, op);
+            done
+        } else {
+            parent_done
+        };
+        let suffix_flow = Flow {
+            evidence: Some(context_evidence),
+            resume_evidence: Some(context_evidence),
+            done: Some(dynamic_done),
+            dispatch: Some(parent_dispatch),
+            ..flow.clone()
+        };
+        self.convert_sequence(
+            source_ops.to_vec(),
+            start,
+            block,
+            &mut body_mapping,
+            &suffix_flow,
+        )?;
         let region = self.single_block_region(location, block);
-        let captures = ordered_external_values(self.ctx, region);
-        let never = self.never_type();
-        let function = core::func(self.ctx, never, [result_type]).as_type_ref();
-        let closure_ty = closure::closure(self.ctx, function).as_type_ref();
+        let captures = self.continuation_captures(region, flow);
+        let closure_ty = self.completion_type(result_type, flow.boundary_result);
         let lambda = closure::lambda(self.ctx, location, captures, closure_ty, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok(lambda.result(self.ctx))
+    }
+
+    /// Adapt a call returning `value_type` to the caller's result-indexed
+    /// `Done`/`Dispatch` boundary. Both adapters are immutable closure frames;
+    /// the callee never needs to inspect or clone an opaque caller continuation.
+    fn build_cps_call_adapters(
+        &mut self,
+        value_type: TypeRef,
+        completion: ValueRef,
+        flow: &Flow,
+        location: Location,
+    ) -> Result<(Vec<OpRef>, ValueRef, ValueRef), TributeControlToCpsError> {
+        let boundary = flow.boundary_result;
+        let current_done = flow.done.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS call has no verified Done boundary",
+            )
+        })?;
+        let current_dispatch = flow.dispatch.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS call has no verified Dispatch boundary",
+            )
+        })?;
+        let context_evidence = flow.resume_evidence.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS call has no verified dynamic evidence context",
+            )
+        })?;
+
+        let done_block = self.make_block(location, &[value_type]);
+        let done_value = self.ctx.block_args(done_block)[0];
+        let current_parent = self.pack_parent(
+            done_block,
+            location,
+            boundary,
+            current_done,
+            current_dispatch,
+        );
+        let done_tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            completion,
+            [context_evidence, current_parent, done_value],
+        );
+        set_calling_convention(self.ctx, done_tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(done_block, done_tail.op_ref());
+        let done_region = self.single_block_region(location, done_block);
+        let done_captures = ordered_external_values(self.ctx, done_region);
+        let done_ty = self.done_k_type(value_type);
+        let done_lambda = closure::lambda(self.ctx, location, done_captures, done_ty, done_region);
+        set_calling_convention(self.ctx, done_lambda.op_ref(), CallingConvention::Cps);
+
+        let factory = self.build_dispatch_adapter_factory(location, value_type, boundary);
+        let dispatch_ty = self.dispatch_type(value_type);
+        let dispatch_call = func::call(
+            self.ctx,
+            location,
+            [completion, current_dispatch],
+            dispatch_ty,
+            factory,
+        );
+        set_calling_convention(self.ctx, dispatch_call.op_ref(), CallingConvention::Direct);
+
+        Ok((
+            vec![done_lambda.op_ref(), dispatch_call.op_ref()],
+            done_lambda.result(self.ctx),
+            dispatch_call.result(self.ctx),
+        ))
+    }
+
+    /// Rebuild an exact `Resume<R>` from the dynamic `Parent<R>` supplied by
+    /// a later handler arm. Both ordinary call adapters and lexical handler
+    /// dispatchers use this same immutable continuation frame.
+    fn build_rebound_resume(
+        &mut self,
+        location: Location,
+        value_type: TypeRef,
+        boundary: TypeRef,
+        resume_body: ValueRef,
+        completion: ValueRef,
+        dispatch_rebuild: ResumeDispatchRebuild,
+    ) -> (OpRef, ValueRef) {
+        let evidence_type = self.evidence_type();
+        let anyref = self.anyref_type();
+        let parent_type = self.parent_types(boundary).reference;
+        let block = self.make_block(location, &[evidence_type, parent_type, anyref]);
+        let args = self.ctx.block_args(block).to_vec();
+        let (next_done_op, next_done) =
+            self.build_done_adapter(value_type, completion, args[0], args[1], location);
+        self.ctx.push_op(block, next_done_op);
+        let dispatch_type = self.dispatch_type(value_type);
+        let rebuilt_dispatch = match dispatch_rebuild {
+            ResumeDispatchRebuild::Adapter { factory } => {
+                let (_, outer_dispatch) = self.unpack_parent(block, location, boundary, args[1]);
+                func::call(
+                    self.ctx,
+                    location,
+                    [completion, outer_dispatch],
+                    dispatch_type,
+                    factory,
+                )
+            }
+            ResumeDispatchRebuild::LocalFactory(LocalDispatchFactory {
+                factory,
+                args: mut factory_args,
+            }) => {
+                factory_args.insert(0, args[1]);
+                func::call(self.ctx, location, factory_args, dispatch_type, factory)
+            }
+        };
+        set_calling_convention(
+            self.ctx,
+            rebuilt_dispatch.op_ref(),
+            CallingConvention::Direct,
+        );
+        self.ctx.push_op(block, rebuilt_dispatch.op_ref());
+        let parent = self.pack_parent(
+            block,
+            location,
+            value_type,
+            next_done,
+            rebuilt_dispatch.result(self.ctx),
+        );
+        let tail =
+            func::tail_call_indirect(self.ctx, location, resume_body, [args[0], parent, args[2]]);
+        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(block, tail.op_ref());
+        let region = self.single_block_region(location, block);
+        let closure_type = self.erased_resumption_type(boundary);
+        let resume = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, region),
+            closure_type,
+            region,
+        );
+        set_calling_convention(self.ctx, resume.op_ref(), CallingConvention::Cps);
+        (resume.op_ref(), resume.result(self.ctx))
+    }
+
+    /// Emit a direct factory for the `Dispatch<X>` adapter used at a CPS call
+    /// inside a `Flow<R>`.  The factory is recursive only in the construction
+    /// sense: every resumed invocation allocates a fresh dispatcher which
+    /// captures the dynamically supplied `Parent<R>`.  The direct factory
+    /// call builds a closure; it is never a control-flow fallback.
+    fn build_dispatch_adapter_factory(
+        &mut self,
+        location: Location,
+        value_type: TypeRef,
+        boundary: TypeRef,
+    ) -> Symbol {
+        let symbol = self.fresh_helper("make_dispatch_adapter");
+        let completion_ty = self.completion_type(value_type, boundary);
+        let outer_dispatch_ty = self.dispatch_type(boundary);
+        let dispatch_ty = self.dispatch_type(value_type);
+        let factory_ty =
+            core::func(self.ctx, dispatch_ty, [completion_ty, outer_dispatch_ty]).as_type_ref();
+        let factory_block = self.make_block(location, &[completion_ty, outer_dispatch_ty]);
+        let factory_args = self.ctx.block_args(factory_block).to_vec();
+        let completion = factory_args[0];
+        let outer_dispatch = factory_args[1];
+
+        let anyref = self.anyref_type();
+        let evidence_type = self.evidence_type();
+        let i32_type = self.i32_type();
+        let erased_resume_value_ty = self.erased_resumption_type(value_type);
+        let dispatch_block = self.make_block(
+            location,
+            &[
+                evidence_type,
+                erased_resume_value_ty,
+                i32_type,
+                i32_type,
+                i32_type,
+                anyref,
+            ],
+        );
+        let dispatch_args = self.ctx.block_args(dispatch_block).to_vec();
+        let context_evidence = dispatch_args[0];
+        let resume_value = dispatch_args[1];
+        let prompt = dispatch_args[2];
+        let ability_id = dispatch_args[3];
+        let op_id = dispatch_args[4];
+        let payload = dispatch_args[5];
+
+        let (resume_op, resume_lambda) = self.build_rebound_resume(
+            location,
+            value_type,
+            boundary,
+            resume_value,
+            completion,
+            ResumeDispatchRebuild::Adapter { factory: symbol },
+        );
+        self.ctx.push_op(dispatch_block, resume_op);
+        let dispatch_tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            outer_dispatch,
+            [
+                context_evidence,
+                resume_lambda,
+                prompt,
+                ability_id,
+                op_id,
+                payload,
+            ],
+        );
+        set_calling_convention(self.ctx, dispatch_tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(dispatch_block, dispatch_tail.op_ref());
+        let dispatch_region = self.single_block_region(location, dispatch_block);
+        let dispatch_lambda = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, dispatch_region),
+            dispatch_ty,
+            dispatch_region,
+        );
+        set_calling_convention(self.ctx, dispatch_lambda.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(factory_block, dispatch_lambda.op_ref());
+        let ret = func::r#return(self.ctx, location, [dispatch_lambda.result(self.ctx)]);
+        self.ctx.push_op(factory_block, ret.op_ref());
+        let region = self.single_block_region(location, factory_block);
+        let factory = func::func(self.ctx, location, symbol, factory_ty, region);
+        set_calling_convention(self.ctx, factory.op_ref(), CallingConvention::Direct);
+        self.ctx.push_op(self.module_block, factory.op_ref());
+        symbol
+    }
+
+    /// Build only the `Done<X>` half of a result-indexed CPS boundary.
+    ///
+    /// This is used by a handler's normal completion: the handler answer
+    /// crosses `after_handle`, while the handler's own dispatch remains the
+    /// enclosing dispatch. Keeping the frame immutable is what makes nested
+    /// resumes compose rather than overwrite an ambient root continuation.
+    fn build_done_adapter(
+        &mut self,
+        value_type: TypeRef,
+        completion: ValueRef,
+        context_evidence: ValueRef,
+        current_parent: ValueRef,
+        location: Location,
+    ) -> (OpRef, ValueRef) {
+        let block = self.make_block(location, &[value_type]);
+        let value = self.ctx.block_args(block)[0];
+        let tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            completion,
+            [context_evidence, current_parent, value],
+        );
+        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(block, tail.op_ref());
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let done_type = self.done_k_type(value_type);
+        let lambda = closure::lambda(self.ctx, location, captures, done_type, region);
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        (lambda.op_ref(), lambda.result(self.ctx))
     }
 
     fn lower_func_ref(
@@ -1620,8 +2623,9 @@ impl<'a> Converter<'a> {
             .collect();
         let evidence_ty = self.evidence_type();
         let done_k_ty = self.done_k_type(result);
+        let dispatch_ty = self.dispatch_type(result);
         let abi = CallableAbi::new(result_convention, source_params.clone(), result);
-        let logical_params = abi.lowered_params(evidence_ty, done_k_ty);
+        let logical_params = abi.lowered_params_with_dispatch(evidence_ty, done_k_ty, dispatch_ty);
         let env_ty = self.anyref_type();
         let physical_params = abi.interpose_environment(&logical_params, env_ty);
         let physical_result = if result_convention == CallingConvention::Cps {
@@ -1631,21 +2635,29 @@ impl<'a> Converter<'a> {
         };
         let adapter_ty =
             core::func(self.ctx, physical_result, physical_params.clone()).as_type_ref();
-        let block = self.make_block(location, &physical_params);
-        let args = self.ctx.block_args(block).to_vec();
         let evidence_offset = usize::from(result_convention.needs_evidence());
+        let block = self.make_block(location, &physical_params);
+        self.ctx.block_mut(block).args[evidence_offset]
+            .attrs
+            .insert(
+                Symbol::new("bind_name"),
+                Attribute::Symbol(Symbol::new("__env")),
+            );
+        let args = self.ctx.block_args(block).to_vec();
         // The environment is interposed immediately after optional evidence,
         // so a present done continuation is the following slot.
         let done_offset = evidence_offset + 1;
+        let dispatch_offset = done_offset + 1;
         let source_offset = usize::from(result_convention.needs_evidence())
             + 1
-            + usize::from(result_convention.needs_done_k());
+            + usize::from(result_convention.needs_done_k()) * 2;
         let mut target_args = Vec::new();
         if target.convention.needs_evidence() {
             target_args.push(args[0]);
         }
         if target.convention.needs_done_k() {
             target_args.push(args[done_offset]);
+            target_args.push(args[dispatch_offset]);
         }
         target_args.extend_from_slice(&args[source_offset..]);
         if target.convention == CallingConvention::Cps {
@@ -1714,7 +2726,6 @@ impl<'a> Converter<'a> {
     fn build_completion_continuation(
         &mut self,
         source_region: RegionRef,
-        final_k: ValueRef,
         mapping: &HashMap<ValueRef, ValueRef>,
         flow: &Flow,
         location: Location,
@@ -1722,15 +2733,26 @@ impl<'a> Converter<'a> {
         let source_block = self.ctx.region(source_region).blocks[0];
         let source_arg = self.ctx.block_args(source_block)[0];
         let arg_type = self.convert_type(self.ctx.value_ty(source_arg));
-        let block = self.make_block(location, &[arg_type]);
+        let evidence_type = self.evidence_type();
+        let parent_type = self.parent_types(flow.boundary_result).reference;
+        let block = self.make_block(location, &[evidence_type, parent_type, arg_type]);
+        let context_evidence = self.ctx.block_args(block)[0];
+        let parent_value = self.ctx.block_args(block)[1];
+        let (parent_done, parent_dispatch) =
+            self.unpack_parent(block, location, flow.boundary_result, parent_value);
         let mut body_mapping = mapping.clone();
-        body_mapping.insert(source_arg, self.ctx.block_args(block)[0]);
+        body_mapping.insert(source_arg, self.ctx.block_args(block)[2]);
         let completion_flow = Flow {
             convention: CallingConvention::Cps,
-            evidence: flow.evidence,
-            exit_k: Some(final_k),
-            root_exit_k: Some(final_k),
-            answer_type: flow.answer_type,
+            evidence: Some(context_evidence),
+            resume_evidence: Some(context_evidence),
+            done: Some(parent_done),
+            dispatch: Some(parent_dispatch),
+            boundary_result: flow.boundary_result,
+            resume_after: None,
+            resume_done: None,
+            void_done: None,
+            preserve_scf_yield: false,
         };
         self.convert_sequence(
             self.ctx.block(source_block).ops.to_vec(),
@@ -1740,51 +2762,11 @@ impl<'a> Converter<'a> {
             &completion_flow,
         )?;
         let body = self.single_block_region(location, block);
-        let captures = ordered_external_values(self.ctx, body);
-        let never = self.never_type();
-        let function = core::func(self.ctx, never, [arg_type]).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let captures = self.continuation_captures(body, flow);
+        let closure_type = self.completion_type(arg_type, flow.boundary_result);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, body);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok((lambda.op_ref(), lambda.result(self.ctx)))
-    }
-
-    fn rebind_generated_continuation(
-        &mut self,
-        value: ValueRef,
-        old_root: ValueRef,
-        new_root: ValueRef,
-        destination: BlockRef,
-        cache: &mut HashMap<ValueRef, ValueRef>,
-    ) -> Result<ValueRef, TributeControlToCpsError> {
-        if value == old_root {
-            return Ok(new_root);
-        }
-        if let Some(rebound) = cache.get(&value) {
-            return Ok(*rebound);
-        }
-        let trunk_ir::ValueDef::OpResult(def, _) = self.ctx.value_def(value) else {
-            return Ok(value);
-        };
-        if !closure::Lambda::matches(self.ctx, def) {
-            return Ok(value);
-        }
-        let mut mapping = HashMap::from([(old_root, new_root)]);
-        for capture in self.ctx.op_operands(def).to_vec() {
-            let rebound = self.rebind_generated_continuation(
-                capture,
-                old_root,
-                new_root,
-                destination,
-                cache,
-            )?;
-            mapping.insert(capture, rebound);
-        }
-        let rebound_op = self.clone_plain_op(def, &mut mapping)?;
-        self.ctx.push_op(destination, rebound_op);
-        let rebound = self.ctx.op_result(rebound_op, 0);
-        cache.insert(value, rebound);
-        Ok(rebound)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1799,38 +2781,23 @@ impl<'a> Converter<'a> {
         location: Location,
     ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
         let input_type = self.convert_type(input_type);
-        let done_k_type = self.done_k_type(flow.answer_type);
-        let block = self.make_block(location, &[done_k_type, input_type]);
-        let resume_done = self.ctx.block_args(block)[0];
-        let resume_input = self.ctx.block_args(block)[1];
+        let evidence_type = self.evidence_type();
+        let parent_type = self.parent_types(flow.boundary_result).reference;
+        let block = self.make_block(location, &[evidence_type, parent_type, input_type]);
+        let resume_evidence = self.ctx.block_args(block)[0];
+        let parent_value = self.ctx.block_args(block)[1];
+        let (resume_done, resume_dispatch) =
+            self.unpack_parent(block, location, flow.boundary_result, parent_value);
+        let resume_input = self.ctx.block_args(block)[2];
         let mut body_mapping = mapping.clone();
         body_mapping.insert(source_result, resume_input);
-        let mut suffix_flow = flow.clone();
-        let old_root = flow.root_exit_k.ok_or_else(|| {
-            TributeControlToCpsError::one(
-                POST_CPS_BOUNDARY,
-                None,
-                Some(location),
-                "resumptive computation has no root continuation",
-            )
-        })?;
-        let current_exit = flow.exit_k.ok_or_else(|| {
-            TributeControlToCpsError::one(
-                POST_CPS_BOUNDARY,
-                None,
-                Some(location),
-                "resumptive computation has no current continuation",
-            )
-        })?;
-        let rebound_exit = self.rebind_generated_continuation(
-            current_exit,
-            old_root,
-            resume_done,
-            block,
-            &mut HashMap::new(),
-        )?;
-        suffix_flow.exit_k = Some(rebound_exit);
-        suffix_flow.root_exit_k = Some(resume_done);
+        let suffix_flow = Flow {
+            evidence: Some(resume_evidence),
+            resume_evidence: Some(resume_evidence),
+            done: Some(resume_done),
+            dispatch: Some(resume_dispatch),
+            ..flow.clone()
+        };
         self.convert_sequence(
             source_ops.to_vec(),
             start,
@@ -1839,8 +2806,8 @@ impl<'a> Converter<'a> {
             &suffix_flow,
         )?;
         let region = self.single_block_region(location, block);
-        let captures = ordered_external_values(self.ctx, region);
-        let closure_type = self.resumption_type(input_type, flow.answer_type);
+        let captures = self.continuation_captures(region, &suffix_flow);
+        let closure_type = self.resumption_type(input_type, flow.boundary_result);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok((lambda.op_ref(), lambda.result(self.ctx)))
@@ -1879,9 +2846,13 @@ impl<'a> Converter<'a> {
             state_type,
         );
 
-        let done_k_type = self.done_k_type(answer_type);
-        let block = self.make_block(location, &[done_k_type, input_type]);
+        let evidence_type = self.evidence_type();
+        let parent_type = self.parent_types(answer_type).reference;
+        let anyref = self.anyref_type();
+        let block = self.make_block(location, &[evidence_type, parent_type, anyref]);
         let args = self.ctx.block_args(block).to_vec();
+        let input = core::unrealized_conversion_cast(self.ctx, location, args[2], input_type);
+        self.ctx.push_op(block, input.op_ref());
         let consumed = adt::struct_get(
             self.ctx,
             location,
@@ -1909,8 +2880,12 @@ impl<'a> Converter<'a> {
             0,
         );
         self.ctx.push_op(enter_block, mark.op_ref());
-        let tail =
-            func::tail_call_indirect(self.ctx, location, raw_continuation, args.iter().copied());
+        let tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            raw_continuation,
+            [args[0], args[1], input.result(self.ctx)],
+        );
         set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
         self.ctx.push_op(enter_block, tail.op_ref());
         let enter_region = self.single_block_region(location, enter_block);
@@ -1927,7 +2902,7 @@ impl<'a> Converter<'a> {
         self.ctx.push_op(block, guard.op_ref());
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
-        let closure_type = self.resumption_type(input_type, answer_type);
+        let closure_type = self.erased_resumption_type(answer_type);
         let wrapper = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, wrapper.op_ref(), CallingConvention::Cps);
         (
@@ -1936,19 +2911,27 @@ impl<'a> Converter<'a> {
         )
     }
 
+    /// Callback ABIs carry dynamic evidence explicitly. Ordinary closure
+    /// captures are therefore determined solely by lexical value use.
+    fn continuation_captures(&self, region: RegionRef, flow: &Flow) -> Vec<ValueRef> {
+        let _ = flow;
+        ordered_external_values(self.ctx, region)
+    }
+
     fn build_reject_continuation(
         &mut self,
-        input_type: TypeRef,
+        _input_type: TypeRef,
         answer_type: TypeRef,
         location: Location,
     ) -> (OpRef, ValueRef) {
-        let input_type = self.convert_type(input_type);
-        let done_k_type = self.done_k_type(answer_type);
-        let block = self.make_block(location, &[done_k_type, input_type]);
+        let evidence_type = self.evidence_type();
+        let parent_type = self.parent_types(answer_type).reference;
+        let anyref = self.anyref_type();
+        let block = self.make_block(location, &[evidence_type, parent_type, anyref]);
         let unreachable = func::unreachable(self.ctx, location);
         self.ctx.push_op(block, unreachable.op_ref());
         let region = self.single_block_region(location, block);
-        let closure_type = self.resumption_type(input_type, answer_type);
+        let closure_type = self.erased_resumption_type(answer_type);
         let lambda = closure::lambda(
             self.ctx,
             location,
@@ -1978,11 +2961,12 @@ impl<'a> Converter<'a> {
             ));
         }
         let location = self.ctx.op(source).location;
+        let resume_flow = flow.clone();
         let old_result = self.ctx.op_result(source, 0);
         let input_type = self.ctx.op_result_types(source)[0];
         let continuation = if type_is(self.ctx, input_type, "core", "never") {
             let (op, value) =
-                self.build_reject_continuation(input_type, flow.answer_type, location);
+                self.build_reject_continuation(input_type, flow.boundary_result, location);
             self.ctx.push_op(block, op);
             value
         } else {
@@ -1992,13 +2976,17 @@ impl<'a> Converter<'a> {
                 old_result,
                 input_type,
                 mapping,
-                flow,
+                &resume_flow,
                 location,
             )?;
             self.ctx.push_op(block, raw_op);
             let converted_input = self.convert_type(input_type);
-            let (ops, one_shot) =
-                self.build_one_shot_wrapper(raw, converted_input, flow.answer_type, location);
+            let (ops, one_shot) = self.build_one_shot_wrapper(
+                raw,
+                converted_input,
+                resume_flow.boundary_result,
+                location,
+            );
             for op in ops {
                 self.ctx.push_op(block, op);
             }
@@ -2026,6 +3014,22 @@ impl<'a> Converter<'a> {
         let perform = ability::perform(
             self.ctx,
             location,
+            resume_flow.resume_evidence.ok_or_else(|| {
+                TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    Some(source),
+                    Some(location),
+                    "general operation has no verified dynamic evidence context",
+                )
+            })?,
+            resume_flow.dispatch.ok_or_else(|| {
+                TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    Some(source),
+                    Some(location),
+                    "general operation has no verified Dispatch boundary",
+                )
+            })?,
             continuation,
             args,
             never,
@@ -2054,6 +3058,7 @@ impl<'a> Converter<'a> {
             ));
         }
         let location = self.ctx.op(source).location;
+        let resume_flow = flow.clone();
         let token_source = self.ctx.op_operands(source)[0];
         let value_source = self.ctx.op_operands(source)[1];
         let token = mapping.get(&token_source).copied().unwrap_or(token_source);
@@ -2066,7 +3071,7 @@ impl<'a> Converter<'a> {
             old_result,
             result_type,
             mapping,
-            flow,
+            &resume_flow,
             location,
         )?;
         let suffix_op = match self.ctx.value_def(suffix) {
@@ -2074,7 +3079,33 @@ impl<'a> Converter<'a> {
             _ => unreachable!("suffix is produced by closure.lambda"),
         };
         self.ctx.push_op(block, suffix_op);
-        let tail = func::tail_call_indirect(self.ctx, location, token, [suffix, value]);
+        let answer_type = self.convert_type(result_type);
+        let (adapter_ops, arm_done, arm_dispatch) =
+            self.build_cps_call_adapters(answer_type, suffix, &resume_flow, location)?;
+        for op in adapter_ops {
+            self.ctx.push_op(block, op);
+        }
+        let arm_parent = self.pack_parent(
+            block,
+            location,
+            resume_flow.boundary_result,
+            arm_done,
+            arm_dispatch,
+        );
+        let context_evidence = resume_flow.resume_evidence.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(location),
+                "resume has no verified dynamic evidence context",
+            )
+        })?;
+        let tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            token,
+            [context_evidence, arm_parent, value],
+        );
         set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
         self.ctx.push_op(block, tail.op_ref());
         Ok(())
@@ -2084,8 +3115,7 @@ impl<'a> Converter<'a> {
         &mut self,
         source: OpRef,
         outer_mapping: &HashMap<ValueRef, ValueRef>,
-        handle_exit: ValueRef,
-        handle_answer: TypeRef,
+        outer_flow: &Flow,
     ) -> Result<HandlerArmInfo, TributeControlToCpsError> {
         let location = self.ctx.op(source).location;
         let ability_ref = self
@@ -2124,27 +3154,54 @@ impl<'a> Converter<'a> {
             .map(|arg| self.convert_type(self.ctx.value_ty(*arg)))
             .collect();
         let mut params = vec![evidence_type];
+        let parent_type = (kind == Symbol::new("op"))
+            .then(|| self.parent_types(outer_flow.boundary_result).reference);
+        if let Some(parent_type) = parent_type {
+            params.push(parent_type);
+        }
+        // A general handler arm evaluates under its outer lexical evidence,
+        // but receives the effect-point evidence separately for any resume
+        // context it constructs.
+        if kind == Symbol::new("op") {
+            params.push(evidence_type);
+        }
         params.extend_from_slice(&converted_args);
         let block = self.make_block(location, &params);
         let mut mapping = outer_mapping.clone();
+        let source_offset =
+            1 + usize::from(parent_type.is_some()) + usize::from(kind == Symbol::new("op"));
         for (old, new) in source_args
             .into_iter()
-            .zip(self.ctx.block_args(block)[1..].iter().copied())
+            .zip(self.ctx.block_args(block)[source_offset..].iter().copied())
         {
             mapping.insert(old, new);
         }
         let evidence = self.ctx.block_args(block)[0];
+        let resume_evidence = (kind == Symbol::new("op")).then(|| self.ctx.block_args(block)[2]);
         let convention = if kind == Symbol::new("fn") {
             CallingConvention::EvidenceDirect
         } else {
             CallingConvention::Cps
         };
+        let parent_values = parent_type.map(|_| {
+            self.unpack_parent(
+                block,
+                location,
+                outer_flow.boundary_result,
+                self.ctx.block_args(block)[1],
+            )
+        });
         let flow = Flow {
             convention,
             evidence: Some(evidence),
-            exit_k: (convention == CallingConvention::Cps).then_some(handle_exit),
-            root_exit_k: (convention == CallingConvention::Cps).then_some(handle_exit),
-            answer_type: handle_answer,
+            resume_evidence: resume_evidence.or(Some(evidence)),
+            done: parent_values.map(|(done, _)| done),
+            dispatch: parent_values.map(|(_, dispatch)| dispatch),
+            boundary_result: outer_flow.boundary_result,
+            resume_after: outer_flow.resume_after,
+            resume_done: outer_flow.resume_done,
+            void_done: outer_flow.void_done,
+            preserve_scf_yield: false,
         };
         self.convert_sequence(
             self.ctx.block(source_block).ops.to_vec(),
@@ -2161,7 +3218,7 @@ impl<'a> Converter<'a> {
             self.convert_type(operation_result)
         };
         let function = core::func(self.ctx, result, params).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let closure_type = physical_closure_type(self.ctx, function, convention);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), convention);
         Ok(HandlerArmInfo {
@@ -2173,6 +3230,7 @@ impl<'a> Converter<'a> {
             operation_result: self.convert_type(operation_result),
             params: converted_args,
             has_resume_token,
+            parent_type,
         })
     }
 
@@ -2221,6 +3279,38 @@ impl<'a> Converter<'a> {
         arms: &[HandlerArmInfo],
         general: bool,
     ) -> (OpRef, ValueRef) {
+        // The marker's compatibility handler slot is deliberately not a final
+        // control path.  Final `effect.dispatch_cps` reaches the exact local
+        // dispatcher factory above, where a `Parent<A>` is available.  Keep a
+        // typed rejecting placeholder here instead of casting the old marker
+        // continuation into the new `ResumeExact<I, A>` ABI.
+        if general {
+            let evidence_type = self.evidence_type();
+            let parent_type = arms
+                .iter()
+                .find(|arm| arm.kind == Symbol::new("op"))
+                .and_then(|arm| arm.parent_type)
+                .unwrap_or_else(|| self.parent_types(arms[0].operation_result).reference);
+            let i32_type = self.i32_type();
+            let anyref = self.anyref_type();
+            let params = [evidence_type, parent_type, i32_type, anyref];
+            let block = self.make_block(location, &params);
+            let unreachable = func::unreachable(self.ctx, location);
+            self.ctx.push_op(block, unreachable.op_ref());
+            let region = self.single_block_region(location, block);
+            let never = self.never_type();
+            let function = core::func(self.ctx, never, params).as_type_ref();
+            let closure_type = physical_closure_type(self.ctx, function, CallingConvention::Cps);
+            let lambda = closure::lambda(
+                self.ctx,
+                location,
+                std::iter::empty::<ValueRef>(),
+                closure_type,
+                region,
+            );
+            set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+            return (lambda.op_ref(), lambda.result(self.ctx));
+        }
         let evidence_type = self.evidence_type();
         let anyref = self.anyref_type();
         let i32_type = self
@@ -2311,19 +3401,415 @@ impl<'a> Converter<'a> {
 
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
+        let convention = if general {
+            CallingConvention::Cps
+        } else {
+            CallingConvention::EvidenceDirect
+        };
         let function = core::func(self.ctx, result, params).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let closure_type = physical_closure_type(self.ctx, function, convention);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
-        set_calling_convention(
-            self.ctx,
-            lambda.op_ref(),
-            if general {
-                CallingConvention::Cps
-            } else {
-                CallingConvention::EvidenceDirect
-            },
-        );
+        set_calling_convention(self.ctx, lambda.op_ref(), convention);
         (lambda.op_ref(), lambda.result(self.ctx))
+    }
+
+    /// Emit an immutable recursive factory for a lexical handle dispatcher.
+    /// A factory invocation captures one exact `Parent<A>` in the returned
+    /// dispatcher.  Resuming a body invokes the same factory with a new
+    /// parent, so a nested resume cannot overwrite an outer arm suffix.
+    fn build_local_cps_dispatch_factory(
+        &mut self,
+        location: Location,
+        arms: &[HandlerArmInfo],
+        body_type: TypeRef,
+        answer_type: TypeRef,
+    ) -> Symbol {
+        let symbol = self.fresh_helper("make_local_dispatch");
+        let parent_type = self.parent_types(answer_type).reference;
+        let evidence_type = self.evidence_type();
+        let i32_type = self.i32_type();
+        let completion_type = self.completion_type(body_type, answer_type);
+        let mut params = vec![parent_type, evidence_type, i32_type, completion_type];
+        params.extend(arms.iter().map(|arm| self.ctx.value_ty(arm.value)));
+        let dispatch_type = self.dispatch_type(body_type);
+        let factory_type = core::func(self.ctx, dispatch_type, params.clone()).as_type_ref();
+        let factory_block = self.make_block(location, &params);
+        let args = self.ctx.block_args(factory_block).to_vec();
+        let mut factory_arms = arms.to_vec();
+        for (arm, value) in factory_arms.iter_mut().zip(args[4..].iter().copied()) {
+            arm.value = value;
+        }
+        let (_, parent_dispatch) =
+            self.unpack_parent(factory_block, location, answer_type, args[0]);
+        let foreign_factory = LocalDispatchFactory {
+            factory: symbol,
+            args: args[1..].to_vec(),
+        };
+        let (foreign_op, foreign_dispatch) = self.build_local_foreign_dispatch(
+            location,
+            body_type,
+            answer_type,
+            parent_dispatch,
+            args[3],
+            foreign_factory,
+        );
+        self.ctx.push_op(factory_block, foreign_op);
+        let dispatcher = self.build_local_cps_dispatcher_instance(
+            location,
+            &factory_arms,
+            body_type,
+            answer_type,
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            foreign_dispatch,
+            symbol,
+            args[1..].to_vec(),
+        );
+        self.ctx.push_op(factory_block, dispatcher.0);
+        let ret = func::r#return(self.ctx, location, [dispatcher.1]);
+        self.ctx.push_op(factory_block, ret.op_ref());
+        let region = self.single_block_region(location, factory_block);
+        let factory = func::func(self.ctx, location, symbol, factory_type, region);
+        set_calling_convention(self.ctx, factory.op_ref(), CallingConvention::Direct);
+        self.ctx.push_op(self.module_block, factory.op_ref());
+        symbol
+    }
+
+    /// Forward a foreign operation through the enclosing dispatcher while
+    /// retaining this lexical handle's factory for a later resumption.
+    fn build_local_foreign_dispatch(
+        &mut self,
+        location: Location,
+        body_type: TypeRef,
+        answer_type: TypeRef,
+        parent_dispatch: ValueRef,
+        completion: ValueRef,
+        local_factory: LocalDispatchFactory,
+    ) -> (OpRef, ValueRef) {
+        let evidence_type = self.evidence_type();
+        let i32_type = self.i32_type();
+        let anyref = self.anyref_type();
+        let body_resume_type = self.erased_resumption_type(body_type);
+        let block = self.make_block(
+            location,
+            &[
+                evidence_type,
+                body_resume_type,
+                i32_type,
+                i32_type,
+                i32_type,
+                anyref,
+            ],
+        );
+        let args = self.ctx.block_args(block).to_vec();
+        let (resume_op, resume) = self.build_rebound_resume(
+            location,
+            body_type,
+            answer_type,
+            args[1],
+            completion,
+            ResumeDispatchRebuild::LocalFactory(local_factory),
+        );
+        self.ctx.push_op(block, resume_op);
+        let foreign_tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            parent_dispatch,
+            [args[0], resume, args[2], args[3], args[4], args[5]],
+        );
+        set_calling_convention(self.ctx, foreign_tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(block, foreign_tail.op_ref());
+        let region = self.single_block_region(location, block);
+        let dispatch_type = self.dispatch_type(body_type);
+        let dispatch = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, region),
+            dispatch_type,
+            region,
+        );
+        set_calling_convention(self.ctx, dispatch.op_ref(), CallingConvention::Cps);
+        (dispatch.op_ref(), dispatch.result(self.ctx))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_local_cps_dispatcher_instance(
+        &mut self,
+        location: Location,
+        arms: &[HandlerArmInfo],
+        body_type: TypeRef,
+        answer_type: TypeRef,
+        parent: ValueRef,
+        outer_evidence: ValueRef,
+        prompt_tag: ValueRef,
+        completion: ValueRef,
+        foreign_dispatch: ValueRef,
+        factory: Symbol,
+        factory_static_args: Vec<ValueRef>,
+    ) -> (OpRef, ValueRef) {
+        let anyref = self.anyref_type();
+        let i32_type = self.i32_type();
+        let i1_type = self
+            .ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i1")).build());
+        let evidence_type = self.evidence_type();
+        let params = [
+            evidence_type,
+            self.erased_resumption_type(body_type),
+            i32_type,
+            i32_type,
+            i32_type,
+            anyref,
+        ];
+        let block = self.make_block(location, &params);
+        let args = self.ctx.block_args(block).to_vec();
+        let effect_evidence = args[0];
+        let resume = args[1];
+        let prompt = args[2];
+        let ability_id = args[3];
+        let op_id = args[4];
+        let payload = args[5];
+
+        let foreign_block = self.make_block(location, &[]);
+        let foreign_tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            foreign_dispatch,
+            [effect_evidence, resume, prompt, ability_id, op_id, payload],
+        );
+        set_calling_convention(self.ctx, foreign_tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(foreign_block, foreign_tail.op_ref());
+        let foreign_region = self.single_block_region(location, foreign_block);
+
+        let selected_block = self.make_block(location, &[]);
+        for arm in arms.iter().filter(|arm| arm.kind == Symbol::new("op")) {
+            let case_block = self.make_block(location, &[]);
+            let arm_ability =
+                ability::ability_id_const(self.ctx, location, i32_type, arm.ability_ref);
+            self.ctx.push_op(case_block, arm_ability.op_ref());
+            let same_ability = arith::cmpi(
+                self.ctx,
+                location,
+                ability_id,
+                arm_ability.result(self.ctx),
+                i1_type,
+                Symbol::new("eq"),
+            );
+            self.ctx.push_op(case_block, same_ability.op_ref());
+
+            let local_block = self.make_block(location, &[]);
+            let mut call_args = vec![outer_evidence, parent, effect_evidence];
+            call_args.extend(self.unpack_handler_payload(local_block, location, payload, arm));
+            if arm.has_resume_token {
+                let token_type = *arm.params.last().expect("resume arm has token type");
+                let token_function = cps_closure_function_type(self.ctx, token_type)
+                    .expect("pre-CPS validation proved a CPS resume token closure");
+                let input_type =
+                    *self.ctx.types.get(token_function).params.get(3).expect(
+                        "resume token has Evidence, Parent and exact source-input parameters",
+                    );
+                let (token_op, token) = self.build_exact_handler_token(
+                    location,
+                    HandlerTokenFactory {
+                        resume_body: resume,
+                        completion,
+                        input_type,
+                        body_type,
+                        answer_type,
+                        dispatch_factory: factory,
+                        dispatch_factory_args: factory_static_args.clone(),
+                    },
+                );
+                self.ctx.push_op(local_block, token_op);
+                call_args.push(token);
+            }
+            let local_tail = func::tail_call_indirect(self.ctx, location, arm.value, call_args);
+            set_calling_convention(self.ctx, local_tail.op_ref(), CallingConvention::Cps);
+            self.ctx.push_op(local_block, local_tail.op_ref());
+            let local_region = self.single_block_region(location, local_block);
+
+            let fallback_block = self.make_block(location, &[]);
+            let fallback_tail = func::tail_call_indirect(
+                self.ctx,
+                location,
+                foreign_dispatch,
+                [effect_evidence, resume, prompt, ability_id, op_id, payload],
+            );
+            set_calling_convention(self.ctx, fallback_tail.op_ref(), CallingConvention::Cps);
+            self.ctx.push_op(fallback_block, fallback_tail.op_ref());
+            let fallback_region = self.single_block_region(location, fallback_block);
+            let never = self.never_type();
+            let choice = scf::r#if(
+                self.ctx,
+                location,
+                same_ability.result(self.ctx),
+                never,
+                local_region,
+                fallback_region,
+            );
+            self.ctx.push_op(case_block, choice.op_ref());
+            let case_region = self.single_block_region(location, case_block);
+            let op_index = ability::compute_op_idx(
+                self.ctx.types.get(arm.ability_ref).attrs.get_symbol("name"),
+                Some(arm.op_name),
+            );
+            let case = scf::case(
+                self.ctx,
+                location,
+                Attribute::Int(op_index as i128),
+                case_region,
+            );
+            self.ctx.push_op(selected_block, case.op_ref());
+        }
+        let default_block = self.make_block(location, &[]);
+        let default_tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            foreign_dispatch,
+            [effect_evidence, resume, prompt, ability_id, op_id, payload],
+        );
+        set_calling_convention(self.ctx, default_tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(default_block, default_tail.op_ref());
+        let default_region = self.single_block_region(location, default_block);
+        let default = scf::default(self.ctx, location, default_region);
+        self.ctx.push_op(selected_block, default.op_ref());
+        let selected_region = self.single_block_region(location, selected_block);
+        let selected = scf::switch(self.ctx, location, op_id, selected_region);
+
+        let same_prompt = arith::cmpi(
+            self.ctx,
+            location,
+            prompt,
+            prompt_tag,
+            i1_type,
+            Symbol::new("eq"),
+        );
+        self.ctx.push_op(block, same_prompt.op_ref());
+        let local_switch_block = self.make_block(location, &[]);
+        self.ctx.push_op(local_switch_block, selected.op_ref());
+        let local_switch_region = self.single_block_region(location, local_switch_block);
+        let never = self.never_type();
+        let choose = scf::r#if(
+            self.ctx,
+            location,
+            same_prompt.result(self.ctx),
+            never,
+            local_switch_region,
+            foreign_region,
+        );
+        self.ctx.push_op(block, choose.op_ref());
+        let region = self.single_block_region(location, block);
+        let captures = ordered_external_values(self.ctx, region);
+        let dispatch_type = self.dispatch_type(body_type);
+        let lambda = closure::lambda(self.ctx, location, captures, dispatch_type, region);
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        (lambda.op_ref(), lambda.result(self.ctx))
+    }
+
+    /// Adapt a typed handler token without erasing a continuation. Only the
+    /// source operation input crosses the exact `I -> anyref` boundary.
+    fn build_exact_handler_token(
+        &mut self,
+        location: Location,
+        factory: HandlerTokenFactory,
+    ) -> (OpRef, ValueRef) {
+        let HandlerTokenFactory {
+            resume_body,
+            completion,
+            input_type,
+            body_type,
+            answer_type,
+            dispatch_factory,
+            dispatch_factory_args,
+        } = factory;
+        let anyref = self.anyref_type();
+        let evidence_type = self.evidence_type();
+        let answer_parent_type = self.parent_types(answer_type).reference;
+        let exact_block =
+            self.make_block(location, &[evidence_type, answer_parent_type, input_type]);
+        let exact_args = self.ctx.block_args(exact_block).to_vec();
+        let resume_block = self.make_block(location, &[evidence_type, answer_parent_type, anyref]);
+        let resume_args = self.ctx.block_args(resume_block).to_vec();
+        let next_block = self.make_block(location, &[body_type]);
+        let next_value = self.ctx.block_args(next_block)[0];
+        let next_tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            completion,
+            [resume_args[0], resume_args[1], next_value],
+        );
+        set_calling_convention(self.ctx, next_tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(next_block, next_tail.op_ref());
+        let next_region = self.single_block_region(location, next_block);
+        let next_captures = ordered_external_values(self.ctx, next_region);
+        let body_done_type = self.done_k_type(body_type);
+        let next_done = closure::lambda(
+            self.ctx,
+            location,
+            next_captures,
+            body_done_type,
+            next_region,
+        );
+        set_calling_convention(self.ctx, next_done.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(resume_block, next_done.op_ref());
+        let mut factory_args = vec![resume_args[1]];
+        factory_args.extend(dispatch_factory_args);
+        let body_dispatch_type = self.dispatch_type(body_type);
+        let dispatch = func::call(
+            self.ctx,
+            location,
+            factory_args,
+            body_dispatch_type,
+            dispatch_factory,
+        );
+        set_calling_convention(self.ctx, dispatch.op_ref(), CallingConvention::Direct);
+        self.ctx.push_op(resume_block, dispatch.op_ref());
+        let parent = self.pack_parent(
+            resume_block,
+            location,
+            body_type,
+            next_done.result(self.ctx),
+            dispatch.result(self.ctx),
+        );
+        let resume_tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            resume_body,
+            [resume_args[0], parent, resume_args[2]],
+        );
+        set_calling_convention(self.ctx, resume_tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(resume_block, resume_tail.op_ref());
+        let resume_region = self.single_block_region(location, resume_block);
+        let resume_captures = ordered_external_values(self.ctx, resume_region);
+        let erased_resume_type = self.erased_resumption_type(answer_type);
+        let resume = closure::lambda(
+            self.ctx,
+            location,
+            resume_captures,
+            erased_resume_type,
+            resume_region,
+        );
+        set_calling_convention(self.ctx, resume.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(exact_block, resume.op_ref());
+        let erased = core::unrealized_conversion_cast(self.ctx, location, exact_args[2], anyref);
+        self.ctx.push_op(exact_block, erased.op_ref());
+        let tail = func::tail_call_indirect(
+            self.ctx,
+            location,
+            resume.result(self.ctx),
+            [exact_args[0], exact_args[1], erased.result(self.ctx)],
+        );
+        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(exact_block, tail.op_ref());
+        let exact_region = self.single_block_region(location, exact_block);
+        let exact_captures = ordered_external_values(self.ctx, exact_region);
+        let token_type = self.resumption_type(input_type, answer_type);
+        let token = closure::lambda(self.ctx, location, exact_captures, token_type, exact_region);
+        set_calling_convention(self.ctx, token.op_ref(), CallingConvention::Cps);
+        (token.op_ref(), token.result(self.ctx))
     }
 
     fn lower_handle(
@@ -2361,6 +3847,19 @@ impl<'a> Converter<'a> {
             _ => unreachable!("handle continuation is produced by closure.lambda"),
         };
         self.ctx.push_op(block, after_handle_op);
+        let i32_type = self.i32_type();
+        let prompt_tag = effect::fresh_prompt_tag(self.ctx, location, i32_type);
+        let prompt_tag_value = prompt_tag.result(self.ctx);
+        self.ctx.push_op(block, prompt_tag.op_ref());
+
+        // A normal handler-arm yield has answer type `A`, but general
+        // operations inside the arm still cross the enclosing `O` dispatch
+        // boundary. `after_done` is the sole immutable bridge between them.
+        let (after_adapter_ops, after_done, after_dispatch) =
+            self.build_cps_call_adapters(handle_answer, after_handle, flow, location)?;
+        for op in after_adapter_ops {
+            self.ctx.push_op(block, op);
+        }
 
         let regions = self.ctx.op(source).regions.to_vec();
         let [body_source, completion_source, handlers_region] = regions.as_slice() else {
@@ -2371,8 +3870,20 @@ impl<'a> Converter<'a> {
         let handlers_block = self.ctx.region(handlers_region).blocks[0];
         let mut handler_arms = Vec::new();
         let source_handlers = self.ctx.block(handlers_block).ops.to_vec();
+        let handler_flow = Flow {
+            convention: CallingConvention::Cps,
+            evidence: flow.evidence,
+            resume_evidence: flow.resume_evidence,
+            done: None,
+            dispatch: None,
+            boundary_result: handle_answer,
+            resume_after: None,
+            resume_done: None,
+            void_done: None,
+            preserve_scf_yield: false,
+        };
         for handler in source_handlers {
-            let arm = self.lower_handler_arm(handler, mapping, after_handle, handle_answer)?;
+            let arm = self.lower_handler_arm(handler, mapping, &handler_flow)?;
             self.ctx.push_op(block, arm.op);
             handler_arms.push(arm);
         }
@@ -2406,20 +3917,71 @@ impl<'a> Converter<'a> {
         let body_flow_base = Flow {
             convention: CallingConvention::Cps,
             evidence: Some(extended_evidence),
-            exit_k: Some(after_handle),
-            root_exit_k: Some(after_handle),
-            answer_type: handle_answer,
+            resume_evidence: Some(extended_evidence),
+            done: None,
+            dispatch: Some(after_dispatch),
+            boundary_result: handle_answer,
+            resume_after: None,
+            resume_done: None,
+            void_done: None,
+            preserve_scf_yield: false,
         };
         let (completion_op, completion_k) = self.build_completion_continuation(
             completion_source,
-            after_handle,
             &body_mapping,
             &body_flow_base,
             location,
         )?;
         self.ctx.push_op(body_block, completion_op);
+        let body_type = self.convert_type(
+            self.ctx.value_ty(
+                self.ctx
+                    .block_args(self.ctx.region(completion_source).blocks[0])[0],
+            ),
+        );
+        let after_parent = self.pack_parent(
+            body_block,
+            location,
+            handle_answer,
+            after_done,
+            after_dispatch,
+        );
+        let (body_done_op, body_done) = self.build_done_adapter(
+            body_type,
+            completion_k,
+            extended_evidence,
+            after_parent,
+            location,
+        );
+        self.ctx.push_op(body_block, body_done_op);
+        let outer_evidence = self.current_evidence(source, flow)?;
+        let local_dispatch_factory = self.build_local_cps_dispatch_factory(
+            location,
+            &handler_arms,
+            body_type,
+            handle_answer,
+        );
+        let mut local_factory_args =
+            vec![after_parent, outer_evidence, prompt_tag_value, completion_k];
+        local_factory_args.extend(handler_arms.iter().map(|arm| arm.value));
+        let body_dispatch_type = self.dispatch_type(body_type);
+        let local_dispatch_call = func::call(
+            self.ctx,
+            location,
+            local_factory_args,
+            body_dispatch_type,
+            local_dispatch_factory,
+        );
+        set_calling_convention(
+            self.ctx,
+            local_dispatch_call.op_ref(),
+            CallingConvention::Direct,
+        );
+        self.ctx.push_op(body_block, local_dispatch_call.op_ref());
         let body_flow = Flow {
-            exit_k: Some(completion_k),
+            done: Some(body_done),
+            dispatch: Some(local_dispatch_call.result(self.ctx)),
+            boundary_result: body_type,
             ..body_flow_base
         };
         let source_body_block = self.ctx.region(body_source).blocks[0];
@@ -2436,6 +3998,7 @@ impl<'a> Converter<'a> {
             self.ctx,
             location,
             current_evidence,
+            prompt_tag_value,
             dispatchers,
             Attribute::List(ability_refs.into_iter().map(Attribute::Type).collect()),
             body_region,
@@ -2458,8 +4021,24 @@ impl<'a> Converter<'a> {
             let dialect = self.ctx.op(source).dialect;
             let name = self.ctx.op(source).name;
             if dialect == Symbol::new("scf") && name == Symbol::new("yield") {
+                if flow.preserve_scf_yield {
+                    let cloned = self.clone_plain_op(source, mapping)?;
+                    self.ctx.push_op(block, cloned);
+                    return Ok(());
+                }
                 let values = self.ctx.op_operands(source);
                 if values.is_empty() {
+                    if let Some(void_done) = flow.void_done {
+                        let tail = func::tail_call_indirect(
+                            self.ctx,
+                            location,
+                            void_done,
+                            std::iter::empty::<ValueRef>(),
+                        );
+                        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+                        self.ctx.push_op(block, tail.op_ref());
+                        return Ok(());
+                    }
                     self.emit_void_exit(block, location, flow)?;
                     return Ok(());
                 }
@@ -2489,6 +4068,34 @@ impl<'a> Converter<'a> {
                 self.lower_structured_if(source, &source_ops, index, block, mapping, flow)?;
                 return Ok(());
             }
+            // Source case lowering can use an unrealized cast into the
+            // logical bottom solely to join an `op -> Never` arm with a
+            // normal arm. At a proven CPS structured exit, that cast carries
+            // no runtime value: route the represented input directly to the
+            // active `Flow<R>` instead. Any other Never cast remains for the
+            // named boundary verifier to reject.
+            if flow.convention == CallingConvention::Cps
+                && dialect == Symbol::new("core")
+                && name == Symbol::new("unrealized_conversion_cast")
+            {
+                let results = self.ctx.op_results(source);
+                let operands = self.ctx.op_operands(source);
+                if let ([result], [input]) = (results, operands)
+                    && type_is(self.ctx, self.ctx.value_ty(*result), "core", "never")
+                    && !self.ctx.uses(*result).is_empty()
+                    && self.ctx.uses(*result).iter().all(|use_| {
+                        self.ctx.op(use_.user).dialect == Symbol::new("scf")
+                            && self.ctx.op(use_.user).name == Symbol::new("yield")
+                    })
+                {
+                    let input = mapping.get(input).copied().unwrap_or(*input);
+                    if self.ctx.value_ty(input) == flow.boundary_result {
+                        mapping.insert(*result, input);
+                        index += 1;
+                        continue;
+                    }
+                }
+            }
             if dialect != Symbol::new("tribute_control") {
                 let cloned = self.clone_plain_op(source, mapping)?;
                 self.ctx.push_op(block, cloned);
@@ -2497,6 +4104,11 @@ impl<'a> Converter<'a> {
             }
 
             match name.with_str(|value| value.to_owned()).as_str() {
+                "unreachable" => {
+                    let unreachable = func::unreachable(self.ctx, location);
+                    self.ctx.push_op(block, unreachable.op_ref());
+                    return Ok(());
+                }
                 "return" | "yield" => {
                     let value = self.ctx.op_operands(source)[0];
                     let value = mapping.get(&value).copied().unwrap_or(value);
@@ -2525,7 +4137,7 @@ impl<'a> Converter<'a> {
                         .get_symbol("callee")
                         .expect("pre-CPS validation checked direct callee");
                     let target = self
-                        .current_func(target_symbol)
+                        .current_direct_call_target(source, target_symbol)
                         .expect("pre-CPS validation resolved direct callee in this module");
                     if target.convention == CallingConvention::Cps {
                         if flow.convention != CallingConvention::Cps {
@@ -2533,12 +4145,15 @@ impl<'a> Converter<'a> {
                                 POST_CPS_BOUNDARY,
                                 Some(source),
                                 Some(location),
-                                "a non-CPS callable cannot call a CPS target",
+                                format!(
+                                    "a {:?} callable cannot call CPS target @{}",
+                                    flow.convention, target_symbol
+                                ),
                             ));
                         }
                         let old_result = self.ctx.op_result(source, 0);
                         let result_type = self.ctx.op_result_types(source)[0];
-                        let continuation = self.build_suffix_continuation(
+                        let completion = self.build_suffix_continuation(
                             &source_ops,
                             index + 1,
                             old_result,
@@ -2547,12 +4162,19 @@ impl<'a> Converter<'a> {
                             flow,
                             location,
                         )?;
-                        let continuation_op = match self.ctx.value_def(continuation) {
+                        let completion_op = match self.ctx.value_def(completion) {
                             trunk_ir::ValueDef::OpResult(op, _) => op,
                             _ => unreachable!("continuation is produced by closure.lambda"),
                         };
-                        self.ctx.push_op(block, continuation_op);
-                        let mut args = vec![self.current_evidence(source, flow)?, continuation];
+                        self.ctx.push_op(block, completion_op);
+                        let value_type = self.convert_type(result_type);
+                        let (adapter_ops, done, dispatch) =
+                            self.build_cps_call_adapters(value_type, completion, flow, location)?;
+                        for op in adapter_ops {
+                            self.ctx.push_op(block, op);
+                        }
+                        let mut args =
+                            vec![self.current_resume_evidence(source, flow)?, done, dispatch];
                         args.extend(
                             self.ctx
                                 .op_operands(source)
@@ -2591,7 +4213,7 @@ impl<'a> Converter<'a> {
                         }
                         let old_result = self.ctx.op_result(source, 0);
                         let result_type = self.ctx.op_result_types(source)[0];
-                        let continuation = self.build_suffix_continuation(
+                        let completion = self.build_suffix_continuation(
                             &source_ops,
                             index + 1,
                             old_result,
@@ -2600,12 +4222,19 @@ impl<'a> Converter<'a> {
                             flow,
                             location,
                         )?;
-                        let continuation_op = match self.ctx.value_def(continuation) {
+                        let completion_op = match self.ctx.value_def(completion) {
                             trunk_ir::ValueDef::OpResult(op, _) => op,
                             _ => unreachable!("continuation is produced by closure.lambda"),
                         };
-                        self.ctx.push_op(block, continuation_op);
-                        let mut args = vec![self.current_evidence(source, flow)?, continuation];
+                        self.ctx.push_op(block, completion_op);
+                        let value_type = self.convert_type(result_type);
+                        let (adapter_ops, done, dispatch) =
+                            self.build_cps_call_adapters(value_type, completion, flow, location)?;
+                        for op in adapter_ops {
+                            self.ctx.push_op(block, op);
+                        }
+                        let mut args =
+                            vec![self.current_resume_evidence(source, flow)?, done, dispatch];
                         args.extend(
                             source_args
                                 .iter()
@@ -2751,11 +4380,12 @@ impl<'a> Converter<'a> {
         let abi = CallableAbi::new(info.convention, source_params, source_result);
         let evidence_ty = self.evidence_type();
         let done_k_ty = self.done_k_type(source_result);
-        let params = abi.lowered_params(evidence_ty, done_k_ty);
+        let dispatch_ty = self.dispatch_type(source_result);
+        let params = abi.lowered_params_with_dispatch(evidence_ty, done_k_ty, dispatch_ty);
         let block = self.make_block(location, &params);
         let mut mapping = HashMap::new();
         for (old, new) in self.ctx.block_args(source_block).to_vec().into_iter().zip(
-            self.ctx.block_args(block)[abi.source_param_offset()..]
+            self.ctx.block_args(block)[abi.source_param_offset_with_dispatch()..]
                 .iter()
                 .copied(),
         ) {
@@ -2765,16 +4395,26 @@ impl<'a> Converter<'a> {
             .convention
             .needs_evidence()
             .then(|| self.ctx.block_args(block)[0]);
-        let exit_k = info
+        let done_index = usize::from(info.convention.needs_evidence());
+        let done = info
             .convention
             .needs_done_k()
-            .then(|| self.ctx.block_args(block)[usize::from(info.convention.needs_evidence())]);
+            .then(|| self.ctx.block_args(block)[done_index]);
+        let dispatch = info
+            .convention
+            .needs_done_k()
+            .then(|| self.ctx.block_args(block)[done_index + 1]);
         let flow = Flow {
             convention: info.convention,
             evidence,
-            exit_k,
-            root_exit_k: exit_k,
-            answer_type: source_result,
+            resume_evidence: evidence,
+            done,
+            dispatch,
+            boundary_result: source_result,
+            resume_after: None,
+            resume_done: None,
+            void_done: None,
+            preserve_scf_yield: false,
         };
         self.convert_sequence(
             self.ctx.block(source_block).ops.to_vec(),
@@ -2874,6 +4514,8 @@ fn collect_callable_graph(
                             convention: convert_convention(convention),
                             source_result: callable.result(ctx),
                             source_params: callable.params(ctx).to_vec(),
+                            intrinsic_declaration: data.regions.is_empty()
+                                && data.attributes.get_str("abi") == Some("intrinsic"),
                         },
                     );
                 }
@@ -2909,8 +4551,12 @@ fn verify_candidate_or_restore_aliases(
     ctx: &mut IrContext,
     candidate: Module,
     source_aliases: &[(Symbol, TypeRef)],
+    generated_aliases: &[(Symbol, TypeRef)],
 ) -> Result<(), TributeControlToCpsError> {
     if let Err(error) = verify_tribute_control_post_cps(ctx, candidate) {
+        for (name, _) in generated_aliases {
+            ctx.remove_type_alias(*name);
+        }
         for (name, ty) in source_aliases {
             ctx.register_type_alias(*name, *ty);
         }
@@ -2951,6 +4597,7 @@ pub fn tribute_control_to_cps(
     let module_location = ctx.op(module.op()).location;
     let source_aliases = ctx.type_aliases().to_vec();
     let mut converted_aliases = Vec::with_capacity(source_aliases.len());
+    let generated_parent_aliases;
     let new_block = ctx.create_block(BlockData {
         location: ctx.block(source_blocks[0]).location,
         args: vec![],
@@ -2982,7 +4629,9 @@ pub fn tribute_control_to_cps(
                 .iter()
                 .map(|(name, ty)| (*name, converter.convert_type(*ty))),
         );
+        generated_parent_aliases = converter.parent_layout_aliases.clone();
     }
+    converted_aliases.extend(generated_parent_aliases.iter().copied());
     let new_region = ctx.create_region(RegionData {
         location: ctx.region(source_region).location,
         blocks: trunk_ir::smallvec::smallvec![new_block],
@@ -2994,7 +4643,12 @@ pub fn tribute_control_to_cps(
     for (name, ty) in &converted_aliases {
         ctx.register_type_alias(*name, *ty);
     }
-    verify_candidate_or_restore_aliases(ctx, candidate, &source_aliases)?;
+    verify_candidate_or_restore_aliases(
+        ctx,
+        candidate,
+        &source_aliases,
+        &generated_parent_aliases,
+    )?;
 
     ctx.detach_region(new_region);
     ctx.remove_op(candidate.op());
@@ -3005,6 +4659,9 @@ pub fn tribute_control_to_cps(
         ctx.detach_region(new_region);
         ctx.op_mut(module.op()).regions.push(source_region);
         ctx.region_mut(source_region).parent_op = Some(module.op());
+        for (name, _) in &generated_parent_aliases {
+            ctx.remove_type_alias(*name);
+        }
         for (name, ty) in &source_aliases {
             ctx.register_type_alias(*name, *ty);
         }
@@ -3103,6 +4760,34 @@ mod tests {
     }
 
     #[test]
+    fn logical_unreachable_legalizes_only_after_the_pre_cps_boundary() {
+        let input = r#"core.module @test {
+  tribute_control.func @select(%condition: core.i1, %value: core.i32) -> core.i32 convention(direct) {
+    %selected = scf.if %condition : core.i32 {
+      scf.yield %value
+    } {
+      tribute_control.unreachable
+    }
+    tribute_control.return %selected
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        verify_tribute_control_pre_cps(&ctx, module, &[]).unwrap();
+        let source = print_module(&ctx, module.op());
+        assert!(source.contains("tribute_control.unreachable"), "{source}");
+        assert!(!source.contains("func.unreachable"), "{source}");
+
+        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        let lowered = print_module(&ctx, module.op());
+        assert!(lowered.contains("func.unreachable"), "{lowered}");
+        assert!(
+            !lowered.contains("tribute_control.unreachable"),
+            "{lowered}"
+        );
+        verify_tribute_control_post_cps(&ctx, module).unwrap();
+    }
+
+    #[test]
     fn textual_direct_evidence_and_cps_transfers_preserve_exact_abis() {
         let input = r#"core.module @test {
   !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
@@ -3144,6 +4829,21 @@ mod tests {
         assert!(printed.contains("tribute.calling_convention = 1"));
         assert!(printed.contains("tribute.calling_convention = 2"));
         assert!(!printed.contains("tribute_control."), "{printed}");
+        let evidence = ability::evidence_adt_type_ref(&mut ctx);
+        let has_explicit_dispatch_context = ctx.types.iter().any(|(closure, _)| {
+            let Some(function) = cps_closure_function_type(&ctx, closure) else {
+                return false;
+            };
+            let params = &ctx.types.get(function).params;
+            params.len() == 4
+                && type_is(&ctx, params[0], "core", "never")
+                && params[1] == evidence
+                && tribute_core::cps_parent_result_type(&ctx, params[2]).is_some()
+        });
+        assert!(
+            has_explicit_dispatch_context,
+            "CPS callback ABI must retain explicit evidence before Parent<R>: {printed}"
+        );
 
         let mut reparsed = IrContext::new();
         let reparsed_module = parse_test_module(&mut reparsed, &printed);
@@ -3447,8 +5147,8 @@ mod tests {
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
         ctx.register_type_alias(alias_name, converted_type);
 
-        let error =
-            verify_candidate_or_restore_aliases(&mut ctx, candidate, &source_aliases).unwrap_err();
+        let error = verify_candidate_or_restore_aliases(&mut ctx, candidate, &source_aliases, &[])
+            .unwrap_err();
         assert_eq!(error.boundary, POST_CPS_BOUNDARY);
         assert_eq!(ctx.type_alias_by_name(alias_name), Some(source_type));
         assert_eq!(ctx.type_alias_by_type(source_type), Some(alias_name));
@@ -3498,6 +5198,30 @@ mod tests {
         let (ctx, module) = parse(malformed_delimiter);
         let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
         assert!(error.to_string().contains("requires an evidence operand"));
+    }
+
+    #[test]
+    fn pre_boundary_rejects_control_callable_cast_without_mutating_input() {
+        let input = r#"core.module @test {
+  !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  tribute_control.func @broken(%callback: !direct) -> core.i32 convention(direct) {
+    %forged = core.unrealized_conversion_cast %callback : !cps
+    %zero = arith.const {value = 0} : core.i32
+    tribute_control.return %zero
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let before = print_module(&ctx, module.op());
+        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+        assert!(
+            error
+                .to_string()
+                .contains("CPS control callables may not cross unrealized conversion casts"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]
@@ -3623,13 +5347,114 @@ mod tests {
     }
 
     #[test]
+    fn post_boundary_rejects_parent_mutation_control_cast_and_mismatched_resume() {
+        let input = r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = core.i32}
+  !done = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !resume = closure.closure(core.func(core.never, !parent, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !dispatch = closure.closure(core.func(core.never, !resume, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !parent_layout = adt.struct() {fields = [[@done, !done], [@dispatch, !dispatch]], name = @Parent, tribute.cps_parent_result = core.i32}
+  func.func @broken(%parent: !parent, %done: !done, %resume: !resume, %wrong: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    %erased = core.unrealized_conversion_cast %parent : tribute_rt.anyref
+    adt.struct_set %parent, %done {field = 0, type = !parent_layout}
+    func.tail_call_indirect %resume, %wrong {tribute.calling_convention = 2}
+  }
+}"#;
+        let (ctx, module) = parse(input);
+        let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        let text = error.to_string();
+        assert!(
+            text.contains("may not cross unrealized conversion casts"),
+            "{text}"
+        );
+        assert!(text.contains("Parent is immutable"), "{text}");
+        assert!(
+            text.contains("operands do not match its exact control closure signature"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn post_boundary_preflights_parent_layouts_and_rejects_obsolete_done_first_forms() {
+        let malformed = [
+            (
+                r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = core.i32}
+  func.func @dead(%parent: !parent) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+                "requires exactly one canonical immutable layout",
+            ),
+            (
+                r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = core.i32}
+  !done = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !resume = closure.closure(core.func(core.never, !parent, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !dispatch = closure.closure(core.func(core.never, !resume, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !layout = adt.struct() {fields = [[@dispatch, !dispatch], [@done, !done]], name = @Parent, tribute.cps_parent_result = core.i32}
+  func.func @dead(%parent: !parent) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+                "requires exactly one canonical immutable layout",
+            ),
+            (
+                r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = core.i32}
+  !other_parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = core.i64}
+  !done = closure.closure(core.func(core.never, core.i64)) {tribute.calling_convention = 2}
+  !resume = closure.closure(core.func(core.never, !other_parent, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !dispatch = closure.closure(core.func(core.never, !resume, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !layout = adt.struct() {fields = [[@done, !done], [@dispatch, !dispatch]], name = @Parent, tribute.cps_parent_result = core.i64}
+  func.func @dead(%parent: !parent) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+                "requires exactly one canonical immutable layout",
+            ),
+            (
+                r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = core.i32}
+  !done = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !resume = closure.closure(core.func(core.never, !parent, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !dispatch = closure.closure(core.func(core.never, !resume, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !canonical = adt.struct() {fields = [[@done, !done], [@dispatch, !dispatch]], name = @Parent, tribute.cps_parent_result = core.i32}
+  !conflicting = adt.struct() {fields = [[@dispatch, !dispatch], [@done, !done]], name = @Parent, tribute.cps_parent_result = core.i32}
+  func.func @dead(%parent: !parent) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+                "requires exactly one canonical immutable layout",
+            ),
+            (
+                r#"core.module @test {
+  !done = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !obsolete_completion = closure.closure(core.func(core.never, !done, core.i32)) {tribute.calling_convention = 2}
+  func.func @dead(%completion: !obsolete_completion) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+                "must take explicit Evidence, Parent<R>",
+            ),
+        ];
+        for (input, expected) in malformed {
+            let (ctx, module) = parse(input);
+            let before = print_module(&ctx, module.op());
+            let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+            assert!(error.to_string().contains(expected), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
     fn post_boundary_rejects_nonphysical_dispatchers_and_residual_control_ops() {
         let dispatcher_input = r#"core.module @test {
   !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !tr = closure.closure(core.func(tribute_rt.anyref, !evidence, core.i32, tribute_rt.anyref))
   !general = closure.closure(core.func(core.never, !evidence, tribute_rt.anyref, core.i32, tribute_rt.anyref))
-  func.func @caller(%ev: !evidence, %tr: !tr, %general: !general) -> core.never attributes {tribute.calling_convention = 2} {
-    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+  func.func @caller(%ev: !evidence, %prompt: core.i32, %tr: !tr, %general: !general) -> core.never attributes {tribute.calling_convention = 2} {
+    ability.handle_dispatch %ev, %prompt, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }
@@ -3646,14 +5471,14 @@ mod tests {
 
         let wrong_abi_input = r#"core.module @test {
   !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  func.func @caller(%ev: !evidence) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @caller(%ev: !evidence, %prompt: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     %tr = closure.lambda(%inner: !evidence) -> tribute_rt.anyref {tribute.calling_convention = 1} {
       func.unreachable
     }
     %general = closure.lambda(%inner: !evidence) -> core.never {tribute.calling_convention = 2} {
       func.unreachable
     }
-    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+    ability.handle_dispatch %ev, %prompt, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }
@@ -3670,14 +5495,14 @@ mod tests {
 
         let wrong_metadata_input = r#"core.module @test {
   !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  func.func @caller(%ev: !evidence) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @caller(%ev: !evidence, %prompt: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     %tr = closure.lambda(%inner: !evidence, %op_idx: core.i32, %payload: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 0} {
       func.unreachable
     }
     %general = closure.lambda(%inner: !evidence, %continuation: tribute_rt.anyref, %op_idx: core.i32, %payload: tribute_rt.anyref) -> core.never {tribute.calling_convention = 1} {
       func.unreachable
     }
-    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+    ability.handle_dispatch %ev, %prompt, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }
@@ -3798,9 +5623,86 @@ mod tests {
         find_one_shot_state_ops(&ctx, module.op(), &mut consumed_get, &mut consumed_set);
         assert_eq!(consumed_get, consumed_set);
         assert!(consumed_get.is_some(), "one-shot state was not emitted");
+
+        let mut parent_packs = 0;
+        let mut parent_dispatch_unpacks = 0;
+        let mut parent_mutations = 0;
+        let mut control_casts = 0;
+        fn inspect_parent_flow(
+            ctx: &IrContext,
+            op: OpRef,
+            parent_packs: &mut usize,
+            parent_dispatch_unpacks: &mut usize,
+            parent_mutations: &mut usize,
+            control_casts: &mut usize,
+        ) {
+            let operands = ctx.op_operands(op);
+            if adt::StructNew::matches(ctx, op)
+                && ctx.op_results(op).first().is_some_and(|value| {
+                    tribute_core::cps_parent_result_type(ctx, ctx.value_ty(*value)).is_some()
+                })
+            {
+                *parent_packs += 1;
+            }
+            if adt::StructGet::matches(ctx, op)
+                && operands.first().is_some_and(|value| {
+                    tribute_core::cps_parent_result_type(ctx, ctx.value_ty(*value)).is_some()
+                })
+                && ctx.op(op).attributes.get_u32("field") == Ok(Some(1))
+            {
+                *parent_dispatch_unpacks += 1;
+            }
+            if adt::StructSet::matches(ctx, op)
+                && operands.first().is_some_and(|value| {
+                    tribute_core::cps_parent_result_type(ctx, ctx.value_ty(*value)).is_some()
+                })
+            {
+                *parent_mutations += 1;
+            }
+            if core::UnrealizedConversionCast::matches(ctx, op)
+                && (operands.first().is_some_and(|value| {
+                    tribute_core::cps_parent_result_type(ctx, ctx.value_ty(*value)).is_some()
+                        || cps_closure_function_type(ctx, ctx.value_ty(*value)).is_some()
+                }) || ctx.op_results(op).first().is_some_and(|value| {
+                    tribute_core::cps_parent_result_type(ctx, ctx.value_ty(*value)).is_some()
+                        || cps_closure_function_type(ctx, ctx.value_ty(*value)).is_some()
+                }))
+            {
+                *control_casts += 1;
+            }
+            for region in ctx.op(op).regions.iter().copied() {
+                for block in ctx.region(region).blocks.iter().copied() {
+                    for child in ctx.block(block).ops.iter().copied() {
+                        inspect_parent_flow(
+                            ctx,
+                            child,
+                            parent_packs,
+                            parent_dispatch_unpacks,
+                            parent_mutations,
+                            control_casts,
+                        );
+                    }
+                }
+            }
+        }
+        inspect_parent_flow(
+            &ctx,
+            module.op(),
+            &mut parent_packs,
+            &mut parent_dispatch_unpacks,
+            &mut parent_mutations,
+            &mut control_casts,
+        );
+        assert!(parent_packs >= 2, "expected immutable Parent flow packs");
+        assert!(
+            parent_dispatch_unpacks >= 1,
+            "raw resumptions must unpack the dynamic dispatch from Parent"
+        );
+        assert_eq!(parent_mutations, 0, "Parent must stay immutable");
+        assert_eq!(control_casts, 0, "control values must not be erased");
         let printed = print_module(&ctx, module.op());
         assert_eq!(printed.matches("ability.handle_dispatch").count(), 1);
-        assert!(!printed.contains("effect."));
+        assert!(printed.contains("effect.fresh_prompt_tag"));
         assert!(printed.contains("ability_refs = [core.ability_ref"));
         assert!(printed.contains("func.tail_call_indirect"));
         assert!(printed.contains("adt.struct_set"));
@@ -3887,7 +5789,7 @@ mod tests {
         let [delimiter] = delimiters.as_slice() else {
             panic!("expected one final delimiter");
         };
-        assert_eq!(ctx.op_operands(*delimiter).len(), 3);
+        assert_eq!(ctx.op_operands(*delimiter).len(), 4);
         let Some(Attribute::List(ability_refs)) = ctx.op(*delimiter).attributes.get("ability_refs")
         else {
             panic!("final delimiter must have ability_refs");
@@ -3896,7 +5798,7 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("value = 9"));
         assert!(printed.contains("func.tail_call_indirect"));
-        assert!(!printed.contains("effect."));
+        assert!(printed.contains("effect.fresh_prompt_tag"));
     }
 
     #[test]
@@ -4067,9 +5969,95 @@ mod tests {
         tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert_eq!(printed.matches("ability.handle_dispatch").count(), 2);
-        assert!(!printed.contains("effect."));
+        assert!(printed.contains("effect.fresh_prompt_tag"));
         assert!(printed.matches("func.tail_call_indirect").count() >= 3);
         assert!(!printed.contains("__tribute_cps_control"));
+    }
+
+    #[test]
+    fn foreign_resume_rebuilds_the_inner_local_dispatcher() {
+        let input = r#"core.module @test {
+  tribute_control.func @nested(%input: core.i32) -> core.i32 convention(cps) {
+    %outer = tribute_control.handle : core.i32 {
+      %inner = tribute_control.handle : core.i32 {
+        %first = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @A}, op_name = @ask, operation_kind = @op} : core.i32
+        %second = tribute_control.perform %first {ability_ref = core.ability_ref() {name = @B}, op_name = @ask, operation_kind = @op} : core.i32
+        tribute_control.yield %second
+      } {
+        ^inner_completion(%value: core.i32):
+          tribute_control.yield %value
+      } {
+        tribute_control.handler {ability_ref = core.ability_ref() {name = @B}, kind = @op, op_name = @ask, operation_result_type = core.i32} {
+          ^inner_arm(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+            %resumed = tribute_control.resume %token, %argument : core.i32
+            tribute_control.yield %resumed
+        }
+      }
+      tribute_control.yield %inner
+    } {
+      ^outer_completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @A}, kind = @op, op_name = @ask, operation_result_type = core.i32} {
+        ^outer_arm(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+          %resumed = tribute_control.resume %token, %argument : core.i32
+          tribute_control.yield %resumed
+      }
+    }
+    tribute_control.return %outer
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let mut abilities = HashMap::new();
+        for (ty, data) in ctx.types.iter() {
+            if data.dialect == Symbol::new("core")
+                && data.name == Symbol::new("ability_ref")
+                && let Some(name) = data.attrs.get_symbol("name")
+            {
+                abilities.insert(name, ty);
+            }
+        }
+        let declarations = [
+            tribute_control::OperationDeclaration::new(
+                abilities[&Symbol::new("A")],
+                Symbol::new("ask"),
+                Symbol::new("op"),
+                vec![i32_type],
+                i32_type,
+            ),
+            tribute_control::OperationDeclaration::new(
+                abilities[&Symbol::new("B")],
+                Symbol::new("ask"),
+                Symbol::new("op"),
+                vec![i32_type],
+                i32_type,
+            ),
+        ];
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        let printed = print_module(&ctx, module.op());
+        assert_eq!(printed.matches("ability.handle_dispatch").count(), 2);
+        assert_eq!(
+            printed
+                .matches("func.func @__tribute_make_local_dispatch")
+                .count(),
+            2,
+        );
+        assert!(
+            printed
+                .matches("callee = @__tribute_make_local_dispatch")
+                .count()
+                >= 6,
+            "the resumed foreign flow must rebuild the inner local dispatcher: {printed}"
+        );
+        assert!(!printed.contains("tribute_control."));
     }
 
     #[test]
@@ -4133,6 +6121,99 @@ mod tests {
         assert!(!printed.contains("@consumed"));
         assert!(!printed.contains("adt.struct_set"));
         assert!(!printed.contains("adt.ref_null"));
+    }
+
+    #[test]
+    fn textual_structured_never_keeps_the_outer_dispatch_resume_boundary() {
+        let input = r#"core.module @test {
+  tribute_control.func @abort_conditional(%input: core.i32, %condition: core.i1) -> core.i32 convention(cps) {
+    %never = scf.if %condition : core.never {
+      %abort = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @Abort}, op_name = @abort, operation_kind = @op} : core.never
+      scf.yield %abort
+    } {
+      %value = arith.const {value = 42} : core.i32
+      %coerced = core.unrealized_conversion_cast %value : core.never
+      scf.yield %coerced
+    }
+    tribute_control.return %input
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let ability_ref = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("ability_ref"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let never_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("never"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let declarations = [tribute_control::OperationDeclaration::new(
+            ability_ref,
+            Symbol::new("abort"),
+            Symbol::new("op"),
+            vec![i32_type],
+            never_type,
+        )];
+
+        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+
+        fn collect_performs(ctx: &IrContext, op: OpRef, performs: &mut Vec<OpRef>) {
+            if ability::Perform::matches(ctx, op) {
+                performs.push(op);
+            }
+            for region in ctx.op(op).regions.iter().copied() {
+                for block in ctx.region(region).blocks.iter().copied() {
+                    for child in ctx.block(block).ops.iter().copied() {
+                        collect_performs(ctx, child, performs);
+                    }
+                }
+            }
+        }
+
+        let mut performs = Vec::new();
+        collect_performs(&ctx, module.op(), &mut performs);
+        assert_eq!(performs.len(), 1);
+        for perform in performs {
+            let operands = ctx.op_operands(perform);
+            let dispatch = cps_closure_function_type(&ctx, ctx.value_ty(operands[1]))
+                .expect("structured Never perform must retain a typed Dispatch<R>");
+            assert_eq!(
+                ctx.value_ty(operands[2]),
+                ctx.types.get(dispatch).params[2],
+                "reject Resume<R> must match the active outer Dispatch<R>"
+            );
+        }
+
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("scf.if"));
+        assert!(printed.contains(" : core.never"));
+        assert_eq!(printed.matches("ability.perform").count(), 1);
+        assert!(
+            !printed.lines().any(|line| {
+                line.contains("core.unrealized_conversion_cast") && line.contains(": core.never")
+            }),
+            "bottom join coercion must not survive as a runtime Never value: {printed}"
+        );
+        assert!(!printed.contains("tribute_control."));
+        let mut reparsed = IrContext::new();
+        let reparsed_module = parse_test_module(&mut reparsed, &printed);
+        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
     }
 
     #[test]

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -20,6 +20,7 @@
 //! binary search (O(log n)) since the evidence array is maintained in sorted order
 //! by ability_id.
 
+use tribute_core::{CallingConvention, set_calling_convention};
 use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
@@ -253,8 +254,8 @@ impl RewritePattern for EffectExtendPattern {
             return false;
         };
 
-        let result_ty = ctx.op_result_types(op)[0];
         let loc = ctx.op(op).location;
+        let result_ty = ctx.op_result_types(op)[0];
         let call_result = insert_evidence_extend_call(
             ctx,
             loc,
@@ -348,90 +349,61 @@ impl RewritePattern for EffectDispatchCpsPattern {
         };
 
         let loc = ctx.op(op).location;
-        let result_ty = ctx.op_result_types(op)[0];
+        if !ctx.op_result_types(op).is_empty() {
+            return false;
+        }
         let ability_ref = dispatch_op.ability_ref(ctx);
-        let (dispatch_closure, owner_tag) = insert_dispatch_closure_and_owner(
+        let (table_idx, env) = insert_closure_parts(ctx, loc, dispatch_op.dispatch(ctx), rewriter);
+        let i32_ty = intern_i32(ctx);
+        let ability_id =
+            wasm_dialect::i32_const(ctx, loc, i32_ty, compute_ability_id(ctx, ability_ref));
+        let ability_id_value = ability_id.result(ctx);
+        rewriter.insert_op(ability_id.op_ref());
+        let marker_ty = ability::marker_adt_type_ref(ctx);
+        let marker = wasm_dialect::call(
             ctx,
             loc,
-            dispatch_op.evidence(ctx),
-            ability_ref,
-            rewriter,
+            [dispatch_op.evidence(ctx), ability_id_value],
+            [marker_ty],
+            Symbol::new(evidence_abi::LOOKUP),
         );
-        let (table_idx, env) = insert_closure_parts(ctx, loc, dispatch_closure, rewriter);
+        let prompt = wasm_dialect::struct_get(
+            ctx,
+            loc,
+            marker.results(ctx)[0],
+            i32_ty,
+            MARKER_IDX,
+            MarkerField::PromptTag.index(),
+        );
+        let prompt_value = prompt.result(ctx);
+        rewriter.insert_op(marker.op_ref());
+        rewriter.insert_op(prompt.op_ref());
         let op_idx = insert_op_idx_const(ctx, loc, ability_ref, dispatch_op.op_name(ctx), rewriter);
 
-        let call = wasm_dialect::call_indirect(
+        let tail = wasm_dialect::return_call_indirect(
             ctx,
             loc,
             [
                 table_idx,
                 dispatch_op.evidence(ctx),
                 env,
-                dispatch_op.continuation(ctx),
-                owner_tag,
+                dispatch_op.resume(ctx),
+                prompt_value,
+                ability_id_value,
                 op_idx,
                 dispatch_op.payload(ctx),
             ],
-            [result_ty],
             0,
             0,
         );
-        let call_result = call.results(ctx)[0];
-        rewriter.insert_op(call.op_ref());
-        rewriter.erase_op(vec![call_result]);
+        set_calling_convention(ctx, tail.op_ref(), CallingConvention::Cps);
+        rewriter.replace_op(tail.op_ref());
         true
     }
 
     fn name(&self) -> &'static str {
         "EffectDispatchCpsPattern"
     }
-}
-
-/// Extract the general handler closure and its dynamic owner from one selected
-/// Marker. WasmGC keeps both fields in the same immutable Marker struct.
-fn insert_dispatch_closure_and_owner(
-    ctx: &mut IrContext,
-    loc: Location,
-    evidence: ValueRef,
-    ability_ref_ty: TypeRef,
-    rewriter: &mut PatternRewriter<'_>,
-) -> (ValueRef, ValueRef) {
-    let ability_id = compute_ability_id(ctx, ability_ref_ty);
-    let i32_ty = intern_i32(ctx);
-    let marker_ty = ability::marker_adt_type_ref(ctx);
-    let closure_ty = crate::wasm::type_converter::closure_adt_type(ctx);
-
-    let ability_id_const = wasm_dialect::i32_const(ctx, loc, i32_ty, ability_id);
-    let lookup = wasm_dialect::call(
-        ctx,
-        loc,
-        [evidence, ability_id_const.result(ctx)],
-        [marker_ty],
-        Symbol::new(evidence_abi::LOOKUP),
-    );
-    let marker = lookup.results(ctx)[0];
-    let closure_get = wasm_dialect::struct_get(
-        ctx,
-        loc,
-        marker,
-        closure_ty,
-        MARKER_IDX,
-        MarkerField::HandlerDispatch.index(),
-    );
-    let owner_get = wasm_dialect::struct_get(
-        ctx,
-        loc,
-        marker,
-        i32_ty,
-        MARKER_IDX,
-        MarkerField::PromptTag.index(),
-    );
-
-    rewriter.insert_op(ability_id_const.op_ref());
-    rewriter.insert_op(lookup.op_ref());
-    rewriter.insert_op(closure_get.op_ref());
-    rewriter.insert_op(owner_get.op_ref());
-    (closure_get.result(ctx), owner_get.result(ctx))
 }
 
 /// Pattern that matches `ability.evidence_extend` and replaces it with
@@ -1294,9 +1266,9 @@ fn build_extend_search_loop(
 // Helper functions
 // =============================================================================
 
-/// Get the WASM reference type for Evidence (wasm.arrayref).
+/// Get the exact physical Wasm type for Evidence.
 fn evidence_ref_type(ctx: &mut IrContext) -> TypeRef {
-    trunk_ir::dialect::wasm::arrayref(ctx).as_type_ref()
+    super::type_converter::evidence_wasm_type(ctx)
 }
 
 /// Intern a `core.i32` type.
@@ -1368,18 +1340,21 @@ mod tests {
     }
 
     #[test]
-    fn textual_dispatch_cps_lowers_to_wasm_indirect_call() {
+    fn textual_dispatch_cps_lowers_to_resultless_wasm_tail_call() {
         let output = lower_text(
             r#"core.module @test {
-  func.func @run(%ev: wasm.arrayref, %k: wasm.anyref, %payload: wasm.anyref) -> wasm.anyref {
-    %result = effect.dispatch_cps %ev, %k, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : wasm.anyref
-    func.return %result
+  func.func @run(%ev: wasm.arrayref, %dispatch: wasm.anyref, %resume: wasm.anyref, %payload: wasm.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
   }
 }"#,
         );
 
         assert!(!output.contains("effect.dispatch_cps"), "{output}");
         assert!(output.contains("__tribute_evidence_lookup"), "{output}");
+        let run_ir = output
+            .split("func.func @run")
+            .nth(1)
+            .expect("textual fixture must retain its run function");
 
         fn result_name(line: &str) -> &str {
             line.split_whitespace()
@@ -1394,54 +1369,46 @@ mod tests {
                 .next()
                 .expect("wasm.struct_get must have a struct operand")
         }
-        let handler_field = format!("field_idx = {}", MarkerField::HandlerDispatch.index());
-        let prompt_field = format!("field_idx = {}", MarkerField::PromptTag.index());
-        let handler_get = output
-            .lines()
-            .find(|line| line.contains("wasm.struct_get") && line.contains(&handler_field))
-            .expect("CPS dispatch must extract MarkerField::HandlerDispatch");
-        let marker = struct_operand(handler_get);
-        let handler = result_name(handler_get);
-        let owner_get = output
-            .lines()
-            .find(|line| {
-                line.contains("wasm.struct_get")
-                    && line.contains(&prompt_field)
-                    && struct_operand(line) == marker
-            })
-            .expect("CPS dispatch must extract MarkerField::PromptTag from the same Marker");
-        let owner = result_name(owner_get);
+        let dispatch = "%1";
         let table_get = output
             .lines()
             .find(|line| {
                 line.contains("wasm.struct_get")
-                    && struct_operand(line) == handler
+                    && struct_operand(line) == dispatch
                     && line.contains("field_idx = 0")
             })
-            .expect("CPS dispatch must unpack the handler closure table index");
+            .expect("CPS dispatch must unpack the Dispatch closure table index");
         let table = result_name(table_get);
         let env_get = output
             .lines()
             .find(|line| {
                 line.contains("wasm.struct_get")
-                    && struct_operand(line) == handler
+                    && struct_operand(line) == dispatch
                     && line.contains("field_idx = 1")
             })
-            .expect("CPS dispatch must unpack the handler closure environment");
+            .expect("CPS dispatch must unpack the Dispatch closure environment");
         let env = result_name(env_get);
         let indirect = output
             .lines()
-            .find(|line| line.contains("wasm.call_indirect"))
-            .expect("CPS dispatch must lower to wasm.call_indirect");
+            .find(|line| line.contains("wasm.return_call_indirect"))
+            .expect("CPS dispatch must lower to wasm.return_call_indirect");
         assert!(
             indirect.contains(&format!(
-                "wasm.call_indirect {table}, %0, {env}, %1, {owner},"
+                "wasm.return_call_indirect {table}, %0, {env}, %2,"
             )),
-            "CPS indirect call must pass the extracted owner after k:\n{output}"
+            "CPS tail call must pass explicit evidence, environment, then the exact Resume value:\n{output}"
         );
         assert!(
-            indirect.contains(", %2 {table ="),
+            indirect.contains(", %3 {table ="),
             "CPS indirect call must retain the source payload as its final argument:\n{output}"
+        );
+        assert!(
+            !run_ir.contains("wasm.call_indirect"),
+            "final CPS dispatch must use a proper-tail transfer:\n{output}"
+        );
+        assert!(
+            !output.contains("wasm.call_indirect"),
+            "final CPS dispatch must not emit an ordinary indirect call:\n{output}"
         );
     }
 

--- a/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/intrinsic_to_wasm.rs
@@ -91,9 +91,43 @@ pub fn lower(ctx: &mut IrContext, module: Module) {
         .add_pattern(BytesLenPattern)
         .add_pattern(BytesGetOrPanicPattern)
         .add_pattern(BytesRangeEqualPattern)
-        .add_pattern(BytesConcatPattern);
+        .add_pattern(BytesConcatPattern)
+        .add_pattern(BytesIntrinsicFuncDeclPattern);
 
     applicator.apply_partial(ctx, module);
+}
+
+/// Remove the exact intrinsic declaration after every call has been lowered.
+struct BytesIntrinsicFuncDeclPattern;
+
+impl RewritePattern for BytesIntrinsicFuncDeclPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(function) = wasm_dialect::Func::from_op(ctx, op) else {
+            return false;
+        };
+        let name = function.sym_name(ctx);
+        let lowered_here = [
+            "__bytes_len",
+            "__bytes_get_or_panic",
+            "__bytes_concat",
+            "__tribute_bytes_len",
+            "__tribute_bytes_concat",
+            "__tribute_bytes_range_equal",
+            "__tribute_bytes_slice_or_panic",
+        ]
+        .iter()
+        .any(|candidate| name == Symbol::new(candidate));
+        if !ctx.op(op).regions.is_empty() || !lowered_here {
+            return false;
+        }
+        rewriter.erase_op(vec![]);
+        true
+    }
 }
 
 // =============================================================================

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -27,6 +27,7 @@ use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 use super::const_to_wasm::ConstAnalysis;
 use super::io::IoAnalysis;
 use super::type_converter::{self, wasm_type_converter};
+use super::type_physicalization::physicalize_wasm_target_types;
 use trunk_ir_wasm_backend::gc_types::{EVIDENCE_IDX, STEP_IDX, STEP_TAG_DONE};
 
 const WASM_BACKEND_READY_BOUNDARY: &str = "wasm-backend-ready";
@@ -36,6 +37,7 @@ pub enum WasmLowerError {
     Conversion(ConversionError),
     Pass(PassError),
     Const(super::const_to_wasm::ConstValidationError),
+    TypePhysicalization(super::type_physicalization::WasmTypePhysicalizationError),
 }
 
 impl fmt::Display for WasmLowerError {
@@ -44,6 +46,7 @@ impl fmt::Display for WasmLowerError {
             Self::Conversion(error) => error.fmt(f),
             Self::Pass(error) => error.fmt(f),
             Self::Const(error) => error.fmt(f),
+            Self::TypePhysicalization(error) => error.fmt(f),
         }
     }
 }
@@ -54,6 +57,7 @@ impl std::error::Error for WasmLowerError {
             Self::Conversion(error) => Some(error),
             Self::Pass(error) => Some(error),
             Self::Const(error) => Some(error),
+            Self::TypePhysicalization(error) => Some(error),
         }
     }
 }
@@ -73,6 +77,12 @@ impl From<PassError> for WasmLowerError {
 impl From<super::const_to_wasm::ConstValidationError> for WasmLowerError {
     fn from(error: super::const_to_wasm::ConstValidationError) -> Self {
         Self::Const(error)
+    }
+}
+
+impl From<super::type_physicalization::WasmTypePhysicalizationError> for WasmLowerError {
+    fn from(error: super::type_physicalization::WasmTypePhysicalizationError) -> Self {
+        Self::TypePhysicalization(error)
     }
 }
 
@@ -192,7 +202,8 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowe
 }
 
 /// Assign module-local GC indices after all type-conversion materialization.
-pub fn finalize_wasm_gc_types(ctx: &mut IrContext, module: Module) -> Result<(), ConversionError> {
+pub fn finalize_wasm_gc_types(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowerError> {
+    physicalize_wasm_target_types(ctx, module)?;
     trunk_ir_wasm_backend::passes::wasm_gc_to_wasm::lower(ctx, module);
     PatternApplicator::new(TypeConverter::new())
         .with_target(wasm_emission_ready_target())
@@ -814,7 +825,7 @@ mod tests {
     fn wasm_start_passes_empty_evidence_to_evidence_direct_main() {
         let mut ctx = IrContext::new();
         let location = Location::new(PathRef::from_u32(0), Span::default());
-        let evidence_ty = intern_type(&mut ctx, "wasm", "arrayref");
+        let evidence_ty = type_converter::evidence_wasm_type(&mut ctx);
         let nil_ty = intern_type(&mut ctx, "core", "nil");
         let const_analysis = ConstAnalysis {
             allocations: vec![],

--- a/crates/tribute-passes/src/wasm/mod.rs
+++ b/crates/tribute-passes/src/wasm/mod.rs
@@ -22,3 +22,4 @@ pub mod lower;
 pub mod normalize_primitive_types;
 pub mod tribute_rt_to_wasm;
 pub mod type_converter;
+pub(crate) mod type_physicalization;

--- a/crates/tribute-passes/src/wasm/type_converter.rs
+++ b/crates/tribute-passes/src/wasm/type_converter.rs
@@ -14,7 +14,7 @@
 //! | `tribute_rt.float`  | `core.f64`      | Float as f64                        |
 //! | `tribute_rt.intref` | `wasm.i31ref`   | Boxed integer reference             |
 //! | `tribute_rt.anyref` | `wasm.anyref`   | Any reference type                  |
-//! | `adt.typeref<T>`    | `wasm.structref`| Generic struct reference            |
+//! | `adt.typeref<T>`    | `wasm.structref`| Generic struct reference, except exact CPS Parent |
 //!
 //! ## Materializations
 //!
@@ -30,6 +30,7 @@ use trunk_ir::dialect::wasm_gc as wasm_gc_dialect;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::type_converter::{MaterializeResult, TypeConverter};
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
+use trunk_ir_wasm_backend::gc_types::EVIDENCE_ARRAY_TYPE_ATTR;
 
 // =============================================================================
 // Helper: intern a simple type (no params, no attrs)
@@ -110,7 +111,11 @@ pub use tribute_ir::dialect::ability::marker_adt_type_ref as marker_adt_type;
 /// This is distinct from `ability::evidence_adt_type_ref()` which returns
 /// `core.array(Marker)` for high-level IR representation.
 pub fn evidence_wasm_type(ctx: &mut IrContext) -> TypeRef {
-    intern_type(ctx, Symbol::new("wasm"), Symbol::new("arrayref"))
+    ctx.types.intern(
+        TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("arrayref"))
+            .attr(EVIDENCE_ARRAY_TYPE_ATTR, Attribute::Bool(true))
+            .build(),
+    )
 }
 
 /// Get the canonical Step ADT type (arena version).
@@ -186,6 +191,13 @@ fn is_adt_struct_type(ctx: &IrContext, ty: TypeRef) -> bool {
 /// Check if a type is an `adt.typeref` type.
 fn is_adt_typeref(ctx: &IrContext, ty: TypeRef) -> bool {
     is_type(ctx, ty, Symbol::new("adt"), Symbol::new("typeref"))
+}
+
+/// A CPS Parent is an exact nominal control-flow value.  Unlike ordinary ADT
+/// references it must retain its identity through Wasm signature conversion so
+/// its canonical GC layout can type closure-environment fields and parameters.
+fn is_cps_parent_type(ctx: &IrContext, ty: TypeRef) -> bool {
+    tribute_core::cps_parent_result_type(ctx, ty).is_some()
 }
 
 /// Check if a type has the `is_variant` attribute set to true.
@@ -447,9 +459,11 @@ pub fn wasm_type_converter(ctx: &mut IrContext) -> TypeConverter {
         }
     });
 
-    // Convert adt.typeref -> wasm.structref (generic struct reference)
+    // Convert ordinary adt.typeref -> wasm.structref (generic struct reference).
+    // CPS Parent references retain their exact nominal identity: their layout
+    // is indexed after cast materialization with the rest of WasmGC types.
     tc.add_conversion(move |ctx, ty| {
-        if is_adt_typeref(ctx, ty) {
+        if is_adt_typeref(ctx, ty) && !is_cps_parent_type(ctx, ty) {
             Some(structref_ty)
         } else {
             None
@@ -862,4 +876,83 @@ pub fn wasm_type_converter(ctx: &mut IrContext) -> TypeConverter {
     });
 
     tc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::dialect::wasm;
+    use trunk_ir::ops::DialectOp;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::rewrite::{PatternApplicator, WasmFuncSignatureConversionPattern};
+
+    #[test]
+    fn cps_parent_typeref_retains_nominal_wasm_identity() {
+        let mut ctx = IrContext::new();
+        let i32_ty = intern_type(&mut ctx, Symbol::new("core"), Symbol::new("i32"));
+        let anyref_ty = intern_type(&mut ctx, Symbol::new("tribute_rt"), Symbol::new("anyref"));
+        let evidence_ty = intern_type(&mut ctx, Symbol::new("ability"), Symbol::new("evidence"));
+        let parent = tribute_core::cps_parent_ref_type(&mut ctx, Symbol::new("ParentI32"), i32_ty);
+        let done = tribute_core::cps_done_type(&mut ctx, i32_ty);
+        let dispatch =
+            tribute_core::cps_dispatch_type(&mut ctx, evidence_ty, parent, anyref_ty, i32_ty);
+        let layout = tribute_core::cps_parent_layout_type(
+            &mut ctx,
+            Symbol::new("ParentI32"),
+            i32_ty,
+            done,
+            dispatch,
+        );
+        let ordinary = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("typeref"))
+                .attr("name", Attribute::Symbol(Symbol::new("Ordinary")))
+                .build(),
+        );
+        let structref_ty = intern_type(&mut ctx, Symbol::new("wasm"), Symbol::new("structref"));
+
+        let converter = wasm_type_converter(&mut ctx);
+
+        assert_eq!(converter.convert_type_or_identity(&ctx, parent), parent);
+        assert_eq!(
+            converter.convert_type_or_identity(&ctx, ordinary),
+            structref_ty
+        );
+        let Attribute::List(fields) = ctx.types.get(layout).attrs.get("fields").unwrap() else {
+            panic!("Parent layout must carry fields");
+        };
+        let Attribute::List(done_field) = &fields[0] else {
+            panic!("Parent done field must be a pair");
+        };
+        let Attribute::List(dispatch_field) = &fields[1] else {
+            panic!("Parent dispatch field must be a pair");
+        };
+        assert_eq!(done_field[1], Attribute::Type(done));
+        assert_eq!(dispatch_field[1], Attribute::Type(dispatch));
+    }
+
+    #[test]
+    fn wasm_signature_conversion_keeps_cps_parent_parameter_canonical() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !parent = adt.typeref() {name = @ParentI32, tribute.cps_parent_result = core.i32}
+  wasm.func @capture(%parent: !parent) -> core.nil {
+    wasm.return
+  }
+}"#,
+        );
+        let parent = ctx.type_alias_by_name(Symbol::new("parent")).unwrap();
+
+        PatternApplicator::new(wasm_type_converter(&mut ctx))
+            .add_pattern(WasmFuncSignatureConversionPattern)
+            .apply_partial(&mut ctx, module);
+
+        let function = wasm::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        let signature = ctx.types.get(function.r#type(&ctx));
+        let body = function.body(&ctx);
+        let entry = ctx.region(body).blocks[0];
+        assert_eq!(signature.params[1], parent);
+        assert_eq!(ctx.value_ty(ctx.block_arg(entry, 0)), parent);
+    }
 }

--- a/crates/tribute-passes/src/wasm/type_physicalization.rs
+++ b/crates/tribute-passes/src/wasm/type_physicalization.rs
@@ -1,0 +1,448 @@
+//! Recursive target-type physicalization for the final Wasm boundary.
+//!
+//! This runs after conversion-cast materialization and before typed WasmGC
+//! operations receive module-local indices.  It preserves nominal outer types
+//! while converting every target-visible primitive leaf and nested type
+//! attribute through the canonical Wasm type converter.
+
+use std::collections::{HashMap, HashSet};
+
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::refs::{BlockRef, OpRef, TypeRef};
+use trunk_ir::rewrite::Module;
+use trunk_ir::types::{Attribute, TypeData};
+use trunk_ir_wasm_backend::gc_types::concrete_wasm_ref_type;
+
+use super::type_converter::wasm_type_converter;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmTypePhysicalizationError(String);
+
+impl WasmTypePhysicalizationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for WasmTypePhysicalizationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for WasmTypePhysicalizationError {}
+
+/// Physicalize every type surface visible to the final Wasm backend.
+///
+/// Conversion is planned in full before an alias, operation, or block argument
+/// reference is changed.  Interning target types during planning is harmless;
+/// any error leaves the module's canonical IR byte-identical.
+pub(crate) fn physicalize_wasm_target_types(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), WasmTypePhysicalizationError> {
+    let ops = collect_ops(ctx, module.op());
+    let blocks = collect_blocks(ctx, &ops);
+    let aliases = ctx.type_aliases().to_vec();
+    let mut converter = RecursiveWasmTypeConverter::new(ctx);
+    let mut plan = WasmTypePhysicalizationPlan::default();
+
+    for (name, ty) in aliases {
+        let converted = converter.convert_type(ty)?;
+        if converted != ty {
+            plan.aliases.push((name, converted));
+        }
+    }
+
+    for op in ops {
+        let result_types = converter.ctx.op_result_types(op).to_vec();
+        for (index, ty) in result_types.into_iter().enumerate() {
+            let converted = converter.convert_type(ty)?;
+            if converted != ty {
+                plan.op_results.push((op, index as u32, converted));
+            }
+        }
+        let attributes = converter
+            .ctx
+            .op(op)
+            .attributes
+            .iter()
+            .map(|(name, value)| (*name, value.clone()))
+            .collect::<Vec<_>>();
+        for (name, value) in attributes {
+            let converted = converter.convert_attribute(value.clone())?;
+            if converted != value {
+                plan.op_attributes.push((op, name, converted));
+            }
+        }
+    }
+
+    for block in blocks {
+        let args = converter.ctx.block(block).args.clone();
+        for (index, arg) in args.into_iter().enumerate() {
+            let converted = converter.convert_type(arg.ty)?;
+            if converted != arg.ty {
+                plan.block_arg_types.push((block, index, converted));
+            }
+            for (name, value) in arg.attrs {
+                let converted = converter.convert_attribute(value.clone())?;
+                if converted != value {
+                    plan.block_arg_attributes
+                        .push((block, index, name, converted));
+                }
+            }
+        }
+    }
+
+    drop(converter);
+    for (name, ty) in plan.aliases {
+        ctx.register_type_alias(name, ty);
+    }
+    for (op, index, ty) in plan.op_results {
+        ctx.set_op_result_type(op, index, ty);
+    }
+    for (op, name, value) in plan.op_attributes {
+        ctx.op_mut(op).attributes.insert(name, value);
+    }
+    for (block, index, ty) in plan.block_arg_types {
+        ctx.set_block_arg_type(block, index as u32, ty);
+    }
+    for (block, index, name, value) in plan.block_arg_attributes {
+        ctx.block_mut(block).args[index].attrs.insert(name, value);
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct WasmTypePhysicalizationPlan {
+    aliases: Vec<(Symbol, TypeRef)>,
+    op_results: Vec<(OpRef, u32, TypeRef)>,
+    op_attributes: Vec<(OpRef, Symbol, Attribute)>,
+    block_arg_types: Vec<(BlockRef, usize, TypeRef)>,
+    block_arg_attributes: Vec<(BlockRef, usize, Symbol, Attribute)>,
+}
+
+struct RecursiveWasmTypeConverter<'a> {
+    ctx: &'a mut IrContext,
+    converter: trunk_ir::rewrite::TypeConverter,
+    cache: HashMap<TypeRef, TypeRef>,
+    visiting: HashSet<TypeRef>,
+}
+
+impl<'a> RecursiveWasmTypeConverter<'a> {
+    fn new(ctx: &'a mut IrContext) -> Self {
+        let converter = wasm_type_converter(ctx);
+        Self {
+            ctx,
+            converter,
+            cache: HashMap::new(),
+            visiting: HashSet::new(),
+        }
+    }
+
+    fn convert_type(&mut self, ty: TypeRef) -> Result<TypeRef, WasmTypePhysicalizationError> {
+        if let Some(&converted) = self.cache.get(&ty) {
+            return Ok(converted);
+        }
+        if !self.visiting.insert(ty) {
+            return Err(WasmTypePhysicalizationError::new(
+                "wasm target type physicalization: recursive TypeRef graph is unsupported",
+            ));
+        }
+
+        let data = self.ctx.types.get(ty).clone();
+        self.validate_type(&data)?;
+        if data.dialect == Symbol::new("core") && data.name == Symbol::new("ref") {
+            let converted = self.convert_core_ref(ty, &data)?;
+            self.visiting.remove(&ty);
+            self.cache.insert(ty, converted);
+            return Ok(converted);
+        }
+        let converted_params = data
+            .params
+            .iter()
+            .copied()
+            .map(|parameter| self.convert_type(parameter))
+            .collect::<Result<Vec<_>, _>>()?;
+        let converted_attributes = data
+            .attrs
+            .iter()
+            .map(|(name, value)| Ok((*name, self.convert_attribute(value.clone())?)))
+            .collect::<Result<Vec<_>, WasmTypePhysicalizationError>>()?;
+
+        let converted = if preserves_nominal_identity(&data) {
+            self.rebuild(&data, converted_params, converted_attributes, ty)
+        } else if data.dialect == Symbol::new("adt") && data.name == Symbol::new("typeref") {
+            // A regular nominal reference has no target-level layout of its
+            // own.  Its source-only `name` metadata must not create a second
+            // wasm.structref TypeRef; all ordinary nominal references share
+            // the canonical abstract struct reference in the Wasm ABI.
+            self.converter.convert_type(self.ctx, ty).ok_or_else(|| {
+                WasmTypePhysicalizationError::new(
+                    "wasm target type physicalization: ordinary adt.typeref has no wasm.structref conversion",
+                )
+            })?
+        } else if let Some(target) = self.converter.convert_type(self.ctx, ty) {
+            self.rebuild_target(target, converted_attributes)
+        } else {
+            self.rebuild(&data, converted_params, converted_attributes, ty)
+        };
+        self.visiting.remove(&ty);
+        self.cache.insert(ty, converted);
+        Ok(converted)
+    }
+
+    fn convert_attribute(
+        &mut self,
+        attribute: Attribute,
+    ) -> Result<Attribute, WasmTypePhysicalizationError> {
+        match attribute {
+            Attribute::Type(ty) => Ok(Attribute::Type(self.convert_type(ty)?)),
+            Attribute::List(values) => Ok(Attribute::List(
+                values
+                    .into_iter()
+                    .map(|value| self.convert_attribute(value))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            attribute => Ok(attribute),
+        }
+    }
+
+    /// Preserve the canonical source pointee for the only concrete `core.ref`
+    /// form representable by the Wasm ABI.  Recursing through that pointee
+    /// would turn `core.array(core.i8)` into `wasm.arrayref` and lose the
+    /// concrete Bytes-array identity consumed by GC collection and emission.
+    fn convert_core_ref(
+        &mut self,
+        original: TypeRef,
+        data: &TypeData,
+    ) -> Result<TypeRef, WasmTypePhysicalizationError> {
+        if concrete_wasm_ref_type(self.ctx, original).is_none() {
+            return Err(WasmTypePhysicalizationError::new(
+                "wasm target type physicalization: unsupported core.ref pointee; expected core.array(core.i8)",
+            ));
+        }
+        let attributes = data
+            .attrs
+            .iter()
+            .map(|(name, value)| Ok((*name, self.convert_attribute(value.clone())?)))
+            .collect::<Result<Vec<_>, WasmTypePhysicalizationError>>()?;
+        Ok(self.rebuild(data, data.params.to_vec(), attributes, original))
+    }
+
+    fn validate_type(&self, data: &TypeData) -> Result<(), WasmTypePhysicalizationError> {
+        if data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure") {
+            let Some(&signature) = data.params.first() else {
+                return Err(WasmTypePhysicalizationError::new(
+                    "wasm target type physicalization: closure.closure requires one core.func parameter",
+                ));
+            };
+            if data.params.len() != 1
+                || self.ctx.types.get(signature).dialect != Symbol::new("core")
+                || self.ctx.types.get(signature).name != Symbol::new("func")
+            {
+                return Err(WasmTypePhysicalizationError::new(
+                    "wasm target type physicalization: closure.closure requires one core.func parameter",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn rebuild(
+        &mut self,
+        data: &TypeData,
+        params: Vec<TypeRef>,
+        attributes: Vec<(Symbol, Attribute)>,
+        original: TypeRef,
+    ) -> TypeRef {
+        if data.params.as_slice() == params.as_slice()
+            && attributes
+                .iter()
+                .all(|(name, value)| data.attrs.get(name) == Some(value))
+        {
+            return original;
+        }
+        let mut rebuilt = data.clone();
+        rebuilt.params = params.into();
+        rebuilt.attrs.clear();
+        rebuilt.attrs.extend(attributes);
+        self.ctx.types.intern(rebuilt)
+    }
+
+    fn rebuild_target(&mut self, target: TypeRef, attributes: Vec<(Symbol, Attribute)>) -> TypeRef {
+        if attributes.is_empty() {
+            return target;
+        }
+        let mut data = self.ctx.types.get(target).clone();
+        data.attrs.extend(attributes);
+        self.ctx.types.intern(data)
+    }
+}
+
+fn preserves_nominal_identity(data: &TypeData) -> bool {
+    data.dialect == Symbol::new("adt")
+        && (data.name == Symbol::new("struct")
+            || data.name == Symbol::new("enum")
+            || data.name == Symbol::new("variant_inst")
+            // Ordinary nominal references are physicalized to wasm.structref.
+            // The exact CPS Parent is the one reference whose nominal layout
+            // must survive for GC type-index collection.
+            || (data.name == Symbol::new("typeref")
+                && data.attrs.contains_key("tribute.cps_parent_result")))
+}
+
+fn collect_ops(ctx: &IrContext, root: OpRef) -> Vec<OpRef> {
+    fn visit(ctx: &IrContext, op: OpRef, ops: &mut Vec<OpRef>) {
+        ops.push(op);
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child, ops);
+                }
+            }
+        }
+    }
+    let mut ops = Vec::new();
+    visit(ctx, root, &mut ops);
+    ops
+}
+
+fn collect_blocks(ctx: &IrContext, ops: &[OpRef]) -> Vec<BlockRef> {
+    let mut blocks = Vec::new();
+    for &op in ops {
+        for region in ctx.op(op).regions.iter().copied() {
+            blocks.extend(ctx.region(region).blocks.iter().copied());
+        }
+    }
+    blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+    use trunk_ir::types::TypeDataBuilder;
+
+    #[test]
+    fn physicalizes_nested_target_type_surfaces_without_erasing_nominal_identity() {
+        let input = r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = tribute_rt.anyref}
+  !layout = adt.struct() {fields = [[@payload, tribute_rt.anyref], [@items, core.array(tribute_rt.bool)]], metadata = [tribute_rt.intref, [tribute_rt.float, !parent]], name = @Parent}
+  func.func @outer(%parent: !parent, %payload: tribute_rt.anyref) -> tribute_rt.anyref {
+    func.func @nested(%captured: tribute_rt.anyref) -> tribute_rt.anyref {
+      func.unreachable
+    }
+    %packed = wasm_gc.struct_new %payload {type = !layout} : !parent
+    func.unreachable
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        physicalize_wasm_target_types(&mut ctx, module).unwrap();
+
+        let printed = print_module(&ctx, module.op());
+        assert!(!printed.contains("tribute_rt.anyref"), "{printed}");
+        assert!(!printed.contains("tribute_rt.bool"), "{printed}");
+        assert!(!printed.contains("tribute_rt.intref"), "{printed}");
+        assert!(!printed.contains("tribute_rt.float"), "{printed}");
+        assert!(printed.contains("!parent = adt.typeref()"), "{printed}");
+        assert!(printed.contains("!layout = adt.struct()"), "{printed}");
+        assert!(printed.contains("wasm_gc.struct_new"), "{printed}");
+    }
+
+    #[test]
+    fn physicalized_nominal_aliases_and_nested_signature_reparse() {
+        let input = r#"core.module @test {
+  !parent = adt.typeref() {name = @Parent, tribute.cps_parent_result = tribute_rt.anyref}
+  !layout = adt.struct() {fields = [[@payload, tribute_rt.anyref]], metadata = [tribute_rt.intref, !parent], name = @Parent}
+  func.func @outer(%parent: !parent, %payload: tribute_rt.anyref) -> tribute_rt.anyref {
+    func.unreachable
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        physicalize_wasm_target_types(&mut ctx, module).unwrap();
+        let printed = print_module(&ctx, module.op());
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &printed);
+    }
+
+    #[test]
+    fn malformed_closure_type_fails_before_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @f() -> core.nil {
+    func.return
+  }
+}"#,
+        );
+        let malformed = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("closure"), Symbol::new("closure")).build());
+        ctx.register_type_alias(Symbol::new("malformed"), malformed);
+        let before = print_module(&ctx, module.op());
+
+        let error = physicalize_wasm_target_types(&mut ctx, module).unwrap_err();
+
+        assert!(error.to_string().contains("closure.closure requires"));
+        assert_eq!(print_module(&ctx, module.op()), before);
+        assert_eq!(
+            ctx.type_alias_by_name(Symbol::new("malformed")),
+            Some(malformed)
+        );
+    }
+
+    #[test]
+    fn preserves_bytes_backing_reference_identity_and_nullability() {
+        let input = r#"core.module @test {
+  !bytes_data = core.ref(core.array(core.i8)) {nullable = false}
+  !optional_bytes_data = core.ref(core.array(core.i8)) {nullable = true}
+  !layout = adt.struct() {fields = [[@data, !bytes_data], [@optional_data, !optional_bytes_data]], name = @BytesFields}
+  func.func @f(%data: !bytes_data, %optional_data: !optional_bytes_data) -> core.nil {
+    %fields = wasm_gc.struct_new %data, %optional_data {type = !layout} : !layout
+    func.unreachable
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        physicalize_wasm_target_types(&mut ctx, module).unwrap();
+
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            printed.contains("core.ref(core.array(core.i8)) {nullable = false}"),
+            "{printed}"
+        );
+        assert!(
+            printed.contains("core.ref(core.array(core.i8)) {nullable = true}"),
+            "{printed}"
+        );
+        assert!(!printed.contains("core.ref(wasm.arrayref)"), "{printed}");
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &printed);
+    }
+
+    #[test]
+    fn unsupported_core_reference_fails_before_mutation() {
+        let input = r#"core.module @test {
+  !unsupported = core.ref(core.i32) {nullable = false}
+  func.func @f(%value: !unsupported) -> core.nil {
+    func.unreachable
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = physicalize_wasm_target_types(&mut ctx, module).unwrap_err();
+
+        assert!(error.to_string().contains("unsupported core.ref pointee"));
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+}

--- a/crates/trunk-ir-cranelift-backend/src/calling_convention.rs
+++ b/crates/trunk-ir-cranelift-backend/src/calling_convention.rs
@@ -1,0 +1,91 @@
+//! Cranelift-owned calling-convention metadata.
+//!
+//! Languages project their callable ABI onto the `clif.calling_convention`
+//! attribute before this backend lowers or emits `clif.*`.  The generic
+//! backend intentionally does not know how that provenance was established.
+
+use cranelift_codegen::isa::CallConv;
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::dialect::clif;
+use trunk_ir::refs::OpRef;
+
+use crate::{CompilationError, CompilationResult};
+
+/// Read the explicit Cranelift calling convention for an operation.
+///
+/// Untagged generic TrunkIR keeps the target platform ABI for backwards
+/// compatibility.  A frontend that requires a stronger contract must attach
+/// and validate this metadata before reaching the generic backend.
+pub(crate) fn calling_convention_for_op(
+    ctx: &IrContext,
+    op: OpRef,
+    platform: CallConv,
+) -> CompilationResult<CallConv> {
+    let Some(value) = ctx
+        .op(op)
+        .attributes
+        .get_symbol(clif::CALLING_CONVENTION_ATTR)
+    else {
+        return Ok(platform);
+    };
+
+    if value == Symbol::new(clif::CALLING_CONVENTION_PLATFORM) {
+        Ok(platform)
+    } else if value == Symbol::new(clif::CALLING_CONVENTION_TAIL) {
+        Ok(CallConv::Tail)
+    } else {
+        Err(CompilationError::ir_validation(format!(
+            "invalid {} `{value}`",
+            clif::CALLING_CONVENTION_ATTR
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cranelift_codegen::isa::CallConv;
+    use trunk_ir::OperationDataBuilder;
+    use trunk_ir::Span;
+    use trunk_ir::context::IrContext;
+    use trunk_ir::refs::OpRef;
+    use trunk_ir::types::{Attribute, Location};
+
+    use super::*;
+
+    fn op_with_convention(ctx: &mut IrContext, convention: &str) -> OpRef {
+        let path = ctx.paths.intern("test.trb".to_owned());
+        let location = Location::new(path, Span::new(0, 0));
+        let data = OperationDataBuilder::new(location, Symbol::new("clif"), Symbol::new("func"))
+            .attr(
+                clif::CALLING_CONVENTION_ATTR,
+                Attribute::Symbol(Symbol::from_dynamic(convention)),
+            )
+            .build(ctx);
+        ctx.create_op(data)
+    }
+
+    #[test]
+    fn maps_tail_and_platform_metadata_without_a_global_module_convention() {
+        let mut ctx = IrContext::new();
+        let tail = op_with_convention(&mut ctx, clif::CALLING_CONVENTION_TAIL);
+        let platform = op_with_convention(&mut ctx, clif::CALLING_CONVENTION_PLATFORM);
+
+        assert_eq!(
+            calling_convention_for_op(&ctx, tail, CallConv::AppleAarch64).unwrap(),
+            CallConv::Tail
+        );
+        assert_eq!(
+            calling_convention_for_op(&ctx, platform, CallConv::AppleAarch64).unwrap(),
+            CallConv::AppleAarch64
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_generic_calling_convention() {
+        let mut ctx = IrContext::new();
+        let op = op_with_convention(&mut ctx, "unknown");
+        let error = calling_convention_for_op(&ctx, op, CallConv::AppleAarch64).unwrap_err();
+        assert!(error.to_string().contains("clif.calling_convention"));
+    }
+}

--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -15,6 +15,7 @@ use trunk_ir::dialect::clif;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 
+use crate::calling_convention::calling_convention_for_op;
 use crate::{CompilationError, CompilationResult};
 
 /// Parse a condition symbol into a Cranelift integer condition code.
@@ -161,8 +162,8 @@ pub(crate) struct FunctionTranslator<'a> {
     data_refs: &'a HashMap<Symbol, cl_ir::GlobalValue>,
     /// Maps TrunkIR block refs to Cranelift blocks.
     pub(crate) block_map: HashMap<BlockRef, cl_ir::Block>,
-    /// The ISA calling convention (used for indirect calls).
-    call_conv: CallConv,
+    /// The target platform calling convention used for untagged generic IR.
+    platform_call_conv: cranelift_codegen::isa::CallConv,
     /// The platform pointer type (e.g. I64 on 64-bit).
     ptr_ty: cl_types::Type,
 }
@@ -173,7 +174,7 @@ impl<'a> FunctionTranslator<'a> {
         builder: FunctionBuilder<'a>,
         func_refs: &'a HashMap<Symbol, cl_ir::FuncRef>,
         data_refs: &'a HashMap<Symbol, cl_ir::GlobalValue>,
-        call_conv: CallConv,
+        platform_call_conv: cranelift_codegen::isa::CallConv,
         ptr_ty: cl_types::Type,
     ) -> Self {
         Self {
@@ -183,7 +184,7 @@ impl<'a> FunctionTranslator<'a> {
             func_refs,
             data_refs,
             block_map: HashMap::new(),
-            call_conv,
+            platform_call_conv,
             ptr_ty,
         }
     }
@@ -516,7 +517,8 @@ impl<'a> FunctionTranslator<'a> {
                 .collect::<CompilationResult<_>>()?;
 
             let sig_ty = rci.sig(ctx);
-            let sig = translate_signature(ctx, sig_ty, self.call_conv, self.ptr_ty)?;
+            let call_conv = calling_convention_for_op(ctx, op, self.platform_call_conv)?;
+            let sig = translate_signature(ctx, sig_ty, call_conv, self.ptr_ty)?;
             let sig_ref = self.builder.import_signature(sig);
 
             self.builder
@@ -535,7 +537,8 @@ impl<'a> FunctionTranslator<'a> {
                 .collect::<CompilationResult<_>>()?;
 
             let sig_ty = call_ind.sig(ctx);
-            let sig = translate_signature(ctx, sig_ty, self.call_conv, self.ptr_ty)?;
+            let call_conv = calling_convention_for_op(ctx, op, self.platform_call_conv)?;
+            let sig = translate_signature(ctx, sig_ty, call_conv, self.ptr_ty)?;
             let sig_ref = self.builder.import_signature(sig);
 
             let inst = self.builder.ins().call_indirect(sig_ref, callee, &args);

--- a/crates/trunk-ir-cranelift-backend/src/lib.rs
+++ b/crates/trunk-ir-cranelift-backend/src/lib.rs
@@ -16,6 +16,7 @@
 //! - `validation`: Pre-emit validation (all ops must be clif.*)
 
 pub mod adt_layout;
+mod calling_convention;
 mod errors;
 mod function;
 pub mod passes;

--- a/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
@@ -25,19 +25,18 @@ use tracing::warn;
 
 use crate::adt_layout::{
     compute_enum_layout, compute_struct_layout, find_variant_layout, get_enum_variants,
+    get_struct_fields, type_size_align,
 };
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::adt;
-use trunk_ir::dialect::clif;
-use trunk_ir::dialect::core;
+use trunk_ir::dialect::{adt, arith, clif, core};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
     TypeConverter,
 };
-use trunk_ir::types::TypeDataBuilder;
+use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 /// Lower ADT operations to clif dialect.
 ///
@@ -117,6 +116,13 @@ impl RewritePattern for StructGetPattern {
             return false;
         }
 
+        let Some((_, field_ty)) =
+            get_struct_fields(ctx, struct_ty).and_then(|fields| fields.get(field_idx).copied())
+        else {
+            warn!("adt_to_clif arena: struct_get field metadata is missing");
+            return false;
+        };
+
         let loc = ctx.op(op).location;
         let offset =
             i32::try_from(layout.field_offsets[field_idx]).expect("field offset exceeds i32");
@@ -129,6 +135,24 @@ impl RewritePattern for StructGetPattern {
             return false;
         };
         let result_ty = tc.convert_type_or_identity(ctx, result_ty);
+        let field_native_ty = tc.convert_type_or_identity(ctx, field_ty);
+
+        if type_size_align(ctx, field_native_ty).0 == 0 {
+            if result_ty != core::nil(ctx).as_type_ref() {
+                warn!("adt_to_clif arena: zero-sized struct field has non-Nil result");
+                return false;
+            }
+
+            let result = struct_get.result(ctx);
+            if !ctx.has_uses(result) {
+                rewriter.erase_op_with_unused_results();
+                return true;
+            }
+
+            let unit = arith::r#const(ctx, loc, result_ty, Attribute::Unit);
+            rewriter.replace_op(unit.op_ref());
+            return true;
+        }
 
         let load_op = clif::load(ctx, loc, ref_val, result_ty, offset);
         rewriter.replace_op(load_op.op_ref());
@@ -160,6 +184,17 @@ impl RewritePattern for StructSetPattern {
 
         if field_idx >= layout.field_offsets.len() {
             return false;
+        }
+
+        let Some((_, field_ty)) =
+            get_struct_fields(ctx, struct_ty).and_then(|fields| fields.get(field_idx).copied())
+        else {
+            return false;
+        };
+        let native_ty = tc.convert_type_or_identity(ctx, field_ty);
+        if type_size_align(ctx, native_ty).0 == 0 {
+            rewriter.erase_op(vec![]);
+            return true;
         }
 
         let loc = ctx.op(op).location;
@@ -456,6 +491,57 @@ mod tests {
 }"#,
         );
         insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn zero_sized_struct_set_does_not_materialize_a_clif_store() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @test_fn() -> core.nil {
+    %0 = clif.iconst {value = 0} : core.ptr
+    %1 = arith.const {value = unit} : core.nil
+    adt.struct_set %0, %1 {field = 0, type = adt.struct(core.nil) {fields = [[@value, core.nil]], name = @Cell}}
+    func.return
+  }
+}"#,
+        );
+        assert!(!result.contains("adt.struct_set"), "{result}");
+        assert!(!result.contains("clif.store"), "{result}");
+    }
+
+    #[test]
+    fn zero_sized_struct_get_materializes_unit_without_a_clif_load() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @test_fn() -> core.nil {
+    %0 = clif.iconst {value = 0} : core.ptr
+    %1 = adt.struct_get %0 {field = 0, type = adt.struct(core.nil) {fields = [[@value, core.nil]], name = @Cell}} : core.nil
+    func.return %1
+  }
+}"#,
+        );
+        assert!(!result.contains("adt.struct_get"), "{result}");
+        assert!(!result.contains("clif.load"), "{result}");
+        assert!(
+            result.contains("arith.const {value = unit} : core.nil"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn unused_zero_sized_struct_get_is_erased_without_a_native_value() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @test_fn() -> core.nil {
+    %0 = clif.iconst {value = 0} : core.ptr
+    %1 = adt.struct_get %0 {field = 0, type = adt.struct(core.nil) {fields = [[@value, core.nil]], name = @Cell}} : core.nil
+    func.return
+  }
+}"#,
+        );
+        assert!(!result.contains("adt.struct_get"), "{result}");
+        assert!(!result.contains("arith.const"), "{result}");
+        assert!(!result.contains("clif.load"), "{result}");
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -13,7 +13,7 @@ use trunk_ir::context::IrContext;
 use trunk_ir::dialect::clif;
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
-use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
@@ -38,6 +38,7 @@ pub fn lower(
         .add_pattern(FuncCallIndirectPattern)
         .add_pattern(FuncReturnPattern)
         .add_pattern(FuncTailCallPattern)
+        .add_pattern(FuncTailCallIndirectPattern)
         .add_pattern(FuncUnreachablePattern)
         .add_pattern(FuncConstantPattern)
         .with_target(func_to_clif_target());
@@ -185,16 +186,16 @@ impl RewritePattern for FuncCallPattern {
         };
 
         let callee = call_op.callee(ctx);
-        let new_op = crate::passes::cf_to_clif::rebuild_op_as(
-            ctx,
-            op,
-            Symbol::new("clif"),
-            Symbol::new("call"),
-        );
-        ctx.op_mut(new_op)
-            .attributes
-            .insert(Symbol::new("callee"), Attribute::Symbol(callee));
-        rewriter.replace_op(new_op);
+        let location = ctx.op(op).location;
+        let args = ctx.op_operands(op).to_vec();
+        let result = rewriter
+            .result_type(ctx, op, 0)
+            .unwrap_or_else(|| core::nil(ctx).as_type_ref());
+        let new_op = clif::call(ctx, location, args, result, callee);
+        let mut attrs = ctx.op(op).attributes.clone();
+        attrs.remove(Symbol::new("callee"));
+        ctx.op_mut(new_op.op_ref()).attributes.extend(attrs);
+        rewriter.replace_op(new_op.op_ref());
         true
     }
 }
@@ -218,17 +219,26 @@ impl RewritePattern for FuncCallIndirectPattern {
             return false;
         }
 
-        // Collect arg types (skip operand 0 = callee).
-        // Operand types are already converted by the applicator's cast insertion.
-        let param_types: Vec<TypeRef> = operands[1..].iter().map(|&v| ctx.value_ty(v)).collect();
-
-        // Result type with conversion applied
-        let result_ty = rewriter.result_type(ctx, op, 0);
-
-        // Build sig type matching translate_signature layout:
-        // params[0] = return type, params[1..] = parameter types
-        let ret_ty = result_ty.unwrap_or_else(|| core::nil(ctx).as_type_ref());
-        let sig_ty = core::func(ctx, ret_ty, param_types.iter().copied()).as_type_ref();
+        // Closure lowering records the exact callable ABI before replacing a
+        // typed closure with an untyped function/table reference. Prefer that
+        // contract over representation operands, whose pointer types cannot
+        // recover source-data positions such as an erased resume input.
+        let sig_ty = ctx
+            .op(op)
+            .attributes
+            .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
+            .unwrap_or_else(|| {
+                let param_types: Vec<TypeRef> = operands[1..]
+                    .iter()
+                    .map(|&value| ctx.value_ty(value))
+                    .collect();
+                let result_ty = rewriter.result_type(ctx, op, 0);
+                let ret_ty = result_ty.unwrap_or_else(|| core::nil(ctx).as_type_ref());
+                core::func(ctx, ret_ty, param_types.iter().copied()).as_type_ref()
+            });
+        let Some(sig_ty) = lower_indirect_signature(ctx, rewriter.type_converter(), sig_ty) else {
+            return false;
+        };
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,
@@ -239,6 +249,9 @@ impl RewritePattern for FuncCallIndirectPattern {
         ctx.op_mut(new_op)
             .attributes
             .insert(Symbol::new("sig"), Attribute::Type(sig_ty));
+        ctx.op_mut(new_op)
+            .attributes
+            .remove(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR));
         rewriter.replace_op(new_op);
         true
     }
@@ -256,6 +269,16 @@ impl RewritePattern for FuncReturnPattern {
     ) -> bool {
         if func::Return::from_op(ctx, op).is_err() {
             return false;
+        }
+        let operands = ctx.op_operands(op);
+        if operands.len() == 1 {
+            let value_ty = ctx.value_ty(operands[0]);
+            let data = ctx.types.get(value_ty);
+            if data.dialect == Symbol::new("core") && data.name == Symbol::new("nil") {
+                let new_op = clif::r#return(ctx, ctx.op(op).location, []);
+                rewriter.replace_op(new_op.op_ref());
+                return true;
+            }
         }
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,
@@ -295,6 +318,78 @@ impl RewritePattern for FuncTailCallPattern {
         rewriter.replace_op(new_op);
         true
     }
+}
+
+/// Pattern: `func.tail_call_indirect` -> `clif.return_call_indirect`
+struct FuncTailCallIndirectPattern;
+
+impl RewritePattern for FuncTailCallIndirectPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if func::TailCallIndirect::from_op(ctx, op).is_err() {
+            return false;
+        }
+
+        let operands = ctx.op_operands(op).to_vec();
+        if operands.is_empty() || !ctx.op_result_types(op).is_empty() {
+            return false;
+        }
+
+        let sig_ty = ctx
+            .op(op)
+            .attributes
+            .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
+            .unwrap_or_else(|| {
+                let param_types: Vec<TypeRef> = operands[1..]
+                    .iter()
+                    .map(|&value| ctx.value_ty(value))
+                    .collect();
+                let nil_ty = core::nil(ctx).as_type_ref();
+                core::func(ctx, nil_ty, param_types.iter().copied()).as_type_ref()
+            });
+        let Some(sig_ty) = lower_indirect_signature(ctx, rewriter.type_converter(), sig_ty) else {
+            return false;
+        };
+
+        let new_op = crate::passes::cf_to_clif::rebuild_op_as(
+            ctx,
+            op,
+            Symbol::new("clif"),
+            Symbol::new("return_call_indirect"),
+        );
+        ctx.op_mut(new_op)
+            .attributes
+            .insert(Symbol::new("sig"), Attribute::Type(sig_ty));
+        ctx.op_mut(new_op)
+            .attributes
+            .remove(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR));
+        rewriter.replace_op(new_op);
+        true
+    }
+}
+
+/// Project the exact indirect ABI through the target type converter.  The
+/// provenance records logical closure values, while the native call boundary
+/// receives their lowered pointer representation; source scalar parameters
+/// such as a resumed `core.i32` stay scalar.
+fn lower_indirect_signature(
+    ctx: &mut IrContext,
+    converter: &TypeConverter,
+    signature: TypeRef,
+) -> Option<TypeRef> {
+    let callable = core::Func::from_type_ref(ctx, signature)?;
+    let result_ty = callable.r#return(ctx);
+    let params = callable.params(ctx).to_vec();
+    let result = converter.convert_type_or_identity(ctx, result_ty);
+    let params: Vec<_> = params
+        .iter()
+        .map(|&param| converter.convert_type_or_identity(ctx, param))
+        .collect();
+    Some(core::func(ctx, result, params).as_type_ref())
 }
 
 /// Pattern: `func.unreachable` -> `clif.trap`
@@ -437,6 +532,38 @@ mod tests {
     }
 
     #[test]
+    fn nil_return_has_no_clif_value_operand() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @test_fn() -> core.nil {
+    %0 = arith.const {value = unit} : core.nil
+    func.return %0
+  }
+}"#,
+        );
+        assert!(result.contains("clif.return\n"), "{result}");
+        assert!(!result.contains("clif.return %"), "{result}");
+    }
+
+    #[test]
+    fn bodyless_func_declaration_lowers_without_fabricating_a_body() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @imported(%value: core.i32) -> core.i32 attributes {abi = "C"}
+  func.func @defined() -> core.nil {
+    func.return
+  }
+}"#,
+        );
+
+        assert!(result.contains(
+            "clif.func {abi = \"C\", sym_name = @imported, type = core.func(core.i32, core.i32)}"
+        ));
+        assert!(result.contains("clif.func {sym_name = @defined, type = core.func(core.nil)} {"));
+        assert!(!result.contains("sym_name = @imported, type = core.func(core.i32, core.i32)} {"));
+    }
+
+    #[test]
     fn test_call_indirect_to_clif() {
         let result = run_pass(
             r#"core.module @test {
@@ -449,6 +576,36 @@ mod tests {
 }"#,
         );
         insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn preserves_per_transfer_calling_convention_for_tail_and_ordinary_indirect_calls() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @done() -> core.nil attributes {clif.calling_convention = @tail} {
+    func.return
+  }
+  func.func @tail_direct() -> core.nil attributes {clif.calling_convention = @tail} {
+    func.tail_call {callee = @done, clif.calling_convention = @tail}
+  }
+  func.func @tail_indirect(%callee: core.i32) -> core.nil attributes {clif.calling_convention = @tail} {
+    func.tail_call_indirect %callee {clif.calling_convention = @tail}
+  }
+  func.func @ordinary_indirect(%callee: core.i32) -> core.i32 attributes {clif.calling_convention = @platform} {
+    %result = func.call_indirect %callee {clif.calling_convention = @platform} : core.i32
+    func.return %result
+  }
+}"#,
+        );
+
+        assert!(
+            result.contains("clif.return_call {callee = @done, clif.calling_convention = @tail}")
+        );
+        assert!(result.contains("clif.return_call_indirect %0 {clif.calling_convention = @tail"));
+        assert!(result.contains("clif.call_indirect %0 {clif.calling_convention = @platform"));
+        assert!(
+            !result.contains("clif.return_call_indirect %0 {clif.calling_convention = @platform")
+        );
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -22,6 +22,7 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef};
 use trunk_ir::rewrite::Module;
 
+use crate::calling_convention::calling_convention_for_op;
 use crate::function::{FunctionTranslator, translate_signature, translate_type};
 use crate::{CompilationError, CompilationResult, validate_clif_ir};
 
@@ -384,9 +385,11 @@ fn emit_module_impl(
             Linkage::Local
         };
 
+        let function_call_conv = calling_convention_for_op(ctx, func_op, call_conv)?;
+
         // Skip imported functions whose types can't be translated to Cranelift
         // (e.g., prelude extern functions using core.bytes that are never called).
-        let sig = match translate_signature(ctx, func_type_ref, call_conv, ptr_ty) {
+        let sig = match translate_signature(ctx, func_type_ref, function_call_conv, ptr_ty) {
             Ok(sig) => sig,
             Err(_) if has_abi => continue,
             Err(e) => return Err(e),
@@ -447,7 +450,8 @@ fn emit_module_impl(
         let name_sym = func_wrapped.sym_name(ctx);
         let func_type_ref = func_wrapped.r#type(ctx);
 
-        let sig = translate_signature(ctx, func_type_ref, call_conv, ptr_ty)?;
+        let function_call_conv = calling_convention_for_op(ctx, func_op, call_conv)?;
+        let sig = translate_signature(ctx, func_type_ref, function_call_conv, ptr_ty)?;
         let func_id = func_ids[&name_sym];
 
         let mut cl_func =

--- a/crates/trunk-ir-cranelift-backend/src/validation.rs
+++ b/crates/trunk-ir-cranelift-backend/src/validation.rs
@@ -6,7 +6,10 @@
 //! Dialect validation errors prevent emission from proceeding.
 
 use trunk_ir::context::IrContext;
-use trunk_ir::rewrite::{ConversionTarget, Module};
+use trunk_ir::dialect::{clif, core};
+use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::rewrite::{ConversionTarget, LegalityDecision, Module};
+use trunk_ir::walk::{WalkAction, walk_region};
 
 use crate::{CompilationError, CompilationResult};
 
@@ -39,7 +42,8 @@ pub fn validate_clif_ir(ctx: &IrContext, module: Module) -> CompilationResult<()
     let failures = target.verify_full(ctx, body);
 
     if failures.is_empty() {
-        return Ok(());
+        return validate_indirect_call_signatures(ctx, body)
+            .map_err(CompilationError::ir_validation);
     }
 
     let errors: Vec<String> = failures
@@ -54,13 +58,94 @@ pub fn validate_clif_ir(ctx: &IrContext, module: Module) -> CompilationResult<()
     Err(CompilationError::ir_validation(message))
 }
 
+/// Ensure that an indirect call's explicit signature describes the actual
+/// SSA arguments that reach Cranelift. This prevents a pointer-sized closure
+/// representation from silently replacing an `i32` source-data slot.
+fn validate_indirect_call_signatures(
+    ctx: &IrContext,
+    body: trunk_ir::RegionRef,
+) -> Result<(), String> {
+    let mut error = None;
+    let _ = walk_region::<()>(ctx, body, &mut |op| {
+        if error.is_some() {
+            return std::ops::ControlFlow::Break(());
+        }
+        let is_tail = clif::ReturnCallIndirect::matches(ctx, op);
+        if !is_tail && !clif::CallIndirect::matches(ctx, op) {
+            return std::ops::ControlFlow::Continue(WalkAction::Advance);
+        }
+
+        let Some(sig_ty) = ctx.op(op).attributes.get_type("sig") else {
+            error = Some(format!(
+                "indirect call {}.{} has no exact `sig` attribute",
+                ctx.op(op).dialect,
+                ctx.op(op).name
+            ));
+            return std::ops::ControlFlow::Break(());
+        };
+        let Some(signature) = core::Func::from_type_ref(ctx, sig_ty) else {
+            error = Some("indirect call `sig` is not a core.func type".to_owned());
+            return std::ops::ControlFlow::Break(());
+        };
+        let operands = ctx.op_operands(op);
+        let params = signature.params(ctx);
+        if operands.len() != params.len() + 1
+            || operands[1..]
+                .iter()
+                .zip(params)
+                .any(|(&operand, &expected)| ctx.value_ty(operand) != expected)
+        {
+            error = Some(format!(
+                "indirect call {}.{} operands do not match its exact signature",
+                ctx.op(op).dialect,
+                ctx.op(op).name
+            ));
+            return std::ops::ControlFlow::Break(());
+        }
+        if is_tail && !is_core_nil(ctx, signature.r#return(ctx)) {
+            error = Some("indirect proper-tail call must have a core.nil result".to_owned());
+            return std::ops::ControlFlow::Break(());
+        }
+        std::ops::ControlFlow::Continue(WalkAction::Advance)
+    });
+    error.map_or(Ok(()), Err)
+}
+
+fn is_core_nil(ctx: &IrContext, ty: trunk_ir::TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == trunk_ir::Symbol::new("core") && data.name == trunk_ir::Symbol::new("nil")
+}
+
 /// Conversion target for IR that is ready for Cranelift emission.
 pub fn native_backend_ready_target() -> ConversionTarget {
-    let mut target = ConversionTarget::new();
-    target.add_legal_dialect("clif");
-    target.add_legal_op("core", "module");
-    target
+    ConversionTarget::new()
+        .legal_op("core", "module")
+        .dynamic_dialect("clif", |ctx, op| {
+            if is_emittable_clif_operation(ctx, op) {
+                LegalityDecision::Legal
+            } else {
+                LegalityDecision::Illegal
+            }
+        })
 }
+
+fn is_emittable_clif_operation(ctx: &IrContext, op: trunk_ir::OpRef) -> bool {
+    if ctx.op(op).dialect != trunk_ir::Symbol::new("clif") {
+        return false;
+    }
+    ctx.op(op).name.with_str(|name| {
+        CLIF_EMITTER_OPERATIONS
+            .split_whitespace()
+            .any(|supported| supported == name)
+    })
+}
+
+const CLIF_EMITTER_OPERATIONS: &str = r#"
+func call call_indirect return iconst f32const f64const iadd isub imul sdiv udiv srem urem
+ineg fadd fsub fmul fdiv fneg icmp fcmp band bor bxor ishl sshr ushr brif jump br_table
+trap return_call return_call_indirect load store atomic_rmw stack_slot stack_addr symbol_addr
+ireduce uextend sextend fpromote fdemote fcvt_to_sint fcvt_from_sint fcvt_to_uint fcvt_from_uint
+"#;
 
 #[cfg(test)]
 mod tests {
@@ -126,5 +211,31 @@ mod tests {
         assert!(err.contains("native-backend-ready"));
         assert!(err.contains("arith.add"));
         assert!(err.contains("Unknown"));
+    }
+
+    #[test]
+    fn native_backend_ready_rejects_unknown_clif_operations() {
+        let (mut ctx, loc) = test_ctx();
+        let module = make_module(&mut ctx, loc, "clif", "unknown");
+
+        let error = validate_clif_ir(&ctx, module).unwrap_err().to_string();
+
+        assert!(error.contains("clif.unknown"), "{error}");
+    }
+
+    #[test]
+    fn native_backend_ready_rejects_indirect_signature_type_mismatch() {
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
+    clif.return_call_indirect %callee, %value {sig = core.func(core.nil, core.i64)}
+  }
+}"#,
+        );
+
+        let error = validate_clif_ir(&ctx, module).unwrap_err().to_string();
+        assert!(error.contains("operands do not match its exact signature"));
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -25,7 +25,8 @@ use handlers::{
     handle_i64_store, handle_i64_store8, handle_i64_store16, handle_i64_store32, handle_if,
     handle_local_get, handle_local_set, handle_local_tee, handle_loop, handle_memory_grow,
     handle_memory_size, handle_ref_cast, handle_ref_func, handle_ref_null, handle_ref_test,
-    handle_return_call, handle_struct_get, handle_struct_new, handle_struct_set,
+    handle_return_call, handle_return_call_indirect, handle_struct_get, handle_struct_new,
+    handle_struct_set,
 };
 use helpers::*;
 use value_emission::*;
@@ -1003,6 +1004,8 @@ fn emit_op_nested(
         handle_call_indirect(ctx, op, emit_ctx, module_info, function)
     } else if let Ok(return_call_op) = wasm_dialect::ReturnCall::from_op(ctx, op) {
         handle_return_call(ctx, return_call_op, emit_ctx, module_info, function)
+    } else if wasm_dialect::ReturnCallIndirect::matches(ctx, op) {
+        handle_return_call_indirect(ctx, op, emit_ctx, module_info, function)
     } else if let Ok(local_op) = wasm_dialect::LocalGet::from_op(ctx, op) {
         handle_local_get(ctx, local_op, emit_ctx, function)
     } else if let Ok(local_op) = wasm_dialect::LocalSet::from_op(ctx, op) {
@@ -1166,7 +1169,9 @@ fn should_adjust_handler_return_to_i32(ctx: &IrContext, region: RegionRef) -> bo
 fn region_contains_call_indirect(ctx: &IrContext, region: RegionRef) -> bool {
     for &block_ref in &ctx.region(region).blocks {
         for &op in &ctx.block(block_ref).ops {
-            if wasm_dialect::CallIndirect::matches(ctx, op) {
+            if wasm_dialect::CallIndirect::matches(ctx, op)
+                || wasm_dialect::ReturnCallIndirect::matches(ctx, op)
+            {
                 return true;
             }
             for &nested_region in &ctx.op(op).regions {

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -129,8 +129,11 @@ pub(crate) fn collect_call_indirect_types(
                     )?;
                 }
 
-                // Check if this is a call_indirect
-                if wasm_dialect::CallIndirect::matches(ctx, op) {
+                // Ordinary and proper-tail indirect calls share table/type-index
+                // machinery. Proper-tail transfers use the physical void result.
+                let is_call_indirect = wasm_dialect::CallIndirect::matches(ctx, op);
+                let is_return_call_indirect = wasm_dialect::ReturnCallIndirect::matches(ctx, op);
+                if is_call_indirect || is_return_call_indirect {
                     // Build function type from operands and results
                     let operands: Vec<_> = ctx.op_operands(op).to_vec();
 
@@ -181,11 +184,19 @@ pub(crate) fn collect_call_indirect_types(
                     // WebAssembly GC has separate type hierarchies for anyref and funcref,
                     // so we can't cast between them.
                     let result_types: Vec<_> = ctx.op_result_types(op).to_vec();
-                    let mut result_ty = match result_types.first().copied() {
-                        Some(ty) => ty,
-                        None => continue, // Skip if no result
+                    let mut result_ty = if is_return_call_indirect {
+                        ctx.types.intern(TypeData {
+                            dialect: Symbol::new("core"),
+                            name: Symbol::new("nil"),
+                            params: Default::default(),
+                            attrs: Default::default(),
+                        })
+                    } else {
+                        match result_types.first().copied() {
+                            Some(ty) => ty,
+                            None => continue,
+                        }
                     };
-
                     // If result type is anyref but enclosing function returns funcref,
                     // use funcref as the result type. This is needed because WebAssembly GC has
                     // separate type hierarchies for anyref and funcref - you can't cast between them.
@@ -329,7 +340,9 @@ pub(crate) fn has_call_indirect(ctx: &IrContext, module: Module) -> bool {
                 }
 
                 // Check if this is a call_indirect
-                if wasm_dialect::CallIndirect::matches(ctx, op) {
+                if wasm_dialect::CallIndirect::matches(ctx, op)
+                    || wasm_dialect::ReturnCallIndirect::matches(ctx, op)
+                {
                     return true;
                 }
             }

--- a/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
@@ -13,12 +13,12 @@ use trunk_ir::Symbol;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
-use trunk_ir::types::TypeData;
+use trunk_ir::types::{Attribute, TypeData, TypeDataBuilder};
 use wasm_encoder::{FieldType, StorageType, ValType};
 
 use crate::gc_types::{
-    self, CONTINUATION_IDX, EVIDENCE_IDX, FIRST_USER_TYPE_IDX, GcTypeDef, MARKER_IDX,
-    RESUME_WRAPPER_IDX, STEP_IDX,
+    self, CONTINUATION_IDX, EVIDENCE_ARRAY_TYPE_ATTR, EVIDENCE_IDX, FIRST_USER_TYPE_IDX, GcTypeDef,
+    MARKER_IDX, RESUME_WRAPPER_IDX, STEP_IDX,
 };
 use crate::{CompilationError, CompilationResult};
 
@@ -101,17 +101,12 @@ fn get_canonical_type_name(ctx: &IrContext, ty: TypeRef) -> Option<Symbol> {
         }
     }
 
-    // Check if this is an adt.enum type
+    // A typeref and its declaration carry the same explicit nominal identity.
+    // Both are valid field descriptions for an ADT reference at this boundary.
     if data.dialect == Symbol::new("adt")
-        && data.name == Symbol::new("enum")
-        && let Some(name_sym) = data.attrs.get_symbol("name")
-    {
-        return Some(name_sym);
-    }
-
-    // Check if this is an adt.struct type
-    if data.dialect == Symbol::new("adt")
-        && data.name == Symbol::new("struct")
+        && ["enum", "struct", "typeref"]
+            .into_iter()
+            .any(|name| data.name == Symbol::new(name))
         && let Some(name_sym) = data.attrs.get_symbol("name")
     {
         return Some(name_sym);
@@ -123,14 +118,15 @@ fn get_canonical_type_name(ctx: &IrContext, ty: TypeRef) -> Option<Symbol> {
 /// Normalize a type for GC struct field comparison.
 ///
 /// Normalizes tribute_rt types and variant instances to their canonical form.
-fn normalize_type_for_gc(ctx: &IrContext, ty: TypeRef) -> TypeRef {
+fn normalize_type_for_gc(ctx: &mut IrContext, ty: TypeRef) -> TypeRef {
     let data = ctx.types.get(ty);
 
-    // Normalize variant instance types to their base enum
-    if data.dialect == Symbol::new("adt")
-        && let Some(base_enum) = data.attrs.get_type("base_enum")
-    {
-        return base_enum;
+    // A concrete variant can inhabit a recursively typed field only through
+    // the physical struct supertype.  Keeping its logical base enum here
+    // would make the GC definition record `anyref` while uses expect the
+    // `structref` selected by signature physicalization.
+    if data.dialect == Symbol::new("adt") && data.attrs.get_type("base_enum").is_some() {
+        return intern_wasm_structref(ctx);
     }
 
     // Note: tribute_rt types (int, nat, bool, float, any, intref) should be
@@ -139,7 +135,7 @@ fn normalize_type_for_gc(ctx: &IrContext, ty: TypeRef) -> TypeRef {
 }
 
 /// Check if two types are semantically equivalent for GC struct fields.
-fn types_equivalent_for_gc(ctx: &IrContext, ty1: TypeRef, ty2: TypeRef) -> bool {
+fn types_equivalent_for_gc(ctx: &mut IrContext, ty1: TypeRef, ty2: TypeRef) -> bool {
     // First try direct comparison
     if ty1 == ty2 {
         return true;
@@ -188,7 +184,7 @@ fn types_equivalent_for_gc(ctx: &IrContext, ty1: TypeRef, ty2: TypeRef) -> bool 
 
 /// Record a struct field type
 fn record_struct_field(
-    ctx: &IrContext,
+    ctx: &mut IrContext,
     type_idx: u32,
     builder: &mut GcTypeBuilder,
     field_idx: u32,
@@ -210,9 +206,16 @@ fn record_struct_field(
     if let Some(existing) = builder.fields[idx] {
         // Check if types are semantically equivalent
         if !types_equivalent_for_gc(ctx, existing, ty) {
+            let existing_data = ctx.types.get(existing);
+            let new_data = ctx.types.get(ty);
             return Err(CompilationError::type_error(format!(
-                "struct type index {type_idx} field {field_idx} type mismatch: existing={:?}, new={:?}",
-                existing, ty
+                "struct type index {type_idx} field {field_idx} type mismatch: existing={:?} ({}.{}), new={:?} ({}.{})",
+                existing,
+                existing_data.dialect,
+                existing_data.name,
+                ty,
+                new_data.dialect,
+                new_data.name,
             )));
         }
     } else {
@@ -256,11 +259,23 @@ fn type_to_field_type(
     })
 }
 
-/// Create a wasm.arrayref TypeRef.
-fn intern_wasm_arrayref(ctx: &mut IrContext) -> TypeRef {
+/// Create the exact Wasm array reference used by evidence storage.
+///
+/// A bare `wasm.arrayref` can be an unrelated source array and must not claim
+/// the Evidence builtin index.
+fn intern_wasm_evidence_arrayref(ctx: &mut IrContext) -> TypeRef {
+    ctx.types.intern(
+        TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("arrayref"))
+            .attr(EVIDENCE_ARRAY_TYPE_ATTR, Attribute::Bool(true))
+            .build(),
+    )
+}
+
+/// Create a wasm.structref TypeRef.
+fn intern_wasm_structref(ctx: &mut IrContext) -> TypeRef {
     ctx.types.intern(TypeData {
         dialect: Symbol::new("wasm"),
-        name: Symbol::new("arrayref"),
+        name: Symbol::new("structref"),
         params: Default::default(),
         attrs: Default::default(),
     })
@@ -291,12 +306,8 @@ pub(crate) fn collect_gc_types(
     // Step marker type needs to be registered so wasm.if can use it
     let step_ty = intern_named_adt_struct(ctx, "_Step");
     type_idx_by_type.insert(step_ty, STEP_IDX);
-    // Abstract wasm.arrayref maps to EVIDENCE_IDX because type_converter lowers
-    // all core::Array types to wasm::Arrayref (which erases element type info).
-    // Currently the only array in the system is the evidence array, so this is safe.
-    // TODO: if user-defined arrays are added, this will need per-element-type indices.
-    let arrayref_ty = intern_wasm_arrayref(ctx);
-    type_idx_by_type.insert(arrayref_ty, EVIDENCE_IDX);
+    let evidence_arrayref_ty = intern_wasm_evidence_arrayref(ctx);
+    type_idx_by_type.insert(evidence_arrayref_ty, EVIDENCE_IDX);
     // Marker ADT type needs to be registered so wasm.struct_new for Marker reuses MARKER_IDX
     // instead of creating a separate user type index.
     let marker_ty = intern_named_adt_struct(ctx, "_Marker");
@@ -601,4 +612,35 @@ pub(crate) fn collect_gc_types(
     result.extend(user_types);
 
     Ok((result, type_idx_by_type))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+
+    #[test]
+    fn canonical_nominal_typeref_and_definition_share_a_gc_field_layout() {
+        let mut ctx = IrContext::new();
+        let source = r#"core.module @test {
+  !String = adt.enum() {name = @String, variants = []}
+  !StringRef = adt.typeref() {name = @String}
+  !Box = adt.struct() {fields = [[@value, !StringRef]], name = @Box}
+
+  wasm.func @main() -> core.nil {
+    %ref = wasm.ref_null {heap_type = @anyref} : !StringRef
+    %definition = wasm.ref_null {heap_type = @anyref} : !String
+    %first = wasm.struct_new %ref {type_idx = TYPE_INDEX} : !Box
+    %second = wasm.struct_new %definition {type_idx = TYPE_INDEX} : !Box
+    wasm.return
+  }
+}"#;
+        let module = parse_test_module(
+            &mut ctx,
+            &source.replace("TYPE_INDEX", &FIRST_USER_TYPE_IDX.to_string()),
+        );
+
+        let (types, _) = collect_gc_types(&mut ctx, module).expect("matching nominal field types");
+        assert!(types.len() > FIRST_USER_TYPE_IDX as usize);
+    }
 }

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -4,6 +4,7 @@
 //! - wasm.call (direct function call)
 //! - wasm.call_indirect (indirect function call via i32 table index)
 //! - wasm.return_call (tail call)
+//! - wasm.return_call_indirect (indirect tail call)
 
 use tracing::debug;
 use trunk_ir::IrContext;
@@ -192,32 +193,22 @@ pub(crate) fn handle_call_indirect(
         ctx.types.get(result_ty).name
     );
 
-    // Get or compute type_idx
+    // The lowering pattern leaves a placeholder `type_idx = 0` on this op.
+    // Resolve the exact collected signature index at emission time.
     let attrs = &ctx.op(op).attributes;
-    let type_idx = match attr_u32(attrs, Symbol::new("type_idx")) {
-        Ok(idx) => {
-            debug!("call_indirect emit: using type_idx from attribute: {}", idx);
-            idx
-        }
-        Err(_) => {
-            // Look up type index
-            let idx = module_info
-                .type_idx_by_type
-                .get(&func_type)
-                .copied()
-                .ok_or_else(|| {
-                    debug!(
-                        "call_indirect emit: func_type not found in type_idx_by_type! func_type={:?}",
-                        func_type
-                    );
-                    CompilationError::invalid_module(
-                        "wasm.call_indirect function type not registered in type section",
-                    )
-                })?;
-            debug!("call_indirect emit: looked up type_idx: {}", idx);
-            idx
-        }
-    };
+    let type_idx = module_info
+        .type_idx_by_type
+        .get(&func_type)
+        .copied()
+        .ok_or_else(|| {
+            debug!(
+                "call_indirect emit: func_type not found in type_idx_by_type! func_type={:?}",
+                func_type
+            );
+            CompilationError::invalid_module(
+                "wasm.call_indirect function type not registered in type section",
+            )
+        })?;
 
     // call_indirect with i32 table index
     // IR operand order: [table_idx, arg1, arg2, ...]
@@ -263,6 +254,71 @@ pub(crate) fn handle_return_call(
     Ok(())
 }
 
+/// Handle wasm.return_call_indirect operation (indirect tail call).
+pub(crate) fn handle_return_call_indirect(
+    ctx: &IrContext,
+    op: OpRef,
+    emit_ctx: &FunctionEmitContext,
+    module_info: &ModuleInfo,
+    function: &mut Function,
+) -> CompilationResult<()> {
+    let operands = ctx.op_operands(op);
+    if operands.is_empty() {
+        return Err(CompilationError::invalid_module(
+            "wasm.return_call_indirect requires at least a table index operand",
+        ));
+    }
+    if !ctx.op_result_types(op).is_empty() {
+        return Err(CompilationError::invalid_module(
+            "wasm.return_call_indirect must not produce a result",
+        ));
+    }
+
+    let table_index = operands[0];
+    let table_index_ty = helpers::value_type(ctx, table_index);
+    if !helpers::is_type(ctx, table_index_ty, "core", "i32") {
+        let data = ctx.types.get(table_index_ty);
+        return Err(CompilationError::invalid_module(format!(
+            "return_call_indirect first operand must be i32 table index, got {}.{}",
+            data.dialect, data.name
+        )));
+    }
+
+    let param_types: Vec<TypeRef> = operands
+        .iter()
+        .skip(1)
+        .map(|value| helpers::value_type(ctx, *value))
+        .collect();
+    let func_type = find_void_func_type_in_registry(ctx, &param_types, module_info)?;
+    // The lowering pattern leaves a placeholder `type_idx = 0` on this op.
+    // Tail calls must use the index assigned to the exact collected signature;
+    // unlike ordinary calls, an attribute here is never authoritative.
+    let type_index = module_info
+        .type_idx_by_type
+        .get(&func_type)
+        .copied()
+        .ok_or_else(|| {
+            CompilationError::invalid_module(
+                "wasm.return_call_indirect function type not registered in type section",
+            )
+        })?;
+    let attrs = &ctx.op(op).attributes;
+    let table = match attrs.get("table") {
+        Some(_) => attr_u32(attrs, Symbol::new("table"))?,
+        None => 0,
+    };
+
+    for &operand in operands.iter().skip(1) {
+        emit_value(ctx, operand, emit_ctx, function)?;
+    }
+    emit_value(ctx, table_index, emit_ctx, function)?;
+    function.instruction(&Instruction::ReturnCallIndirect {
+        type_index,
+        table_index: table,
+    });
+    Ok(())
+}
+
 // ============================================================================
 // Helper functions
 // ============================================================================
@@ -305,4 +361,128 @@ fn find_func_type_in_registry(
     Err(CompilationError::invalid_module(
         "wasm.call_indirect function type not registered in type section",
     ))
+}
+
+fn find_void_func_type_in_registry(
+    ctx: &IrContext,
+    params: &[TypeRef],
+    module_info: &ModuleInfo,
+) -> CompilationResult<TypeRef> {
+    for &ty_ref in module_info.type_idx_by_type.keys() {
+        if helpers::func_type_parts(ctx, ty_ref).is_some_and(|(ty_params, ty_result)| {
+            helpers::is_nil_type(ctx, ty_result) && ty_params == params
+        }) {
+            return Ok(ty_ref);
+        }
+    }
+    for &ty_ref in module_info.func_types.values() {
+        if helpers::func_type_parts(ctx, ty_ref).is_some_and(|(ty_params, ty_result)| {
+            helpers::is_nil_type(ctx, ty_result) && ty_params == params
+        }) {
+            return Ok(ty_ref);
+        }
+    }
+    Err(CompilationError::invalid_module(
+        "wasm.return_call_indirect void function type not registered in type section",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use trunk_ir::Span;
+    use trunk_ir::refs::PathRef;
+    use trunk_ir::types::{Location, TypeDataBuilder};
+    use wasm_encoder::ValType;
+
+    use crate::emit::CommonTypes;
+
+    use super::*;
+
+    #[test]
+    fn return_call_indirect_emits_registered_nonzero_type_index() {
+        let mut ctx = IrContext::new();
+        let location = Location::new(PathRef::from_u32(0), Span::default());
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let nil_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("nil")).build());
+        let func_ty = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                .param(nil_ty)
+                .build(),
+        );
+        let table = wasm_dialect::i32_const(&mut ctx, location, i32_ty, 0);
+        let table_result = table.result(&ctx);
+        let tail = wasm_dialect::return_call_indirect(&mut ctx, location, vec![table_result], 0, 0);
+        let emit_ctx = FunctionEmitContext {
+            value_locals: HashMap::from([(table_result, 0)]),
+            effective_types: HashMap::new(),
+            func_return_type: None,
+        };
+        let module_info = ModuleInfo {
+            type_idx_by_type: HashMap::from([(func_ty, 7)]),
+            ..ModuleInfo::default()
+        };
+        let mut function = Function::new([(1, ValType::I32)]);
+
+        handle_return_call_indirect(&ctx, tail.op_ref(), &emit_ctx, &module_info, &mut function)
+            .expect("tail indirect call should emit");
+
+        let body = function.into_raw_body();
+        assert!(
+            body.ends_with(&[0x13, 0x07, 0x00]),
+            "registered type index must be emitted in return_call_indirect"
+        );
+    }
+
+    #[test]
+    fn call_indirect_emits_registered_nonzero_type_index() {
+        let mut ctx = IrContext::new();
+        let location = Location::new(PathRef::from_u32(0), Span::default());
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let anyref_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("anyref")).build());
+        let funcref_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("funcref")).build());
+        let func_ty = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                .param(i32_ty)
+                .build(),
+        );
+        let table = wasm_dialect::i32_const(&mut ctx, location, i32_ty, 0);
+        let table_result = table.result(&ctx);
+        let call =
+            wasm_dialect::call_indirect(&mut ctx, location, vec![table_result], vec![i32_ty], 0, 0);
+        let call_result = call.results(&ctx)[0];
+        let emit_ctx = FunctionEmitContext {
+            value_locals: HashMap::from([(table_result, 0), (call_result, 1)]),
+            effective_types: HashMap::new(),
+            func_return_type: None,
+        };
+        let module_info = ModuleInfo {
+            type_idx_by_type: HashMap::from([(func_ty, 7)]),
+            common_types: CommonTypes {
+                anyref: Some(anyref_ty),
+                funcref: Some(funcref_ty),
+                ..CommonTypes::default()
+            },
+            ..ModuleInfo::default()
+        };
+        let mut function = Function::new([(2, ValType::I32)]);
+
+        handle_call_indirect(&ctx, call.op_ref(), &emit_ctx, &module_info, &mut function)
+            .expect("ordinary indirect call should emit");
+
+        let body = function.into_raw_body();
+        assert!(body.windows(3).any(|window| window == [0x11, 0x07, 0x00]));
+        assert!(!body.windows(3).any(|window| window == [0x13, 0x07, 0x00]));
+    }
 }

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/mod.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/mod.rs
@@ -16,7 +16,9 @@ pub(super) use array_handlers::{
     handle_array_copy, handle_array_get, handle_array_get_s, handle_array_get_u, handle_array_new,
     handle_array_new_default, handle_array_set,
 };
-pub(super) use call_handlers::{handle_call, handle_call_indirect, handle_return_call};
+pub(super) use call_handlers::{
+    handle_call, handle_call_indirect, handle_return_call, handle_return_call_indirect,
+};
 pub(super) use const_handlers::{
     handle_f32_const, handle_f64_const, handle_i32_const, handle_i64_const,
 };

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -12,7 +12,7 @@ use trunk_ir::types::{Attribute, AttributeMap};
 use wasm_encoder::{AbstractHeapType, HeapType, RefType, ValType};
 
 use crate::errors::CompilationErrorKind;
-use crate::gc_types::{BYTES_ARRAY_IDX, BYTES_STRUCT_IDX, CLOSURE_STRUCT_IDX, STEP_IDX};
+use crate::gc_types::{BYTES_STRUCT_IDX, CLOSURE_STRUCT_IDX, STEP_IDX, concrete_wasm_ref_type};
 use crate::{CompilationError, CompilationResult};
 
 // ============================================================================
@@ -123,12 +123,8 @@ pub(crate) fn type_to_valtype(
             nullable: false,
             heap_type: HeapType::Concrete(BYTES_STRUCT_IDX),
         }))
-    } else if is_bytes_array_ref(ctx, ty) {
-        let nullable = ctx.types.get(ty).attrs.get_bool("nullable") == Some(true);
-        Ok(ValType::Ref(RefType {
-            nullable,
-            heap_type: HeapType::Concrete(BYTES_ARRAY_IDX),
-        }))
+    } else if let Some(reference) = concrete_wasm_ref_type(ctx, ty) {
+        Ok(ValType::Ref(reference))
     } else if is_type(ctx, ty, "core", "ptr") {
         Ok(ValType::I32)
     } else if let Some(&type_idx) = type_idx_by_type.get(&ty) {
@@ -204,21 +200,6 @@ pub(crate) fn type_to_valtype(
             data.dialect, data.name
         )))
     }
-}
-
-fn is_bytes_array_ref(ctx: &IrContext, ty: TypeRef) -> bool {
-    let reference = ctx.types.get(ty);
-    if reference.dialect != Symbol::new("core")
-        || reference.name != Symbol::new("ref")
-        || reference.params.len() != 1
-    {
-        return false;
-    }
-    let array = ctx.types.get(reference.params[0]);
-    array.dialect == Symbol::new("core")
-        && array.name == Symbol::new("array")
-        && array.params.len() == 1
-        && is_type(ctx, array.params[0], "core", "i8")
 }
 
 /// Convert an IR return type to WebAssembly result types.
@@ -346,6 +327,8 @@ pub(crate) fn attr_u32(attrs: &AttributeMap, key: Symbol) -> CompilationResult<u
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gc_types::BYTES_ARRAY_IDX;
+    use trunk_ir::dialect::core;
     use trunk_ir::types::TypeDataBuilder;
 
     #[test]
@@ -370,5 +353,26 @@ mod tests {
                 },
             })
         );
+    }
+
+    #[test]
+    fn bytes_backing_reference_uses_concrete_array_index_and_nullability() {
+        let mut ctx = IrContext::new();
+        let i8_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i8")).build());
+        let array_ty = core::array(&mut ctx, i8_ty).as_type_ref();
+
+        for (nullable, expected_nullable) in [(false, false), (true, true)] {
+            let reference = core::r#ref(&mut ctx, array_ty, nullable).as_type_ref();
+            assert_eq!(
+                type_to_valtype(&ctx, reference, &HashMap::new())
+                    .expect("Bytes backing reference is supported"),
+                ValType::Ref(RefType {
+                    nullable: expected_nullable,
+                    heap_type: HeapType::Concrete(BYTES_ARRAY_IDX),
+                })
+            );
+        }
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/gc_types.rs
+++ b/crates/trunk-ir-wasm-backend/src/gc_types.rs
@@ -18,7 +18,15 @@
 //! Index 9+: User-defined types (structs, arrays, variants, closures, etc.)
 //! ```
 
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::refs::TypeRef;
 use wasm_encoder::{FieldType, HeapType, RefType, StorageType, ValType};
+
+/// Marks the exact physical array type used for ability evidence.  A bare
+/// `wasm.arrayref` may also represent an unrelated erased source array, so it
+/// must never be inferred to use the Evidence builtin index.
+pub const EVIDENCE_ARRAY_TYPE_ATTR: &str = "wasm.evidence_array";
 
 /// Type index for BoxedF64 (Float wrapper for polymorphic contexts).
 /// This is always index 0 in the GC type section.
@@ -61,6 +69,38 @@ pub const CONTINUATION_IDX: u32 = 7;
 /// This is always index 8 in the GC type section.
 /// Packages captured state and resume value for continuation resume functions.
 pub const RESUME_WRAPPER_IDX: u32 = 8;
+
+/// Return the concrete WasmGC reference representation for a supported
+/// `core.ref` value.
+///
+/// The Bytes backing array is the only `core.ref` form in the Wasm ABI.  Keep
+/// its source-level pointee intact until emission so every consumer resolves
+/// the same concrete builtin array index and nullability.
+pub fn concrete_wasm_ref_type(ctx: &IrContext, ty: TypeRef) -> Option<RefType> {
+    let reference = ctx.types.get(ty);
+    if reference.dialect != Symbol::new("core")
+        || reference.name != Symbol::new("ref")
+        || reference.params.len() != 1
+    {
+        return None;
+    }
+
+    let array = ctx.types.get(reference.params[0]);
+    if array.dialect != Symbol::new("core")
+        || array.name != Symbol::new("array")
+        || array.params.len() != 1
+        || !ctx
+            .types
+            .is_dialect(array.params[0], Symbol::new("core"), Symbol::new("i8"))
+    {
+        return None;
+    }
+
+    Some(RefType {
+        nullable: reference.attrs.get_bool("nullable") == Some(true),
+        heap_type: HeapType::Concrete(BYTES_ARRAY_IDX),
+    })
+}
 
 /// First type index available for user-defined types.
 pub const FIRST_USER_TYPE_IDX: u32 = 9;

--- a/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/adt_to_wasm.rs
@@ -53,18 +53,12 @@ use trunk_ir::rewrite::{
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
-/// Prefer a substituted operand type only when it still carries ADT identity.
-/// Erased representations such as `anyref` cannot identify the enum whose
-/// variant is being tested or cast.
-fn resolved_enum_type(ctx: &IrContext, operand_ty: TypeRef, attr_ty: TypeRef) -> TypeRef {
-    let operand = ctx.types.get(operand_ty);
-    if operand.dialect == Symbol::new("adt")
-        && (operand.name == Symbol::new("enum") || operand.name == Symbol::new("typeref"))
-    {
-        operand_ty
-    } else {
-        attr_ty
-    }
+/// The logical variant operation's `type` attribute is its exact enum-layout
+/// identity. Operand types may be an equivalent `adt.typeref` or already have
+/// an erased target representation, neither of which may choose a distinct
+/// WasmGC nominal variant type.
+fn canonical_enum_type(ctx: &IrContext, attr_ty: TypeRef) -> Option<TypeRef> {
+    get_enum_variants(ctx, attr_ty).map(|_| attr_ty)
 }
 
 /// Lower adt dialect to wasm dialect using arena IR.
@@ -208,7 +202,9 @@ impl RewritePattern for VariantNewPattern {
 
         let loc = ctx.op(op).location;
         let tag_sym = variant_new.tag(ctx);
-        let base_type = variant_new.r#type(ctx);
+        let Some(base_type) = canonical_enum_type(ctx, variant_new.r#type(ctx)) else {
+            return false;
+        };
         let fields: Vec<_> = variant_new.fields(ctx).to_vec();
 
         // Create variant-specific type: Expr + Add -> Expr$Add
@@ -280,9 +276,9 @@ impl RewritePattern for VariantIsPattern {
         let ref_val = variant_is.r#ref(ctx);
         let result_ty = variant_is.result_ty(ctx);
 
-        // Prefer a substituted operand type only while it retains ADT identity.
-        let operand_ty = ctx.value_ty(ref_val);
-        let enum_type = resolved_enum_type(ctx, operand_ty, variant_is.r#type(ctx));
+        let Some(enum_type) = canonical_enum_type(ctx, variant_is.r#type(ctx)) else {
+            return false;
+        };
 
         // Create variant-specific type for the ref.test
         let variant_type = make_variant_type(ctx, enum_type, tag);
@@ -314,10 +310,9 @@ impl RewritePattern for VariantCastPattern {
         let tag = variant_cast.tag(ctx);
         let ref_val = variant_cast.r#ref(ctx);
 
-        // Prefer a substituted operand type only while it retains ADT identity.
-        let operand_ty = ctx.value_ty(ref_val);
-        let attr_type = variant_cast.r#type(ctx);
-        let enum_type = resolved_enum_type(ctx, operand_ty, attr_type);
+        let Some(enum_type) = canonical_enum_type(ctx, variant_cast.r#type(ctx)) else {
+            return false;
+        };
 
         // Create variant-specific type for the ref.cast
         let variant_type = make_variant_type(ctx, enum_type, tag);
@@ -350,17 +345,23 @@ impl RewritePattern for VariantGetPattern {
         let loc = ctx.op(op).location;
         let ref_val = variant_get.r#ref(ctx);
         let field_idx = variant_get.field(ctx);
-        let declared_field_ty = get_enum_variants(ctx, variant_get.r#type(ctx))
+        let Some(enum_type) = canonical_enum_type(ctx, variant_get.r#type(ctx)) else {
+            return false;
+        };
+        let Some(declared_field_ty) = get_enum_variants(ctx, enum_type)
             .and_then(|variants| {
                 variants
                     .into_iter()
                     .find(|(tag, _)| *tag == variant_get.tag(ctx))
             })
-            .and_then(|(_, fields)| fields.get(field_idx as usize).copied());
+            .and_then(|(_, fields)| fields.get(field_idx as usize).copied())
+        else {
+            return false;
+        };
         // String::Leaf has the canonical core.bytes layout even though frontend
         // pattern extraction is temporarily erased to anyref. Keep other fields
         // on the normal type-converter path.
-        let result_ty = declared_field_ty
+        let result_ty = Some(declared_field_ty)
             .filter(|ty| {
                 let data = ctx.types.get(*ty);
                 data.dialect == Symbol::new("core") && data.name == Symbol::new("bytes")
@@ -370,7 +371,7 @@ impl RewritePattern for VariantGetPattern {
         let variant_type = if ctx.types.get(operand_ty).attrs.get_bool("is_variant") == Some(true) {
             operand_ty
         } else {
-            make_variant_type(ctx, variant_get.r#type(ctx), variant_get.tag(ctx))
+            make_variant_type(ctx, enum_type, variant_get.tag(ctx))
         };
 
         // Infer type from the operand (the cast result has the variant-specific type)
@@ -592,21 +593,24 @@ mod tests {
     use trunk_ir::parser::parse_test_module;
 
     #[test]
-    fn resolved_enum_type_rejects_erased_operands() {
+    fn canonical_enum_type_requires_an_exact_enum_layout() {
         let mut ctx = IrContext::new();
+        let _module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !E = adt.enum() {name = @E, variants = []}
+  !ERef = adt.typeref() {name = @E}
+}"#,
+        );
         let enum_ty = ctx
-            .types
-            .intern(TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("enum")).build());
+            .type_alias_by_name(Symbol::new("E"))
+            .expect("enum layout");
         let typeref_ty = ctx
-            .types
-            .intern(TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("typeref")).build());
-        let erased_ty = ctx
-            .types
-            .intern(TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("anyref")).build());
+            .type_alias_by_name(Symbol::new("ERef"))
+            .expect("enum reference");
 
-        assert_eq!(resolved_enum_type(&ctx, enum_ty, typeref_ty), enum_ty);
-        assert_eq!(resolved_enum_type(&ctx, typeref_ty, enum_ty), typeref_ty);
-        assert_eq!(resolved_enum_type(&ctx, erased_ty, enum_ty), enum_ty);
+        assert_eq!(canonical_enum_type(&ctx, enum_ty), Some(enum_ty));
+        assert_eq!(canonical_enum_type(&ctx, typeref_ty), None);
     }
 
     #[test]
@@ -616,8 +620,8 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   !S = adt.struct() {fields = [[@value, core.i32]], name = @S}
-  !E = adt.typeref(core.i32) {name = @E}
-  !EUnresolved = adt.typeref() {name = @E}
+  !E = adt.enum() {name = @E, variants = [[@Some, [core.i32]]]}
+  !ERef = adt.typeref() {name = @E}
   !A = core.array(core.i32)
 
   wasm.func @main() -> core.nil {
@@ -627,10 +631,10 @@ mod tests {
     %field = adt.struct_get %struct {type = !S, field = 0} : core.i32
     adt.struct_set %struct, %field {type = !S, field = 0}
 
-    %variant = adt.variant_new %one {type = !E, tag = @Some} : !E
+    %variant = adt.variant_new %one {type = !E, tag = @Some} : !ERef
     %is_some = adt.variant_is %variant {type = !E, tag = @Some} : core.i32
-    %cast = adt.variant_cast %variant {type = !E, tag = @Some} : !E
-    %payload = adt.variant_get %cast {type = !EUnresolved, tag = @Some, field = 0} : core.i32
+    %cast = adt.variant_cast %variant {type = !E, tag = @Some} : !ERef
+    %payload = adt.variant_get %cast {type = !E, tag = @Some, field = 0} : core.i32
 
     %empty = adt.array_new {type = !A} : !A
     %default = adt.array_new %one {type = !A} : !A
@@ -689,5 +693,64 @@ mod tests {
             .get_type("type")
             .expect("struct_get type must be a Type attribute");
         assert_eq!(variant_ty, ctx.value_ty(ctx.op_operands(variant_get)[0]));
+    }
+
+    #[test]
+    fn variant_operations_share_the_exact_enum_layout_when_values_use_typerefs() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !ERef = adt.typeref() {name = @E}
+  !E = adt.enum() {name = @E, variants = [[@Leaf, [core.i32]], [@Branch, [!ERef]]]}
+
+  wasm.func @main(%input: !ERef) -> core.nil {
+    %zero = wasm.i32_const {value = 0} : core.i32
+    %leaf = adt.variant_new %zero {type = !E, tag = @Leaf} : !ERef
+    %is_leaf = adt.variant_is %input {type = !E, tag = @Leaf} : core.i1
+    %cast = adt.variant_cast %input {type = !E, tag = @Leaf} : !ERef
+    %payload = adt.variant_get %cast {type = !E, tag = @Leaf, field = 0} : core.i32
+    wasm.return
+  }
+}"#,
+        );
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let func = module.ops(&ctx)[0];
+        let body = ctx.op(func).regions[0];
+        let block = ctx.region(body).blocks[0];
+        let variant_types: Vec<_> = ctx
+            .block(block)
+            .ops
+            .iter()
+            .copied()
+            .filter_map(|op| {
+                let data = ctx.op(op);
+                if data.dialect != wasm_gc_dialect::DIALECT_NAME() {
+                    return None;
+                }
+                match data.name {
+                    name if name == Symbol::new("struct_new")
+                        || name == Symbol::new("struct_get") =>
+                    {
+                        data.attributes.get_type("type")
+                    }
+                    name if name == Symbol::new("ref_test") || name == Symbol::new("ref_cast") => {
+                        data.attributes.get_type("target_type")
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+        assert_eq!(variant_types.len(), 4);
+        assert!(variant_types.iter().all(|ty| *ty == variant_types[0]));
+        assert_eq!(
+            ctx.types.get(variant_types[0]).attrs.get_type("base_enum"),
+            Some(
+                ctx.type_alias_by_name(Symbol::new("E"))
+                    .expect("enum layout")
+            )
+        );
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -6,6 +6,7 @@
 //! - `func.call_indirect` -> `wasm.call_indirect`
 //! - `func.return` -> `wasm.return`
 //! - `func.tail_call` -> `wasm.return_call`
+//! - `func.tail_call_indirect` -> `wasm.return_call_indirect`
 //! - `func.unreachable` -> `wasm.unreachable`
 //! - `func.constant` -> `wasm.i32_const` (function table index)
 //!
@@ -16,7 +17,6 @@
 
 use std::collections::HashMap;
 
-use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
@@ -25,10 +25,15 @@ use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, clone_attrs_except,
 };
-use trunk_ir::types::TypeDataBuilder;
+use trunk_ir::types::{Attribute, TypeDataBuilder};
 use trunk_ir::{BlockData, RegionData};
+use trunk_ir::{OperationDataBuilder, Symbol};
 
 use trunk_ir::smallvec::smallvec;
+
+// Closure lowering preserves this generic func-dialect provenance until the
+// target ABI consumes it. Wasm derives its final type index during collection.
+const INDIRECT_CALL_SIGNATURE_ATTR: &str = func::INDIRECT_CALL_SIGNATURE_ATTR;
 
 /// Lower func dialect to wasm dialect using arena IR.
 ///
@@ -46,6 +51,7 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
             .add_pattern(FuncCallIndirectPattern)
             .add_pattern(FuncReturnPattern)
             .add_pattern(FuncTailCallPattern)
+            .add_pattern(FuncTailCallIndirectPattern)
             .add_pattern(FuncUnreachablePattern)
             .add_pattern(FuncConstantPattern {
                 table_indices: HashMap::new(),
@@ -73,6 +79,7 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(FuncCallIndirectPattern)
         .add_pattern(FuncReturnPattern)
         .add_pattern(FuncTailCallPattern)
+        .add_pattern(FuncTailCallIndirectPattern)
         .add_pattern(FuncUnreachablePattern)
         .add_pattern(FuncConstantPattern {
             table_indices: table_indices.clone(),
@@ -186,8 +193,20 @@ impl RewritePattern for FuncFuncPattern {
         let loc = ctx.op(op).location;
         let sym_name = func_op.sym_name(ctx);
         let func_type = func_op.r#type(ctx);
-        let body = func_op.body(ctx);
         let attrs_to_preserve = clone_attrs_except(ctx, op, &["sym_name", "type"]);
+        let Some(&body) = ctx.op(op).regions.first() else {
+            let mut builder =
+                OperationDataBuilder::new(loc, Symbol::new("wasm"), Symbol::new("func"))
+                    .attr("sym_name", Attribute::Symbol(sym_name))
+                    .attr("type", Attribute::Type(func_type));
+            for (name, value) in attrs_to_preserve {
+                builder = builder.attr(name, value);
+            }
+            let new_data = builder.build(ctx);
+            let new_op = ctx.create_op(new_data);
+            rewriter.replace_op(new_op);
+            return true;
+        };
 
         // Detach body region so it can be reused in the new wasm.func
         ctx.detach_region(body);
@@ -218,9 +237,18 @@ impl RewritePattern for FuncCallPattern {
         let loc = ctx.op(op).location;
         let callee = call_op.callee(ctx);
         let args: Vec<_> = ctx.op_operands(op).to_vec();
-        let result_types: Vec<TypeRef> = ctx.op_result_types(op).to_vec();
+        let result_types: Vec<TypeRef> = ctx
+            .op_result_types(op)
+            .iter()
+            .enumerate()
+            .filter_map(|(index, _)| rewriter.result_type(ctx, op, index))
+            .collect();
+        let attrs_to_preserve = clone_attrs_except(ctx, op, &["callee"]);
 
         let new_op = wasm_dialect::call(ctx, loc, args, result_types, callee);
+        ctx.op_mut(new_op.op_ref())
+            .attributes
+            .extend(attrs_to_preserve);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -246,10 +274,18 @@ impl RewritePattern for FuncCallIndirectPattern {
         let loc = ctx.op(op).location;
         let all_operands: Vec<_> = ctx.op_operands(op).to_vec();
         let result_types: Vec<TypeRef> = ctx.op_result_types(op).to_vec();
+        let attrs_to_preserve = clone_attrs_except(
+            ctx,
+            op,
+            &["type_idx", "table", INDIRECT_CALL_SIGNATURE_ATTR],
+        );
 
         // Build wasm.call_indirect with same operands
         // The emit phase will resolve the type_idx and table attributes
         let new_op = wasm_dialect::call_indirect(ctx, loc, all_operands, result_types, 0, 0);
+        ctx.op_mut(new_op.op_ref())
+            .attributes
+            .extend(attrs_to_preserve);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -295,8 +331,47 @@ impl RewritePattern for FuncTailCallPattern {
         let loc = ctx.op(op).location;
         let callee = tail_call_op.callee(ctx);
         let args: Vec<_> = ctx.op_operands(op).to_vec();
+        let attrs_to_preserve = clone_attrs_except(ctx, op, &["callee"]);
 
         let new_op = wasm_dialect::return_call(ctx, loc, args, callee);
+        ctx.op_mut(new_op.op_ref())
+            .attributes
+            .extend(attrs_to_preserve);
+        rewriter.replace_op(new_op.op_ref());
+        true
+    }
+}
+
+/// Pattern for `func.tail_call_indirect` -> `wasm.return_call_indirect`
+struct FuncTailCallIndirectPattern;
+
+impl RewritePattern for FuncTailCallIndirectPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if func::TailCallIndirect::from_op(ctx, op).is_err() || !ctx.op_result_types(op).is_empty()
+        {
+            return false;
+        }
+
+        let loc = ctx.op(op).location;
+        let operands = ctx.op_operands(op).to_vec();
+        if operands.is_empty() {
+            return false;
+        }
+        let attrs_to_preserve = clone_attrs_except(
+            ctx,
+            op,
+            &["type_idx", "table", INDIRECT_CALL_SIGNATURE_ATTR],
+        );
+
+        let new_op = wasm_dialect::return_call_indirect(ctx, loc, operands, 0, 0);
+        ctx.op_mut(new_op.op_ref())
+            .attributes
+            .extend(attrs_to_preserve);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -380,8 +455,8 @@ fn intern_funcref_type(ctx: &mut IrContext) -> TypeRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trunk_ir::dialect::core;
     use trunk_ir::parser::parse_test_module;
-    use trunk_ir::types::Attribute;
 
     #[test]
     fn func_to_wasm_preserves_custom_function_attributes() {
@@ -407,5 +482,113 @@ mod tests {
             ctx.op(lowered).attributes.get("custom"),
             Some(&Attribute::Int(7))
         );
+    }
+
+    #[test]
+    fn func_to_wasm_preserves_root_wrapper_and_call_identity_markers() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main() -> core.nil {
+    %call = func.call {callee = @__tribute_cps_main} : core.nil
+    func.return %call
+  }
+}"#,
+        );
+        let wrapper = module.ops(&ctx)[0];
+        let body = func::Func::from_op(&ctx, wrapper).unwrap().body(&ctx);
+        let root_call = ctx.block(ctx.region(body).blocks[0]).ops[0];
+        ctx.op_mut(wrapper)
+            .attributes
+            .insert(Symbol::new("tribute.root_wrapper"), Attribute::Bool(true));
+        ctx.op_mut(root_call)
+            .attributes
+            .insert(Symbol::new("tribute.root_cps_call"), Attribute::Bool(true));
+        ctx.op_mut(root_call)
+            .attributes
+            .insert(Symbol::new("tribute.calling_convention"), Attribute::Int(2));
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let wrapper = module.ops(&ctx)[0];
+        assert!(wasm_dialect::Func::from_op(&ctx, wrapper).is_ok());
+        assert_eq!(
+            ctx.op(wrapper).attributes.get_bool("tribute.root_wrapper"),
+            Some(true)
+        );
+        let body = wasm_dialect::Func::from_op(&ctx, wrapper)
+            .unwrap()
+            .body(&ctx);
+        let root_call = ctx.block(ctx.region(body).blocks[0]).ops[0];
+        assert!(wasm_dialect::Call::from_op(&ctx, root_call).is_ok());
+        assert_eq!(
+            ctx.op(root_call)
+                .attributes
+                .get_bool("tribute.root_cps_call"),
+            Some(true)
+        );
+        assert_eq!(
+            ctx.op(root_call)
+                .attributes
+                .get_i128("tribute.calling_convention"),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn func_to_wasm_consumes_indirect_callable_provenance() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main(%callee: core.i32, %argument: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %argument
+  }
+}"#,
+        );
+        let function = module.ops(&ctx)[0];
+        let body = func::Func::from_op(&ctx, function).unwrap().body(&ctx);
+        let tail = ctx.block(ctx.region(body).blocks[0]).ops[0];
+        let nil_ty = core::nil(&mut ctx).as_type_ref();
+        let i32_ty = intern_i32_type(&mut ctx);
+        let signature = core::func(&mut ctx, nil_ty, [i32_ty]).as_type_ref();
+        ctx.op_mut(tail).attributes.insert(
+            Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
+            Attribute::Type(signature),
+        );
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let function = module.ops(&ctx)[0];
+        let body = wasm_dialect::Func::from_op(&ctx, function)
+            .unwrap()
+            .body(&ctx);
+        let tail = ctx.block(ctx.region(body).blocks[0]).ops[0];
+        assert!(wasm_dialect::ReturnCallIndirect::from_op(&ctx, tail).is_ok());
+        assert!(
+            !ctx.op(tail)
+                .attributes
+                .contains_key(INDIRECT_CALL_SIGNATURE_ATTR)
+        );
+    }
+
+    #[test]
+    fn func_to_wasm_preserves_bodyless_declaration_scope() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @decl(%value: core.i32) -> core.i32 attributes {abi = "C"}
+}"#,
+        );
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let lowered = module.ops(&ctx)[0];
+        let declaration = wasm_dialect::Func::from_op(&ctx, lowered).unwrap();
+        assert!(ctx.op(lowered).regions.is_empty());
+        assert_eq!(ctx.op(lowered).attributes.get_text("abi").unwrap(), "C");
+        assert_eq!(ctx.types.get(declaration.r#type(&ctx)).params.len(), 2);
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
@@ -2,21 +2,26 @@
 //!
 //! This pass converts structured control flow operations to wasm control:
 //! - `scf.if` -> `wasm.if`
+//! - resultless `scf.switch` -> nested `wasm.if` comparisons
 //! - `scf.loop` -> `wasm.block(wasm.loop(...))`
 //! - `scf.yield` -> `wasm.yield` (tracks region result value)
 //! - `scf.continue` -> `wasm.br(target=1)` (branch to loop)
 //! - `scf.break` -> `wasm.br(target=2)` (branch to outer block, past if and loop)
 
+use std::collections::HashSet;
+
+use trunk_ir::Symbol;
 use trunk_ir::context::{BlockData, IrContext, RegionData};
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::scf;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
-use trunk_ir::refs::OpRef;
+use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::smallvec::smallvec;
+use trunk_ir::types::Attribute;
 
 /// Lower scf dialect to wasm dialect using arena IR.
 ///
@@ -25,11 +30,206 @@ use trunk_ir::smallvec::smallvec;
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
     let applicator = PatternApplicator::new(type_converter)
         .add_pattern(ScfIfPattern)
+        .add_pattern(ScfSwitchPattern)
         .add_pattern(ScfLoopPattern)
         .add_pattern(ScfYieldPattern)
         .add_pattern(ScfContinuePattern)
         .add_pattern(ScfBreakPattern);
     applicator.apply_partial(ctx, module);
+}
+
+/// A fully validated `scf.switch` shape, collected before any region is
+/// detached.  Post-CPS switches are resultless and their arms end in proper
+/// tail transfers, which maps directly to nested resultless `wasm.if`s.
+struct SwitchShape {
+    discriminant: ValueRef,
+    discriminant_ty: trunk_ir::TypeRef,
+    cases: Vec<(i32, RegionRef)>,
+    default: RegionRef,
+}
+
+/// Pattern for resultless `scf.switch` -> source-order nested `wasm.if`.
+struct ScfSwitchPattern;
+
+impl RewritePattern for ScfSwitchPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if !scf::Switch::matches(ctx, op) {
+            return false;
+        }
+        let Some(shape) = validate_switch(ctx, op) else {
+            return false;
+        };
+
+        let loc = ctx.op(op).location;
+        for (_, region) in &shape.cases {
+            ctx.detach_region(*region);
+        }
+        ctx.detach_region(shape.default);
+
+        if let Some(((value, then_region), remaining_cases)) = shape.cases.split_first() {
+            let else_region = build_switch_chain(
+                ctx,
+                loc,
+                shape.discriminant,
+                shape.discriminant_ty,
+                remaining_cases,
+                shape.default,
+            );
+            let (constant, condition) =
+                switch_condition(ctx, loc, shape.discriminant, shape.discriminant_ty, *value);
+            rewriter.insert_op(constant);
+            rewriter.insert_op(condition);
+            let nil = core::nil(ctx).as_type_ref();
+            let wasm_if = wasm_dialect::r#if(
+                ctx,
+                loc,
+                ctx.op_results(condition)[0],
+                nil,
+                *then_region,
+                else_region,
+            );
+            // `wasm.if` carries a logical nil result even when its physical
+            // block type is empty, whereas resultless `scf.switch` has no IR
+            // result slot.  Insert then erase rather than asking the generic
+            // replacement API to RAUW incompatible result vectors.
+            rewriter.insert_op(wasm_if.op_ref());
+            rewriter.erase_op(vec![]);
+        } else {
+            // A default-only switch is the degenerate structured chain.  Its
+            // sole arm has already been validated as a zero-argument block,
+            // so splice its operations in place without introducing a CFG.
+            let default_block = ctx.region(shape.default).blocks[0];
+            let default_ops = ctx.block(default_block).ops.to_vec();
+            for default_op in default_ops {
+                ctx.detach_op(default_op);
+                rewriter.insert_op(default_op);
+            }
+            rewriter.erase_op(vec![]);
+        }
+        true
+    }
+}
+
+fn validate_switch(ctx: &IrContext, op: OpRef) -> Option<SwitchShape> {
+    let data = ctx.op(op);
+    if ctx.op_operands(op).len() != 1 || !ctx.op_result_types(op).is_empty() {
+        return None;
+    }
+    let discriminant = ctx.op_operands(op)[0];
+    let discriminant_ty = ctx.value_ty(discriminant);
+    let discriminant_data = ctx.types.get(discriminant_ty);
+    if discriminant_data.dialect != Symbol::new("core")
+        || discriminant_data.name != Symbol::new("i32")
+        || data.regions.len() != 1
+    {
+        return None;
+    }
+    let body_blocks = &ctx.region(data.regions[0]).blocks;
+    let [body] = body_blocks.as_slice() else {
+        return None;
+    };
+    if !ctx.block_args(*body).is_empty() {
+        return None;
+    }
+
+    let mut cases = Vec::new();
+    let mut values = HashSet::new();
+    let mut default = None;
+    for &wrapper in &ctx.block(*body).ops {
+        let wrapper_data = ctx.op(wrapper);
+        let region = match wrapper_data.regions.as_slice() {
+            [region] => *region,
+            _ => return None,
+        };
+        let arm_blocks = &ctx.region(region).blocks;
+        let [arm] = arm_blocks.as_slice() else {
+            return None;
+        };
+        if !ctx.block_args(*arm).is_empty()
+            || !ctx.op_operands(wrapper).is_empty()
+            || !ctx.op_result_types(wrapper).is_empty()
+        {
+            return None;
+        }
+        if scf::Case::matches(ctx, wrapper) {
+            let Attribute::Int(value) = wrapper_data.attributes.get(Symbol::new("value"))? else {
+                return None;
+            };
+            let value = i32::try_from(*value).ok()?;
+            if !values.insert(value) {
+                return None;
+            }
+            cases.push((value, region));
+        } else if scf::Default::matches(ctx, wrapper) {
+            if default.replace(region).is_some() {
+                return None;
+            }
+        } else {
+            return None;
+        }
+    }
+    Some(SwitchShape {
+        discriminant,
+        discriminant_ty,
+        cases,
+        default: default?,
+    })
+}
+
+fn switch_condition(
+    ctx: &mut IrContext,
+    loc: trunk_ir::Location,
+    discriminant: ValueRef,
+    discriminant_ty: trunk_ir::TypeRef,
+    value: i32,
+) -> (OpRef, OpRef) {
+    let constant = wasm_dialect::i32_const(ctx, loc, discriminant_ty, value);
+    let comparison = wasm_dialect::i32_eq(
+        ctx,
+        loc,
+        discriminant,
+        constant.result(ctx),
+        discriminant_ty,
+    );
+    (constant.op_ref(), comparison.op_ref())
+}
+
+fn build_switch_chain(
+    ctx: &mut IrContext,
+    loc: trunk_ir::Location,
+    discriminant: ValueRef,
+    discriminant_ty: trunk_ir::TypeRef,
+    cases: &[(i32, RegionRef)],
+    default: RegionRef,
+) -> RegionRef {
+    let mut fallback = default;
+    for (value, then_region) in cases.iter().rev() {
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let (constant, comparison) =
+            switch_condition(ctx, loc, discriminant, discriminant_ty, *value);
+        ctx.push_op(block, constant);
+        ctx.push_op(block, comparison);
+        let condition = ctx.op_results(comparison)[0];
+        let nil = core::nil(ctx).as_type_ref();
+        let nested = wasm_dialect::r#if(ctx, loc, condition, nil, *then_region, fallback);
+        ctx.push_op(block, nested.op_ref());
+        fallback = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+    }
+    fallback
 }
 
 /// Pattern for `scf.if` -> `wasm.if`
@@ -267,3 +467,144 @@ impl RewritePattern for ScfBreakPattern {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ops::ControlFlow;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+    use trunk_ir::walk::{WalkAction, walk_op};
+
+    fn lower_text(input: &str) -> String {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        lower(&mut ctx, module, TypeConverter::new());
+        let printed = print_module(&ctx, module.op());
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &printed);
+        printed
+    }
+
+    fn count_ops(ctx: &IrContext, module: Module, dialect: &str, name: &str) -> usize {
+        let mut count = 0;
+        let dialect = Symbol::from_dynamic(dialect);
+        let name = Symbol::from_dynamic(name);
+        let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+            let data = ctx.op(op);
+            if data.dialect == dialect && data.name == name {
+                count += 1;
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        count
+    }
+
+    #[test]
+    fn lowers_ordered_resultless_switch_to_nested_wasm_ifs() {
+        let input = r#"core.module @test {
+  func.func @one() -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @two() -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @dispatch(%tag: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    scf.switch %tag {
+      scf.case {value = 7} {
+        func.tail_call {callee = @one, tribute.calling_convention = 2}
+      }
+      scf.case {value = 9} {
+        func.tail_call {callee = @two, tribute.calling_convention = 2}
+      }
+      scf.default {
+        func.unreachable
+      }
+    }
+  }
+}"#;
+
+        let printed = lower_text(input);
+        assert!(!printed.contains("scf.switch"), "{printed}");
+        assert!(!printed.contains("scf.case"), "{printed}");
+        assert!(!printed.contains("scf.default"), "{printed}");
+        assert_eq!(printed.matches("wasm.if").count(), 2, "{printed}");
+        assert_eq!(printed.matches("wasm.i32_eq").count(), 2, "{printed}");
+        assert!(
+            printed.find("wasm.i32_const {value = 7}").unwrap()
+                < printed.find("wasm.i32_const {value = 9}").unwrap(),
+            "case comparisons must retain source order:\n{printed}"
+        );
+        assert_eq!(printed.matches("func.tail_call").count(), 2, "{printed}");
+        assert_eq!(printed.matches("func.unreachable").count(), 3, "{printed}");
+    }
+
+    #[test]
+    fn lowers_default_only_switch_by_splicing_its_tail_arm() {
+        let input = r#"core.module @test {
+  func.func @dispatch(%tag: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    scf.switch %tag {
+      scf.default {
+        func.unreachable
+      }
+    }
+  }
+}"#;
+
+        let printed = lower_text(input);
+        assert!(!printed.contains("scf.switch"), "{printed}");
+        assert_eq!(printed.matches("wasm.if").count(), 0, "{printed}");
+        assert_eq!(printed.matches("func.unreachable").count(), 1, "{printed}");
+    }
+
+    #[test]
+    fn malformed_switches_remain_byte_identical() {
+        let malformed = [
+            (
+                r#"core.module @test {
+  func.func @dispatch(%tag: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    scf.switch %tag {
+      scf.case {value = 1} { func.unreachable }
+    }
+  }
+}"#,
+                "missing default",
+            ),
+            (
+                r#"core.module @test {
+  func.func @dispatch(%tag: core.i64) -> core.never attributes {tribute.calling_convention = 2} {
+    scf.switch %tag {
+      scf.default { func.unreachable }
+    }
+  }
+}"#,
+                "non-i32 discriminant",
+            ),
+            (
+                r#"core.module @test {
+  func.func @dispatch(%tag: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    scf.switch %tag {
+      scf.case {value = 1} { func.unreachable }
+      scf.case {value = 1} { func.unreachable }
+      scf.default { func.unreachable }
+    }
+  }
+}"#,
+                "duplicate case value",
+            ),
+        ];
+
+        for (input, description) in malformed {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, input);
+            let before = print_module(&ctx, module.op());
+            lower(&mut ctx, module, TypeConverter::new());
+            assert_eq!(
+                print_module(&ctx, module.op()),
+                before,
+                "{description} must fail before mutation"
+            );
+            assert_eq!(count_ops(&ctx, module, "scf", "switch"), 1);
+        }
+    }
+}

--- a/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
@@ -13,7 +13,8 @@ use trunk_ir::rewrite::{
 
 use crate::gc_types::{
     BOXED_F64_IDX, BYTES_ARRAY_IDX, BYTES_STRUCT_IDX, CLOSURE_STRUCT_IDX, CONTINUATION_IDX,
-    EVIDENCE_IDX, FIRST_USER_TYPE_IDX, MARKER_IDX, RESUME_WRAPPER_IDX, STEP_IDX,
+    EVIDENCE_ARRAY_TYPE_ATTR, EVIDENCE_IDX, FIRST_USER_TYPE_IDX, MARKER_IDX, RESUME_WRAPPER_IDX,
+    STEP_IDX,
 };
 
 fn named_adt(ctx: &IrContext, ty: TypeRef, expected: &'static str) -> bool {
@@ -64,6 +65,13 @@ fn builtin_type_idx(ctx: &IrContext, ty: TypeRef) -> Option<u32> {
         Some(MARKER_IDX)
     } else if is_evidence_array(ctx, ty) {
         Some(EVIDENCE_IDX)
+    } else if is_abstract_heap_type(ctx, ty)
+        && ctx.types.get(ty).name == Symbol::new("arrayref")
+        && ctx.types.get(ty).attrs.get_bool(EVIDENCE_ARRAY_TYPE_ATTR) == Some(true)
+    {
+        // EvidenceDirect entry construction preserves this exact marker after
+        // source evidence becomes its physical abstract array representation.
+        Some(EVIDENCE_IDX)
     } else if named_adt(ctx, ty, "_Continuation") {
         Some(CONTINUATION_IDX)
     } else if named_adt(ctx, ty, "_ResumeWrapper") {
@@ -93,7 +101,9 @@ fn collect_typed_ops(ctx: &IrContext, region: RegionRef, types: &mut Vec<TypeRef
     for &block in &ctx.region(region).blocks {
         for &op in &ctx.block(block).ops {
             let mut push = |ty| {
-                if !types.contains(&ty) && !is_abstract_heap_type(ctx, ty) {
+                if !types.contains(&ty)
+                    && (builtin_type_idx(ctx, ty).is_some() || !is_abstract_heap_type(ctx, ty))
+                {
                     types.push(ty);
                 }
             };
@@ -450,6 +460,70 @@ mod tests {
             .map(|op| op.type_idx(&ctx))
             .collect();
         assert_eq!(indices, vec![Some(FIRST_USER_TYPE_IDX), None]);
+    }
+
+    #[test]
+    fn lowers_marked_evidence_array_allocation_to_the_builtin_index() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !evidence = wasm.arrayref() {wasm.evidence_array = true}
+  wasm.func @main() -> core.nil {
+    %zero = wasm.i32_const {value = 0} : core.i32
+    wasm.return
+  }
+}"#,
+        );
+        let evidence = ctx
+            .type_aliases()
+            .iter()
+            .find_map(|(name, ty)| (*name == Symbol::new("evidence")).then_some(*ty))
+            .expect("textual evidence type alias");
+        let func = module.ops(&ctx)[0];
+        let block = ctx.region(ctx.op(func).regions[0]).blocks[0];
+        let zero = ctx.block(block).ops[0];
+        let location = ctx.op(zero).location;
+        let size = ctx.op_result(zero, 0);
+        let return_op = ctx.block(block).ops[1];
+        let allocation = wasm_gc::array_new_default(&mut ctx, location, size, evidence, evidence);
+        ctx.insert_op_before(block, return_op, allocation.op_ref());
+
+        lower(&mut ctx, module);
+
+        let allocation = ctx
+            .block(block)
+            .ops
+            .iter()
+            .find_map(|&op| wasm::ArrayNewDefault::from_op(&ctx, op).ok())
+            .expect("typed evidence allocation should lower");
+        assert_eq!(allocation.type_idx(&ctx), EVIDENCE_IDX);
+    }
+
+    #[test]
+    fn generic_abstract_array_does_not_claim_the_evidence_index() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @main() -> core.nil {
+    %zero = wasm.i32_const {value = 0} : core.i32
+    %array = wasm_gc.array_new_default %zero {type = wasm.arrayref} : wasm.arrayref
+    wasm.return
+  }
+}"#,
+        );
+
+        lower(&mut ctx, module);
+
+        let func = module.ops(&ctx)[0];
+        let block = ctx.region(ctx.op(func).regions[0]).blocks[0];
+        assert!(
+            ctx.block(block)
+                .ops
+                .iter()
+                .any(|&op| { wasm_gc::ArrayNewDefault::from_op(&ctx, op).is_ok() })
+        );
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -8,7 +8,8 @@
 use trunk_ir::IrContext;
 use trunk_ir::Module;
 use trunk_ir::Symbol;
-use trunk_ir::refs::{OpRef, RegionRef};
+use trunk_ir::refs::OpRef;
+use trunk_ir::rewrite::{ConversionTarget, LegalityDecision};
 
 use crate::{CompilationError, CompilationResult};
 
@@ -31,12 +32,14 @@ impl std::fmt::Display for ValidationError {
 ///
 /// Returns an error if validation fails, preventing emission.
 pub fn validate_wasm_ir(ctx: &IrContext, module: Module) -> CompilationResult<()> {
-    let mut errors: Vec<String> = Vec::new();
-
     let body = module
         .body(ctx)
         .ok_or_else(|| CompilationError::invalid_module("module has no body region"))?;
-    validate_region(ctx, body, 0, &mut errors);
+    let errors = wasm_backend_ready_target()
+        .verify_full(ctx, body)
+        .into_iter()
+        .map(|failure| failure.to_string())
+        .collect::<Vec<_>>();
 
     if errors.is_empty() {
         Ok(())
@@ -50,46 +53,80 @@ pub fn validate_wasm_ir(ctx: &IrContext, module: Module) -> CompilationResult<()
     }
 }
 
-/// Validate a region recursively.
-fn validate_region(ctx: &IrContext, region: RegionRef, depth: usize, errors: &mut Vec<String>) {
-    for &block_ref in &ctx.region(region).blocks {
-        for &op in &ctx.block(block_ref).ops {
-            validate_operation(ctx, op, depth, errors);
-        }
-    }
+/// Exact operation boundary accepted by the Wasm emitter.
+///
+/// TrunkIR has no dialect-operation registry.  Keep the inventory at the
+/// backend boundary so a fabricated `wasm.*` operation cannot pass merely by
+/// sharing the emitter dialect prefix.
+pub fn wasm_backend_ready_target() -> ConversionTarget {
+    ConversionTarget::new()
+        .legal_op("core", "module")
+        .dynamic_dialect("wasm", |ctx, op| {
+            if is_emittable_wasm_operation(ctx, op) {
+                LegalityDecision::Legal
+            } else {
+                LegalityDecision::Illegal
+            }
+        })
 }
 
-/// Validate a single operation.
-fn validate_operation(ctx: &IrContext, op: OpRef, depth: usize, errors: &mut Vec<String>) {
-    let op_data = ctx.op(op);
-    let dialect = op_data.dialect;
-    let name = op_data.name;
-
-    // Check dialect - must be wasm (with specific exceptions)
-    if !is_allowed_dialect(ctx, op, depth) {
-        errors.push(format!("Non-wasm operation found: {}.{}", dialect, name));
+fn is_emittable_wasm_operation(ctx: &IrContext, op: OpRef) -> bool {
+    if ctx.op(op).dialect != Symbol::new("wasm") {
+        return false;
     }
-
-    // Recursively validate nested regions
-    for &region in &op_data.regions {
-        validate_region(ctx, region, depth + 1, errors);
-    }
+    ctx.op(op).name.with_str(|name| {
+        WASM_EMITTER_OPERATIONS
+            .split_whitespace()
+            .any(|supported| supported == name)
+    })
 }
 
-/// Check if an operation's dialect is allowed in the emit phase.
-fn is_allowed_dialect(ctx: &IrContext, op: OpRef, depth: usize) -> bool {
-    let wasm_dialect = Symbol::new("wasm");
-    let op_data = ctx.op(op);
+const WASM_EMITTER_OPERATIONS: &str = r#"
+block loop if br br_if return yield drop call call_indirect return_call
+return_call_indirect unreachable nop func import_func export_func export_memory
+memory data table elem global global_get global_set
+i32_const i32_add i32_sub i32_mul i32_div_s i32_div_u i32_rem_s i32_rem_u
+i32_eq i32_ne i32_lt_s i32_lt_u i32_le_s i32_le_u i32_gt_s i32_gt_u
+i32_ge_s i32_ge_u i32_and i32_or i32_xor i32_shl i32_shr_s i32_shr_u
+i64_const i64_add i64_sub i64_mul i64_div_s i64_div_u i64_rem_s i64_rem_u
+i64_eq i64_ne i64_lt_s i64_lt_u i64_le_s i64_le_u i64_gt_s i64_gt_u
+i64_ge_s i64_ge_u i64_and i64_or i64_xor i64_shl i64_shr_s i64_shr_u
+f32_const f32_add f32_sub f32_mul f32_div f32_neg f32_eq f32_ne f32_lt f32_le
+f32_gt f32_ge f64_const f64_add f64_sub f64_mul f64_div f64_neg f64_eq f64_ne
+f64_lt f64_le f64_gt f64_ge local_get local_set local_tee struct_new struct_get
+struct_set array_new array_new_default array_new_data bytes_from_data array_get
+array_get_s array_get_u array_set array_len array_copy ref_null ref_func
+ref_is_null ref_cast ref_test ref_i31 i31_get_s i31_get_u i32_wrap_i64
+i64_extend_i32_s i64_extend_i32_u i32_trunc_f32_s i32_trunc_f32_u
+i32_trunc_f64_s i32_trunc_f64_u i64_trunc_f32_s i64_trunc_f32_u
+i64_trunc_f64_s i64_trunc_f64_u f32_convert_i32_s f32_convert_i32_u
+f32_convert_i64_s f32_convert_i64_u f64_convert_i32_s f64_convert_i32_u
+f64_convert_i64_s f64_convert_i64_u f32_demote_f64 f64_promote_f32
+i32_reinterpret_f32 i64_reinterpret_f64 f32_reinterpret_i32 f64_reinterpret_i64
+memory_size memory_grow i32_load i64_load f32_load f64_load i32_load8_s i32_load8_u
+i32_load16_s i32_load16_u i64_load8_s i64_load8_u i64_load16_s i64_load16_u
+i64_load32_s i64_load32_u i32_store i64_store f32_store f64_store i32_store8
+i32_store16 i64_store8 i64_store16 i64_store32
+"#;
 
-    if op_data.dialect == wasm_dialect {
-        return true;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+
+    #[test]
+    fn rejects_unknown_wasm_operation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @main() -> core.nil {
+    wasm.unknown
+    wasm.return
+  }
+}"#,
+        );
+        let error = validate_wasm_ir(&ctx, module).unwrap_err().to_string();
+        assert!(error.contains("wasm.unknown"), "{error}");
     }
-
-    // Allow core.module only at the top level (depth 0)
-    if depth == 0 && op_data.dialect == Symbol::new("core") && op_data.name == Symbol::new("module")
-    {
-        return true;
-    }
-
-    false
 }

--- a/crates/trunk-ir/src/adt_layout.rs
+++ b/crates/trunk-ir/src/adt_layout.rs
@@ -105,6 +105,10 @@ pub fn type_size_align(ctx: &IrContext, ty: TypeRef) -> (u32, u32) {
         (8, 8)
     } else if name == Symbol::new("f32") {
         (4, 4)
+    } else if name == Symbol::new("nil") {
+        // Unit carries no native payload. Keep its declared field metadata so
+        // source layout identity is stable, but do not reserve a scalar slot.
+        (0, 1)
     } else {
         // f64, ptr, and any unknown types default to 8-byte size/align
         (8, 8)
@@ -296,4 +300,55 @@ pub fn compute_enum_layout(
 /// Find the variant layout for a given tag name.
 pub fn find_variant_layout(layout: &EnumLayout, tag: Symbol) -> Option<&VariantFieldLayout> {
     layout.variant_layouts.iter().find(|v| v.name == tag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rewrite::type_converter::TypeConverter;
+    use crate::smallvec::smallvec;
+    use crate::types::{AttributeMap, TypeData};
+
+    fn core_type(ctx: &mut IrContext, name: &str) -> TypeRef {
+        ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::from_dynamic(name),
+            params: smallvec![],
+            attrs: AttributeMap::new(),
+        })
+    }
+
+    #[test]
+    fn nil_struct_field_has_no_payload_between_represented_fields() {
+        let mut ctx = IrContext::new();
+        let i32_ty = core_type(&mut ctx, "i32");
+        let nil_ty = core_type(&mut ctx, "nil");
+        let i64_ty = core_type(&mut ctx, "i64");
+        let fields = Attribute::List(vec![
+            Attribute::List(vec![
+                Attribute::Symbol(Symbol::new("before")),
+                Attribute::Type(i32_ty),
+            ]),
+            Attribute::List(vec![
+                Attribute::Symbol(Symbol::new("unit")),
+                Attribute::Type(nil_ty),
+            ]),
+            Attribute::List(vec![
+                Attribute::Symbol(Symbol::new("after")),
+                Attribute::Type(i64_ty),
+            ]),
+        ]);
+        let struct_ty = ctx.types.intern(TypeData {
+            dialect: Symbol::new("adt"),
+            name: Symbol::new("struct"),
+            params: smallvec![i32_ty, nil_ty, i64_ty],
+            attrs: [(Symbol::new("fields"), fields)].into_iter().collect(),
+        });
+
+        let layout = compute_struct_layout(&ctx, struct_ty, &TypeConverter::new()).unwrap();
+
+        assert_eq!(layout.field_offsets, vec![0, 4, 8]);
+        assert_eq!(layout.total_size, 16);
+        assert_eq!(layout.alignment, 8);
+    }
 }

--- a/crates/trunk-ir/src/context.rs
+++ b/crates/trunk-ir/src/context.rs
@@ -205,6 +205,15 @@ impl IrContext {
         self.type_alias_by_type.insert(ty, name);
     }
 
+    /// Remove one type alias and its reverse lookup entry.
+    pub fn remove_type_alias(&mut self, name: Symbol) -> Option<TypeRef> {
+        let ty = self.type_alias_by_name.remove(&name)?;
+        self.type_alias_by_type.remove(&ty);
+        self.type_aliases
+            .retain(|(candidate, _)| *candidate != name);
+        Some(ty)
+    }
+
     /// Look up a type alias by name.
     pub fn type_alias_by_name(&self, name: Symbol) -> Option<TypeRef> {
         self.type_alias_by_name.get(&name).copied()
@@ -554,6 +563,44 @@ impl IrContext {
         self.block_arg_values[block] = new_list;
 
         new_value
+    }
+
+    /// Remove an unused block argument and return its stable value reference.
+    ///
+    /// Remaining argument values keep their identity while their defining
+    /// indices are updated. Callers must first rewrite every use of the
+    /// removed value; silently dropping a live SSA value would corrupt the
+    /// use-chain.
+    pub fn remove_block_arg(&mut self, block: BlockRef, index: u32) -> ValueRef {
+        let index = index as usize;
+        let values: SmallVec<[ValueRef; 8]> = self.block_arg_values[block]
+            .as_slice(&self.value_pool)
+            .into();
+        assert!(
+            index < values.len(),
+            "remove_block_arg: index {index} out of bounds for {block}"
+        );
+        let removed = values[index];
+        assert!(
+            self.uses[removed].is_empty(),
+            "remove_block_arg: cannot remove live block argument {removed}"
+        );
+
+        self.blocks[block].args.remove(index);
+        let mut remaining = EntityList::new();
+        for (old_index, &value) in values.iter().enumerate() {
+            if old_index == index {
+                continue;
+            }
+            if let ValueDef::BlockArg(value_block, value_index) = self.values[value].def {
+                debug_assert_eq!(value_block, block);
+                self.values[value].def =
+                    ValueDef::BlockArg(value_block, value_index - u32::from(old_index > index));
+            }
+            remaining.push(value, &mut self.value_pool);
+        }
+        self.block_arg_values[block] = remaining;
+        removed
     }
 
     /// Set the type of a block argument.
@@ -1324,6 +1371,40 @@ mod tests {
         assert_eq!(ctx.block_args(block).len(), 1);
         assert_eq!(ctx.block_arg(block, 0), new_arg);
         assert_eq!(ctx.value_def(new_arg), ValueDef::BlockArg(block, 0));
+    }
+
+    #[test]
+    fn remove_unused_block_arg_preserves_remaining_value_identity() {
+        let mut ctx = IrContext::new();
+        let loc = test_location(&mut ctx);
+        let i32_ty = i32_type(&mut ctx);
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![
+                BlockArgData {
+                    ty: i32_ty,
+                    attrs: AttributeMap::new(),
+                },
+                BlockArgData {
+                    ty: i32_ty,
+                    attrs: AttributeMap::new(),
+                },
+                BlockArgData {
+                    ty: i32_ty,
+                    attrs: AttributeMap::new(),
+                },
+            ],
+            ops: SmallVec::new(),
+            parent_region: None,
+        });
+        let first = ctx.block_arg(block, 0);
+        let removed = ctx.block_arg(block, 1);
+        let last = ctx.block_arg(block, 2);
+
+        assert_eq!(ctx.remove_block_arg(block, 1), removed);
+        assert_eq!(ctx.block_args(block), [first, last]);
+        assert_eq!(ctx.value_def(first), ValueDef::BlockArg(block, 0));
+        assert_eq!(ctx.value_def(last), ValueDef::BlockArg(block, 1));
     }
 
     #[test]

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -1,5 +1,14 @@
 //! Arena-based clif dialect.
 
+/// Calling-convention metadata consumed by the Cranelift backend.
+///
+/// This is deliberately backend-owned rather than language-owned: frontends
+/// project their proven callable ABI onto either [`CALLING_CONVENTION_PLATFORM`]
+/// or [`CALLING_CONVENTION_TAIL`] before lowering `func.*` to `clif.*`.
+pub const CALLING_CONVENTION_ATTR: &str = "clif.calling_convention";
+pub const CALLING_CONVENTION_PLATFORM: &str = "platform";
+pub const CALLING_CONVENTION_TAIL: &str = "tail";
+
 #[trunk_ir::dialect]
 mod clif {
     // Module

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -1,5 +1,12 @@
 //! Arena-based func dialect.
 
+/// Exact physical callable signature preserved when closure lowering projects
+/// a typed closure value to an untyped function/table reference.
+///
+/// Backends must consume this metadata rather than reconstructing an indirect
+/// signature from representation operands.
+pub const INDIRECT_CALL_SIGNATURE_ATTR: &str = "func.indirect_call_signature";
+
 // === Operation registrations ===
 crate::register_pure_op!(func.constant);
 crate::register_isolated_op!(func.func);

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -53,6 +53,9 @@ mod wasm {
     #[attr(callee: Symbol)]
     fn return_call(#[rest] args: ()) {}
 
+    #[attr(type_idx: u32, table: u32)]
+    fn return_call_indirect(#[rest] args: ()) {}
+
     fn unreachable() {}
     fn nop() -> result {}
 

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -42,10 +42,10 @@ impl RewriteScope for Module {
 }
 
 impl RewriteScope for func::Func {
-    type Regions = std::iter::Once<RegionRef>;
+    type Regions = std::option::IntoIter<RegionRef>;
 
     fn regions(self, ctx: &IrContext) -> Self::Regions {
-        std::iter::once(self.body(ctx))
+        ctx.op(self.op_ref()).regions.first().copied().into_iter()
     }
 
     fn module_first_block(self, _ctx: &IrContext) -> Option<BlockRef> {
@@ -54,10 +54,10 @@ impl RewriteScope for func::Func {
 }
 
 impl RewriteScope for wasm::Func {
-    type Regions = std::iter::Once<RegionRef>;
+    type Regions = std::option::IntoIter<RegionRef>;
 
     fn regions(self, ctx: &IrContext) -> Self::Regions {
-        std::iter::once(self.body(ctx))
+        ctx.op(self.op_ref()).regions.first().copied().into_iter()
     }
 
     fn module_first_block(self, _ctx: &IrContext) -> Option<BlockRef> {
@@ -490,6 +490,21 @@ mod tests {
         func::Func::from_op(ctx, func_op).expect("test func should be valid")
     }
 
+    fn make_bodyless_declaration(
+        ctx: &mut IrContext,
+        loc: Location,
+        dialect: &'static str,
+        name: &'static str,
+    ) -> OpRef {
+        let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
+        let func_ty = crate::dialect::core::func(ctx, nil_ty, []).as_type_ref();
+        let declaration = OperationDataBuilder::new(loc, Symbol::new(dialect), Symbol::new("func"))
+            .attr("sym_name", Attribute::Symbol(Symbol::new(name)))
+            .attr("type", Attribute::Type(func_ty))
+            .build(ctx);
+        ctx.create_op(declaration)
+    }
+
     fn first_nested_op(ctx: &IrContext, op: OpRef) -> OpRef {
         let region = ctx.op(op).regions[0];
         let block = ctx.region(region).blocks[0];
@@ -730,6 +745,36 @@ mod tests {
             ctx.op(first_nested_op(&ctx, sibling_func.op_ref())).name,
             Symbol::new("source")
         );
+    }
+
+    #[test]
+    fn bodyless_func_declaration_has_empty_rewrite_scope() {
+        let (mut ctx, loc) = test_ctx();
+        let declaration = make_bodyless_declaration(&mut ctx, loc, "func", "external");
+        let declaration =
+            func::Func::from_op(&ctx, declaration).expect("bodyless func declaration");
+
+        let result =
+            PatternApplicator::new(TypeConverter::new()).apply_partial(&mut ctx, declaration);
+
+        assert!(result.reached_fixpoint);
+        assert_eq!(result.total_changes, 0);
+        assert!(ctx.op(declaration.op_ref()).regions.is_empty());
+    }
+
+    #[test]
+    fn bodyless_wasm_declaration_has_empty_rewrite_scope() {
+        let (mut ctx, loc) = test_ctx();
+        let declaration = make_bodyless_declaration(&mut ctx, loc, "wasm", "external");
+        let declaration =
+            wasm::Func::from_op(&ctx, declaration).expect("bodyless wasm declaration");
+
+        let result =
+            PatternApplicator::new(TypeConverter::new()).apply_partial(&mut ctx, declaration);
+
+        assert!(result.reached_fixpoint);
+        assert_eq!(result.total_changes, 0);
+        assert!(ctx.op(declaration.op_ref()).regions.is_empty());
     }
 
     #[test]

--- a/crates/trunk-ir/src/rewrite/rewriter.rs
+++ b/crates/trunk-ir/src/rewrite/rewriter.rs
@@ -15,6 +15,8 @@ pub(crate) struct Mutations {
     pub(crate) replacement: Option<OpRef>,
     /// If set, the operation is erased and its results mapped to these values.
     pub(crate) erase_values: Option<Vec<ValueRef>>,
+    /// Erase the operation only when every result is unused.
+    pub(crate) erase_unused_results: bool,
     /// Operations to add at module level.
     pub(crate) module_ops: Vec<OpRef>,
 }
@@ -32,6 +34,7 @@ pub struct PatternRewriter<'a> {
     prefix_ops: Vec<OpRef>,
     replacement: Option<OpRef>,
     erase_values: Option<Vec<ValueRef>>,
+    erase_unused_results: bool,
     module_ops: Vec<OpRef>,
 }
 
@@ -43,6 +46,7 @@ impl<'a> PatternRewriter<'a> {
             prefix_ops: Vec::new(),
             replacement: None,
             erase_values: None,
+            erase_unused_results: false,
             module_ops: Vec::new(),
         }
     }
@@ -68,7 +72,7 @@ impl<'a> PatternRewriter<'a> {
     /// then remove the old op from its block and insert the new one.
     pub fn replace_op(&mut self, new_op: OpRef) {
         debug_assert!(
-            self.replacement.is_none() && self.erase_values.is_none(),
+            self.replacement.is_none() && self.erase_values.is_none() && !self.erase_unused_results,
             "replace_op called after replace_op or erase_op"
         );
         self.replacement = Some(new_op);
@@ -80,10 +84,22 @@ impl<'a> PatternRewriter<'a> {
     /// The applicator will RAUW each old result to the corresponding value.
     pub fn erase_op(&mut self, replacement_values: Vec<ValueRef>) {
         debug_assert!(
-            self.replacement.is_none() && self.erase_values.is_none(),
+            self.replacement.is_none() && self.erase_values.is_none() && !self.erase_unused_results,
             "erase_op called after replace_op or erase_op"
         );
         self.erase_values = Some(replacement_values);
+    }
+
+    /// Erase the current operation without replacing its results.
+    ///
+    /// Every result must be unused. This is the result-bearing analogue of
+    /// erasing a resultless terminator and avoids self-RAUW placeholders.
+    pub fn erase_op_with_unused_results(&mut self) {
+        debug_assert!(
+            self.replacement.is_none() && self.erase_values.is_none() && !self.erase_unused_results,
+            "erase_op_with_unused_results called after replace_op or erase_op"
+        );
+        self.erase_unused_results = true;
     }
 
     /// Add an operation at module level (e.g., an outlined function).
@@ -98,6 +114,7 @@ impl<'a> PatternRewriter<'a> {
         !self.prefix_ops.is_empty()
             || self.replacement.is_some()
             || self.erase_values.is_some()
+            || self.erase_unused_results
             || !self.module_ops.is_empty()
     }
 
@@ -107,6 +124,7 @@ impl<'a> PatternRewriter<'a> {
             prefix_ops: self.prefix_ops,
             replacement: self.replacement,
             erase_values: self.erase_values,
+            erase_unused_results: self.erase_unused_results,
             module_ops: self.module_ops,
         }
     }
@@ -217,6 +235,16 @@ pub(crate) fn apply_mutations(
             ctx.remove_op_from_block(block, original_op);
         }
         ctx.remove_op(original_op);
+    } else if mutations.erase_unused_results {
+        let old_results: Vec<ValueRef> = ctx.op_results(original_op).to_vec();
+        assert!(
+            old_results.iter().all(|result| !ctx.has_uses(*result)),
+            "erase_op_with_unused_results: operation has a live result"
+        );
+        if let Some(block) = parent_block {
+            ctx.remove_op_from_block(block, original_op);
+        }
+        ctx.remove_op(original_op);
     }
 
     // 3. Add module-level ops
@@ -224,5 +252,70 @@ pub(crate) fn apply_mutations(
         for module_op in mutations.module_ops {
             ctx.push_op(module_block, module_op);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::{BlockData, IrContext};
+    use crate::dialect::{arith, func};
+    use crate::location::Span;
+    use crate::symbol::Symbol;
+    use crate::types::{Attribute, Location, TypeDataBuilder};
+
+    fn context_and_location() -> (IrContext, Location) {
+        let mut ctx = IrContext::new();
+        let path = ctx.paths.intern("rewriter-test.trunkir".to_string());
+        (ctx, Location::new(path, Span::new(0, 0)))
+    }
+
+    fn i32_type(ctx: &mut IrContext) -> crate::refs::TypeRef {
+        ctx.types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
+    }
+
+    #[test]
+    fn erase_op_with_unused_results_removes_result_bearing_op() {
+        let (mut ctx, location) = context_and_location();
+        let i32_type = i32_type(&mut ctx);
+        let constant = arith::r#const(&mut ctx, location, i32_type, Attribute::Int(1));
+        let block = ctx.create_block(BlockData {
+            location,
+            args: Default::default(),
+            ops: Default::default(),
+            parent_region: None,
+        });
+        ctx.push_op(block, constant.op_ref());
+
+        let converter = TypeConverter::new();
+        let mut rewriter = PatternRewriter::new(&converter);
+        rewriter.erase_op_with_unused_results();
+        apply_mutations(&mut ctx, constant.op_ref(), rewriter.take_mutations(), None);
+
+        assert!(ctx.block(block).ops.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "erase_op_with_unused_results: operation has a live result")]
+    fn erase_op_with_unused_results_rejects_live_result() {
+        let (mut ctx, location) = context_and_location();
+        let i32_type = i32_type(&mut ctx);
+        let constant = arith::r#const(&mut ctx, location, i32_type, Attribute::Int(1));
+        let constant_result = constant.result(&ctx);
+        let ret = func::r#return(&mut ctx, location, [constant_result]);
+        let block = ctx.create_block(BlockData {
+            location,
+            args: Default::default(),
+            ops: Default::default(),
+            parent_region: None,
+        });
+        ctx.push_op(block, constant.op_ref());
+        ctx.push_op(block, ret.op_ref());
+
+        let converter = TypeConverter::new();
+        let mut rewriter = PatternRewriter::new(&converter);
+        rewriter.erase_op_with_unused_results();
+        apply_mutations(&mut ctx, constant.op_ref(), rewriter.take_mutations(), None);
     }
 }

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -136,6 +136,44 @@ fn rewrite_function_signature(
     true
 }
 
+/// Convert a declaration signature without inventing a body region.
+fn rewrite_declaration_signature(
+    ctx: &mut IrContext,
+    op: OpRef,
+    rewriter: &mut PatternRewriter<'_>,
+    func_type: TypeRef,
+) -> bool {
+    let Some(sig) = convert_func_signature(ctx, func_type, rewriter.type_converter()) else {
+        return false;
+    };
+    let new_func_type = rebuild_func_type(ctx, &sig);
+    let data = ctx.op(op);
+    let location = data.location;
+    let dialect = data.dialect;
+    let name = data.name;
+    let successors = data.successors.to_vec();
+    let mut attributes = data.attributes.clone();
+    let operands = ctx.op_operands(op).to_vec();
+    let results = ctx.op_result_types(op).to_vec();
+    attributes.insert(
+        crate::Symbol::new("type"),
+        crate::types::Attribute::Type(new_func_type),
+    );
+    let mut builder = crate::OperationDataBuilder::new(location, dialect, name)
+        .operands(operands)
+        .results(results);
+    for (name, value) in attributes {
+        builder = builder.attr(name, value);
+    }
+    for successor in successors {
+        builder = builder.successor(successor);
+    }
+    let new_data = builder.build(ctx);
+    let new_op = ctx.create_op(new_data);
+    rewriter.replace_op(new_op);
+    true
+}
+
 /// Pattern that converts `func.func` operation signatures using a `TypeConverter`.
 ///
 /// This pattern:
@@ -157,7 +195,9 @@ impl RewritePattern for FuncSignatureConversionPattern {
         };
 
         let func_type = func_op.r#type(ctx);
-        let body = func_op.body(ctx);
+        let Some(&body) = ctx.op(op).regions.first() else {
+            return rewrite_declaration_signature(ctx, op, rewriter, func_type);
+        };
         let sym_name = func_op.sym_name(ctx);
         let loc = ctx.op(op).location;
 
@@ -188,7 +228,9 @@ impl RewritePattern for WasmFuncSignatureConversionPattern {
         };
 
         let func_type = wasm_func_op.r#type(ctx);
-        let body = wasm_func_op.body(ctx);
+        let Some(&body) = ctx.op(op).regions.first() else {
+            return rewrite_declaration_signature(ctx, op, rewriter, func_type);
+        };
         let sym_name = wasm_func_op.sym_name(ctx);
         let loc = ctx.op(op).location;
 
@@ -527,5 +569,54 @@ mod tests {
         let ops = module.ops(&ctx);
         let original_func = func::Func::from_op(&ctx, ops[0]).unwrap();
         assert_eq!(original_func.r#type(&ctx), func_ty);
+    }
+
+    #[test]
+    fn bodyless_func_declaration_converts_without_inventing_a_region() {
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @decl(%value: core.i32) -> core.i32
+}"#,
+        );
+        let i32_ty = i32_type(&mut ctx);
+        let i64_ty = i64_type(&mut ctx);
+        let first = PatternApplicator::new(i32_to_i64_converter(i32_ty, i64_ty))
+            .add_pattern(FuncSignatureConversionPattern)
+            .apply_partial(&mut ctx, module);
+        assert_eq!(first.total_changes, 1);
+        assert!(first.reached_fixpoint);
+        let second = PatternApplicator::new(i32_to_i64_converter(i32_ty, i64_ty))
+            .add_pattern(FuncSignatureConversionPattern)
+            .apply_partial(&mut ctx, module);
+        assert_eq!(second.total_changes, 0);
+        assert!(second.reached_fixpoint);
+
+        let declaration = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        assert!(ctx.op(declaration.op_ref()).regions.is_empty());
+        let signature = ctx.types.get(declaration.r#type(&ctx));
+        assert_eq!(signature.params.as_slice(), [i64_ty, i64_ty]);
+    }
+
+    #[test]
+    fn bodyless_wasm_declaration_converts_without_inventing_a_region() {
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @decl(%value: core.i32) -> core.i32
+}"#,
+        );
+        let i32_ty = i32_type(&mut ctx);
+        let i64_ty = i64_type(&mut ctx);
+        PatternApplicator::new(i32_to_i64_converter(i32_ty, i64_ty))
+            .add_pattern(WasmFuncSignatureConversionPattern)
+            .apply_partial(&mut ctx, module);
+
+        let declaration = wasm::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        assert!(ctx.op(declaration.op_ref()).regions.is_empty());
+        let signature = ctx.types.get(declaration.r#type(&ctx));
+        assert_eq!(signature.params.as_slice(), [i64_ty, i64_ty]);
     }
 }

--- a/crates/trunk-ir/src/transforms/global_dce.rs
+++ b/crates/trunk-ir/src/transforms/global_dce.rs
@@ -4,7 +4,7 @@
 //! Reachability roots include:
 //! - Functions named "main" or "_start"
 //! - Functions referenced by `wasm.export_func`
-//! - Functions with `abi` attribute (externally callable)
+//! - Body-bearing functions with an `abi` attribute (externally callable)
 //! - Custom entry points from configuration
 //!
 //! Builds a call graph by analyzing `func.call`, `func.tail_call`, and
@@ -181,9 +181,13 @@ impl GlobalDcePass {
                         self.reachability_roots.insert(func_name);
                     }
 
-                    // Treat abi functions as entry points so their callees
-                    // are also considered reachable.
-                    if ctx.op(op).attributes.contains_key(self.syms.abi) {
+                    // Body-bearing ABI functions are externally callable
+                    // entry points. A bodyless ABI declaration is an import:
+                    // retain it only when a call or function reference reaches
+                    // it, unless another explicit entry/export rule selected it.
+                    if ctx.op(op).attributes.contains_key(self.syms.abi)
+                        && !ctx.op(op).regions.is_empty()
+                    {
                         self.reachability_roots.insert(func_name);
                     }
 
@@ -438,6 +442,15 @@ mod tests {
         func::func(ctx, loc, sym_name, fn_ty, body).op_ref()
     }
 
+    fn build_bodyless_abi_decl(ctx: &mut IrContext, loc: Location, name: &str) -> OpRef {
+        let data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
+            .attr("sym_name", Attribute::Symbol(Symbol::from_dynamic(name)))
+            .attr("type", Attribute::Type(fn_type(ctx)))
+            .attr("abi", Attribute::String("C".to_owned()))
+            .build(ctx);
+        ctx.create_op(data)
+    }
+
     fn build_func_with_call(ctx: &mut IrContext, loc: Location, name: &str, callee: &str) -> OpRef {
         let fn_ty = fn_type(ctx);
         let i32_ty = i32_type(ctx);
@@ -617,41 +630,68 @@ mod tests {
     }
 
     #[test]
-    fn preserves_extern_declarations() {
+    fn removes_unreferenced_bodyless_abi_declaration() {
+        let (mut ctx, loc) = test_ctx();
+        let main = build_simple_func(&mut ctx, loc, "main");
+        let extern_op = build_bodyless_abi_decl(&mut ctx, loc, "extern_fn");
+        assert!(ctx.op(extern_op).regions.is_empty());
+
+        let module = build_module(&mut ctx, loc, vec![main, extern_op]);
+
+        let result = eliminate_dead_functions(&mut ctx, module);
+
+        assert_eq!(result.removed_count, 1);
+        assert_eq!(result.removed_functions, vec![Symbol::new("extern_fn")]);
+        assert_eq!(count_funcs(&ctx, module), 1);
+    }
+
+    #[test]
+    fn keeps_bodyless_abi_declarations_referenced_by_call_edges() {
         let (mut ctx, loc) = test_ctx();
         let fn_ty = fn_type(&mut ctx);
-        let main = build_simple_func(&mut ctx, loc, "main");
+        let direct = build_bodyless_abi_decl(&mut ctx, loc, "direct_import");
+        let tail = build_bodyless_abi_decl(&mut ctx, loc, "tail_import");
+        let first_class = build_bodyless_abi_decl(&mut ctx, loc, "first_class_import");
 
-        // Build an unreachable extern func with abi attribute
         let entry = ctx.create_block(BlockData {
             location: loc,
             args: vec![],
             ops: smallvec![],
             parent_region: None,
         });
+        let i32_ty = i32_type(&mut ctx);
+        let call = func::call(
+            &mut ctx,
+            loc,
+            std::iter::empty(),
+            i32_ty,
+            Symbol::new("direct_import"),
+        );
+        ctx.push_op(entry, call.op_ref());
+        let constant = func::constant(&mut ctx, loc, fn_ty, Symbol::new("first_class_import"));
+        ctx.push_op(entry, constant.op_ref());
+        let tail_call =
+            OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("tail_call"))
+                .attr("callee", Attribute::Symbol(Symbol::new("tail_import")))
+                .build(&mut ctx);
+        let tail_call = ctx.create_op(tail_call);
+        ctx.push_op(entry, tail_call);
         let body = ctx.create_region(RegionData {
             location: loc,
             blocks: smallvec![entry],
             parent_op: None,
         });
-        let extern_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
-            .attr("sym_name", Attribute::Symbol(Symbol::new("extern_fn")))
-            .attr("type", Attribute::Type(fn_ty))
-            .attr("abi", Attribute::String("C".to_owned()))
-            .region(body)
-            .build(&mut ctx);
-        let extern_op = ctx.create_op(extern_data);
-
-        let module = build_module(&mut ctx, loc, vec![main, extern_op]);
+        let main = func::func(&mut ctx, loc, Symbol::new("main"), fn_ty, body).op_ref();
+        let module = build_module(&mut ctx, loc, vec![direct, tail, first_class, main]);
 
         let result = eliminate_dead_functions(&mut ctx, module);
 
         assert_eq!(result.removed_count, 0);
-        assert_eq!(count_funcs(&ctx, module), 2);
+        assert_eq!(count_funcs(&ctx, module), 4);
     }
 
     #[test]
-    fn abi_function_callees_are_reachable() {
+    fn body_bearing_abi_function_and_its_callees_are_reachable() {
         let (mut ctx, loc) = test_ctx();
         let fn_ty = fn_type(&mut ctx);
 
@@ -690,6 +730,7 @@ mod tests {
             .region(body)
             .build(&mut ctx);
         let extern_op = ctx.create_op(extern_data);
+        assert!(!ctx.op(extern_op).regions.is_empty());
 
         let module = build_module(&mut ctx, loc, vec![main, helper, extern_op]);
 

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -53,7 +53,10 @@ pub fn lower_scf_to_cf(ctx: &mut IrContext, module: Module) {
 
 /// Lower all `scf` operations in one function to `cf` operations.
 pub fn lower_scf_to_cf_func(ctx: &mut IrContext, func: func::Func) {
-    transform_region(ctx, func.body(ctx));
+    let Some(&body) = ctx.op(func.op_ref()).regions.first() else {
+        return;
+    };
+    transform_region(ctx, body);
 }
 
 /// Build a function-anchored SCF-to-CF lowering pass.
@@ -796,6 +799,48 @@ mod tests {
             untouched_names.iter().any(|n| n.starts_with("scf.")),
             "untouched function should retain scf ops: {untouched_names:?}"
         );
+    }
+
+    #[test]
+    fn function_scoped_scf_lowering_preserves_bodyless_declarations() {
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @decl(%value: core.i32) -> core.i32 attributes {abi = "C"}
+  func.func @defined() -> core.nil {
+    %condition = arith.const {value = true} : core.i1
+    scf.if %condition : core.nil {
+      scf.yield
+    } {
+      scf.yield
+    }
+    func.return
+  }
+}"#,
+        );
+
+        let mut pm = crate::pass::PassManager::new();
+        pm.nest::<func::Func>().add_pass(scf_to_cf_pass());
+        let core_module = core::Module::from_op(&ctx, module.op()).unwrap();
+        pm.run(&mut ctx, core_module).unwrap();
+
+        let declaration = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        assert!(ctx.op(declaration.op_ref()).regions.is_empty());
+        assert!(
+            ctx.op(declaration.op_ref())
+                .attributes
+                .get_text("abi")
+                .is_some_and(|abi| abi == "C")
+        );
+
+        let defined = func::Func::from_op(&ctx, module.ops(&ctx)[1]).unwrap();
+        let names = collect_op_names(&ctx, defined.body(&ctx));
+        assert!(
+            !names.iter().any(|name| name.starts_with("scf.")),
+            "{names:?}"
+        );
+        assert!(names.iter().any(|name| name == "cf.cond_br"), "{names:?}");
     }
 
     #[test]

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -495,6 +495,7 @@ pub fn is_proper_tail_terminator(ctx: &IrContext, op: OpRef) -> bool {
                 data.name.with_str(|name| name.to_owned()).as_str(),
                 "perform" | "handle_dispatch"
             ))
+        || (data.dialect == Symbol::new("effect") && data.name == Symbol::new("dispatch_cps"))
         || (data.dialect == Symbol::new("scf")
             && matches!(
                 data.name.with_str(|name| name.to_owned()).as_str(),
@@ -553,6 +554,13 @@ fn validate_scf_if_structure(ctx: &IrContext, op: OpRef, errors: &mut Vec<Valida
 
         let yield_data = ctx.op(yield_op);
         if yield_data.dialect != Symbol::new("scf") || yield_data.name != Symbol::new("yield") {
+            let unreachable = (yield_data.dialect == Symbol::new("tribute_control")
+                && yield_data.name == Symbol::new("unreachable"))
+                || (yield_data.dialect == Symbol::new("func")
+                    && yield_data.name == Symbol::new("unreachable"));
+            if unreachable {
+                continue;
+            }
             let never_result = match ctx.op_result_types(op) {
                 [ty] => {
                     let ty = ctx.types.get(*ty);
@@ -1913,6 +1921,7 @@ mod tests {
     } {
       scf.yield %x
     }
+
     func.return %r
   }
 }"#;
@@ -1924,6 +1933,25 @@ mod tests {
         assert_eq!(operation_errors.len(), 1);
         assert!(operation_errors[0].contains("operation verifier failed for scf.if"));
         assert!(operation_errors[0].contains("then_region must terminate with scf.yield"));
+    }
+
+    #[test]
+    fn scf_if_value_region_accepts_logical_unreachable_terminator() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1, %value: core.i32) -> core.i32 {
+    %result = scf.if %cond : core.i32 {
+      scf.yield %value
+    } {
+      tribute_control.unreachable
+    }
+    func.return %result
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
     }
 
     #[test]

--- a/examples/salsa_usage.rs
+++ b/examples/salsa_usage.rs
@@ -38,10 +38,12 @@ fn basic_database_usage() {
     let tree = parser.parse(source_code, None).expect("tree");
     let source = SourceCst::from_path(&db, "example.tr", source_code.into(), Some(tree));
 
-    let Some((ctx, module)) = compile_frontend(&db, source) else {
+    let Some(frontend) = compile_frontend(&db, source) else {
         println!("Compilation failed");
         return;
     };
+    let ctx = frontend.context;
+    let module = frontend.module;
 
     // Print module name if available
     if let Some(name) = module.name(&ctx) {
@@ -55,9 +57,10 @@ fn basic_database_usage() {
     // Display the lowered functions
     for (i, op_ref) in ops.iter().enumerate() {
         let op_data = ctx.op(*op_ref);
-        if op_data.dialect == Symbol::new("func") && op_data.name == Symbol::new("func") {
+        if op_data.dialect == Symbol::new("tribute_control") && op_data.name == Symbol::new("func")
+        {
             if let Some(name) = op_data.attributes.get_symbol("sym_name") {
-                println!("  Operation {}: func.func \"{}\"", i + 1, name);
+                println!("  Operation {}: tribute_control.func \"{}\"", i + 1, name);
             }
         } else {
             println!(
@@ -89,10 +92,12 @@ fn incremental_compilation_demo() {
 
     // Lower it
     println!("Initial lowering...");
-    let Some((ctx1, m1)) = compile_frontend(&db, source_file) else {
+    let Some(frontend1) = compile_frontend(&db, source_file) else {
         println!("Initial compilation failed");
         return;
     };
+    let ctx1 = frontend1.context;
+    let m1 = frontend1.module;
     let ops1 = m1.ops(&ctx1);
     println!("Lowered {} operations", ops1.len());
 
@@ -105,19 +110,23 @@ fn incremental_compilation_demo() {
 
     // Lower again - Salsa will automatically detect the change and recompute
     // the internal tracked queries, then produce fresh arena IR.
-    let Some((ctx2, m2)) = compile_frontend(&db, source_file) else {
+    let Some(frontend2) = compile_frontend(&db, source_file) else {
         println!("Recompilation failed");
         return;
     };
+    let ctx2 = frontend2.context;
+    let m2 = frontend2.module;
     let ops2 = m2.ops(&ctx2);
     println!("Lowered {} operations after modification", ops2.len());
 
     // Lower again without changes - internally Salsa caches the tracked
     // queries, so this recomputation is fast.
-    let Some((ctx3, m3)) = compile_frontend(&db, source_file) else {
+    let Some(frontend3) = compile_frontend(&db, source_file) else {
         println!("Cached compilation failed");
         return;
     };
+    let ctx3 = frontend3.context;
+    let m3 = frontend3.module;
     let ops3 = m3.ops(&ctx3);
     println!("Cached result identical: {}", ops2.len() == ops3.len());
 

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -42,35 +42,45 @@ type과 source parameter/result만 사용하며 evidence, environment, `done_k`�
 | ---- | ---- | ---- |
 | `Direct` | 소스 parameter | 소스 result |
 | `EvidenceDirect` | evidence 뒤 소스 parameter | 소스 result |
-| `Cps` | evidence, `done_k`, source parameter 순서 | logical `core.never`, physical empty result |
+| `Cps` | evidence, `Done<R>`, `Dispatch<R>`, 소스 parameter 순서 | logical `core.never`, physical empty result |
 
-Parameter 순서는 기존 `CallableAbi` 순서다. `Cps`의 `done_k`는 source result를
-받고 logical `core.never`를 반환한다. Control lowering 뒤 worker와 continuation은
-result vector가 비어 있으며 제어 값을 반환하지 않는다.
+Parameter 순서는 기존 `CallableAbi` 순서다. CPS continuation 형상은 모두 exact
+`tribute.calling_convention = 2`를 가진 closure이며 다음과 같다.
 
-Conversion은 먼저 모든 logical callable type, definition, lambda, `func_ref`,
-direct/indirect call, return의 대응 관계를 검증하고 physical symbol과 type을
-계산한 뒤 함께 rewrite한다:
+```text
+Done<R>             = closure(core.func<never, R>)
+Parent<R>           = immutable private struct { done: Done<R>, dispatch: Dispatch<R> }
+Completion<X, R>    = closure(core.func<never, Evidence, Parent<R>, X>)
+ResumeExact<I, R>   = closure(core.func<never, Evidence, Parent<R>, I>)
+Resume<R>           = closure(core.func<never, Evidence, Parent<R>, anyref>)
+Dispatch<R>         = closure(core.func<never,
+                         Evidence, Resume<R>, i32 prompt_tag, i32 ability_id,
+                         i32 op_id, anyref payload>)
+```
 
-- `tribute_control.func`는 `func.func`와 physical `core.func`를 만든다.
-- `tribute_control.lambda`는 physical `closure.lambda`와
-  `closure.closure<core.func<...>>`를 만든다. 이 단계의 signature에는
-  `CallableAbi` hidden parameter가 있지만 environment는 없으며, 기존 closure
-  lowering이 environment를 interpose한다.
-- `tribute_control.func_ref`는 빈 environment의 `closure.new`와 env-bearing
-  adapter `func.func`를 만든다. Adapter는 result callable의 같거나 더 강한
-  convention을 사용하고 필요한 hidden operand와 source argument를 대상 physical
-  worker에 전달하므로 named function도 다른 closure와 같은 `call_indirect` ABI를
-  갖는다. 기존 closure lowering은 이 `closure.new`를 `func.constant`와 physical
-  closure struct로 바꾼다.
-- `Direct`/`EvidenceDirect`의 `tribute_control.call`과 `call_indirect`는 각각
-  physical `func.call`과 `func.call_indirect`가 된다. `Cps` call은 suffix를
-  `done_k`로 전달하고 named target에는 `func.tail_call`, dynamic target에는
-  `func.tail_call_indirect`를 쓴다. Evidence와 environment는 `CallableAbi`
-  순서로 삽입한다.
-- `tribute_control.return`은 `Direct`/`EvidenceDirect`에서 `func.return`이 된다.
-  `Cps`에서는 `done_k(value)`로 `func.tail_call_indirect`하며 뒤에
-  `func.return`이나 result가 없다.
+이 typed CPS control callback ABI에서 `anyref` 위치는 `Resume<R>`의 source
+operation input과 payload뿐이다. `Done`, completion, resumption, dispatch,
+control result의 erase/cast는 금지한다.
+`Flow<R> = (Done<R>, Dispatch<R>)`, `Context<R> = (Evidence, Parent<R>)`는
+컴파일러 내부 pair이고 `Parent<R>`만 이를 pack하는 immutable nominal SSA 값이다.
+재개 callback은 명시적 `Context<R>`를 받아 nearest prompt와 parent dispatch를
+함께 복원한다. mutation, global slot, carrier, ordinary-call fallback과 control
+result는 없으며 CPS worker/continuation은 empty result만 가진다.
+
+Conversion은 callable graph 전체를 검증한 뒤 physical symbol/type을 함께
+rewrite한다.
+
+- definition/lambda/`func_ref`는 `func.func` 또는 typed `closure.closure`가 된다.
+  closure type은 exact convention attribute를 보존하고 closure lowering만
+  environment를 interpose한다.
+- Direct/EvidenceDirect call은 일반 call이다. Boundary `R`에서 source result `X`인
+  CPS call은 `Completion<X,R>`, `Done<X>`, `Dispatch<X>` adapter를 만들어
+  resume 시 받은 `Context<R>`로 fresh `Parent<X>`를 구성한 뒤 proper-tail
+  transfer한다.
+- CPS return은 `Done<R>(value)`로 tail transfer하며 result나 `func.return`이 없다.
+- typed closure를 pointer로 바꿀 때 `func.indirect_call_signature`에 exact physical
+  ABI를 보존한다. target은 이 provenance만 사용해 zero-size parameter를 투영한다.
+  convention/type/symbol 불일치는 conversion failure다.
 
 알려진 CPS target으로의 최종 이전은 `func.tail_call`, closure, continuation,
 `done_k`처럼 동적인 target으로의 이전은 `func.tail_call_indirect`를 사용한다.
@@ -80,18 +90,11 @@ vector는 비어 있어야 한다.
 `tribute.calling_convention = 2`를 붙여 backend-ready verifier가 semantic role을
 식별하게 한다.
 
-기존 `CallableAbi::interpose_environment`에 따라 extracted lambda와 `func_ref`
-adapter의 최종 parameter 순서는 `Direct`에서 `environment, source...`,
-`EvidenceDirect`에서 `evidence, environment, source...`, `Cps`에서
-`evidence, environment, done_k, source...`다. `call_indirect`도 같은 순서로
-environment를 삽입한다.
-
-생성한 physical definition, lambda, adapter, direct/indirect call에는 logical
-type의 convention을 기존 `tribute.calling_convention` attribute로 복사한다.
-Metadata/type/symbol 불일치는 conversion failure이며 hidden operand를 추측하지
-않는다. TrunkIR의 `TypeConverter`, function signature conversion, dialect
-builder를 재사용하되 `tribute_control` 전용 graph pattern은
-`tribute_control_to_cps`가 소유한다.
+Environment 뒤 parameter 순서는 Direct `source...`, EvidenceDirect
+`evidence, source...`, Cps `evidence, Done<R>, Dispatch<R>, source...`이며 closure
+lowering 뒤에는 environment를 evidence 다음에 넣는다. Function/call은 operation
+attribute, closure value는 outer closure type attribute를 convention provenance로
+사용한다.
 
 같은 legalization에서 각 `tribute_control.perform`을 typecheck된
 `operation_kind`에 따라 변환한다. `@fn`은 suffix를 capture하지 않고
@@ -121,8 +124,9 @@ operation을 왼쪽에서 오른쪽으로 소비한다:
   `ability.perform`을 만든다. 후속 `lower_ability_perform`이 각각
   `effect.dispatch_tail`과 `effect.dispatch_cps`로 낮춘다. Operand packing은
   이 lower 경계에서만 수행한다.
-  `op -> Never`에는 suffix를 capture하지 않고 기존 필수 ABI operand에 실제
-  zero-capture reject continuation을 공급한다.
+  `op -> I`에는 exact one-shot `ResumeExact<I,R>`를 만들고 input `I`만 source
+  data로 box한 `Resume<R>`를 현재 `Dispatch<R>`에 tail transfer한다. `op -> Never`에는
+  suffix를 capture하지 않고 typed reject `Resume<R>`를 공급한다.
 - `tribute_control.yield value`는 region의 `exit_k(value)`를 호출한다.
 
 일반 structured control은 기존 `scf.*` dialect에 남고
@@ -218,7 +222,7 @@ payload, closure environment와 dispatch closure field에 쓰는 일반 `anyref`
   { ability_ref = @Logger, op_name = @log }
 ```
 
-Shared lowering converts it to a target-independent effect ABI operation:
+공통 lowering은 이를 target-independent effect ABI operation으로 바꾼다.
 
 ```text
 %payload = cast %arg to anyref
@@ -226,8 +230,7 @@ Shared lowering converts it to a target-independent effect ABI operation:
   { ability_ref = @Logger, op_name = @log }
 ```
 
-Native lowering then lowers that ABI operation to the evidence lookup
-and indirect-call representation:
+Native lowering은 이 ABI operation을 evidence lookup과 indirect call로 낮춘다.
 
 ```text
 %marker = ability.evidence_lookup %ev { ability_ref = @Logger }
@@ -241,37 +244,32 @@ and indirect-call representation:
 즉 `fn` operation은 CPS 변환, continuation allocation, resume dispatch를
 우회한다.
 
-### `op` operation: tail-call CPS dispatch
+### `op` operation의 typed tail-call CPS dispatch
 
 직접형 입력은 위 규칙의 `operation_kind = @op` perform이며,
-`tribute_control_to_cps`는 block suffix에서 continuation closure를 구성해
-`ability.perform`으로 내린다.
+`tribute_control_to_cps`는 block suffix에서 exact one-shot
+`ResumeExact<I,R>`와 result-indexed `Resume<R>`를 구성해 `ability.perform`으로 내린다.
 
 ```text
-ability.perform %continuation, %arg
+ability.perform %evidence, %dispatch, %resume, %arg
   { ability_ref = @State, op_name = @get }
 ```
 
-Shared lowering converts it to a target-independent effect ABI operation:
+공통 lowering은 이를 target-independent effect ABI operation으로 바꾼다.
 
 ```text
 %payload = cast %arg to anyref
-%cont = cast %continuation to anyref
-effect.dispatch_cps %ev, %cont, %payload
+effect.dispatch_cps %ev, %dispatch, %resume, %payload
   { ability_ref = @State, op_name = @get }
 ```
 
-Native lowering then finds the `handler_dispatch` closure in evidence and
-tail-calls it:
+Native/Wasm lowering은 evidence에서 nearest prompt tag를 찾은 뒤 명시적으로 받은
+typed dispatch closure를 tail-call한다.
 
 ```text
-%marker = ability.evidence_lookup %ev { ability_ref = @State }
-%handler = adt.struct_get %marker, MarkerField::HandlerDispatch
-%fn = adt.struct_get %handler, 0
-%env = adt.struct_get %handler, 1
-%op_idx = arith.const <hash(State, get)>
-func.tail_call_indirect %fn(
-  %ev, %env, %continuation_anyref, %op_idx, %arg_anyref)
+%prompt = ability.evidence_lookup %ev { ability_ref = @State }
+func.tail_call_indirect %dispatch(
+  %ev, %resume, %prompt, <ability_id>, <op_id>, %arg_anyref)
 ```
 
 Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므로,
@@ -283,111 +281,43 @@ semantic lowering 이후의 별도 IR optimization이다.
 
 ### Root `main` delimiter
 
-Root `main`은 하나뿐인 target-independent CPS delimiter다. Source residual-effect
-계약은 기존 pure-or-`Io` entry를 유지하며 residual general effect는 backend 전에
-거부한다. Nested module의 `main`은 일반 worker다.
+Root `main`만 target-independent CPS delimiter다. Nested module의 `main`은 일반
+worker이며 residual general effect는 backend 전에 거부한다. CPS entry와 root
+`done_k`는 shared IR에서 `core.never`, target에서는 empty result다.
 
-Target-independent 경계는 Direct/EvidenceDirect export wrapper가 source result
-type의 completion cell과 이를 capture한 root `done_k`를 소유한다는 추상 조합
-계약만 정한다. Shared IR에서 CPS entry와 `done_k`의 result는 `core.never`이며,
-`func.tail_call`과 `func.tail_call_indirect` verifier도 caller/callee의
-`core.never` 일치를 검사한다.
+Direct/EvidenceDirect wrapper는 completion cell과 root `done_k`를 만들고 ordinary
+call로 CPS worker를 시작한다. `done_k`는 source result를 한 번 저장하고, wrapper는
+tail chain 뒤 cell을 읽어 반환한다. Shared `func.call` result 계약은 유지하며
+trampoline, carrier, sentinel과 call 뒤 return fallback은 없다.
 
-Target signature lowering은 이 CPS signature를 native/Wasm empty-result
-signature로 바꾼 뒤 실제 wrapper와 ordinary call을 합성한다. Wasm은 nil/void
-machinery처럼 target이 지원하는 표현을 사용한다. Root `done_k`는 source result를
-cell에 정확히 한 번 쓰고 target empty result로 반환하며, wrapper는
-proper-tail-call chain이 끝난 뒤 cell을 읽어 source result로 반환한다. Shared
-`core.func<Return, ...>`와 `func.call`의 단일 logical result 계약을 유지하고 새
-zero-result call 형상을 요구하지 않으며 두 번째 control carrier도 도입하지
-않는다. 이 adapter는 answer-type polymorphism, trampoline, in-band sentinel 또는
-control carrier가 아니다.
+### `handle`: immutable completion + dispatch closure
 
-### `handle`: evidence extension + handler closures
+Body type이 `B`, handle answer가 `A`, enclosing result가 `O`이면
+`after_handle: Completion<A,O>`와 `completion: Completion<B,A>`를 만든다. 정상 body
+completion은 둘을 순서대로 한 번 실행한다. Token은 받은 fresh
+`Evidence, Parent<A>`로 `Flow<B>`와 local dispatcher를 다시 만들어 raw `Resume<B>`에
+전달한다. 따라서 nested resume도 immutable suffix stack을 보존한다. Non-resumed arm은
+`Parent<A>.done(answer)`로 직접 tail transfer한다. Foreign prompt도 capture한
+`Parent<A>.dispatch`와 재구성한 `Flow<B>`로 forward한다.
 
-`handle` lowering은 두 종류의 dispatch closure를 만든다.
+`Dispatch<R>`는 `(Evidence, Resume<R>, prompt_tag, ability_id, op_idx, payload) ->
+Never`인 immutable general-`op` dispatch chain이다. `tr_dispatch_fn`은 `fn`
+operation의 `(op_idx, value) -> anyref` closure이며, 이 `anyref`는 erased source
+result일 뿐 control 값이 아니다.
 
-- `handler_dispatch`: `(k, op_idx, value) -> ()`
-  - general `op` handlers용
-  - closure environment가 handle exit를 소유하며 `resume`과 non-resuming exit는
-    각 continuation으로 indirect tail transfer한다.
-- `tr_dispatch_fn`: `(op_idx, value) -> anyref`
-  - `fn` handlers용
-  - `anyref`는 erased source result이며 CPS control carrier가 아니다.
-
-`resolve_evidence`는 handler boundary에서 새 marker를 만들어 evidence를
-확장한다.
-
-Shared evidence resolution represents handler installation with the same effect
-ABI instead of constructing the concrete Marker layout directly:
+`resolve_evidence`는 concrete storage를 보지 않고 다음 effect ABI로 handler를
+설치한다.
 
 ```text
-%ev2 = effect.extend %ev, %prompt_tag, %tr_dispatch_fn, %handler_dispatch
+%ev2 = effect.extend %ev, %prompt_tag, %tr_dispatch_fn, %metadata
   { ability_ref = @State }
 ```
 
-Backends lower `effect.extend` to their own evidence representation. The native
-backend maps it to the `__tribute_evidence_extend` ABI.
-
-```text
-struct Marker {
-    ability_id: i32,
-    prompt_tag: i32,
-    tr_dispatch_fn: ptr,
-    handler_dispatch: ptr,
-}
-```
-
-Evidence는 ability id 기준으로 정렬된 marker 배열이며, handler 설치 시
-새 evidence 값을 만든다.
-
-Marker layout과 evidence runtime ABI는 `tribute-ir`의
-`ability::MarkerField`와 `ability::evidence_abi`가 컴파일러 내부의 단일
-정의다. 필드 순서는 다음과 같고 모든 shared pass와 backend lowering은 이
-순서를 직접 숫자로 복제하지 않는다.
-
-| Field | Index | Type | Meaning |
-| --- | ---: | --- | --- |
-| `ability_id` | 0 | `i32` | stable ability key for sorted evidence lookup |
-| `prompt_tag` | 1 | `i32` | prompt installed for the active handler |
-| `tr_dispatch_fn` | 2 | `ptr` | tail-resumptive dispatch closure or null |
-| `handler_dispatch` | 3 | `ptr` | full CPS dispatch closure or null |
-
-WasmGC uses the same field order and shared field identifiers, but its concrete
-GC marker type stores the dispatch closures as `anyref` closure references
-instead of native `ptr` values. Wasm effect ABI lowering therefore expands
-`effect.dispatch_tail` and `effect.dispatch_cps` into evidence lookup,
-`wasm.struct_get` of the selected marker closure, closure table-index/env
-decomposition, and `wasm.call_indirect`.
-
-Empty evidence is represented in high-level IR as an empty `core.array(Marker)`
-or null evidence placeholder, and backend lowering turns that into the target
-runtime representation. Native lowering maps it to `__tribute_evidence_empty()`.
-When a handler for the same `ability_id` is nested inside an outer handler,
-evidence extension replaces the existing marker so lookup resolves to the
-nearest handler.
-
-Native runtime ABI:
-
-```text
-__tribute_evidence_empty() -> ptr
-__tribute_evidence_lookup(ev: ptr, ability_id: i32) -> i32
-__tribute_evidence_extend(
-    ev: ptr,
-    ability_id: i32,
-    prompt_tag: i32,
-    tr_dispatch_fn: ptr,
-    handler_dispatch: ptr,
-) -> ptr
-__tribute_evidence_lookup_tr(ev: ptr, ability_id: i32) -> ptr
-__tribute_evidence_lookup_handler(ev: ptr, ability_id: i32) -> ptr
-```
-
-### `ability.handle_dispatch`
-
-`ability.handle_dispatch`는 runtime dispatch loop가 아니다. Effect 발생 시점에서
-이미 handler closure로 tail-call되므로,
-`lower_handle_dispatch`는 body result에 `done` handler를 적용하는 역할만 한다.
+Evidence는 ability id로 정렬된 immutable marker 배열이다. 같은 ability의 nested
+handler는 nearest marker를 선택한다. Marker storage와 field 번호는 backend-private다.
+Native는 evidence runtime ABI로, WasmGC는 target closure 표현으로 이를 낮춘다.
+`effect.dispatch_cps`는 marker closure를 읽지 않고 명시적 `Dispatch`를 분해해
+proper tail transfer한다.
 
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="shared-middle-end-pipeline"></a>
@@ -410,56 +340,15 @@ ast_to_ir (tribute_control callable/control + ordinary value IR)
 → backend-ready verification
 ```
 
-`tribute_control_to_cps`의 출력은 physical `func.*`/`closure.*` callable 표면과
-logical `ability.*` dispatch 표면이다. Closure pass가 전자를 소비하고,
-ability/evidence pass가 후자를 `effect.*`까지 낮춘 뒤 backend가 evidence runtime
-call, closure decomposition과 proper tail transfer로 제거한다. 다른 일반
-최적화는 이 경계 사이에 놓일 수 있지만 각 named legality를 바꾸지 않는다.
+`tribute_control_to_cps`는 physical callable과 logical `ability.*` dispatch를 만든다.
+Closure pass가 전자를, ability/evidence pass가 후자를 `effect.*`까지 소비한 뒤
+backend가 evidence runtime과 proper tail transfer로 제거한다.
 
-## Effect ABI Boundary
+## Effect ABI 경계
 
-The `effect` dialect is the target-independent boundary between language
-semantics and concrete runtime layout.
-
-Initial operations:
-
-- `effect.extend(evidence, prompt_tag, tr_dispatch_fn, handler_dispatch)
-  { ability_ref } -> evidence`
-- `effect.dispatch_tail(evidence, payload) { ability_ref, op_name } -> result`
-- `effect.dispatch_cps(evidence, continuation, payload)
-  { ability_ref, op_name } -> ()`
-
-Rules:
-
-- `ability.perform` and `ability.call` are illegal after the shared
-  ability-dispatch lowering boundary.
-- `effect.*` operations may remain after shared lowering and before
-  backend-specific effect ABI lowering.
-- `effect.dispatch_cps`는 control result를 만들지 않으며 backend lowering은
-  handler-dispatch closure로 proper indirect tail transfer한다.
-- Backend-ready conversion targets must reject residual `effect.*` operations.
-- Shared passes must not inspect Marker field numbers, handler-table storage
-  layout, closure field positions, or backend function-pointer representation.
-- Payload value는 shared lowering에서 이미 single value로 pack한다. 직접형 frontend는
-  source-logical `tribute_control.perform` operand를 유지하며 dispatch 전략에
-  맞춰 pack하지 않는다. 누락된 payload는 `effect.*`에 도달하기 전에
-  target-independent null/empty value로 명시적으로 표현한다.
-
-## Backend Implications
-
-### Native
-
-Evidence runtime은 `tribute-runtime`의
-`__tribute_evidence_*` C ABI 함수로 제공되고, native effect ABI lowering은
-`effect.*`를 marker lookup helper, runtime evidence extension, closure
-decomposition, and indirect calls로 변환한다.
-
-### WasmGC
-
-WasmGC도 같은 shared middle-end를 사용한다. `wasm/evidence_to_wasm`은
-`effect.extend`를 marker construction + `__tribute_evidence_extend` helper
-call로 낮추고, `effect.dispatch_tail` / `effect.dispatch_cps`는
-`__tribute_evidence_lookup`, marker closure field access, closure
-table-index/env unpacking으로 낮춘다. CPS control transfer는
-`func.tail_call_indirect`를 거쳐 `wasm.return_call_indirect`가 된다. Source data를
-반환하는 일반 indirect call은 계속 `wasm.call_indirect`를 사용할 수 있다.
+`effect` dialect는 language semantics와 runtime layout 사이의 target-independent
+경계다. `effect.extend`, source-result `effect.dispatch_tail`, resultless
+`effect.dispatch_cps`만 허용한다. 공통 ability-dispatch 뒤 `ability.*`는, backend
+ABI lowering 뒤 `effect.*`는 illegal이다. `dispatch_cps`는 명시적 Dispatch closure로
+proper indirect tail transfer하며 control result를 만들지 않는다. Wasm의 일반
+source-data indirect call은 계속 `wasm.call_indirect`를 사용한다.

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -80,6 +80,27 @@ must not require source or shared-IR changes.
 
 ### Native 타겟
 
+#### `Nil` 영-크기 ABI
+
+Native ABI에서 `core.nil`은 Cranelift scalar가 아니다. `core.func`의 `Nil`
+parameter와 대응하는 entry argument, 직접/간접 call 및 tail transfer operand는
+정확히 검증된 callable signature를 기준으로 함께 제거한다. 비어 있는 값은
+`Nil` return marker와 type metadata에만 남으며, 임의의 정수나 pointer로
+물질화하지 않는다.
+
+함수 정의, declaration, `func.constant`, closure callable type, call site는 같은
+signature projection을 사용한다. 일치하지 않는 arity 또는 type은 mutation 전에
+거부한다. 이 규칙은 Wasm의 nullable-reference `Nil` 표현과 공유하지 않는다.
+
+#### CPS proper-tail ABI
+
+검증된 CPS worker, continuation, handler와 `done_k`의 내부 Cranelift signature는
+`Tail` calling convention을 쓴다. 이에 대응하는 `func.tail_call`과
+`func.tail_call_indirect`도 같은 `Tail` signature로 proper-tail transfer한다.
+Direct/EvidenceDirect function, root wrapper, import, runtime, RTTI와 일반 indirect
+call은 target platform ABI를 유지한다. 두 ABI 사이에는 trampoline 또는
+ordinary call 뒤 return fallback이 없다.
+
 ```mermaid
 flowchart TB
     input["TrunkIR Module\n(func.*, arith.*, scf.*, adt.*, evidence runtime calls)"]

--- a/new-plans/generics.md
+++ b/new-plans/generics.md
@@ -95,6 +95,10 @@ Monomorph  Uniform Rep
 | 제네릭 함수            | **다형적 재귀** | Uniform representation |
 | Effect만 다형적인 함수 | -               | Evidence passing       |
 
+Uniform representation은 다형적인 **소스 데이터**에만 적용한다. 유지된
+제네릭 본문과 특수화 본문은 결과 인덱스가 있는 `Parent`·`Done`·`Resume`·`Dispatch`
+제어 타입을 정확히 구성하며, 이를 `anyref`로 소거하거나 변환 캐스트하지 않는다.
+
 ---
 
 ## Monomorphization

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -290,14 +290,15 @@ struct Marker {
     ability_id: i32,      // ability 식별자 (컴파일 타임 결정)
     prompt_tag: i32,      // 런타임 prompt 식별자
     tr_dispatch_fn: ptr,  // fn operation용 tail-resumptive dispatch closure
-    handler_dispatch: ptr // op operation용 CPS handler dispatch closure
 }
 ```
 
 **설계 결정:**
 
 - `ability_id`와 `prompt_tag`는 `i32`로 통일한다.
-- dispatch field는 target별 closure/function reference 표현으로 lowering한다.
+- `tr_dispatch_fn`은 target별 closure/function reference 표현으로 lowering한다.
+  `op` operation의 CPS Dispatch는 marker에 저장하지 않고 호출 지점의 typed control
+  operand으로 전달한다.
   Native marker는 closure pointer를 저장하고, WasmGC marker는
   `(table_idx: i32, env: anyref)` closure struct reference를 `anyref`로 저장한다.
 - 별도의 opaque 타입(`ability.evidence_ptr`, `ability.marker`) 대신 struct/array 사용
@@ -307,10 +308,12 @@ struct Marker {
 
 ### Handler Dispatch Closures
 
-Operation table 대신 handler boundary에서 두 종류의 dispatch closure를 만든다:
+Handler boundary는 `fn` operation용 dispatch closure를 만든다:
 
 - `tr_dispatch_fn`: `fn` operation 전용. `(op_idx, value) -> anyref`
-- `handler_dispatch`: `op` operation 전용. `(k, op_idx, value) -> ()`
+
+`op` operation의 `Dispatch<R>`는 `Parent<R>`에 capture된 typed CPS closure이며,
+`(Resume<R>, prompt_tag, ability_id, op_idx, payload) -> Never`로 tail transfer한다.
 
 `op_idx`는 ability 이름과 operation 이름의 stable hash로 계산한다. 호출 지점과
 handler dispatch closure가 같은 hash 함수를 사용하므로, handler arm 등록 순서에
@@ -331,9 +334,9 @@ func.call_indirect(handler, ...)
 
 Shared lowering은 concrete marker 접근을 직접 만들지 않고 `effect.*` ABI
 operation을 생성한다. Native lowering에서는 이를 `__tribute_evidence_*` C ABI와
-native closure pointer 호출로 대체한다. Wasm lowering은 같은 ability id와 marker
-field 순서를 사용해 binary search helper를 생성하고, marker에 저장된 `anyref`
-closure를 `(table_idx, env)`로 풀어 `wasm.call_indirect`를 emit한다.
+native closure pointer 호출로 대체한다. Wasm lowering은 evidence lookup에는 marker를
+사용하고, CPS Dispatch operand는 `(table_idx, env)`로 풀어
+`wasm.return_call_indirect`를 emit한다.
 
 ### Handler 설치
 
@@ -346,7 +349,6 @@ fn run_state(comp: fn(Evidence) -> a, init: s, ev: Evidence) -> a {
         ability_id: STATE_ID,
         prompt_tag: tag,
         tr_dispatch_fn: state_tr_dispatch,
-        handler_dispatch: state_handler_dispatch,
     }
 
     // evidence_extend: 정렬 유지하며 marker 삽입, 새 배열 반환
@@ -488,6 +490,10 @@ fn-only or empty ability    → EvidenceDirect
 ability containing any op  → Cps
 open or otherwise unknown e → Cps
 ```
+
+람다 값의 `Direct` 판정은 람다 본문이 만든 evaluation row를 그 본문의
+제약만 푼 직후에 검사한다. 이 row가 닫힌 빈 row일 때만 `Direct`이며,
+알려진 effect 또는 열린 tail은 이후 문맥이 넓히기 전에도 `Cps`다.
 
 이 ability-level convention bound는 operation declaration의 source `fn`/`op`
 kind를 erase하지 않는다. Typechecking이 resolve된 operation에 kind를 저장하고
@@ -955,14 +961,14 @@ it is part of frontend IR construction rather than a standalone pass. The
 function-anchored lowering point after case construction is `scf_to_cf_pass()`,
 which runs under `PassManager::nest::<func.func>()`.
 
-`typecheck` solves function-local unification variables where constraints make
-them concrete and generalizes remaining polymorphic variables into stable
-`BoundVar` indices. Generalization covers the function signature, checked body,
-and post-solve deferred UFCS callee types so later TDNR and monomorphization do
-not see raw solver variables in typed references. Each type-scheme
-instantiation freshens both bound type variables and quantified effect-row variables,
-while preserving repeated references to the same row variable within that
-single instantiation.
+`typecheck`는 제약으로 결정된 함수-지역 unification variable을 구체 타입으로
+치환한다. 함수 `TypeScheme`은 callable interface에 나타나는 나머지 변수만 안정된
+`BoundVar`로 quantify한다. 본문, node/callee/handler/perform/lambda metadata와
+deferred UFCS callee는 같은 치환 뒤 지역 `let` scheme으로 일반화되거나 보통의
+모호성 진단과 오류 복구를 거쳐야 하며, typed reference에 raw solver variable이
+남아서는 안 된다. TypeScheme 인스턴스화는 bound type variable과 quantify된
+effect-row variable을 모두 freshen하되, 한 인스턴스 안의 같은 row variable 참조는
+보존한다.
 
 Local scopes store `TypeScheme` bindings. At each `let`, the checker solves the
 constraint prefix through that binding and separately tracks the effect of
@@ -1041,13 +1047,11 @@ struct Marker {
     ability_id: i32,
     prompt_tag: i32,
     tr_dispatch_fn: ptr,
-    handler_dispatch: ptr,
 }
 ```
 
-위 `ptr` 표기는 high-level/native 설명이다. WasmGC의 concrete `_Marker` GC type은
-같은 field order를 유지하되 dispatch closure field를 `anyref` closure reference로
-저장한다.
+위 `ptr` 표기는 high-level/native 설명이다. WasmGC의 concrete marker type은
+같은 의미의 tail-resumptive closure reference를 target representation으로 저장한다.
 
 타입 시스템 수준에서는 ability row에 대해 parameterized된다:
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -75,6 +75,11 @@ operation을 recursively legal로 표시해서 nested illegal operation을 가�
 
 최종 native/Wasm 경계는 `tribute.calling_convention = 2` (`Cps`)인 worker와 생성된
 continuation/`done_k`/handler-dispatch의 result가 비어 있는지도 검사한다.
+타겟 signature lowering은 `func.func`의 operation convention, convention이
+명시된 outer `closure.closure` type, `func.constant`의 exact target symbol만
+provenance로 인정한다. Tag 없는 nested `core.func<core.never, ...>`는 CPS라고
+추측하지 않고 거부하며, 같은 구조의 Direct/EvidenceDirect source `Never`
+callable은 바꾸지 않는다.
 CPS control result 역할의 `anyref`, nominal `__tribute_cps_control` enum과
 result-producing CPS dispatch는 illegal이다. Boxed source value, effect payload,
 closure environment와 dispatch field의 일반 `anyref` 사용은 허용한다.
@@ -164,13 +169,18 @@ resolution을 검사하며 physical `core.func`나 `closure.closure`를 componen
 | `tribute_control.handler` | handle 안의 `fn` 또는 general `op` handler arm을 기술 |
 | `tribute_control.resume` | resumptive general handler arm에 바인딩된 affine resumption을 소비 |
 | `tribute_control.yield` | 실행 가능한 `tribute_control` region을 logical value로 종료 |
+| `tribute_control.unreachable` | exhaustive residual region을 value 없이 종료 |
 
 `func.tail_call`, `func.tail_call_indirect`, `func.constant`, `func.unreachable`의
 logical 복제는 없다. Tail 형상은 legalization 결과이고 named function value는
 `func_ref`가 표현한다. Legalization은 알려진 target에 `func.tail_call`, closure,
 continuation과 `done_k` target에 새 `func.tail_call_indirect`를 만들 수 있다.
-`func.constant`는 후속 physical closure lowering이 만들며 `func.unreachable`은
-reject adapter 같은 compiler helper 안에서만 legalization 뒤에 사용한다.
+`func.constant`는 후속 physical closure lowering이 만든다.
+
+`tribute_control.unreachable`은 operand, result, region이 없는 terminator다.
+Checker가 exhaustive로 증명한 residual `scf.if` arm에서만 사용하며,
+`core.nil`이나 conversion cast로 result를 위조하지 않는다. Legalization은 이를
+`func.unreachable`으로 바꾼다.
 
 이 dialect는 opaque type `tribute_control.resume_token<input, answer>`도
 소유한다. `input`은 중단된 operation continuation이 받는 값이고, `answer`는

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -84,6 +84,14 @@ trunk-ir (Mid-level)
 WebAssembly Binary
 ```
 
+결과 없는 `scf.switch`는 case의 source 순서를 보존한 `wasm.i32_const` /
+`wasm.i32_eq`와 중첩 `wasm.if`로 내린다. 마지막 else는 반드시 default arm이며,
+이 경로는 `cf.*`나 별도 control carrier를 만들지 않는다.
+
+Cast materialization 뒤 GC type index를 정하기 전에 Wasm target boundary가
+signature, result, block argument, attribute와 nominal layout의 모든 중첩 type leaf를
+물리화한다. 바깥 ADT/nominal identity와 field 순서는 유지한다.
+
 Effect lowering은 target별로 수행한다. Shared ability lowering은 `effect.*`를
 만들며 Marker field 번호나 closure layout을 검사하지 않는다.
 `wasm/evidence_to_wasm`은 evidence lookup/extend helper를 만들고 closure struct

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -67,6 +67,7 @@ use salsa::Accumulator;
 use std::path::Path;
 use tree_sitter::Parser;
 use tribute_front::source_file::parse_with_rope;
+use tribute_ir::dialect::tribute_control::OperationDeclaration;
 use tribute_passes::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 use tribute_passes::generic_type_converter;
 use trunk_ir::Span;
@@ -86,6 +87,14 @@ pub struct DumpIrError {
 
 impl From<PassError> for DumpIrError {
     fn from(error: PassError) -> Self {
+        Self {
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<tribute_passes::target_abi::TargetAbiError> for DumpIrError {
+    fn from(error: tribute_passes::target_abi::TargetAbiError) -> Self {
         Self {
             message: error.to_string(),
         }
@@ -186,6 +195,16 @@ impl Default for OptimizationOptions {
 pub enum SharedPipelineStage {
     /// Immediately after AST-to-IR lowering, before shared middle-end passes.
     AfterFrontend,
+    /// Immediately after atomic source-logical control legalization.
+    AfterControlLegalization,
+}
+
+/// Arena frontend output plus the exact semantic declarations consumed by
+/// source-logical control legalization.
+pub struct FrontendCompilation {
+    pub context: IrContext,
+    pub module: Module,
+    pub operation_declarations: Vec<OperationDeclaration>,
 }
 
 /// Stable native-pipeline boundaries available to optimization tests.
@@ -283,8 +302,14 @@ fn prelude_module<'db>(db: &'db dyn salsa::Database) -> Option<ast_typeck::TypeC
         db,
         tdnr_ast,
         result.function_types,
-        result.constructor_types,
-        result.node_types,
+        ast_typeck::NominalTypeMetadata {
+            constructor_types: result.constructor_types,
+            type_definitions: result.type_definitions,
+        },
+        ast_typeck::ExpressionTypeMetadata {
+            node_types: result.node_types,
+            call_callee_types: result.call_callee_types,
+        },
         result.ability_conventions,
         ast_typeck::ability_schemas(&result.ability_definitions),
         result.handler_operations,
@@ -339,6 +364,66 @@ fn prelude_exports<'db>(db: &'db dyn salsa::Database) -> Option<PreludeExports<'
     Some(prelude_exports)
 }
 
+/// Merge declarations exactly as prelude name injection resolves them: a user
+/// function shadows a prelude function with the same name in the same lexical
+/// module, while unrelated prelude members remain available.
+fn merge_prelude_declarations<'db>(
+    prelude: Vec<tribute_front::ast::Decl<tribute_front::ast::TypedRef<'db>>>,
+    user: &[tribute_front::ast::Decl<tribute_front::ast::TypedRef<'db>>],
+) -> Vec<tribute_front::ast::Decl<tribute_front::ast::TypedRef<'db>>> {
+    use tribute_front::ast::Decl;
+
+    fn function_name<'db>(
+        decl: &Decl<tribute_front::ast::TypedRef<'db>>,
+    ) -> Option<trunk_ir::Symbol> {
+        match decl {
+            Decl::Function(function) => Some(function.name),
+            Decl::ExternFunction(function) => Some(function.name),
+            Decl::Struct(_) | Decl::Enum(_) | Decl::Ability(_) | Decl::Use(_) | Decl::Module(_) => {
+                None
+            }
+        }
+    }
+
+    let mut merged = Vec::with_capacity(prelude.len() + user.len());
+    let mut folded_modules = std::collections::HashSet::new();
+    for declaration in prelude {
+        match declaration {
+            Decl::Function(_) | Decl::ExternFunction(_) => {
+                let name = function_name(&declaration).expect("function declaration has a name");
+                if user
+                    .iter()
+                    .any(|candidate| function_name(candidate) == Some(name))
+                {
+                    continue;
+                }
+                merged.push(declaration);
+            }
+            Decl::Module(mut prelude_module) => {
+                let user_body = user
+                    .iter()
+                    .find_map(|candidate| match candidate {
+                        Decl::Module(module) if module.name == prelude_module.name => Some(module),
+                        _ => None,
+                    })
+                    .and_then(|module| module.body.as_ref());
+                if let Some(user_body) = user_body
+                    && let Some(prelude_body) = prelude_module.body.take()
+                {
+                    prelude_module.body = Some(merge_prelude_declarations(prelude_body, user_body));
+                    folded_modules.insert(prelude_module.name);
+                }
+                merged.push(Decl::Module(prelude_module));
+            }
+            declaration => merged.push(declaration),
+        }
+    }
+    merged.extend(user.iter().filter(|declaration| {
+        !matches!(declaration, Decl::Module(module) if folded_modules.contains(&module.name))
+    }).cloned());
+    merged
+}
+
 /// Merge prelude decls into user's typed AST and lower to arena IR.
 ///
 /// This performs AST-level prelude merge (prepending prelude decls to user decls),
@@ -349,14 +434,23 @@ fn merge_and_lower_to_ir<'db>(
     db: &'db dyn salsa::Database,
     typed: &ast_typeck::TypeCheckOutput<'db>,
     source: SourceCst,
-    options: OptimizationOptions,
-) -> (IrContext, Module) {
+) -> FrontendCompilation {
     use tribute_front::ast::TypedRef;
 
     let user_module = typed.module(db);
     let user_fn_types = typed.function_types(db);
-    let user_node_types = typed.node_types(db);
+    let user_expression_types = typed.expression_types(db);
+    let user_node_types = &user_expression_types.node_types;
+    let user_call_callee_types = &user_expression_types.call_callee_types;
     let user_span_map = typed.span_map(db);
+    let user_nominal_types = typed.nominal_types(db);
+    let user_constructor_types = &user_nominal_types.constructor_types;
+    let user_type_definitions = &user_nominal_types.type_definitions;
+    let user_ability_definitions = typed.ability_definitions(db);
+    let user_handler_operations = typed.handler_operations(db);
+    let user_perform_operations = typed.perform_operations(db);
+    let user_lambda_signatures = typed.lambda_signatures(db);
+    let user_exhaustive_cases = typed.exhaustive_cases(db);
 
     // Merge prelude at AST level
     let user_ability_conventions = typed.ability_conventions(db);
@@ -364,18 +458,36 @@ fn merge_and_lower_to_ir<'db>(
         merged_module,
         merged_fn_types,
         merged_node_types,
+        merged_call_callee_types,
         merged_ability_conventions,
+        merged_constructor_types,
+        merged_type_definitions,
+        merged_ability_definitions,
+        merged_handler_operations,
+        merged_perform_operations,
+        merged_lambda_signatures,
+        merged_exhaustive_cases,
         merged_span_map,
     ) = if let Some(prelude) = prelude_module(db) {
         let prelude_module_ast = prelude.module(db);
         let prelude_fn_types = prelude.function_types(db);
-        let prelude_node_types = prelude.node_types(db);
+        let prelude_expression_types = prelude.expression_types(db);
+        let prelude_node_types = &prelude_expression_types.node_types;
+        let prelude_call_callee_types = &prelude_expression_types.call_callee_types;
         let prelude_ability_conventions = prelude.ability_conventions(db);
+        let prelude_nominal_types = prelude.nominal_types(db);
+        let prelude_constructor_types = &prelude_nominal_types.constructor_types;
+        let prelude_type_definitions = &prelude_nominal_types.type_definitions;
+        let prelude_ability_definitions = prelude.ability_definitions(db);
+        let prelude_handler_operations = prelude.handler_operations(db);
+        let prelude_perform_operations = prelude.perform_operations(db);
+        let prelude_lambda_signatures = prelude.lambda_signatures(db);
+        let prelude_exhaustive_cases = prelude.exhaustive_cases(db);
         let prelude_span_map = prelude.span_map(db);
 
         // Prepend prelude decls before user decls
-        let mut merged_decls = prelude_module_ast.decls.clone();
-        merged_decls.extend(user_module.decls.iter().cloned());
+        let merged_decls =
+            merge_prelude_declarations(prelude_module_ast.decls.clone(), &user_module.decls);
 
         let merged_ast = tribute_front::ast::Module::<TypedRef<'db>>::new(
             user_module.id,
@@ -393,9 +505,43 @@ fn merge_and_lower_to_ir<'db>(
             prelude_node_types.iter().cloned().collect();
         node_types.extend(user_node_types.iter().cloned());
 
+        let mut call_callee_types: std::collections::HashMap<_, _> =
+            prelude_call_callee_types.iter().cloned().collect();
+        call_callee_types.extend(user_call_callee_types.iter().cloned());
+
         let mut ability_conventions: std::collections::HashMap<_, _> =
             prelude_ability_conventions.iter().cloned().collect();
         ability_conventions.extend(user_ability_conventions.iter().cloned());
+
+        let mut constructor_types: std::collections::HashMap<_, _> =
+            prelude_constructor_types.iter().cloned().collect();
+        constructor_types.extend(user_constructor_types.iter().cloned());
+
+        let mut type_definitions: std::collections::HashMap<_, _> =
+            prelude_type_definitions.iter().cloned().collect();
+        type_definitions.extend(user_type_definitions.iter().cloned());
+
+        let mut ability_definitions: std::collections::HashMap<_, _> =
+            ast_typeck::ability_definitions_from_schemas(prelude_ability_definitions);
+        ability_definitions.extend(ast_typeck::ability_definitions_from_schemas(
+            user_ability_definitions,
+        ));
+
+        let mut handler_operations: std::collections::HashMap<_, _> =
+            prelude_handler_operations.iter().cloned().collect();
+        handler_operations.extend(user_handler_operations.iter().cloned());
+
+        let mut perform_operations: std::collections::HashMap<_, _> =
+            prelude_perform_operations.iter().cloned().collect();
+        perform_operations.extend(user_perform_operations.iter().cloned());
+
+        let mut lambda_signatures: std::collections::HashMap<_, _> =
+            prelude_lambda_signatures.iter().cloned().collect();
+        lambda_signatures.extend(user_lambda_signatures.iter().cloned());
+
+        let mut exhaustive_cases: std::collections::HashSet<_> =
+            prelude_exhaustive_cases.iter().copied().collect();
+        exhaustive_cases.extend(user_exhaustive_cases.iter().copied());
 
         // Merge span maps (user overrides prelude on conflict)
         let merged_span_map = user_span_map.merge(&prelude_span_map);
@@ -404,52 +550,103 @@ fn merge_and_lower_to_ir<'db>(
             merged_ast,
             fn_types,
             node_types,
+            call_callee_types,
             ability_conventions,
+            constructor_types,
+            type_definitions,
+            ability_definitions,
+            handler_operations,
+            perform_operations,
+            lambda_signatures,
+            exhaustive_cases,
             merged_span_map,
         )
     } else {
         let fn_types: std::collections::HashMap<_, _> = user_fn_types.iter().cloned().collect();
         let node_types: std::collections::HashMap<_, _> = user_node_types.iter().cloned().collect();
+        let call_callee_types: std::collections::HashMap<_, _> =
+            user_call_callee_types.iter().cloned().collect();
         let ability_conventions: std::collections::HashMap<_, _> =
             user_ability_conventions.iter().cloned().collect();
         (
             user_module.clone(),
             fn_types,
             node_types,
+            call_callee_types,
             ability_conventions,
+            user_constructor_types.iter().cloned().collect(),
+            user_type_definitions.iter().cloned().collect(),
+            ast_typeck::ability_definitions_from_schemas(user_ability_definitions),
+            user_handler_operations.iter().cloned().collect(),
+            user_perform_operations.iter().cloned().collect(),
+            user_lambda_signatures.iter().cloned().collect(),
+            user_exhaustive_cases.iter().copied().collect(),
             user_span_map.clone(),
         )
     };
 
     // Monomorphize generic functions
-    let mono_result =
-        tribute_front::monomorphize::monomorphize_functions(db, merged_module, merged_fn_types);
+    let mono_result = tribute_front::monomorphize::monomorphize_functions(
+        db,
+        merged_module,
+        merged_fn_types,
+        tribute_front::monomorphize::MonomorphizeMetadata {
+            constructor_types: merged_constructor_types,
+            type_definitions: merged_type_definitions,
+            node_types: merged_node_types,
+            call_callee_types: merged_call_callee_types,
+            specialized_call_callee_nodes: Default::default(),
+            ability_conventions: merged_ability_conventions,
+            ability_definitions: merged_ability_definitions,
+            handler_operations: merged_handler_operations,
+            perform_operations: merged_perform_operations,
+            lambda_signatures: merged_lambda_signatures,
+            exhaustive_cases: merged_exhaustive_cases,
+        },
+    );
     let merged_module = mono_result.module;
     let merged_fn_types: std::collections::HashMap<_, _> =
         mono_result.function_types.into_iter().collect();
+    let tribute_front::monomorphize::MonomorphizeMetadata {
+        constructor_types: merged_constructor_types,
+        type_definitions: _,
+        node_types: merged_node_types,
+        call_callee_types: merged_call_callee_types,
+        specialized_call_callee_nodes: merged_specialized_call_callee_nodes,
+        ability_conventions: merged_ability_conventions,
+        ability_definitions: merged_ability_definitions,
+        handler_operations: merged_handler_operations,
+        perform_operations: merged_perform_operations,
+        lambda_signatures: merged_lambda_signatures,
+        exhaustive_cases: merged_exhaustive_cases,
+    } = mono_result.metadata;
 
     // AST → TrunkIR (arena)
     let source_uri = source.uri(db).as_str();
     let mut ir = IrContext::new();
-    let module = ast_to_ir::TypedModule {
+    let frontend = ast_to_ir::TypedModule {
         ast: merged_module,
         span_map: merged_span_map,
         function_types: merged_fn_types,
-        constructor_types: typed.constructor_types(db).iter().cloned().collect(),
+        constructor_types: merged_constructor_types,
         node_types: merged_node_types,
+        call_callee_types: merged_call_callee_types,
+        specialized_call_callee_nodes: merged_specialized_call_callee_nodes,
         ability_conventions: merged_ability_conventions,
-        ability_definitions: ast_typeck::ability_definitions_from_schemas(
-            typed.ability_definitions(db),
-        ),
-        handler_operations: typed.handler_operations(db).iter().cloned().collect(),
-        perform_operations: typed.perform_operations(db).iter().cloned().collect(),
-        lambda_signatures: typed.lambda_signatures(db).iter().cloned().collect(),
-        exhaustive_cases: typed.exhaustive_cases(db).iter().copied().collect(),
+        ability_definitions: merged_ability_definitions,
+        handler_operations: merged_handler_operations,
+        perform_operations: merged_perform_operations,
+        lambda_signatures: merged_lambda_signatures,
+        exhaustive_cases: merged_exhaustive_cases,
         well_known_types: typed.well_known_types(db),
     }
-    .lower_to_legacy_ir_with_options(db, &mut ir, source_uri, options.ast_to_ir);
+    .lower_to_ir(db, &mut ir, source_uri);
 
-    (ir, module)
+    FrontendCompilation {
+        context: ir,
+        module: frontend.module,
+        operation_declarations: frontend.operation_declarations,
+    }
 }
 
 /// Run frontend (parse → typecheck → TDNR) and lower to arena IR.
@@ -459,15 +656,14 @@ fn merge_and_lower_to_ir<'db>(
 pub fn compile_frontend(
     db: &dyn salsa::Database,
     source: SourceCst,
-) -> Option<(IrContext, Module)> {
-    compile_frontend_with_options(db, source, OptimizationOptions::production())
+) -> Option<FrontendCompilation> {
+    compile_frontend_with_options(db, source)
 }
 
 fn compile_frontend_with_options(
     db: &dyn salsa::Database,
     source: SourceCst,
-    options: OptimizationOptions,
-) -> Option<(IrContext, Module)> {
+) -> Option<FrontendCompilation> {
     let typed = parse_and_lower_ast(db, source)?;
     let has_frontend_errors = parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
         .iter()
@@ -475,7 +671,7 @@ fn compile_frontend_with_options(
     if has_frontend_errors {
         return None;
     }
-    Some(merge_and_lower_to_ir(db, &typed, source, options))
+    Some(merge_and_lower_to_ir(db, &typed, source))
 }
 
 /// Result of the full compilation pipeline.
@@ -540,9 +736,15 @@ fn compile_to_wasm(ctx: &mut IrContext, module: Module) -> WasmCompilationResult
     {
         let _span = tracing::info_span!("wasm_gc_to_wasm_after_casts").entered();
         tribute_passes::wasm::lower::finalize_wasm_gc_types(ctx, module)
-            .map_err(tribute_passes::wasm::lower::WasmLowerError::from)
             .map_err(wasm_lowering_failure)?;
     }
+
+    tribute_passes::backend_ready::verify_tribute_backend_ready(
+        ctx,
+        module,
+        tribute_passes::backend_ready::TributeBackend::Wasm,
+    )
+    .map_err(|error| CompilationError::ir_validation(error.to_string()))?;
 
     // Phase 3 - Emit WASM binary
     let _span = tracing::info_span!("emit_module_to_wasm").entered();
@@ -563,16 +765,24 @@ pub fn run_through_evidence_params(
     db: &dyn salsa::Database,
     source: SourceCst,
 ) -> PassResult<Option<(IrContext, Module)>> {
-    let Some((mut ctx, m)) = compile_frontend(db, source) else {
+    let Some(FrontendCompilation {
+        mut context,
+        module,
+        operation_declarations,
+    }) = compile_frontend(db, source)
+    else {
         return Ok(None);
     };
-    let core_module =
-        core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
+    let core_module = core_dialect::Module::from_op(&context, module.op())
+        .expect("frontend output must be a core.module");
     let mut pm = PassManager::new();
-    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
-        .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith);
-    pm.run(&mut ctx, core_module)?;
-    Ok(Some((ctx, m)))
+    pm.add_pass(
+        tribute_passes::tribute_control_to_cps::TributeControlToCps::new(operation_declarations),
+    )
+    .add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
+    .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith);
+    pm.run(&mut context, core_module)?;
+    Ok(Some((context, module)))
 }
 
 /// Run pipeline through closure lower (for testing).
@@ -583,19 +793,27 @@ pub fn run_through_closure_lower(
     db: &dyn salsa::Database,
     source: SourceCst,
 ) -> PassResult<Option<(IrContext, Module)>> {
-    let Some((mut ctx, m)) = compile_frontend(db, source) else {
+    let Some(FrontendCompilation {
+        mut context,
+        module,
+        operation_declarations,
+    }) = compile_frontend(db, source)
+    else {
         return Ok(None);
     };
-    let core_module =
-        core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
+    let core_module = core_dialect::Module::from_op(&context, module.op())
+        .expect("frontend output must be a core.module");
     let mut pm = PassManager::new();
-    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
-        .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
-        .add_pass(tribute_passes::closure_lower::PrepareClosureLowering);
+    pm.add_pass(
+        tribute_passes::tribute_control_to_cps::TributeControlToCps::new(operation_declarations),
+    )
+    .add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
+    .add_pass(tribute_passes::intrinsic_to_arith::LowerIntrinsicToArith)
+    .add_pass(tribute_passes::closure_lower::PrepareClosureLowering);
     pm.nest::<func_dialect::Func>()
         .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
-    pm.run(&mut ctx, core_module)?;
-    Ok(Some((ctx, m)))
+    pm.run(&mut context, core_module)?;
+    Ok(Some((context, module)))
 }
 
 // =============================================================================
@@ -619,21 +837,37 @@ fn run_shared_pipeline(
 fn run_shared_pipeline_with_options(
     db: &dyn salsa::Database,
     source: SourceCst,
-    options: OptimizationOptions,
+    _options: OptimizationOptions,
     stop_after: Option<SharedPipelineStage>,
 ) -> PassResult<Option<(IrContext, Module)>> {
-    let Some((mut ctx, m)) = compile_frontend_with_options(db, source, options) else {
+    let Some(FrontendCompilation {
+        mut context,
+        module,
+        operation_declarations,
+    }) = compile_frontend_with_options(db, source)
+    else {
         return Ok(None);
     };
 
     if stop_after == Some(SharedPipelineStage::AfterFrontend) {
-        return Ok(Some((ctx, m)));
+        return Ok(Some((context, module)));
     }
 
     // Middle-end passes, sequenced through the PassManager (#268).
     // Registration order == execution order.
-    let core_module =
-        core_dialect::Module::from_op(&ctx, m.op()).expect("frontend output must be a core.module");
+    let core_module = core_dialect::Module::from_op(&context, module.op())
+        .expect("frontend output must be a core.module");
+    let mut control_pm = PassManager::new();
+    control_pm.add_pass(
+        tribute_passes::tribute_control_to_cps::TributeControlToCps::new(operation_declarations),
+    );
+    install_debug_use_chain_verifier(&mut control_pm);
+    control_pm.run(&mut context, core_module)?;
+
+    if stop_after == Some(SharedPipelineStage::AfterControlLegalization) {
+        return Ok(Some((context, module)));
+    }
+
     let mut structural_pm = PassManager::new();
     structural_pm
         .add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda)
@@ -646,22 +880,21 @@ fn run_shared_pipeline_with_options(
         .nest::<func_dialect::Func>()
         .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
     install_debug_use_chain_verifier(&mut structural_pm);
-    structural_pm.run(&mut ctx, core_module)?;
+    structural_pm.run(&mut context, core_module)?;
 
     // CPS effect handling, function-local phase: lower_ability_perform produces
     // ability.evidence_lookup ops that resolve_evidence needs to process.
     let mut ability_pm = PassManager::new();
     ability_pm
         .nest::<func_dialect::Func>()
-        .add_pass(tribute_passes::lower_ability_perform::LowerAbilityPerform)
-        .add_pass(tribute_passes::tail_resumptive::ConvertTailResumptive);
+        .add_pass(tribute_passes::lower_ability_perform::LowerAbilityPerform);
     install_debug_use_chain_verifier(&mut ability_pm);
-    ability_pm.run(&mut ctx, core_module)?;
+    ability_pm.run(&mut context, core_module)?;
 
     let mut evidence_pm = PassManager::new();
     evidence_pm.add_pass(tribute_passes::resolve_evidence::ResolveEvidenceDispatch);
     install_debug_use_chain_verifier(&mut evidence_pm);
-    evidence_pm.run(&mut ctx, core_module)?;
+    evidence_pm.run(&mut context, core_module)?;
 
     // Final function-local ability conversion. This consumes handle_dispatch ops
     // after resolve_evidence expands evidence setup.
@@ -670,9 +903,9 @@ fn run_shared_pipeline_with_options(
         .nest::<func_dialect::Func>()
         .add_pass(tribute_passes::lower_handle_dispatch::LowerHandleDispatch);
     install_debug_use_chain_verifier(&mut ability_boundary_pm);
-    ability_boundary_pm.run(&mut ctx, core_module)?;
+    ability_boundary_pm.run(&mut context, core_module)?;
 
-    Ok(Some((ctx, m)))
+    Ok(Some((context, module)))
 }
 
 /// Dump shared IR at a named optimization boundary.
@@ -827,6 +1060,9 @@ fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), DumpIr
         trunk_ir::transforms::inline::inline_functions(ctx, m, analyses);
     });
 
+    tribute_passes::target_abi::lower_cps_signatures_to_physical(ctx, m)?;
+    tribute_passes::target_abi::compose_root_entry_bridge(ctx, m)?;
+
     run_cleanup_passes(ctx, m);
     Ok(())
 }
@@ -842,6 +1078,10 @@ fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Dump
     trunk_ir::analysis::AnalysisCache::scope(ctx, |ctx, analyses| {
         trunk_ir::transforms::inline::inline_functions(ctx, m, analyses);
     });
+
+    tribute_passes::target_abi::lower_cps_signatures_to_physical(ctx, m)?;
+    tribute_passes::target_abi::compose_root_entry_bridge(ctx, m)?;
+    tribute_passes::target_abi::lower_native_nil_abi(ctx, m)?;
 
     if let Ok(core_module) = core_dialect::Module::from_op(ctx, m.op()) {
         tribute_passes::native::evidence::prepare_native_evidence_runtime(ctx, m);
@@ -1000,6 +1240,9 @@ fn prepare_module_to_native(
     // Phase 1 - Lower func dialect to clif dialect
     let ownership_summaries;
     {
+        tribute_passes::native::calling_convention::project_to_clif(ctx, module).map_err(
+            |error| trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string()),
+        )?;
         let (type_converter, _) =
             tribute_passes::native::type_converter::native_type_converter(ctx);
         ownership_summaries = tribute_passes::native::ownership_summary::compute_and_attach(
@@ -1151,6 +1394,15 @@ fn prepare_module_to_native(
 
     // Phase 3.5 - Lower RC operations (retain/release) to inline clif code
     tribute_passes::native::rc_lowering::lower_rc(ctx, module);
+
+    tribute_passes::backend_ready::verify_tribute_backend_ready(
+        ctx,
+        module,
+        tribute_passes::backend_ready::TributeBackend::Native,
+    )
+    .map_err(|error| {
+        trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string())
+    })?;
 
     // Phase 4 - Validate and emit
     let _emit_span = tracing::info_span!("emit_module_to_native").entered();
@@ -1314,8 +1566,14 @@ pub fn parse_and_lower_ast<'db>(
         db,
         tdnr_ast,
         result.function_types,
-        result.constructor_types,
-        result.node_types,
+        ast_typeck::NominalTypeMetadata {
+            constructor_types: result.constructor_types,
+            type_definitions: result.type_definitions,
+        },
+        ast_typeck::ExpressionTypeMetadata {
+            node_types: result.node_types,
+            call_callee_types: result.call_callee_types,
+        },
         result.ability_conventions,
         ast_typeck::ability_schemas(&result.ability_definitions),
         result.handler_operations,
@@ -1714,15 +1972,30 @@ mod tests {
     }
 
     #[salsa_test]
-    fn pre_825_legacy_route_has_no_logical_control_leak(db: &salsa::DatabaseImpl) {
-        // Temporary pre-#825 compatibility routing: this must continue to
-        // specialize a representative generic source program into physical IR
-        // until the shared logical-control pipeline owns composition. Remove
-        // this fixture with the legacy route.
+    fn production_frontend_route_is_source_logical(db: &salsa::DatabaseImpl) {
         let source = source_from_str(
             "legacy-route.trb",
             r#"
 struct Packet(a) { value: a }
+
+enum Choice(a) {
+    Pick(a)
+    Skip
+}
+
+pub mod Nested {
+    pub enum Maybe(a) {
+        Just(a)
+        Missing
+    }
+
+    pub fn choose(value: Maybe(a), fallback: a) -> a {
+        case value {
+            Just(item) -> item
+            Missing -> fallback
+        }
+    }
+}
 
 fn select(packet: Packet(a), values: List(a)) -> a {
     let singleton = [packet.value]
@@ -1739,33 +2012,55 @@ fn select(packet: Packet(a), values: List(a)) -> a {
 fn main() {
     let packet = Packet { value: +1 }
     let _ = select(packet, [+2])
+    let _ = case Pick(+3) {
+        Pick(value) -> value
+        Skip -> +0
+    }
+    let _ = Nested::choose(Nested::Just(+4), +0)
 }
 "#,
         );
         let result = compile_frontend(db, source);
         assert!(
             result.is_some(),
-            "legacy frontend route should lower before shared passes: {:#?}",
+            "source-logical frontend route should lower before shared passes: {:#?}",
             parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
         );
-        let (ctx, module) = result.unwrap();
-        let output = trunk_ir::printer::print_module(&ctx, module.op());
+        let FrontendCompilation {
+            context,
+            module,
+            operation_declarations: _,
+        } = result.unwrap();
+        let output = trunk_ir::printer::print_module(&context, module.op());
         for forbidden in [
-            "tribute_control.",
-            "tribute_control.callable",
-            "resume_token",
+            "func.func",
+            "func.call",
+            "func.return",
+            "closure.",
+            "ability.legacy_",
         ] {
             assert!(
                 !output.contains(forbidden),
-                "legacy route leaked logical control representation `{forbidden}`:\n{output}"
+                "production frontend leaked physical/legacy representation `{forbidden}`:\n{output}"
             );
         }
-        assert!(output.contains("func.func"), "{output}");
+        assert!(output.contains("tribute_control.func"), "{output}");
         assert!(
             output.contains("Packet$Int")
-                && output.contains("func.func @select(")
-                && output.contains("closure.lambda"),
-            "root pipeline must retain the specialized physical generic layout, callable, and lambda:\n{output}"
+                && output.contains("Choice$Int")
+                && output.contains("Nested::Maybe$Int")
+                && output.contains("tribute_control.func @\"Nested::choose$Int\"(")
+                && output.contains("tribute_control.lambda"),
+            "root pipeline must retain specialized logical generic layouts, constructors, \
+             callables, and lambda:\n{output}"
+        );
+        assert!(
+            output.contains("tag = @Pick")
+                && output.contains("tag = @Just")
+                && !output.contains("tag = @Choice$Int$Pick")
+                && !output.contains("tag = @Nested::Maybe$Int$Just"),
+            "specialized enum constructor identity must not change the runtime variant tag:\n\
+             {output}"
         );
     }
 
@@ -2047,7 +2342,11 @@ fn main() ->{std::io::Io} Nil {
 
         let result = compile_frontend(db, source);
         assert!(result.is_some());
-        let (ctx, m) = result.unwrap();
+        let FrontendCompilation {
+            context: ctx,
+            module: m,
+            ..
+        } = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
     }
 
@@ -2057,8 +2356,49 @@ fn main() ->{std::io::Io} Nil {
 
         let result = compile_frontend(db, source);
         assert!(result.is_some());
-        let (ctx, m) = result.unwrap();
+        let FrontendCompilation {
+            context: ctx,
+            module: m,
+            ..
+        } = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
+    }
+
+    #[salsa_test]
+    fn user_list_member_shadows_prelude_declaration_in_logical_ir(db: &salsa::DatabaseImpl) {
+        let source = source_from_str(
+            "list_shadow.trb",
+            r#"
+pub mod List {
+    pub fn prepend(value: Nat, tail: Nat) -> Nat { value + tail }
+}
+
+fn main() {
+    let _value = List::prepend(20, 22)
+    Nil
+}
+"#,
+        );
+        let FrontendCompilation {
+            context, module, ..
+        } = compile_frontend(db, source).unwrap_or_else(|| {
+            panic!(
+                "source-logical frontend output: {:?}",
+                parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
+            )
+        });
+        let output = trunk_ir::printer::print_module(&context, module.op());
+        assert_eq!(
+            output
+                .matches(r#"tribute_control.func @"List::prepend""#)
+                .count(),
+            1,
+            "user and prelude declarations must not share one emitted identity: {output}"
+        );
+        assert!(
+            output.contains("List::__tribute_list_prepend_intrinsic"),
+            "the non-shadowed builtin intrinsic identity must remain available: {output}"
+        );
     }
 
     #[salsa_test]
@@ -2079,8 +2419,11 @@ fn main() -> String { "hello" }
             .well_known_types(db)
             .string
             .expect("prelude String identity");
-        let (ctx, module) =
-            merge_and_lower_to_ir(db, &typed, source, OptimizationOptions::production());
+        let FrontendCompilation {
+            context: ctx,
+            module,
+            ..
+        } = merge_and_lower_to_ir(db, &typed, source);
         let string_ty = tribute_ir::metadata::WellKnownTypes::from_module(&ctx, module.op())
             .string
             .expect("String IR metadata");
@@ -2135,7 +2478,11 @@ fn main() -> String { "hello" }
             "{:?}",
             parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
         );
-        let (ctx, m) = result.unwrap();
+        let FrontendCompilation {
+            context: ctx,
+            module: m,
+            ..
+        } = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
     }
 
@@ -2155,7 +2502,11 @@ fn main() -> String { "hello" }
 
         let result = compile_frontend(db, source);
         assert!(result.is_some());
-        let (ctx, m) = result.unwrap();
+        let FrontendCompilation {
+            context: ctx,
+            module: m,
+            ..
+        } = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
     }
 

--- a/tests/active_pipeline_goldens.rs
+++ b/tests/active_pipeline_goldens.rs
@@ -3,7 +3,7 @@
 //! These snapshots intentionally target textual IR at named pipeline stages:
 //! shared middle-end IR and native-target IR.
 
-use std::fmt::Write;
+use std::ops::ControlFlow;
 
 use insta::assert_snapshot;
 use itertools::Itertools;
@@ -11,7 +11,10 @@ use salsa_test_macros::salsa_test;
 use tribute::Diagnostic;
 use tribute::pipeline::{compile_with_diagnostics, dump_ir};
 use tribute_front::SourceCst;
-use trunk_ir::printer::print_module;
+use trunk_ir::parser::parse_test_module;
+use trunk_ir::printer::{print_module, print_op};
+use trunk_ir::walk::{WalkAction, walk_op};
+use trunk_ir::{IrContext, Module, Symbol};
 
 fn assert_no_diagnostics(stage: &str, diagnostics: &[Diagnostic]) {
     assert!(
@@ -26,87 +29,73 @@ fn assert_no_diagnostics(stage: &str, diagnostics: &[Diagnostic]) {
     );
 }
 
-fn is_active_pipeline_function(header: &str) -> bool {
+fn is_active_pipeline_function(ctx: &IrContext, op: trunk_ir::OpRef) -> bool {
+    let data = ctx.op(op);
+    if data.dialect != Symbol::new("func") || data.name != Symbol::new("func") {
+        return false;
+    }
+    let Some(symbol) = data.attributes.get_symbol("sym_name") else {
+        return false;
+    };
+    let name = symbol.to_string();
     let selected_names = [
-        "@__tribute_evidence_",
-        "@__tribute_next_tag",
-        "@main",
-        "@use_console",
-        "@run",
-        "@run_state",
-        "@run_state_with_console",
-        "@run_all",
-        "@bump",
-        "@step",
-        "\"run::",
-        "\"run_state::",
-        "\"run_state_with_console::",
-        "\"run_all::",
-        "\"bump::",
-        "\"step::",
-        "\"direct_fn::__lambda",
-        "\"direct_fn_native::__lambda",
-        "\"resumptive_op::__lambda",
-        "\"resumptive_op_native::__lambda",
-        "\"mixed_nested::__lambda",
-        "\"mixed_nested_native::__lambda",
+        "__tribute_evidence_",
+        "__tribute_next_tag",
+        "main",
+        "use_console",
+        "run",
+        "run_state",
+        "run_state_with_console",
+        "run_all",
+        "bump",
+        "step",
+        "run::",
+        "run_state::",
+        "run_state_with_console::",
+        "run_all::",
+        "bump::",
+        "step::",
+        "direct_fn::__lambda",
+        "direct_fn_native::__lambda",
+        "resumptive_op::__lambda",
+        "resumptive_op_native::__lambda",
+        "mixed_nested::__lambda",
+        "mixed_nested_native::__lambda",
     ];
 
-    selected_names.iter().any(|name| header.contains(name))
+    selected_names.iter().any(|prefix| name.starts_with(prefix))
 }
 
-fn brace_delta(line: &str) -> isize {
-    line.chars().fold(0, |delta, ch| match ch {
-        '{' => delta + 1,
-        '}' => delta - 1,
-        _ => delta,
-    })
-}
-
-fn append_line(output: &mut String, line: &str) {
-    if !output.is_empty() {
-        output.push('\n');
-    }
-    write!(output, "{line}").expect("fmt::Write to String never fails");
+fn parse_ir(ir_text: &str) -> (IrContext, Module) {
+    let mut ctx = IrContext::new();
+    let module = parse_test_module(&mut ctx, ir_text);
+    (ctx, module)
 }
 
 fn filter_ir_for_active_pipeline(ir_text: &str) -> String {
-    let mut output = String::new();
-    let mut lines = ir_text.lines().peekable();
-
-    while let Some(line) = lines.next() {
-        if line.starts_with("core.module ") || line.trim_start().starts_with('!') {
-            append_line(&mut output, line);
-            continue;
-        }
-
-        if !line.trim_start().starts_with("func.func ") {
-            continue;
-        }
-
-        let include_function = is_active_pipeline_function(line);
-        let mut depth = brace_delta(line);
-
-        if include_function {
-            if !output.is_empty() {
-                output.push('\n');
-            }
-            append_line(&mut output, line);
-        }
-
-        while depth > 0 {
-            let body_line = lines
-                .next()
-                .expect("function body should close before the module ends");
-            depth += brace_delta(body_line);
-            if include_function {
-                append_line(&mut output, body_line);
-            }
-        }
-    }
-
-    append_line(&mut output, "}");
-    output
+    let (ctx, module) = parse_ir(ir_text);
+    let selected: Vec<_> = module
+        .ops(&ctx)
+        .into_iter()
+        .filter(|&op| is_active_pipeline_function(&ctx, op))
+        .collect();
+    let full = print_module(&ctx, module.op());
+    let preamble = full
+        .lines()
+        .take_while(|line| !line.starts_with("  func.func "))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let functions = selected
+        .into_iter()
+        .map(|op| {
+            print_op(&ctx, op)
+                .lines()
+                .map(|line| format!("  {line}"))
+                .join("\n")
+        })
+        .join("\n");
+    let separator = if preamble.ends_with('\n') { "" } else { "\n" };
+    format!("{preamble}{separator}{functions}\n}}")
 }
 
 fn snapshot_shared_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str) -> String {
@@ -120,7 +109,7 @@ fn snapshot_shared_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str)
     filter_ir_for_active_pipeline(&print_module(&ctx, module.op()))
 }
 
-fn snapshot_native_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str) -> String {
+fn native_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str) -> String {
     let source = SourceCst::from_source_str(db, name, code);
     let ir_text = dump_ir(db, source, true).expect("native pipeline dump should succeed");
     let diagnostics: Vec<Diagnostic> = dump_ir::accumulated::<Diagnostic>(db, source, true)
@@ -128,9 +117,179 @@ fn snapshot_native_pipeline_ir(db: &dyn salsa::Database, name: &str, code: &str)
         .cloned()
         .collect();
     assert_no_diagnostics("native pipeline", &diagnostics);
-    filter_ir_for_active_pipeline(&ir_text)
+    ir_text
 }
 
+fn assert_no_production_control_artifacts(ir_text: &str) {
+    for forbidden in [
+        "__tribute_cps_control",
+        "@Normal",
+        "@Escape",
+        "tribute_control.",
+        "ability.legacy_",
+    ] {
+        assert!(
+            !ir_text.contains(forbidden),
+            "production native fixture contains forbidden `{forbidden}` artifact:\n{ir_text}"
+        );
+    }
+
+    let (ctx, module) = parse_ir(ir_text);
+    assert_no_dead_int_unbox_in_module(&ctx, module);
+
+    for op in module.ops(&ctx) {
+        let data = ctx.op(op);
+        if data.dialect != Symbol::new("func")
+            || data.name != Symbol::new("func")
+            || data.attributes.get_i128("tribute.calling_convention") != Some(2)
+        {
+            continue;
+        }
+        assert!(
+            function_returns_core_nil(&ctx, op),
+            "CPS function must have a physically empty result:\n{}",
+            print_module(&ctx, module.op())
+        );
+    }
+}
+
+/// Source operation inputs may cross the erased payload boundary and therefore
+/// legitimately unbox.  The retired carrier path instead left an unconsumed
+/// `unbox_int` after its placeholder re-erasure was resolved.
+fn assert_no_dead_int_unbox_in_module(ctx: &IrContext, module: Module) {
+    let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+        let data = ctx.op(op);
+        if data.dialect == Symbol::new("tribute_rt") && data.name == Symbol::new("unbox_int") {
+            let results = ctx.op_results(op);
+            assert_eq!(results.len(), 1, "unbox_int must have one SSA result");
+            assert!(
+                ctx.has_uses(results[0]),
+                "production native fixture contains a dead placeholder `unbox_int`:\n{}",
+                print_module(ctx, module.op())
+            );
+        }
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+}
+
+fn is_core_nil(ctx: &IrContext, ty: trunk_ir::TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::new("core") && data.name == Symbol::new("nil")
+}
+
+fn function_returns_core_nil(ctx: &IrContext, op: trunk_ir::OpRef) -> bool {
+    let Some(function_type) = ctx.op(op).attributes.get_type("type") else {
+        return false;
+    };
+    let data = ctx.types.get(function_type);
+    data.dialect == Symbol::new("core")
+        && data.name == Symbol::new("func")
+        && data
+            .params
+            .first()
+            .is_some_and(|&result| is_core_nil(ctx, result))
+}
+
+fn exact_marker(ctx: &IrContext, op: trunk_ir::OpRef, marker: &str) -> bool {
+    ctx.op(op).attributes.get_bool(marker) == Some(true)
+}
+
+fn unique_marked_function(ctx: &IrContext, module: Module, marker: &str) -> trunk_ir::OpRef {
+    let matches: Vec<_> = module
+        .ops(ctx)
+        .into_iter()
+        .filter(|&op| {
+            let data = ctx.op(op);
+            data.dialect == Symbol::new("func")
+                && data.name == Symbol::new("func")
+                && exact_marker(ctx, op, marker)
+        })
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one `{marker}` in full native IR:\n{}",
+        print_module(ctx, module.op())
+    );
+    matches[0]
+}
+
+fn function_symbol(ctx: &IrContext, op: trunk_ir::OpRef) -> Symbol {
+    ctx.op(op)
+        .attributes
+        .get_symbol("sym_name")
+        .expect("function must have a symbol")
+}
+
+fn assert_root_cps_topology(ir_text: &str) {
+    let (ctx, module) = parse_ir(ir_text);
+    let worker = unique_marked_function(&ctx, module, "tribute.root_cps_worker");
+    let wrapper = unique_marked_function(&ctx, module, "tribute.root_wrapper");
+    let done = unique_marked_function(&ctx, module, "tribute.root_done_k");
+    let worker_symbol = function_symbol(&ctx, worker);
+    let wrapper_symbol = function_symbol(&ctx, wrapper);
+    let done_symbol = function_symbol(&ctx, done);
+
+    assert_eq!(
+        ctx.op(worker)
+            .attributes
+            .get_i128("tribute.calling_convention"),
+        Some(2)
+    );
+    assert!(function_returns_core_nil(&ctx, worker));
+    assert!(matches!(
+        ctx.op(wrapper)
+            .attributes
+            .get_i128("tribute.calling_convention"),
+        Some(0 | 1)
+    ));
+    assert_eq!(
+        ctx.op(done)
+            .attributes
+            .get_i128("tribute.calling_convention"),
+        Some(2)
+    );
+    assert!(function_returns_core_nil(&ctx, done));
+    assert_ne!(worker_symbol, wrapper_symbol);
+    assert_ne!(worker_symbol, done_symbol);
+    assert_ne!(wrapper_symbol, done_symbol);
+
+    let mut root_calls = Vec::new();
+    let mut done_constants = Vec::new();
+    let _ = walk_op::<()>(&ctx, wrapper, &mut |op| {
+        let data = ctx.op(op);
+        if exact_marker(&ctx, op, "tribute.root_cps_call") {
+            root_calls.push(op);
+        }
+        if data.dialect == Symbol::new("func")
+            && data.name == Symbol::new("constant")
+            && data.attributes.get_symbol("func_ref") == Some(done_symbol)
+        {
+            done_constants.push(op);
+        }
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    assert_eq!(
+        root_calls.len(),
+        1,
+        "root wrapper must have one marked CPS call"
+    );
+    assert_eq!(
+        done_constants.len(),
+        1,
+        "root wrapper must capture its marked done continuation"
+    );
+
+    let root_call = root_calls[0];
+    let data = ctx.op(root_call);
+    assert_eq!(data.dialect, Symbol::new("func"));
+    assert_eq!(data.name, Symbol::new("call"));
+    assert_eq!(data.attributes.get_symbol("callee"), Some(worker_symbol));
+    assert_eq!(
+        data.attributes.get_i128("tribute.calling_convention"),
+        Some(2)
+    );
+}
 const DIRECT_FN_SOURCE: &str = r#"
 ability Console {
     fn read() -> Int
@@ -229,6 +388,42 @@ fn main() {
 }
 "#;
 
+#[test]
+#[should_panic(expected = "dead placeholder `unbox_int`")]
+fn dead_int_unbox_cannot_borrow_a_use_from_a_later_function() {
+    let (ctx, module) = parse_ir(
+        r#"
+core.module @test {
+  func.func @first(%0: tribute_rt.anyref) -> core.nil {
+    %6 = tribute_rt.unbox_int %0 : core.i32
+    func.return
+  }
+  func.func @second(%0: core.i32) -> core.nil {
+    %6 = arith.addi %0, %0 : core.i32
+    %7 = arith.addi %6, %0 : core.i32
+    func.return
+  }
+}
+"#,
+    );
+    assert_no_dead_int_unbox_in_module(&ctx, module);
+}
+
+#[test]
+fn state_get_unbox_used_by_its_immediate_tail_transfer_is_allowed() {
+    let (ctx, module) = parse_ir(
+        r#"
+core.module @test {
+  func.func @state_get_resume(%0: tribute_rt.anyref, %1: core.ptr, %2: core.ptr) -> core.nil {
+    %6 = tribute_rt.unbox_int %0 : core.i32
+    func.tail_call_indirect %1, %2, %6 { type = core.func(core.nil, core.ptr, core.i32) }
+  }
+}
+"#,
+    );
+    assert_no_dead_int_unbox_in_module(&ctx, module);
+}
+
 #[salsa_test]
 fn shared_pipeline_direct_fn_ability_call(db: &salsa::DatabaseImpl) {
     let ir_text = snapshot_shared_pipeline_ir(db, "direct_fn.trb", DIRECT_FN_SOURCE);
@@ -255,18 +450,24 @@ fn shared_pipeline_float_comparison_predicates(db: &salsa::DatabaseImpl) {
 
 #[salsa_test]
 fn native_pipeline_direct_fn_ability_call(db: &salsa::DatabaseImpl) {
-    let ir_text = snapshot_native_pipeline_ir(db, "direct_fn_native.trb", DIRECT_FN_SOURCE);
-    assert_snapshot!(ir_text);
+    let full_ir = native_pipeline_ir(db, "direct_fn_native.trb", DIRECT_FN_SOURCE);
+    assert_no_production_control_artifacts(&full_ir);
+    assert_root_cps_topology(&full_ir);
+    assert_snapshot!(filter_ir_for_active_pipeline(&full_ir));
 }
 
 #[salsa_test]
 fn native_pipeline_resumptive_op_continuation(db: &salsa::DatabaseImpl) {
-    let ir_text = snapshot_native_pipeline_ir(db, "resumptive_op_native.trb", RESUMPTIVE_OP_SOURCE);
-    assert_snapshot!(ir_text);
+    let full_ir = native_pipeline_ir(db, "resumptive_op_native.trb", RESUMPTIVE_OP_SOURCE);
+    assert_no_production_control_artifacts(&full_ir);
+    assert_root_cps_topology(&full_ir);
+    assert_snapshot!(filter_ir_for_active_pipeline(&full_ir));
 }
 
 #[salsa_test]
 fn native_pipeline_mixed_nested_handler_boundary(db: &salsa::DatabaseImpl) {
-    let ir_text = snapshot_native_pipeline_ir(db, "mixed_nested_native.trb", MIXED_NESTED_SOURCE);
-    assert_snapshot!(ir_text);
+    let full_ir = native_pipeline_ir(db, "mixed_nested_native.trb", MIXED_NESTED_SOURCE);
+    assert_no_production_control_artifacts(&full_ir);
+    assert_root_cps_topology(&full_ir);
+    assert_snapshot!(filter_ir_for_active_pipeline(&full_ir));
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -209,6 +209,57 @@ pub fn compile_and_run_native_with_stdin_asan(
     )
 }
 
+/// Compile one native test profile once, then run it for each supplied stdin
+/// case. This keeps multi-input semantic tests below the per-test timeout
+/// without changing their compiler, optimization, or sanitizer coverage.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_stdin_cases(
+    source_name: &str,
+    source_code: &str,
+    inputs: &[&[u8]],
+) -> Vec<Output> {
+    compile_and_run_native_with_stdin_cases_impl(
+        source_name,
+        source_code,
+        false,
+        NativeTestOptimizations::production(),
+        inputs,
+    )
+}
+
+/// Like [`compile_and_run_native_with_stdin_cases`], using baseline
+/// optimization choices.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_stdin_cases_baseline_optimizations(
+    source_name: &str,
+    source_code: &str,
+    inputs: &[&[u8]],
+) -> Vec<Output> {
+    compile_and_run_native_with_stdin_cases_impl(
+        source_name,
+        source_code,
+        false,
+        NativeTestOptimizations::baseline(),
+        inputs,
+    )
+}
+
+/// Like [`compile_and_run_native_with_stdin_cases`], with ASan enabled.
+#[allow(dead_code)]
+pub fn compile_and_run_native_with_stdin_cases_asan(
+    source_name: &str,
+    source_code: &str,
+    inputs: &[&[u8]],
+) -> Vec<Output> {
+    compile_and_run_native_with_stdin_cases_impl(
+        source_name,
+        source_code,
+        true,
+        NativeTestOptimizations::production(),
+        inputs,
+    )
+}
+
 /// Compile and run Tribute source after closing native stdin.
 #[cfg(unix)]
 #[allow(dead_code)]
@@ -310,6 +361,43 @@ fn compile_and_run_native_impl(
     test_optimizations: NativeTestOptimizations,
     stdin: NativeStdin<'_>,
 ) -> Output {
+    with_compiled_native(
+        source_name,
+        source_code,
+        sanitize_address,
+        test_optimizations,
+        |exec_path| run_native_binary(exec_path, stdin),
+    )
+}
+
+fn compile_and_run_native_with_stdin_cases_impl(
+    source_name: &str,
+    source_code: &str,
+    sanitize_address: bool,
+    test_optimizations: NativeTestOptimizations,
+    inputs: &[&[u8]],
+) -> Vec<Output> {
+    with_compiled_native(
+        source_name,
+        source_code,
+        sanitize_address,
+        test_optimizations,
+        |exec_path| {
+            inputs
+                .iter()
+                .map(|input| run_native_binary(exec_path, NativeStdin::Bytes(input)))
+                .collect()
+        },
+    )
+}
+
+fn with_compiled_native<T>(
+    source_name: &str,
+    source_code: &str,
+    sanitize_address: bool,
+    test_optimizations: NativeTestOptimizations,
+    run: impl FnOnce(&std::path::Path) -> T,
+) -> T {
     use tribute::database::parse_with_thread_local;
 
     let source_rope = Rope::from_str(source_code);
@@ -347,46 +435,49 @@ fn compile_and_run_native_impl(
             std::fs::set_permissions(&exec_path, perms).expect("Failed to set permissions");
         }
 
-        // Run the executable
-        let mut command = Command::new(&exec_path);
-        match stdin {
-            NativeStdin::Bytes(input) => {
-                let mut child = command
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped())
-                    .spawn()
-                    .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"));
-                let mut child_stdin = child.stdin.take().expect("piped stdin");
-                let input = input.to_vec();
-                let writer = std::thread::spawn(move || child_stdin.write_all(&input));
-                let output = child.wait_with_output().expect("wait for native binary");
-                writer
-                    .join()
-                    .expect("native stdin writer panicked")
-                    .expect("write native stdin");
-                output
-            }
-            #[cfg(unix)]
-            NativeStdin::Closed => {
-                use std::os::unix::process::CommandExt;
-
-                unsafe {
-                    command.pre_exec(|| {
-                        if close(0) == 0 {
-                            Ok(())
-                        } else {
-                            Err(std::io::Error::last_os_error())
-                        }
-                    });
-                }
-                command
-                    .output()
-                    .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"))
-            }
-            NativeStdin::Null => command
-                .output()
-                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}")),
-        }
+        run(&exec_path)
     })
+}
+
+fn run_native_binary(exec_path: &std::path::Path, stdin: NativeStdin<'_>) -> Output {
+    let mut command = Command::new(exec_path);
+    match stdin {
+        NativeStdin::Bytes(input) => {
+            let mut child = command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"));
+            let mut child_stdin = child.stdin.take().expect("piped stdin");
+            let input = input.to_vec();
+            let writer = std::thread::spawn(move || child_stdin.write_all(&input));
+            let output = child.wait_with_output().expect("wait for native binary");
+            writer
+                .join()
+                .expect("native stdin writer panicked")
+                .expect("write native stdin");
+            output
+        }
+        #[cfg(unix)]
+        NativeStdin::Closed => {
+            use std::os::unix::process::CommandExt;
+
+            unsafe {
+                command.pre_exec(|| {
+                    if close(0) == 0 {
+                        Ok(())
+                    } else {
+                        Err(std::io::Error::last_os_error())
+                    }
+                });
+            }
+            command
+                .output()
+                .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}"))
+        }
+        NativeStdin::Null => command
+            .output()
+            .unwrap_or_else(|e| panic!("Failed to execute native binary: {e}")),
+    }
 }

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -86,60 +86,73 @@ fn main() {
 "#
 }
 
-#[test]
-fn test_cps_control_carrier_preserves_read_outcome_and_nested_zero_resume() {
-    for (name, stdin, expected) in [
+fn read_outcome_cases() -> [(&'static str, &'static [u8], &'static str); 2] {
+    [
         (
             "input",
-            b"typed\n".as_slice(),
+            b"typed\n",
             "line:typed\nline:resumed-suffix-inner-do-outer-do\nline:outer-do-eof\n",
         ),
         (
             "eof",
-            b"".as_slice(),
+            b"",
             "eof\nline:resumed-suffix-inner-do-outer-do\nline:outer-do-eof\n",
         ),
-    ] {
-        let profiles = [
-            (
-                "production",
-                common::compile_and_run_native_with_stdin(
-                    &format!("cps_control_read_outcome_{name}_production.trb"),
-                    cps_control_read_outcome_program(),
-                    stdin,
-                ),
-            ),
-            (
-                "baseline",
-                common::compile_and_run_native_with_stdin_baseline_optimizations(
-                    &format!("cps_control_read_outcome_{name}_baseline.trb"),
-                    cps_control_read_outcome_program(),
-                    stdin,
-                ),
-            ),
-            (
-                "asan",
-                common::compile_and_run_native_with_stdin_asan(
-                    &format!("cps_control_read_outcome_{name}_asan.trb"),
-                    cps_control_read_outcome_program(),
-                    stdin,
-                ),
-            ),
-        ];
-        for (profile, output) in profiles {
-            assert!(
-                output.status.success(),
-                "{name}/{profile}: exit={:?}, stderr='{}'",
-                output.status,
-                String::from_utf8_lossy(&output.stderr),
-            );
-            assert_eq!(
-                String::from_utf8_lossy(&output.stdout),
-                expected,
-                "{name}/{profile}"
-            );
-        }
+    ]
+}
+
+fn assert_read_outcome_cases(profile: &str, outputs: Vec<std::process::Output>) {
+    let cases = read_outcome_cases();
+    assert_eq!(outputs.len(), cases.len());
+    for ((name, _, expected), output) in cases.iter().zip(outputs) {
+        assert!(
+            output.status.success(),
+            "{name}/{profile}: exit={:?}, stderr='{}'",
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            *expected,
+            "{name}/{profile}"
+        );
     }
+}
+
+#[test]
+fn test_cps_control_carrier_preserves_read_outcome_and_nested_zero_resume_production() {
+    let cases = read_outcome_cases();
+    let inputs: Vec<_> = cases.iter().map(|(_, stdin, _)| *stdin).collect();
+    let outputs = common::compile_and_run_native_with_stdin_cases(
+        "cps_control_read_outcome_production.trb",
+        cps_control_read_outcome_program(),
+        &inputs,
+    );
+    assert_read_outcome_cases("production", outputs);
+}
+
+#[test]
+fn test_cps_control_carrier_preserves_read_outcome_and_nested_zero_resume_baseline() {
+    let cases = read_outcome_cases();
+    let inputs: Vec<_> = cases.iter().map(|(_, stdin, _)| *stdin).collect();
+    let outputs = common::compile_and_run_native_with_stdin_cases_baseline_optimizations(
+        "cps_control_read_outcome_baseline.trb",
+        cps_control_read_outcome_program(),
+        &inputs,
+    );
+    assert_read_outcome_cases("baseline", outputs);
+}
+
+#[test]
+fn test_cps_control_carrier_preserves_read_outcome_and_nested_zero_resume_asan() {
+    let cases = read_outcome_cases();
+    let inputs: Vec<_> = cases.iter().map(|(_, stdin, _)| *stdin).collect();
+    let outputs = common::compile_and_run_native_with_stdin_cases_asan(
+        "cps_control_read_outcome_asan.trb",
+        cps_control_read_outcome_program(),
+        &inputs,
+    );
+    assert_read_outcome_cases("asan", outputs);
 }
 
 fn cps_control_outer_nonresumptive_crosses_inner_handle_program() -> &'static str {
@@ -743,6 +756,34 @@ fn main() {
     assert_native_output("fn_handler_arm.trb", code, "42");
 }
 
+/// Tail-resumptive `fn` arms return their own operation result, not the
+/// enclosing handle answer. A `Nil` operation therefore cannot overwrite the
+/// preceding `Nat` call's source value.
+#[test]
+fn test_fn_handler_arm_preserves_each_operation_result_type() {
+    let code = r#"ability Console {
+    fn read() -> Nat
+    fn print(value: Nat) -> Nil
+}
+
+fn use_console() ->{Console} Nat {
+    let value = Console::read()
+    Console::print(value)
+    value
+}
+
+fn main() {
+    let result = handle use_console() {
+        do value { value }
+        fn Console::read() { 42 }
+        fn Console::print(value) { Nil }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("fn_handler_arm_result_types.trb", code, "42");
+}
+
 // =============================================================================
 // Handler Result Transformation Tests
 // =============================================================================
@@ -846,6 +887,194 @@ fn main() {
 }
 "#;
     assert_native_output("handler_transforms_resumed_result.trb", code, "42");
+}
+
+/// A resumed body reaches the completion exactly once before its answer is
+/// returned to the outer continuation.
+#[test]
+fn test_handler_one_resume_runs_nonidentity_completion_once() {
+    let code = r#"ability Ask {
+    op ask() -> Nat
+}
+
+fn body() ->{Ask} Nat {
+    Ask::ask() + 1
+}
+
+fn main() {
+    let result = handle body() {
+        do value { value + value }
+        op Ask::ask() { resume 10 }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("handler_one_resume_completion_once.trb", code, "22");
+}
+
+/// The handle body and answer types are independent. The effectful callee is
+/// separately declared, so the CPS call boundary must retain the answer-indexed
+/// Done/Dispatch ABI instead of equating it with the body's String result.
+#[test]
+fn test_handler_resumed_callee_can_change_answer_type() {
+    let code = r#"ability Ask {
+    op ask() -> String
+}
+
+fn separately_compiled() ->{Ask} String {
+    Ask::ask()
+}
+
+fn main() {
+    let answer = handle separately_compiled() {
+        do _body { 7 }
+        op Ask::ask() { resume "payload" }
+    }
+    __tribute_print_nat(answer)
+}
+"#;
+    assert_native_output("handler_resumed_answer_type_change.trb", code, "7");
+}
+
+/// Each re-entrant resume owns an immutable arm-local suffix.  The second
+/// perform completes and runs its suffix before the first resumed suffix is
+/// re-entered; no mutable delimiter slot may overwrite the outer suffix.
+#[test]
+fn test_handler_reentrant_resumes_preserve_suffix_stack() {
+    let code = r#"ability Ask {
+    op ask() -> Nat
+}
+
+fn twice() ->{Ask} Nat {
+    let first = Ask::ask()
+    first + Ask::ask()
+}
+
+fn main() {
+    let result = handle twice() {
+        do value { value + 1 }
+        op Ask::ask() {
+            let resumed = resume 10
+            resumed + 100
+        }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    // The inner resume completes to 21, then its arm-local suffix yields
+    // 121.  That is the resumed result observed by the suspended outer arm,
+    // whose own suffix must still run and yield 221.
+    assert_native_output("handler_reentrant_resume_suffix_stack.trb", code, "221");
+}
+
+/// A foreign operation reached by a resumed inner body must use the Parent
+/// captured by that resume.  Its outer handler returns to the suspended inner
+/// arm suffix rather than the initial handle entry flow.
+#[test]
+fn test_handler_resumed_foreign_dispatch_preserves_arm_suffix() {
+    let code = r#"ability Inner {
+    op ask() -> Nat
+}
+
+ability Outer {
+    op ask() -> Nat
+}
+
+fn body() ->{Inner, Outer} Nat {
+    let inner = Inner::ask()
+    inner + Outer::ask()
+}
+
+fn run_inner() ->{Inner, Outer} Nat {
+    handle body() {
+        do value { value + 1 }
+        op Inner::ask() {
+            let resumed = resume 10
+            resumed + 100
+        }
+    }
+}
+
+fn main() {
+    let result = handle run_inner() {
+        do value { value }
+        op Outer::ask() { resume 5 }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output("handler_resumed_foreign_dispatch_suffix.trb", code, "116");
+}
+
+/// The call-boundary adapter must rebuild its dispatcher from the dynamic
+/// Parent supplied to the resumed callback, not from the call site's initial
+/// dispatch capture. This exercises the same re-entrant suffix stack through
+/// a first-class CPS call.
+#[test]
+fn test_handler_indirect_reentrant_resumes_preserve_suffix_stack() {
+    let code = r#"ability Ask {
+    op ask() -> Nat
+}
+
+fn twice() ->{Ask} Nat {
+    let first = Ask::ask()
+    first + Ask::ask()
+}
+
+fn apply(f: fn() ->{Ask} Nat) ->{Ask} Nat {
+    f()
+}
+
+fn main() {
+    let result = handle apply(twice) {
+        do value { value + 1 }
+        op Ask::ask() {
+            let resumed = resume 10
+            resumed + 100
+        }
+    }
+    __tribute_print_nat(result)
+}
+"#;
+    assert_native_output(
+        "handler_indirect_reentrant_resume_suffix_stack.trb",
+        code,
+        "221",
+    );
+}
+
+/// A re-entrant body can produce Nat while the handle answer and every
+/// arm-local resume suffix produce String. Parent<A> therefore cannot be
+/// conflated with the body's result index.
+#[test]
+fn test_handler_answer_changing_reentrant_resumes_preserve_suffix_stack() {
+    let code = r#"use std::io::print_line
+
+ability Ask {
+    op ask() -> Nat
+}
+
+fn twice() ->{Ask} Nat {
+    let first = Ask::ask()
+    first + Ask::ask()
+}
+
+fn main() {
+    let result = handle twice() {
+        do _value { "done" }
+        op Ask::ask() {
+            let resumed = resume 10
+            resumed <> "!"
+        }
+    }
+    print_line(result)
+}
+"#;
+    assert_native_output(
+        "handler_answer_changing_reentrant_resume_suffix_stack.trb",
+        code,
+        "done!!",
+    );
 }
 
 // =============================================================================

--- a/tests/effect_var_collision.rs
+++ b/tests/effect_var_collision.rs
@@ -14,8 +14,29 @@
 mod common;
 
 use salsa_test_macros::salsa_test;
-use tribute::pipeline::compile_with_diagnostics;
+use tribute::pipeline::{
+    OptimizationOptions, SharedPipelineStage, compile_with_diagnostics, dump_shared_ir_at_stage,
+};
 use tribute_front::SourceCst;
+
+fn logical_function<'a>(ir: &'a str, name: &str) -> &'a str {
+    let markers = [
+        format!("tribute_control.func @{name}"),
+        format!("func.func @{name}"),
+    ];
+    let start = markers
+        .iter()
+        .filter_map(|marker| ir.find(marker))
+        .min()
+        .unwrap_or_else(|| panic!("missing logical function {name}:\n{ir}"));
+    let function = &ir[start..];
+    let end = ["\n  tribute_control.func @", "\n  func.func @"]
+        .iter()
+        .filter_map(|marker| function[1..].find(marker).map(|offset| offset + 1))
+        .min()
+        .unwrap_or(function.len());
+    &function[..end]
+}
 
 /// Test that pure lambdas inside effectful functions have distinct effect variables.
 ///
@@ -124,6 +145,22 @@ fn main() { }
 "#;
 
     let source = SourceCst::from_source_str(db, "pure_in_effectful.trb", code);
+    let logical = dump_shared_ir_at_stage(
+        db,
+        source,
+        SharedPipelineStage::AfterFrontend,
+        OptimizationOptions::production(),
+    )
+    .expect("source-logical dump must succeed");
+    let worker = logical_function(&logical, "effectful_using_pure");
+    assert!(
+        worker.contains("tribute_control.lambda(") && worker.contains("convention(direct)"),
+        "a pure callback must remain Direct inside an effectful worker:\n{worker}"
+    );
+    assert!(
+        !worker.contains("core.unrealized_conversion_cast"),
+        "the exact Direct callback parameter must not require a control cast:\n{worker}"
+    );
     let result = compile_with_diagnostics(db, source);
 
     for diag in &result.diagnostics {
@@ -138,6 +175,118 @@ fn main() { }
         "Type checking should succeed - pure lambda should remain pure even in effectful context. \
          Got {} diagnostics. If this fails with a type mismatch, it indicates EffectVar collision.",
         result.diagnostics.len()
+    );
+}
+
+/// A CPS worker sequences its own operation through a continuation, but a
+/// closed pure callback value remains Direct at the independently typed call.
+#[salsa_test]
+fn test_direct_callback_remains_direct_inside_cps_worker(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "direct_callback_in_cps.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+fn apply_pure(f: fn(Int) ->{} Int, x: Int) ->{} Int {
+    f(x)
+}
+
+fn effectful_using_pure(init: Int) ->{State(Int)} Int {
+    let pure_fn = fn(x: Int) { x * +2 }
+    let _ = State::get()
+    apply_pure(pure_fn, init)
+}
+
+fn main() { }
+"#,
+    );
+    let logical = dump_shared_ir_at_stage(
+        db,
+        source,
+        SharedPipelineStage::AfterFrontend,
+        OptimizationOptions::production(),
+    )
+    .expect("source-logical dump must succeed");
+    let worker = logical_function(&logical, "effectful_using_pure");
+
+    assert!(
+        worker.contains("convention(cps)"),
+        "the enclosing operation worker must use CPS:\n{worker}"
+    );
+    assert!(
+        worker.contains("tribute_control.lambda(") && worker.contains("convention(direct)"),
+        "the closed callback must keep its Direct callable convention:\n{worker}"
+    );
+    assert!(
+        worker.contains("tribute_control.call") && worker.contains("callee = @apply_pure"),
+        "the Direct callback must feed the exact Direct parameter:\n{worker}"
+    );
+    assert!(
+        !worker.contains("core.unrealized_conversion_cast"),
+        "the logical worker must not cast control callable values:\n{worker}"
+    );
+
+    let post_cps = dump_shared_ir_at_stage(
+        db,
+        source,
+        SharedPipelineStage::AfterControlLegalization,
+        OptimizationOptions::production(),
+    )
+    .expect("CPS legalization must preserve the direct callback");
+    let worker = logical_function(&post_cps, "effectful_using_pure");
+    assert!(
+        worker.contains("tribute.calling_convention = 2"),
+        "the enclosing worker must remain CPS after legalization:\n{worker}"
+    );
+    assert!(
+        worker.contains("closure.lambda") && worker.contains("tribute.calling_convention = 0"),
+        "the callback closure must remain an ordinary Direct closure:\n{worker}"
+    );
+    assert!(
+        worker.contains("func.tail_call_indirect"),
+        "the enclosing CPS worker must end through its continuation:\n{worker}"
+    );
+    assert!(
+        worker.contains("callee = @apply_pure, tribute.calling_convention = 0"),
+        "the Direct callback call must remain an ordinary Direct call:\n{worker}"
+    );
+}
+
+/// A lambda that evaluates an open effect-polymorphic callback remains Cps;
+/// an empty known row prefix alone is not proof that the body is pure.
+#[salsa_test]
+fn test_open_effect_callback_body_remains_cps(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "open_effect_lambda.trb",
+        r#"
+fn invoke(f: fn(Int) ->{e} Int, value: Int) ->{e} Int { f(value) }
+
+fn relay(g: fn(Int) ->{e} Int, value: Int) ->{e} Int {
+    invoke(fn(inner) { g(inner) }, value)
+}
+
+fn main() { }
+"#,
+    );
+    let logical = dump_shared_ir_at_stage(
+        db,
+        source,
+        SharedPipelineStage::AfterFrontend,
+        OptimizationOptions::production(),
+    )
+    .expect("open-effect lambda must lower as a Cps callable");
+    let relay = logical_function(&logical, "relay");
+    assert!(
+        relay.contains("tribute_control.lambda(") && relay.contains("convention(cps)"),
+        "an open effect row evaluated by the lambda body must retain Cps:\n{relay}"
+    );
+    assert!(
+        !relay.contains("core.unrealized_conversion_cast"),
+        "the open-effect callable already has the exact Cps convention:\n{relay}"
     );
 }
 

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -12,8 +12,9 @@ use tribute::database::parse_with_thread_local;
 use tribute_front::SourceCst;
 use tribute_passes::evidence::has_evidence_first_param;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::func;
+use trunk_ir::dialect::{adt, core, func};
 use trunk_ir::ops::DialectOp;
+use trunk_ir::printer::print_module;
 use trunk_ir::rewrite::Module;
 
 /// Helper to compile code through AST pipeline and return arena IR.
@@ -21,14 +22,49 @@ fn compile_to_ir(db: &dyn salsa::Database, code: &str, name: &str) -> (IrContext
     let source_code = Rope::from_str(code);
     let tree = parse_with_thread_local(&source_code, None);
     let source_file = SourceCst::from_path(db, name, source_code.clone(), tree);
-    let (mut ctx, m) =
-        tribute::pipeline::compile_frontend(db, source_file).expect("compilation should succeed");
+    let tribute::pipeline::FrontendCompilation {
+        context: mut ctx,
+        module: m,
+        operation_declarations,
+    } = tribute::pipeline::compile_frontend(db, source_file).expect("compilation should succeed");
     let core_module = trunk_ir::dialect::core::Module::from_op(&ctx, m.op())
         .expect("frontend output must be a core.module");
     let mut pm = trunk_ir::pass::PassManager::new();
-    pm.add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda);
+    pm.add_pass(
+        tribute_passes::tribute_control_to_cps::TributeControlToCps::new(operation_declarations),
+    )
+    .add_pass(tribute_passes::lower_closure_lambda::LowerClosureLambda);
     pm.run(&mut ctx, core_module).unwrap();
     (ctx, m)
+}
+
+/// Compile only to the source-logical boundary.
+fn compile_source_logical_ir(
+    db: &dyn salsa::Database,
+    code: &str,
+    name: &str,
+) -> (IrContext, Module) {
+    let source_code = Rope::from_str(code);
+    let tree = parse_with_thread_local(&source_code, None);
+    let source_file = SourceCst::from_path(db, name, source_code, tree);
+    let tribute::pipeline::FrontendCompilation {
+        context, module, ..
+    } = tribute::pipeline::compile_frontend(db, source_file).expect("compilation should succeed");
+    (context, module)
+}
+
+fn logical_function_text<'a>(ir: &'a str, name: &str) -> &'a str {
+    let unquoted = format!("tribute_control.func @{name}(");
+    let quoted = format!("tribute_control.func @\"{name}\"(");
+    let start = ir
+        .find(&unquoted)
+        .or_else(|| ir.find(&quoted))
+        .unwrap_or_else(|| panic!("missing logical function `{name}`:\n{ir}"));
+    let tail = &ir[start..];
+    let end = tail[1..]
+        .find("\n  tribute_control.func ")
+        .map_or(tail.len(), |offset| offset + 1);
+    &tail[..end]
 }
 
 /// Helper to check which functions have evidence as first parameter.
@@ -45,7 +81,88 @@ fn get_functions_with_evidence(ctx: &IrContext, module: &Module) -> Vec<(String,
     results
 }
 
-/// Return `(source parameter count, has evidence, has done_k, returns anyref)`.
+fn is_type(ctx: &IrContext, ty: trunk_ir::refs::TypeRef, dialect: &str, name: &str) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == trunk_ir::Symbol::from_dynamic(dialect)
+        && data.name == trunk_ir::Symbol::from_dynamic(name)
+}
+
+/// Whether a Cps worker owns the complete result-indexed callback ABI.
+///
+/// The worker receives `Evidence, Done<R>, Dispatch<R>` and returns
+/// `core.never`.  The Dispatch's Resume closure in turn proves the exact
+/// immutable `Parent<R>` layout, rather than relying on an erased carrier.
+fn has_cps_callback_params(
+    ctx: &IrContext,
+    result: trunk_ir::refs::TypeRef,
+    evidence: trunk_ir::refs::TypeRef,
+    done: trunk_ir::refs::TypeRef,
+    dispatch: trunk_ir::refs::TypeRef,
+) -> bool {
+    if !is_type(ctx, result, "core", "never")
+        || !tribute_ir::dialect::ability::is_evidence_type_ref(ctx, evidence)
+    {
+        return false;
+    }
+
+    let Some(done_func) = tribute_core::cps_closure_function_type(ctx, done) else {
+        return false;
+    };
+    let done_params = &ctx.types.get(done_func).params;
+    if done_params.len() != 2 || !is_type(ctx, done_params[0], "core", "never") {
+        return false;
+    }
+    let source_result = done_params[1];
+
+    let Some(dispatch_func) = tribute_core::cps_closure_function_type(ctx, dispatch) else {
+        return false;
+    };
+    let dispatch_params = &ctx.types.get(dispatch_func).params;
+    let [
+        dispatch_result,
+        dispatch_evidence,
+        resume,
+        prompt,
+        ability,
+        operation,
+        payload,
+    ] = dispatch_params.as_slice()
+    else {
+        return false;
+    };
+    if !is_type(ctx, *dispatch_result, "core", "never")
+        || *dispatch_evidence != evidence
+        || !is_type(ctx, *prompt, "core", "i32")
+        || !is_type(ctx, *ability, "core", "i32")
+        || !is_type(ctx, *operation, "core", "i32")
+        || !is_type(ctx, *payload, "tribute_rt", "anyref")
+    {
+        return false;
+    }
+
+    let Some(resume_func) = tribute_core::cps_closure_function_type(ctx, *resume) else {
+        return false;
+    };
+    let resume_params = &ctx.types.get(resume_func).params;
+    let [resume_result, resume_evidence, parent, input] = resume_params.as_slice() else {
+        return false;
+    };
+    is_type(ctx, *resume_result, "core", "never")
+        && *resume_evidence == evidence
+        && is_type(ctx, *input, "tribute_rt", "anyref")
+        && tribute_core::cps_parent_result_type(ctx, *parent) == Some(source_result)
+        && tribute_core::has_canonical_cps_parent_layout(ctx, *parent, dispatch)
+}
+
+fn has_cps_callback_abi(ctx: &IrContext, func_ty: trunk_ir::refs::TypeRef) -> bool {
+    let params = &ctx.types.get(func_ty).params;
+    let [result, evidence, done, dispatch, ..] = params.as_slice() else {
+        return false;
+    };
+    has_cps_callback_params(ctx, *result, *evidence, *done, *dispatch)
+}
+
+/// Return `(source parameter count, has evidence, has exact CPS callbacks, returns never)`.
 fn function_abi(ctx: &IrContext, module: &Module, target: &str) -> (usize, bool, bool, bool) {
     let func_op = module
         .ops(ctx)
@@ -61,28 +178,22 @@ fn function_abi(ctx: &IrContext, module: &Module, target: &str) -> (usize, bool,
     let has_evidence = params
         .first()
         .is_some_and(|ty| tribute_ir::dialect::ability::is_evidence_type_ref(ctx, *ty));
-    let hidden_count = usize::from(has_evidence)
-        + usize::from(
-            has_evidence
-                && params.get(1).is_some_and(|ty| {
-                    let ty = ctx.types.get(*ty);
-                    ty.dialect == trunk_ir::Symbol::new("tribute_rt")
-                        && ty.name == trunk_ir::Symbol::new("anyref")
-                }),
-        );
-    let has_done_k = hidden_count == 2;
-    let result = ctx.types.get(data.params[0]);
-    let returns_anyref = result.dialect == trunk_ir::Symbol::new("tribute_rt")
-        && result.name == trunk_ir::Symbol::new("anyref");
+    let has_cps_callbacks = has_cps_callback_abi(ctx, func_ty);
+    let hidden_count = if has_cps_callbacks {
+        3
+    } else {
+        usize::from(has_evidence)
+    };
+    let returns_never = is_type(ctx, data.params[0], "core", "never");
     (
         params.len() - hidden_count,
         has_evidence,
-        has_done_k,
-        returns_anyref,
+        has_cps_callbacks,
+        returns_never,
     )
 }
 
-fn function_param_names(ctx: &IrContext, module: &Module, target: &str) -> Vec<String> {
+fn function_type(ctx: &IrContext, module: &Module, target: &str) -> trunk_ir::refs::TypeRef {
     let func_op = module
         .ops(ctx)
         .into_iter()
@@ -91,17 +202,55 @@ fn function_param_names(ctx: &IrContext, module: &Module, target: &str) -> Vec<S
             (func_op.sym_name(ctx) == target).then_some(func_op)
         })
         .unwrap_or_else(|| panic!("missing function '{target}'"));
-    let entry = ctx.region(func_op.body(ctx)).blocks[0];
-    ctx.block(entry)
-        .args
-        .iter()
-        .map(|arg| {
-            arg.attrs
-                .get_symbol("bind_name")
-                .map(|name| name.to_string())
-                .unwrap_or_else(|| "_".to_owned())
-        })
-        .collect()
+    func_op.r#type(ctx)
+}
+
+fn function_param_types(
+    ctx: &IrContext,
+    module: &Module,
+    target: &str,
+) -> Vec<trunk_ir::refs::TypeRef> {
+    ctx.types.get(function_type(ctx, module, target)).params[1..].to_vec()
+}
+
+fn assert_no_control_unrealized_casts(ctx: &IrContext, module: &Module) {
+    fn is_control_type(ctx: &IrContext, ty: trunk_ir::refs::TypeRef) -> bool {
+        let data = ctx.types.get(ty);
+        (data.dialect == trunk_ir::Symbol::new("adt")
+            && data.name == trunk_ir::Symbol::new("typeref")
+            && data.attrs.get_type("tribute.cps_parent_result").is_some())
+            || (data.dialect == trunk_ir::Symbol::new("closure")
+                && data.name == trunk_ir::Symbol::new("closure")
+                && data.attrs.get_i128("tribute.calling_convention") == Some(2))
+    }
+
+    fn visit(ctx: &IrContext, op: trunk_ir::refs::OpRef) {
+        if core::UnrealizedConversionCast::matches(ctx, op) {
+            let is_control = ctx
+                .op_operands(op)
+                .iter()
+                .any(|value| is_control_type(ctx, ctx.value_ty(*value)))
+                || ctx
+                    .op_results(op)
+                    .iter()
+                    .any(|value| is_control_type(ctx, ctx.value_ty(*value)));
+            assert!(
+                !is_control,
+                "Parent and CPS closure values must not cross an unrealized conversion cast"
+            );
+        }
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    visit(ctx, child);
+                }
+            }
+        }
+    }
+
+    for op in module.ops(ctx) {
+        visit(ctx, op);
+    }
 }
 
 #[test]
@@ -215,17 +364,232 @@ fn main() { }
     TributeDatabaseImpl::default().attach(|db| {
         let (ctx, module) = compile_to_ir(db, code, "closure_calling_conventions.trb");
 
-        assert_eq!(
-            function_param_names(&ctx, &module, "direct_closure::__clam_0"),
-            ["__env", "x"]
+        let direct = function_param_types(&ctx, &module, "direct_closure::__clam_0");
+        assert!(
+            matches!(direct.as_slice(), [environment, value]
+                if is_type(&ctx, *environment, "tribute_rt", "anyref")
+                    && is_type(&ctx, *value, "core", "i32")),
+            "Direct closure must interpose only its environment: {direct:?}"
         );
-        assert_eq!(
-            function_param_names(&ctx, &module, "evidence_direct_closure::__clam_0"),
-            ["__evidence", "__env", "x"]
+
+        let evidence_direct =
+            function_param_types(&ctx, &module, "evidence_direct_closure::__clam_0");
+        assert!(
+            matches!(evidence_direct.as_slice(), [evidence, environment, value]
+                if tribute_ir::dialect::ability::is_evidence_type_ref(&ctx, *evidence)
+                    && is_type(&ctx, *environment, "tribute_rt", "anyref")
+                    && is_type(&ctx, *value, "core", "i32")),
+            "EvidenceDirect closure must interpose env after evidence: {evidence_direct:?}"
         );
-        assert_eq!(
-            function_param_names(&ctx, &module, "cps_closure::__clam_0"),
-            ["__evidence", "__env", "__done_k"]
+
+        let cps_type = function_type(&ctx, &module, "cps_closure::__clam_0");
+        let cps = &ctx.types.get(cps_type).params;
+        assert!(
+            matches!(cps.as_slice(), [result, evidence, environment, done, dispatch]
+                if is_type(&ctx, *environment, "tribute_rt", "anyref")
+                    && has_cps_callback_params(&ctx, *result, *evidence, *done, *dispatch)),
+            "CPS closure must interpose env after evidence and preserve exact Done/Dispatch: {cps:?}"
+        );
+    });
+}
+
+#[test]
+fn fn_handler_dispatchers_use_the_erased_payload_abi_after_environment_interposition() {
+    let code = r#"
+ability Ask {
+    fn ask() -> Nat
+}
+
+ability Pair {
+    fn add(left: Nat, right: Nat) -> Nat
+}
+
+fn call_ask() ->{Ask} Nat { Ask::ask() }
+fn call_pair() ->{Pair} Nat { Pair::add(15, 27) }
+
+fn one() -> Nat {
+    handle call_ask() {
+        do value { value }
+        fn Ask::ask() { 42 }
+    }
+}
+
+fn two() -> Nat {
+    handle call_pair() {
+        do value { value }
+        fn Pair::add(left, right) { left + right }
+    }
+}
+"#;
+
+    fn is_type(ctx: &IrContext, ty: trunk_ir::TypeRef, dialect: &str, name: &str) -> bool {
+        let data = ctx.types.get(ty);
+        data.dialect == trunk_ir::Symbol::from_dynamic(dialect)
+            && data.name == trunk_ir::Symbol::from_dynamic(name)
+    }
+
+    fn count_struct_gets(ctx: &IrContext, op: trunk_ir::refs::OpRef) -> usize {
+        let mut count = usize::from(adt::StructGet::from_op(ctx, op).is_ok());
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for child in ctx.block(block).ops.iter().copied() {
+                    count += count_struct_gets(ctx, child);
+                }
+            }
+        }
+        count
+    }
+
+    TributeDatabaseImpl::default().attach(|db| {
+        let (ctx, module) = compile_to_ir(db, code, "fn_handler_dispatcher_abi.trb");
+        let mut payload_field_counts = Vec::new();
+        for op in module.ops(&ctx) {
+            let Ok(function) = func::Func::from_op(&ctx, op) else {
+                continue;
+            };
+            if ctx.op(op).attributes.get_i128("tribute.calling_convention") != Some(1) {
+                continue;
+            }
+            let ty = ctx.types.get(function.r#type(&ctx));
+            let params = &ty.params[1..];
+            let is_dispatcher = ty.params.len() == 5
+                && is_type(&ctx, ty.params[0], "tribute_rt", "anyref")
+                && tribute_ir::dialect::ability::is_evidence_type_ref(&ctx, params[0])
+                && is_type(&ctx, params[1], "tribute_rt", "anyref")
+                && is_type(&ctx, params[2], "core", "i32")
+                && is_type(&ctx, params[3], "tribute_rt", "anyref");
+            if is_dispatcher {
+                payload_field_counts.push(count_struct_gets(&ctx, op));
+            }
+        }
+
+        assert_eq!(payload_field_counts.len(), 2, "{payload_field_counts:?}");
+        assert!(
+            payload_field_counts.iter().any(|count| *count >= 3),
+            "the two-argument arm must unpack the canonical payload product: {payload_field_counts:?}"
+        );
+
+        let printed = print_module(&ctx, module.op());
+        let mut reparsed = IrContext::new();
+        trunk_ir::parser::parse_test_module(&mut reparsed, &printed);
+    });
+}
+
+#[test]
+fn test_generic_recursive_handler_call_specializes_without_control_casts() {
+    let code = r#"
+ability State(s) {
+    op get() -> s
+    op set(value: s) -> Nil
+}
+
+fn set_then_get() ->{State(Int)} Int {
+    State::set(+100)
+    State::get()
+}
+
+fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
+    handle comp() {
+        do result { result }
+        op State::get() { run_state(fn() { resume init }, init) }
+        op State::set(value) { run_state(fn() { resume Nil }, value) }
+    }
+}
+
+fn main() {
+    let _ = run_state(fn() { set_then_get() }, +0)
+}
+"#;
+
+    TributeDatabaseImpl::default().attach(|db| {
+        let (ctx, module) = compile_to_ir(db, code, "generic_recursive_handler.trb");
+        let canonical = print_module(&ctx, module.op());
+        let names = get_functions_with_evidence(&ctx, &module)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>();
+        assert!(
+            names.iter().any(|name| name == "run_state$Int$Int"),
+            "the recursive concrete handler call must use its exact specialization: {names:?}"
+        );
+        assert!(
+            canonical.contains("func.func @\"run_state$Int$Int\"(")
+                || canonical.contains("func.func @run_state$Int$Int("),
+            "canonical post-CPS IR must retain the exact specialized worker:\n{canonical}"
+        );
+        assert_no_control_unrealized_casts(&ctx, &module);
+    });
+}
+
+#[test]
+fn test_transitive_generic_handler_specialization_retains_exact_control_types() {
+    let code = r#"
+ability A {
+    op do_a() -> Nat
+}
+
+fn run_b(value: a) -> a { value }
+
+fn run_a(comp: fn() ->{e, A} a) ->{e} a {
+    handle comp() {
+        do result { run_b(result) }
+        op A::do_a() { run_a(fn() { resume 10 }) }
+    }
+}
+
+fn main() {
+    let _ = run_a(fn() { A::do_a() })
+}
+"#;
+
+    TributeDatabaseImpl::default().attach(|db| {
+        let (ctx, module) = compile_source_logical_ir(db, code, "transitive_generic_handler.trb");
+        let logical = print_module(&ctx, module.op());
+        for name in ["run_a", "run_b", "run_a$Nat", "run_b$Nat"] {
+            assert_eq!(
+                logical
+                    .lines()
+                    .filter(|line| {
+                        let line = line.trim_start();
+                        line.starts_with(&format!("tribute_control.func @{name}("))
+                            || line.starts_with(&format!("tribute_control.func @\"{name}\"("))
+                    })
+                    .count(),
+                1,
+                "expected one retained/generated `{name}`:\n{logical}"
+            );
+        }
+        let concrete_run_a = logical_function_text(&logical, "run_a$Nat");
+        assert!(
+            concrete_run_a.contains("callee = @\"run_b$Nat\"")
+                && concrete_run_a.contains(": core.i32"),
+            "the generated handler must rewrite its deferred call to run_b$Nat:\n{logical}"
+        );
+        let concrete_run_b = logical_function_text(&logical, "run_b$Nat");
+        assert!(
+            concrete_run_b.contains("tribute_control.return"),
+            "the deferred helper must have one concrete Nat body:\n{concrete_run_b}"
+        );
+        let generic_run_a = logical_function_text(&logical, "run_a");
+        assert!(
+            generic_run_a.contains("tribute_rt.anyref"),
+            "the retained generic body may erase only source data:\n{logical}"
+        );
+        for (name, function) in [("run_a", generic_run_a), ("run_a$Nat", concrete_run_a)] {
+            assert!(
+                function.contains("tribute_control.lambda") && function.contains("convention(cps)"),
+                "the resumptive nested lambda in `{name}` must be CPS directly:\n{function}"
+            );
+            assert!(
+                !function.contains("convention(direct)"),
+                "`{name}` must not wrap a Direct resumptive lambda in CPS:\n{function}"
+            );
+        }
+        assert!(
+            !generic_run_a.contains("core.unrealized_conversion_cast")
+                && !concrete_run_a.contains("core.unrealized_conversion_cast")
+                && !concrete_run_b.contains("core.unrealized_conversion_cast"),
+            "generic lowering must never cast CPS control identity:\n{logical}"
         );
     });
 }
@@ -399,6 +763,9 @@ fn main() { }
         // Count evidence params per function via block args
         for op in module.ops(&ctx) {
             if let Ok(func_op) = func::Func::from_op(&ctx, op) {
+                if ctx.op(op).regions.is_empty() {
+                    continue;
+                }
                 let name = func_op.sym_name(&ctx).to_string();
                 let body = func_op.body(&ctx);
                 let blocks = &ctx.region(body).blocks;

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -61,68 +61,6 @@ fn focused_rc_ops(ir: &str) -> String {
         .join("\n")
 }
 
-fn identity_done_symbols(ir: &str) -> Vec<&str> {
-    let lines: Vec<_> = ir.lines().collect();
-    lines
-        .windows(2)
-        .filter_map(|pair| {
-            let header = pair[0].trim_start();
-            (header.starts_with("func.func ")
-                && header.contains("%2: tribute_rt.anyref) -> tribute_rt.anyref")
-                && pair[1].trim() == "func.return %2")
-                .then(|| {
-                    header
-                        .strip_prefix("func.func ")
-                        .expect("checked prefix")
-                        .split('(')
-                        .next()
-                        .expect("function header has parameters")
-                })
-        })
-        .collect()
-}
-
-fn focused_identity_done_ir(ir: &str) -> String {
-    let symbols = identity_done_symbols(ir);
-    ir.lines()
-        .filter(|line| symbols.iter().any(|symbol| line.contains(symbol)))
-        .map(str::trim)
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn normal_done_symbols(ir: &str) -> Vec<&str> {
-    let lines: Vec<_> = ir.lines().collect();
-    lines
-        .windows(3)
-        .filter_map(|window| {
-            let header = window[0].trim_start();
-            (header.starts_with("func.func ")
-                && header.contains("%2: tribute_rt.anyref) -> tribute_rt.anyref")
-                && window[1].trim()
-                    == "%3 = adt.variant_new %2 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref"
-                && window[2].trim() == "func.return %3")
-                .then(|| {
-                    header
-                        .strip_prefix("func.func ")
-                        .expect("checked prefix")
-                        .split('(')
-                        .next()
-                        .expect("function header has parameters")
-                })
-        })
-        .collect()
-}
-
-fn lambda_function_count(ir: &str) -> usize {
-    ir.lines()
-        .filter(|line| {
-            let line = line.trim_start();
-            line.starts_with("func.func ") && line.contains("::__lambda_")
-        })
-        .count()
-}
-
 #[test]
 fn done_continuation_dedup_preserves_native_execution() {
     let disabled = compile_and_run_native_with_done_continuation_dedup(
@@ -458,71 +396,40 @@ fn temporary_field_borrows_have_focused_before_after_ir(db: &salsa::DatabaseImpl
 }
 
 #[salsa_test]
-fn done_continuation_dedup_has_focused_before_after_ir(db: &salsa::DatabaseImpl) {
+fn done_continuation_policy_isolated_at_frontend(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,
         "done_continuation_dedup_snapshot.trb",
         DONE_CONTINUATION_DEDUP_STATE,
     );
-    let before = dump_shared_ir_at_stage(
+    let baseline = dump_shared_ir_at_stage(
         db,
         source,
         SharedPipelineStage::AfterFrontend,
         OptimizationOptions::baseline(),
     )
-    .expect("unoptimized frontend IR should be available");
-    let after = dump_shared_ir_at_stage(
+    .expect("baseline frontend IR should be available");
+    let production = dump_shared_ir_at_stage(
         db,
         source,
         SharedPipelineStage::AfterFrontend,
         OptimizationOptions::production(),
     )
-    .expect("optimized frontend IR should be available");
+    .expect("production frontend IR should be available");
 
-    let before_symbols = identity_done_symbols(&before);
-    let after_symbols = identity_done_symbols(&after);
-    let before_normal_symbols = normal_done_symbols(&before);
-    let after_normal_symbols = normal_done_symbols(&after);
-    assert!(
-        before_symbols.len() > 1,
-        "fixture must generate duplicate identity done continuations"
-    );
-    assert_eq!(after_symbols.len(), 1);
-    assert!(
-        before_normal_symbols.len() > 1,
-        "fixture must generate duplicate Normal done continuations"
-    );
-    assert_eq!(after_normal_symbols.len(), 1);
-    assert_eq!(
-        lambda_function_count(&before) - before_symbols.len() - before_normal_symbols.len(),
-        lambda_function_count(&after) - after_symbols.len() - after_normal_symbols.len(),
-        "capturing and user-authored lambdas must remain distinct"
-    );
-
-    let before_references: usize = before_symbols
-        .iter()
-        .map(|symbol| before.matches(&format!("func_ref = {symbol}")).count())
-        .sum();
-    let after_references = after
-        .matches(&format!("func_ref = {}", after_symbols[0]))
-        .count();
-    assert_eq!(before_references, after_references);
-
-    let before_normal_references: usize = before_normal_symbols
-        .iter()
-        .map(|symbol| before.matches(&format!("func_ref = {symbol}")).count())
-        .sum();
-    let after_normal_references = after
-        .matches(&format!("func_ref = {}", after_normal_symbols[0]))
-        .count();
-    assert_eq!(before_normal_references, after_normal_references);
-
-    assert_snapshot!(
-        "done_continuation_dedup_before",
-        focused_identity_done_ir(&before)
-    );
-    assert_snapshot!(
-        "done_continuation_dedup_after",
-        focused_identity_done_ir(&after)
-    );
+    assert_eq!(baseline, production);
+    assert!(baseline.contains("tribute_control.func"), "{baseline}");
+    for forbidden in [
+        "func.func",
+        "func.call",
+        "func.return",
+        "__tribute_cps_control",
+        "@Normal",
+        "@Escape",
+    ] {
+        assert!(
+            !baseline.contains(forbidden),
+            "AfterFrontend must remain source-logical and must not contain `{forbidden}`:\n{baseline}"
+        );
+    }
 }

--- a/tests/salsa_integration.rs
+++ b/tests/salsa_integration.rs
@@ -8,10 +8,10 @@ use tribute_passes::diagnostic::Diagnostic;
 use trunk_ir::Symbol;
 use trunk_ir::{IrContext, Module};
 
-/// Helper to check whether a `func.func` with the given `sym_name` exists
-/// among the top-level operations of an arena module.
+/// Helper to check whether a source-logical `tribute_control.func` with the
+/// given `sym_name` exists among an arena module's top-level operations.
 fn find_func_by_name(ctx: &IrContext, module: &Module, name: &str) -> bool {
-    let func_dialect = Symbol::new("func");
+    let func_dialect = Symbol::new("tribute_control");
     let func_name = Symbol::new("func");
     let sym_name_key = Symbol::new("sym_name");
     module.ops(ctx).iter().any(|&op_ref| {
@@ -31,9 +31,11 @@ fn compile_frontend_with_diagnostics(
     db: &dyn salsa::Database,
     source: SourceCst,
 ) -> Result<(IrContext, Module), Vec<&Diagnostic>> {
-    compile_frontend(db, source).ok_or_else(|| {
-        tribute::pipeline::parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
-    })
+    compile_frontend(db, source)
+        .map(|frontend| (frontend.context, frontend.module))
+        .ok_or_else(|| {
+            tribute::pipeline::parse_and_lower_ast::accumulated::<Diagnostic>(db, source)
+        })
 }
 
 fn expect_compilation_success(db: &dyn salsa::Database, source: SourceCst) -> (IrContext, Module) {

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -1,178 +1,213 @@
 ---
 source: tests/active_pipeline_goldens.rs
-expression: ir_text
+expression: filter_ir_for_active_pipeline(&full_ir)
 ---
 core.module @direct_fn_native {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
-  !t0 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !__tribute_parent_ty6 = adt.typeref() {name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !"run::__clam_4::env" = adt.struct() {fields = [[@_0, closure.closure(core.func(core.i32, !t0)) {tribute.calling_convention = 1}], [@_1, closure.closure(core.func(core.nil, !t0, core.i32)) {tribute.calling_convention = 1}]], name = @"run::__clam_4::env"}
+  !__tribute_root_completion_cell = adt.struct(core.nil) {fields = [[@value, core.nil]], name = @__tribute_root_completion_cell}
+  !t7 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6, core.i32)
+  !__tribute_parent_ty57 = adt.typeref() {name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t4 = closure.closure(core.func(core.nil, !t0, closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t5 = closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, core.i32)) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty57]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t4]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::env"}
+  !t8 = closure.closure(core.func(core.nil, core.i32)) {tribute.calling_convention = 2}
+  !t9 = closure.closure(core.func(core.nil)) {tribute.calling_convention = 2}
+  !"main::__clam_1::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t4], [@_2, !t5], [@_3, !t0]], name = @"main::__clam_1::env"}
+  !t11 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6, tribute_rt.anyref)
+  !__tribute_parent_ty57_1 = adt.struct() {fields = [[@done, !t9], [@dispatch, !t4]], name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !__tribute_ability_payload_7dc9fb1b = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_7dc9fb1b}
+  !t12 = core.func(core.nil, tribute_rt.anyref, core.i32)
+  !t13 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty57, core.i32)
+  !t14 = core.func(core.nil, !t0, !__tribute_parent_ty6, tribute_rt.anyref)
+  !t3 = closure.closure(!t14) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env"}
+  !t6 = core.func(core.nil, !t0, tribute_rt.anyref, !t3, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t10 = core.func(core.nil, !t0, !t3, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t1 = closure.closure(!t10) {tribute.calling_convention = 2}
+  !__tribute_parent_ty6_1 = adt.struct() {fields = [[@done, !t8], [@dispatch, !t1]], name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !"__tribute_make_local_dispatch_14::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t1]], name = @"__tribute_make_local_dispatch_14::__clam_0::env"}
+  !t15 = core.func(core.nil, !t0, !__tribute_parent_ty6, core.i32)
+  !t2 = closure.closure(!t15) {tribute.calling_convention = 2}
+  !"run::__clam_1::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env"}
+  !"run::__clam_7::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"run::__clam_7::env"}
+  !"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_13::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_13::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::env"}
+  !__tribute_ability_payload_2796d93e = adt.struct() {fields = [], name = @__tribute_ability_payload_2796d93e}
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup_tr(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_empty() -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_extend(%0: core.ptr, %1: core.i32, %2: core.i32, %3: core.ptr, %4: core.ptr) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup(%0: core.ptr, %1: core.i32) -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
-  func.func @"direct_fn_native::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run(%0: !t0, %1: !t8, %2: !t1) -> core.nil attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run::__clam_0"} : !t15
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run::__clam_1::env"} : !"run::__clam_1::env"
+      %7 = func.constant {func_ref = @"run::__clam_1"} : core.func(core.nil, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_13, tribute.calling_convention = 0} : !t1
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run::__clam_2"} : core.func(core.i32, !t0)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run::__clam_3"} : core.func(core.nil, !t0, core.i32)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.struct_new %12, %15 {type = !"run::__clam_4::env"} : !"run::__clam_4::env"
+      %17 = func.constant {func_ref = @"run::__clam_4"} : core.func(tribute_rt.anyref, !t0, core.i32, tribute_rt.anyref)
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run::__clam_5"} : core.func(core.nil, !t0, !__tribute_parent_ty6, core.i32, tribute_rt.anyref)
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = arith.const {value = 1361557906} : core.i32
+      %24 = core.unrealized_conversion_cast %18 : core.ptr
+      %25 = core.unrealized_conversion_cast %21 : core.ptr
+      %26 = func.call %0, %23, %22, %24, %25 {callee = @__tribute_evidence_extend} : core.ptr
+      %27 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %28 = func.constant {func_ref = @"run::__clam_6"} : !t15
+      %29 = adt.struct_new %28, %27 {type = !_closure} : !_closure
+      %30 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %31 = adt.struct_new %29, %26, %30 {type = !"run::__clam_7::env"} : !"run::__clam_7::env"
+      %32 = func.constant {func_ref = @"run::__clam_7"} : core.func(core.nil, core.i32)
+      %33 = adt.struct_new %32, %31 {type = !_closure} : !_closure
+      %34 = adt.struct_get %30 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %35 = func.call %29, %34 {callee = @__tribute_make_dispatch_adapter_15, tribute.calling_convention = 0} : !t1
+      %36 = adt.struct_new {type = !__tribute_ability_payload_2796d93e} : !__tribute_ability_payload_2796d93e
+      %37 = arith.const {value = 1361557906} : core.i32
+      %38 = func.call %26, %37 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %39 = arith.const {value = 664197438} : core.i32
+      %40 = adt.struct_get %38 {field = 0, type = !_closure} : core.i32
+      %41 = adt.struct_get %38 {field = 1, type = !_closure} : tribute_rt.anyref
+      %42 = func.call_indirect %40, %26, %41, %39, %36 : tribute_rt.anyref
+      %43 = tribute_rt.unbox_int %42 : core.i32
+      %44 = adt.struct_new %43 {type = !__tribute_ability_payload_7dc9fb1b} : !__tribute_ability_payload_7dc9fb1b
+      %45 = arith.const {value = 1361557906} : core.i32
+      %46 = func.call %26, %45 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %47 = arith.const {value = 2110389019} : core.i32
+      %48 = adt.struct_get %46 {field = 0, type = !_closure} : core.i32
+      %49 = adt.struct_get %46 {field = 1, type = !_closure} : tribute_rt.anyref
+      %50 = func.call_indirect %48, %26, %49, %47, %44 : tribute_rt.anyref
+      %51 = core.unrealized_conversion_cast %50 : core.nil
+      %52 = adt.struct_get %33 {field = 0, type = !_closure} : core.i32
+      %53 = adt.struct_get %33 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %52, %53, %43 {func.indirect_call_signature = !t12, tribute.calling_convention = 2}
+  }
+  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t8
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t12, tribute.calling_convention = 2}
+  }
+  func.func @"run::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run::__clam_1::env"} : !"run::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run::__clam_1::env"} : !t8
+      %4 = adt.struct_get %2 {field = 1, type = !"run::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t7, tribute.calling_convention = 2}
+  }
+  func.func @"run::__clam_2"(%0: !t0, %1: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %2 = arith.const {value = 41} : core.i32
       func.return %2
   }
-
-  func.func @"direct_fn_native::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.variant_new %2 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %3
+  func.func @"run::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32) -> core.nil attributes {tribute.calling_convention = 1} {
+      func.return
   }
-
-  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
-      %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = func.constant {func_ref = @"direct_fn_native::__lambda_0"} : !t0
-      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"run::__clam_0"} : !t0
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = func.constant {func_ref = @"direct_fn_native::__lambda_1"} : !t0
-      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-      %10 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref)
-      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
-      %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %17 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
-      %19 = func.call {callee = @__tribute_next_tag} : core.i32
-      %20 = arith.const {value = 1361557906} : core.i32
-      %21 = core.unrealized_conversion_cast %18 : core.ptr
-      %22 = core.unrealized_conversion_cast %15 : core.ptr
-      %23 = func.call %0, %20, %19, %21, %22 {callee = @__tribute_evidence_extend} : core.ptr
-      %24 = func.call_indirect %11, %23, %12, %9 : tribute_rt.anyref
-      %25 = adt.variant_is %24 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %26 = scf.if %25 : tribute_rt.anyref {
-          %27 = adt.variant_cast %24 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %28 = adt.variant_get %27 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %29 = tribute_rt.unbox_int %28 : core.i32
-          %30 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-          %31 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-          %32 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %33 = func.call_indirect %31, %23, %32, %28 : tribute_rt.anyref
-          scf.yield %33
-      } {
-          %34 = adt.variant_cast %24 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %35 = adt.variant_get %34 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %36 = adt.variant_get %34 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %37 = arith.cmpi %35, %19 {predicate = @eq} : core.i1
-          %38 = scf.if %37 : tribute_rt.anyref {
-              %39 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-              %40 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-              %41 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %42 = func.call_indirect %40, %39, %41, %36 : tribute_rt.anyref
-              scf.yield %42
-          } {
-              scf.yield %24
+  func.func @"run::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      %4 = adt.ref_cast %1 {type = !"run::__clam_4::env"} : !"run::__clam_4::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"run::__clam_4::env"} : closure.closure(core.func(core.i32, !t0)) {tribute.calling_convention = 1}
+      %6 = adt.struct_get %4 {field = 1, type = !"run::__clam_4::env"} : closure.closure(core.func(core.nil, !t0, core.i32)) {tribute.calling_convention = 1}
+      scf.switch %2 {
+          scf.case {value = 664197438} {
+              %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+              %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+              %9 = func.call_indirect %7, %0, %8 {func.indirect_call_signature = core.func(core.i32, !t0, tribute_rt.anyref), tribute.calling_convention = 1} : core.i32
+              %10 = tribute_rt.box_int %9 : tribute_rt.anyref
+              func.return %10
           }
-          scf.yield %38
+          scf.case {value = 2110389019} {
+              %11 = adt.struct_get %3 {field = 0, type = !__tribute_ability_payload_7dc9fb1b} : core.i32
+              %12 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+              %13 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+              %14 = func.call_indirect %12, %0, %13, %11 {func.indirect_call_signature = core.func(core.nil, !t0, tribute_rt.anyref, core.i32), tribute.calling_convention = 1} : core.nil
+              %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
+              func.return %15
+          }
+          scf.default {
+              func.unreachable
+          }
       }
-      %43 = tribute_rt.unbox_int %26 : core.i32
-      %44 = arith.const {value = unit} : core.nil
-      func.return %44
   }
-
-  func.func @"run::__clam_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = arith.const {value = 1361557906} : core.i32
-      %6 = func.call %0, %5 {callee = @__tribute_evidence_lookup_tr} : core.ptr
-      %7 = arith.const {value = 664197438} : core.i32
-      %8 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %9 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %10 = func.call_indirect %8, %0, %9, %7, %4 : tribute_rt.anyref
-      %11 = tribute_rt.unbox_int %10 : core.i32
-      %12 = arith.const {value = 1361557906} : core.i32
-      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_tr} : core.ptr
-      %14 = arith.const {value = 2110389019} : core.i32
-      %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %17 = func.call_indirect %15, %0, %16, %14, %10 : tribute_rt.anyref
-      %18 = core.unrealized_conversion_cast %17 : core.nil
-      %19 = core.unrealized_conversion_cast %2 : closure.closure(!t0)
-      %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-      %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-      %22 = func.call_indirect %20, %0, %21, %10 : tribute_rt.anyref
-      func.return %22
+  func.func @"run::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32, %4: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      func.unreachable
   }
-
-  func.func @"run::__clam_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 664197438} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %10 = func.constant {func_ref = @"direct_fn_native::__lambda_0"} : !t0
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 41} : core.i32
-          %13 = tribute_rt.box_int %12 : tribute_rt.anyref
-          %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-          %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 : tribute_rt.anyref
-          scf.yield %16
-      } {
-          %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %18 = func.constant {func_ref = @"direct_fn_native::__lambda_0"} : !t0
-          %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
-          %20 = arith.const {value = unit} : core.nil
-          %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
-          %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-          %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-          %24 = func.call_indirect %22, %0, %23, %21 : tribute_rt.anyref
-          scf.yield %24
-      }
-      func.return %8
+  func.func @"run::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t8
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t12, tribute.calling_convention = 2}
   }
-
-  func.func @"run::__clam_2"(%0: !t1, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
-      %4 = arith.const {value = 664197438} : core.i32
-      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
-      %6 = scf.if %5 : tribute_rt.anyref {
-          %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %8 = func.constant {func_ref = @"direct_fn_native::__lambda_0"} : !t0
-          %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-          %10 = arith.const {value = 41} : core.i32
-          %11 = tribute_rt.box_int %10 : tribute_rt.anyref
-          %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-          %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 : tribute_rt.anyref
-          scf.yield %14
-      } {
-          %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %16 = func.constant {func_ref = @"direct_fn_native::__lambda_0"} : !t0
-          %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
-          %18 = arith.const {value = unit} : core.nil
-          %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
-          %20 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
-          %21 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
-          %22 = func.call_indirect %20, %0, %21, %19 : tribute_rt.anyref
-          scf.yield %22
-      }
-      func.return %6
+  func.func @"run::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run::__clam_7::env"} : !"run::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run::__clam_7::env"} : !t2
+      %4 = adt.struct_get %2 {field = 1, type = !"run::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run::__clam_7::env"} : !__tribute_parent_ty6
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t7, tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty57, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty57_1} : !t9
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"main::__clam_1::env"} : !t9
+      %4 = adt.struct_get %2 {field = 1, type = !"main::__clam_1::env"} : !t4
+      %5 = adt.struct_get %2 {field = 2, type = !"main::__clam_1::env"} : !t5
+      %6 = adt.struct_get %2 {field = 3, type = !"main::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty57_1} : !__tribute_parent_ty57
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
+  }
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0, tribute.root_wrapper = true} {
+      %0 = arith.const {value = unit} : core.nil
+      %1 = adt.struct_new %0 {type = !__tribute_root_completion_cell} : !__tribute_root_completion_cell
+      %2 = func.constant {func_ref = @__tribute_root_done_k} : core.func(core.nil)
+      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
+      %4 = core.unrealized_conversion_cast %3 : !t9
+      %5 = func.constant {func_ref = @__tribute_root_reject_dispatch} : core.func(core.nil, tribute_rt.anyref, !t0, closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)
+      %6 = adt.struct_new %5, %1 {type = !_closure} : !_closure
+      %7 = core.unrealized_conversion_cast %6 : !t4
+      %8 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %9 = func.call %8, %4, %7 {callee = @__tribute_cps_main, tribute.calling_convention = 2, tribute.root_cps_call = true} : core.nil
+      func.return
   }
 }

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -1,131 +1,112 @@
 ---
 source: tests/active_pipeline_goldens.rs
-expression: ir_text
+expression: filter_ir_for_active_pipeline(&full_ir)
 ---
 core.module @mixed_nested_native {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
-  !t0 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !t1 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
-  !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
-  !"run_state_with_console::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state_with_console::__clam_1::__clam_0::env"}
-  !"run_state_with_console::__clam_1::__clam_1::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state_with_console::__clam_1::__clam_1::env"}
-  !t2 = closure.closure(!t0)
-  !t3 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref)
-
+  !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
+  !__tribute_parent_ty6 = adt.typeref() {name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !t4 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6, core.i32)
+  !t5 = closure.closure(core.func(core.nil, core.i32)) {tribute.calling_convention = 2}
+  !t7 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6, tribute_rt.anyref)
+  !t8 = core.func(core.nil, !t0, !__tribute_parent_ty6, tribute_rt.anyref)
+  !t3 = closure.closure(!t8) {tribute.calling_convention = 2}
+  !t6 = core.func(core.nil, !t0, tribute_rt.anyref, !t3, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t9 = core.func(core.nil, !t0, !t3, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t1 = closure.closure(!t9) {tribute.calling_convention = 2}
+  !__tribute_parent_ty6_1 = adt.struct() {fields = [[@done, !t5], [@dispatch, !t1]], name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !t10 = core.func(core.nil, !t0, !__tribute_parent_ty6, core.i32)
+  !t2 = closure.closure(!t10) {tribute.calling_convention = 2}
+  !t11 = core.func(core.nil, tribute_rt.anyref, core.i32)
+  !"run_state_with_console::__clam_2::__clam_1::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_2::__clam_1::env"}
+  !"run_state_with_console::__clam_3::__clam_1::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_3::__clam_1::env"}
+  !"run_state_with_console::__clam_1::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_1::env"}
+  !"run_state_with_console::__clam_9::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_9::env"}
+  !"run_all::__clam_1::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_all::__clam_1::env"}
+  !"run_all::__clam_9::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_all::__clam_9::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::__clam_0::env"}
+  !"run_state_with_console::__clam_7::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"run_state_with_console::__clam_7::env"}
+  !"run_all::__clam_7::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"run_all::__clam_7::env"}
+  !t12 = closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, !t2)) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_23::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_23::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_24::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_24::__clam_0::env"}
+  !"__tribute_make_local_dispatch_22::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t1]], name = @"__tribute_make_local_dispatch_22::__clam_0::env"}
+  !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32]], name = @"step::__clam_0::__clam_0::env"}
+  !"run_all::__clam_4::env" = adt.struct() {fields = [[@_0, closure.closure(core.func(core.i32, !t0)) {tribute.calling_convention = 1}], [@_1, closure.closure(core.func(core.nil, !t0, core.i32)) {tribute.calling_convention = 1}]], name = @"run_all::__clam_4::env"}
+  !__tribute_root_completion_cell = adt.struct(core.nil) {fields = [[@value, core.nil]], name = @__tribute_root_completion_cell}
+  !__tribute_one_shot_state_13 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_13}
+  !__tribute_one_shot_state_14 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_14}
+  !"step::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_14], [@_1, !t2]], name = @"step::__clam_1::env"}
+  !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"step::__clam_0::env"}
+  !__tribute_parent_ty57 = adt.typeref() {name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t14 = closure.closure(core.func(core.nil, !t0, closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t15 = closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, core.i32)) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t0], [@_2, !__tribute_parent_ty57]], name = @"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_25::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t14]], name = @"__tribute_make_dispatch_adapter_25::__clam_0::env"}
+  !t16 = closure.closure(core.func(core.nil)) {tribute.calling_convention = 2}
+  !"main::__clam_1::env" = adt.struct() {fields = [[@_0, !t16], [@_1, !t14], [@_2, !t15], [@_3, !t0]], name = @"main::__clam_1::env"}
+  !__tribute_parent_ty57_1 = adt.struct() {fields = [[@done, !t16], [@dispatch, !t14]], name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !__tribute_ability_payload_50641714 = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_50641714}
+  !__tribute_ability_payload_7dc9fb1b = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_7dc9fb1b}
+  !t18 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty57, core.i32)
+  !t19 = core.func(core.nil, !t0, !__tribute_parent_ty6, core.i32, tribute_rt.anyref)
+  !t20 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6)
+  !t21 = core.func(core.nil, !t0, !__tribute_parent_ty6)
+  !t17 = closure.closure(!t21) {tribute.calling_convention = 2}
+  !t13 = closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, core.i32, !t17)) {tribute.calling_convention = 2}
+  !"__tribute_make_local_dispatch_18::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t2], [@_2, !t0], [@_3, !t12], [@_4, !t13], [@_5, !__tribute_parent_ty6], [@_6, !t1]], name = @"__tribute_make_local_dispatch_18::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t12], [@_4, !t13], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t12], [@_4, !t13], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t12], [@_4, !t13], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t12], [@_4, !t13], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env"}
+  !"step::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_13], [@_1, !t17]], name = @"step::__clam_0::__clam_1::env"}
+  !t22 = core.func(tribute_rt.anyref, !t0, core.i32, tribute_rt.anyref)
+  !__tribute_ability_payload_7590c57e = adt.struct() {fields = [], name = @__tribute_ability_payload_7590c57e}
+  !__tribute_ability_payload_2796d93e = adt.struct() {fields = [], name = @__tribute_ability_payload_2796d93e}
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup_tr(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_empty() -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_extend(%0: core.ptr, %1: core.i32, %2: core.i32, %3: core.ptr, %4: core.ptr) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup(%0: core.ptr, %1: core.i32) -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
-  func.func @"mixed_nested_native::__lambda_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"mixed_nested_native::__lambda_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.variant_new %2 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %3
-  }
-
-  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
-      %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = func.constant {func_ref = @"mixed_nested_native::__lambda_0"} : !t0
-      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"run_all::__clam_0"} : !t0
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = func.constant {func_ref = @"mixed_nested_native::__lambda_1"} : !t0
-      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-      %10 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = func.constant {func_ref = @"run_all::__clam_1"} : !t3
-      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
-      %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %17 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
-      %19 = func.call {callee = @__tribute_next_tag} : core.i32
-      %20 = arith.const {value = 1361557906} : core.i32
-      %21 = core.unrealized_conversion_cast %18 : core.ptr
-      %22 = core.unrealized_conversion_cast %15 : core.ptr
-      %23 = func.call %0, %20, %19, %21, %22 {callee = @__tribute_evidence_extend} : core.ptr
-      %24 = func.call_indirect %11, %23, %12, %9 : tribute_rt.anyref
-      %25 = adt.variant_is %24 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %26 = scf.if %25 : tribute_rt.anyref {
-          %27 = adt.variant_cast %24 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %28 = adt.variant_get %27 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %29 = tribute_rt.unbox_int %28 : core.i32
-          %30 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-          %31 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-          %32 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %33 = func.call_indirect %31, %23, %32, %28 : tribute_rt.anyref
-          scf.yield %33
-      } {
-          %34 = adt.variant_cast %24 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %35 = adt.variant_get %34 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %36 = adt.variant_get %34 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %37 = arith.cmpi %35, %19 {predicate = @eq} : core.i1
-          %38 = scf.if %37 : tribute_rt.anyref {
-              %39 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-              %40 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-              %41 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %42 = func.call_indirect %40, %39, %41, %36 : tribute_rt.anyref
-              scf.yield %42
-          } {
-              scf.yield %24
-          }
-          scf.yield %38
-      }
-      %43 = tribute_rt.unbox_int %26 : core.i32
-      %44 = arith.const {value = unit} : core.nil
-      func.return %44
-  }
-
-  func.func @"step::__clam_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::env"} : core.i32
-      %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::env"} : tribute_rt.anyref
-      %6 = tribute_rt.unbox_int %2 : core.i32
-      %7 = arith.addi %6, %4 : core.i32
-      %8 = adt.struct_new %4, %6, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
-      %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t0
-      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = tribute_rt.box_int %7 : tribute_rt.anyref
-      %12 = arith.const {value = 3214451656} : core.i32
-      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_handler} : core.ptr
-      %14 = func.call %0, %12 {callee = @__tribute_evidence_lookup} : core.i32
-      %15 = arith.const {value = 1348736788} : core.i32
-      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %18 = func.call_indirect %16, %0, %17, %10, %14, %15, %11 : tribute_rt.anyref
-      func.return %18
-  }
-
-  func.func @"run_state_with_console::__clam_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+  func.func @step(%0: !t0, %1: !t5, %2: !t1) -> core.nil attributes {tribute.calling_convention = 2} {
+      %3 = adt.struct_new {type = !__tribute_ability_payload_2796d93e} : !__tribute_ability_payload_2796d93e
       %4 = arith.const {value = 1361557906} : core.i32
       %5 = func.call %0, %4 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %6 = arith.const {value = 664197438} : core.i32
@@ -133,236 +114,417 @@ core.module @mixed_nested_native {
       %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
       %9 = func.call_indirect %7, %0, %8, %6, %3 : tribute_rt.anyref
       %10 = tribute_rt.unbox_int %9 : core.i32
-      %11 = adt.struct_new %10, %2 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
-      %12 = func.constant {func_ref = @"step::__clam_0"} : !t0
+      %11 = adt.struct_new %10 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %12 = func.constant {func_ref = @"step::__clam_0"} : !t10
       %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = arith.const {value = 3214451656} : core.i32
-      %16 = func.call %0, %15 {callee = @__tribute_evidence_lookup_handler} : core.ptr
-      %17 = func.call %0, %15 {callee = @__tribute_evidence_lookup} : core.i32
-      %18 = arith.const {value = 1972422014} : core.i32
-      %19 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
-      %20 = adt.struct_get %16 {field = 1, type = !_closure} : tribute_rt.anyref
-      %21 = func.call_indirect %19, %0, %20, %13, %17, %18, %14 : tribute_rt.anyref
-      func.return %21
+      %14 = arith.const {value = 0} : core.i1
+      %15 = adt.struct_new %14 {type = !__tribute_one_shot_state_14} : !__tribute_one_shot_state_14
+      %16 = adt.struct_new %15, %13 {type = !"step::__clam_1::env"} : !"step::__clam_1::env"
+      %17 = func.constant {func_ref = @"step::__clam_1"} : !t8
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.struct_new {type = !__tribute_ability_payload_7590c57e} : !__tribute_ability_payload_7590c57e
+      %20 = arith.const {value = 2726052536} : core.i32
+      %21 = func.call %0, %20 {callee = @__tribute_evidence_lookup} : core.i32
+      %22 = arith.const {value = 1972422014} : core.i32
+      %23 = adt.struct_get %2 {field = 0, type = !_closure} : core.i32
+      %24 = adt.struct_get %2 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %23, %0, %24, %18, %21, %20, %22, %19 {tribute.calling_convention = 2}
   }
-
-  func.func @"run_state_with_console::__clam_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 1972422014} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.struct_new %3 {type = !"run_state_with_console::__clam_1::__clam_0::env"} : !"run_state_with_console::__clam_1::__clam_0::env"
-          %10 = func.constant {func_ref = @"run_state_with_console::__clam_1::__clam_0"} : !t0
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 7} : core.i32
-          %13 = core.unrealized_conversion_cast %2 : !t2
-          %14 = tribute_rt.box_int %12 : tribute_rt.anyref
-          %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-          %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 : tribute_rt.anyref
-          %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-          %19 = scf.if %18 : tribute_rt.anyref {
-              %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %21 = adt.variant_get %20 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %22 = tribute_rt.unbox_int %21 : core.i32
-              %23 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-              %24 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %25 = func.call_indirect %23, %0, %24, %21 : tribute_rt.anyref
-              %26 = adt.variant_cast %25 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %27 = adt.variant_get %26 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-              %28 = adt.variant_get %26 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %29 = arith.cmpi %27, %3 {predicate = @eq} : core.i1
-              %30 = scf.if %29 : tribute_rt.anyref {
-                  %31 = adt.variant_new %28 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  scf.yield %31
-              } {
-                  scf.yield %25
-              }
-              scf.yield %30
-          } {
-              scf.yield %17
-          }
-          scf.yield %19
-      } {
-          %32 = adt.struct_new %3 {type = !"run_state_with_console::__clam_1::__clam_1::env"} : !"run_state_with_console::__clam_1::__clam_1::env"
-          %33 = func.constant {func_ref = @"run_state_with_console::__clam_1::__clam_1"} : !t0
-          %34 = adt.struct_new %33, %32 {type = !_closure} : !_closure
-          %35 = arith.const {value = unit} : core.nil
-          %36 = core.unrealized_conversion_cast %2 : !t2
-          %37 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
-          %38 = adt.struct_get %36 {field = 0, type = !_closure} : core.i32
-          %39 = adt.struct_get %36 {field = 1, type = !_closure} : tribute_rt.anyref
-          %40 = func.call_indirect %38, %0, %39, %37 : tribute_rt.anyref
-          %41 = adt.variant_is %40 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-          %42 = scf.if %41 : tribute_rt.anyref {
-              %43 = adt.variant_cast %40 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %44 = adt.variant_get %43 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %45 = tribute_rt.unbox_int %44 : core.i32
-              %46 = adt.struct_get %34 {field = 0, type = !_closure} : core.i32
-              %47 = adt.struct_get %34 {field = 1, type = !_closure} : tribute_rt.anyref
-              %48 = func.call_indirect %46, %0, %47, %44 : tribute_rt.anyref
-              %49 = adt.variant_cast %48 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %50 = adt.variant_get %49 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-              %51 = adt.variant_get %49 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %52 = arith.cmpi %50, %3 {predicate = @eq} : core.i1
-              %53 = scf.if %52 : tribute_rt.anyref {
-                  %54 = adt.variant_new %51 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  scf.yield %54
-              } {
-                  scf.yield %48
-              }
-              scf.yield %53
-          } {
-              scf.yield %40
-          }
-          scf.yield %42
-      }
-      func.return %8
-  }
-
-  func.func @"run_all::__clam_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"mixed_nested_native::__lambda_0"} : !t0
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t0
-      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
+  func.func @run_state_with_console(%0: !t0, %1: !t5, %2: !t1) -> core.nil attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t10
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run_state_with_console::__clam_1::env"} : !"run_state_with_console::__clam_1::env"
+      %7 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : core.func(core.nil, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_15, tribute.calling_convention = 0} : !t1
       %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %11 = func.constant {func_ref = @"mixed_nested_native::__lambda_1"} : !t0
+      %11 = func.constant {func_ref = @"run_state_with_console::__clam_2"} : core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, !t2)
       %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
-      %13 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-      %14 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-      %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %16 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t3
-      %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
-      %18 = arith.const {value = 0} : tribute_rt.anyref
-      %19 = func.call {callee = @__tribute_next_tag} : core.i32
-      %20 = arith.const {value = 3214451656} : core.i32
-      %21 = core.unrealized_conversion_cast %18 : core.ptr
-      %22 = core.unrealized_conversion_cast %17 : core.ptr
-      %23 = func.call %0, %20, %19, %21, %22 {callee = @__tribute_evidence_extend} : core.ptr
-      %24 = func.call_indirect %13, %23, %14, %12 : tribute_rt.anyref
-      %25 = adt.variant_is %24 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %26 = scf.if %25 : tribute_rt.anyref {
-          %27 = adt.variant_cast %24 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %28 = adt.variant_get %27 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %29 = tribute_rt.unbox_int %28 : core.i32
-          %30 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-          %31 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-          %32 = func.call_indirect %30, %23, %31, %28 : tribute_rt.anyref
-          scf.yield %32
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run_state_with_console::__clam_3"} : core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, core.i32, !t17)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %17 = func.constant {func_ref = @"run_state_with_console::__clam_4"} : !t22
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run_state_with_console::__clam_5"} : !t19
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = arith.const {value = 2726052536} : core.i32
+      %24 = core.unrealized_conversion_cast %18 : core.ptr
+      %25 = core.unrealized_conversion_cast %21 : core.ptr
+      %26 = func.call %0, %23, %22, %24, %25 {callee = @__tribute_evidence_extend} : core.ptr
+      %27 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %28 = func.constant {func_ref = @"run_state_with_console::__clam_6"} : !t10
+      %29 = adt.struct_new %28, %27 {type = !_closure} : !_closure
+      %30 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %31 = adt.struct_new %29, %26, %30 {type = !"run_state_with_console::__clam_7::env"} : !"run_state_with_console::__clam_7::env"
+      %32 = func.constant {func_ref = @"run_state_with_console::__clam_7"} : core.func(core.nil, core.i32)
+      %33 = adt.struct_new %32, %31 {type = !_closure} : !_closure
+      %34 = func.call %30, %0, %22, %29, %12, %15 {callee = @__tribute_make_local_dispatch_18, tribute.calling_convention = 0} : !t1
+      %35 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %36 = func.constant {func_ref = @"run_state_with_console::__clam_8"} : !t10
+      %37 = adt.struct_new %36, %35 {type = !_closure} : !_closure
+      %38 = adt.struct_new %33, %34, %37, %26 {type = !"run_state_with_console::__clam_9::env"} : !"run_state_with_console::__clam_9::env"
+      %39 = func.constant {func_ref = @"run_state_with_console::__clam_9"} : core.func(core.nil, core.i32)
+      %40 = adt.struct_new %39, %38 {type = !_closure} : !_closure
+      %41 = func.call %37, %34 {callee = @__tribute_make_dispatch_adapter_20, tribute.calling_convention = 0} : !t1
+      func.tail_call %26, %40, %41 {callee = @step, tribute.calling_convention = 2}
+  }
+  func.func @run_all(%0: !t0, %1: !t5, %2: !t1) -> core.nil attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_all::__clam_0"} : !t10
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run_all::__clam_1::env"} : !"run_all::__clam_1::env"
+      %7 = func.constant {func_ref = @"run_all::__clam_1"} : core.func(core.nil, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_21, tribute.calling_convention = 0} : !t1
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(core.i32, !t0)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run_all::__clam_3"} : core.func(core.nil, !t0, core.i32)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.struct_new %12, %15 {type = !"run_all::__clam_4::env"} : !"run_all::__clam_4::env"
+      %17 = func.constant {func_ref = @"run_all::__clam_4"} : !t22
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run_all::__clam_5"} : !t19
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = arith.const {value = 1361557906} : core.i32
+      %24 = core.unrealized_conversion_cast %18 : core.ptr
+      %25 = core.unrealized_conversion_cast %21 : core.ptr
+      %26 = func.call %0, %23, %22, %24, %25 {callee = @__tribute_evidence_extend} : core.ptr
+      %27 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %28 = func.constant {func_ref = @"run_all::__clam_6"} : !t10
+      %29 = adt.struct_new %28, %27 {type = !_closure} : !_closure
+      %30 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %31 = adt.struct_new %29, %26, %30 {type = !"run_all::__clam_7::env"} : !"run_all::__clam_7::env"
+      %32 = func.constant {func_ref = @"run_all::__clam_7"} : core.func(core.nil, core.i32)
+      %33 = adt.struct_new %32, %31 {type = !_closure} : !_closure
+      %34 = adt.struct_get %30 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %35 = func.call %29, %34 {callee = @__tribute_make_dispatch_adapter_23, tribute.calling_convention = 0} : !t1
+      %36 = adt.struct_new %22, %35 {type = !"__tribute_make_local_dispatch_22::__clam_0::env"} : !"__tribute_make_local_dispatch_22::__clam_0::env"
+      %37 = func.constant {func_ref = @"__tribute_make_local_dispatch_22::__clam_0"} : !t9
+      %38 = adt.struct_new %37, %36 {type = !_closure} : !_closure
+      %39 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %40 = func.constant {func_ref = @"run_all::__clam_8"} : !t10
+      %41 = adt.struct_new %40, %39 {type = !_closure} : !_closure
+      %42 = adt.struct_new %33, %38, %41, %26 {type = !"run_all::__clam_9::env"} : !"run_all::__clam_9::env"
+      %43 = func.constant {func_ref = @"run_all::__clam_9"} : core.func(core.nil, core.i32)
+      %44 = adt.struct_new %43, %42 {type = !_closure} : !_closure
+      %45 = func.call %41, %38 {callee = @__tribute_make_dispatch_adapter_24, tribute.calling_convention = 0} : !t1
+      func.tail_call %26, %44, %45 {callee = @run_state_with_console, tribute.calling_convention = 2}
+  }
+  func.func @"step::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"step::__clam_0::env"} : core.i32
+      %6 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %7 = arith.addi %3, %5 : core.i32
+      %8 = adt.struct_new %3, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
+      %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t21
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = arith.const {value = 0} : core.i1
+      %12 = adt.struct_new %11 {type = !__tribute_one_shot_state_13} : !__tribute_one_shot_state_13
+      %13 = adt.struct_new %12, %10 {type = !"step::__clam_0::__clam_1::env"} : !"step::__clam_0::__clam_1::env"
+      %14 = func.constant {func_ref = @"step::__clam_0::__clam_1"} : !t8
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.struct_new %7 {type = !__tribute_ability_payload_50641714} : !__tribute_ability_payload_50641714
+      %17 = arith.const {value = 2726052536} : core.i32
+      %18 = func.call %0, %17 {callee = @__tribute_evidence_lookup} : core.i32
+      %19 = arith.const {value = 1348736788} : core.i32
+      %20 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+      %21 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %20, %0, %21, %15, %18, %17, %19, %16 {tribute.calling_convention = 2}
+  }
+  func.func @"step::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"step::__clam_1::env"} : !"step::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"step::__clam_1::env"} : !__tribute_one_shot_state_14
+      %6 = adt.struct_get %4 {field = 1, type = !"step::__clam_1::env"} : !t2
+      %7 = tribute_rt.unbox_int %3 : core.i32
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_14} : core.i1
+      %9 = scf.if %8 : core.nil {
+          func.unreachable
       } {
-          %33 = adt.variant_cast %24 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %34 = adt.variant_get %33 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %35 = adt.variant_get %33 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %36 = arith.cmpi %34, %19 {predicate = @eq} : core.i1
-          %37 = scf.if %36 : tribute_rt.anyref {
-              %38 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-              %39 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-              %40 = func.call_indirect %38, %0, %39, %35 : tribute_rt.anyref
-              scf.yield %40
-          } {
-              scf.yield %24
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_14}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2, %7 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+      }
+  }
+  func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_1::env"} : !"run_state_with_console::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_1::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: !t0, %4: !t2) -> core.nil attributes {tribute.calling_convention = 2} {
+      %5 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %6 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %7 = arith.const {value = 7} : core.i32
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run_state_with_console::__clam_2::__clam_0"} : !t10
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = adt.struct_new %5, %6, %10, %3 {type = !"run_state_with_console::__clam_2::__clam_1::env"} : !"run_state_with_console::__clam_2::__clam_1::env"
+      %12 = func.constant {func_ref = @"run_state_with_console::__clam_2::__clam_1"} : core.func(core.nil, core.i32)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = func.call %10, %6 {callee = @__tribute_make_dispatch_adapter_16, tribute.calling_convention = 0} : !t1
+      %15 = adt.struct_new %13, %14 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %16 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %16, %3, %17, %15, %7 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: !t0, %4: core.i32, %5: !t17) -> core.nil attributes {tribute.calling_convention = 2} {
+      %6 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %7 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run_state_with_console::__clam_3::__clam_0"} : !t10
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = adt.struct_new %6, %7, %10, %3 {type = !"run_state_with_console::__clam_3::__clam_1::env"} : !"run_state_with_console::__clam_3::__clam_1::env"
+      %12 = func.constant {func_ref = @"run_state_with_console::__clam_3::__clam_1"} : core.func(core.nil, core.i32)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = func.call %10, %7 {callee = @__tribute_make_dispatch_adapter_17, tribute.calling_convention = 0} : !t1
+      %15 = adt.struct_new %13, %14 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %16 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %16, %3, %17, %15 {func.indirect_call_signature = !t20, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      scf.switch %2 {
+          scf.default {
+              func.unreachable
           }
-          scf.yield %37
       }
-      %41 = tribute_rt.unbox_int %26 : core.i32
-      %42 = core.unrealized_conversion_cast %2 : !t2
-      %43 = adt.struct_get %42 {field = 0, type = !_closure} : core.i32
-      %44 = adt.struct_get %42 {field = 1, type = !_closure} : tribute_rt.anyref
-      %45 = func.call_indirect %43, %0, %44, %26 : tribute_rt.anyref
-      func.return %45
   }
-
-  func.func @"run_all::__clam_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 664197438} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %10 = func.constant {func_ref = @"mixed_nested_native::__lambda_0"} : !t0
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 3} : core.i32
-          %13 = tribute_rt.box_int %12 : tribute_rt.anyref
-          %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-          %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 : tribute_rt.anyref
-          scf.yield %16
-      } {
-          %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %18 = func.constant {func_ref = @"mixed_nested_native::__lambda_0"} : !t0
-          %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
-          %20 = arith.const {value = unit} : core.nil
-          %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
-          %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-          %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-          %24 = func.call_indirect %22, %0, %23, %21 : tribute_rt.anyref
-          scf.yield %24
+  func.func @"run_state_with_console::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32, %4: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      func.unreachable
+  }
+  func.func @"run_state_with_console::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_7::env"} : !"run_state_with_console::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_7::env"} : !t2
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_7::env"} : !__tribute_parent_ty6
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_8"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_9"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_9::env"} : !"run_state_with_console::__clam_9::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_9::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_9::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_9::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_9::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_all::__clam_1::env"} : !"run_all::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_all::__clam_1::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_all::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_all::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_all::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_2"(%0: !t0, %1: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %2 = arith.const {value = 3} : core.i32
+      func.return %2
+  }
+  func.func @"run_all::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32) -> core.nil attributes {tribute.calling_convention = 1} {
+      func.return
+  }
+  func.func @"run_all::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      %4 = adt.ref_cast %1 {type = !"run_all::__clam_4::env"} : !"run_all::__clam_4::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"run_all::__clam_4::env"} : closure.closure(core.func(core.i32, !t0)) {tribute.calling_convention = 1}
+      %6 = adt.struct_get %4 {field = 1, type = !"run_all::__clam_4::env"} : closure.closure(core.func(core.nil, !t0, core.i32)) {tribute.calling_convention = 1}
+      scf.switch %2 {
+          scf.case {value = 664197438} {
+              %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+              %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+              %9 = func.call_indirect %7, %0, %8 {func.indirect_call_signature = core.func(core.i32, !t0, tribute_rt.anyref), tribute.calling_convention = 1} : core.i32
+              %10 = tribute_rt.box_int %9 : tribute_rt.anyref
+              func.return %10
+          }
+          scf.case {value = 2110389019} {
+              %11 = adt.struct_get %3 {field = 0, type = !__tribute_ability_payload_7dc9fb1b} : core.i32
+              %12 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+              %13 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+              %14 = func.call_indirect %12, %0, %13, %11 {func.indirect_call_signature = core.func(core.nil, !t0, tribute_rt.anyref, core.i32), tribute.calling_convention = 1} : core.nil
+              %15 = core.unrealized_conversion_cast %14 : tribute_rt.anyref
+              func.return %15
+          }
+          scf.default {
+              func.unreachable
+          }
       }
-      func.return %8
   }
-
-  func.func @"run_all::__clam_2"(%0: !t1, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
-      %4 = arith.const {value = 664197438} : core.i32
-      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
-      %6 = scf.if %5 : tribute_rt.anyref {
-          %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %8 = func.constant {func_ref = @"mixed_nested_native::__lambda_0"} : !t0
-          %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-          %10 = arith.const {value = 3} : core.i32
-          %11 = tribute_rt.box_int %10 : tribute_rt.anyref
-          %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-          %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 : tribute_rt.anyref
-          scf.yield %14
-      } {
-          %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %16 = func.constant {func_ref = @"mixed_nested_native::__lambda_0"} : !t0
-          %17 = adt.struct_new %16, %15 {type = !_closure} : !_closure
-          %18 = arith.const {value = unit} : core.nil
-          %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
-          %20 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
-          %21 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
-          %22 = func.call_indirect %20, %0, %21, %19 : tribute_rt.anyref
-          scf.yield %22
-      }
-      func.return %6
+  func.func @"run_all::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32, %4: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      func.unreachable
   }
-
-  func.func @"step::__clam_0::__clam_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"run_all::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_all::__clam_7::env"} : !"run_all::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_all::__clam_7::env"} : !t2
+      %4 = adt.struct_get %2 {field = 1, type = !"run_all::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run_all::__clam_7::env"} : !__tribute_parent_ty6
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_8"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_9"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_all::__clam_9::env"} : !"run_all::__clam_9::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_all::__clam_9::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_all::__clam_9::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_all::__clam_9::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_all::__clam_9::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty57, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty57_1} : !t16
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"main::__clam_1::env"} : !t16
+      %4 = adt.struct_get %2 {field = 1, type = !"main::__clam_1::env"} : !t14
+      %5 = adt.struct_get %2 {field = 2, type = !"main::__clam_1::env"} : !t15
+      %6 = adt.struct_get %2 {field = 3, type = !"main::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty57_1} : !__tribute_parent_ty57
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t18, tribute.calling_convention = 2}
+  }
+  func.func @"step::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6) -> core.nil attributes {tribute.calling_convention = 2} {
       %3 = adt.ref_cast %1 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
       %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::__clam_0::env"} : core.i32
       %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::__clam_0::env"} : core.i32
-      %6 = adt.struct_get %3 {field = 2, type = !"step::__clam_0::__clam_0::env"} : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %2 : core.nil
-      %8 = tribute_rt.box_int %5 : tribute_rt.anyref
-      %9 = arith.const {value = 1361557906} : core.i32
-      %10 = func.call %0, %9 {callee = @__tribute_evidence_lookup_tr} : core.ptr
-      %11 = arith.const {value = 2110389019} : core.i32
-      %12 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
-      %13 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = func.call_indirect %12, %0, %13, %11, %8 : tribute_rt.anyref
-      %15 = core.unrealized_conversion_cast %14 : core.nil
-      %16 = arith.addi %5, %4 : core.i32
-      %17 = core.unrealized_conversion_cast %6 : !t2
-      %18 = tribute_rt.box_int %16 : tribute_rt.anyref
-      %19 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
-      %20 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
-      %21 = func.call_indirect %19, %0, %20, %18 : tribute_rt.anyref
-      func.return %21
+      %6 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %7 = adt.struct_new %4 {type = !__tribute_ability_payload_7dc9fb1b} : !__tribute_ability_payload_7dc9fb1b
+      %8 = arith.const {value = 1361557906} : core.i32
+      %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup_tr} : core.ptr
+      %10 = arith.const {value = 2110389019} : core.i32
+      %11 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
+      %12 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
+      %13 = func.call_indirect %11, %0, %12, %10, %7 : tribute_rt.anyref
+      %14 = core.unrealized_conversion_cast %13 : core.nil
+      %15 = arith.addi %4, %5 : core.i32
+      %16 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %16, %17, %15 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
   }
-
-  func.func @"run_state_with_console::__clam_1::__clam_0"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state_with_console::__clam_1::__clam_0::env"} : !"run_state_with_console::__clam_1::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state_with_console::__clam_1::__clam_0::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"step::__clam_0::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"step::__clam_0::__clam_1::env"} : !"step::__clam_0::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"step::__clam_0::__clam_1::env"} : !__tribute_one_shot_state_13
+      %6 = adt.struct_get %4 {field = 1, type = !"step::__clam_0::__clam_1::env"} : !t17
+      %7 = core.unrealized_conversion_cast %3 : core.nil
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_13} : core.i1
+      %9 = scf.if %8 : core.nil {
+          func.unreachable
+      } {
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_13}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2 {func.indirect_call_signature = !t20, tribute.calling_convention = 2}
+      }
   }
-
-  func.func @"run_state_with_console::__clam_1::__clam_1"(%0: !t1, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state_with_console::__clam_1::__clam_1::env"} : !"run_state_with_console::__clam_1::__clam_1::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state_with_console::__clam_1::__clam_1::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"run_state_with_console::__clam_2::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_2::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_2::__clam_1::env"} : !"run_state_with_console::__clam_2::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_3::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t11, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_3::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_3::__clam_1::env"} : !"run_state_with_console::__clam_3::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0, tribute.root_wrapper = true} {
+      %0 = arith.const {value = unit} : core.nil
+      %1 = adt.struct_new %0 {type = !__tribute_root_completion_cell} : !__tribute_root_completion_cell
+      %2 = func.constant {func_ref = @__tribute_root_done_k} : core.func(core.nil)
+      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
+      %4 = core.unrealized_conversion_cast %3 : !t16
+      %5 = func.constant {func_ref = @__tribute_root_reject_dispatch} : core.func(core.nil, tribute_rt.anyref, !t0, closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)
+      %6 = adt.struct_new %5, %1 {type = !_closure} : !_closure
+      %7 = core.unrealized_conversion_cast %6 : !t14
+      %8 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %9 = func.call %8, %4, %7 {callee = @__tribute_cps_main, tribute.calling_convention = 2, tribute.root_cps_call = true} : core.nil
+      func.return
   }
 }

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -1,239 +1,362 @@
 ---
 source: tests/active_pipeline_goldens.rs
-expression: ir_text
+expression: filter_ir_for_active_pipeline(&full_ir)
 ---
 core.module @resumptive_op_native {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
-  !"run_state::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state::__clam_1::__clam_0::env"}
-  !"run_state::__clam_1::__clam_1::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state::__clam_1::__clam_1::env"}
-  !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
-  !t2 = closure.closure(!t1)
-
+  !__tribute_parent_ty6 = adt.typeref() {name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !t4 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6, core.i32)
+  !t5 = closure.closure(core.func(core.nil, core.i32)) {tribute.calling_convention = 2}
+  !t6 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6, tribute_rt.anyref)
+  !t8 = core.func(core.nil, !t0, !__tribute_parent_ty6, tribute_rt.anyref)
+  !t3 = closure.closure(!t8) {tribute.calling_convention = 2}
+  !t7 = core.func(core.nil, !t0, tribute_rt.anyref, !t3, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t9 = core.func(core.nil, !t0, !t3, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t1 = closure.closure(!t9) {tribute.calling_convention = 2}
+  !__tribute_parent_ty6_1 = adt.struct() {fields = [[@done, !t5], [@dispatch, !t1]], name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !t10 = core.func(core.nil, !t0, !__tribute_parent_ty6, core.i32)
+  !t2 = closure.closure(!t10) {tribute.calling_convention = 2}
+  !"run_state::__clam_2::__clam_1::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state::__clam_2::__clam_1::env"}
+  !"run_state::__clam_3::__clam_1::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state::__clam_3::__clam_1::env"}
+  !"run_state::__clam_1::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state::__clam_1::env"}
+  !"run_state::__clam_9::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state::__clam_9::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env"}
+  !"run_state::__clam_7::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"run_state::__clam_7::env"}
+  !t11 = closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, !t2)) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::env"}
+  !t14 = core.func(core.nil, tribute_rt.anyref, core.i32)
+  !__tribute_root_completion_cell = adt.struct(core.nil) {fields = [[@value, core.nil]], name = @__tribute_root_completion_cell}
+  !__tribute_one_shot_state_13 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_13}
+  !__tribute_one_shot_state_14 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_14}
+  !"bump::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_14], [@_1, !t2]], name = @"bump::__clam_1::env"}
+  !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"bump::__clam_0::__clam_0::env"}
+  !__tribute_parent_ty57 = adt.typeref() {name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t13 = closure.closure(core.func(core.nil, !t0, closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t15 = closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, core.i32)) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t0], [@_2, !__tribute_parent_ty57]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t13]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::env"}
+  !t16 = closure.closure(core.func(core.nil)) {tribute.calling_convention = 2}
+  !"main::__clam_1::env" = adt.struct() {fields = [[@_0, !t16], [@_1, !t13], [@_2, !t15], [@_3, !t0]], name = @"main::__clam_1::env"}
+  !__tribute_parent_ty57_1 = adt.struct() {fields = [[@done, !t16], [@dispatch, !t13]], name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !__tribute_ability_payload_50641714 = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_50641714}
+  !t18 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty57, core.i32)
+  !t19 = core.func(core.nil, !t0, tribute_rt.anyref, !__tribute_parent_ty6)
+  !t20 = core.func(core.nil, !t0, !__tribute_parent_ty6)
+  !t17 = closure.closure(!t20) {tribute.calling_convention = 2}
+  !t12 = closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, core.i32, !t17)) {tribute.calling_convention = 2}
+  !"__tribute_make_local_dispatch_18::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t2], [@_2, !t0], [@_3, !t11], [@_4, !t12], [@_5, !__tribute_parent_ty6], [@_6, !t1]], name = @"__tribute_make_local_dispatch_18::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t11], [@_4, !t12], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t11], [@_4, !t12], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t11], [@_4, !t12], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t11], [@_4, !t12], [@_5, !t3]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env"}
+  !"bump::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_13], [@_1, !t17]], name = @"bump::__clam_0::__clam_1::env"}
+  !__tribute_ability_payload_7590c57e = adt.struct() {fields = [], name = @__tribute_ability_payload_7590c57e}
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup_tr(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_empty() -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_extend(%0: core.ptr, %1: core.i32, %2: core.i32, %3: core.ptr, %4: core.ptr) -> core.ptr attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup(%0: core.ptr, %1: core.i32) -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
-  func.func @"resumptive_op_native::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op_native::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.variant_new %2 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %3
-  }
-
-  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
-      %0 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = func.constant {func_ref = @"resumptive_op_native::__lambda_0"} : !t1
-      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"run_state::__clam_0"} : !t1
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = func.constant {func_ref = @"resumptive_op_native::__lambda_1"} : !t1
-      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-      %10 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref)
-      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
-      %16 = arith.const {value = 0} : tribute_rt.anyref
-      %17 = func.call {callee = @__tribute_next_tag} : core.i32
-      %18 = arith.const {value = 3214451656} : core.i32
-      %19 = core.unrealized_conversion_cast %16 : core.ptr
-      %20 = core.unrealized_conversion_cast %15 : core.ptr
-      %21 = func.call %0, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
-      %22 = func.call_indirect %11, %21, %12, %9 : tribute_rt.anyref
-      %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %24 = scf.if %23 : tribute_rt.anyref {
-          %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %26 = adt.variant_get %25 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %27 = tribute_rt.unbox_int %26 : core.i32
-          %28 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-          %29 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-          %30 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %31 = func.call_indirect %29, %21, %30, %26 : tribute_rt.anyref
-          scf.yield %31
-      } {
-          %32 = adt.variant_cast %22 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %33 = adt.variant_get %32 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %34 = adt.variant_get %32 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %35 = arith.cmpi %33, %17 {predicate = @eq} : core.i1
-          %36 = scf.if %35 : tribute_rt.anyref {
-              %37 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-              %38 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-              %39 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %40 = func.call_indirect %38, %37, %39, %34 : tribute_rt.anyref
-              scf.yield %40
-          } {
-              scf.yield %22
-          }
-          scf.yield %36
-      }
-      %41 = tribute_rt.unbox_int %24 : core.i32
-      %42 = arith.const {value = unit} : core.nil
-      func.return %42
-  }
-
-  func.func @"bump::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::env"} : tribute_rt.anyref
-      %5 = tribute_rt.unbox_int %2 : core.i32
-      %6 = arith.const {value = 1} : core.i32
-      %7 = arith.addi %5, %6 : core.i32
-      %8 = adt.struct_new %5, %4 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
-      %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t1
+  func.func @bump(%0: !t0, %1: !t5, %2: !t1) -> core.nil attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"bump::__clam_0"} : !t10
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = arith.const {value = 0} : core.i1
+      %7 = adt.struct_new %6 {type = !__tribute_one_shot_state_14} : !__tribute_one_shot_state_14
+      %8 = adt.struct_new %7, %5 {type = !"bump::__clam_1::env"} : !"bump::__clam_1::env"
+      %9 = func.constant {func_ref = @"bump::__clam_1"} : !t8
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = tribute_rt.box_int %7 : tribute_rt.anyref
-      %12 = arith.const {value = 3214451656} : core.i32
-      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_handler} : core.ptr
-      %14 = func.call %0, %12 {callee = @__tribute_evidence_lookup} : core.i32
-      %15 = arith.const {value = 1348736788} : core.i32
-      %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-      %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %18 = func.call_indirect %16, %0, %17, %10, %14, %15, %11 : tribute_rt.anyref
-      func.return %18
+      %11 = adt.struct_new {type = !__tribute_ability_payload_7590c57e} : !__tribute_ability_payload_7590c57e
+      %12 = arith.const {value = 2726052536} : core.i32
+      %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup} : core.i32
+      %14 = arith.const {value = 1972422014} : core.i32
+      %15 = adt.struct_get %2 {field = 0, type = !_closure} : core.i32
+      %16 = adt.struct_get %2 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %15, %0, %16, %10, %13, %12, %14, %11 {tribute.calling_convention = 2}
   }
-
-  func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = func.call {callee = @__tribute_evidence_empty} : core.ptr
-      %4 = adt.struct_new %2 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
-      %5 = func.constant {func_ref = @"bump::__clam_0"} : !t1
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = arith.const {value = 3214451656} : core.i32
-      %9 = func.call %0, %8 {callee = @__tribute_evidence_lookup_handler} : core.ptr
-      %10 = func.call %0, %8 {callee = @__tribute_evidence_lookup} : core.i32
-      %11 = arith.const {value = 1972422014} : core.i32
-      %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-      %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = func.call_indirect %12, %0, %13, %6, %10, %11, %7 : tribute_rt.anyref
-      func.return %14
+  func.func @run_state(%0: !t0, %1: !t5, %2: !t1) -> core.nil attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_state::__clam_0"} : !t10
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run_state::__clam_1::env"} : !"run_state::__clam_1::env"
+      %7 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(core.nil, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_15, tribute.calling_convention = 0} : !t1
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_state::__clam_2"} : core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, !t2)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run_state::__clam_3"} : core.func(core.nil, !t0, !__tribute_parent_ty6, !t0, core.i32, !t17)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %17 = func.constant {func_ref = @"run_state::__clam_4"} : core.func(tribute_rt.anyref, !t0, core.i32, tribute_rt.anyref)
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run_state::__clam_5"} : core.func(core.nil, !t0, !__tribute_parent_ty6, core.i32, tribute_rt.anyref)
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = arith.const {value = 2726052536} : core.i32
+      %24 = core.unrealized_conversion_cast %18 : core.ptr
+      %25 = core.unrealized_conversion_cast %21 : core.ptr
+      %26 = func.call %0, %23, %22, %24, %25 {callee = @__tribute_evidence_extend} : core.ptr
+      %27 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %28 = func.constant {func_ref = @"run_state::__clam_6"} : !t10
+      %29 = adt.struct_new %28, %27 {type = !_closure} : !_closure
+      %30 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %31 = adt.struct_new %29, %26, %30 {type = !"run_state::__clam_7::env"} : !"run_state::__clam_7::env"
+      %32 = func.constant {func_ref = @"run_state::__clam_7"} : core.func(core.nil, core.i32)
+      %33 = adt.struct_new %32, %31 {type = !_closure} : !_closure
+      %34 = func.call %30, %0, %22, %29, %12, %15 {callee = @__tribute_make_local_dispatch_18, tribute.calling_convention = 0} : !t1
+      %35 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %36 = func.constant {func_ref = @"run_state::__clam_8"} : !t10
+      %37 = adt.struct_new %36, %35 {type = !_closure} : !_closure
+      %38 = adt.struct_new %33, %34, %37, %26 {type = !"run_state::__clam_9::env"} : !"run_state::__clam_9::env"
+      %39 = func.constant {func_ref = @"run_state::__clam_9"} : core.func(core.nil, core.i32)
+      %40 = adt.struct_new %39, %38 {type = !_closure} : !_closure
+      %41 = func.call %37, %34 {callee = @__tribute_make_dispatch_adapter_20, tribute.calling_convention = 0} : !t1
+      func.tail_call %26, %40, %41 {callee = @bump, tribute.calling_convention = 2}
   }
-
-  func.func @"run_state::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 1972422014} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.struct_new %3 {type = !"run_state::__clam_1::__clam_0::env"} : !"run_state::__clam_1::__clam_0::env"
-          %10 = func.constant {func_ref = @"run_state::__clam_1::__clam_0"} : !t1
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 10} : core.i32
-          %13 = core.unrealized_conversion_cast %2 : !t2
-          %14 = tribute_rt.box_int %12 : tribute_rt.anyref
-          %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-          %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 : tribute_rt.anyref
-          %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-          %19 = scf.if %18 : tribute_rt.anyref {
-              %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %21 = adt.variant_get %20 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %22 = tribute_rt.unbox_int %21 : core.i32
-              %23 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-              %24 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %25 = func.call_indirect %23, %0, %24, %21 : tribute_rt.anyref
-              %26 = adt.variant_cast %25 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %27 = adt.variant_get %26 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-              %28 = adt.variant_get %26 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %29 = arith.cmpi %27, %3 {predicate = @eq} : core.i1
-              %30 = scf.if %29 : tribute_rt.anyref {
-                  %31 = adt.variant_new %28 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  scf.yield %31
-              } {
-                  scf.yield %25
-              }
-              scf.yield %30
-          } {
-              scf.yield %17
-          }
-          scf.yield %19
+  func.func @"bump::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %5 = arith.const {value = 1} : core.i32
+      %6 = arith.addi %3, %5 : core.i32
+      %7 = adt.struct_new %3 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
+      %8 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t20
+      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
+      %10 = arith.const {value = 0} : core.i1
+      %11 = adt.struct_new %10 {type = !__tribute_one_shot_state_13} : !__tribute_one_shot_state_13
+      %12 = adt.struct_new %11, %9 {type = !"bump::__clam_0::__clam_1::env"} : !"bump::__clam_0::__clam_1::env"
+      %13 = func.constant {func_ref = @"bump::__clam_0::__clam_1"} : !t8
+      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
+      %15 = adt.struct_new %6 {type = !__tribute_ability_payload_50641714} : !__tribute_ability_payload_50641714
+      %16 = arith.const {value = 2726052536} : core.i32
+      %17 = func.call %0, %16 {callee = @__tribute_evidence_lookup} : core.i32
+      %18 = arith.const {value = 1348736788} : core.i32
+      %19 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %20 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %19, %0, %20, %14, %17, %16, %18, %15 {tribute.calling_convention = 2}
+  }
+  func.func @"bump::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"bump::__clam_1::env"} : !"bump::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"bump::__clam_1::env"} : !__tribute_one_shot_state_14
+      %6 = adt.struct_get %4 {field = 1, type = !"bump::__clam_1::env"} : !t2
+      %7 = tribute_rt.unbox_int %3 : core.i32
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_14} : core.i1
+      %9 = scf.if %8 : core.nil {
+          func.unreachable
       } {
-          %32 = adt.struct_new %3 {type = !"run_state::__clam_1::__clam_1::env"} : !"run_state::__clam_1::__clam_1::env"
-          %33 = func.constant {func_ref = @"run_state::__clam_1::__clam_1"} : !t1
-          %34 = adt.struct_new %33, %32 {type = !_closure} : !_closure
-          %35 = arith.const {value = unit} : core.nil
-          %36 = core.unrealized_conversion_cast %2 : !t2
-          %37 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
-          %38 = adt.struct_get %36 {field = 0, type = !_closure} : core.i32
-          %39 = adt.struct_get %36 {field = 1, type = !_closure} : tribute_rt.anyref
-          %40 = func.call_indirect %38, %0, %39, %37 : tribute_rt.anyref
-          %41 = adt.variant_is %40 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-          %42 = scf.if %41 : tribute_rt.anyref {
-              %43 = adt.variant_cast %40 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %44 = adt.variant_get %43 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %45 = tribute_rt.unbox_int %44 : core.i32
-              %46 = adt.struct_get %34 {field = 0, type = !_closure} : core.i32
-              %47 = adt.struct_get %34 {field = 1, type = !_closure} : tribute_rt.anyref
-              %48 = func.call_indirect %46, %0, %47, %44 : tribute_rt.anyref
-              %49 = adt.variant_cast %48 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %50 = adt.variant_get %49 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-              %51 = adt.variant_get %49 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %52 = arith.cmpi %50, %3 {predicate = @eq} : core.i1
-              %53 = scf.if %52 : tribute_rt.anyref {
-                  %54 = adt.variant_new %51 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  scf.yield %54
-              } {
-                  scf.yield %48
-              }
-              scf.yield %53
-          } {
-              scf.yield %40
-          }
-          scf.yield %42
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_14}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2, %7 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
       }
-      func.return %8
   }
-
-  func.func @"bump::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t14, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_1::env"} : !"run_state::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_1::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: !t0, %4: !t2) -> core.nil attributes {tribute.calling_convention = 2} {
+      %5 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %6 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %7 = arith.const {value = 10} : core.i32
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run_state::__clam_2::__clam_0"} : !t10
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = adt.struct_new %5, %6, %10, %3 {type = !"run_state::__clam_2::__clam_1::env"} : !"run_state::__clam_2::__clam_1::env"
+      %12 = func.constant {func_ref = @"run_state::__clam_2::__clam_1"} : core.func(core.nil, core.i32)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = func.call %10, %6 {callee = @__tribute_make_dispatch_adapter_16, tribute.calling_convention = 0} : !t1
+      %15 = adt.struct_new %13, %14 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %16 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %16, %3, %17, %15, %7 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: !t0, %4: core.i32, %5: !t17) -> core.nil attributes {tribute.calling_convention = 2} {
+      %6 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %7 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run_state::__clam_3::__clam_0"} : !t10
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = adt.struct_new %6, %7, %10, %3 {type = !"run_state::__clam_3::__clam_1::env"} : !"run_state::__clam_3::__clam_1::env"
+      %12 = func.constant {func_ref = @"run_state::__clam_3::__clam_1"} : core.func(core.nil, core.i32)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = func.call %10, %7 {callee = @__tribute_make_dispatch_adapter_17, tribute.calling_convention = 0} : !t1
+      %15 = adt.struct_new %13, %14 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %16 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %16, %3, %17, %15 {func.indirect_call_signature = !t19, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      scf.switch %2 {
+          scf.default {
+              func.unreachable
+          }
+      }
+  }
+  func.func @"run_state::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32, %4: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      func.unreachable
+  }
+  func.func @"run_state::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t14, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_7::env"} : !"run_state::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_7::env"} : !t2
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_7::env"} : !__tribute_parent_ty6
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_8"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t14, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_9"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_9::env"} : !"run_state::__clam_9::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_9::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_9::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_9::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_9::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty57, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty57_1} : !t16
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"main::__clam_1::env"} : !t16
+      %4 = adt.struct_get %2 {field = 1, type = !"main::__clam_1::env"} : !t13
+      %5 = adt.struct_get %2 {field = 2, type = !"main::__clam_1::env"} : !t15
+      %6 = adt.struct_get %2 {field = 3, type = !"main::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty57_1} : !__tribute_parent_ty57
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t18, tribute.calling_convention = 2}
+  }
+  func.func @"bump::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6) -> core.nil attributes {tribute.calling_convention = 2} {
       %3 = adt.ref_cast %1 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
       %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::__clam_0::env"} : core.i32
-      %5 = adt.struct_get %3 {field = 1, type = !"bump::__clam_0::__clam_0::env"} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %2 : core.nil
-      %7 = core.unrealized_conversion_cast %5 : !t2
-      %8 = tribute_rt.box_int %4 : tribute_rt.anyref
-      %9 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = func.call_indirect %9, %0, %10, %8 : tribute_rt.anyref
-      func.return %11
+      %5 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %6 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %4 {func.indirect_call_signature = !t14, tribute.calling_convention = 2}
   }
-
-  func.func @"run_state::__clam_1::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state::__clam_1::__clam_0::env"} : !"run_state::__clam_1::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state::__clam_1::__clam_0::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"bump::__clam_0::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"bump::__clam_0::__clam_1::env"} : !"bump::__clam_0::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"bump::__clam_0::__clam_1::env"} : !__tribute_one_shot_state_13
+      %6 = adt.struct_get %4 {field = 1, type = !"bump::__clam_0::__clam_1::env"} : !t17
+      %7 = core.unrealized_conversion_cast %3 : core.nil
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_13} : core.i1
+      %9 = scf.if %8 : core.nil {
+          func.unreachable
+      } {
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_13}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2 {func.indirect_call_signature = !t19, tribute.calling_convention = 2}
+      }
   }
-
-  func.func @"run_state::__clam_1::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state::__clam_1::__clam_1::env"} : !"run_state::__clam_1::__clam_1::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state::__clam_1::__clam_1::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"run_state::__clam_2::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t14, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_2::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_2::__clam_1::env"} : !"run_state::__clam_2::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_2::__clam_1::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_2::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_2::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_2::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_3::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t5
+      %5 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %5, %6, %3 {func.indirect_call_signature = !t14, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_3::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_3::__clam_1::env"} : !"run_state::__clam_3::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_3::__clam_1::env"} : !t5
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_3::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_3::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_3::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t4, tribute.calling_convention = 2}
+  }
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0, tribute.root_wrapper = true} {
+      %0 = arith.const {value = unit} : core.nil
+      %1 = adt.struct_new %0 {type = !__tribute_root_completion_cell} : !__tribute_root_completion_cell
+      %2 = func.constant {func_ref = @__tribute_root_done_k} : core.func(core.nil)
+      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
+      %4 = core.unrealized_conversion_cast %3 : !t16
+      %5 = func.constant {func_ref = @__tribute_root_reject_dispatch} : core.func(core.nil, tribute_rt.anyref, !t0, closure.closure(core.func(core.nil, !t0, !__tribute_parent_ty57, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)
+      %6 = adt.struct_new %5, %1 {type = !_closure} : !_closure
+      %7 = core.unrealized_conversion_cast %6 : !t13
+      %8 = func.call {callee = @__tribute_evidence_empty} : core.ptr
+      %9 = func.call %8, %4, %7 {callee = @__tribute_cps_main, tribute.calling_convention = 2, tribute.root_cps_call = true} : core.nil
+      func.return
   }
 }

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -4,201 +4,321 @@ expression: ir_text
 ---
 core.module @direct_fn {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
-  !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !String = adt.typeref() {name = @String}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !String_1 = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [!String, !String, core.i32]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !Result_1 = adt.typeref() {name = @Result}
+  !"String::Cursor_1" = adt.typeref() {name = @"String::Cursor"}
+  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [!String, !"String::Cursor_1"]], [@CursorChunk, [core.bytes, core.i32, core.i32, !"String::Cursor_1"]]]}
+  !__tribute_parent_ty25_1 = adt.typeref() {name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !Option_1 = adt.typeref() {name = @Option}
+  !__tribute_parent_ty17_1 = adt.typeref() {name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !__tribute_parent_ty5_1 = adt.typeref() {name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
-  !t2 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !t1 = closure.closure(!t2)
-  !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
-  !"Result::map_err::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map_err::__clam_0::env"}
-  !"Option::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Option::map::__clam_0::env"}
-  !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
+  !__tribute_parent_ty6_1 = adt.typeref() {name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !"Result$Int$Int::ParseError" = adt.typeref() {name = @"Result$Int$Int::ParseError"}
+  !t14 = core.func(core.never, tribute_rt.anyref, !Result_1)
+  !t18 = core.func(core.never, !Result_1)
+  !t4 = closure.closure(!t18) {tribute.calling_convention = 2}
+  !t20 = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !t29 = core.func(core.never, tribute_rt.anyref, !Option_1)
+  !t30 = core.func(core.never, !Option_1)
+  !t10 = closure.closure(!t30) {tribute.calling_convention = 2}
+  !t31 = core.func(core.never, !String)
+  !t13 = closure.closure(!t31) {tribute.calling_convention = 2}
+  !t32 = core.func(core.never, tribute_rt.anyref)
+  !__tribute_ability_payload_7dc9fb1b = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_7dc9fb1b}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
-  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !t4 = core.ability_ref() {name = @"abilities::Throw"}
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !t42 = closure.closure(core.func(core.never, core.nil)) {tribute.calling_convention = 2}
+  !__tribute_parent_ty57_1 = adt.typeref() {name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t43 = core.func(core.never, tribute_rt.anyref, !String)
+  !"Int::ParseError_1" = adt.typeref() {name = @"Int::ParseError"}
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, !String]], name = @"std::io::SystemError"}
+  !__tribute_parent_ty0_1 = adt.typeref() {name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !__tribute_ability_payload_2796d93e = adt.struct() {fields = [], name = @__tribute_ability_payload_2796d93e}
+  !t56 = core.func(core.never, tribute_rt.anyref, core.i32)
+  !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [!"std::io::SystemError_1"]]]}
+  !"std::io::Error_1" = adt.typeref() {name = @"std::io::Error"}
+  !__tribute_ability_payload_0efb32ee = adt.struct() {fields = [[@arg0, !"std::io::Error_1"]], name = @__tribute_ability_payload_0efb32ee}
+  !t55 = core.ability_ref(!"std::io::Error_1") {name = @"abilities::Throw"}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t3 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
-  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-
+  !t15 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, !Result_1)
+  !t16 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t17 = core.func(core.never, !t0, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t7 = closure.closure(!t17) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env"}
+  !t21 = closure.closure(core.func(core.never, !t0, closure.closure(core.func(core.never, !t0, !__tribute_parent_ty57_1, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t23 = core.func(core.never, !t0, tribute_rt.anyref, !t7, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t24 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty0_1, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t26 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, !Option_1)
+  !t27 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, !String)
+  !t28 = core.func(core.never, !t0, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t25 = closure.closure(!t28) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t24]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t24]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env"}
+  !t33 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty57_1, core.i32)) {tribute.calling_convention = 2}
+  !"main::__clam_1::env" = adt.struct() {fields = [[@_0, !t42], [@_1, !t21], [@_2, !t33], [@_3, !t0]], name = @"main::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t33], [@_1, !t0], [@_2, !__tribute_parent_ty57_1]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::env" = adt.struct() {fields = [[@_0, !t33], [@_1, !t21]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::env"}
+  !t34 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t35 = core.func(core.never, !t0, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t11 = closure.closure(!t35) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t24]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env"}
+  !__tribute_parent_ty57 = adt.struct() {fields = [[@done, !t42], [@dispatch, !t21]], name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t36 = core.func(core.never, !t0, tribute_rt.anyref, !t11, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t38 = core.func(core.never, !t0, !t7, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t1 = closure.closure(!t38) {tribute.calling_convention = 2}
+  !__tribute_parent_ty25 = adt.struct() {fields = [[@done, !t4], [@dispatch, !t1]], name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !"Result::map_err::__clam_3::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t7], [@_3, !t0]], name = @"Result::map_err::__clam_3::env"}
+  !"Result::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t7], [@_3, !t0]], name = @"Result::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::env"}
+  !t40 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6_1, core.i32)
+  !t41 = core.func(core.never, !t0, !__tribute_parent_ty25_1, !Result_1)
+  !t5 = closure.closure(!t41) {tribute.calling_convention = 2}
+  !"Result::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::and_then::__clam_1::env"}
+  !"Result::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::and_then::__clam_3::env"}
+  !"Result::map_err::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::map_err::__clam_1::env"}
+  !"Result::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t7]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t7]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t7]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t7]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::env"}
+  !t46 = core.func(core.never, !t0, tribute_rt.anyref, !t25, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t47 = core.func(core.never, !t0, !t11, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t2 = closure.closure(!t47) {tribute.calling_convention = 2}
+  !__tribute_parent_ty17 = adt.struct() {fields = [[@done, !t10], [@dispatch, !t2]], name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !"Option::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t10], [@_1, !t2], [@_2, !t11], [@_3, !t0]], name = @"Option::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::env"}
+  !t48 = core.func(core.never, !t0, !t24, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t22 = closure.closure(!t48) {tribute.calling_convention = 2}
+  !t44 = closure.closure(core.func(core.never, !t0, closure.closure(!t32) {tribute.calling_convention = 2}, !t22, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t45 = core.func(core.never, !t0, tribute_rt.anyref, closure.closure(!t32) {tribute.calling_convention = 2}, !t22, tribute_rt.anyref)
+  !t49 = core.func(core.never, !t0, !t25, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t3 = closure.closure(!t49) {tribute.calling_convention = 2}
+  !__tribute_parent_ty5 = adt.struct() {fields = [[@done, !t13], [@dispatch, !t3]], name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
+  !t50 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t51 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6_1, tribute_rt.anyref)
+  !t52 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty0_1, tribute_rt.anyref)
+  !t53 = core.func(core.never, !t0, !__tribute_parent_ty17_1, !Option_1)
+  !t8 = closure.closure(!t53) {tribute.calling_convention = 2}
+  !"Option::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t10], [@_1, !t2], [@_2, !t8], [@_3, !t0]], name = @"Option::and_then::__clam_1::env"}
+  !"Option::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t10], [@_1, !t2], [@_2, !t8], [@_3, !t0]], name = @"Option::and_then::__clam_3::env"}
+  !"Option::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t10], [@_1, !t2], [@_2, !t8], [@_3, !t0]], name = @"Option::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t11]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t11]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t11]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::env"}
+  !t54 = core.func(core.never, !t0, !__tribute_parent_ty5_1, !String)
+  !t9 = closure.closure(!t54) {tribute.calling_convention = 2}
+  !"std::io::read_line::__clam_1::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t3], [@_2, !t9], [@_3, !t0]], name = @"std::io::read_line::__clam_1::env"}
+  !"std::io::read_line::__clam_3::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t3], [@_2, !t9], [@_3, !t0]], name = @"std::io::read_line::__clam_3::env"}
+  !"std::io::read_line::__clam_6::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t3], [@_2, !t9], [@_3, !t0]], name = @"std::io::read_line::__clam_6::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t25]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t25]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t25]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::env"}
+  !__tribute_parent_ty0 = adt.struct() {fields = [[@done, closure.closure(!t32) {tribute.calling_convention = 2}], [@dispatch, !t22]], name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !t57 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty57_1, core.i32)
+  !t58 = core.func(core.never, !t0, !__tribute_parent_ty6_1, tribute_rt.anyref)
+  !t19 = closure.closure(!t58) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t33], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env"}
+  !t37 = core.func(core.never, !t0, tribute_rt.anyref, !t19, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t39 = core.func(core.never, !t0, !t19, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t6 = closure.closure(!t39) {tribute.calling_convention = 2}
+  !__tribute_parent_ty6 = adt.struct() {fields = [[@done, !t20], [@dispatch, !t6]], name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !"__tribute_make_local_dispatch_14::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t6]], name = @"__tribute_make_local_dispatch_14::__clam_0::env"}
+  !t59 = core.func(core.never, !t0, !__tribute_parent_ty6_1, core.i32)
+  !t12 = closure.closure(!t59) {tribute.calling_convention = 2}
+  !"run::__clam_1::env" = adt.struct() {fields = [[@_0, !t20], [@_1, !t6], [@_2, !t12], [@_3, !t0]], name = @"run::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env"}
+  !"run::__clam_7::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"run::__clam_7::env"}
+  !"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_13::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_13::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_13::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::env"}
+  !t60 = closure.closure(core.func(core.nil, !t0, core.i32)) {tribute.calling_convention = 1}
+  !t61 = closure.closure(core.func(core.i32, !t0)) {tribute.calling_convention = 1}
+  !"run::__clam_4::env" = adt.struct() {fields = [[@_0, !t61], [@_1, !t60]], name = @"run::__clam_4::env"}
+  !"std::io::ReadLineResult_1" = adt.typeref() {name = @"std::io::ReadLineResult"}
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
       func.unreachable
   }
-    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
-
   func.func @use_console(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = effect.dispatch_tail %0, %1 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
-      %3 = core.unrealized_conversion_cast %2 : core.i32
-      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
-      %5 = effect.dispatch_tail %0, %4 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %5 : core.nil
-      func.return %3
+      %1 = adt.struct_new {type = !__tribute_ability_payload_2796d93e} : !__tribute_ability_payload_2796d93e
+      %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref
+      %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
+      %4 = core.unrealized_conversion_cast %3 : core.i32
+      %5 = adt.struct_new %4 {type = !__tribute_ability_payload_7dc9fb1b} : !__tribute_ability_payload_7dc9fb1b
+      %6 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
+      %7 = effect.dispatch_tail %0, %6 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
+      %8 = core.unrealized_conversion_cast %7 : core.nil
+      func.return %4
   }
-
-  func.func @"direct_fn::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run(%0: !t0, %1: !t20, %2: !t6) -> core.never attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run::__clam_0"} : !t59
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run::__clam_1::env"} : !"run::__clam_1::env"
+      %7 = func.constant {func_ref = @"run::__clam_1"} : core.func(core.never, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_13, tribute.calling_convention = 0} : !t6
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run::__clam_2"} : core.func(core.i32, !t0)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run::__clam_3"} : core.func(core.nil, !t0, core.i32)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.struct_new %12, %15 {type = !"run::__clam_4::env"} : !"run::__clam_4::env"
+      %17 = func.constant {func_ref = @"run::__clam_4"} : core.func(tribute_rt.anyref, !t0, core.i32, tribute_rt.anyref)
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run::__clam_5"} : core.func(core.never, !t0, !__tribute_parent_ty6_1, core.i32, tribute_rt.anyref)
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = effect.extend %0, %22, %18, %21 {ability_ref = core.ability_ref() {name = @Console}} : !t0
+      %24 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %25 = func.constant {func_ref = @"run::__clam_6"} : !t59
+      %26 = adt.struct_new %25, %24 {type = !_closure} : !_closure
+      %27 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %28 = adt.struct_new %26, %23, %27 {type = !"run::__clam_7::env"} : !"run::__clam_7::env"
+      %29 = func.constant {func_ref = @"run::__clam_7"} : core.func(core.never, core.i32)
+      %30 = adt.struct_new %29, %28 {type = !_closure} : !_closure
+      %31 = func.call %27, %0, %22, %26, %12, %15 {callee = @__tribute_make_local_dispatch_14, tribute.calling_convention = 0} : !t6
+      %32 = func.call %23 {callee = @use_console, tribute.calling_convention = 1} : core.i32
+      %33 = adt.struct_get %30 {field = 0, type = !_closure} : core.i32
+      %34 = adt.struct_get %30 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %33, %34, %32 {func.indirect_call_signature = !t56, tribute.calling_convention = 2}
+  }
+  func.func @main(%0: !t0, %1: !t42, %2: !t21) -> core.never attributes {tribute.calling_convention = 2, tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"main::__clam_0"} : core.func(core.never, !t0, !__tribute_parent_ty57_1, core.i32)
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %7 = func.constant {func_ref = @"main::__clam_1"} : core.func(core.never, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_16, tribute.calling_convention = 0} : !t6
+      func.tail_call %0, %8, %9 {callee = @run, tribute.calling_convention = 2}
+  }
+  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t20
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t6
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t56, tribute.calling_convention = 2}
+  }
+  func.func @"run::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run::__clam_1::env"} : !"run::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run::__clam_1::env"} : !t20
+      %4 = adt.struct_get %2 {field = 1, type = !"run::__clam_1::env"} : !t6
+      %5 = adt.struct_get %2 {field = 2, type = !"run::__clam_1::env"} : !t12
+      %6 = adt.struct_get %2 {field = 3, type = !"run::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t40, tribute.calling_convention = 2}
+  }
+  func.func @"run::__clam_2"(%0: !t0, %1: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %2 = arith.const {value = 41} : core.i32
       func.return %2
   }
-
-  func.func @"direct_fn::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.variant_new %2 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
+  func.func @"run::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32) -> core.nil attributes {tribute.calling_convention = 1} {
+      %3 = arith.const {value = unit} : core.nil
       func.return %3
   }
-
-  func.func @run() -> core.i32 attributes {tribute.calling_convention = 0} {
-      %0 = arith.const {value = 0} : core.i32
-      %1 = adt.array_new %0 {type = !t0} : !t0
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"direct_fn::__lambda_0"} : !t2
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"run::__clam_0"} : !t2
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %9 = func.constant {func_ref = @"direct_fn::__lambda_1"} : !t2
-      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = adt.ref_null {type = !t0} : !t0
-      %12 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
-      %13 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref)
-      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-      %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %18 = func.constant {func_ref = @"run::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
-      %20 = func.call {callee = @__tribute_next_tag} : core.i32
-      %21 = effect.extend %1, %20, %19, %16 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %22 = func.call_indirect %12, %21, %13, %10 : tribute_rt.anyref
-      %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %24 = scf.if %23 : tribute_rt.anyref {
-          %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %26 = adt.variant_get %25 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %27 = core.unrealized_conversion_cast %26 : core.i32
-          %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
-          %29 = adt.ref_null {type = !t0} : !t0
-          %30 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-          %31 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-          %32 = func.call_indirect %30, %21, %31, %28 : tribute_rt.anyref
-          scf.yield %32
-      } {
-          %33 = adt.variant_cast %22 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %34 = adt.variant_get %33 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %35 = adt.variant_get %33 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %36 = arith.cmpi %34, %20 {predicate = @eq} : core.i1
-          %37 = scf.if %36 : tribute_rt.anyref {
-              %38 = adt.ref_null {type = !t0} : !t0
-              %39 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-              %40 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-              %41 = func.call_indirect %39, %38, %40, %35 : tribute_rt.anyref
-              scf.yield %41
-          } {
-              scf.yield %22
+  func.func @"run::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      %4 = adt.ref_cast %1 {type = !"run::__clam_4::env"} : !"run::__clam_4::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"run::__clam_4::env"} : !t61
+      %6 = adt.struct_get %4 {field = 1, type = !"run::__clam_4::env"} : !t60
+      scf.switch %2 {
+          scf.case {value = 664197438} {
+              %7 = core.unrealized_conversion_cast %3 : !__tribute_ability_payload_2796d93e
+              %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+              %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+              %10 = func.call_indirect %8, %0, %9 {func.indirect_call_signature = core.func(core.i32, !t0, tribute_rt.anyref), tribute.calling_convention = 1} : core.i32
+              %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+              func.return %11
           }
-          scf.yield %37
-      }
-      %42 = core.unrealized_conversion_cast %24 : core.i32
-      func.return %42
-  }
-
-  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
-      %0 = func.call {callee = @run, tribute.calling_convention = 0} : core.i32
-      %1 = arith.const {value = unit} : core.nil
-      func.return %1
-  }
-
-  func.func @"run::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_null {type = !t0} : !t0
-      %4 = func.call %0 {callee = @use_console} : core.i32
-      %5 = core.unrealized_conversion_cast %2 : !t1
-      %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %6 : tribute_rt.anyref
-      func.return %9
-  }
-
-  func.func @"run::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 664197438} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %10 = func.constant {func_ref = @"direct_fn::__lambda_0"} : !t2
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 41} : core.i32
-          %13 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
-          %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-          %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 : tribute_rt.anyref
-          scf.yield %16
-      } {
-          %17 = arith.const {value = 1} : core.i1
-          %18 = scf.if %17 : tribute_rt.anyref {
-              %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %20 = func.constant {func_ref = @"direct_fn::__lambda_0"} : !t2
-              %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
-              %22 = arith.const {value = unit} : core.nil
-              %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
-              %24 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
-              %25 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 : tribute_rt.anyref
-              scf.yield %26
-          } {
+          scf.case {value = 2110389019} {
+              %12 = core.unrealized_conversion_cast %3 : !__tribute_ability_payload_7dc9fb1b
+              %13 = adt.struct_get %12 {field = 0, type = !__tribute_ability_payload_7dc9fb1b} : core.i32
+              %14 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+              %15 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+              %16 = func.call_indirect %14, %0, %15, %13 {func.indirect_call_signature = core.func(core.nil, !t0, tribute_rt.anyref, core.i32), tribute.calling_convention = 1} : core.nil
+              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+              func.return %17
+          }
+          scf.default {
               func.unreachable
           }
-          scf.yield %18
       }
-      func.return %8
   }
-
-  func.func @"run::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
-      %4 = arith.const {value = 664197438} : core.i32
-      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
-      %6 = scf.if %5 : tribute_rt.anyref {
-          %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %8 = func.constant {func_ref = @"direct_fn::__lambda_0"} : !t2
-          %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-          %10 = arith.const {value = 41} : core.i32
-          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-          %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-          %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 : tribute_rt.anyref
-          scf.yield %14
-      } {
-          %15 = arith.const {value = 1} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = func.constant {func_ref = @"direct_fn::__lambda_0"} : !t2
-              %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
-              %20 = arith.const {value = unit} : core.nil
-              %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
-              %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-              %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-              %24 = func.call_indirect %22, %0, %23, %21 : tribute_rt.anyref
-              scf.yield %24
-          } {
-              func.unreachable
-          }
-          scf.yield %16
-      }
-      func.return %6
+  func.func @"run::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32, %4: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      func.unreachable
+  }
+  func.func @"run::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t20
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t6
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t56, tribute.calling_convention = 2}
+  }
+  func.func @"run::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run::__clam_7::env"} : !"run::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run::__clam_7::env"} : !t12
+      %4 = adt.struct_get %2 {field = 1, type = !"run::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run::__clam_7::env"} : !__tribute_parent_ty6_1
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t40, tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty57_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty57} : !t42
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty57} : !t21
+      %6 = arith.const {value = unit} : core.nil
+      %7 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %7, %8, %6 {func.indirect_call_signature = core.func(core.never, tribute_rt.anyref, core.nil), tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"main::__clam_1::env"} : !t42
+      %4 = adt.struct_get %2 {field = 1, type = !"main::__clam_1::env"} : !t21
+      %5 = adt.struct_get %2 {field = 2, type = !"main::__clam_1::env"} : !t33
+      %6 = adt.struct_get %2 {field = 3, type = !"main::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty57} : !__tribute_parent_ty57_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t57, tribute.calling_convention = 2}
   }
 }

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
@@ -3,50 +3,143 @@ source: tests/active_pipeline_goldens.rs
 expression: ir_text
 ---
 core.module @float_comparisons {
-  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
-  !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !String = adt.typeref() {name = @String}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !String_1 = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [!String, !String, core.i32]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !Result_1 = adt.typeref() {name = @Result}
+  !"String::Cursor_1" = adt.typeref() {name = @"String::Cursor"}
+  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [!String, !"String::Cursor_1"]], [@CursorChunk, [core.bytes, core.i32, core.i32, !"String::Cursor_1"]]]}
+  !__tribute_parent_ty25_1 = adt.typeref() {name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !Option_1 = adt.typeref() {name = @Option}
+  !__tribute_parent_ty17_1 = adt.typeref() {name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !__tribute_parent_ty5_1 = adt.typeref() {name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
-  !"Result::map_err::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map_err::__clam_0::env"}
-  !"Option::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Option::map::__clam_0::env"}
-  !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
+  !"Result$Int$Int::ParseError" = adt.typeref() {name = @"Result$Int$Int::ParseError"}
+  !t12 = core.func(core.never, tribute_rt.anyref, !Result_1)
+  !t16 = core.func(core.never, !Result_1)
+  !t4 = closure.closure(!t16) {tribute.calling_convention = 2}
+  !t24 = core.func(core.never, tribute_rt.anyref, !Option_1)
+  !t25 = core.func(core.never, !Option_1)
+  !t9 = closure.closure(!t25) {tribute.calling_convention = 2}
+  !t26 = core.func(core.never, !String)
+  !t11 = closure.closure(!t26) {tribute.calling_convention = 2}
+  !t27 = core.func(core.never, tribute_rt.anyref)
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
-  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !t3 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !t1 = closure.closure(!t3)
-  !t4 = core.ability_ref() {name = @"abilities::Throw"}
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
+  !t33 = core.func(core.never, tribute_rt.anyref, !String)
+  !"Int::ParseError_1" = adt.typeref() {name = @"Int::ParseError"}
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, !String]], name = @"std::io::SystemError"}
+  !__tribute_parent_ty0_1 = adt.typeref() {name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [!"std::io::SystemError_1"]]]}
+  !"std::io::Error_1" = adt.typeref() {name = @"std::io::Error"}
+  !__tribute_ability_payload_0efb32ee = adt.struct() {fields = [[@arg0, !"std::io::Error_1"]], name = @__tribute_ability_payload_0efb32ee}
+  !t44 = core.ability_ref(!"std::io::Error_1") {name = @"abilities::Throw"}
+  !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
-  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !__tuple_i1_i1_i1_i1_i1_i1_1 = adt.typeref() {name = @__tuple_i1_i1_i1_i1_i1_i1}
-
+  !t13 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, !Result_1)
+  !t14 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t15 = core.func(core.never, !t0, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t6 = closure.closure(!t15) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env"}
+  !t18 = core.func(core.never, !t0, tribute_rt.anyref, !t6, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t19 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty0_1, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t21 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, !Option_1)
+  !t22 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, !String)
+  !t23 = core.func(core.never, !t0, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t20 = closure.closure(!t23) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env"}
+  !t28 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t29 = core.func(core.never, !t0, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t10 = closure.closure(!t29) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t10], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t10], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env"}
+  !t30 = core.func(core.never, !t0, tribute_rt.anyref, !t10, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t31 = core.func(core.never, !t0, !t6, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t1 = closure.closure(!t31) {tribute.calling_convention = 2}
+  !__tribute_parent_ty25 = adt.struct() {fields = [[@done, !t4], [@dispatch, !t1]], name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !"Result::map_err::__clam_3::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t6], [@_3, !t0]], name = @"Result::map_err::__clam_3::env"}
+  !"Result::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t6], [@_3, !t0]], name = @"Result::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::env"}
+  !t32 = core.func(core.never, !t0, !__tribute_parent_ty25_1, !Result_1)
+  !t5 = closure.closure(!t32) {tribute.calling_convention = 2}
+  !"Result::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::and_then::__clam_1::env"}
+  !"Result::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::and_then::__clam_3::env"}
+  !"Result::map_err::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::map_err::__clam_1::env"}
+  !"Result::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t5], [@_3, !t0]], name = @"Result::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::env" = adt.struct() {fields = [[@_0, !t5], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::env"}
+  !t36 = core.func(core.never, !t0, tribute_rt.anyref, !t20, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t37 = core.func(core.never, !t0, !t10, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t2 = closure.closure(!t37) {tribute.calling_convention = 2}
+  !__tribute_parent_ty17 = adt.struct() {fields = [[@done, !t9], [@dispatch, !t2]], name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !"Option::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t2], [@_2, !t10], [@_3, !t0]], name = @"Option::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t10], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::env"}
+  !t38 = core.func(core.never, !t0, !t19, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t17 = closure.closure(!t38) {tribute.calling_convention = 2}
+  !t34 = closure.closure(core.func(core.never, !t0, closure.closure(!t27) {tribute.calling_convention = 2}, !t17, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t35 = core.func(core.never, !t0, tribute_rt.anyref, closure.closure(!t27) {tribute.calling_convention = 2}, !t17, tribute_rt.anyref)
+  !t39 = core.func(core.never, !t0, !t20, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t3 = closure.closure(!t39) {tribute.calling_convention = 2}
+  !__tribute_parent_ty5 = adt.struct() {fields = [[@done, !t11], [@dispatch, !t3]], name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
+  !t40 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t41 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty0_1, tribute_rt.anyref)
+  !t42 = core.func(core.never, !t0, !__tribute_parent_ty17_1, !Option_1)
+  !t7 = closure.closure(!t42) {tribute.calling_convention = 2}
+  !"Option::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t2], [@_2, !t7], [@_3, !t0]], name = @"Option::and_then::__clam_1::env"}
+  !"Option::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t2], [@_2, !t7], [@_3, !t0]], name = @"Option::and_then::__clam_3::env"}
+  !"Option::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t2], [@_2, !t7], [@_3, !t0]], name = @"Option::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::env"}
+  !t43 = core.func(core.never, !t0, !__tribute_parent_ty5_1, !String)
+  !t8 = closure.closure(!t43) {tribute.calling_convention = 2}
+  !"std::io::read_line::__clam_1::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t3], [@_2, !t8], [@_3, !t0]], name = @"std::io::read_line::__clam_1::env"}
+  !"std::io::read_line::__clam_3::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t3], [@_2, !t8], [@_3, !t0]], name = @"std::io::read_line::__clam_3::env"}
+  !"std::io::read_line::__clam_6::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t3], [@_2, !t8], [@_3, !t0]], name = @"std::io::read_line::__clam_6::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t20]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t20]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t20]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::env"}
+  !__tribute_parent_ty0 = adt.struct() {fields = [[@done, closure.closure(!t27) {tribute.calling_convention = 2}], [@dispatch, !t17]], name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool_1 = adt.typeref() {name = @__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool}
+  !"std::io::ReadLineResult_1" = adt.typeref() {name = @"std::io::ReadLineResult"}
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
       func.unreachable
   }
-    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
-
-  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
+  func.func @main() -> core.nil attributes {tribute.calling_convention = 0, tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
       %0 = arith.const {value = 1.0} : core.f64
       %1 = arith.const {value = 2.0} : core.f64
       %2 = arith.cmpf %0, %1 {predicate = @oeq} : core.i1
@@ -55,7 +148,7 @@ core.module @float_comparisons {
       %5 = arith.cmpf %0, %1 {predicate = @ole} : core.i1
       %6 = arith.cmpf %0, %1 {predicate = @ogt} : core.i1
       %7 = arith.cmpf %0, %1 {predicate = @oge} : core.i1
-      %8 = adt.struct_new %2, %3, %4, %5, %6, %7 {type = !__tuple_i1_i1_i1_i1_i1_i1} : !__tuple_i1_i1_i1_i1_i1_i1_1
+      %8 = adt.struct_new %2, %3, %4, %5, %6, %7 {type = !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool} : !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool_1
       %9 = arith.const {value = unit} : core.nil
       func.return %9
   }

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -4,390 +4,629 @@ expression: ir_text
 ---
 core.module @mixed_nested {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
-  !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
-  !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
+  !String = adt.typeref() {name = @String}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !__tribute_parent_ty6_1 = adt.typeref() {name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !String_1 = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [!String, !String, core.i32]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !Result_1 = adt.typeref() {name = @Result}
+  !"String::Cursor_1" = adt.typeref() {name = @"String::Cursor"}
+  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [!String, !"String::Cursor_1"]], [@CursorChunk, [core.bytes, core.i32, core.i32, !"String::Cursor_1"]]]}
+  !t4 = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !__tribute_parent_ty25_1 = adt.typeref() {name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !Option_1 = adt.typeref() {name = @Option}
+  !__tribute_parent_ty17_1 = adt.typeref() {name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !__tribute_parent_ty5_1 = adt.typeref() {name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
-  !t2 = closure.closure(!t1)
-  !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
-  !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
-  !"run_state_with_console::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state_with_console::__clam_1::__clam_0::env"}
-  !"run_state_with_console::__clam_1::__clam_1::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state_with_console::__clam_1::__clam_1::env"}
-  !"Result::map_err::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map_err::__clam_0::env"}
-  !"Option::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Option::map::__clam_0::env"}
-  !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
+  !"Result$Int$Int::ParseError" = adt.typeref() {name = @"Result$Int$Int::ParseError"}
+  !t22 = core.func(core.never, tribute_rt.anyref, !Result_1)
+  !t23 = core.func(core.never, tribute_rt.anyref, core.i32)
+  !t27 = core.func(core.never, !Result_1)
+  !t8 = closure.closure(!t27) {tribute.calling_convention = 2}
+  !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32]], name = @"step::__clam_0::__clam_0::env"}
+  !t38 = core.func(core.never, tribute_rt.anyref, !Option_1)
+  !t39 = core.func(core.never, !Option_1)
+  !t15 = closure.closure(!t39) {tribute.calling_convention = 2}
+  !t40 = core.func(core.never, !String)
+  !t21 = closure.closure(!t40) {tribute.calling_convention = 2}
+  !t41 = core.func(core.never, tribute_rt.anyref)
+  !__tribute_one_shot_state_13 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_13}
+  !__tribute_one_shot_state_14 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_14}
+  !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"step::__clam_0::env"}
+  !__tribute_ability_payload_50641714 = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_50641714}
+  !__tribute_ability_payload_7dc9fb1b = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_7dc9fb1b}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
-  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !t4 = core.ability_ref() {name = @"abilities::Throw"}
-  !t5 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref)
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !t48 = closure.closure(core.func(core.never, core.nil)) {tribute.calling_convention = 2}
+  !__tribute_parent_ty57_1 = adt.typeref() {name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t49 = core.func(core.never, tribute_rt.anyref, !String)
+  !"Int::ParseError_1" = adt.typeref() {name = @"Int::ParseError"}
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, !String]], name = @"std::io::SystemError"}
+  !__tribute_parent_ty0_1 = adt.typeref() {name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !__tribute_ability_payload_7590c57e = adt.struct() {fields = [], name = @__tribute_ability_payload_7590c57e}
+  !__tribute_ability_payload_2796d93e = adt.struct() {fields = [], name = @__tribute_ability_payload_2796d93e}
+  !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [!"std::io::SystemError_1"]]]}
+  !"std::io::Error_1" = adt.typeref() {name = @"std::io::Error"}
+  !__tribute_ability_payload_0efb32ee = adt.struct() {fields = [[@arg0, !"std::io::Error_1"]], name = @__tribute_ability_payload_0efb32ee}
+  !t60 = core.ability_ref(!"std::io::Error_1") {name = @"abilities::Throw"}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t3 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
-  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-
+  !t10 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6_1, core.i32)
+  !t16 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6_1, tribute_rt.anyref)
+  !t17 = core.func(core.never, !t0, !__tribute_parent_ty6_1, tribute_rt.anyref)
+  !t6 = closure.closure(!t17) {tribute.calling_convention = 2}
+  !t14 = core.func(core.never, !t0, tribute_rt.anyref, !t6, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t18 = core.func(core.never, !t0, !t6, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t1 = closure.closure(!t18) {tribute.calling_convention = 2}
+  !__tribute_parent_ty6 = adt.struct() {fields = [[@done, !t4], [@dispatch, !t1]], name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !t20 = core.func(core.never, !t0, !__tribute_parent_ty6_1, core.i32)
+  !t2 = closure.closure(!t20) {tribute.calling_convention = 2}
+  !t24 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, !Result_1)
+  !t25 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t26 = core.func(core.never, !t0, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t11 = closure.closure(!t26) {tribute.calling_convention = 2}
+  !"run_state_with_console::__clam_2::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_2::__clam_1::env"}
+  !"run_state_with_console::__clam_3::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_3::__clam_1::env"}
+  !"run_state_with_console::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_1::env"}
+  !"run_state_with_console::__clam_9::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_state_with_console::__clam_9::env"}
+  !"run_all::__clam_1::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_all::__clam_1::env"}
+  !"run_all::__clam_9::env" = adt.struct() {fields = [[@_0, !t4], [@_1, !t1], [@_2, !t2], [@_3, !t0]], name = @"run_all::__clam_9::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env"}
+  !"run_state_with_console::__clam_7::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"run_state_with_console::__clam_7::env"}
+  !"run_all::__clam_7::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, !__tribute_parent_ty6_1]], name = @"run_all::__clam_7::env"}
+  !t29 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty6_1, !t0, !t2)) {tribute.calling_convention = 2}
+  !t30 = closure.closure(core.func(core.never, !t0, closure.closure(core.func(core.never, !t0, !__tribute_parent_ty57_1, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t32 = core.func(core.never, !t0, tribute_rt.anyref, !t11, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t33 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty0_1, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t35 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, !Option_1)
+  !t36 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, !String)
+  !t37 = core.func(core.never, !t0, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t34 = closure.closure(!t37) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_23::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_24::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t33]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t33]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_23::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_23::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_24::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_24::__clam_0::env"}
+  !"__tribute_make_local_dispatch_22::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t1]], name = @"__tribute_make_local_dispatch_22::__clam_0::env"}
+  !"step::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_14], [@_1, !t2]], name = @"step::__clam_1::env"}
+  !t42 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty57_1, core.i32)) {tribute.calling_convention = 2}
+  !"main::__clam_1::env" = adt.struct() {fields = [[@_0, !t48], [@_1, !t30], [@_2, !t42], [@_3, !t0]], name = @"main::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t42], [@_1, !t0], [@_2, !__tribute_parent_ty57_1]], name = @"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t42], [@_1, !t6]], name = @"__tribute_make_dispatch_adapter_25::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_25::__clam_0::env" = adt.struct() {fields = [[@_0, !t42], [@_1, !t30]], name = @"__tribute_make_dispatch_adapter_25::__clam_0::env"}
+  !t43 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t44 = core.func(core.never, !t0, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t19 = closure.closure(!t44) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t19], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t19], [@_1, !t33]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env"}
+  !__tribute_parent_ty57 = adt.struct() {fields = [[@done, !t48], [@dispatch, !t30]], name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t45 = core.func(core.never, !t0, tribute_rt.anyref, !t19, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t46 = core.func(core.never, !t0, !t11, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t3 = closure.closure(!t46) {tribute.calling_convention = 2}
+  !__tribute_parent_ty25 = adt.struct() {fields = [[@done, !t8], [@dispatch, !t3]], name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !"Result::map_err::__clam_3::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3], [@_2, !t11], [@_3, !t0]], name = @"Result::map_err::__clam_3::env"}
+  !"Result::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3], [@_2, !t11], [@_3, !t0]], name = @"Result::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::env"}
+  !t47 = core.func(core.never, !t0, !__tribute_parent_ty25_1, !Result_1)
+  !t9 = closure.closure(!t47) {tribute.calling_convention = 2}
+  !"Result::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3], [@_2, !t9], [@_3, !t0]], name = @"Result::and_then::__clam_1::env"}
+  !"Result::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3], [@_2, !t9], [@_3, !t0]], name = @"Result::and_then::__clam_3::env"}
+  !"Result::map_err::__clam_1::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3], [@_2, !t9], [@_3, !t0]], name = @"Result::map_err::__clam_1::env"}
+  !"Result::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t3], [@_2, !t9], [@_3, !t0]], name = @"Result::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t11]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t11]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t11]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t11]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t3]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::env"}
+  !t52 = core.func(core.never, !t0, tribute_rt.anyref, !t34, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t53 = core.func(core.never, !t0, !t19, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t5 = closure.closure(!t53) {tribute.calling_convention = 2}
+  !__tribute_parent_ty17 = adt.struct() {fields = [[@done, !t15], [@dispatch, !t5]], name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !"Option::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t5], [@_2, !t19], [@_3, !t0]], name = @"Option::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t19], [@_1, !t5]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::env"}
+  !t54 = core.func(core.never, !t0, !t33, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t31 = closure.closure(!t54) {tribute.calling_convention = 2}
+  !t50 = closure.closure(core.func(core.never, !t0, closure.closure(!t41) {tribute.calling_convention = 2}, !t31, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t51 = core.func(core.never, !t0, tribute_rt.anyref, closure.closure(!t41) {tribute.calling_convention = 2}, !t31, tribute_rt.anyref)
+  !t55 = core.func(core.never, !t0, !t34, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t7 = closure.closure(!t55) {tribute.calling_convention = 2}
+  !__tribute_parent_ty5 = adt.struct() {fields = [[@done, !t21], [@dispatch, !t7]], name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
+  !t56 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t57 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty0_1, tribute_rt.anyref)
+  !t58 = core.func(core.never, !t0, !__tribute_parent_ty17_1, !Option_1)
+  !t12 = closure.closure(!t58) {tribute.calling_convention = 2}
+  !"Option::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t5], [@_2, !t12], [@_3, !t0]], name = @"Option::and_then::__clam_1::env"}
+  !"Option::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t5], [@_2, !t12], [@_3, !t0]], name = @"Option::and_then::__clam_3::env"}
+  !"Option::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t5], [@_2, !t12], [@_3, !t0]], name = @"Option::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t19]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t5]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t5]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t5]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::env"}
+  !t59 = core.func(core.never, !t0, !__tribute_parent_ty5_1, !String)
+  !t13 = closure.closure(!t59) {tribute.calling_convention = 2}
+  !"std::io::read_line::__clam_1::env" = adt.struct() {fields = [[@_0, !t21], [@_1, !t7], [@_2, !t13], [@_3, !t0]], name = @"std::io::read_line::__clam_1::env"}
+  !"std::io::read_line::__clam_3::env" = adt.struct() {fields = [[@_0, !t21], [@_1, !t7], [@_2, !t13], [@_3, !t0]], name = @"std::io::read_line::__clam_3::env"}
+  !"std::io::read_line::__clam_6::env" = adt.struct() {fields = [[@_0, !t21], [@_1, !t7], [@_2, !t13], [@_3, !t0]], name = @"std::io::read_line::__clam_6::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t34]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t34]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t34]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t7]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t7]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::env" = adt.struct() {fields = [[@_0, !t13], [@_1, !t7]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::env"}
+  !__tribute_parent_ty0 = adt.struct() {fields = [[@done, closure.closure(!t41) {tribute.calling_convention = 2}], [@dispatch, !t31]], name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !t62 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty57_1, core.i32)
+  !t63 = core.func(core.never, !t0, !__tribute_parent_ty6_1, core.i32, tribute_rt.anyref)
+  !t64 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6_1, core.nil)
+  !t65 = core.func(core.never, !t0, !__tribute_parent_ty6_1, core.nil)
+  !t61 = closure.closure(!t65) {tribute.calling_convention = 2}
+  !t28 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty6_1, !t0, core.i32, !t61)) {tribute.calling_convention = 2}
+  !"__tribute_make_local_dispatch_18::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t2], [@_2, !t0], [@_3, !t29], [@_4, !t28], [@_5, !__tribute_parent_ty6_1], [@_6, !t1]], name = @"__tribute_make_local_dispatch_18::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t29], [@_4, !t28], [@_5, !t6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t29], [@_4, !t28], [@_5, !t6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t29], [@_4, !t28], [@_5, !t6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !t2], [@_1, !t0], [@_2, core.i32], [@_3, !t29], [@_4, !t28], [@_5, !t6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env"}
+  !"step::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_13], [@_1, !t61]], name = @"step::__clam_0::__clam_1::env"}
+  !t66 = closure.closure(core.func(core.nil, !t0, core.i32)) {tribute.calling_convention = 1}
+  !t67 = closure.closure(core.func(core.i32, !t0)) {tribute.calling_convention = 1}
+  !"run_all::__clam_4::env" = adt.struct() {fields = [[@_0, !t67], [@_1, !t66]], name = @"run_all::__clam_4::env"}
+  !t68 = core.func(tribute_rt.anyref, !t0, core.i32, tribute_rt.anyref)
+  !"std::io::ReadLineResult_1" = adt.typeref() {name = @"std::io::ReadLineResult"}
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
       func.unreachable
   }
-    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
-
-  func.func @step(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = effect.dispatch_tail %0, %2 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
-      %4 = core.unrealized_conversion_cast %3 : core.i32
-      %5 = adt.struct_new %4, %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
-      %6 = func.constant {func_ref = @"step::__clam_0"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %9 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-      %10 = effect.dispatch_cps %0, %9, %8 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      func.return %10
+  func.func @step(%0: !t0, %1: !t4, %2: !t1) -> core.never attributes {tribute.calling_convention = 2} {
+      %3 = adt.struct_new {type = !__tribute_ability_payload_2796d93e} : !__tribute_ability_payload_2796d93e
+      %4 = core.unrealized_conversion_cast %3 : tribute_rt.anyref
+      %5 = effect.dispatch_tail %0, %4 {ability_ref = core.ability_ref() {name = @Console}, op_name = @read} : tribute_rt.anyref
+      %6 = core.unrealized_conversion_cast %5 : core.i32
+      %7 = adt.struct_new %6 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %8 = func.constant {func_ref = @"step::__clam_0"} : !t20
+      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
+      %10 = arith.const {value = 0} : core.i1
+      %11 = adt.struct_new %10 {type = !__tribute_one_shot_state_14} : !__tribute_one_shot_state_14
+      %12 = adt.struct_new %11, %9 {type = !"step::__clam_1::env"} : !"step::__clam_1::env"
+      %13 = func.constant {func_ref = @"step::__clam_1"} : !t17
+      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
+      %15 = adt.struct_new {type = !__tribute_ability_payload_7590c57e} : !__tribute_ability_payload_7590c57e
+      %16 = core.unrealized_conversion_cast %15 : tribute_rt.anyref
+      effect.dispatch_cps %0, %2, %14, %16 {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get}
   }
-
-  func.func @"mixed_nested::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @run_state_with_console(%0: !t0, %1: !t4, %2: !t1) -> core.never attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t20
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run_state_with_console::__clam_1::env"} : !"run_state_with_console::__clam_1::env"
+      %7 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : core.func(core.never, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_15, tribute.calling_convention = 0} : !t1
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_state_with_console::__clam_2"} : core.func(core.never, !t0, !__tribute_parent_ty6_1, !t0, !t2)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run_state_with_console::__clam_3"} : core.func(core.never, !t0, !__tribute_parent_ty6_1, !t0, core.i32, !t61)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %17 = func.constant {func_ref = @"run_state_with_console::__clam_4"} : !t68
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run_state_with_console::__clam_5"} : !t63
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = effect.extend %0, %22, %18, %21 {ability_ref = core.ability_ref(core.i32) {name = @State}} : !t0
+      %24 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %25 = func.constant {func_ref = @"run_state_with_console::__clam_6"} : !t20
+      %26 = adt.struct_new %25, %24 {type = !_closure} : !_closure
+      %27 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %28 = adt.struct_new %26, %23, %27 {type = !"run_state_with_console::__clam_7::env"} : !"run_state_with_console::__clam_7::env"
+      %29 = func.constant {func_ref = @"run_state_with_console::__clam_7"} : core.func(core.never, core.i32)
+      %30 = adt.struct_new %29, %28 {type = !_closure} : !_closure
+      %31 = func.call %27, %0, %22, %26, %12, %15 {callee = @__tribute_make_local_dispatch_18, tribute.calling_convention = 0} : !t1
+      %32 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %33 = func.constant {func_ref = @"run_state_with_console::__clam_8"} : !t20
+      %34 = adt.struct_new %33, %32 {type = !_closure} : !_closure
+      %35 = adt.struct_new %30, %31, %34, %23 {type = !"run_state_with_console::__clam_9::env"} : !"run_state_with_console::__clam_9::env"
+      %36 = func.constant {func_ref = @"run_state_with_console::__clam_9"} : core.func(core.never, core.i32)
+      %37 = adt.struct_new %36, %35 {type = !_closure} : !_closure
+      %38 = func.call %34, %31 {callee = @__tribute_make_dispatch_adapter_20, tribute.calling_convention = 0} : !t1
+      func.tail_call %23, %37, %38 {callee = @step, tribute.calling_convention = 2}
+  }
+  func.func @run_all(%0: !t0, %1: !t4, %2: !t1) -> core.never attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_all::__clam_0"} : !t20
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run_all::__clam_1::env"} : !"run_all::__clam_1::env"
+      %7 = func.constant {func_ref = @"run_all::__clam_1"} : core.func(core.never, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_21, tribute.calling_convention = 0} : !t1
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(core.i32, !t0)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run_all::__clam_3"} : core.func(core.nil, !t0, core.i32)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.struct_new %12, %15 {type = !"run_all::__clam_4::env"} : !"run_all::__clam_4::env"
+      %17 = func.constant {func_ref = @"run_all::__clam_4"} : !t68
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run_all::__clam_5"} : !t63
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = effect.extend %0, %22, %18, %21 {ability_ref = core.ability_ref() {name = @Console}} : !t0
+      %24 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %25 = func.constant {func_ref = @"run_all::__clam_6"} : !t20
+      %26 = adt.struct_new %25, %24 {type = !_closure} : !_closure
+      %27 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %28 = adt.struct_new %26, %23, %27 {type = !"run_all::__clam_7::env"} : !"run_all::__clam_7::env"
+      %29 = func.constant {func_ref = @"run_all::__clam_7"} : core.func(core.never, core.i32)
+      %30 = adt.struct_new %29, %28 {type = !_closure} : !_closure
+      %31 = func.call %27, %0, %22, %26, %12, %15 {callee = @__tribute_make_local_dispatch_22, tribute.calling_convention = 0} : !t1
+      %32 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %33 = func.constant {func_ref = @"run_all::__clam_8"} : !t20
+      %34 = adt.struct_new %33, %32 {type = !_closure} : !_closure
+      %35 = adt.struct_new %30, %31, %34, %23 {type = !"run_all::__clam_9::env"} : !"run_all::__clam_9::env"
+      %36 = func.constant {func_ref = @"run_all::__clam_9"} : core.func(core.never, core.i32)
+      %37 = adt.struct_new %36, %35 {type = !_closure} : !_closure
+      %38 = func.call %34, %31 {callee = @__tribute_make_dispatch_adapter_24, tribute.calling_convention = 0} : !t1
+      func.tail_call %23, %37, %38 {callee = @run_state_with_console, tribute.calling_convention = 2}
+  }
+  func.func @main(%0: !t0, %1: !t48, %2: !t30) -> core.never attributes {tribute.calling_convention = 2, tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"main::__clam_0"} : core.func(core.never, !t0, !__tribute_parent_ty57_1, core.i32)
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %7 = func.constant {func_ref = @"main::__clam_1"} : core.func(core.never, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_25, tribute.calling_convention = 0} : !t1
+      func.tail_call %0, %8, %9 {callee = @run_all, tribute.calling_convention = 2}
+  }
+  func.func @"step::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"step::__clam_0::env"} : core.i32
+      %6 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %7 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %8 = arith.addi %3, %5 : core.i32
+      %9 = adt.struct_new %3, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
+      %10 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t65
+      %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
+      %12 = arith.const {value = 0} : core.i1
+      %13 = adt.struct_new %12 {type = !__tribute_one_shot_state_13} : !__tribute_one_shot_state_13
+      %14 = adt.struct_new %13, %11 {type = !"step::__clam_0::__clam_1::env"} : !"step::__clam_0::__clam_1::env"
+      %15 = func.constant {func_ref = @"step::__clam_0::__clam_1"} : !t17
+      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
+      %17 = adt.struct_new %8 {type = !__tribute_ability_payload_50641714} : !__tribute_ability_payload_50641714
+      %18 = core.unrealized_conversion_cast %17 : tribute_rt.anyref
+      effect.dispatch_cps %0, %7, %16, %18 {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @set}
+  }
+  func.func @"step::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"step::__clam_1::env"} : !"step::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"step::__clam_1::env"} : !__tribute_one_shot_state_14
+      %6 = adt.struct_get %4 {field = 1, type = !"step::__clam_1::env"} : !t2
+      %7 = core.unrealized_conversion_cast %3 : core.i32
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_14} : core.i1
+      %9 = scf.if %8 : core.never {
+          func.unreachable
+      } {
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_14}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2, %7 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+      }
+  }
+  func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_1::env"} : !"run_state_with_console::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_1::env"} : !t4
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: !t0, %4: !t2) -> core.never attributes {tribute.calling_convention = 2} {
+      %5 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %6 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %7 = arith.const {value = 7} : core.i32
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run_state_with_console::__clam_2::__clam_0"} : !t20
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = adt.struct_new %5, %6, %10, %3 {type = !"run_state_with_console::__clam_2::__clam_1::env"} : !"run_state_with_console::__clam_2::__clam_1::env"
+      %12 = func.constant {func_ref = @"run_state_with_console::__clam_2::__clam_1"} : core.func(core.never, core.i32)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = func.call %10, %6 {callee = @__tribute_make_dispatch_adapter_16, tribute.calling_convention = 0} : !t1
+      %15 = adt.struct_new %13, %14 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %16 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %16, %3, %17, %15, %7 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: !t0, %4: core.i32, %5: !t61) -> core.never attributes {tribute.calling_convention = 2} {
+      %6 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %7 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %8 = arith.const {value = unit} : core.nil
+      %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %10 = func.constant {func_ref = @"run_state_with_console::__clam_3::__clam_0"} : !t20
+      %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
+      %12 = adt.struct_new %6, %7, %11, %3 {type = !"run_state_with_console::__clam_3::__clam_1::env"} : !"run_state_with_console::__clam_3::__clam_1::env"
+      %13 = func.constant {func_ref = @"run_state_with_console::__clam_3::__clam_1"} : core.func(core.never, core.i32)
+      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
+      %15 = func.call %11, %7 {callee = @__tribute_make_dispatch_adapter_17, tribute.calling_convention = 0} : !t1
+      %16 = adt.struct_new %14, %15 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %17 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %18 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %17, %3, %18, %16, %8 {func.indirect_call_signature = !t64, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      scf.switch %2 {
+          scf.default {
+              func.unreachable
+          }
+      }
+  }
+  func.func @"run_state_with_console::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32, %4: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      func.unreachable
+  }
+  func.func @"run_state_with_console::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_7::env"} : !"run_state_with_console::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_7::env"} : !t2
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_7::env"} : !__tribute_parent_ty6_1
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_8"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
+  }
+  func.func @"run_state_with_console::__clam_9"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_9::env"} : !"run_state_with_console::__clam_9::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_9::env"} : !t4
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_9::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_9::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_9::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_all::__clam_1::env"} : !"run_all::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_all::__clam_1::env"} : !t4
+      %4 = adt.struct_get %2 {field = 1, type = !"run_all::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_all::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_all::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_2"(%0: !t0, %1: tribute_rt.anyref) -> core.i32 attributes {tribute.calling_convention = 1} {
+      %2 = arith.const {value = 3} : core.i32
       func.return %2
   }
-
-  func.func @"mixed_nested::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.variant_new %2 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
+  func.func @"run_all::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32) -> core.nil attributes {tribute.calling_convention = 1} {
+      %3 = arith.const {value = unit} : core.nil
       func.return %3
   }
-
-  func.func @run_state_with_console(%0: !t0) -> core.i32 attributes {tribute.calling_convention = 1} {
-      %1 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %2 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
-      %3 = adt.struct_new %2, %1 {type = !_closure} : !_closure
-      %4 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %5 = func.constant {func_ref = @"run_state_with_console::__clam_0"} : !t1
-      %6 = adt.struct_new %5, %4 {type = !_closure} : !_closure
-      %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %8 = func.constant {func_ref = @"mixed_nested::__lambda_1"} : !t1
-      %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-      %10 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
-      %11 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %12 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %13 = func.constant {func_ref = @"run_state_with_console::__clam_1"} : !t5
-      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
-      %15 = arith.const {value = 0} : tribute_rt.anyref
-      %16 = func.call {callee = @__tribute_next_tag} : core.i32
-      %17 = effect.extend %0, %16, %15, %14 {ability_ref = core.ability_ref() {name = @State}} : !t0
-      %18 = func.call_indirect %10, %17, %11, %9 : tribute_rt.anyref
-      %19 = adt.variant_is %18 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %20 = scf.if %19 : tribute_rt.anyref {
-          %21 = adt.variant_cast %18 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %22 = adt.variant_get %21 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %23 = core.unrealized_conversion_cast %22 : core.i32
-          %24 = core.unrealized_conversion_cast %23 : tribute_rt.anyref
-          %25 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-          %26 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %27 = func.call_indirect %25, %17, %26, %24 : tribute_rt.anyref
-          scf.yield %27
-      } {
-          %28 = adt.variant_cast %18 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %29 = adt.variant_get %28 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %30 = adt.variant_get %28 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %31 = arith.cmpi %29, %16 {predicate = @eq} : core.i1
-          %32 = scf.if %31 : tribute_rt.anyref {
-              %33 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
-              %34 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %35 = func.call_indirect %33, %0, %34, %30 : tribute_rt.anyref
-              scf.yield %35
-          } {
-              scf.yield %18
+  func.func @"run_all::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      %4 = adt.ref_cast %1 {type = !"run_all::__clam_4::env"} : !"run_all::__clam_4::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"run_all::__clam_4::env"} : !t67
+      %6 = adt.struct_get %4 {field = 1, type = !"run_all::__clam_4::env"} : !t66
+      scf.switch %2 {
+          scf.case {value = 664197438} {
+              %7 = core.unrealized_conversion_cast %3 : !__tribute_ability_payload_2796d93e
+              %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+              %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+              %10 = func.call_indirect %8, %0, %9 {func.indirect_call_signature = core.func(core.i32, !t0, tribute_rt.anyref), tribute.calling_convention = 1} : core.i32
+              %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
+              func.return %11
           }
-          scf.yield %32
-      }
-      %36 = core.unrealized_conversion_cast %20 : core.i32
-      func.return %36
-  }
-
-  func.func @run_all() -> core.i32 attributes {tribute.calling_convention = 0} {
-      %0 = arith.const {value = 0} : core.i32
-      %1 = adt.array_new %0 {type = !t0} : !t0
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"run_all::__clam_0"} : !t1
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %9 = func.constant {func_ref = @"mixed_nested::__lambda_1"} : !t1
-      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = adt.ref_null {type = !t0} : !t0
-      %12 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
-      %13 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run_all::__clam_1"} : !t5
-      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-      %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %18 = func.constant {func_ref = @"run_all::__clam_2"} : core.func(tribute_rt.anyref, core.i32, tribute_rt.anyref)
-      %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
-      %20 = func.call {callee = @__tribute_next_tag} : core.i32
-      %21 = effect.extend %1, %20, %19, %16 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %22 = func.call_indirect %12, %21, %13, %10 : tribute_rt.anyref
-      %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %24 = scf.if %23 : tribute_rt.anyref {
-          %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %26 = adt.variant_get %25 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %27 = core.unrealized_conversion_cast %26 : core.i32
-          %28 = core.unrealized_conversion_cast %27 : tribute_rt.anyref
-          %29 = adt.ref_null {type = !t0} : !t0
-          %30 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-          %31 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-          %32 = func.call_indirect %30, %21, %31, %28 : tribute_rt.anyref
-          scf.yield %32
-      } {
-          %33 = adt.variant_cast %22 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %34 = adt.variant_get %33 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %35 = adt.variant_get %33 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %36 = arith.cmpi %34, %20 {predicate = @eq} : core.i1
-          %37 = scf.if %36 : tribute_rt.anyref {
-              %38 = adt.ref_null {type = !t0} : !t0
-              %39 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-              %40 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-              %41 = func.call_indirect %39, %38, %40, %35 : tribute_rt.anyref
-              scf.yield %41
-          } {
-              scf.yield %22
+          scf.case {value = 2110389019} {
+              %12 = core.unrealized_conversion_cast %3 : !__tribute_ability_payload_7dc9fb1b
+              %13 = adt.struct_get %12 {field = 0, type = !__tribute_ability_payload_7dc9fb1b} : core.i32
+              %14 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+              %15 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+              %16 = func.call_indirect %14, %0, %15, %13 {func.indirect_call_signature = core.func(core.nil, !t0, tribute_rt.anyref, core.i32), tribute.calling_convention = 1} : core.nil
+              %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+              func.return %17
           }
-          scf.yield %37
-      }
-      %42 = core.unrealized_conversion_cast %24 : core.i32
-      func.return %42
-  }
-
-  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
-      %0 = func.call {callee = @run_all, tribute.calling_convention = 0} : core.i32
-      %1 = arith.const {value = unit} : core.nil
-      func.return %1
-  }
-
-  func.func @"step::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::env"} : core.i32
-      %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::env"} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %2 : core.i32
-      %7 = arith.addi %6, %4 : core.i32
-      %8 = adt.struct_new %4, %6, %5 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
-      %9 = func.constant {func_ref = @"step::__clam_0::__clam_0"} : !t1
-      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-      %12 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %13 = effect.dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      func.return %13
-  }
-
-  func.func @"run_state_with_console::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = func.call %0, %2 {callee = @step, tribute.calling_convention = 2} : tribute_rt.anyref
-      func.return %3
-  }
-
-  func.func @"run_state_with_console::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 1972422014} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.struct_new %3 {type = !"run_state_with_console::__clam_1::__clam_0::env"} : !"run_state_with_console::__clam_1::__clam_0::env"
-          %10 = func.constant {func_ref = @"run_state_with_console::__clam_1::__clam_0"} : !t1
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 7} : core.i32
-          %13 = core.unrealized_conversion_cast %2 : !t2
-          %14 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
-          %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-          %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 : tribute_rt.anyref
-          %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-          %19 = scf.if %18 : tribute_rt.anyref {
-              %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %21 = adt.variant_get %20 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %22 = core.unrealized_conversion_cast %21 : core.i32
-              %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
-              %24 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-              %25 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 : tribute_rt.anyref
-              %27 = adt.variant_cast %26 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %28 = adt.variant_get %27 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-              %29 = adt.variant_get %27 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %30 = arith.cmpi %28, %3 {predicate = @eq} : core.i1
-              %31 = scf.if %30 : tribute_rt.anyref {
-                  %32 = adt.variant_new %29 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  scf.yield %32
-              } {
-                  scf.yield %26
-              }
-              scf.yield %31
-          } {
-              scf.yield %17
-          }
-          scf.yield %19
-      } {
-          %33 = arith.const {value = 1} : core.i1
-          %34 = scf.if %33 : tribute_rt.anyref {
-              %35 = adt.struct_new %3 {type = !"run_state_with_console::__clam_1::__clam_1::env"} : !"run_state_with_console::__clam_1::__clam_1::env"
-              %36 = func.constant {func_ref = @"run_state_with_console::__clam_1::__clam_1"} : !t1
-              %37 = adt.struct_new %36, %35 {type = !_closure} : !_closure
-              %38 = arith.const {value = unit} : core.nil
-              %39 = core.unrealized_conversion_cast %2 : !t2
-              %40 = core.unrealized_conversion_cast %38 : tribute_rt.anyref
-              %41 = adt.struct_get %39 {field = 0, type = !_closure} : core.i32
-              %42 = adt.struct_get %39 {field = 1, type = !_closure} : tribute_rt.anyref
-              %43 = func.call_indirect %41, %0, %42, %40 : tribute_rt.anyref
-              %44 = adt.variant_is %43 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-              %45 = scf.if %44 : tribute_rt.anyref {
-                  %46 = adt.variant_cast %43 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %47 = adt.variant_get %46 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %48 = core.unrealized_conversion_cast %47 : core.i32
-                  %49 = core.unrealized_conversion_cast %48 : tribute_rt.anyref
-                  %50 = adt.struct_get %37 {field = 0, type = !_closure} : core.i32
-                  %51 = adt.struct_get %37 {field = 1, type = !_closure} : tribute_rt.anyref
-                  %52 = func.call_indirect %50, %0, %51, %49 : tribute_rt.anyref
-                  %53 = adt.variant_cast %52 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %54 = adt.variant_get %53 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-                  %55 = adt.variant_get %53 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %56 = arith.cmpi %54, %3 {predicate = @eq} : core.i1
-                  %57 = scf.if %56 : tribute_rt.anyref {
-                      %58 = adt.variant_new %55 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                      scf.yield %58
-                  } {
-                      scf.yield %52
-                  }
-                  scf.yield %57
-              } {
-                  scf.yield %43
-              }
-              scf.yield %45
-          } {
+          scf.default {
               func.unreachable
           }
-          scf.yield %34
       }
-      func.return %8
   }
-
-  func.func @"run_all::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_null {type = !t0} : !t0
-      %4 = func.call %0 {callee = @run_state_with_console} : core.i32
-      %5 = core.unrealized_conversion_cast %2 : !t2
-      %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
-      %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %6 : tribute_rt.anyref
-      func.return %9
+  func.func @"run_all::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32, %4: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      func.unreachable
   }
-
-  func.func @"run_all::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 664197438} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %10 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 3} : core.i32
-          %13 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
-          %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-          %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 : tribute_rt.anyref
-          scf.yield %16
+  func.func @"run_all::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_all::__clam_7::env"} : !"run_all::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_all::__clam_7::env"} : !t2
+      %4 = adt.struct_get %2 {field = 1, type = !"run_all::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run_all::__clam_7::env"} : !__tribute_parent_ty6_1
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_8"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
+  }
+  func.func @"run_all::__clam_9"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_all::__clam_9::env"} : !"run_all::__clam_9::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_all::__clam_9::env"} : !t4
+      %4 = adt.struct_get %2 {field = 1, type = !"run_all::__clam_9::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_all::__clam_9::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_all::__clam_9::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty57_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty57} : !t48
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty57} : !t30
+      %6 = arith.const {value = unit} : core.nil
+      %7 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %7, %8, %6 {func.indirect_call_signature = core.func(core.never, tribute_rt.anyref, core.nil), tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"main::__clam_1::env"} : !t48
+      %4 = adt.struct_get %2 {field = 1, type = !"main::__clam_1::env"} : !t30
+      %5 = adt.struct_get %2 {field = 2, type = !"main::__clam_1::env"} : !t42
+      %6 = adt.struct_get %2 {field = 3, type = !"main::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty57} : !__tribute_parent_ty57_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t62, tribute.calling_convention = 2}
+  }
+  func.func @"step::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"step::__clam_0::__clam_0::env"} : core.i32
+      %6 = adt.struct_get %4 {field = 1, type = !"step::__clam_0::__clam_0::env"} : core.i32
+      %7 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %8 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %9 = adt.struct_new %5 {type = !__tribute_ability_payload_7dc9fb1b} : !__tribute_ability_payload_7dc9fb1b
+      %10 = core.unrealized_conversion_cast %9 : tribute_rt.anyref
+      %11 = effect.dispatch_tail %0, %10 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
+      %12 = core.unrealized_conversion_cast %11 : core.nil
+      %13 = arith.addi %5, %6 : core.i32
+      %14 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
+      %15 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %14, %15, %13 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
+  }
+  func.func @"step::__clam_0::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"step::__clam_0::__clam_1::env"} : !"step::__clam_0::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"step::__clam_0::__clam_1::env"} : !__tribute_one_shot_state_13
+      %6 = adt.struct_get %4 {field = 1, type = !"step::__clam_0::__clam_1::env"} : !t61
+      %7 = core.unrealized_conversion_cast %3 : core.nil
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_13} : core.i1
+      %9 = scf.if %8 : core.never {
+          func.unreachable
       } {
-          %17 = arith.const {value = 1} : core.i1
-          %18 = scf.if %17 : tribute_rt.anyref {
-              %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %20 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
-              %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
-              %22 = arith.const {value = unit} : core.nil
-              %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
-              %24 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
-              %25 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 : tribute_rt.anyref
-              scf.yield %26
-          } {
-              func.unreachable
-          }
-          scf.yield %18
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_13}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2, %7 {func.indirect_call_signature = !t64, tribute.calling_convention = 2}
       }
-      func.return %8
   }
-
-  func.func @"run_all::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref {
-      %4 = arith.const {value = 664197438} : core.i32
-      %5 = arith.cmpi %2, %4 {predicate = @eq} : core.i1
-      %6 = scf.if %5 : tribute_rt.anyref {
-          %7 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-          %8 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
-          %9 = adt.struct_new %8, %7 {type = !_closure} : !_closure
-          %10 = arith.const {value = 3} : core.i32
-          %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-          %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
-          %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 : tribute_rt.anyref
-          scf.yield %14
-      } {
-          %15 = arith.const {value = 1} : core.i1
-          %16 = scf.if %15 : tribute_rt.anyref {
-              %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-              %18 = func.constant {func_ref = @"mixed_nested::__lambda_0"} : !t1
-              %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
-              %20 = arith.const {value = unit} : core.nil
-              %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
-              %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
-              %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-              %24 = func.call_indirect %22, %0, %23, %21 : tribute_rt.anyref
-              scf.yield %24
-          } {
-              func.unreachable
-          }
-          scf.yield %16
-      }
-      func.return %6
+  func.func @"run_state_with_console::__clam_2::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
   }
-
-  func.func @"step::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"step::__clam_0::__clam_0::env"} : !"step::__clam_0::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"step::__clam_0::__clam_0::env"} : core.i32
-      %5 = adt.struct_get %3 {field = 1, type = !"step::__clam_0::__clam_0::env"} : core.i32
-      %6 = adt.struct_get %3 {field = 2, type = !"step::__clam_0::__clam_0::env"} : tribute_rt.anyref
-      %7 = core.unrealized_conversion_cast %2 : core.nil
-      %8 = core.unrealized_conversion_cast %5 : tribute_rt.anyref
-      %9 = effect.dispatch_tail %0, %8 {ability_ref = core.ability_ref() {name = @Console}, op_name = @print} : tribute_rt.anyref
-      %10 = core.unrealized_conversion_cast %9 : core.nil
-      %11 = arith.addi %5, %4 : core.i32
-      %12 = core.unrealized_conversion_cast %6 : !t2
-      %13 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
-      %14 = adt.struct_get %12 {field = 0, type = !_closure} : core.i32
-      %15 = adt.struct_get %12 {field = 1, type = !_closure} : tribute_rt.anyref
-      %16 = func.call_indirect %14, %0, %15, %13 : tribute_rt.anyref
-      func.return %16
+  func.func @"run_state_with_console::__clam_2::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_2::__clam_1::env"} : !"run_state_with_console::__clam_2::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t4
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_2::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
   }
-
-  func.func @"run_state_with_console::__clam_1::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state_with_console::__clam_1::__clam_0::env"} : !"run_state_with_console::__clam_1::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state_with_console::__clam_1::__clam_0::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"run_state_with_console::__clam_3::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6} : !t4
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t23, tribute.calling_convention = 2}
   }
-
-  func.func @"run_state_with_console::__clam_1::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state_with_console::__clam_1::__clam_1::env"} : !"run_state_with_console::__clam_1::__clam_1::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state_with_console::__clam_1::__clam_1::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"run_state_with_console::__clam_3::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state_with_console::__clam_3::__clam_1::env"} : !"run_state_with_console::__clam_3::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t4
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t2
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state_with_console::__clam_3::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6} : !__tribute_parent_ty6_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t10, tribute.calling_convention = 2}
   }
 }

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -3,256 +3,469 @@ source: tests/active_pipeline_goldens.rs
 expression: ir_text
 ---
 core.module @resumptive_op {
-  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
+  !String = adt.typeref() {name = @String}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !String_1 = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [!String, !String, core.i32]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !__tribute_parent_ty6 = adt.typeref() {name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !Result_1 = adt.typeref() {name = @Result}
+  !"String::Cursor_1" = adt.typeref() {name = @"String::Cursor"}
+  !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [!String, !"String::Cursor_1"]], [@CursorChunk, [core.bytes, core.i32, core.i32, !"String::Cursor_1"]]]}
+  !__tribute_parent_ty25_1 = adt.typeref() {name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !t7 = closure.closure(core.func(core.never, core.i32)) {tribute.calling_convention = 2}
+  !Option_1 = adt.typeref() {name = @Option}
+  !__tribute_parent_ty17_1 = adt.typeref() {name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !__tribute_parent_ty5_1 = adt.typeref() {name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
-  !t2 = core.func(tribute_rt.anyref, tribute_rt.anyref)
-  !t1 = closure.closure(!t2)
-  !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
-  !"run_state::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state::__clam_1::__clam_0::env"}
-  !"run_state::__clam_1::__clam_1::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state::__clam_1::__clam_1::env"}
-  !"Result::map_err::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map_err::__clam_0::env"}
-  !"Option::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Option::map::__clam_0::env"}
-  !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
-  !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
+  !"Result$Int$Int::ParseError" = adt.typeref() {name = @"Result$Int$Int::ParseError"}
+  !t20 = core.func(core.never, tribute_rt.anyref, !Result_1)
+  !t24 = core.func(core.never, !Result_1)
+  !t6 = closure.closure(!t24) {tribute.calling_convention = 2}
+  !t37 = core.func(core.never, tribute_rt.anyref, !Option_1)
+  !t38 = core.func(core.never, tribute_rt.anyref, core.i32)
+  !t39 = core.func(core.never, !Option_1)
+  !t14 = closure.closure(!t39) {tribute.calling_convention = 2}
+  !t40 = core.func(core.never, !String)
+  !t17 = closure.closure(!t40) {tribute.calling_convention = 2}
+  !t41 = core.func(core.never, tribute_rt.anyref)
+  !__tribute_one_shot_state_13 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_13}
+  !__tribute_one_shot_state_14 = adt.struct() {fields = [[@consumed, core.i1]], name = @__tribute_one_shot_state_14}
+  !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"bump::__clam_0::__clam_0::env"}
+  !__tribute_ability_payload_50641714 = adt.struct() {fields = [[@arg0, core.i32]], name = @__tribute_ability_payload_50641714}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
-  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !t4 = core.ability_ref() {name = @"abilities::Throw"}
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !t48 = closure.closure(core.func(core.never, core.nil)) {tribute.calling_convention = 2}
+  !__tribute_parent_ty57_1 = adt.typeref() {name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t49 = core.func(core.never, tribute_rt.anyref, !String)
+  !"Int::ParseError_1" = adt.typeref() {name = @"Int::ParseError"}
+  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, !String]], name = @"std::io::SystemError"}
+  !__tribute_parent_ty0_1 = adt.typeref() {name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !__tribute_ability_payload_7590c57e = adt.struct() {fields = [], name = @__tribute_ability_payload_7590c57e}
+  !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
+  !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [!"std::io::SystemError_1"]]]}
+  !"std::io::Error_1" = adt.typeref() {name = @"std::io::Error"}
+  !__tribute_ability_payload_0efb32ee = adt.struct() {fields = [[@arg0, !"std::io::Error_1"]], name = @__tribute_ability_payload_0efb32ee}
+  !t60 = core.ability_ref(!"std::io::Error_1") {name = @"abilities::Throw"}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t3 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
-  !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-
+  !t13 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6, core.i32)
+  !t16 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6, tribute_rt.anyref)
+  !t19 = core.func(core.never, !t0, !__tribute_parent_ty6, tribute_rt.anyref)
+  !t10 = closure.closure(!t19) {tribute.calling_convention = 2}
+  !t18 = core.func(core.never, !t0, tribute_rt.anyref, !t10, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t21 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, !Result_1)
+  !t22 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t23 = core.func(core.never, !t0, !__tribute_parent_ty25_1, tribute_rt.anyref)
+  !t9 = closure.closure(!t23) {tribute.calling_convention = 2}
+  !t25 = core.func(core.never, !t0, !t10, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t1 = closure.closure(!t25) {tribute.calling_convention = 2}
+  !__tribute_parent_ty6_1 = adt.struct() {fields = [[@done, !t7], [@dispatch, !t1]], name = @__tribute_parent_ty6, tribute.cps_parent_result = core.i32}
+  !t26 = core.func(core.never, !t0, !__tribute_parent_ty6, core.i32)
+  !t3 = closure.closure(!t26) {tribute.calling_convention = 2}
+  !"run_state::__clam_2::__clam_1::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t1], [@_2, !t3], [@_3, !t0]], name = @"run_state::__clam_2::__clam_1::env"}
+  !"run_state::__clam_3::__clam_1::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t1], [@_2, !t3], [@_3, !t0]], name = @"run_state::__clam_3::__clam_1::env"}
+  !"run_state::__clam_1::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t1], [@_2, !t3], [@_3, !t0]], name = @"run_state::__clam_1::env"}
+  !"run_state::__clam_9::env" = adt.struct() {fields = [[@_0, !t7], [@_1, !t1], [@_2, !t3], [@_3, !t0]], name = @"run_state::__clam_9::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::__clam_0::env"}
+  !"run_state::__clam_7::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, !__tribute_parent_ty6]], name = @"run_state::__clam_7::env"}
+  !t28 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty6, !t0, !t3)) {tribute.calling_convention = 2}
+  !t29 = closure.closure(core.func(core.never, !t0, closure.closure(core.func(core.never, !t0, !__tribute_parent_ty57_1, tribute_rt.anyref)) {tribute.calling_convention = 2}, core.i32, core.i32, core.i32, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t31 = core.func(core.never, !t0, tribute_rt.anyref, !t9, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t32 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty0_1, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t34 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, !Option_1)
+  !t35 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, !String)
+  !t36 = core.func(core.never, !t0, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t33 = closure.closure(!t36) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t32]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t32]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_15::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_15::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_16::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_16::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_17::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_17::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_19::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_19::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_20::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t1]], name = @"__tribute_make_dispatch_adapter_20::__clam_0::env"}
+  !"bump::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_14], [@_1, !t3]], name = @"bump::__clam_1::env"}
+  !t42 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty57_1, core.i32)) {tribute.calling_convention = 2}
+  !"main::__clam_1::env" = adt.struct() {fields = [[@_0, !t48], [@_1, !t29], [@_2, !t42], [@_3, !t0]], name = @"main::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t42], [@_1, !t0], [@_2, !__tribute_parent_ty57_1]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t42], [@_1, !t10]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_21::__clam_0::env" = adt.struct() {fields = [[@_0, !t42], [@_1, !t29]], name = @"__tribute_make_dispatch_adapter_21::__clam_0::env"}
+  !t43 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t44 = core.func(core.never, !t0, !__tribute_parent_ty17_1, tribute_rt.anyref)
+  !t15 = closure.closure(!t44) {tribute.calling_convention = 2}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t32]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::__clam_0::env"}
+  !__tribute_parent_ty57 = adt.struct() {fields = [[@done, !t48], [@dispatch, !t29]], name = @__tribute_parent_ty57, tribute.cps_parent_result = core.nil}
+  !t45 = core.func(core.never, !t0, tribute_rt.anyref, !t15, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t46 = core.func(core.never, !t0, !t9, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t2 = closure.closure(!t46) {tribute.calling_convention = 2}
+  !__tribute_parent_ty25 = adt.struct() {fields = [[@done, !t6], [@dispatch, !t2]], name = @__tribute_parent_ty25, tribute.cps_parent_result = !Result_1}
+  !"Result::map_err::__clam_3::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t2], [@_2, !t9], [@_3, !t0]], name = @"Result::map_err::__clam_3::env"}
+  !"Result::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t2], [@_2, !t9], [@_3, !t0]], name = @"Result::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_5::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_5::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_7::__clam_0::env" = adt.struct() {fields = [[@_0, !t9], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_7::__clam_0::env"}
+  !t47 = core.func(core.never, !t0, !__tribute_parent_ty25_1, !Result_1)
+  !t8 = closure.closure(!t47) {tribute.calling_convention = 2}
+  !"Result::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t2], [@_2, !t8], [@_3, !t0]], name = @"Result::and_then::__clam_1::env"}
+  !"Result::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t2], [@_2, !t8], [@_3, !t0]], name = @"Result::and_then::__clam_3::env"}
+  !"Result::map_err::__clam_1::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t2], [@_2, !t8], [@_3, !t0]], name = @"Result::map_err::__clam_1::env"}
+  !"Result::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t6], [@_1, !t2], [@_2, !t8], [@_3, !t0]], name = @"Result::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t0], [@_2, !__tribute_parent_ty25_1]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t9]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t9]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t9]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t9]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_4::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_4::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_6::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_6::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_8::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_8::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_9::__clam_0::env" = adt.struct() {fields = [[@_0, !t8], [@_1, !t2]], name = @"__tribute_make_dispatch_adapter_9::__clam_0::env"}
+  !t52 = core.func(core.never, !t0, tribute_rt.anyref, !t33, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t53 = core.func(core.never, !t0, !t15, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t4 = closure.closure(!t53) {tribute.calling_convention = 2}
+  !__tribute_parent_ty17 = adt.struct() {fields = [[@done, !t14], [@dispatch, !t4]], name = @__tribute_parent_ty17, tribute.cps_parent_result = !Option_1}
+  !"Option::map::__clam_3::env" = adt.struct() {fields = [[@_0, !t14], [@_1, !t4], [@_2, !t15], [@_3, !t0]], name = @"Option::map::__clam_3::env"}
+  !"__tribute_make_dispatch_adapter_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t15], [@_1, !t4]], name = @"__tribute_make_dispatch_adapter_1::__clam_0::env"}
+  !t54 = core.func(core.never, !t0, !t32, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t30 = closure.closure(!t54) {tribute.calling_convention = 2}
+  !t50 = closure.closure(core.func(core.never, !t0, closure.closure(!t41) {tribute.calling_convention = 2}, !t30, tribute_rt.anyref)) {tribute.calling_convention = 2}
+  !t51 = core.func(core.never, !t0, tribute_rt.anyref, closure.closure(!t41) {tribute.calling_convention = 2}, !t30, tribute_rt.anyref)
+  !t55 = core.func(core.never, !t0, !t33, core.i32, core.i32, core.i32, tribute_rt.anyref)
+  !t5 = closure.closure(!t55) {tribute.calling_convention = 2}
+  !__tribute_parent_ty5 = adt.struct() {fields = [[@done, !t17], [@dispatch, !t5]], name = @__tribute_parent_ty5, tribute.cps_parent_result = !String}
+  !t56 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty5_1, tribute_rt.anyref)
+  !t57 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty0_1, tribute_rt.anyref)
+  !t58 = core.func(core.never, !t0, !__tribute_parent_ty17_1, !Option_1)
+  !t11 = closure.closure(!t58) {tribute.calling_convention = 2}
+  !"Option::and_then::__clam_1::env" = adt.struct() {fields = [[@_0, !t14], [@_1, !t4], [@_2, !t11], [@_3, !t0]], name = @"Option::and_then::__clam_1::env"}
+  !"Option::and_then::__clam_3::env" = adt.struct() {fields = [[@_0, !t14], [@_1, !t4], [@_2, !t11], [@_3, !t0]], name = @"Option::and_then::__clam_3::env"}
+  !"Option::map::__clam_1::env" = adt.struct() {fields = [[@_0, !t14], [@_1, !t4], [@_2, !t11], [@_3, !t0]], name = @"Option::map::__clam_1::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t0], [@_2, !__tribute_parent_ty17_1]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t15]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t15]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t15]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t4]], name = @"__tribute_make_dispatch_adapter_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_2::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t4]], name = @"__tribute_make_dispatch_adapter_2::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_3::__clam_0::env" = adt.struct() {fields = [[@_0, !t11], [@_1, !t4]], name = @"__tribute_make_dispatch_adapter_3::__clam_0::env"}
+  !t59 = core.func(core.never, !t0, !__tribute_parent_ty5_1, !String)
+  !t12 = closure.closure(!t59) {tribute.calling_convention = 2}
+  !"std::io::read_line::__clam_1::env" = adt.struct() {fields = [[@_0, !t17], [@_1, !t5], [@_2, !t12], [@_3, !t0]], name = @"std::io::read_line::__clam_1::env"}
+  !"std::io::read_line::__clam_3::env" = adt.struct() {fields = [[@_0, !t17], [@_1, !t5], [@_2, !t12], [@_3, !t0]], name = @"std::io::read_line::__clam_3::env"}
+  !"std::io::read_line::__clam_6::env" = adt.struct() {fields = [[@_0, !t17], [@_1, !t5], [@_2, !t12], [@_3, !t0]], name = @"std::io::read_line::__clam_6::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t0], [@_2, !__tribute_parent_ty5_1]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t33]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t33]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t33]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_10::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t5]], name = @"__tribute_make_dispatch_adapter_10::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_11::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t5]], name = @"__tribute_make_dispatch_adapter_11::__clam_0::env"}
+  !"__tribute_make_dispatch_adapter_12::__clam_0::env" = adt.struct() {fields = [[@_0, !t12], [@_1, !t5]], name = @"__tribute_make_dispatch_adapter_12::__clam_0::env"}
+  !__tribute_parent_ty0 = adt.struct() {fields = [[@done, closure.closure(!t41) {tribute.calling_convention = 2}], [@dispatch, !t30]], name = @__tribute_parent_ty0, tribute.cps_parent_result = tribute_rt.anyref}
+  !t62 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty57_1, core.i32)
+  !t63 = core.func(core.never, !t0, tribute_rt.anyref, !__tribute_parent_ty6, core.nil)
+  !t64 = core.func(core.never, !t0, !__tribute_parent_ty6, core.nil)
+  !t61 = closure.closure(!t64) {tribute.calling_convention = 2}
+  !t27 = closure.closure(core.func(core.never, !t0, !__tribute_parent_ty6, !t0, core.i32, !t61)) {tribute.calling_convention = 2}
+  !"__tribute_make_local_dispatch_18::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, !t3], [@_2, !t0], [@_3, !t28], [@_4, !t27], [@_5, !__tribute_parent_ty6], [@_6, !t1]], name = @"__tribute_make_local_dispatch_18::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, core.i32], [@_3, !t28], [@_4, !t27], [@_5, !t10]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, core.i32], [@_3, !t28], [@_4, !t27], [@_5, !t10]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, core.i32], [@_3, !t28], [@_4, !t27], [@_5, !t10]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_0::env"}
+  !"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !t3], [@_1, !t0], [@_2, core.i32], [@_3, !t28], [@_4, !t27], [@_5, !t10]], name = @"__tribute_make_local_dispatch_18::__clam_0::__clam_1::env"}
+  !"bump::__clam_0::__clam_1::env" = adt.struct() {fields = [[@_0, !__tribute_one_shot_state_13], [@_1, !t61]], name = @"bump::__clam_0::__clam_1::env"}
+  !"std::io::ReadLineResult_1" = adt.typeref() {name = @"std::io::ReadLineResult"}
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable
   }
-
   func.func @__tribute_evidence_extend(%0: !t0, %1: !_Marker) -> !t0 {
       func.unreachable
   }
-
   func.func @__tribute_evidence_lookup(%0: !t0, %1: core.i32) -> !_Marker {
       func.unreachable
   }
-    !"std::io::SystemError_1" = adt.typeref() {name = @"std::io::SystemError"}
-
-  func.func @bump(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 2} {
-      %2 = adt.struct_new %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
-      %3 = func.constant {func_ref = @"bump::__clam_0"} : !t2
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %7 = effect.dispatch_cps %0, %6, %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-      func.return %7
-  }
-
-  func.func @"resumptive_op::__lambda_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      func.return %2
-  }
-
-  func.func @"resumptive_op::__lambda_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.variant_new %2 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %3
-  }
-
-  func.func @run_state() -> core.i32 attributes {tribute.calling_convention = 0} {
-      %0 = arith.const {value = 0} : core.i32
-      %1 = adt.array_new %0 {type = !t0} : !t0
-      %2 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %3 = func.constant {func_ref = @"resumptive_op::__lambda_0"} : !t2
-      %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
-      %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %6 = func.constant {func_ref = @"run_state::__clam_0"} : !t2
-      %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
-      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %9 = func.constant {func_ref = @"resumptive_op::__lambda_1"} : !t2
+  func.func @bump(%0: !t0, %1: !t7, %2: !t1) -> core.never attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"bump::__clam_0"} : !t26
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = arith.const {value = 0} : core.i1
+      %7 = adt.struct_new %6 {type = !__tribute_one_shot_state_14} : !__tribute_one_shot_state_14
+      %8 = adt.struct_new %7, %5 {type = !"bump::__clam_1::env"} : !"bump::__clam_1::env"
+      %9 = func.constant {func_ref = @"bump::__clam_1"} : !t19
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = adt.ref_null {type = !t0} : !t0
-      %12 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
-      %13 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref)
-      %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
-      %17 = arith.const {value = 0} : tribute_rt.anyref
-      %18 = func.call {callee = @__tribute_next_tag} : core.i32
-      %19 = effect.extend %1, %18, %17, %16 {ability_ref = core.ability_ref() {name = @State}} : !t0
-      %20 = func.call_indirect %12, %19, %13, %10 : tribute_rt.anyref
-      %21 = adt.variant_is %20 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-      %22 = scf.if %21 : tribute_rt.anyref {
-          %23 = adt.variant_cast %20 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %24 = adt.variant_get %23 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-          %25 = core.unrealized_conversion_cast %24 : core.i32
-          %26 = core.unrealized_conversion_cast %25 : tribute_rt.anyref
-          %27 = adt.ref_null {type = !t0} : !t0
-          %28 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-          %29 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-          %30 = func.call_indirect %28, %19, %29, %26 : tribute_rt.anyref
-          scf.yield %30
-      } {
-          %31 = adt.variant_cast %20 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %32 = adt.variant_get %31 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-          %33 = adt.variant_get %31 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-          %34 = arith.cmpi %32, %18 {predicate = @eq} : core.i1
-          %35 = scf.if %34 : tribute_rt.anyref {
-              %36 = adt.ref_null {type = !t0} : !t0
-              %37 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
-              %38 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-              %39 = func.call_indirect %37, %36, %38, %33 : tribute_rt.anyref
-              scf.yield %39
-          } {
-              scf.yield %20
-          }
-          scf.yield %35
-      }
-      %40 = core.unrealized_conversion_cast %22 : core.i32
-      func.return %40
+      %11 = adt.struct_new {type = !__tribute_ability_payload_7590c57e} : !__tribute_ability_payload_7590c57e
+      %12 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
+      effect.dispatch_cps %0, %2, %10, %12 {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get}
   }
-
-  func.func @main() -> core.nil attributes {tribute.calling_convention = 0} {
-      %0 = func.call {callee = @run_state, tribute.calling_convention = 0} : core.i32
-      %1 = arith.const {value = unit} : core.nil
-      func.return %1
+  func.func @run_state(%0: !t0, %1: !t7, %2: !t1) -> core.never attributes {tribute.calling_convention = 2} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"run_state::__clam_0"} : !t26
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"run_state::__clam_1::env"} : !"run_state::__clam_1::env"
+      %7 = func.constant {func_ref = @"run_state::__clam_1"} : core.func(core.never, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_15, tribute.calling_convention = 0} : !t1
+      %10 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %11 = func.constant {func_ref = @"run_state::__clam_2"} : core.func(core.never, !t0, !__tribute_parent_ty6, !t0, !t3)
+      %12 = adt.struct_new %11, %10 {type = !_closure} : !_closure
+      %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %14 = func.constant {func_ref = @"run_state::__clam_3"} : core.func(core.never, !t0, !__tribute_parent_ty6, !t0, core.i32, !t61)
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %17 = func.constant {func_ref = @"run_state::__clam_4"} : core.func(tribute_rt.anyref, !t0, core.i32, tribute_rt.anyref)
+      %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
+      %19 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %20 = func.constant {func_ref = @"run_state::__clam_5"} : core.func(core.never, !t0, !__tribute_parent_ty6, core.i32, tribute_rt.anyref)
+      %21 = adt.struct_new %20, %19 {type = !_closure} : !_closure
+      %22 = func.call {callee = @__tribute_next_tag} : core.i32
+      %23 = effect.extend %0, %22, %18, %21 {ability_ref = core.ability_ref(core.i32) {name = @State}} : !t0
+      %24 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %25 = func.constant {func_ref = @"run_state::__clam_6"} : !t26
+      %26 = adt.struct_new %25, %24 {type = !_closure} : !_closure
+      %27 = adt.struct_new %8, %9 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %28 = adt.struct_new %26, %23, %27 {type = !"run_state::__clam_7::env"} : !"run_state::__clam_7::env"
+      %29 = func.constant {func_ref = @"run_state::__clam_7"} : core.func(core.never, core.i32)
+      %30 = adt.struct_new %29, %28 {type = !_closure} : !_closure
+      %31 = func.call %27, %0, %22, %26, %12, %15 {callee = @__tribute_make_local_dispatch_18, tribute.calling_convention = 0} : !t1
+      %32 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %33 = func.constant {func_ref = @"run_state::__clam_8"} : !t26
+      %34 = adt.struct_new %33, %32 {type = !_closure} : !_closure
+      %35 = adt.struct_new %30, %31, %34, %23 {type = !"run_state::__clam_9::env"} : !"run_state::__clam_9::env"
+      %36 = func.constant {func_ref = @"run_state::__clam_9"} : core.func(core.never, core.i32)
+      %37 = adt.struct_new %36, %35 {type = !_closure} : !_closure
+      %38 = func.call %34, %31 {callee = @__tribute_make_dispatch_adapter_20, tribute.calling_convention = 0} : !t1
+      func.tail_call %23, %37, %38 {callee = @bump, tribute.calling_convention = 2}
   }
-
-  func.func @"bump::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"bump::__clam_0::env"} : !"bump::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::env"} : tribute_rt.anyref
-      %5 = core.unrealized_conversion_cast %2 : core.i32
+  func.func @main(%0: !t0, %1: !t48, %2: !t29) -> core.never attributes {tribute.calling_convention = 2, tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
+      %3 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %4 = func.constant {func_ref = @"main::__clam_0"} : core.func(core.never, !t0, !__tribute_parent_ty57_1, core.i32)
+      %5 = adt.struct_new %4, %3 {type = !_closure} : !_closure
+      %6 = adt.struct_new %1, %2, %5, %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %7 = func.constant {func_ref = @"main::__clam_1"} : core.func(core.never, core.i32)
+      %8 = adt.struct_new %7, %6 {type = !_closure} : !_closure
+      %9 = func.call %5, %2 {callee = @__tribute_make_dispatch_adapter_21, tribute.calling_convention = 0} : !t1
+      func.tail_call %0, %8, %9 {callee = @run_state, tribute.calling_convention = 2}
+  }
+  func.func @"bump::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
       %6 = arith.const {value = 1} : core.i32
-      %7 = arith.addi %5, %6 : core.i32
-      %8 = adt.struct_new %5, %4 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
-      %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t2
+      %7 = arith.addi %3, %6 : core.i32
+      %8 = adt.struct_new %3 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
+      %9 = func.constant {func_ref = @"bump::__clam_0::__clam_0"} : !t64
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
-      %11 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-      %12 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %13 = effect.dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
-      func.return %13
+      %11 = arith.const {value = 0} : core.i1
+      %12 = adt.struct_new %11 {type = !__tribute_one_shot_state_13} : !__tribute_one_shot_state_13
+      %13 = adt.struct_new %12, %10 {type = !"bump::__clam_0::__clam_1::env"} : !"bump::__clam_0::__clam_1::env"
+      %14 = func.constant {func_ref = @"bump::__clam_0::__clam_1"} : !t19
+      %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
+      %16 = adt.struct_new %7 {type = !__tribute_ability_payload_50641714} : !__tribute_ability_payload_50641714
+      %17 = core.unrealized_conversion_cast %16 : tribute_rt.anyref
+      effect.dispatch_cps %0, %5, %15, %17 {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @set}
   }
-
-  func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_null {type = !t0} : !t0
-      %4 = func.call %0, %2 {callee = @bump} : tribute_rt.anyref
-      func.return %4
-  }
-
-  func.func @"run_state::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref, %3: core.i32, %4: core.i32, %5: tribute_rt.anyref) -> tribute_rt.anyref {
-      %6 = arith.const {value = 1972422014} : core.i32
-      %7 = arith.cmpi %4, %6 {predicate = @eq} : core.i1
-      %8 = scf.if %7 : tribute_rt.anyref {
-          %9 = adt.struct_new %3 {type = !"run_state::__clam_1::__clam_0::env"} : !"run_state::__clam_1::__clam_0::env"
-          %10 = func.constant {func_ref = @"run_state::__clam_1::__clam_0"} : !t2
-          %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
-          %12 = arith.const {value = 10} : core.i32
-          %13 = core.unrealized_conversion_cast %2 : !t1
-          %14 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
-          %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
-          %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 : tribute_rt.anyref
-          %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-          %19 = scf.if %18 : tribute_rt.anyref {
-              %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %21 = adt.variant_get %20 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-              %22 = core.unrealized_conversion_cast %21 : core.i32
-              %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
-              %24 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
-              %25 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 : tribute_rt.anyref
-              %27 = adt.variant_cast %26 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %28 = adt.variant_get %27 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-              %29 = adt.variant_get %27 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-              %30 = arith.cmpi %28, %3 {predicate = @eq} : core.i1
-              %31 = scf.if %30 : tribute_rt.anyref {
-                  %32 = adt.variant_new %29 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  scf.yield %32
-              } {
-                  scf.yield %26
-              }
-              scf.yield %31
-          } {
-              scf.yield %17
-          }
-          scf.yield %19
+  func.func @"bump::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"bump::__clam_1::env"} : !"bump::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"bump::__clam_1::env"} : !__tribute_one_shot_state_14
+      %6 = adt.struct_get %4 {field = 1, type = !"bump::__clam_1::env"} : !t3
+      %7 = core.unrealized_conversion_cast %3 : core.i32
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_14} : core.i1
+      %9 = scf.if %8 : core.never {
+          func.unreachable
       } {
-          %33 = arith.const {value = 1} : core.i1
-          %34 = scf.if %33 : tribute_rt.anyref {
-              %35 = adt.struct_new %3 {type = !"run_state::__clam_1::__clam_1::env"} : !"run_state::__clam_1::__clam_1::env"
-              %36 = func.constant {func_ref = @"run_state::__clam_1::__clam_1"} : !t2
-              %37 = adt.struct_new %36, %35 {type = !_closure} : !_closure
-              %38 = arith.const {value = unit} : core.nil
-              %39 = core.unrealized_conversion_cast %2 : !t1
-              %40 = core.unrealized_conversion_cast %38 : tribute_rt.anyref
-              %41 = adt.struct_get %39 {field = 0, type = !_closure} : core.i32
-              %42 = adt.struct_get %39 {field = 1, type = !_closure} : tribute_rt.anyref
-              %43 = func.call_indirect %41, %0, %42, %40 : tribute_rt.anyref
-              %44 = adt.variant_is %43 {tag = @Normal, type = !__tribute_cps_control} : core.i1
-              %45 = scf.if %44 : tribute_rt.anyref {
-                  %46 = adt.variant_cast %43 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %47 = adt.variant_get %46 {field = 0, tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %48 = core.unrealized_conversion_cast %47 : core.i32
-                  %49 = core.unrealized_conversion_cast %48 : tribute_rt.anyref
-                  %50 = adt.struct_get %37 {field = 0, type = !_closure} : core.i32
-                  %51 = adt.struct_get %37 {field = 1, type = !_closure} : tribute_rt.anyref
-                  %52 = func.call_indirect %50, %0, %51, %49 : tribute_rt.anyref
-                  %53 = adt.variant_cast %52 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %54 = adt.variant_get %53 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
-                  %55 = adt.variant_get %53 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-                  %56 = arith.cmpi %54, %3 {predicate = @eq} : core.i1
-                  %57 = scf.if %56 : tribute_rt.anyref {
-                      %58 = adt.variant_new %55 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
-                      scf.yield %58
-                  } {
-                      scf.yield %52
-                  }
-                  scf.yield %57
-              } {
-                  scf.yield %43
-              }
-              scf.yield %45
-          } {
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_14}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2, %7 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
+      }
+  }
+  func.func @"run_state::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t38, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_1::env"} : !"run_state::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_1::env"} : !t7
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_1::env"} : !t3
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_2"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: !t0, %4: !t3) -> core.never attributes {tribute.calling_convention = 2} {
+      %5 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %6 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %7 = arith.const {value = 10} : core.i32
+      %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %9 = func.constant {func_ref = @"run_state::__clam_2::__clam_0"} : !t26
+      %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
+      %11 = adt.struct_new %5, %6, %10, %3 {type = !"run_state::__clam_2::__clam_1::env"} : !"run_state::__clam_2::__clam_1::env"
+      %12 = func.constant {func_ref = @"run_state::__clam_2::__clam_1"} : core.func(core.never, core.i32)
+      %13 = adt.struct_new %12, %11 {type = !_closure} : !_closure
+      %14 = func.call %10, %6 {callee = @__tribute_make_dispatch_adapter_16, tribute.calling_convention = 0} : !t1
+      %15 = adt.struct_new %13, %14 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %16 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %17 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %16, %3, %17, %15, %7 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_3"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: !t0, %4: core.i32, %5: !t61) -> core.never attributes {tribute.calling_convention = 2} {
+      %6 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %7 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %8 = arith.const {value = unit} : core.nil
+      %9 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+      %10 = func.constant {func_ref = @"run_state::__clam_3::__clam_0"} : !t26
+      %11 = adt.struct_new %10, %9 {type = !_closure} : !_closure
+      %12 = adt.struct_new %6, %7, %11, %3 {type = !"run_state::__clam_3::__clam_1::env"} : !"run_state::__clam_3::__clam_1::env"
+      %13 = func.constant {func_ref = @"run_state::__clam_3::__clam_1"} : core.func(core.never, core.i32)
+      %14 = adt.struct_new %13, %12 {type = !_closure} : !_closure
+      %15 = func.call %11, %7 {callee = @__tribute_make_dispatch_adapter_17, tribute.calling_convention = 0} : !t1
+      %16 = adt.struct_new %14, %15 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %17 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %18 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %17, %3, %18, %16, %8 {func.indirect_call_signature = !t63, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_4"(%0: !t0, %1: tribute_rt.anyref, %2: core.i32, %3: tribute_rt.anyref) -> tribute_rt.anyref attributes {tribute.calling_convention = 1} {
+      scf.switch %2 {
+          scf.default {
               func.unreachable
           }
-          scf.yield %34
       }
-      func.return %8
   }
-
-  func.func @"bump::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"bump::__clam_0::__clam_0::env"} : core.i32
-      %5 = adt.struct_get %3 {field = 1, type = !"bump::__clam_0::__clam_0::env"} : tribute_rt.anyref
-      %6 = core.unrealized_conversion_cast %2 : core.nil
-      %7 = core.unrealized_conversion_cast %5 : !t1
-      %8 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %9 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
-      %10 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = func.call_indirect %9, %0, %10, %8 : tribute_rt.anyref
-      func.return %11
+  func.func @"run_state::__clam_5"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32, %4: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      func.unreachable
   }
-
-  func.func @"run_state::__clam_1::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state::__clam_1::__clam_0::env"} : !"run_state::__clam_1::__clam_0::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state::__clam_1::__clam_0::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"run_state::__clam_6"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t38, tribute.calling_convention = 2}
   }
-
-  func.func @"run_state::__clam_1::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: tribute_rt.anyref) -> tribute_rt.anyref {
-      %3 = adt.ref_cast %1 {type = !"run_state::__clam_1::__clam_1::env"} : !"run_state::__clam_1::__clam_1::env"
-      %4 = adt.struct_get %3 {field = 0, type = !"run_state::__clam_1::__clam_1::env"} : core.i32
-      %5 = adt.variant_new %4, %2 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
-      func.return %5
+  func.func @"run_state::__clam_7"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_7::env"} : !"run_state::__clam_7::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_7::env"} : !t3
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_7::env"} : !t0
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_7::env"} : !__tribute_parent_ty6
+      %6 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %4, %7, %5, %1 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_8"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t38, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_9"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_9::env"} : !"run_state::__clam_9::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_9::env"} : !t7
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_9::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_9::env"} : !t3
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_9::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty57_1, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty57} : !t48
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty57} : !t29
+      %6 = arith.const {value = unit} : core.nil
+      %7 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %8 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %7, %8, %6 {func.indirect_call_signature = core.func(core.never, tribute_rt.anyref, core.nil), tribute.calling_convention = 2}
+  }
+  func.func @"main::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"main::__clam_1::env"} : !"main::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"main::__clam_1::env"} : !t48
+      %4 = adt.struct_get %2 {field = 1, type = !"main::__clam_1::env"} : !t29
+      %5 = adt.struct_get %2 {field = 2, type = !"main::__clam_1::env"} : !t42
+      %6 = adt.struct_get %2 {field = 3, type = !"main::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty57} : !__tribute_parent_ty57_1
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t62, tribute.calling_convention = 2}
+  }
+  func.func @"bump::__clam_0::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"bump::__clam_0::__clam_0::env"} : !"bump::__clam_0::__clam_0::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"bump::__clam_0::__clam_0::env"} : core.i32
+      %6 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %7 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %8 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %9, %5 {func.indirect_call_signature = !t38, tribute.calling_convention = 2}
+  }
+  func.func @"bump::__clam_0::__clam_1"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.ref_cast %1 {type = !"bump::__clam_0::__clam_1::env"} : !"bump::__clam_0::__clam_1::env"
+      %5 = adt.struct_get %4 {field = 0, type = !"bump::__clam_0::__clam_1::env"} : !__tribute_one_shot_state_13
+      %6 = adt.struct_get %4 {field = 1, type = !"bump::__clam_0::__clam_1::env"} : !t61
+      %7 = core.unrealized_conversion_cast %3 : core.nil
+      %8 = adt.struct_get %5 {field = 0, type = !__tribute_one_shot_state_13} : core.i1
+      %9 = scf.if %8 : core.never {
+          func.unreachable
+      } {
+          %10 = arith.const {value = 1} : core.i1
+          adt.struct_set %5, %10 {field = 0, type = !__tribute_one_shot_state_13}
+          %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
+          %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
+          func.tail_call_indirect %11, %0, %12, %2, %7 {func.indirect_call_signature = !t63, tribute.calling_convention = 2}
+      }
+  }
+  func.func @"run_state::__clam_2::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t38, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_2::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_2::__clam_1::env"} : !"run_state::__clam_2::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_2::__clam_1::env"} : !t7
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_2::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_2::__clam_1::env"} : !t3
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_2::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_3::__clam_0"(%0: !t0, %1: tribute_rt.anyref, %2: !__tribute_parent_ty6, %3: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %4 = adt.struct_get %2 {field = 0, type = !__tribute_parent_ty6_1} : !t7
+      %5 = adt.struct_get %2 {field = 1, type = !__tribute_parent_ty6_1} : !t1
+      %6 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
+      %7 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %6, %7, %3 {func.indirect_call_signature = !t38, tribute.calling_convention = 2}
+  }
+  func.func @"run_state::__clam_3::__clam_1"(%0: tribute_rt.anyref, %1: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+      %2 = adt.ref_cast %0 {type = !"run_state::__clam_3::__clam_1::env"} : !"run_state::__clam_3::__clam_1::env"
+      %3 = adt.struct_get %2 {field = 0, type = !"run_state::__clam_3::__clam_1::env"} : !t7
+      %4 = adt.struct_get %2 {field = 1, type = !"run_state::__clam_3::__clam_1::env"} : !t1
+      %5 = adt.struct_get %2 {field = 2, type = !"run_state::__clam_3::__clam_1::env"} : !t3
+      %6 = adt.struct_get %2 {field = 3, type = !"run_state::__clam_3::__clam_1::env"} : !t0
+      %7 = adt.struct_new %3, %4 {type = !__tribute_parent_ty6_1} : !__tribute_parent_ty6
+      %8 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
+      %9 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
+      func.tail_call_indirect %8, %6, %9, %7, %1 {func.indirect_call_signature = !t13, tribute.calling_convention = 2}
   }
 }

--- a/tests/snapshots/diagnostic_snapshots__diag_handler_arm_wrong_signature.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_handler_arm_wrong_signature.snap
@@ -2,6 +2,12 @@
 source: tests/diagnostic_snapshots.rs
 expression: result.diagnostics
 ---
+- message: cannot infer a concrete type for 2 body-local expressions
+  span:
+    start: 138
+    end: 388
+  severity: Error
+  phase: TypeChecking
 - message: "handler arm has 2 parameter(s), but operation 'set' expects 1"
   span:
     start: 337

--- a/tests/snapshots/diagnostic_snapshots__diag_unresolved_name.snap
+++ b/tests/snapshots/diagnostic_snapshots__diag_unresolved_name.snap
@@ -8,6 +8,12 @@ expression: result.diagnostics
     end: 32
   severity: Error
   phase: NameResolution
+- message: cannot infer a concrete type for 1 body-local expression
+  span:
+    start: 0
+    end: 34
+  severity: Error
+  phase: TypeChecking
 - message: "function 'main' must return Nil, but returns `Int`"
   span:
     start: 0

--- a/tests/wasm_compilation.rs
+++ b/tests/wasm_compilation.rs
@@ -115,6 +115,31 @@ fn main() ->{std::io::Io} Nil {
     expect_wasm_compilation_success(db, source, "Should compile function with params");
 }
 
+#[salsa_test]
+fn test_compile_user_list_member_shadowing_prelude(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "list_member_shadowing.trb",
+        r#"
+pub mod List {
+    pub fn prepend(value: Nat, tail: Nat) -> Nat { value + tail }
+}
+
+fn main() ->{std::io::Io} Nil {
+    case List::prepend(20, 22) {
+        42 -> std::io::print_line("ok")
+        _ -> std::io::print_line("unexpected")
+    }
+}
+"#,
+    );
+    expect_wasm_compilation_success(
+        db,
+        source,
+        "Should compile a user List member that shadows the prelude member",
+    );
+}
+
 /// The target-independent root delimiter keeps an open-callback `main` on the
 /// Direct/EvidenceDirect entry ABI, so Wasm never receives a CPS entrypoint.
 #[salsa_test]
@@ -413,5 +438,33 @@ fn main() ->{std::io::Io} Nil {
         db,
         source,
         "Should compile CPS ability dispatch through wasm effect ABI lowering",
+    );
+}
+
+#[salsa_test]
+fn test_compile_transitive_generic_handler_specializations(db: &salsa::DatabaseImpl) {
+    let code = r#"
+ability A {
+    op do_a() -> Nat
+}
+
+fn run_b(value: a) -> a { value }
+
+fn run_a(comp: fn() ->{e, A} a) ->{e} a {
+    handle comp() {
+        do result { run_b(result) }
+        op A::do_a() { run_a(fn() { resume 10 }) }
+    }
+}
+
+fn main() {
+    let _ = run_a(fn() { A::do_a() })
+}
+"#;
+    let source = SourceCst::from_source_str(db, "transitive_generic_handler.trb", code);
+    expect_wasm_compilation_success(
+        db,
+        source,
+        "Should compile retained and specialized generic handler workers",
     );
 }


### PR DESCRIPTION
Closes #825.

- Preserve exact frontend callable metadata through the production boundary.
- Lower source-logical control through typed CPS and the shared pipeline.
- Integrate the target ABI for native and Wasm.

Checks: `cargo fmt --all`, `git diff --check`, `cargo check --workspace`; frontend CPS lowering (51/51), evidence/lambda ABI (9/9), and CPS-dispatch Wasm compilation (1/1).

Known status: six active-pipeline snapshots are stale; the full workspace gate is not yet green.