### PR TITLE
Preserve metadata through generic specialization

### DIFF
--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -14,8 +14,9 @@ pub fn collect_instantiations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
     function_types: &[(trunk_ir::Symbol, TypeScheme<'db>)],
+    call_callee_types: &HashMap<crate::ast::NodeId, Type<'db>>,
 ) -> HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>> {
-    let mut collector = InstantiationCollector::new(db, function_types);
+    let mut collector = InstantiationCollector::new(db, function_types, call_callee_types);
     collector.visit_module(module);
     collector.instantiations
 }
@@ -118,16 +119,18 @@ fn extract_recursive<'db>(
     }
 }
 
-struct InstantiationCollector<'db> {
+struct InstantiationCollector<'a, 'db> {
     db: &'db dyn salsa::Database,
     schemes: HashMap<FuncDefId<'db>, TypeScheme<'db>>,
+    call_callee_types: &'a HashMap<crate::ast::NodeId, Type<'db>>,
     instantiations: HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
 }
 
-impl<'db> InstantiationCollector<'db> {
+impl<'a, 'db> InstantiationCollector<'a, 'db> {
     fn new(
         db: &'db dyn salsa::Database,
         function_types: &[(trunk_ir::Symbol, TypeScheme<'db>)],
+        call_callee_types: &'a HashMap<crate::ast::NodeId, Type<'db>>,
     ) -> Self {
         let schemes = function_types
             .iter()
@@ -137,18 +140,24 @@ impl<'db> InstantiationCollector<'db> {
         Self {
             db,
             schemes,
+            call_callee_types,
             instantiations: HashMap::new(),
         }
     }
 
-    fn try_record(&mut self, typed_ref: &TypedRef<'db>) {
+    fn try_record(&mut self, node_id: crate::ast::NodeId, typed_ref: &TypedRef<'db>) {
         let ResolvedRef::Function { id } = &typed_ref.resolved else {
             return;
         };
         let Some(scheme) = self.schemes.get(id) else {
             return;
         };
-        let Some(type_args) = extract_type_args(self.db, *scheme, typed_ref.ty) else {
+        let concrete = self
+            .call_callee_types
+            .get(&node_id)
+            .copied()
+            .unwrap_or(typed_ref.ty);
+        let Some(type_args) = extract_type_args(self.db, *scheme, concrete) else {
             return;
         };
         self.instantiations
@@ -180,7 +189,7 @@ impl<'db> InstantiationCollector<'db> {
     fn visit_expr(&mut self, expr: &Expr<TypedRef<'db>>) {
         match expr.kind.as_ref() {
             ExprKind::Var(typed_ref) => {
-                self.try_record(typed_ref);
+                self.try_record(expr.id, typed_ref);
             }
             ExprKind::Call { callee, args } => {
                 self.visit_expr(callee);

--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -160,6 +160,9 @@ impl<'a, 'db> InstantiationCollector<'a, 'db> {
         let Some(type_args) = extract_type_args(self.db, *scheme, concrete) else {
             return;
         };
+        if !type_args.iter().all(|ty| is_concrete_type(self.db, *ty)) {
+            return;
+        }
         self.instantiations
             .entry(*id)
             .or_default()
@@ -266,6 +269,31 @@ impl<'a, 'db> InstantiationCollector<'a, 'db> {
             Stmt::Let { value, .. } => self.visit_expr(value),
             Stmt::Expr { expr, .. } => self.visit_expr(expr),
         }
+    }
+}
+
+fn is_concrete_type(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+    match ty.kind(db) {
+        TypeKind::Named { args, .. } => args.iter().all(|arg| is_concrete_type(db, *arg)),
+        TypeKind::Func { params, result, .. } => {
+            params.iter().all(|param| is_concrete_type(db, *param)) && is_concrete_type(db, *result)
+        }
+        TypeKind::Tuple(elements) => elements
+            .iter()
+            .all(|element| is_concrete_type(db, *element)),
+        TypeKind::Int
+        | TypeKind::Nat
+        | TypeKind::Float
+        | TypeKind::Bool
+        | TypeKind::Bytes
+        | TypeKind::Rune
+        | TypeKind::Nil
+        | TypeKind::Never
+        | TypeKind::Error => true,
+        TypeKind::BoundVar { .. }
+        | TypeKind::UniVar { .. }
+        | TypeKind::App { .. }
+        | TypeKind::Continuation { .. } => false,
     }
 }
 

--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -275,8 +275,15 @@ impl<'a, 'db> InstantiationCollector<'a, 'db> {
 fn is_concrete_type(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
     match ty.kind(db) {
         TypeKind::Named { args, .. } => args.iter().all(|arg| is_concrete_type(db, *arg)),
-        TypeKind::Func { params, result, .. } => {
-            params.iter().all(|param| is_concrete_type(db, *param)) && is_concrete_type(db, *result)
+        TypeKind::Func {
+            params,
+            result,
+            effect,
+            ..
+        } => {
+            params.iter().all(|param| is_concrete_type(db, *param))
+                && is_concrete_type(db, *result)
+                && is_concrete_effect_row(db, *effect)
         }
         TypeKind::Tuple(elements) => elements
             .iter()
@@ -288,13 +295,29 @@ fn is_concrete_type(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
         | TypeKind::Bytes
         | TypeKind::Rune
         | TypeKind::Nil
-        | TypeKind::Never
-        | TypeKind::Error => true,
+        | TypeKind::Never => true,
         TypeKind::BoundVar { .. }
         | TypeKind::UniVar { .. }
         | TypeKind::App { .. }
-        | TypeKind::Continuation { .. } => false,
+        | TypeKind::Error => false,
+        TypeKind::Continuation {
+            arg,
+            result,
+            effect,
+        } => {
+            is_concrete_type(db, *arg)
+                && is_concrete_type(db, *result)
+                && is_concrete_effect_row(db, *effect)
+        }
     }
+}
+
+fn is_concrete_effect_row(db: &dyn salsa::Database, row: crate::ast::EffectRow<'_>) -> bool {
+    row.rest(db).is_none()
+        && row
+            .effects(db)
+            .iter()
+            .all(|effect| effect.args.iter().all(|arg| is_concrete_type(db, *arg)))
 }
 
 // ============================================================================
@@ -535,7 +558,8 @@ impl<'a, 'db> TypeInstantiationVisitor<'a, 'db> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{EffectRow, TypeParam, TypeScheme};
+    use crate::ast::{AbilityId, Effect, EffectRow, EffectVar, TypeParam, TypeScheme};
+    use trunk_ir::Symbol;
 
     use super::*;
 
@@ -559,6 +583,73 @@ mod tests {
 
     fn pure_effect(db: &dyn salsa::Database) -> EffectRow<'_> {
         EffectRow::new(db, vec![], None)
+    }
+
+    fn direct_function_type<'db>(
+        db: &'db dyn salsa::Database,
+        effect: EffectRow<'db>,
+    ) -> Type<'db> {
+        let int = Type::new(db, TypeKind::Int);
+        Type::new(
+            db,
+            TypeKind::Func {
+                params: vec![int],
+                result: int,
+                effect,
+                minimum_convention: crate::ast::CallingConvention::Direct,
+            },
+        )
+    }
+
+    #[test]
+    fn concrete_type_accepts_closed_effect_rows_with_concrete_ability_arguments() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let row = EffectRow::new(
+            &db,
+            vec![Effect {
+                ability_id: AbilityId::source(&db, Symbol::new("State")),
+                args: vec![int],
+            }],
+            None,
+        );
+
+        assert!(is_concrete_type(&db, direct_function_type(&db, row)));
+    }
+
+    #[test]
+    fn concrete_type_rejects_open_effect_rows() {
+        let db = TestDb::default();
+        let open = EffectRow::open(&db, EffectVar { id: 0 });
+        let int = Type::new(&db, TypeKind::Int);
+        let continuation = Type::new(
+            &db,
+            TypeKind::Continuation {
+                arg: int,
+                result: int,
+                effect: open,
+            },
+        );
+
+        assert!(!is_concrete_type(&db, direct_function_type(&db, open)));
+        assert!(!is_concrete_type(&db, continuation));
+    }
+
+    #[test]
+    fn concrete_type_rejects_error_types_in_effect_arguments() {
+        let db = TestDb::default();
+        let error = Type::new(&db, TypeKind::Error);
+        let row = EffectRow::new(
+            &db,
+            vec![Effect {
+                ability_id: AbilityId::source(&db, Symbol::new("State")),
+                args: vec![error],
+            }],
+            None,
+        );
+
+        assert!(!is_concrete_type(&db, error));
+        assert!(!is_concrete_type(&db, direct_function_type(&db, row)));
     }
 
     // ========================================================================

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -11,6 +11,8 @@ use crate::ast::{CtorId, Decl, FuncDefId, Module, NodeId, Type, TypeScheme, Type
 use crate::typeck::subst::substitute_bound_vars;
 use crate::typeck::{InstantiatedHandlerOperation, InstantiatedPerformOperation, LambdaSignature};
 
+const MAX_TRANSITIVE_SPECIALIZATION_ROUNDS: usize = 64;
+
 /// Exact typechecking metadata keyed by source NodeId.
 pub struct MonomorphizeMetadata<'db> {
     pub constructor_types: HashMap<CtorId<'db>, TypeScheme<'db>>,
@@ -47,46 +49,67 @@ pub fn monomorphize_functions<'db>(
 
     // === Function monomorphization ===
 
-    // Step 1: Collect function instantiations
-    let func_instantiations =
-        collect::collect_instantiations(db, &module, &fn_types_vec, &metadata.call_callee_types);
+    let source_function_types = fn_types_vec.clone();
+    let mut module = module;
+    let mut all_function_types = fn_types_vec;
+    let mut instantiations = HashMap::new();
+    let mut reached_fixpoint = false;
 
-    let module = if !func_instantiations.is_empty() {
-        // Step 2: Generate specialized functions
+    // A concrete clone can reveal direct calls that were abstract in its
+    // source body. Clone the metadata first, then collect only unseen keys.
+    for _ in 0..MAX_TRANSITIVE_SPECIALIZATION_ROUNDS {
+        let discovered = collect::collect_instantiations(
+            db,
+            &module,
+            &source_function_types,
+            &metadata.call_callee_types,
+        );
+        let mut new_instantiations = HashMap::new();
+        for (func_id, type_arg_sets) in discovered {
+            let known = instantiations.entry(func_id).or_insert_with(HashSet::new);
+            for type_args in type_arg_sets {
+                if known.insert(type_args.clone()) {
+                    new_instantiations
+                        .entry(func_id)
+                        .or_insert_with(HashSet::new)
+                        .insert(type_args);
+                }
+            }
+        }
+        if new_instantiations.is_empty() {
+            reached_fixpoint = true;
+            break;
+        }
+
         let (specialized_decls, specialized_fn_types, metadata_origins) =
-            specialize::generate_specializations(db, &module, &func_instantiations, &fn_types_vec);
+            specialize::generate_specializations(
+                db,
+                &module,
+                &new_instantiations,
+                &source_function_types,
+            );
         for (type_args, origins) in metadata_origins {
             specialize_metadata(db, &mut metadata, &type_args, &origins);
         }
 
-        // Build rewrite map
-        let rewrite_map = build_rewrite_map(db, &func_instantiations, &fn_types_vec);
-
-        // Step 3: Rewrite call sites in the module
-        let rewritten_module = rewrite::rewrite_module(db, module, &fn_types_vec, &rewrite_map);
-
-        // Step 4: Rewrite call sites inside specialized function bodies
+        let rewrite_map = build_rewrite_map(db, &instantiations, &source_function_types);
+        let rewritten_module =
+            rewrite::rewrite_module(db, module, &source_function_types, &rewrite_map);
         let specialized_decls: Vec<Decl<TypedRef<'db>>> =
             specialized_decls.into_iter().map(Decl::Function).collect();
         let rewritten_specialized =
-            rewrite::rewrite_decls(db, specialized_decls, &fn_types_vec, &rewrite_map);
+            rewrite::rewrite_decls(db, specialized_decls, &source_function_types, &rewrite_map);
 
-        // Step 5: Append specialized functions to module
         let mut decls = rewritten_module.decls;
         decls.extend(rewritten_specialized);
-
-        // Update function types for downstream
-        let mut all_fn_types = fn_types_vec;
-        all_fn_types.extend(specialized_fn_types);
-
-        // Return intermediate result with updated fn_types
-        let module = Module::new(rewritten_module.id, rewritten_module.name, decls);
-        (module, all_fn_types)
-    } else {
-        (module, fn_types_vec)
-    };
-
-    let (module, fn_types_vec) = module;
+        module = Module::new(rewritten_module.id, rewritten_module.name, decls);
+        all_function_types.extend(specialized_fn_types);
+    }
+    assert!(
+        reached_fixpoint,
+        "generic specialization exceeded the deterministic expansion limit"
+    );
+    let fn_types_vec = all_function_types;
 
     // === Type monomorphization (struct/enum) ===
 

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -3,16 +3,30 @@ pub mod mangle;
 mod rewrite;
 pub mod specialize;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use trunk_ir::Symbol;
 
-use crate::ast::{Decl, FuncDefId, Module, Type, TypeScheme, TypedRef};
+use crate::ast::{CtorId, Decl, FuncDefId, Module, NodeId, Type, TypeScheme, TypedRef};
+use crate::typeck::subst::substitute_bound_vars;
+use crate::typeck::{InstantiatedHandlerOperation, InstantiatedPerformOperation, LambdaSignature};
+
+/// Exact typechecking metadata keyed by source NodeId.
+pub struct MonomorphizeMetadata<'db> {
+    pub constructor_types: HashMap<CtorId<'db>, TypeScheme<'db>>,
+    pub node_types: HashMap<NodeId, Type<'db>>,
+    pub call_callee_types: HashMap<NodeId, Type<'db>>,
+    pub handler_operations: HashMap<NodeId, InstantiatedHandlerOperation<'db>>,
+    pub perform_operations: HashMap<NodeId, InstantiatedPerformOperation<'db>>,
+    pub lambda_signatures: HashMap<NodeId, LambdaSignature<'db>>,
+    pub exhaustive_cases: HashSet<NodeId>,
+}
 
 /// Result of monomorphization: updated module + function types.
 pub struct MonomorphizeResult<'db> {
     pub module: Module<TypedRef<'db>>,
     pub function_types: Vec<(Symbol, TypeScheme<'db>)>,
+    pub metadata: MonomorphizeMetadata<'db>,
 }
 
 /// Run monomorphization on a typed module.
@@ -26,6 +40,7 @@ pub fn monomorphize_functions<'db>(
     db: &'db dyn salsa::Database,
     module: Module<TypedRef<'db>>,
     function_types: HashMap<Symbol, TypeScheme<'db>>,
+    mut metadata: MonomorphizeMetadata<'db>,
 ) -> MonomorphizeResult<'db> {
     let fn_types_vec: Vec<(Symbol, TypeScheme<'db>)> =
         function_types.iter().map(|(k, v)| (*k, *v)).collect();
@@ -33,12 +48,16 @@ pub fn monomorphize_functions<'db>(
     // === Function monomorphization ===
 
     // Step 1: Collect function instantiations
-    let func_instantiations = collect::collect_instantiations(db, &module, &fn_types_vec);
+    let func_instantiations =
+        collect::collect_instantiations(db, &module, &fn_types_vec, &metadata.call_callee_types);
 
     let module = if !func_instantiations.is_empty() {
         // Step 2: Generate specialized functions
-        let (specialized_decls, specialized_fn_types) =
+        let (specialized_decls, specialized_fn_types, metadata_origins) =
             specialize::generate_specializations(db, &module, &func_instantiations, &fn_types_vec);
+        for (type_args, origins) in metadata_origins {
+            specialize_metadata(db, &mut metadata, &type_args, &origins);
+        }
 
         // Build rewrite map
         let rewrite_map = build_rewrite_map(db, &func_instantiations, &fn_types_vec);
@@ -97,7 +116,109 @@ pub fn monomorphize_functions<'db>(
     MonomorphizeResult {
         module,
         function_types: fn_types_vec,
+        metadata,
     }
+}
+
+fn specialize_metadata<'db>(
+    db: &'db dyn salsa::Database,
+    metadata: &mut MonomorphizeMetadata<'db>,
+    type_args: &[Type<'db>],
+    origins: &HashSet<NodeId>,
+) {
+    let variant = specialize::type_args_variant(type_args);
+    clone_type_table(db, &mut metadata.node_types, variant, type_args, origins);
+    clone_type_table(
+        db,
+        &mut metadata.call_callee_types,
+        variant,
+        type_args,
+        origins,
+    );
+    let handlers = metadata.handler_operations.clone();
+    for (id, operation) in handlers.into_iter().filter(|(id, _)| origins.contains(id)) {
+        metadata.handler_operations.insert(
+            id.with_variant(variant),
+            InstantiatedHandlerOperation {
+                ability: operation.ability,
+                ability_args: operation
+                    .ability_args
+                    .into_iter()
+                    .map(|ty| substitute_type(db, ty, type_args))
+                    .collect(),
+                kind: operation.kind,
+                params: operation
+                    .params
+                    .into_iter()
+                    .map(|ty| substitute_type(db, ty, type_args))
+                    .collect(),
+                result: substitute_type(db, operation.result, type_args),
+            },
+        );
+    }
+    let performs = metadata.perform_operations.clone();
+    for (id, operation) in performs.into_iter().filter(|(id, _)| origins.contains(id)) {
+        metadata.perform_operations.insert(
+            id.with_variant(variant),
+            InstantiatedPerformOperation {
+                ability: operation.ability,
+                ability_args: operation
+                    .ability_args
+                    .into_iter()
+                    .map(|ty| substitute_type(db, ty, type_args))
+                    .collect(),
+                kind: operation.kind,
+                params: operation
+                    .params
+                    .into_iter()
+                    .map(|ty| substitute_type(db, ty, type_args))
+                    .collect(),
+                result: substitute_type(db, operation.result, type_args),
+            },
+        );
+    }
+    let lambdas = metadata.lambda_signatures.clone();
+    for (id, signature) in lambdas.into_iter().filter(|(id, _)| origins.contains(id)) {
+        metadata.lambda_signatures.insert(
+            id.with_variant(variant),
+            LambdaSignature {
+                function_type: substitute_type(db, signature.function_type, type_args),
+                convention: signature.convention,
+            },
+        );
+    }
+    let exhaustive: Vec<_> = metadata
+        .exhaustive_cases
+        .iter()
+        .copied()
+        .filter(|id| origins.contains(id))
+        .collect();
+    metadata
+        .exhaustive_cases
+        .extend(exhaustive.into_iter().map(|id| id.with_variant(variant)));
+}
+
+fn clone_type_table<'db>(
+    db: &'db dyn salsa::Database,
+    table: &mut HashMap<NodeId, Type<'db>>,
+    variant: std::num::NonZero<u64>,
+    type_args: &[Type<'db>],
+    origins: &HashSet<NodeId>,
+) {
+    let source = table.clone();
+    for (id, ty) in source.into_iter().filter(|(id, _)| origins.contains(id)) {
+        table.insert(id.with_variant(variant), substitute_type(db, ty, type_args));
+    }
+}
+
+fn substitute_type<'db>(
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    type_args: &[Type<'db>],
+) -> Type<'db> {
+    substitute_bound_vars(db, ty, type_args).unwrap_or_else(|index, max| {
+        panic!("BoundVar index out of range in specialization metadata: index={index}, subst.len()={max}")
+    })
 }
 
 /// Build a map from (original FuncDefId, concrete callee type) → mangled Symbol

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -158,8 +158,16 @@ fn specialize_metadata<'db>(
         type_args,
         origins,
     );
-    let handlers = metadata.handler_operations.clone();
-    for (id, operation) in handlers.into_iter().filter(|(id, _)| origins.contains(id)) {
+    let handlers: Vec<_> = origins
+        .iter()
+        .filter_map(|id| {
+            metadata
+                .handler_operations
+                .get(id)
+                .map(|operation| (*id, operation.clone()))
+        })
+        .collect();
+    for (id, operation) in handlers {
         metadata.handler_operations.insert(
             id.with_variant(variant),
             InstantiatedHandlerOperation {
@@ -179,8 +187,16 @@ fn specialize_metadata<'db>(
             },
         );
     }
-    let performs = metadata.perform_operations.clone();
-    for (id, operation) in performs.into_iter().filter(|(id, _)| origins.contains(id)) {
+    let performs: Vec<_> = origins
+        .iter()
+        .filter_map(|id| {
+            metadata
+                .perform_operations
+                .get(id)
+                .map(|operation| (*id, operation.clone()))
+        })
+        .collect();
+    for (id, operation) in performs {
         metadata.perform_operations.insert(
             id.with_variant(variant),
             InstantiatedPerformOperation {
@@ -200,8 +216,16 @@ fn specialize_metadata<'db>(
             },
         );
     }
-    let lambdas = metadata.lambda_signatures.clone();
-    for (id, signature) in lambdas.into_iter().filter(|(id, _)| origins.contains(id)) {
+    let lambdas: Vec<_> = origins
+        .iter()
+        .filter_map(|id| {
+            metadata
+                .lambda_signatures
+                .get(id)
+                .map(|signature| (*id, signature.clone()))
+        })
+        .collect();
+    for (id, signature) in lambdas {
         metadata.lambda_signatures.insert(
             id.with_variant(variant),
             LambdaSignature {
@@ -210,11 +234,10 @@ fn specialize_metadata<'db>(
             },
         );
     }
-    let exhaustive: Vec<_> = metadata
-        .exhaustive_cases
+    let exhaustive: Vec<_> = origins
         .iter()
         .copied()
-        .filter(|id| origins.contains(id))
+        .filter(|id| metadata.exhaustive_cases.contains(id))
         .collect();
     metadata
         .exhaustive_cases
@@ -228,8 +251,11 @@ fn clone_type_table<'db>(
     type_args: &[Type<'db>],
     origins: &HashSet<NodeId>,
 ) {
-    let source = table.clone();
-    for (id, ty) in source.into_iter().filter(|(id, _)| origins.contains(id)) {
+    let source: Vec<_> = origins
+        .iter()
+        .filter_map(|id| table.get(id).map(|ty| (*id, *ty)))
+        .collect();
+    for (id, ty) in source {
         table.insert(id.with_variant(variant), substitute_type(db, ty, type_args));
     }
 }

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use trunk_ir::Symbol;
 
-use crate::ast::{CtorId, Decl, FuncDefId, Module, NodeId, Type, TypeScheme, TypedRef};
+use crate::ast::{CtorId, Decl, FuncDefId, Module, NodeId, Type, TypeDefId, TypeScheme, TypedRef};
 use crate::typeck::subst::substitute_bound_vars;
 use crate::typeck::{InstantiatedHandlerOperation, InstantiatedPerformOperation, LambdaSignature};
 
@@ -121,6 +121,12 @@ pub fn monomorphize_functions<'db>(
         // Generate specialized struct/enum declarations
         let specialized_structs =
             specialize::generate_struct_specializations(db, &module, &type_instantiations);
+        specialize_struct_constructor_metadata(
+            db,
+            &module,
+            &type_instantiations,
+            &mut metadata.constructor_types,
+        );
         let specialized_enums =
             specialize::generate_enum_specializations(db, &module, &type_instantiations);
 
@@ -143,6 +149,65 @@ pub fn monomorphize_functions<'db>(
         function_types: fn_types_vec,
         metadata,
     }
+}
+
+/// Generate exact constructor schemes for specialized struct declarations.
+///
+/// A struct constructor shares its canonical qualified identity with its type,
+/// so source-logical lowering looks up the generated mangled name directly.
+fn specialize_struct_constructor_metadata<'db>(
+    db: &'db dyn salsa::Database,
+    module: &Module<TypedRef<'db>>,
+    instantiations: &HashMap<TypeDefId<'db>, HashSet<Vec<Type<'db>>>>,
+    constructor_types: &mut HashMap<CtorId<'db>, TypeScheme<'db>>,
+) {
+    let struct_decls = specialize::collect_struct_decls(db, module);
+    let mut entries = Vec::new();
+
+    for (id, type_arg_sets) in instantiations {
+        let Some(structure) = struct_decls.get(id) else {
+            continue;
+        };
+        if structure.type_params.is_empty() {
+            continue;
+        }
+        let Some(source_scheme) = constructor_types
+            .get(&CtorId::new(db, id.qualified(db)))
+            .copied()
+        else {
+            continue;
+        };
+        for type_args in type_arg_sets {
+            entries.push(specialize_struct_constructor_scheme(
+                db,
+                *id,
+                type_args,
+                source_scheme,
+            ));
+        }
+    }
+
+    entries.sort_by_key(|(id, _)| id.qualified(db));
+    for (ctor, scheme) in entries {
+        constructor_types.entry(ctor).or_insert(scheme);
+    }
+}
+
+fn specialize_struct_constructor_scheme<'db>(
+    db: &'db dyn salsa::Database,
+    type_id: TypeDefId<'db>,
+    type_args: &[Type<'db>],
+    source_scheme: TypeScheme<'db>,
+) -> (CtorId<'db>, TypeScheme<'db>) {
+    let name = mangle::mangle_type_name(db, type_id, type_id.qualified(db), type_args);
+    let body = substitute_type(db, source_scheme.body(db), type_args);
+    let scheme = TypeScheme::new(
+        db,
+        Vec::new(),
+        source_scheme.effect_params(db).clone(),
+        body,
+    );
+    (CtorId::new(db, name), scheme)
 }
 
 fn specialize_metadata<'db>(
@@ -305,7 +370,10 @@ fn build_rewrite_map<'db>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{AbilityId, CallingConvention, EffectRow, OpDeclKind, TypeKind};
+    use crate::ast::{
+        AbilityId, CallingConvention, EffectRow, OpDeclKind, StructDecl, TypeKind, TypeParam,
+        TypeParamDecl,
+    };
 
     #[salsa::db]
     #[derive(Default)]
@@ -315,6 +383,72 @@ mod tests {
 
     #[salsa::db]
     impl salsa::Database for TestDb {}
+
+    #[test]
+    fn specialized_struct_constructor_scheme_uses_mangled_key_and_concrete_fields() {
+        let db = TestDb::default();
+        let bound = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let int = Type::new(&db, TypeKind::Int);
+        let structure = StructDecl {
+            id: NodeId::from_raw(1),
+            is_pub: false,
+            name: Symbol::new("nested::Holder"),
+            type_params: vec![TypeParamDecl {
+                id: NodeId::from_raw(2),
+                name: Symbol::new("a"),
+                bounds: vec![],
+            }],
+            fields: vec![],
+        };
+        let type_id = TypeDefId::source(&db, structure.name, structure.id);
+        let holder = Type::new(
+            &db,
+            TypeKind::Named {
+                id: type_id,
+                name: structure.name,
+                args: vec![bound],
+            },
+        );
+        let source_scheme = TypeScheme::new(
+            &db,
+            vec![TypeParam::anonymous()],
+            Vec::new(),
+            Type::new(
+                &db,
+                TypeKind::Func {
+                    params: vec![bound],
+                    result: holder,
+                    effect: EffectRow::pure(&db),
+                    minimum_convention: CallingConvention::Direct,
+                },
+            ),
+        );
+        let module = Module::new(NodeId::from_raw(0), None, vec![Decl::Struct(structure)]);
+        let instantiations = HashMap::from([(type_id, HashSet::from([vec![int]]))]);
+        let source_ctor = CtorId::new(&db, Symbol::new("nested::Holder"));
+        let mut constructor_types = HashMap::from([(source_ctor, source_scheme)]);
+        specialize_struct_constructor_metadata(
+            &db,
+            &module,
+            &instantiations,
+            &mut constructor_types,
+        );
+
+        let ctor = CtorId::new(&db, Symbol::new("nested::Holder$Int"));
+        assert_eq!(constructor_types.get(&source_ctor), Some(&source_scheme));
+        let specialized = constructor_types
+            .get(&ctor)
+            .expect("one generic struct instantiation must produce one constructor scheme");
+        assert!(specialized.is_mono(&db));
+        let TypeKind::Func { params, result, .. } = specialized.body(&db).kind(&db) else {
+            panic!("specialized constructor must retain a callable schema")
+        };
+        assert!(matches!(params.as_slice(), [param] if *param == int));
+        assert!(matches!(
+            result.kind(&db),
+            TypeKind::Named { args, .. } if args.as_slice() == [int]
+        ));
+    }
 
     #[test]
     fn specialization_metadata_rekeys_and_substitutes_sparse_tables() {

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -81,29 +81,31 @@ pub fn monomorphize_functions<'db>(
             break;
         }
 
-        let (specialized_decls, specialized_fn_types, metadata_origins) =
-            specialize::generate_specializations(
-                db,
-                &module,
-                &new_instantiations,
-                &source_function_types,
-            );
-        for (type_args, origins) in metadata_origins {
+        let specializations = specialize::generate_specializations(
+            db,
+            &module,
+            &new_instantiations,
+            &source_function_types,
+        );
+        for (type_args, origins) in specializations.metadata_origins {
             specialize_metadata(db, &mut metadata, &type_args, &origins);
         }
 
         let rewrite_map = build_rewrite_map(db, &instantiations, &source_function_types);
         let rewritten_module =
             rewrite::rewrite_module(db, module, &source_function_types, &rewrite_map);
-        let specialized_decls: Vec<Decl<TypedRef<'db>>> =
-            specialized_decls.into_iter().map(Decl::Function).collect();
+        let specialized_decls: Vec<Decl<TypedRef<'db>>> = specializations
+            .specialized_declarations
+            .into_iter()
+            .map(Decl::Function)
+            .collect();
         let rewritten_specialized =
             rewrite::rewrite_decls(db, specialized_decls, &source_function_types, &rewrite_map);
 
         let mut decls = rewritten_module.decls;
         decls.extend(rewritten_specialized);
         module = Module::new(rewritten_module.id, rewritten_module.name, decls);
-        all_function_types.extend(specialized_fn_types);
+        all_function_types.extend(specializations.specialized_function_types);
     }
     assert!(
         reached_fixpoint,

--- a/crates/tribute-front/src/monomorphize/mod.rs
+++ b/crates/tribute-front/src/monomorphize/mod.rs
@@ -301,3 +301,120 @@ fn build_rewrite_map<'db>(
 
     rewrite_map
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{AbilityId, CallingConvention, EffectRow, OpDeclKind, TypeKind};
+
+    #[salsa::db]
+    #[derive(Default)]
+    struct TestDb {
+        storage: salsa::Storage<Self>,
+    }
+
+    #[salsa::db]
+    impl salsa::Database for TestDb {}
+
+    #[test]
+    fn specialization_metadata_rekeys_and_substitutes_sparse_tables() {
+        let db = TestDb::default();
+        let origin = NodeId::from_raw(1);
+        let bound = Type::new(&db, TypeKind::BoundVar { index: 0 });
+        let int = Type::new(&db, TypeKind::Int);
+        let function = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![bound],
+                result: bound,
+                effect: EffectRow::pure(&db),
+                minimum_convention: CallingConvention::Direct,
+            },
+        );
+        let specialized_function = Type::new(
+            &db,
+            TypeKind::Func {
+                params: vec![int],
+                result: int,
+                effect: EffectRow::pure(&db),
+                minimum_convention: CallingConvention::Direct,
+            },
+        );
+        let ability = AbilityId::source(&db, Symbol::new("Audit"));
+        let operation = |kind| InstantiatedHandlerOperation {
+            ability,
+            ability_args: vec![bound],
+            kind,
+            params: vec![bound],
+            result: bound,
+        };
+        let mut metadata = MonomorphizeMetadata {
+            constructor_types: HashMap::new(),
+            node_types: HashMap::from([(origin, bound)]),
+            call_callee_types: HashMap::from([(origin, bound)]),
+            handler_operations: HashMap::from([(origin, operation(OpDeclKind::Op))]),
+            perform_operations: HashMap::from([(
+                origin,
+                InstantiatedPerformOperation {
+                    ability,
+                    ability_args: vec![bound],
+                    kind: OpDeclKind::Op,
+                    params: vec![bound],
+                    result: bound,
+                },
+            )]),
+            lambda_signatures: HashMap::from([(
+                origin,
+                LambdaSignature {
+                    function_type: function,
+                    convention: CallingConvention::Direct,
+                },
+            )]),
+            exhaustive_cases: HashSet::from([origin]),
+        };
+        let type_args = vec![int];
+        let origins = HashSet::from([origin]);
+
+        specialize_metadata(&db, &mut metadata, &type_args, &origins);
+
+        let clone = origin.with_variant(specialize::type_args_variant(&type_args));
+        assert_eq!(metadata.node_types.get(&clone), Some(&int));
+        assert_eq!(metadata.call_callee_types.get(&clone), Some(&int));
+        assert_eq!(
+            metadata
+                .handler_operations
+                .get(&clone)
+                .unwrap()
+                .ability_args,
+            [int]
+        );
+        assert_eq!(
+            metadata.handler_operations.get(&clone).unwrap().params,
+            [int]
+        );
+        assert_eq!(metadata.handler_operations.get(&clone).unwrap().result, int);
+        assert_eq!(
+            metadata
+                .perform_operations
+                .get(&clone)
+                .unwrap()
+                .ability_args,
+            [int]
+        );
+        assert_eq!(
+            metadata.perform_operations.get(&clone).unwrap().params,
+            [int]
+        );
+        assert_eq!(metadata.perform_operations.get(&clone).unwrap().result, int);
+        assert_eq!(
+            metadata
+                .lambda_signatures
+                .get(&clone)
+                .unwrap()
+                .function_type,
+            specialized_function
+        );
+        assert!(metadata.exhaustive_cases.contains(&clone));
+        assert!(metadata.handler_operations.contains_key(&origin));
+    }
+}

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -38,22 +38,24 @@ pub fn generate_specializations<'db>(
     function_types: &[(Symbol, TypeScheme<'db>)],
 ) -> GeneratedSpecializations<'db> {
     let func_decls = collect_func_decls(module);
+    let extern_functions = collect_extern_function_names(module);
     let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
 
     let mut entries: Vec<SpecializationEntry<'db>> = Vec::new();
+    let mut extern_function_types = Vec::new();
 
     for (func_id, type_arg_sets) in instantiations {
         let qualified = func_id.qualified(db);
-        let Some(func) = func_decls.get(&qualified) else {
+        let func = func_decls.get(&qualified).copied();
+        if func.is_none() && !extern_functions.contains(&qualified) {
             continue;
-        };
+        }
         let Some(scheme) = scheme_map.get(&qualified) else {
             continue;
         };
 
         for type_args in type_arg_sets {
             let mangled = mangle_name(db, qualified, type_args);
-            let specialized = specialize_func_decl(db, func, type_args, mangled);
             let specialized_scheme = TypeScheme::new(
                 db,
                 vec![],
@@ -67,13 +69,21 @@ pub fn generate_specializations<'db>(
                     },
                 ),
             );
-            entries.push((
-                mangled,
-                specialized,
-                specialized_scheme,
-                type_args.clone(),
-                semantic_node_ids(func),
-            ));
+            if let Some(func) = func {
+                let specialized = specialize_func_decl(db, func, type_args, mangled);
+                entries.push((
+                    mangled,
+                    specialized,
+                    specialized_scheme,
+                    type_args.clone(),
+                    semantic_node_ids(func),
+                ));
+            } else {
+                // Extern functions have no AST body to clone, but rewritten
+                // call sites still need their concrete scheme during logical
+                // lowering under the mangled identity.
+                extern_function_types.push((mangled, specialized_scheme));
+            }
         }
     }
 
@@ -81,13 +91,15 @@ pub fn generate_specializations<'db>(
     entries.sort_by_key(|e| e.0);
 
     let mut new_decls = Vec::with_capacity(entries.len());
-    let mut new_function_types = Vec::with_capacity(entries.len());
+    let mut new_function_types = Vec::with_capacity(entries.len() + extern_function_types.len());
     let mut metadata_origins = Vec::with_capacity(entries.len());
     for (name, decl, scheme, type_args, origins) in entries {
         new_decls.push(decl);
         new_function_types.push((name, scheme));
         metadata_origins.push((type_args, origins));
     }
+    new_function_types.extend(extern_function_types);
+    new_function_types.sort_by_key(|(name, _)| *name);
 
     (new_decls, new_function_types, metadata_origins)
 }
@@ -534,6 +546,35 @@ fn collect_func_decls_inner<'a, 'db>(
                 if let Some(body) = &m.body {
                     let len = crate::push_prefix(prefix, m.name);
                     collect_func_decls_inner(body, prefix, map);
+                    prefix.truncate(len);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_extern_function_names<'db>(module: &Module<TypedRef<'db>>) -> HashSet<Symbol> {
+    let mut names = HashSet::new();
+    let mut prefix = String::new();
+    collect_extern_function_names_inner(&module.decls, &mut prefix, &mut names);
+    names
+}
+
+fn collect_extern_function_names_inner<'db>(
+    decls: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+    names: &mut HashSet<Symbol>,
+) {
+    for decl in decls {
+        match decl {
+            Decl::ExternFunction(func) => {
+                names.insert(crate::qualified_symbol(prefix, func.name));
+            }
+            Decl::Module(module) => {
+                if let Some(body) = &module.body {
+                    let len = crate::push_prefix(prefix, module.name);
+                    collect_extern_function_names_inner(body, prefix, names);
                     prefix.truncate(len);
                 }
             }

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -13,11 +13,11 @@ use crate::typeck::subst::substitute_bound_vars;
 
 use super::mangle::{mangle_name, mangle_type_name};
 
-type GeneratedSpecializations<'db> = (
-    Vec<FuncDecl<TypedRef<'db>>>,
-    Vec<(Symbol, TypeScheme<'db>)>,
-    Vec<(Vec<Type<'db>>, HashSet<NodeId>)>,
-);
+pub(super) struct GeneratedSpecializations<'db> {
+    pub(super) specialized_declarations: Vec<FuncDecl<TypedRef<'db>>>,
+    pub(super) specialized_function_types: Vec<(Symbol, TypeScheme<'db>)>,
+    pub(super) metadata_origins: Vec<(Vec<Type<'db>>, HashSet<NodeId>)>,
+}
 
 struct SpecializationEntry<'db> {
     name: Symbol,
@@ -31,7 +31,7 @@ struct SpecializationEntry<'db> {
 ///
 /// Returns a list of new specialized `FuncDecl`s and their corresponding
 /// `(Symbol, TypeScheme)` entries for `function_types`.
-pub fn generate_specializations<'db>(
+pub(super) fn generate_specializations<'db>(
     db: &'db dyn salsa::Database,
     module: &Module<TypedRef<'db>>,
     instantiations: &HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
@@ -102,7 +102,11 @@ pub fn generate_specializations<'db>(
     new_function_types.extend(extern_function_types);
     new_function_types.sort_by_key(|(name, _)| *name);
 
-    (new_decls, new_function_types, metadata_origins)
+    GeneratedSpecializations {
+        specialized_declarations: new_decls,
+        specialized_function_types: new_function_types,
+        metadata_origins,
+    }
 }
 
 fn semantic_node_ids<'db>(func: &FuncDecl<TypedRef<'db>>) -> HashSet<NodeId> {
@@ -1250,19 +1254,23 @@ mod tests {
         let mut instantiations = HashMap::new();
         instantiations.insert(func_id, type_arg_sets);
 
-        let (new_decls, new_fn_types, _) =
+        let specializations =
             generate_specializations(&db, &module, &instantiations, &function_types);
 
-        assert_eq!(new_decls.len(), 2);
-        assert_eq!(new_fn_types.len(), 2);
+        assert_eq!(specializations.specialized_declarations.len(), 2);
+        assert_eq!(specializations.specialized_function_types.len(), 2);
 
         // Verify names are mangled
-        let names: HashSet<String> = new_decls.iter().map(|d| d.name.to_string()).collect();
+        let names: HashSet<String> = specializations
+            .specialized_declarations
+            .iter()
+            .map(|d| d.name.to_string())
+            .collect();
         assert!(names.contains("identity$Int"));
         assert!(names.contains("identity$Float"));
 
         // All specialized TypeSchemes must be monomorphic
-        for (_, scheme) in &new_fn_types {
+        for (_, scheme) in &specializations.specialized_function_types {
             assert!(
                 scheme.is_mono(&db),
                 "specialized scheme should have no type params"

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -505,7 +505,7 @@ fn type_to_annotation(db: &dyn salsa::Database, ty: Type<'_>, id: NodeId) -> Typ
     TypeAnnotation { id, kind }
 }
 
-fn collect_struct_decls<'a, 'db>(
+pub(super) fn collect_struct_decls<'a, 'db>(
     db: &'db dyn salsa::Database,
     module: &'a Module<TypedRef<'db>>,
 ) -> HashMap<TypeDefId<'db>, &'a StructDecl> {

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -13,6 +13,20 @@ use crate::typeck::subst::substitute_bound_vars;
 
 use super::mangle::{mangle_name, mangle_type_name};
 
+type GeneratedSpecializations<'db> = (
+    Vec<FuncDecl<TypedRef<'db>>>,
+    Vec<(Symbol, TypeScheme<'db>)>,
+    Vec<(Vec<Type<'db>>, HashSet<NodeId>)>,
+);
+
+type SpecializationEntry<'db> = (
+    Symbol,
+    FuncDecl<TypedRef<'db>>,
+    TypeScheme<'db>,
+    Vec<Type<'db>>,
+    HashSet<NodeId>,
+);
+
 /// Generate specialized copies of generic functions for each instantiation.
 ///
 /// Returns a list of new specialized `FuncDecl`s and their corresponding
@@ -22,11 +36,11 @@ pub fn generate_specializations<'db>(
     module: &Module<TypedRef<'db>>,
     instantiations: &HashMap<FuncDefId<'db>, HashSet<Vec<Type<'db>>>>,
     function_types: &[(Symbol, TypeScheme<'db>)],
-) -> (Vec<FuncDecl<TypedRef<'db>>>, Vec<(Symbol, TypeScheme<'db>)>) {
+) -> GeneratedSpecializations<'db> {
     let func_decls = collect_func_decls(module);
     let scheme_map: HashMap<Symbol, TypeScheme<'db>> = function_types.iter().cloned().collect();
 
-    let mut entries: Vec<(Symbol, FuncDecl<TypedRef<'db>>, TypeScheme<'db>)> = Vec::new();
+    let mut entries: Vec<SpecializationEntry<'db>> = Vec::new();
 
     for (func_id, type_arg_sets) in instantiations {
         let qualified = func_id.qualified(db);
@@ -53,7 +67,13 @@ pub fn generate_specializations<'db>(
                     },
                 ),
             );
-            entries.push((mangled, specialized, specialized_scheme));
+            entries.push((
+                mangled,
+                specialized,
+                specialized_scheme,
+                type_args.clone(),
+                semantic_node_ids(func),
+            ));
         }
     }
 
@@ -62,12 +82,95 @@ pub fn generate_specializations<'db>(
 
     let mut new_decls = Vec::with_capacity(entries.len());
     let mut new_function_types = Vec::with_capacity(entries.len());
-    for (name, decl, scheme) in entries {
+    let mut metadata_origins = Vec::with_capacity(entries.len());
+    for (name, decl, scheme, type_args, origins) in entries {
         new_decls.push(decl);
         new_function_types.push((name, scheme));
+        metadata_origins.push((type_args, origins));
     }
 
-    (new_decls, new_function_types)
+    (new_decls, new_function_types, metadata_origins)
+}
+
+fn semantic_node_ids<'db>(func: &FuncDecl<TypedRef<'db>>) -> HashSet<NodeId> {
+    fn expr<'db>(value: &Expr<TypedRef<'db>>, ids: &mut HashSet<NodeId>) {
+        ids.insert(value.id);
+        match value.kind.as_ref() {
+            ExprKind::Call { callee, args } => {
+                expr(callee, ids);
+                for arg in args {
+                    expr(arg, ids);
+                }
+            }
+            ExprKind::Block { stmts, value } => {
+                for stmt in stmts {
+                    match stmt {
+                        Stmt::Let { id, value, .. } | Stmt::Expr { id, expr: value } => {
+                            ids.insert(*id);
+                            expr(value, ids);
+                        }
+                    }
+                }
+                expr(value, ids);
+            }
+            ExprKind::Case { scrutinee, arms } => {
+                expr(scrutinee, ids);
+                for arm in arms {
+                    ids.insert(arm.id);
+                    if let Some(guard) = &arm.guard {
+                        expr(guard, ids);
+                    }
+                    expr(&arm.body, ids);
+                }
+            }
+            ExprKind::Lambda { body, .. } => expr(body, ids),
+            ExprKind::Handle { body, handlers } => {
+                expr(body, ids);
+                for handler in handlers {
+                    ids.insert(handler.id);
+                    expr(&handler.body, ids);
+                }
+            }
+            ExprKind::Resume { arg, .. } => expr(arg, ids),
+            ExprKind::Cons { args, .. } | ExprKind::Tuple(args) | ExprKind::List(args) => {
+                for arg in args {
+                    expr(arg, ids);
+                }
+            }
+            ExprKind::Record { fields, spread, .. } => {
+                for (_, value) in fields {
+                    expr(value, ids);
+                }
+                if let Some(value) = spread {
+                    expr(value, ids);
+                }
+            }
+            ExprKind::MethodCall { receiver, args, .. } => {
+                expr(receiver, ids);
+                for arg in args {
+                    expr(arg, ids);
+                }
+            }
+            ExprKind::BinOp { lhs, rhs, .. } => {
+                expr(lhs, ids);
+                expr(rhs, ids);
+            }
+            ExprKind::Var(_)
+            | ExprKind::NatLit(_)
+            | ExprKind::IntLit(_)
+            | ExprKind::FloatLit(_)
+            | ExprKind::StringLit(_)
+            | ExprKind::BytesLit(_)
+            | ExprKind::BoolLit(_)
+            | ExprKind::RuneLit(_)
+            | ExprKind::Nil
+            | ExprKind::Error => {}
+        }
+    }
+    let mut ids = HashSet::new();
+    ids.insert(func.id);
+    expr(&func.body, &mut ids);
+    ids
 }
 
 // ============================================================================
@@ -443,7 +546,7 @@ fn collect_func_decls_inner<'a, 'db>(
 ///
 /// This is used to give specialized AST nodes unique NodeIds that
 /// don't collide with the original or other specializations.
-fn type_args_variant(type_args: &[Type<'_>]) -> NonZero<u64> {
+pub(crate) fn type_args_variant(type_args: &[Type<'_>]) -> NonZero<u64> {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     type_args.hash(&mut hasher);
     let hash = hasher.finish();
@@ -921,7 +1024,7 @@ mod tests {
         let mut instantiations = HashMap::new();
         instantiations.insert(func_id, type_arg_sets);
 
-        let (new_decls, new_fn_types) =
+        let (new_decls, new_fn_types, _) =
             generate_specializations(&db, &module, &instantiations, &function_types);
 
         assert_eq!(new_decls.len(), 2);

--- a/crates/tribute-front/src/monomorphize/specialize.rs
+++ b/crates/tribute-front/src/monomorphize/specialize.rs
@@ -19,13 +19,13 @@ type GeneratedSpecializations<'db> = (
     Vec<(Vec<Type<'db>>, HashSet<NodeId>)>,
 );
 
-type SpecializationEntry<'db> = (
-    Symbol,
-    FuncDecl<TypedRef<'db>>,
-    TypeScheme<'db>,
-    Vec<Type<'db>>,
-    HashSet<NodeId>,
-);
+struct SpecializationEntry<'db> {
+    name: Symbol,
+    declaration: FuncDecl<TypedRef<'db>>,
+    scheme: TypeScheme<'db>,
+    type_args: Vec<Type<'db>>,
+    origins: HashSet<NodeId>,
+}
 
 /// Generate specialized copies of generic functions for each instantiation.
 ///
@@ -53,6 +53,7 @@ pub fn generate_specializations<'db>(
         let Some(scheme) = scheme_map.get(&qualified) else {
             continue;
         };
+        let origins = func.map(semantic_node_ids);
 
         for type_args in type_arg_sets {
             let mangled = mangle_name(db, qualified, type_args);
@@ -71,13 +72,13 @@ pub fn generate_specializations<'db>(
             );
             if let Some(func) = func {
                 let specialized = specialize_func_decl(db, func, type_args, mangled);
-                entries.push((
-                    mangled,
-                    specialized,
-                    specialized_scheme,
-                    type_args.clone(),
-                    semantic_node_ids(func),
-                ));
+                entries.push(SpecializationEntry {
+                    name: mangled,
+                    declaration: specialized,
+                    scheme: specialized_scheme,
+                    type_args: type_args.clone(),
+                    origins: origins.clone().expect("function specialization origins"),
+                });
             } else {
                 // Extern functions have no AST body to clone, but rewritten
                 // call sites still need their concrete scheme during logical
@@ -88,15 +89,15 @@ pub fn generate_specializations<'db>(
     }
 
     // Sort by mangled name for deterministic output (HashMap/HashSet iteration is unordered)
-    entries.sort_by_key(|e| e.0);
+    entries.sort_by_key(|entry| entry.name);
 
     let mut new_decls = Vec::with_capacity(entries.len());
     let mut new_function_types = Vec::with_capacity(entries.len() + extern_function_types.len());
     let mut metadata_origins = Vec::with_capacity(entries.len());
-    for (name, decl, scheme, type_args, origins) in entries {
-        new_decls.push(decl);
-        new_function_types.push((name, scheme));
-        metadata_origins.push((type_args, origins));
+    for entry in entries {
+        new_decls.push(entry.declaration);
+        new_function_types.push((entry.name, entry.scheme));
+        metadata_origins.push((entry.type_args, entry.origins));
     }
     new_function_types.extend(extern_function_types);
     new_function_types.sort_by_key(|(name, _)| *name);
@@ -105,6 +106,37 @@ pub fn generate_specializations<'db>(
 }
 
 fn semantic_node_ids<'db>(func: &FuncDecl<TypedRef<'db>>) -> HashSet<NodeId> {
+    fn pattern<'db>(value: &Pattern<TypedRef<'db>>, ids: &mut HashSet<NodeId>) {
+        ids.insert(value.id);
+        match value.kind.as_ref() {
+            PatternKind::Variant { fields, .. }
+            | PatternKind::Tuple(fields)
+            | PatternKind::List(fields) => {
+                for field in fields {
+                    pattern(field, ids);
+                }
+            }
+            PatternKind::Record { fields, .. } => {
+                for field in fields {
+                    ids.insert(field.id);
+                    if let Some(field_pattern) = &field.pattern {
+                        pattern(field_pattern, ids);
+                    }
+                }
+            }
+            PatternKind::ListRest { head, .. } => {
+                for head_pattern in head {
+                    pattern(head_pattern, ids);
+                }
+            }
+            PatternKind::As { pattern: inner, .. } => pattern(inner, ids),
+            PatternKind::Wildcard
+            | PatternKind::Bind { .. }
+            | PatternKind::Literal(_)
+            | PatternKind::Error => {}
+        }
+    }
+
     fn expr<'db>(value: &Expr<TypedRef<'db>>, ids: &mut HashSet<NodeId>) {
         ids.insert(value.id);
         match value.kind.as_ref() {
@@ -117,7 +149,17 @@ fn semantic_node_ids<'db>(func: &FuncDecl<TypedRef<'db>>) -> HashSet<NodeId> {
             ExprKind::Block { stmts, value } => {
                 for stmt in stmts {
                     match stmt {
-                        Stmt::Let { id, value, .. } | Stmt::Expr { id, expr: value } => {
+                        Stmt::Let {
+                            id,
+                            pattern: binding,
+                            value,
+                            ..
+                        } => {
+                            ids.insert(*id);
+                            pattern(binding, ids);
+                            expr(value, ids);
+                        }
+                        Stmt::Expr { id, expr: value } => {
                             ids.insert(*id);
                             expr(value, ids);
                         }
@@ -129,6 +171,7 @@ fn semantic_node_ids<'db>(func: &FuncDecl<TypedRef<'db>>) -> HashSet<NodeId> {
                 expr(scrutinee, ids);
                 for arm in arms {
                     ids.insert(arm.id);
+                    pattern(&arm.pattern, ids);
                     if let Some(guard) = &arm.guard {
                         expr(guard, ids);
                     }
@@ -140,6 +183,14 @@ fn semantic_node_ids<'db>(func: &FuncDecl<TypedRef<'db>>) -> HashSet<NodeId> {
                 expr(body, ids);
                 for handler in handlers {
                     ids.insert(handler.id);
+                    match &handler.kind {
+                        HandlerKind::Do { binding } => pattern(binding, ids),
+                        HandlerKind::Fn { params, .. } | HandlerKind::Op { params, .. } => {
+                            for param in params {
+                                pattern(param, ids);
+                            }
+                        }
+                    }
                     expr(&handler.body, ids);
                 }
             }
@@ -923,6 +974,140 @@ mod tests {
 
     fn node_id(n: usize) -> NodeId {
         NodeId::from_raw(n)
+    }
+
+    #[test]
+    fn semantic_node_ids_include_nested_pattern_nodes() {
+        let db = TestDb::default();
+        let int = Type::new(&db, TypeKind::Int);
+        let typed_ref = |index| {
+            TypedRef::new(
+                ResolvedRef::Local {
+                    id: crate::ast::LocalId::new(index),
+                    name: Symbol::new("value"),
+                },
+                int,
+            )
+        };
+        let bind = |id, name| {
+            Pattern::new(
+                node_id(id),
+                PatternKind::Bind {
+                    name: Symbol::new(name),
+                    local_id: None,
+                },
+            )
+        };
+        let nil = |id| Expr::new(node_id(id), ExprKind::Nil);
+
+        let let_pattern = Pattern::new(
+            node_id(10),
+            PatternKind::Record {
+                type_name: None,
+                fields: vec![FieldPattern {
+                    id: node_id(11),
+                    name: Symbol::new("field"),
+                    pattern: Some(Pattern::new(
+                        node_id(12),
+                        PatternKind::As {
+                            pattern: Pattern::new(
+                                node_id(13),
+                                PatternKind::Tuple(vec![bind(14, "tuple")]),
+                            ),
+                            name: Symbol::new("record"),
+                            local_id: None,
+                        },
+                    )),
+                }],
+                rest: false,
+            },
+        );
+        let case = Expr::new(
+            node_id(20),
+            ExprKind::Case {
+                scrutinee: nil(21),
+                arms: vec![Arm {
+                    id: node_id(22),
+                    pattern: Pattern::new(
+                        node_id(23),
+                        PatternKind::Variant {
+                            ctor: typed_ref(0),
+                            fields: vec![Pattern::new(
+                                node_id(24),
+                                PatternKind::ListRest {
+                                    head: vec![bind(25, "head")],
+                                    rest: Some(Symbol::new("tail")),
+                                    rest_local_id: None,
+                                },
+                            )],
+                        },
+                    ),
+                    guard: None,
+                    body: nil(26),
+                }],
+            },
+        );
+        let handled = Expr::new(
+            node_id(30),
+            ExprKind::Handle {
+                body: case,
+                handlers: vec![
+                    HandlerArm {
+                        id: node_id(31),
+                        kind: HandlerKind::Do {
+                            binding: Pattern::new(
+                                node_id(32),
+                                PatternKind::List(vec![bind(33, "result")]),
+                            ),
+                        },
+                        body: nil(34),
+                    },
+                    HandlerArm {
+                        id: node_id(35),
+                        kind: HandlerKind::Fn {
+                            ability: typed_ref(1),
+                            op: Symbol::new("fn_op"),
+                            params: vec![Pattern::new(
+                                node_id(36),
+                                PatternKind::Tuple(vec![bind(37, "fn_param")]),
+                            )],
+                        },
+                        body: nil(38),
+                    },
+                ],
+            },
+        );
+        let function = FuncDecl {
+            id: node_id(1),
+            is_pub: false,
+            name: Symbol::new("patterns"),
+            type_params: vec![],
+            params: vec![],
+            return_ty: None,
+            effects: None,
+            body: Expr::new(
+                node_id(2),
+                ExprKind::Block {
+                    stmts: vec![Stmt::Let {
+                        id: node_id(3),
+                        pattern: let_pattern,
+                        ty: None,
+                        value: nil(4),
+                    }],
+                    value: handled,
+                },
+            ),
+        };
+
+        let ids = semantic_node_ids(&function);
+        for id in [
+            1, 3, 10, 11, 12, 13, 14, 22, 23, 24, 25, 31, 32, 33, 35, 36, 37,
+        ] {
+            assert!(
+                ids.contains(&node_id(id)),
+                "semantic metadata must follow nested pattern node {id}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -114,7 +114,9 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
-                ctx.record_call_callee_type(callee.id, callee_ty);
+                if matches!(&*callee.kind, ExprKind::Var(ResolvedRef::Function { .. })) {
+                    ctx.record_call_callee_type(callee.id, callee_ty);
+                }
                 // Conversion re-visits the callee. Keep this one ability-op
                 // inference instance connected to that visit through dedicated
                 // semantic state, never through the concrete node-type table.
@@ -639,7 +641,9 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
-                ctx.record_call_callee_type(callee.id, callee_ty);
+                if matches!(&*callee.kind, ExprKind::Var(ResolvedRef::Function { .. })) {
+                    ctx.record_call_callee_type(callee.id, callee_ty);
+                }
                 if matches!(&*callee.kind, ExprKind::Var(ResolvedRef::AbilityOp { .. })) {
                     ctx.record_ability_op_callee_type(callee.id, callee_ty);
                 }

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -114,6 +114,7 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
+                ctx.record_call_callee_type(callee.id, callee_ty);
                 // Conversion re-visits the callee. Keep this one ability-op
                 // inference instance connected to that visit through dedicated
                 // semantic state, never through the concrete node-type table.
@@ -638,6 +639,7 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
+                ctx.record_call_callee_type(callee.id, callee_ty);
                 if matches!(&*callee.kind, ExprKind::Var(ResolvedRef::AbilityOp { .. })) {
                     ctx.record_ability_op_callee_type(callee.id, callee_ty);
                 }
@@ -1162,7 +1164,9 @@ impl<'db> TypeChecker<'db> {
             ExprKind::BytesLit(b) => ExprKind::BytesLit(b),
             ExprKind::Nil => ExprKind::Nil,
             ExprKind::RuneLit(r) => ExprKind::RuneLit(r),
-            ExprKind::Var(resolved) => ExprKind::Var(self.convert_ref_with_ctx(ctx, resolved)),
+            ExprKind::Var(resolved) => {
+                ExprKind::Var(self.convert_ref_with_ctx(ctx, Some(expr_id), resolved))
+            }
             ExprKind::Call { callee, args } => {
                 let inferred_ability_op_callee = ctx.get_ability_op_callee_type(callee.id);
                 // First, process callee so its type gets recorded
@@ -1212,7 +1216,7 @@ impl<'db> TypeChecker<'db> {
                 }
             }
             ExprKind::Cons { ctor, args } => ExprKind::Cons {
-                ctor: self.convert_ref_with_ctx(ctx, ctor),
+                ctor: self.convert_ref_with_ctx(ctx, None, ctor),
                 args: args
                     .into_iter()
                     .map(|a| self.check_expr_with_ctx(ctx, a, Mode::Infer))
@@ -1223,7 +1227,7 @@ impl<'db> TypeChecker<'db> {
                 fields,
                 spread,
             } => ExprKind::Record {
-                type_name: self.convert_ref_with_ctx(ctx, type_name),
+                type_name: self.convert_ref_with_ctx(ctx, None, type_name),
                 fields: fields
                     .into_iter()
                     .map(|(name, expr)| (name, self.check_expr_with_ctx(ctx, expr, Mode::Infer)))
@@ -1406,9 +1410,12 @@ impl<'db> TypeChecker<'db> {
     fn convert_ref_with_ctx(
         &self,
         ctx: &mut FunctionInferenceContext<'_, 'db>,
+        node_id: Option<crate::ast::NodeId>,
         resolved: ResolvedRef<'db>,
     ) -> TypedRef<'db> {
-        let ty = self.infer_var_with_ctx(ctx, &resolved);
+        let ty = node_id
+            .and_then(|node| ctx.get_call_callee_type(node))
+            .unwrap_or_else(|| self.infer_var_with_ctx(ctx, &resolved));
         TypedRef { resolved, ty }
     }
 
@@ -1845,7 +1852,7 @@ impl<'db> TypeChecker<'db> {
             PatternKind::Bind { name, local_id } => PatternKind::Bind { name, local_id },
             PatternKind::Literal(lit) => PatternKind::Literal(lit),
             PatternKind::Variant { ctor, fields } => PatternKind::Variant {
-                ctor: self.convert_ref_with_ctx(ctx, ctor),
+                ctor: self.convert_ref_with_ctx(ctx, None, ctor),
                 fields: fields
                     .into_iter()
                     .map(|p| self.convert_pattern_with_ctx(ctx, p))
@@ -1856,7 +1863,7 @@ impl<'db> TypeChecker<'db> {
                 fields,
                 rest,
             } => PatternKind::Record {
-                type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, t)),
+                type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, None, t)),
                 fields: fields
                     .into_iter()
                     .map(|f| self.convert_field_pattern_with_ctx(ctx, f))
@@ -2015,7 +2022,7 @@ impl<'db> TypeChecker<'db> {
                     .collect();
 
                 PatternKind::Record {
-                    type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, t)),
+                    type_name: type_name.map(|t| self.convert_ref_with_ctx(ctx, None, t)),
                     fields: converted_fields,
                     rest,
                 }
@@ -2121,7 +2128,7 @@ impl<'db> TypeChecker<'db> {
                 );
                 ctx.record_handler_operation(arm.id, operation);
                 HandlerKind::Fn {
-                    ability: self.convert_ref_with_ctx(ctx, ability),
+                    ability: self.convert_ref_with_ctx(ctx, None, ability),
                     op,
                     params: params
                         .into_iter()
@@ -2173,7 +2180,7 @@ impl<'db> TypeChecker<'db> {
                 }
 
                 HandlerKind::Op {
-                    ability: self.convert_ref_with_ctx(ctx, ability),
+                    ability: self.convert_ref_with_ctx(ctx, None, ability),
                     op,
                     params: params
                         .into_iter()

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -128,6 +128,7 @@ impl<'db> TypeChecker<'db> {
         let constraints = ctx.take_constraints();
         // Take node_types now while ctx is still alive, before we need mutable self access
         let func_node_types = ctx.take_node_types();
+        let func_call_callee_types = ctx.take_call_callee_types();
         let func_handler_operations = ctx.take_handler_operations();
         let func_perform_operations = ctx.take_perform_operations();
         let func_lambda_signatures = ctx.take_lambda_signatures();
@@ -363,6 +364,10 @@ impl<'db> TypeChecker<'db> {
         for (node_id, ty) in func_node_types {
             let substituted = type_subst.apply_with_rows(self.db(), ty, row_subst);
             self.node_types.insert(node_id, substituted);
+        }
+        for (callee_id, ty) in func_call_callee_types {
+            let substituted = type_subst.apply_with_rows(self.db(), ty, row_subst);
+            self.call_callee_types.insert(callee_id, substituted);
         }
         for (arm_id, operation) in func_handler_operations {
             self.handler_operations.insert(

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -366,7 +366,7 @@ impl<'db> TypeChecker<'db> {
             self.node_types.insert(node_id, substituted);
         }
         for (callee_id, ty) in func_call_callee_types {
-            let substituted = type_subst.apply_with_rows(self.db(), ty, row_subst);
+            let substituted = self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index);
             self.call_callee_types.insert(callee_id, substituted);
         }
         for (arm_id, operation) in func_handler_operations {

--- a/crates/tribute-front/src/typeck/checker/mod.rs
+++ b/crates/tribute-front/src/typeck/checker/mod.rs
@@ -49,6 +49,8 @@ pub struct ModuleCheckResult<'db> {
     pub constructor_types: Vec<(crate::ast::CtorId<'db>, TypeScheme<'db>)>,
     /// Node types for IR lowering (NodeId → monomorphic type).
     pub node_types: Vec<(NodeId, Type<'db>)>,
+    /// Exact instantiated types selected for direct call callees.
+    pub call_callee_types: Vec<(NodeId, Type<'db>)>,
     /// Ability-level calling-convention requirements.
     pub ability_conventions: Vec<(crate::ast::AbilityId<'db>, CallingConvention)>,
     /// Exact semantic operation instances for handler arms.
@@ -93,6 +95,7 @@ pub struct TypeChecker<'db> {
     /// Accumulated node types from all functions.
     /// Collects NodeId → Type mappings during type checking.
     node_types: HashMap<NodeId, Type<'db>>,
+    call_callee_types: HashMap<NodeId, Type<'db>>,
     /// Exact handler operation instances collected from each checked function.
     handler_operations: HashMap<NodeId, crate::typeck::InstantiatedHandlerOperation<'db>>,
     perform_operations: HashMap<NodeId, crate::typeck::InstantiatedPerformOperation<'db>>,
@@ -131,6 +134,7 @@ impl<'db> TypeChecker<'db> {
             prefix: String::new(),
             span_map,
             node_types: HashMap::new(),
+            call_callee_types: HashMap::new(),
             handler_operations: HashMap::new(),
             perform_operations: HashMap::new(),
             lambda_signatures: HashMap::new(),
@@ -236,6 +240,8 @@ impl<'db> TypeChecker<'db> {
         // Sort by NodeId to ensure deterministic ordering for Salsa cache stability
         let mut node_types: Vec<(NodeId, Type<'db>)> = self.node_types.into_iter().collect();
         node_types.sort_by_key(|(id, _)| *id);
+        let mut call_callee_types: Vec<_> = self.call_callee_types.into_iter().collect();
+        call_callee_types.sort_by_key(|(id, _)| *id);
         let mut handler_operations: Vec<_> = self.handler_operations.into_iter().collect();
         handler_operations.sort_by_key(|(id, _)| *id);
         let mut perform_operations: Vec<_> = self.perform_operations.into_iter().collect();
@@ -253,6 +259,7 @@ impl<'db> TypeChecker<'db> {
             function_types,
             constructor_types,
             node_types,
+            call_callee_types,
             ability_conventions,
             handler_operations,
             perform_operations,

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -71,6 +71,9 @@ pub struct FunctionInferenceContext<'a, 'db> {
     /// Types of AST nodes (for TypedRef construction).
     node_types: HashMap<NodeId, Type<'db>>,
 
+    /// The solved function type selected for each direct call callee.
+    call_callee_types: HashMap<NodeId, Type<'db>>,
+
     /// Fully instantiated operation metadata for handler arms.
     handler_operations: HashMap<NodeId, InstantiatedHandlerOperation<'db>>,
 
@@ -158,6 +161,7 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             local_scopes: vec![HashMap::new()],
             name_scopes: vec![HashMap::new()],
             node_types: HashMap::new(),
+            call_callee_types: HashMap::new(),
             handler_operations: HashMap::new(),
             perform_operations: HashMap::new(),
             ability_op_callee_types: HashMap::new(),
@@ -347,6 +351,18 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     /// Used for collecting all node types after type checking a function.
     pub fn take_node_types(&mut self) -> HashMap<NodeId, Type<'db>> {
         std::mem::take(&mut self.node_types)
+    }
+
+    pub fn record_call_callee_type(&mut self, callee: NodeId, ty: Type<'db>) {
+        self.call_callee_types.entry(callee).or_insert(ty);
+    }
+
+    pub fn take_call_callee_types(&mut self) -> HashMap<NodeId, Type<'db>> {
+        std::mem::take(&mut self.call_callee_types)
+    }
+
+    pub fn get_call_callee_type(&self, callee: NodeId) -> Option<Type<'db>> {
+        self.call_callee_types.get(&callee).copied()
     }
 
     /// Record the exact semantic operation selected for a handler arm.

--- a/crates/tribute-front/src/typeck/mod.rs
+++ b/crates/tribute-front/src/typeck/mod.rs
@@ -188,6 +188,12 @@ impl WellKnownTypes<'_> {
 /// both can be derived from a single type checking invocation.
 /// Also stores the SpanMap so that downstream stages (e.g., ast_to_ir)
 /// can look up source spans without a separate plumbing path.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
+pub struct ExpressionTypeMetadata<'db> {
+    pub node_types: Vec<(NodeId, Type<'db>)>,
+    pub call_callee_types: Vec<(NodeId, Type<'db>)>,
+}
+
 #[salsa::tracked]
 pub struct TypeCheckOutput<'db> {
     /// The type-checked AST module.
@@ -201,12 +207,9 @@ pub struct TypeCheckOutput<'db> {
     /// reinterpreting source annotations.
     #[returns(ref)]
     pub constructor_types: Vec<(CtorId<'db>, TypeScheme<'db>)>,
-    /// Node types collected during type checking.
-    /// Maps NodeId to its inferred type (after substitution but before generalization).
-    /// Used by IR lowering to get lambda effect types.
-    /// Stored as Vec for Salsa compatibility (HashMap doesn't implement Hash).
+    /// Exact expression types and callee instantiations.
     #[returns(ref)]
-    pub node_types: Vec<(NodeId, Type<'db>)>,
+    pub expression_types: ExpressionTypeMetadata<'db>,
     /// Ability-level calling-convention requirements.
     #[returns(ref)]
     pub ability_conventions: Vec<(AbilityId<'db>, CallingConvention)>,
@@ -296,7 +299,10 @@ pub fn typecheck_module<'db>(
         result.module,
         result.function_types,
         result.constructor_types,
-        result.node_types,
+        ExpressionTypeMetadata {
+            node_types: result.node_types,
+            call_callee_types: result.call_callee_types,
+        },
         result.ability_conventions,
         ability_schemas(&result.ability_definitions),
         result.handler_operations,

--- a/crates/tribute-front/tests/int_text.rs
+++ b/crates/tribute-front/tests/int_text.rs
@@ -73,7 +73,7 @@ fn format_box(value: Int) -> String {
 /// Direct-call metadata preserves the exact concrete instantiation used when
 /// cloning a generic source function for source-logical lowering.
 #[salsa_test]
-fn generic_specialization_transports_lambda_metadata(db: &salsa::DatabaseImpl) {
+fn generic_specialization_transports_direct_callee_metadata(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,
         "generic_lambda_metadata.trb",
@@ -86,7 +86,7 @@ fn use_apply() -> Int { apply(+41) }
 "#,
     );
 
-    generic_specialization_transports_lambda_metadata_inner(db, source);
+    generic_specialization_transports_direct_callee_metadata_inner(db, source);
 }
 
 /// A generic extern discovered through a concrete clone has no AST body to
@@ -179,8 +179,9 @@ fn generic_extern_specialization_has_a_logical_signature_inner(
     );
 }
 
+// This query provides the Salsa accumulator context used by the type checker.
 #[salsa::tracked]
-fn generic_specialization_transports_lambda_metadata_inner(
+fn generic_specialization_transports_direct_callee_metadata_inner(
     db: &dyn salsa::Database,
     source: SourceCst,
 ) {

--- a/crates/tribute-front/tests/int_text.rs
+++ b/crates/tribute-front/tests/int_text.rs
@@ -89,6 +89,96 @@ fn use_apply() -> Int { apply(+41) }
     generic_specialization_transports_lambda_metadata_inner(db, source);
 }
 
+/// A generic extern discovered through a concrete clone has no AST body to
+/// specialize, but source-logical lowering still needs its exact callable
+/// scheme under the mangled identity.
+#[salsa_test]
+fn generic_extern_specialization_has_a_logical_signature(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "generic_extern_metadata.trb",
+        r#"
+extern "intrinsic" fn generic_intrinsic(value: a) -> a
+
+fn through(value: a) -> a {
+    generic_intrinsic(value)
+}
+
+fn use_through() -> Nat { through(0) }
+"#,
+    );
+
+    generic_extern_specialization_has_a_logical_signature_inner(db, source);
+}
+
+#[salsa::tracked]
+fn generic_extern_specialization_has_a_logical_signature_inner(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+) {
+    let parsed = tribute_front::query::parsed_ast(db, source).expect("fixture must parse");
+    let ast = parsed.module(db).clone();
+    let checked = tribute_front::typeck::typecheck_module(
+        db,
+        tribute_front::resolve::resolve_with_env(
+            db,
+            ast.clone(),
+            tribute_front::resolve::build_env(db, &ast),
+            parsed.span_map(db).clone(),
+        ),
+        parsed.span_map(db).clone(),
+    );
+    let typed =
+        tribute_front::tdnr::resolve_tdnr(db, checked.module(db).clone(), std::iter::empty());
+    let mono = tribute_front::monomorphize::monomorphize_functions(
+        db,
+        typed,
+        checked.function_types(db).iter().cloned().collect(),
+        tribute_front::monomorphize::MonomorphizeMetadata {
+            constructor_types: checked.constructor_types(db).iter().cloned().collect(),
+            node_types: checked
+                .expression_types(db)
+                .node_types
+                .iter()
+                .cloned()
+                .collect(),
+            call_callee_types: checked
+                .expression_types(db)
+                .call_callee_types
+                .iter()
+                .cloned()
+                .collect(),
+            handler_operations: checked.handler_operations(db).iter().cloned().collect(),
+            perform_operations: checked.perform_operations(db).iter().cloned().collect(),
+            lambda_signatures: checked.lambda_signatures(db).iter().cloned().collect(),
+            exhaustive_cases: checked.exhaustive_cases(db).iter().copied().collect(),
+        },
+    );
+    let mut ir = IrContext::new();
+    let output = tribute_front::ast_to_ir::TypedModule {
+        ast: mono.module,
+        span_map: checked.span_map(db).clone(),
+        function_types: mono.function_types.into_iter().collect(),
+        constructor_types: mono.metadata.constructor_types,
+        node_types: mono.metadata.node_types,
+        ability_conventions: checked.ability_conventions(db).iter().cloned().collect(),
+        ability_definitions: tribute_front::typeck::ability_definitions_from_schemas(
+            checked.ability_definitions(db),
+        ),
+        handler_operations: mono.metadata.handler_operations,
+        perform_operations: mono.metadata.perform_operations,
+        lambda_signatures: mono.metadata.lambda_signatures,
+        exhaustive_cases: mono.metadata.exhaustive_cases,
+        well_known_types: checked.well_known_types(db),
+    }
+    .lower_to_ir(db, &mut ir, source.uri(db).as_str());
+    let ir_text = print_module(&ir, output.module.op());
+    assert!(
+        ir_text.contains("generic_intrinsic$Nat"),
+        "logical lowering must resolve the concrete generic extern signature:\n{ir_text}"
+    );
+}
+
 #[salsa::tracked]
 fn generic_specialization_transports_lambda_metadata_inner(
     db: &dyn salsa::Database,

--- a/crates/tribute-front/tests/int_text.rs
+++ b/crates/tribute-front/tests/int_text.rs
@@ -7,6 +7,7 @@ use salsa_test_macros::salsa_test;
 use tribute_front::SourceCst;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
+use trunk_ir::printer::print_module;
 
 #[salsa_test]
 fn canonical_int_text_api_resolves_through_prelude(db: &salsa::DatabaseImpl) {
@@ -69,6 +70,93 @@ fn format_box(value: Int) -> String {
     );
 }
 
+/// Direct-call metadata preserves the exact concrete instantiation used when
+/// cloning a generic source function for source-logical lowering.
+#[salsa_test]
+fn generic_specialization_transports_lambda_metadata(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "generic_lambda_metadata.trb",
+        r#"
+fn apply(value: a) -> a {
+    value
+}
+
+fn use_apply() -> Int { apply(+41) }
+"#,
+    );
+
+    generic_specialization_transports_lambda_metadata_inner(db, source);
+}
+
+#[salsa::tracked]
+fn generic_specialization_transports_lambda_metadata_inner(
+    db: &dyn salsa::Database,
+    source: SourceCst,
+) {
+    let parsed = tribute_front::query::parsed_ast(db, source).expect("fixture must parse");
+    let ast = parsed.module(db).clone();
+    let checked = tribute_front::typeck::typecheck_module(
+        db,
+        tribute_front::resolve::resolve_with_env(
+            db,
+            ast.clone(),
+            tribute_front::resolve::build_env(db, &ast),
+            parsed.span_map(db).clone(),
+        ),
+        parsed.span_map(db).clone(),
+    );
+    let typed =
+        tribute_front::tdnr::resolve_tdnr(db, checked.module(db).clone(), std::iter::empty());
+    let mono = tribute_front::monomorphize::monomorphize_functions(
+        db,
+        typed,
+        checked.function_types(db).iter().cloned().collect(),
+        tribute_front::monomorphize::MonomorphizeMetadata {
+            constructor_types: checked.constructor_types(db).iter().cloned().collect(),
+            node_types: checked
+                .expression_types(db)
+                .node_types
+                .iter()
+                .cloned()
+                .collect(),
+            call_callee_types: checked
+                .expression_types(db)
+                .call_callee_types
+                .iter()
+                .cloned()
+                .collect(),
+            handler_operations: checked.handler_operations(db).iter().cloned().collect(),
+            perform_operations: checked.perform_operations(db).iter().cloned().collect(),
+            lambda_signatures: checked.lambda_signatures(db).iter().cloned().collect(),
+            exhaustive_cases: checked.exhaustive_cases(db).iter().copied().collect(),
+        },
+    );
+    let mut ir = IrContext::new();
+    let output = tribute_front::ast_to_ir::TypedModule {
+        ast: mono.module,
+        span_map: checked.span_map(db).clone(),
+        function_types: mono.function_types.into_iter().collect(),
+        constructor_types: mono.metadata.constructor_types,
+        node_types: mono.metadata.node_types,
+        ability_conventions: checked.ability_conventions(db).iter().cloned().collect(),
+        ability_definitions: tribute_front::typeck::ability_definitions_from_schemas(
+            checked.ability_definitions(db),
+        ),
+        handler_operations: mono.metadata.handler_operations,
+        perform_operations: mono.metadata.perform_operations,
+        lambda_signatures: mono.metadata.lambda_signatures,
+        exhaustive_cases: mono.metadata.exhaustive_cases,
+        well_known_types: checked.well_known_types(db),
+    }
+    .lower_to_ir(db, &mut ir, source.uri(db).as_str());
+    let ir_text = print_module(&ir, output.module.op());
+    assert!(
+        ir_text.contains("tribute_control.func @\"apply$Int\""),
+        "the specialized generic function must preserve its checked concrete call type:\n{ir_text}"
+    );
+}
+
 /// The public typecheck-to-logical-lowering boundary carries deterministic,
 /// exact operation declarations rather than reconstructing them from printed
 /// operations. First source use is bounce, then echo; handler repeats dedupe.
@@ -93,7 +181,12 @@ fn public_logical_output_declarations_inner(db: &dyn salsa::Database, source: So
         span_map: checked.span_map(db).clone(),
         function_types: checked.function_types(db).iter().cloned().collect(),
         constructor_types: checked.constructor_types(db).iter().cloned().collect(),
-        node_types: checked.node_types(db).iter().cloned().collect(),
+        node_types: checked
+            .expression_types(db)
+            .node_types
+            .iter()
+            .cloned()
+            .collect(),
         ability_conventions: checked.ability_conventions(db).iter().cloned().collect(),
         ability_definitions: tribute_front::typeck::ability_definitions_from_schemas(
             checked.ability_definitions(db),

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2123,6 +2123,12 @@ fn main() {
             let concrete = "List::__tribute_list_prepend_intrinsic$Int";
 
             assert!(
+                monomorphized
+                    .function_types
+                    .contains_key(&trunk_ir::Symbol::new(concrete)),
+                "monomorphization must retain the concrete prelude intrinsic scheme"
+            );
+            assert!(
                 ast.contains(concrete),
                 "specialized List body must call the concrete intrinsic:\n{ast}"
             );

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2133,8 +2133,7 @@ fn main() {
                 "specialized List body must call the concrete intrinsic:\n{ast}"
             );
             assert!(
-                !ast.contains("List::__tribute_list_prepend_intrinsic$T0")
-                    && !ast.contains("List::__tribute_list_prepend_intrinsic$T1"),
+                !ast.contains("List::__tribute_list_prepend_intrinsic$T"),
                 "specialized List body must not retain generic intrinsic binders:\n{ast}"
             );
         });

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -354,11 +354,23 @@ fn merge_and_lower_to_ir<'db>(
     source: SourceCst,
     options: OptimizationOptions,
 ) -> (IrContext, Module) {
+    merge_and_lower_to_ir_with(db, typed, source, |typed, db, ir, source_uri| {
+        typed.lower_to_legacy_ir_with_options(db, ir, source_uri, options.ast_to_ir)
+    })
+}
+
+fn merge_and_lower_to_ir_with<'db, M>(
+    db: &'db dyn salsa::Database,
+    typed: &ast_typeck::TypeCheckOutput<'db>,
+    source: SourceCst,
+    lower: impl FnOnce(ast_to_ir::TypedModule<'db>, &'db dyn salsa::Database, &mut IrContext, &str) -> M,
+) -> (IrContext, M) {
     use tribute_front::ast::TypedRef;
 
     let user_module = typed.module(db);
     let user_fn_types = typed.function_types(db);
     let user_node_types = &typed.expression_types(db).node_types;
+    let user_call_callee_types = &typed.expression_types(db).call_callee_types;
     let user_span_map = typed.span_map(db);
 
     // Merge prelude at AST level
@@ -367,12 +379,14 @@ fn merge_and_lower_to_ir<'db>(
         merged_module,
         merged_fn_types,
         merged_node_types,
+        merged_call_callee_types,
         merged_ability_conventions,
         merged_span_map,
     ) = if let Some(prelude) = prelude_module(db) {
         let prelude_module_ast = prelude.module(db);
         let prelude_fn_types = prelude.function_types(db);
         let prelude_node_types = &prelude.expression_types(db).node_types;
+        let prelude_call_callee_types = &prelude.expression_types(db).call_callee_types;
         let prelude_ability_conventions = prelude.ability_conventions(db);
         let prelude_span_map = prelude.span_map(db);
 
@@ -396,6 +410,10 @@ fn merge_and_lower_to_ir<'db>(
             prelude_node_types.iter().cloned().collect();
         node_types.extend(user_node_types.iter().cloned());
 
+        let mut call_callee_types: std::collections::HashMap<_, _> =
+            prelude_call_callee_types.iter().cloned().collect();
+        call_callee_types.extend(user_call_callee_types.iter().cloned());
+
         let mut ability_conventions: std::collections::HashMap<_, _> =
             prelude_ability_conventions.iter().cloned().collect();
         ability_conventions.extend(user_ability_conventions.iter().cloned());
@@ -407,18 +425,22 @@ fn merge_and_lower_to_ir<'db>(
             merged_ast,
             fn_types,
             node_types,
+            call_callee_types,
             ability_conventions,
             merged_span_map,
         )
     } else {
         let fn_types: std::collections::HashMap<_, _> = user_fn_types.iter().cloned().collect();
         let node_types: std::collections::HashMap<_, _> = user_node_types.iter().cloned().collect();
+        let call_callee_types: std::collections::HashMap<_, _> =
+            user_call_callee_types.iter().cloned().collect();
         let ability_conventions: std::collections::HashMap<_, _> =
             user_ability_conventions.iter().cloned().collect();
         (
             user_module.clone(),
             fn_types,
             node_types,
+            call_callee_types,
             ability_conventions,
             user_span_map.clone(),
         )
@@ -432,12 +454,7 @@ fn merge_and_lower_to_ir<'db>(
         tribute_front::monomorphize::MonomorphizeMetadata {
             constructor_types: typed.constructor_types(db).iter().cloned().collect(),
             node_types: merged_node_types,
-            call_callee_types: typed
-                .expression_types(db)
-                .call_callee_types
-                .iter()
-                .cloned()
-                .collect(),
+            call_callee_types: merged_call_callee_types,
             handler_operations: typed.handler_operations(db).iter().cloned().collect(),
             perform_operations: typed.perform_operations(db).iter().cloned().collect(),
             lambda_signatures: typed.lambda_signatures(db).iter().cloned().collect(),
@@ -451,23 +468,27 @@ fn merge_and_lower_to_ir<'db>(
     // AST → TrunkIR (arena)
     let source_uri = source.uri(db).as_str();
     let mut ir = IrContext::new();
-    let module = ast_to_ir::TypedModule {
-        ast: merged_module,
-        span_map: merged_span_map,
-        function_types: merged_fn_types,
-        constructor_types: mono_result.metadata.constructor_types,
-        node_types: mono_result.metadata.node_types,
-        ability_conventions: merged_ability_conventions,
-        ability_definitions: ast_typeck::ability_definitions_from_schemas(
-            typed.ability_definitions(db),
-        ),
-        handler_operations: mono_result.metadata.handler_operations,
-        perform_operations: mono_result.metadata.perform_operations,
-        lambda_signatures: mono_result.metadata.lambda_signatures,
-        exhaustive_cases: mono_result.metadata.exhaustive_cases,
-        well_known_types: typed.well_known_types(db),
-    }
-    .lower_to_legacy_ir_with_options(db, &mut ir, source_uri, options.ast_to_ir);
+    let module = lower(
+        ast_to_ir::TypedModule {
+            ast: merged_module,
+            span_map: merged_span_map,
+            function_types: merged_fn_types,
+            constructor_types: mono_result.metadata.constructor_types,
+            node_types: mono_result.metadata.node_types,
+            ability_conventions: merged_ability_conventions,
+            ability_definitions: ast_typeck::ability_definitions_from_schemas(
+                typed.ability_definitions(db),
+            ),
+            handler_operations: mono_result.metadata.handler_operations,
+            perform_operations: mono_result.metadata.perform_operations,
+            lambda_signatures: mono_result.metadata.lambda_signatures,
+            exhaustive_cases: mono_result.metadata.exhaustive_cases,
+            well_known_types: typed.well_known_types(db),
+        },
+        db,
+        &mut ir,
+        source_uri,
+    );
 
     (ir, module)
 }
@@ -2082,6 +2103,35 @@ fn main() ->{std::io::Io} Nil {
         assert!(result.is_some());
         let (ctx, m) = result.unwrap();
         assert_eq!(m.name(&ctx), Some(trunk_ir::Symbol::new("test")));
+    }
+
+    #[test]
+    fn root_prelude_generic_callee_metadata_reaches_concrete_specialization() {
+        salsa::Database::attach(&salsa::DatabaseImpl::default(), |db| {
+            let source = source_from_str(
+                "prelude_list_prepend.trb",
+                r#"
+fn main() {
+    let _ = List::prepend(+1, [])
+}
+"#,
+            );
+            let typed = parse_and_lower_ast(db, source).expect("frontend output");
+            let (_, monomorphized) =
+                merge_and_lower_to_ir_with(db, &typed, source, |typed, _, _, _| typed);
+            let ast = format!("{:#?}", monomorphized.ast);
+            let concrete = "List::__tribute_list_prepend_intrinsic$Int";
+
+            assert!(
+                ast.contains(concrete),
+                "specialized List body must call the concrete intrinsic:\n{ast}"
+            );
+            assert!(
+                !ast.contains("List::__tribute_list_prepend_intrinsic$T0")
+                    && !ast.contains("List::__tribute_list_prepend_intrinsic$T1"),
+                "specialized List body must not retain generic intrinsic binders:\n{ast}"
+            );
+        });
     }
 
     #[salsa_test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -284,7 +284,10 @@ fn prelude_module<'db>(db: &'db dyn salsa::Database) -> Option<ast_typeck::TypeC
         tdnr_ast,
         result.function_types,
         result.constructor_types,
-        result.node_types,
+        ast_typeck::ExpressionTypeMetadata {
+            node_types: result.node_types,
+            call_callee_types: result.call_callee_types,
+        },
         result.ability_conventions,
         ast_typeck::ability_schemas(&result.ability_definitions),
         result.handler_operations,
@@ -355,7 +358,7 @@ fn merge_and_lower_to_ir<'db>(
 
     let user_module = typed.module(db);
     let user_fn_types = typed.function_types(db);
-    let user_node_types = typed.node_types(db);
+    let user_node_types = &typed.expression_types(db).node_types;
     let user_span_map = typed.span_map(db);
 
     // Merge prelude at AST level
@@ -369,7 +372,7 @@ fn merge_and_lower_to_ir<'db>(
     ) = if let Some(prelude) = prelude_module(db) {
         let prelude_module_ast = prelude.module(db);
         let prelude_fn_types = prelude.function_types(db);
-        let prelude_node_types = prelude.node_types(db);
+        let prelude_node_types = &prelude.expression_types(db).node_types;
         let prelude_ability_conventions = prelude.ability_conventions(db);
         let prelude_span_map = prelude.span_map(db);
 
@@ -422,8 +425,25 @@ fn merge_and_lower_to_ir<'db>(
     };
 
     // Monomorphize generic functions
-    let mono_result =
-        tribute_front::monomorphize::monomorphize_functions(db, merged_module, merged_fn_types);
+    let mono_result = tribute_front::monomorphize::monomorphize_functions(
+        db,
+        merged_module,
+        merged_fn_types,
+        tribute_front::monomorphize::MonomorphizeMetadata {
+            constructor_types: typed.constructor_types(db).iter().cloned().collect(),
+            node_types: merged_node_types,
+            call_callee_types: typed
+                .expression_types(db)
+                .call_callee_types
+                .iter()
+                .cloned()
+                .collect(),
+            handler_operations: typed.handler_operations(db).iter().cloned().collect(),
+            perform_operations: typed.perform_operations(db).iter().cloned().collect(),
+            lambda_signatures: typed.lambda_signatures(db).iter().cloned().collect(),
+            exhaustive_cases: typed.exhaustive_cases(db).iter().copied().collect(),
+        },
+    );
     let merged_module = mono_result.module;
     let merged_fn_types: std::collections::HashMap<_, _> =
         mono_result.function_types.into_iter().collect();
@@ -435,16 +455,16 @@ fn merge_and_lower_to_ir<'db>(
         ast: merged_module,
         span_map: merged_span_map,
         function_types: merged_fn_types,
-        constructor_types: typed.constructor_types(db).iter().cloned().collect(),
-        node_types: merged_node_types,
+        constructor_types: mono_result.metadata.constructor_types,
+        node_types: mono_result.metadata.node_types,
         ability_conventions: merged_ability_conventions,
         ability_definitions: ast_typeck::ability_definitions_from_schemas(
             typed.ability_definitions(db),
         ),
-        handler_operations: typed.handler_operations(db).iter().cloned().collect(),
-        perform_operations: typed.perform_operations(db).iter().cloned().collect(),
-        lambda_signatures: typed.lambda_signatures(db).iter().cloned().collect(),
-        exhaustive_cases: typed.exhaustive_cases(db).iter().copied().collect(),
+        handler_operations: mono_result.metadata.handler_operations,
+        perform_operations: mono_result.metadata.perform_operations,
+        lambda_signatures: mono_result.metadata.lambda_signatures,
+        exhaustive_cases: mono_result.metadata.exhaustive_cases,
         well_known_types: typed.well_known_types(db),
     }
     .lower_to_legacy_ir_with_options(db, &mut ir, source_uri, options.ast_to_ir);
@@ -1315,7 +1335,10 @@ pub fn parse_and_lower_ast<'db>(
         tdnr_ast,
         result.function_types,
         result.constructor_types,
-        result.node_types,
+        ast_typeck::ExpressionTypeMetadata {
+            node_types: result.node_types,
+            call_callee_types: result.call_callee_types,
+        },
         result.ability_conventions,
         ast_typeck::ability_schemas(&result.ability_definitions),
         result.handler_operations,


### PR DESCRIPTION
Closes #834.

Captures exact checked callee instances for generic specialization and re-keys/substitutes semantic metadata for cloned NodeIds (node, handler, perform, lambda, and exhaustiveness metadata).

Adds focused generic function/logical-IR coverage and exercises existing generic nominal and nested-type coverage.

Excluded: #835 local-generalization/value-restriction semantics, CPS conversion, target ABI, and backend work.

Validation: focused generic frontend tests, monomorphization unit tests, `cargo fmt`, `cargo clippy -p tribute-front -p tribute -- -D warnings`, and affected-crate checks passed. The full commit-hook suite did not complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generic functions now specialize using concrete call-site types.
  - Generic external functions can be lowered with concrete signatures.
  - Built-in generic calls resolve to concrete intrinsic operations.
  - Type and semantic metadata remains available through specialization and lowering.

- **Bug Fixes**
  - Improved nested and transitive generic specialization.
  - Rejected unresolved or open effect types that could produce invalid specializations.
  - Preserved call, lambda, handler, and exhaustiveness metadata in generated output.

- **Tests**
  - Added coverage for generic calls, external functions, effect rows, and metadata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->