### PR TITLE
Add backend-ready legality verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,6 +1547,7 @@ dependencies = [
  "tribute-core",
  "tribute-ir",
  "trunk-ir",
+ "trunk-ir-cranelift-backend",
  "trunk-ir-wasm-backend",
 ]
 

--- a/crates/tribute-passes/Cargo.toml
+++ b/crates/tribute-passes/Cargo.toml
@@ -13,6 +13,7 @@ tracing.workspace = true
 tribute-core.workspace = true
 tribute-ir.workspace = true
 trunk-ir.workspace = true
+trunk-ir-cranelift-backend.workspace = true
 trunk-ir-wasm-backend.workspace = true
 
 [dev-dependencies]

--- a/crates/tribute-passes/src/backend_ready.rs
+++ b/crates/tribute-passes/src/backend_ready.rs
@@ -1,0 +1,525 @@
+//! Final Tribute backend-boundary verification.
+//!
+//! The generic target validators own operation legality. This module adds the
+//! Tribute contract they intentionally cannot know: all reachable types and
+//! attributes must be legal for the selected target and no logical control
+//! representation may cross into emission.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::ops::ControlFlow;
+
+use tribute_core::{CallingConvention, get_calling_convention};
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::refs::{OpRef, TypeRef};
+use trunk_ir::rewrite::Module;
+use trunk_ir::types::Attribute;
+use trunk_ir::walk::{WalkAction, walk_op};
+
+/// Backend selected for a final Tribute legality boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TributeBackend {
+    Native,
+    Wasm,
+}
+
+impl TributeBackend {
+    fn boundary(self) -> &'static str {
+        match self {
+            Self::Native => "tribute-backend-ready-native",
+            Self::Wasm => "tribute-backend-ready-wasm",
+        }
+    }
+
+    fn dialect(self) -> &'static str {
+        match self {
+            Self::Native => "clif",
+            Self::Wasm => "wasm",
+        }
+    }
+}
+
+/// A non-mutating final-boundary validation error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BackendReadyError(String);
+
+impl BackendReadyError {
+    fn new(backend: TributeBackend, message: impl fmt::Display) -> Self {
+        Self(format!("{}: {message}", backend.boundary()))
+    }
+}
+
+impl fmt::Display for BackendReadyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for BackendReadyError {}
+
+/// Verify that `module` is ready for the selected backend.
+pub fn verify_tribute_backend_ready(
+    ctx: &IrContext,
+    module: Module,
+    backend: TributeBackend,
+) -> Result<(), BackendReadyError> {
+    verify_target_operations(ctx, module, backend)?;
+
+    let mut verifier = RecursiveLegalityWalker::new(ctx, backend);
+    for &(symbol, ty) in ctx.type_aliases() {
+        verifier.verify_symbol(symbol, "type alias")?;
+        verifier.verify_type(ty, TypeSurface::Metadata, "type alias")?;
+    }
+
+    for op in collect_ops(ctx, module.op()) {
+        verifier.verify_operation(op)?;
+    }
+    Ok(())
+}
+
+/// Verify the final native boundary.
+pub fn verify_native_backend_ready(
+    ctx: &IrContext,
+    module: Module,
+) -> Result<(), BackendReadyError> {
+    verify_tribute_backend_ready(ctx, module, TributeBackend::Native)
+}
+
+/// Verify the final Wasm boundary.
+pub fn verify_wasm_backend_ready(ctx: &IrContext, module: Module) -> Result<(), BackendReadyError> {
+    verify_tribute_backend_ready(ctx, module, TributeBackend::Wasm)
+}
+
+fn verify_target_operations(
+    ctx: &IrContext,
+    module: Module,
+    backend: TributeBackend,
+) -> Result<(), BackendReadyError> {
+    match backend {
+        TributeBackend::Native => trunk_ir_cranelift_backend::validate_clif_ir(ctx, module)
+            .map_err(|error| BackendReadyError::new(backend, error)),
+        TributeBackend::Wasm => trunk_ir_wasm_backend::validate_wasm_ir(ctx, module)
+            .map_err(|error| BackendReadyError::new(backend, error)),
+    }
+}
+
+fn collect_ops(ctx: &IrContext, root: OpRef) -> Vec<OpRef> {
+    let mut ops = Vec::new();
+    let _ = walk_op::<()>(ctx, root, &mut |op| {
+        ops.push(op);
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    ops
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+enum TypeSurface {
+    Value,
+    Result,
+    Metadata,
+    Signature,
+}
+
+struct RecursiveLegalityWalker<'ctx> {
+    ctx: &'ctx IrContext,
+    backend: TributeBackend,
+    visited: HashSet<(TypeRef, TypeSurface)>,
+}
+
+impl<'ctx> RecursiveLegalityWalker<'ctx> {
+    fn new(ctx: &'ctx IrContext, backend: TributeBackend) -> Self {
+        Self {
+            ctx,
+            backend,
+            visited: HashSet::new(),
+        }
+    }
+
+    fn verify_operation(&mut self, op: OpRef) -> Result<(), BackendReadyError> {
+        let data = self.ctx.op(op);
+        let surface = format!("operation {}.{}", data.dialect, data.name);
+
+        for &ty in self.ctx.op_result_types(op) {
+            self.verify_type(ty, TypeSurface::Result, &surface)?;
+        }
+        for &operand in self.ctx.op_operands(op) {
+            self.verify_type(self.ctx.value_ty(operand), TypeSurface::Value, &surface)?;
+        }
+        for (key, attribute) in &data.attributes {
+            self.verify_symbol(*key, &surface)?;
+            if self.is_signature_attribute(op, *key) {
+                let Attribute::Type(ty) = attribute else {
+                    return Err(self.error("callable signature attribute is not a type"));
+                };
+                self.verify_type(*ty, TypeSurface::Signature, &surface)?;
+            } else {
+                self.verify_attribute(attribute, TypeSurface::Metadata, &surface)?;
+            }
+        }
+        for &region in &data.regions {
+            for &block in &self.ctx.region(region).blocks {
+                for argument in &self.ctx.block(block).args {
+                    self.verify_type(argument.ty, TypeSurface::Value, "block argument")?;
+                    for attribute in argument.attrs.values() {
+                        self.verify_attribute(
+                            attribute,
+                            TypeSurface::Metadata,
+                            "block argument attribute",
+                        )?;
+                    }
+                }
+            }
+        }
+        self.verify_abi(op)
+    }
+
+    fn verify_type(
+        &mut self,
+        ty: TypeRef,
+        surface: TypeSurface,
+        where_: &str,
+    ) -> Result<(), BackendReadyError> {
+        if !self.visited.insert((ty, surface)) {
+            return Ok(());
+        }
+        let data = self.ctx.types.get(ty);
+        if !type_is_legal(self.backend, surface, data) {
+            return Err(self.error(format!(
+                "illegal type `{}.{}` in {where_}",
+                data.dialect, data.name
+            )));
+        }
+        for &parameter in &data.params {
+            self.verify_type(parameter, TypeSurface::Metadata, "nested type parameter")?;
+        }
+        for attribute in data.attrs.values() {
+            self.verify_attribute(attribute, TypeSurface::Metadata, "type attribute")?;
+        }
+
+        if surface == TypeSurface::Signature {
+            if data.dialect != Symbol::new("core")
+                || data.name != Symbol::new("func")
+                || data.params.is_empty()
+            {
+                return Err(self.error(format!(
+                    "`{}.{}` is not a callable signature in {where_}",
+                    data.dialect, data.name
+                )));
+            }
+            self.verify_type(data.params[0], TypeSurface::Result, "function result")?;
+            for &parameter in &data.params[1..] {
+                self.verify_type(parameter, TypeSurface::Value, "function parameter")?;
+            }
+        }
+        Ok(())
+    }
+
+    fn verify_attribute(
+        &mut self,
+        attribute: &Attribute,
+        surface: TypeSurface,
+        where_: &str,
+    ) -> Result<(), BackendReadyError> {
+        match attribute {
+            Attribute::Type(ty) => self.verify_type(*ty, surface, where_),
+            Attribute::Symbol(symbol) => self.verify_symbol(*symbol, where_),
+            Attribute::List(values) => {
+                for value in values {
+                    self.verify_attribute(value, surface, where_)?;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn verify_symbol(&self, symbol: Symbol, where_: &str) -> Result<(), BackendReadyError> {
+        if symbol == Symbol::new("__tribute_cps_control") {
+            return Err(self.error(format!(
+                "private CPS control carrier `__tribute_cps_control` remains in {where_}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn verify_abi(&mut self, op: OpRef) -> Result<(), BackendReadyError> {
+        let data = self.ctx.op(op);
+        let convention = if data.attributes.contains_key("tribute.calling_convention") {
+            Some(
+                get_calling_convention(self.ctx, op)
+                    .ok_or_else(|| self.error("invalid tribute.calling_convention attribute"))?,
+            )
+        } else {
+            None
+        };
+
+        if convention == Some(CallingConvention::Cps)
+            && data.dialect == Symbol::new(self.backend.dialect())
+            && data.name == Symbol::new("func")
+        {
+            let signature = data
+                .attributes
+                .get_type("type")
+                .ok_or_else(|| self.error("Cps function has no signature"))?;
+            let signature = self.ctx.types.get(signature);
+            if signature.dialect != Symbol::new("core")
+                || signature.name != Symbol::new("func")
+                || signature
+                    .params
+                    .first()
+                    .is_none_or(|&result| !is_core_type(self.ctx, result, "nil"))
+            {
+                return Err(self.error("Cps function result is not physically empty"));
+            }
+        }
+
+        if (data.name == Symbol::new("return_call")
+            || data.name == Symbol::new("return_call_indirect"))
+            && !self.ctx.op_result_types(op).is_empty()
+        {
+            return Err(self.error("result-producing CPS transfer remains"));
+        }
+        Ok(())
+    }
+
+    fn is_signature_attribute(&self, op: OpRef, key: Symbol) -> bool {
+        let data = self.ctx.op(op);
+        data.dialect == Symbol::new(self.backend.dialect())
+            && ((data.name == Symbol::new("func") && key == Symbol::new("type"))
+                || ((data.name == Symbol::new("call_indirect")
+                    || data.name == Symbol::new("return_call_indirect"))
+                    && key == Symbol::new("sig")))
+    }
+
+    fn error(&self, message: impl fmt::Display) -> BackendReadyError {
+        BackendReadyError::new(self.backend, message)
+    }
+}
+
+fn type_is_legal(
+    backend: TributeBackend,
+    surface: TypeSurface,
+    data: &trunk_ir::types::TypeData,
+) -> bool {
+    match surface {
+        TypeSurface::Signature => {
+            data.dialect == Symbol::new("core") && data.name == Symbol::new("func")
+        }
+        TypeSurface::Value => target_value_type(backend, data),
+        TypeSurface::Result => {
+            is_named_type(data.dialect, data.name, "core", "nil")
+                || target_value_type(backend, data)
+        }
+        TypeSurface::Metadata => target_metadata_type(backend, data),
+    }
+}
+
+fn target_value_type(backend: TributeBackend, data: &trunk_ir::types::TypeData) -> bool {
+    match backend {
+        TributeBackend::Native => core_type_is(
+            data.dialect,
+            data.name,
+            &["i1", "i8", "i16", "i32", "i64", "f32", "f64", "ptr"],
+        ),
+        TributeBackend::Wasm => {
+            core_type_is(
+                data.dialect,
+                data.name,
+                &[
+                    "nil", "i1", "i32", "i64", "f32", "f64", "bytes", "ptr", "array", "func",
+                ],
+            ) || adt_type_is(data)
+                || wasm_reference_type(data.dialect, data.name)
+        }
+    }
+}
+
+fn target_metadata_type(backend: TributeBackend, data: &trunk_ir::types::TypeData) -> bool {
+    core_type_is(
+        data.dialect,
+        data.name,
+        &[
+            "func", "nil", "i1", "i8", "i16", "i32", "i64", "f32", "f64", "ptr", "bytes", "ref",
+            "array",
+        ],
+    ) || adt_type_is(data)
+        || (backend == TributeBackend::Wasm && wasm_reference_type(data.dialect, data.name))
+}
+
+fn core_type_is(dialect: Symbol, name: Symbol, names: &[&str]) -> bool {
+    dialect == Symbol::new("core")
+        && names
+            .iter()
+            .any(|candidate| name == Symbol::from_dynamic(candidate))
+}
+
+fn adt_type_is(data: &trunk_ir::types::TypeData) -> bool {
+    data.dialect == Symbol::new("adt")
+        && (["struct", "enum", "typeref", "variant_inst"]
+            .iter()
+            .any(|candidate| data.name == Symbol::from_dynamic(candidate))
+            || data.attrs.get_bool("is_variant") == Some(true))
+}
+
+fn wasm_reference_type(dialect: Symbol, name: Symbol) -> bool {
+    dialect == Symbol::new("wasm")
+        && ["anyref", "i31ref", "structref", "arrayref", "funcref"]
+            .iter()
+            .any(|candidate| name == Symbol::from_dynamic(candidate))
+}
+
+fn is_named_type(
+    dialect: Symbol,
+    name: Symbol,
+    expected_dialect: &str,
+    expected_name: &str,
+) -> bool {
+    dialect == Symbol::from_dynamic(expected_dialect) && name == Symbol::from_dynamic(expected_name)
+}
+
+fn is_core_type(ctx: &IrContext, ty: TypeRef, expected: &str) -> bool {
+    let data = ctx.types.get(ty);
+    is_named_type(data.dialect, data.name, "core", expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+
+    fn verify(ir: &str, backend: TributeBackend) -> Result<(), String> {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        verify_tribute_backend_ready(&ctx, module, backend).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn accepts_textual_backend_functions() {
+        verify(
+            r#"core.module @test {
+  clif.func @main(%value: core.i32) -> core.nil {
+    clif.return
+  }
+}"#,
+            TributeBackend::Native,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_residual_logical_operation() {
+        let error = verify(
+            r#"core.module @test {
+  wasm.func @main() -> core.nil {
+    tribute_control.perform : core.nil
+    wasm.return
+  }
+}"#,
+            TributeBackend::Wasm,
+        )
+        .expect_err("backend boundary must reject logical operations");
+        assert!(error.contains("tribute_control.perform"), "{error}");
+    }
+
+    #[test]
+    fn rejects_logical_type_nested_in_textual_metadata() {
+        let error = verify(
+            r#"core.module @test {
+  !logical = core.array(tribute_control.callable(core.nil))
+  wasm.func @main() -> core.nil {
+    wasm.return
+  }
+}"#,
+            TributeBackend::Wasm,
+        )
+        .expect_err("backend boundary must reject nested logical types");
+        assert!(error.contains("tribute_control.callable"), "{error}");
+    }
+
+    #[test]
+    fn rejects_illegal_types_in_signatures_and_block_arguments() {
+        let error = verify(
+            r#"core.module @test {
+  clif.func @main(%value: core.bytes) -> core.nil {
+    clif.return
+  }
+}"#,
+            TributeBackend::Native,
+        )
+        .expect_err("native value slots cannot carry backend metadata types");
+        assert!(error.contains("core.bytes"), "{error}");
+    }
+
+    #[test]
+    fn rejects_illegal_result_and_attribute_types() {
+        for ir in [
+            r#"core.module @test {
+  clif.func @main() -> core.nil {
+    %logical = clif.unknown : tribute_control.callable(core.nil)
+    clif.return
+  }
+}"#,
+            r#"core.module @test {
+  wasm.func @main() -> core.nil {
+    wasm.return {metadata = [core.array(tribute_control.callable(core.nil))]}
+  }
+}"#,
+        ] {
+            let error = verify(
+                ir,
+                if ir.contains("clif.func") {
+                    TributeBackend::Native
+                } else {
+                    TributeBackend::Wasm
+                },
+            )
+            .expect_err("every type-bearing surface must be checked");
+            assert!(error.contains("tribute_control.callable"), "{error}");
+        }
+    }
+
+    #[test]
+    fn rejects_result_producing_proper_tail_transfers() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @main(%input: core.i32) -> core.nil {
+    clif.return
+  }
+}"#,
+        );
+        let function = module.ops(&ctx)[0];
+        let block = ctx.region(ctx.op(function).regions[0]).blocks[0];
+        let i32 = ctx.value_ty(ctx.block_args(block)[0]);
+        let transfer_data = trunk_ir::OperationDataBuilder::new(
+            ctx.op(function).location,
+            Symbol::new("clif"),
+            Symbol::new("return_call"),
+        )
+        .result(i32)
+        .build(&mut ctx);
+        let transfer = ctx.create_op(transfer_data);
+        ctx.push_op(block, transfer);
+        let error = verify_tribute_backend_ready(&ctx, module, TributeBackend::Native)
+            .expect_err("proper-tail transfers cannot produce a result")
+            .to_string();
+        assert!(error.contains("result-producing CPS transfer"), "{error}");
+    }
+
+    #[test]
+    fn rejects_private_control_carrier_symbol() {
+        let error = verify(
+            r#"core.module @test {
+  !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control}
+  clif.func @main() -> core.nil {
+    clif.return
+  }
+}"#,
+            TributeBackend::Native,
+        )
+        .expect_err("backend boundary must reject the private control carrier");
+        assert!(error.contains("__tribute_cps_control"), "{error}");
+    }
+}

--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod diagnostic;
 
 // === TrunkIR passes ===
+pub mod backend_ready;
 pub mod boxing;
 pub mod closure_lower;
 pub mod evidence;


### PR DESCRIPTION
Closes #837.

Adds an independent verifier that reuses the native and Wasm target operation validators and recursively checks every type-bearing surface and CPS shape.

No pipeline wiring is included; #825 will own production invocation.

Focused checks: `cargo nextest run -p tribute-passes -p trunk-ir` and `cargo clippy -p tribute-passes --all-targets -- -D warnings`.