### PR TITLE
Rebind CPS dispatch through continuation frames

### DIFF
--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -20,19 +20,20 @@ mod ability {
         {}
     }
 
-    /// Perform an ability operation with an explicit continuation closure.
+    /// Perform an ability operation with explicit evidence and a
+    /// ContinuationFrame-carrying continuation closure.
     ///
     /// The continuation closure captures the rest of the computation
     /// after the effect point.
     ///
     /// ```text
-    /// %yr = ability.perform %continuation, [%args...]
+    /// ability.perform %evidence, %dispatch, %resume, [%args...]
     ///   { ability_ref: @State, op_name: @get }
     /// ```
     ///
-    /// Lowered to: evidence lookup → ShiftInfo construction → YieldResult::Shift.
+    /// This final form is resultless and lowers to `effect.dispatch_cps`.
     #[attr(ability_ref: Type, op_name: Symbol)]
-    fn perform(continuation: (), #[rest] values: ()) -> result {}
+    fn perform(evidence: (), dispatch: (), resume: (), #[rest] values: ()) {}
 
     /// Legacy frontend form using the carrier pipeline's null-or-single-value
     /// payload convention until the frontend/pipeline migration is complete.
@@ -90,7 +91,7 @@ mod ability {
     /// evidence. Every body path ends in a proper tail transfer or
     /// `func.unreachable`.
     #[attr(ability_refs: any)]
-    fn handle_dispatch(evidence: (), #[rest] dispatchers: ()) {
+    fn handle_dispatch(evidence: (), prompt_tag: (), #[rest] dispatchers: ()) {
         #[region(body)]
         {}
     }

--- a/crates/tribute-ir/src/dialect/effect.rs
+++ b/crates/tribute-ir/src/dialect/effect.rs
@@ -30,10 +30,20 @@ mod effect {
 
     /// Dispatch a general CPS `op` ability operation.
     ///
-    /// `continuation` is the already-constructed continuation closure and
-    /// `payload` is the single packed operation argument value.
+    /// `dispatch` and `resume` retain their exact result-indexed CPS closure
+    /// types. `payload` is the single packed operation argument value. The
+    /// operation is resultless: backend lowering performs the final proper tail
+    /// transfer.
     #[attr(ability_ref: Type, op_name: Symbol)]
-    fn dispatch_cps(evidence: (), continuation: (), payload: ()) -> result {}
+    fn dispatch_cps(evidence: (), dispatch: (), resume: (), payload: ()) {}
+
+    /// Dispatch the explicitly legacy carrier-based general ability operation.
+    ///
+    /// This is intentionally distinct from [`dispatch_cps`]: the legacy
+    /// production route still has a result-producing continuation and must not
+    /// be inferred from the final resultless operation's shape.
+    #[attr(ability_ref: Type, op_name: Symbol)]
+    fn legacy_dispatch_cps(evidence: (), continuation: (), payload: ()) -> result {}
 }
 
 inventory::submit! { trunk_ir::op_interface::PureOps::register("effect", "extend") }
@@ -116,7 +126,8 @@ mod tests {
         let ability = ability_ref(&mut ctx, "Console");
         let evidence = const_i32(&mut ctx, loc, ptr_ty, 0);
         let payload = const_i32(&mut ctx, loc, anyref_ty, 1);
-        let continuation = const_i32(&mut ctx, loc, anyref_ty, 2);
+        let dispatch = const_i32(&mut ctx, loc, anyref_ty, 2);
+        let resume = const_i32(&mut ctx, loc, anyref_ty, 3);
 
         let tail = super::dispatch_tail(
             &mut ctx,
@@ -131,9 +142,9 @@ mod tests {
             &mut ctx,
             loc,
             evidence,
-            continuation,
+            dispatch,
+            resume,
             payload,
-            anyref_ty,
             ability,
             Symbol::new("get"),
         );
@@ -147,8 +158,24 @@ mod tests {
         assert_eq!(tail_wrapper.payload(&ctx), payload);
         assert_eq!(tail_wrapper.ability_ref(&ctx), ability);
         assert_eq!(tail_wrapper.op_name(&ctx), Symbol::new("print"));
-        assert_eq!(cps_wrapper.continuation(&ctx), continuation);
+        assert_eq!(cps_wrapper.dispatch(&ctx), dispatch);
+        assert_eq!(cps_wrapper.resume(&ctx), resume);
         assert_eq!(cps_wrapper.op_name(&ctx), Symbol::new("get"));
+
+        let legacy = super::legacy_dispatch_cps(
+            &mut ctx,
+            loc,
+            evidence,
+            dispatch,
+            payload,
+            anyref_ty,
+            ability,
+            Symbol::new("legacy_get"),
+        );
+        let legacy_wrapper =
+            super::LegacyDispatchCps::from_op(&ctx, legacy.op_ref()).expect("legacy dispatch");
+        assert_eq!(legacy_wrapper.continuation(&ctx), dispatch);
+        assert_eq!(ctx.value_ty(legacy_wrapper.result(&ctx)), anyref_ty);
 
         let tail_printed = print_op(&ctx, tail.op_ref());
         assert!(tail_printed.contains("effect.dispatch_tail"));

--- a/crates/tribute-passes/src/backend_ready.rs
+++ b/crates/tribute-passes/src/backend_ready.rs
@@ -442,6 +442,7 @@ mod tests {
             "tribute_control.perform",
             "ability.perform",
             "effect.dispatch_cps",
+            "effect.legacy_dispatch_cps",
             "closure.new",
             "list.empty",
             "tribute_io.write",

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -566,6 +566,42 @@ mod tests {
     }
 
     #[test]
+    fn malformed_legacy_performs_remain_unlowered() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  func.func @missing_evidence() -> tribute_rt.anyref {{
+    %k = arith.const {{value = 0}} : tribute_rt.anyref
+    %result = ability.legacy_perform %k {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : tribute_rt.anyref
+    func.return %result
+  }}
+  func.func @multiple_payloads(%ev: {ev_ty}) -> tribute_rt.anyref {{
+    %k = arith.const {{value = 0}} : tribute_rt.anyref
+    %left = arith.const {{value = 1}} : core.i32
+    %right = arith.const {{value = 2}} : core.i32
+    %result = ability.legacy_perform %k, %left, %right {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}} : tribute_rt.anyref
+    func.return %result
+  }}
+}}"#
+            ),
+        );
+
+        lower_ability_perform(&mut ctx, module);
+
+        let output = print_module(&ctx, module.op());
+        assert_eq!(
+            output.matches("ability.legacy_perform").count(),
+            2,
+            "{output}"
+        );
+        assert!(!output.contains("effect.legacy_dispatch_cps"), "{output}");
+    }
+
+    #[test]
     fn test_lower_perform_no_evidence_skips_gracefully() {
         let mut ctx = IrContext::new();
         init_common_types(&mut ctx);

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -220,6 +220,9 @@ impl RewritePattern for LowerLegacyCallPattern {
         let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
         let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
         let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
+        if operands.len() > 1 {
+            return false;
+        }
         let Some(evidence_val) = find_evidence_from_op(ctx, op) else {
             return false;
         };
@@ -599,6 +602,31 @@ mod tests {
             "{output}"
         );
         assert!(!output.contains("effect.legacy_dispatch_cps"), "{output}");
+    }
+
+    #[test]
+    fn malformed_legacy_call_remains_byte_for_byte_unchanged() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  func.func @legacy_call(%ev: {ev_ty}) -> tribute_rt.anyref {{
+    %left = arith.const {{value = 1}} : core.i32
+    %right = arith.const {{value = 2}} : core.i32
+    %result = ability.legacy_call %left, %right {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}} : tribute_rt.anyref
+    func.return %result
+  }}
+}}"#
+            ),
+        );
+        let before = print_module(&ctx, module.op());
+
+        lower_ability_perform(&mut ctx, module);
+
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -11,9 +11,8 @@
 //! // Output:
 //! %payload = pack %args into the canonical operation product
 //! %cont = cast %continuation to anyref
-//! %result = effect.dispatch_cps %evidence, %cont, %payload
+//! effect.dispatch_cps %evidence, %cont, %payload
 //!   { ability_ref: @State, op_name: @get }
-//! func.return %result
 //! ```
 //!
 //! The explicitly named legacy operations retain the old null-or-single-value
@@ -27,9 +26,9 @@ use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{adt, core, func};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
-use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
+use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
-    PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter, erase_op,
+    PatternApplicator, PatternRewriter, RewritePattern, RewriteScope, TypeConverter,
 };
 
 use tribute_ir::dialect::ability;
@@ -58,8 +57,64 @@ pub(crate) fn lower_ability_perform<S: RewriteScope>(ctx: &mut IrContext, scope:
     let types = CommonTypes::new(ctx);
     let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern(LowerPerformPattern { types })
+        .add_pattern(LowerLegacyPerformPattern { types })
+        .add_pattern(LowerLegacyCallPattern { types })
         .add_pattern(LowerCallPattern { types });
     applicator.apply_partial(ctx, scope);
+}
+
+/// Pattern: explicit `ability.legacy_perform` → result-producing legacy ABI.
+struct LowerLegacyPerformPattern {
+    types: CommonTypes,
+}
+
+impl RewritePattern for LowerLegacyPerformPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if ability::LegacyPerform::from_op(ctx, op).is_err() {
+            return false;
+        }
+        let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
+        let Some((&continuation, values)) = operands.split_first() else {
+            return false;
+        };
+        if values.len() > 1 {
+            return false;
+        }
+        let Some(evidence) = find_evidence_from_op(ctx, op) else {
+            return false;
+        };
+        let result_types = ctx.op_result_types(op).to_vec();
+        let [result_ty] = result_types.as_slice() else {
+            return false;
+        };
+        let location = ctx.op(op).location;
+        let ability_ref = ctx.op(op).attributes.get_type("ability_ref").unwrap();
+        let op_name = ctx.op(op).attributes.get_symbol("op_name").unwrap();
+        let payload = pack_legacy_payload(ctx, rewriter, location, values, self.types.anyref);
+        let continuation =
+            core::unrealized_conversion_cast(ctx, location, continuation, self.types.anyref);
+        let continuation_value = continuation.result(ctx);
+        rewriter.insert_op(continuation.op_ref());
+        let dispatch = effect::legacy_dispatch_cps(
+            ctx,
+            location,
+            evidence,
+            continuation_value,
+            payload,
+            *result_ty,
+            ability_ref,
+            op_name,
+        );
+        let result = dispatch.result(ctx);
+        rewriter.insert_op(dispatch.op_ref());
+        rewriter.erase_op(vec![result]);
+        true
+    }
 }
 
 /// PassManager-friendly wrapper for [`lower_ability_perform`].
@@ -78,7 +133,7 @@ impl Pass for LowerAbilityPerform {
     }
 }
 
-/// Pattern: `ability.perform` → `effect.dispatch_cps` + return.
+/// Pattern: final `ability.perform` → resultless `effect.dispatch_cps`.
 struct LowerPerformPattern {
     types: CommonTypes,
 }
@@ -90,120 +145,102 @@ impl RewritePattern for LowerPerformPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let legacy = if ability::Perform::from_op(ctx, op).is_ok() {
-            false
-        } else if ability::LegacyPerform::from_op(ctx, op).is_ok() {
-            true
-        } else {
+        if ability::Perform::from_op(ctx, op).is_err() {
+            // The explicit legacy carrier route is deliberately not coerced
+            // into the final ABI before #825/#826 own its migration.
             return false;
-        };
+        }
+
+        let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
+        if operands.len() < 3 || !ctx.op_result_types(op).is_empty() {
+            return false;
+        }
 
         let location = ctx.op(op).location;
         let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
         let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
 
-        // Operands: [continuation, ...values]
-        let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
-        let continuation_val = operands[0];
-        let value_operands = &operands[1..];
+        // Operands: [evidence, exact dispatch, exact resume, ...values]
+        let evidence_val = operands[0];
+        let dispatch_val = operands[1];
+        let resume_val = operands[2];
+        let value_operands = &operands[3..];
 
         let t = &self.types;
 
-        // Find evidence parameter from enclosing func's entry block.
-        let evidence_val = find_evidence_from_op(ctx, op);
+        let shift_value_val = pack_payload(
+            ctx,
+            rewriter,
+            location,
+            ability_ref_type,
+            op_name_sym,
+            value_operands,
+            t.anyref,
+        );
 
-        // === 1. Find evidence ===
-        let Some(evidence_val) = evidence_val else {
-            // Missing evidence means the frontend detected unhandled effects
-            // and emitted a diagnostic. Skip this op gracefully.
-            return false;
-        };
-
-        // === 2. Build the canonical payload product. ===
-        let shift_value_val = if legacy {
-            pack_legacy_payload(ctx, rewriter, location, value_operands, t.anyref)
-        } else {
-            pack_payload(
-                ctx,
-                rewriter,
-                location,
-                ability_ref_type,
-                op_name_sym,
-                value_operands,
-                t.anyref,
-            )
-        };
-
-        // === 3. Cast continuation closure to anyref ===
-        let cont_anyref =
-            core::unrealized_conversion_cast(ctx, location, continuation_val, t.anyref);
-        rewriter.insert_op(cont_anyref.op_ref());
-
-        // === 4. Dispatch through target-independent effect ABI ===
+        // === 3. Dispatch through the target-independent effect ABI ===
+        // Keep both control closures typed. Only the payload crosses the
+        // target-independent dynamic-storage boundary.
         let dispatch_op = effect::dispatch_cps(
             ctx,
             location,
             evidence_val,
-            cont_anyref.result(ctx),
+            dispatch_val,
+            resume_val,
             shift_value_val,
-            t.anyref,
             ability_ref_type,
             op_name_sym,
         );
         rewriter.insert_op(dispatch_op.op_ref());
-
-        // === 5. Return the dispatch result (cast to function return type) ===
-        let block = ctx.op(op).parent_block.unwrap();
-        if is_in_func_body(ctx, block) {
-            let result_val = dispatch_op.result(ctx);
-            let func_ret_ty = find_enclosing_func_return_type(ctx, block);
-            let ret_op = if let Some(ret_ty) = func_ret_ty {
-                if is_nil_type(ctx, ret_ty) {
-                    // Nil return type = void in Cranelift; return with no args.
-                    func::r#return(ctx, location, std::iter::empty::<ValueRef>())
-                } else if ret_ty != t.anyref {
-                    let cast = core::unrealized_conversion_cast(ctx, location, result_val, ret_ty);
-                    rewriter.insert_op(cast.op_ref());
-                    func::r#return(ctx, location, [cast.result(ctx)])
-                } else {
-                    func::r#return(ctx, location, [result_val])
-                }
-            } else {
-                func::r#return(ctx, location, [result_val])
-            };
-            rewriter.insert_op(ret_op.op_ref());
-        }
-
-        // Erase perform op, mapping its result to the dispatch result.
-        rewriter.erase_op(vec![dispatch_op.result(ctx)]);
-
-        // Remove dead code after the perform op in the same block.
-        // Only do this when we inserted a func.return terminator (i.e., in
-        // func body); in other regions (scf.if, etc.) the existing terminator
-        // (scf.yield) must be preserved.
-        if is_in_func_body(ctx, block) {
-            let dead_ops: Vec<OpRef> = {
-                let ops = &ctx.block(block).ops;
-                let Some(idx) = ops.iter().position(|&o| o == op) else {
-                    return true;
-                };
-                ops[idx + 1..].to_vec()
-            };
-            // Erase unreachable ops after the perform in reverse order
-            // (consumer before producer) so `erase_op`'s result-use check never
-            // trips on a later dead op still consuming an earlier one. Unlike
-            // the previous detach-only loop, this also clears the dead ops'
-            // operand use-chains (#710).
-            for dead_op in dead_ops.into_iter().rev() {
-                erase_op(ctx, dead_op);
-            }
-        }
-
+        rewriter.erase_op(vec![]);
         true
     }
 }
 
-/// Pattern: `ability.call` → `effect.dispatch_tail` (no CPS).
+/// Pattern: `ability.legacy_call` → the pre-CPS carrier dispatch ABI.
+///
+/// Preserve its historical direct result mapping so the compatibility bridge
+/// remains byte-for-byte transparent to later legacy consumers.
+struct LowerLegacyCallPattern {
+    types: CommonTypes,
+}
+
+impl RewritePattern for LowerLegacyCallPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if ability::LegacyCall::from_op(ctx, op).is_err() {
+            return false;
+        }
+
+        let location = ctx.op(op).location;
+        let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
+        let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
+        let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
+        let Some(evidence_val) = find_evidence_from_op(ctx, op) else {
+            return false;
+        };
+        let payload = pack_legacy_payload(ctx, rewriter, location, &operands, self.types.anyref);
+        let dispatch = effect::dispatch_tail(
+            ctx,
+            location,
+            evidence_val,
+            payload,
+            self.types.anyref,
+            ability_ref_type,
+            op_name_sym,
+        );
+        let result = dispatch.result(ctx);
+        rewriter.insert_op(dispatch.op_ref());
+        rewriter.erase_op(vec![result]);
+        true
+    }
+}
+
+/// Pattern: final `ability.call` → `effect.dispatch_tail`.
 struct LowerCallPattern {
     types: CommonTypes,
 }
@@ -215,17 +252,17 @@ impl RewritePattern for LowerCallPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let legacy = if ability::Call::from_op(ctx, op).is_ok() {
-            false
-        } else if ability::LegacyCall::from_op(ctx, op).is_ok() {
-            true
-        } else {
+        if ability::Call::from_op(ctx, op).is_err() {
             return false;
-        };
+        }
 
         let location = ctx.op(op).location;
         let ability_ref_type = ctx.op(op).attributes.get_type("ability_ref").unwrap();
         let op_name_sym = ctx.op(op).attributes.get_symbol("op_name").unwrap();
+        let result_types = ctx.op_result_types(op).to_vec();
+        let [result_type] = result_types.as_slice() else {
+            return false;
+        };
 
         // Operands: [...values]
         let operands: Vec<ValueRef> = ctx.op_operands(op).to_vec();
@@ -244,19 +281,15 @@ impl RewritePattern for LowerCallPattern {
         };
 
         // === 2. Build the canonical payload product. ===
-        let shift_value_val = if legacy {
-            pack_legacy_payload(ctx, rewriter, location, value_operands, t.anyref)
-        } else {
-            pack_payload(
-                ctx,
-                rewriter,
-                location,
-                ability_ref_type,
-                op_name_sym,
-                value_operands,
-                t.anyref,
-            )
-        };
+        let shift_value_val = pack_payload(
+            ctx,
+            rewriter,
+            location,
+            ability_ref_type,
+            op_name_sym,
+            value_operands,
+            t.anyref,
+        );
 
         // === 3. Dispatch through target-independent effect ABI ===
         let dispatch_op = effect::dispatch_tail(
@@ -270,8 +303,15 @@ impl RewritePattern for LowerCallPattern {
         );
         rewriter.insert_op(dispatch_op.op_ref());
 
-        // === 4. Erase ability.call, mapping its result to the dispatch result ===
-        rewriter.erase_op(vec![dispatch_op.result(ctx)]);
+        // The target-independent dispatch ABI erases the operation result.
+        // Restore its exact source type before replacing the typed call result;
+        // later CPS continuations still consume that logical value directly.
+        let typed_result =
+            core::unrealized_conversion_cast(ctx, location, dispatch_op.result(ctx), *result_type);
+        rewriter.insert_op(typed_result.op_ref());
+
+        // === 4. Erase ability.call, mapping its result to the typed dispatch result ===
+        rewriter.erase_op(vec![typed_result.result(ctx)]);
 
         true
     }
@@ -294,18 +334,18 @@ fn pack_payload(
         ctx,
         ability_ref,
         op_name,
-        values
-            .iter()
-            .map(|value| ctx.value_ty(*value))
-            .collect::<Vec<_>>(),
+        values.iter().map(|_| anyref),
     );
-    let payload = adt::struct_new(
-        ctx,
-        location,
-        values.iter().copied(),
-        payload_type,
-        payload_type,
-    );
+    let dynamic_values = values
+        .iter()
+        .map(|&value| {
+            let cast = core::unrealized_conversion_cast(ctx, location, value, anyref);
+            let result = cast.result(ctx);
+            rewriter.insert_op(cast.op_ref());
+            result
+        })
+        .collect::<Vec<_>>();
+    let payload = adt::struct_new(ctx, location, dynamic_values, payload_type, payload_type);
     rewriter.insert_op(payload.op_ref());
     let erased = core::unrealized_conversion_cast(ctx, location, payload.result(ctx), anyref);
     rewriter.insert_op(erased.op_ref());
@@ -319,10 +359,6 @@ fn pack_legacy_payload(
     values: &[ValueRef],
     anyref: TypeRef,
 ) -> ValueRef {
-    assert!(
-        values.len() <= 1,
-        "legacy ability payloads must already be tuple-packed"
-    );
     if let Some(&value) = values.first() {
         let erased = core::unrealized_conversion_cast(ctx, location, value, anyref);
         rewriter.insert_op(erased.op_ref());
@@ -332,37 +368,6 @@ fn pack_legacy_payload(
         rewriter.insert_op(null.op_ref());
         null.result(ctx)
     }
-}
-
-/// Check if a TypeRef is `core.nil` (void return type in Cranelift).
-fn is_nil_type(ctx: &IrContext, ty: trunk_ir::TypeRef) -> bool {
-    let td = ctx.types.get(ty);
-    td.dialect == Symbol::new("core") && td.name == Symbol::new("nil")
-}
-
-/// Find the return type of the enclosing `func.func`.
-fn find_enclosing_func_return_type(ctx: &IrContext, block: BlockRef) -> Option<trunk_ir::TypeRef> {
-    let region = ctx.block(block).parent_region?;
-    let parent_op = ctx.region(region).parent_op?;
-    let func_op = func::Func::from_op(ctx, parent_op).ok()?;
-    let func_ty = func_op.r#type(ctx);
-    let td = ctx.types.get(func_ty);
-    if td.dialect == Symbol::new("core") && td.name == Symbol::new("func") {
-        td.params.first().copied()
-    } else {
-        None
-    }
-}
-
-/// Check if a block belongs directly to a `func.func` body region.
-fn is_in_func_body(ctx: &IrContext, block: BlockRef) -> bool {
-    let Some(region) = ctx.block(block).parent_region else {
-        return false;
-    };
-    let Some(parent_op) = ctx.region(region).parent_op else {
-        return false;
-    };
-    func::Func::matches(ctx, parent_op)
 }
 
 /// Find the evidence parameter by walking up from the op to its enclosing func.
@@ -389,7 +394,6 @@ fn find_evidence_from_op(ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use insta::assert_snapshot;
     use trunk_ir::context::IrContext;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
@@ -414,10 +418,10 @@ mod tests {
             &mut ctx,
             &format!(
                 r#"core.module @test {{
-  func.func @test_fn(%ev: {ev_ty}) -> tribute_rt.anyref {{
-    %k = arith.const {{value = 0}} : tribute_rt.anyref
-    %yr = ability.perform %k {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : tribute_rt.anyref
-    func.return %yr
+  func.func @test_fn(%ev: {ev_ty}) -> core.never {{
+    %dispatch = arith.const {{value = 0}} : tribute_rt.anyref
+    %resume = arith.const {{value = 1}} : tribute_rt.anyref
+    ability.perform %ev, %dispatch, %resume {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}}
   }}
 }}"#
             ),
@@ -426,7 +430,11 @@ mod tests {
         lower_ability_perform(&mut ctx, module);
 
         let ir_text = print_module(&ctx, module.op());
-        assert_snapshot!(ir_text);
+        assert!(!ir_text.contains("ability.perform"), "{ir_text}");
+        assert!(ir_text.contains("effect.dispatch_cps"), "{ir_text}");
+        assert!(!ir_text.contains(" -> tribute_rt.anyref"), "{ir_text}");
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &ir_text);
     }
 
     #[test]
@@ -439,11 +447,11 @@ mod tests {
             &mut ctx,
             &format!(
                 r#"core.module @test {{
-  func.func @test_fn(%ev: {ev_ty}) -> tribute_rt.anyref {{
+  func.func @test_fn(%ev: {ev_ty}) -> core.never {{
     %val = arith.const {{value = 42}} : core.i32
-    %k = arith.const {{value = 0}} : tribute_rt.anyref
-    %yr = ability.perform %k, %val {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}} : tribute_rt.anyref
-    func.return %yr
+    %dispatch = arith.const {{value = 0}} : tribute_rt.anyref
+    %resume = arith.const {{value = 1}} : tribute_rt.anyref
+    ability.perform %ev, %dispatch, %resume, %val {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @set}}
   }}
 }}"#
             ),
@@ -452,7 +460,19 @@ mod tests {
         lower_ability_perform(&mut ctx, module);
 
         let ir_text = print_module(&ctx, module.op());
-        assert_snapshot!(ir_text);
+        assert!(!ir_text.contains("ability.perform"), "{ir_text}");
+        assert!(ir_text.contains("effect.dispatch_cps"), "{ir_text}");
+        assert!(ir_text.contains("adt.struct_new"), "{ir_text}");
+        assert!(
+            ir_text.contains("fields = [[@arg0, tribute_rt.anyref]]"),
+            "payload fields must use the canonical dynamic storage contract:\n{ir_text}"
+        );
+        assert!(
+            ir_text.matches("core.unrealized_conversion_cast").count() >= 2,
+            "the argument and packed product must both retain explicit dynamic views:\n{ir_text}"
+        );
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &ir_text);
     }
 
     #[test]
@@ -477,11 +497,42 @@ mod tests {
         lower_ability_perform(&mut ctx, module);
 
         let ir_text = print_module(&ctx, module.op());
-        assert_snapshot!(ir_text);
+        assert!(!ir_text.contains("ability.call"), "{ir_text}");
+        assert!(ir_text.contains("effect.dispatch_tail"), "{ir_text}");
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &ir_text);
     }
 
     #[test]
-    fn legacy_operations_keep_the_carrier_payload_abi() {
+    fn lower_call_restores_the_exact_typed_result() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  func.func @test_fn(%ev: {ev_ty}) -> core.i32 {{
+    %result = ability.call {{ability_ref = core.ability_ref() {{name = @Counter}}, op_name = @next}} : core.i32
+    func.return %result
+  }}
+}}"#
+            ),
+        );
+
+        lower_ability_perform(&mut ctx, module);
+
+        let ir = print_module(&ctx, module.op());
+        assert!(!ir.contains("ability.call"), "{ir}");
+        assert!(ir.contains("effect.dispatch_tail"), "{ir}");
+        assert!(ir.contains("core.i32"), "{ir}");
+        assert!(ir.contains("core.unrealized_conversion_cast"), "{ir}");
+        let mut reparsed = IrContext::new();
+        parse_test_module(&mut reparsed, &ir);
+    }
+
+    #[test]
+    fn legacy_perform_uses_only_the_explicit_legacy_dispatch_abi() {
         let mut ctx = IrContext::new();
         init_common_types(&mut ctx);
         let ev_ty = evidence_type_str();
@@ -505,10 +556,11 @@ mod tests {
         lower_ability_perform(&mut ctx, module);
 
         let ir = print_module(&ctx, module.op());
-        assert!(!ir.contains("ability.legacy_"));
-        assert!(!ir.contains("__tribute_ability_payload_"));
-        assert!(ir.contains("adt.ref_null"));
-        assert_eq!(ir.matches("effect.dispatch_").count(), 2);
+        assert!(!ir.contains("ability.legacy_perform"));
+        assert!(!ir.contains("ability.legacy_call"));
+        assert!(ir.contains("effect.legacy_dispatch_cps"));
+        assert!(ir.contains("effect.dispatch_tail"));
+        assert!(!ir.contains("effect.dispatch_cps"));
         let mut reparsed = IrContext::new();
         parse_test_module(&mut reparsed, &ir);
     }
@@ -522,10 +574,9 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @test_fn() -> tribute_rt.anyref {
+  func.func @test_fn() -> core.never {
     %k = arith.const {value = 0} : tribute_rt.anyref
-    %yr = ability.perform %k {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
-    func.return %yr
+    ability.perform %k {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
   }
 }"#,
         );
@@ -538,5 +589,26 @@ mod tests {
             ir.contains("ability.perform"),
             "perform op should remain unchanged when evidence is missing, got:\n{ir}"
         );
+    }
+
+    #[test]
+    fn result_bearing_final_perform_is_unchanged() {
+        let mut ctx = IrContext::new();
+        init_common_types(&mut ctx);
+        let ev_ty = evidence_type_str();
+        let source = format!(
+            r#"core.module @test {{
+  func.func @test_fn(%ev: {ev_ty}) -> tribute_rt.anyref {{
+    %k = arith.const {{value = 0}} : tribute_rt.anyref
+    %result = ability.perform %ev, %k {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get}} : tribute_rt.anyref
+    func.return %result
+  }}
+}}"#
+        );
+        let module = parse_test_module(&mut ctx, &source);
+        lower_ability_perform(&mut ctx, module);
+        let output = print_module(&ctx, module.op());
+        assert!(output.contains("ability.perform"), "{output}");
+        assert!(!output.contains("effect.dispatch_cps"), "{output}");
     }
 }

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -24,7 +24,9 @@
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 
-use tribute_core::set_indirect_call_signature;
+use tribute_core::{
+    get_physical_closure_convention, set_calling_convention, set_indirect_call_signature,
+};
 use tribute_ir::dialect::ability::{
     self, MarkerField, compute_op_idx, evidence_abi, evidence_runtime_symbols,
 };
@@ -287,6 +289,7 @@ fn native_effect_abi_target() -> ConversionTarget {
         .recursive_legal_op("func", "func")
         .illegal_op("effect", "extend")
         .illegal_op("effect", "dispatch_tail")
+        .illegal_op("effect", "legacy_dispatch_cps")
         .illegal_op("effect", "dispatch_cps")
 }
 
@@ -298,9 +301,85 @@ fn lower_effect_abi_to_native(
         .with_target(native_effect_abi_target())
         .add_pattern(LowerEffectExtendToNative)
         .add_pattern(LowerEffectDispatchTailToNative)
+        .add_pattern(LowerLegacyEffectDispatchCpsToNative)
         .add_pattern(LowerEffectDispatchCpsToNative)
         .apply_partial_conversion(ctx, func_op, "native-evidence-effect-abi")?;
     Ok(())
+}
+
+/// Lower only the explicit carrier ABI to its historical result-producing call.
+struct LowerLegacyEffectDispatchCpsToNative;
+
+impl RewritePattern for LowerLegacyEffectDispatchCpsToNative {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(dispatch_op) = effect::LegacyDispatchCps::from_op(ctx, op) else {
+            return false;
+        };
+        let result_types = ctx.op_result_types(op).to_vec();
+        let [result_ty] = result_types.as_slice() else {
+            return false;
+        };
+        let loc = ctx.op(op).location;
+        let ptr_ty = core_ptr_type(ctx);
+        let i32_ty = core_i32_type(ctx);
+        let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+        let closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
+        let ability_ref = dispatch_op.ability_ref(ctx);
+        let ability_id = ability::ability_id_const(ctx, loc, i32_ty, ability_ref);
+        let ability_id_value = ability_id.result(ctx);
+        rewriter.insert_op(ability_id.op_ref());
+        let handler = func::call(
+            ctx,
+            loc,
+            [dispatch_op.evidence(ctx), ability_id_value],
+            ptr_ty,
+            Symbol::new(evidence_abi::LOOKUP_HANDLER),
+        );
+        let handler_value = handler.result(ctx);
+        rewriter.insert_op(handler.op_ref());
+        let prompt = func::call(
+            ctx,
+            loc,
+            [dispatch_op.evidence(ctx), ability_id_value],
+            i32_ty,
+            Symbol::new(evidence_abi::LOOKUP),
+        );
+        let prompt_value = prompt.result(ctx);
+        rewriter.insert_op(prompt.op_ref());
+        let op_idx = op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
+        let op_idx_value = op_idx.result(ctx);
+        rewriter.insert_op(op_idx.op_ref());
+        let fn_ptr = adt::struct_get(ctx, loc, handler_value, i32_ty, closure_ty, 0);
+        let env = adt::struct_get(ctx, loc, handler_value, anyref_ty, closure_ty, 1);
+        let fn_ptr_value = fn_ptr.result(ctx);
+        let env_value = env.result(ctx);
+        rewriter.insert_op(fn_ptr.op_ref());
+        rewriter.insert_op(env.op_ref());
+        let call = func::call_indirect(
+            ctx,
+            loc,
+            fn_ptr_value,
+            [
+                dispatch_op.evidence(ctx),
+                env_value,
+                dispatch_op.continuation(ctx),
+                prompt_value,
+                op_idx_value,
+                dispatch_op.payload(ctx),
+            ],
+            *result_ty,
+        );
+        attach_exact_indirect_signature(ctx, call.op_ref());
+        let result = call.result(ctx);
+        rewriter.insert_op(call.op_ref());
+        rewriter.erase_op(vec![result]);
+        true
+    }
 }
 
 #[derive(Debug)]
@@ -379,7 +458,9 @@ fn lower_evidence_dispatch_operand(
     value: ValueRef,
     ptr_ty: TypeRef,
 ) -> OpRef {
-    if crate::closure_lower::is_closure_struct_type_ref(ctx, ctx.value_ty(value)) {
+    if crate::closure_lower::is_closure_struct_type_ref(ctx, ctx.value_ty(value))
+        || get_physical_closure_convention(ctx, ctx.value_ty(value)).is_some()
+    {
         tribute_rt::into_raw(ctx, loc, value, ptr_ty).op_ref()
     } else {
         core::unrealized_conversion_cast(ctx, loc, value, ptr_ty).op_ref()
@@ -520,7 +601,11 @@ impl RewritePattern for LowerEffectDispatchCpsToNative {
         };
 
         let loc = ctx.op(op).location;
-        let ptr_ty = core_ptr_type(ctx);
+        // A result-bearing final dispatch is malformed. Reject it before any
+        // helper op is inserted so partial conversion leaves the IR unchanged.
+        if !ctx.op_result_types(op).is_empty() {
+            return false;
+        }
         let i32_ty = core_i32_type(ctx);
         let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
         let closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
@@ -530,60 +615,53 @@ impl RewritePattern for LowerEffectDispatchCpsToNative {
         let ability_id_val = ability_id_op.result(ctx);
         rewriter.insert_op(ability_id_op.op_ref());
 
-        let dispatch_closure = func::call(
-            ctx,
-            loc,
-            [dispatch_op.evidence(ctx), ability_id_val],
-            ptr_ty,
-            Symbol::new(evidence_abi::LOOKUP_HANDLER),
-        );
-        let dispatch_val = dispatch_closure.result(ctx);
-        rewriter.insert_op(dispatch_closure.op_ref());
-
-        // The native lookup ABI already returns the Marker prompt tag. Thread
-        // that dynamic owner into the general handler closure; it is compared
-        // only against a proven private Escape by shared lowering.
-        let owner_lookup = func::call(
+        let prompt = func::call(
             ctx,
             loc,
             [dispatch_op.evidence(ctx), ability_id_val],
             i32_ty,
             Symbol::new(evidence_abi::LOOKUP),
         );
-        let owner_tag = owner_lookup.result(ctx);
-        rewriter.insert_op(owner_lookup.op_ref());
+        let prompt_val = prompt.result(ctx);
+        rewriter.insert_op(prompt.op_ref());
 
         let op_idx_op = op_idx_const(ctx, loc, i32_ty, ability_ref, dispatch_op.op_name(ctx));
         let op_idx_val = op_idx_op.result(ctx);
         rewriter.insert_op(op_idx_op.op_ref());
 
-        let fn_ptr_get = adt::struct_get(ctx, loc, dispatch_val, i32_ty, closure_ty, 0);
+        let fn_ptr_get =
+            adt::struct_get(ctx, loc, dispatch_op.dispatch(ctx), i32_ty, closure_ty, 0);
         let fn_ptr = fn_ptr_get.result(ctx);
         rewriter.insert_op(fn_ptr_get.op_ref());
 
-        let env_get = adt::struct_get(ctx, loc, dispatch_val, anyref_ty, closure_ty, 1);
+        let env_get = adt::struct_get(
+            ctx,
+            loc,
+            dispatch_op.dispatch(ctx),
+            anyref_ty,
+            closure_ty,
+            1,
+        );
         let env_val = env_get.result(ctx);
         rewriter.insert_op(env_get.op_ref());
 
-        let result_ty = ctx.op_result_types(op)[0];
-        let call = func::call_indirect(
+        let tail = func::tail_call_indirect(
             ctx,
             loc,
             fn_ptr,
             [
                 dispatch_op.evidence(ctx),
                 env_val,
-                dispatch_op.continuation(ctx),
-                owner_tag,
+                dispatch_op.resume(ctx),
+                prompt_val,
+                ability_id_val,
                 op_idx_val,
                 dispatch_op.payload(ctx),
             ],
-            result_ty,
         );
-        attach_exact_indirect_signature(ctx, call.op_ref());
-        let new_result = call.result(ctx);
-        rewriter.insert_op(call.op_ref());
-        rewriter.erase_op(vec![new_result]);
+        attach_exact_indirect_signature(ctx, tail.op_ref());
+        set_calling_convention(ctx, tail.op_ref(), tribute_core::CallingConvention::Cps);
+        rewriter.replace_op(tail.op_ref());
         true
     }
 }
@@ -1119,5 +1197,80 @@ mod tests {
             get_indirect_call_signature(&ctx, inner_call).is_some(),
             "native-generated indirect calls must carry an exact signature"
         );
+    }
+
+    #[test]
+    fn result_bearing_final_dispatch_fails_before_native_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run(%ev: core.ptr, %dispatch: tribute_rt.anyref, %resume: tribute_rt.anyref, %payload: tribute_rt.anyref) -> tribute_rt.anyref {
+    %result = effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+    func.return %result
+  }
+}"#,
+        );
+        let run = func_by_name_recursive(&ctx, module, "run");
+        let before = print_module(&ctx, module.op());
+
+        let error = try_lower_evidence_to_native_func(&mut ctx, run)
+            .expect_err("result-bearing final dispatch must remain illegal");
+
+        assert!(error.to_string().contains("effect.dispatch_cps"), "{error}");
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn resultless_final_dispatch_lowers_to_a_native_proper_tail() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run(%ev: core.ptr, %dispatch: tribute_rt.anyref, %resume: tribute_rt.anyref, %payload: tribute_rt.anyref) -> core.never {
+    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
+  }
+}"#,
+        );
+        let run = func_by_name_recursive(&ctx, module, "run");
+
+        lower_evidence_to_native_func(&mut ctx, run);
+
+        let output = print_module(&ctx, module.op());
+        assert!(!output.contains("effect.dispatch_cps"), "{output}");
+        assert!(
+            output.contains("adt.struct_get %1"),
+            "the native tail must decompose the explicit dispatch operand: {output}"
+        );
+        assert!(
+            !output.contains("core.unrealized_conversion_cast"),
+            "the native tail must not cast the explicit dispatch operand: {output}"
+        );
+        assert!(output.contains("func.tail_call_indirect"), "{output}");
+        assert!(output.contains("func.indirect_call_signature"), "{output}");
+        assert!(
+            output.contains("tribute.calling_convention = 2"),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn legacy_dispatch_lowers_to_an_ordinary_indirect_call() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run(%ev: core.ptr, %continuation: tribute_rt.anyref, %payload: tribute_rt.anyref) -> tribute_rt.anyref {
+    %result = effect.legacy_dispatch_cps %ev, %continuation, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+    func.return %result
+  }
+}"#,
+        );
+        let run = func_by_name_recursive(&ctx, module, "run");
+        lower_evidence_to_native_func(&mut ctx, run);
+        let output = print_module(&ctx, module.op());
+        assert!(!output.contains("effect.legacy_dispatch_cps"), "{output}");
+        assert!(output.contains("func.call_indirect"), "{output}");
+        assert!(!output.contains("func.tail_call_indirect"), "{output}");
     }
 }

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -1273,4 +1273,29 @@ mod tests {
         assert!(output.contains("func.call_indirect"), "{output}");
         assert!(!output.contains("func.tail_call_indirect"), "{output}");
     }
+
+    #[test]
+    fn multi_result_legacy_dispatch_fails_before_native_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run(%ev: core.ptr, %continuation: tribute_rt.anyref, %payload: tribute_rt.anyref) -> tribute_rt.anyref {
+    %first, %second = effect.legacy_dispatch_cps %ev, %continuation, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref, tribute_rt.anyref
+    func.return %first
+  }
+}"#,
+        );
+        let run = func_by_name_recursive(&ctx, module, "run");
+        let before = print_module(&ctx, module.op());
+
+        let error = try_lower_evidence_to_native_func(&mut ctx, run)
+            .expect_err("legacy dispatch must have exactly one result");
+
+        assert!(
+            error.to_string().contains("effect.legacy_dispatch_cps"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
 }

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -78,6 +78,7 @@ impl Error for ResolveEvidenceError {}
 
 struct FinalHandleDispatchShape {
     evidence: ValueRef,
+    prompt_tag: ValueRef,
     dispatcher_pairs: Vec<(TypeRef, ValueRef, ValueRef)>,
     body: RegionRef,
     body_evidence: ValueRef,
@@ -104,11 +105,22 @@ fn final_handle_dispatch_shape(
             "final ability.handle_dispatch must be resultless".into(),
         ));
     }
-    let Some((&evidence, dispatchers)) = operands.split_first() else {
+    let Some((&evidence, rest)) = operands.split_first() else {
         return Err(error(
             "final ability.handle_dispatch requires an evidence operand".into(),
         ));
     };
+    let Some((&prompt_tag, dispatchers)) = rest.split_first() else {
+        return Err(error(
+            "final ability.handle_dispatch requires a prompt-tag operand".into(),
+        ));
+    };
+    let prompt_ty = ctx.types.get(ctx.value_ty(prompt_tag));
+    if prompt_ty.dialect != Symbol::new("core") || prompt_ty.name != Symbol::new("i32") {
+        return Err(error(
+            "final ability.handle_dispatch prompt-tag operand must have type core.i32".into(),
+        ));
+    }
     if !dispatchers.len().is_multiple_of(2) {
         return Err(error(
             "final ability.handle_dispatch dispatcher operands must form exact pairs".into(),
@@ -174,6 +186,7 @@ fn final_handle_dispatch_shape(
     }
     Ok(FinalHandleDispatchShape {
         evidence,
+        prompt_tag,
         dispatcher_pairs,
         body: *body,
         body_evidence: *body_evidence,
@@ -763,16 +776,24 @@ fn transform_shifts_in_block(
             let location = ctx.op(op).location;
             let shape = final_handle_dispatch_shape(ctx, op)?;
             let mut current_ev = shape.evidence;
-            let i32_ty = i32_type_ref(ctx);
-            let prompt = func::call(
-                ctx,
-                location,
-                std::iter::empty::<ValueRef>(),
-                i32_ty,
-                Symbol::new("__tribute_next_tag"),
-            );
-            let prompt_tag = prompt.result(ctx);
-            ctx.insert_op_before(block, op, prompt.op_ref());
+            let mut prompt_tag = shape.prompt_tag;
+            if let ValueDef::OpResult(prompt_op, _) = ctx.value_def(prompt_tag)
+                && effect::FreshPromptTag::from_op(ctx, prompt_op).is_ok()
+            {
+                let i32_ty = i32_type_ref(ctx);
+                let prompt = func::call(
+                    ctx,
+                    location,
+                    std::iter::empty::<ValueRef>(),
+                    i32_ty,
+                    Symbol::new("__tribute_next_tag"),
+                );
+                let resolved = prompt.result(ctx);
+                ctx.insert_op_before(block, op, prompt.op_ref());
+                ctx.replace_all_uses(prompt_tag, resolved);
+                erase_op(ctx, prompt_op);
+                prompt_tag = resolved;
+            }
             let evidence_ty = ability::evidence_adt_type_ref(ctx);
             for (ability_ref, tr_dispatch, handler_dispatch) in shape.dispatcher_pairs {
                 let extend = effect::extend(
@@ -1210,7 +1231,7 @@ mod tests {
     #[test]
     fn final_handle_dispatch_extends_each_ability_pair_and_lowers_resultlessly() {
         let input = final_dispatch_fixture(
-            r#"ability.handle_dispatch %ev, %tr, %handler, %tr2, %handler2 {ability_refs = [core.ability_ref() {name = @State}, core.ability_ref() {name = @Console}]} {
+            r#"ability.handle_dispatch %ev, %prompt, %tr, %handler, %tr2, %handler2 {ability_refs = [core.ability_ref() {name = @State}, core.ability_ref() {name = @Console}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
@@ -1220,7 +1241,7 @@ mod tests {
         resolve_evidence_dispatch(&mut ctx, module).unwrap();
         let resolved = print_module(&ctx, module.op());
         assert_eq!(resolved.matches("effect.extend").count(), 2);
-        assert_eq!(resolved.matches("func.call").count(), 1);
+        assert_eq!(resolved.matches("func.call").count(), 0);
         assert!(resolved.contains("__tribute_next_tag"));
         assert!(resolved.contains("ability.handle_dispatch"));
         let mut extensions = Vec::new();
@@ -1250,7 +1271,7 @@ mod tests {
     fn malformed_final_handle_dispatches_fail_before_mutation() {
         let malformed = [
             (
-                r#"%result = ability.handle_dispatch %ev {ability_refs = []} : core.i32 {
+                r#"%result = ability.handle_dispatch %ev, %prompt {ability_refs = []} : core.i32 {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
@@ -1264,7 +1285,7 @@ mod tests {
                 "requires an evidence operand",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr {ability_refs = []} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
@@ -1275,43 +1296,57 @@ mod tests {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
+                "requires a prompt-tag operand",
+            ),
+            (
+                r#"ability.handle_dispatch %ev, %handler {ability_refs = []} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+                "prompt-tag operand must have type core.i32",
+            ),
+            (
+                r#"ability.handle_dispatch %ev, %prompt {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
                 "requires an ability_refs list",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr, %handler {ability_refs = []} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "cardinality",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = [1]} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr, %handler {ability_refs = [1]} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "entry must be a type",
             ),
             (
-                r#"ability.handle_dispatch %ev, %tr, %handler {ability_refs = [core.i32]} {
+                r#"ability.handle_dispatch %ev, %prompt, %tr, %handler {ability_refs = [core.i32]} {
       ^body(%inner: !evidence):
         func.unreachable
     }"#,
                 "core.ability_ref type",
             ),
             (
-                r#"ability.handle_dispatch %prompt {ability_refs = []} {
+                r#"ability.handle_dispatch %prompt, %prompt {ability_refs = []} {
       ^body(%inner: core.i32):
         func.unreachable
     }"#,
                 "must have the evidence type",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
     }"#,
                 "exactly one block",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^first(%inner: !evidence):
         func.unreachable
       ^second:
@@ -1320,20 +1355,20 @@ mod tests {
                 "exactly one block",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body:
         func.unreachable
     }"#,
                 "one evidence argument",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body(%inner: !evidence):
     }"#,
                 "must end in a proper tail transfer",
             ),
             (
-                r#"ability.handle_dispatch %ev {ability_refs = []} {
+                r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body(%inner: !evidence):
         func.return
     }"#,
@@ -1355,7 +1390,7 @@ mod tests {
     #[test]
     fn structured_final_delimiter_is_a_valid_proper_tail_body() {
         let input = final_dispatch_fixture(
-            r#"ability.handle_dispatch %ev {ability_refs = []} {
+            r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
       ^body(%inner: !evidence):
         %choice = arith.const {value = 0} : core.i32
         scf.switch %choice {
@@ -1363,6 +1398,19 @@ mod tests {
             func.unreachable
           }
         }
+    }"#,
+        );
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, &input);
+        validate_final_handle_dispatches(&ctx, module).unwrap();
+    }
+
+    #[test]
+    fn final_delimiter_accepts_resultless_effect_cps_dispatch() {
+        let input = final_dispatch_fixture(
+            r#"ability.handle_dispatch %ev, %prompt {ability_refs = []} {
+      ^body(%inner: !evidence):
+        effect.dispatch_cps %inner, %tr, %handler, %tr2 {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
     }"#,
         );
         let mut ctx = IrContext::new();

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -1268,6 +1268,32 @@ mod tests {
     }
 
     #[test]
+    fn final_handle_dispatch_materializes_a_fresh_prompt_tag_once() {
+        let input = final_dispatch_fixture(
+            r#"%fresh = effect.fresh_prompt_tag : core.i32
+    ability.handle_dispatch %ev, %fresh, %tr, %handler {ability_refs = [core.ability_ref() {name = @State}]} {
+      ^body(%inner: !evidence):
+        func.unreachable
+    }"#,
+        );
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, &input);
+
+        resolve_evidence_dispatch(&mut ctx, module).unwrap();
+
+        let resolved = print_module(&ctx, module.op());
+        assert!(!resolved.contains("effect.fresh_prompt_tag"), "{resolved}");
+        assert_eq!(
+            resolved
+                .matches("func.call {callee = @__tribute_next_tag}")
+                .count(),
+            1,
+            "{resolved}"
+        );
+        assert_eq!(resolved.matches("func.call").count(), 1, "{resolved}");
+    }
+
+    #[test]
     fn malformed_final_handle_dispatches_fail_before_mutation() {
         let malformed = [
             (

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -8,12 +8,16 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 
-use tribute_core::calling_convention::physical_closure_type_with_environment_index;
+use tribute_core::calling_convention::{
+    cps_closure_function_type, cps_completion_type, cps_continuation_frame_layout_type,
+    cps_continuation_frame_ref_type, cps_done_type, cps_resume_exact_type,
+    physical_closure_type_with_environment_index,
+};
 use tribute_core::{
     CALLING_CONVENTION_ATTR, CallableAbi, CallingConvention, physical_closure_type,
-    set_calling_convention,
+    set_calling_convention, set_indirect_call_signature,
 };
-use tribute_ir::dialect::{ability, closure, tribute_control, tribute_rt};
+use tribute_ir::dialect::{ability, closure, effect, tribute_control, tribute_rt};
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, arith, core, func, scf};
 use trunk_ir::ops::{DialectOp, DialectType};
@@ -298,7 +302,9 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
     fn visit(ctx: &IrContext, op: OpRef, failures: &mut Vec<BoundaryFailure>) {
         if ability::HandleDispatch::matches(ctx, op) {
             let operands = ctx.op_operands(op);
-            if let Some((evidence, dispatchers)) = operands.split_first() {
+            if let Some((evidence, rest)) = operands.split_first()
+                && let Some((_, dispatchers)) = rest.split_first()
+            {
                 let evidence_ty = ctx.value_ty(*evidence);
                 for pair in dispatchers.as_chunks::<2>().0 {
                     check_dispatcher(ctx, op, pair[0], evidence_ty, false, failures);
@@ -744,7 +750,23 @@ struct Converter<'a> {
     funcs_by_module: HashMap<OpRef, HashMap<Symbol, CallableInfo>>,
     current_module: OpRef,
     converted_types: HashMap<TypeRef, TypeRef>,
+    frames: HashMap<TypeRef, FrameTypes>,
+    frame_layout_aliases: Vec<(Symbol, TypeRef)>,
     helper_index: u32,
+}
+
+#[derive(Clone, Copy)]
+struct FrameTypes {
+    reference: TypeRef,
+    layout: TypeRef,
+    done: TypeRef,
+    dispatch: TypeRef,
+}
+
+#[derive(Clone, Copy)]
+struct DispatchFactoryArgs<'a> {
+    prefix: &'a [ValueRef],
+    suffix: &'a [ValueRef],
 }
 
 #[derive(Clone)]
@@ -753,6 +775,12 @@ struct Flow {
     evidence: Option<ValueRef>,
     exit_k: Option<ValueRef>,
     root_exit_k: Option<ValueRef>,
+    /// The exact lexical dispatcher installed by the nearest handle. General
+    /// operations carry it through the effect ABI without erasing it.
+    dispatch: Option<ValueRef>,
+    /// Zero-result structured control uses a private suffix closure whose
+    /// arguments are `(Evidence, ContinuationFrame<R>)` rather than `Done<R>`.
+    void_exit_k: Option<ValueRef>,
     answer_type: TypeRef,
     preserve_scf_yield: bool,
 }
@@ -770,6 +798,8 @@ impl<'a> Converter<'a> {
             funcs_by_module,
             current_module,
             converted_types: HashMap::new(),
+            frames: HashMap::new(),
+            frame_layout_aliases: Vec::new(),
             helper_index: 0,
         }
     }
@@ -798,6 +828,57 @@ impl<'a> Converter<'a> {
         core::never(self.ctx).as_type_ref()
     }
 
+    /// Emit a final CPS tail transfer from the callee's exact typed closure
+    /// contract. This must not reconstruct a signature from physical operands:
+    /// closure extraction interposes an environment later and preserves this
+    /// contract on the resulting indirect transfer.
+    fn emit_cps_tail_call_indirect(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        callee: ValueRef,
+        args: impl IntoIterator<Item = ValueRef>,
+    ) -> Result<OpRef, TributeControlToCpsError> {
+        let args = args.into_iter().collect::<Vec<_>>();
+        let closure_type = self.ctx.value_ty(callee);
+        let signature = cps_closure_function_type(self.ctx, closure_type).ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS indirect tail callee has no exact provenance-bearing closure contract",
+            )
+        })?;
+        let callable = core::Func::from_type_ref(self.ctx, signature).ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS indirect tail callee contract is not core.func",
+            )
+        })?;
+        if callable.r#return(self.ctx) != self.never_type()
+            || callable.params(self.ctx).len() != args.len()
+            || callable
+                .params(self.ctx)
+                .iter()
+                .zip(&args)
+                .any(|(expected, actual)| *expected != self.ctx.value_ty(*actual))
+        {
+            return Err(TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS indirect tail operands differ from the exact closure contract",
+            ));
+        }
+        let tail = func::tail_call_indirect(self.ctx, location, callee, args);
+        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
+        set_indirect_call_signature(self.ctx, tail.op_ref(), signature);
+        self.ctx.push_op(block, tail.op_ref());
+        Ok(tail.op_ref())
+    }
+
     fn evidence_type(&mut self) -> TypeRef {
         ability::evidence_adt_type_ref(self.ctx)
     }
@@ -807,16 +888,312 @@ impl<'a> Converter<'a> {
     }
 
     fn done_k_type(&mut self, answer: TypeRef) -> TypeRef {
-        let never = self.never_type();
-        let function = core::func(self.ctx, never, [answer]).as_type_ref();
-        self.generated_continuation_type(function)
+        cps_done_type(self.ctx, answer)
     }
 
     fn resumption_type(&mut self, input: TypeRef, answer: TypeRef) -> TypeRef {
-        let never = self.never_type();
-        let done_k = self.done_k_type(answer);
-        let function = core::func(self.ctx, never, [done_k, input]).as_type_ref();
-        self.generated_continuation_type(function)
+        let evidence = self.evidence_type();
+        let frame = self.frame_types(answer).reference;
+        cps_resume_exact_type(self.ctx, evidence, input, frame)
+    }
+
+    fn completion_type(&mut self, value: TypeRef, answer: TypeRef) -> TypeRef {
+        let evidence = self.evidence_type();
+        let frame = self.frame_types(answer).reference;
+        cps_completion_type(self.ctx, evidence, value, frame)
+    }
+
+    fn i32_type(&mut self) -> TypeRef {
+        self.ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
+    }
+
+    fn frame_types(&mut self, answer: TypeRef) -> FrameTypes {
+        if let Some(frame) = self.frames.get(&answer).copied() {
+            return frame;
+        }
+        let name = Symbol::from_dynamic(&format!("__tribute_continuation_frame_{answer:?}"));
+        let reference = cps_continuation_frame_ref_type(self.ctx, name, answer);
+        let done = self.done_k_type(answer);
+        let evidence = self.evidence_type();
+        let anyref = self.anyref_type();
+        let i32 = self.i32_type();
+        let dispatch = tribute_core::calling_convention::cps_dispatch_type(
+            self.ctx, evidence, reference, anyref, i32,
+        );
+        let layout = cps_continuation_frame_layout_type(self.ctx, name, answer, done, dispatch);
+        let frame = FrameTypes {
+            reference,
+            layout,
+            done,
+            dispatch,
+        };
+        self.frames.insert(answer, frame);
+        self.frame_layout_aliases.push((name, layout));
+        frame
+    }
+
+    fn unpack_frame(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        answer: TypeRef,
+        frame_value: ValueRef,
+    ) -> (ValueRef, ValueRef) {
+        let frame = self.frame_types(answer);
+        let done = adt::struct_get(self.ctx, location, frame_value, frame.done, frame.layout, 0);
+        self.ctx.push_op(block, done.op_ref());
+        let dispatch = adt::struct_get(
+            self.ctx,
+            location,
+            frame_value,
+            frame.dispatch,
+            frame.layout,
+            1,
+        );
+        self.ctx.push_op(block, dispatch.op_ref());
+        (done.result(self.ctx), dispatch.result(self.ctx))
+    }
+
+    fn pack_frame(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        answer: TypeRef,
+        done: ValueRef,
+        dispatch: ValueRef,
+    ) -> ValueRef {
+        let frame = self.frame_types(answer);
+        let packed = adt::struct_new(
+            self.ctx,
+            location,
+            [done, dispatch],
+            frame.reference,
+            frame.layout,
+        );
+        self.ctx.push_op(block, packed.op_ref());
+        packed.result(self.ctx)
+    }
+
+    fn build_done_adapter(
+        &mut self,
+        value_type: TypeRef,
+        completion: ValueRef,
+        evidence: ValueRef,
+        outer_frame: ValueRef,
+        location: Location,
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
+        let done_block = self.make_block(location, &[value_type]);
+        let value = self.ctx.block_args(done_block)[0];
+        self.emit_cps_tail_call_indirect(
+            done_block,
+            location,
+            completion,
+            [evidence, outer_frame, value],
+        )?;
+        let region = self.single_block_region(location, done_block);
+        let done_type = self.done_k_type(value_type);
+        let done = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, region),
+            done_type,
+            region,
+        );
+        set_calling_convention(self.ctx, done.op_ref(), CallingConvention::Cps);
+        Ok((done.op_ref(), done.result(self.ctx)))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_rebound_resume(
+        &mut self,
+        location: Location,
+        value_type: TypeRef,
+        boundary: TypeRef,
+        resume_body: ValueRef,
+        completion: ValueRef,
+        dispatch_factory: Symbol,
+        dispatch_factory_args: DispatchFactoryArgs<'_>,
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
+        let evidence_type = self.evidence_type();
+        let anyref = self.anyref_type();
+        let boundary_frame = self.frame_types(boundary).reference;
+        let block = self.make_block(location, &[evidence_type, boundary_frame, anyref]);
+        let args = self.ctx.block_args(block).to_vec();
+        let (done_op, done) =
+            self.build_done_adapter(value_type, completion, args[0], args[1], location)?;
+        self.ctx.push_op(block, done_op);
+        let (_, outer_dispatch) = self.unpack_frame(block, location, boundary, args[1]);
+        let dispatch_type = self.frame_types(value_type).dispatch;
+        let mut factory_args = dispatch_factory_args.prefix.to_vec();
+        factory_args.extend([completion, outer_dispatch]);
+        factory_args.extend_from_slice(dispatch_factory_args.suffix);
+        let dispatch = func::call(
+            self.ctx,
+            location,
+            factory_args,
+            dispatch_type,
+            dispatch_factory,
+        );
+        set_calling_convention(self.ctx, dispatch.op_ref(), CallingConvention::Direct);
+        self.ctx.push_op(block, dispatch.op_ref());
+        let frame = self.pack_frame(block, location, value_type, done, dispatch.result(self.ctx));
+        self.emit_cps_tail_call_indirect(block, location, resume_body, [args[0], frame, args[2]])?;
+        let region = self.single_block_region(location, block);
+        let resume_type = tribute_core::calling_convention::cps_resume_type(
+            self.ctx,
+            evidence_type,
+            boundary_frame,
+            anyref,
+        );
+        let resume = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, region),
+            resume_type,
+            region,
+        );
+        set_calling_convention(self.ctx, resume.op_ref(), CallingConvention::Cps);
+        Ok((resume.op_ref(), resume.result(self.ctx)))
+    }
+
+    fn build_dispatch_adapter_factory(
+        &mut self,
+        location: Location,
+        value_type: TypeRef,
+        boundary: TypeRef,
+    ) -> Result<Symbol, TributeControlToCpsError> {
+        let symbol = self.fresh_helper("make_dispatch_adapter");
+        let evidence_type = self.evidence_type();
+        let anyref = self.anyref_type();
+        let i32_type = self.i32_type();
+        let completion_type = self.completion_type(value_type, boundary);
+        let outer_dispatch_type = self.frame_types(boundary).dispatch;
+        let dispatch_type = self.frame_types(value_type).dispatch;
+        let factory_type = core::func(
+            self.ctx,
+            dispatch_type,
+            [completion_type, outer_dispatch_type],
+        )
+        .as_type_ref();
+        let factory_block = self.make_block(location, &[completion_type, outer_dispatch_type]);
+        let factory_args = self.ctx.block_args(factory_block).to_vec();
+        let value_frame = self.frame_types(value_type).reference;
+        let resume_type = tribute_core::calling_convention::cps_resume_type(
+            self.ctx,
+            evidence_type,
+            value_frame,
+            anyref,
+        );
+        let dispatch_block = self.make_block(
+            location,
+            &[
+                evidence_type,
+                resume_type,
+                i32_type,
+                i32_type,
+                i32_type,
+                anyref,
+            ],
+        );
+        let dispatch_args = self.ctx.block_args(dispatch_block).to_vec();
+        let (resume_op, rebound_resume) = self.build_rebound_resume(
+            location,
+            value_type,
+            boundary,
+            dispatch_args[1],
+            factory_args[0],
+            symbol,
+            DispatchFactoryArgs {
+                prefix: &[],
+                suffix: &[],
+            },
+        )?;
+        self.ctx.push_op(dispatch_block, resume_op);
+        self.emit_cps_tail_call_indirect(
+            dispatch_block,
+            location,
+            factory_args[1],
+            [
+                dispatch_args[0],
+                rebound_resume,
+                dispatch_args[2],
+                dispatch_args[3],
+                dispatch_args[4],
+                dispatch_args[5],
+            ],
+        )?;
+        let dispatch_region = self.single_block_region(location, dispatch_block);
+        let dispatch = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, dispatch_region),
+            dispatch_type,
+            dispatch_region,
+        );
+        set_calling_convention(self.ctx, dispatch.op_ref(), CallingConvention::Cps);
+        self.ctx.push_op(factory_block, dispatch.op_ref());
+        let ret = func::r#return(self.ctx, location, [dispatch.result(self.ctx)]);
+        self.ctx.push_op(factory_block, ret.op_ref());
+        let factory_region = self.single_block_region(location, factory_block);
+        let factory = func::func(self.ctx, location, symbol, factory_type, factory_region);
+        set_calling_convention(self.ctx, factory.op_ref(), CallingConvention::Direct);
+        self.ctx.push_op(self.module_block, factory.op_ref());
+        Ok(symbol)
+    }
+
+    fn frame_for_suffix(
+        &mut self,
+        block: BlockRef,
+        location: Location,
+        value_type: TypeRef,
+        flow: &Flow,
+        suffix: ValueRef,
+    ) -> Result<ValueRef, TributeControlToCpsError> {
+        let outer = flow.exit_k.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS transfer has no verified ContinuationFrame",
+            )
+        })?;
+        let evidence = flow.evidence.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                None,
+                Some(location),
+                "CPS transfer has no verified evidence",
+            )
+        })?;
+        let (done_op, done) =
+            self.build_done_adapter(value_type, suffix, evidence, outer, location)?;
+        self.ctx.push_op(block, done_op);
+        let outer_dispatch = match flow.dispatch {
+            Some(dispatch) => dispatch,
+            None => {
+                self.unpack_frame(block, location, flow.answer_type, outer)
+                    .1
+            }
+        };
+        let dispatch_factory =
+            self.build_dispatch_adapter_factory(location, value_type, flow.answer_type)?;
+        let completion_type = self.completion_type(value_type, flow.answer_type);
+        let typed_completion =
+            core::unrealized_conversion_cast(self.ctx, location, suffix, completion_type);
+        self.ctx.push_op(block, typed_completion.op_ref());
+        let dispatch_type = self.frame_types(value_type).dispatch;
+        let dispatch = func::call(
+            self.ctx,
+            location,
+            [typed_completion.result(self.ctx), outer_dispatch],
+            dispatch_type,
+            dispatch_factory,
+        );
+        set_calling_convention(self.ctx, dispatch.op_ref(), CallingConvention::Direct);
+        self.ctx.push_op(block, dispatch.op_ref());
+        Ok(self.pack_frame(block, location, value_type, done, dispatch.result(self.ctx)))
     }
 
     fn generated_continuation_type(&mut self, function: TypeRef) -> TypeRef {
@@ -860,8 +1237,8 @@ impl<'a> Converter<'a> {
                 .collect();
             let abi = CallableAbi::new(convention, params, result);
             let evidence = self.evidence_type();
-            let done_k = self.done_k_type(result);
-            let lowered_params = abi.lowered_params(evidence, done_k);
+            let frame = self.frame_types(result).reference;
+            let lowered_params = abi.lowered_params(evidence, frame);
             let lowered_result = if convention == CallingConvention::Cps {
                 self.never_type()
             } else {
@@ -926,9 +1303,9 @@ impl<'a> Converter<'a> {
             .map(|param| self.convert_type(param))
             .collect();
         let evidence = self.evidence_type();
-        let done_k = self.done_k_type(result);
+        let frame = self.frame_types(result).reference;
         let abi = CallableAbi::new(convention, params, result);
-        let params = abi.lowered_params(evidence, done_k);
+        let params = abi.lowered_params(evidence, frame);
         let result = if convention == CallingConvention::Cps {
             self.never_type()
         } else {
@@ -1250,10 +1627,24 @@ impl<'a> Converter<'a> {
                 branch_mapping.insert(old, new);
             }
             let branch_flow = match continuation {
-                Some(continuation) => Flow {
-                    exit_k: Some(continuation),
+                Some(continuation) if result_types.is_empty() => Flow {
+                    void_exit_k: Some(continuation),
                     ..flow.clone()
                 },
+                Some(continuation) => {
+                    let [source_result_type] = result_types.as_slice() else {
+                        unreachable!("non-void CPS branch has one result")
+                    };
+                    let result_type = self.convert_type(*source_result_type);
+                    let frame =
+                        self.frame_for_suffix(block, location, result_type, flow, continuation)?;
+                    Flow {
+                        exit_k: Some(frame),
+                        root_exit_k: Some(frame),
+                        answer_type: result_type,
+                        ..flow.clone()
+                    }
+                }
                 None => Flow {
                     preserve_scf_yield: true,
                     ..flow.clone()
@@ -1403,7 +1794,7 @@ impl<'a> Converter<'a> {
             let converted_block = self.make_block(case_location, &[]);
             let mut case_mapping = mapping.clone();
             let case_flow = Flow {
-                exit_k: Some(continuation),
+                void_exit_k: Some(continuation),
                 ..flow.clone()
             };
             self.convert_sequence(
@@ -1449,9 +1840,8 @@ impl<'a> Converter<'a> {
                     "CPS region has no verified exit continuation",
                 )
             })?;
-            let tail = func::tail_call_indirect(self.ctx, location, exit_k, [value]);
-            set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-            self.ctx.push_op(block, tail.op_ref());
+            let (done, _) = self.unpack_frame(block, location, flow.answer_type, exit_k);
+            self.emit_cps_tail_call_indirect(block, location, done, [value])?;
         } else {
             let ret = func::r#return(self.ctx, location, [value]);
             self.ctx.push_op(block, ret.op_ref());
@@ -1465,6 +1855,26 @@ impl<'a> Converter<'a> {
         location: Location,
         flow: &Flow,
     ) -> Result<(), TributeControlToCpsError> {
+        if let Some(void_exit) = flow.void_exit_k {
+            let evidence = flow.evidence.ok_or_else(|| {
+                TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    None,
+                    Some(location),
+                    "zero-result suffix has no verified evidence",
+                )
+            })?;
+            let frame = flow.exit_k.ok_or_else(|| {
+                TributeControlToCpsError::one(
+                    POST_CPS_BOUNDARY,
+                    None,
+                    Some(location),
+                    "zero-result suffix has no verified ContinuationFrame",
+                )
+            })?;
+            self.emit_cps_tail_call_indirect(block, location, void_exit, [evidence, frame])?;
+            return Ok(());
+        }
         let exit_k = flow.exit_k.ok_or_else(|| {
             TributeControlToCpsError::one(
                 POST_CPS_BOUNDARY,
@@ -1473,10 +1883,8 @@ impl<'a> Converter<'a> {
                 "structured region has no verified exit continuation",
             )
         })?;
-        let tail =
-            func::tail_call_indirect(self.ctx, location, exit_k, std::iter::empty::<ValueRef>());
-        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-        self.ctx.push_op(block, tail.op_ref());
+        let (done, _) = self.unpack_frame(block, location, flow.answer_type, exit_k);
+        self.emit_cps_tail_call_indirect(block, location, done, std::iter::empty::<ValueRef>())?;
         Ok(())
     }
 
@@ -1488,13 +1896,28 @@ impl<'a> Converter<'a> {
         flow: &Flow,
         location: Location,
     ) -> Result<ValueRef, TributeControlToCpsError> {
-        let block = self.make_block(location, &[]);
+        let evidence_type = self.evidence_type();
+        let frame_type = self.frame_types(flow.answer_type).reference;
+        let block = self.make_block(location, &[evidence_type, frame_type]);
         let mut suffix_mapping = mapping.clone();
-        self.convert_sequence(source_ops.to_vec(), start, block, &mut suffix_mapping, flow)?;
+        let suffix_flow = Flow {
+            evidence: Some(self.ctx.block_args(block)[0]),
+            exit_k: Some(self.ctx.block_args(block)[1]),
+            root_exit_k: Some(self.ctx.block_args(block)[1]),
+            void_exit_k: None,
+            ..flow.clone()
+        };
+        self.convert_sequence(
+            source_ops.to_vec(),
+            start,
+            block,
+            &mut suffix_mapping,
+            &suffix_flow,
+        )?;
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
         let never = self.never_type();
-        let function = core::func(self.ctx, never, std::iter::empty::<TypeRef>()).as_type_ref();
+        let function = core::func(self.ctx, never, [evidence_type, frame_type]).as_type_ref();
         let closure_type = self.generated_continuation_type(function);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
@@ -1520,9 +1943,9 @@ impl<'a> Converter<'a> {
             .map(|ty| self.convert_type(ty))
             .collect();
         let evidence = self.evidence_type();
-        let done_k = self.done_k_type(result);
+        let frame = self.frame_types(result).reference;
         let abi = CallableAbi::new(convention, source_param_types.clone(), result);
-        let params = abi.lowered_params(evidence, done_k);
+        let params = abi.lowered_params(evidence, frame);
         let body_source = self.ctx.op(source).regions[0];
         let entry_source = self.ctx.region(body_source).blocks[0];
         let block = self.make_block(location, &params);
@@ -1548,6 +1971,8 @@ impl<'a> Converter<'a> {
             evidence: evidence_value,
             exit_k,
             root_exit_k: exit_k,
+            void_exit_k: None,
+            dispatch: None,
             answer_type: result,
             preserve_scf_yield: false,
         };
@@ -1623,15 +2048,27 @@ impl<'a> Converter<'a> {
         location: Location,
     ) -> Result<ValueRef, TributeControlToCpsError> {
         let result_type = self.convert_type(result_type);
-        let block = self.make_block(location, &[result_type]);
+        let evidence_type = self.evidence_type();
+        let frame_type = self.frame_types(flow.answer_type).reference;
+        let block = self.make_block(location, &[evidence_type, frame_type, result_type]);
         let mut body_mapping = mapping.clone();
-        body_mapping.insert(source_result, self.ctx.block_args(block)[0]);
-        self.convert_sequence(source_ops.to_vec(), start, block, &mut body_mapping, flow)?;
+        body_mapping.insert(source_result, self.ctx.block_args(block)[2]);
+        let suffix_flow = Flow {
+            evidence: Some(self.ctx.block_args(block)[0]),
+            exit_k: Some(self.ctx.block_args(block)[1]),
+            root_exit_k: Some(self.ctx.block_args(block)[1]),
+            ..flow.clone()
+        };
+        self.convert_sequence(
+            source_ops.to_vec(),
+            start,
+            block,
+            &mut body_mapping,
+            &suffix_flow,
+        )?;
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
-        let never = self.never_type();
-        let function = core::func(self.ctx, never, [result_type]).as_type_ref();
-        let closure_ty = self.generated_continuation_type(function);
+        let closure_ty = self.completion_type(result_type, flow.answer_type);
         let lambda = closure::lambda(self.ctx, location, captures, closure_ty, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok(lambda.result(self.ctx))
@@ -1669,9 +2106,9 @@ impl<'a> Converter<'a> {
             .map(|ty| self.convert_type(ty))
             .collect();
         let evidence_ty = self.evidence_type();
-        let done_k_ty = self.done_k_type(result);
+        let frame_ty = self.frame_types(result).reference;
         let abi = CallableAbi::new(result_convention, source_params.clone(), result);
-        let logical_params = abi.lowered_params(evidence_ty, done_k_ty);
+        let logical_params = abi.lowered_params(evidence_ty, frame_ty);
         let env_ty = self.anyref_type();
         let physical_params = abi.interpose_environment(&logical_params, env_ty);
         let physical_result = if result_convention == CallingConvention::Cps {
@@ -1685,8 +2122,8 @@ impl<'a> Converter<'a> {
         let args = self.ctx.block_args(block).to_vec();
         let evidence_offset = usize::from(result_convention.needs_evidence());
         // The environment is interposed immediately after optional evidence,
-        // so a present done continuation is the following slot.
-        let done_offset = evidence_offset + 1;
+        // so a present ContinuationFrame is the following slot.
+        let frame_offset = evidence_offset + 1;
         let source_offset = usize::from(result_convention.needs_evidence())
             + 1
             + usize::from(result_convention.needs_done_k());
@@ -1695,7 +2132,7 @@ impl<'a> Converter<'a> {
             target_args.push(args[0]);
         }
         if target.convention.needs_done_k() {
-            target_args.push(args[done_offset]);
+            target_args.push(args[frame_offset]);
         }
         target_args.extend_from_slice(&args[source_offset..]);
         if target.convention == CallingConvention::Cps {
@@ -1714,11 +2151,9 @@ impl<'a> Converter<'a> {
             set_calling_convention(self.ctx, call.op_ref(), target.convention);
             self.ctx.push_op(block, call.op_ref());
             if result_convention == CallingConvention::Cps {
-                let done_k = args[done_offset];
-                let tail =
-                    func::tail_call_indirect(self.ctx, location, done_k, [call.result(self.ctx)]);
-                set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-                self.ctx.push_op(block, tail.op_ref());
+                let frame = args[frame_offset];
+                let (done_k, _) = self.unpack_frame(block, location, result, frame);
+                self.emit_cps_tail_call_indirect(block, location, done_k, [call.result(self.ctx)])?;
             } else {
                 let ret = func::r#return(self.ctx, location, [call.result(self.ctx)]);
                 self.ctx.push_op(block, ret.op_ref());
@@ -1764,7 +2199,6 @@ impl<'a> Converter<'a> {
     fn build_completion_continuation(
         &mut self,
         source_region: RegionRef,
-        final_k: ValueRef,
         mapping: &HashMap<ValueRef, ValueRef>,
         flow: &Flow,
         location: Location,
@@ -1772,14 +2206,18 @@ impl<'a> Converter<'a> {
         let source_block = self.ctx.region(source_region).blocks[0];
         let source_arg = self.ctx.block_args(source_block)[0];
         let arg_type = self.convert_type(self.ctx.value_ty(source_arg));
-        let block = self.make_block(location, &[arg_type]);
+        let evidence_type = self.evidence_type();
+        let frame_type = self.frame_types(flow.answer_type).reference;
+        let block = self.make_block(location, &[evidence_type, frame_type, arg_type]);
         let mut body_mapping = mapping.clone();
-        body_mapping.insert(source_arg, self.ctx.block_args(block)[0]);
+        body_mapping.insert(source_arg, self.ctx.block_args(block)[2]);
         let completion_flow = Flow {
             convention: CallingConvention::Cps,
-            evidence: flow.evidence,
-            exit_k: Some(final_k),
-            root_exit_k: Some(final_k),
+            evidence: Some(self.ctx.block_args(block)[0]),
+            exit_k: Some(self.ctx.block_args(block)[1]),
+            root_exit_k: Some(self.ctx.block_args(block)[1]),
+            void_exit_k: None,
+            dispatch: None,
             answer_type: flow.answer_type,
             preserve_scf_yield: false,
         };
@@ -1792,50 +2230,10 @@ impl<'a> Converter<'a> {
         )?;
         let body = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, body);
-        let never = self.never_type();
-        let function = core::func(self.ctx, never, [arg_type]).as_type_ref();
-        let closure_type = self.generated_continuation_type(function);
+        let closure_type = self.completion_type(arg_type, flow.answer_type);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, body);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok((lambda.op_ref(), lambda.result(self.ctx)))
-    }
-
-    fn rebind_generated_continuation(
-        &mut self,
-        value: ValueRef,
-        old_root: ValueRef,
-        new_root: ValueRef,
-        destination: BlockRef,
-        cache: &mut HashMap<ValueRef, ValueRef>,
-    ) -> Result<ValueRef, TributeControlToCpsError> {
-        if value == old_root {
-            return Ok(new_root);
-        }
-        if let Some(rebound) = cache.get(&value) {
-            return Ok(*rebound);
-        }
-        let trunk_ir::ValueDef::OpResult(def, _) = self.ctx.value_def(value) else {
-            return Ok(value);
-        };
-        if !closure::Lambda::matches(self.ctx, def) {
-            return Ok(value);
-        }
-        let mut mapping = HashMap::from([(old_root, new_root)]);
-        for capture in self.ctx.op_operands(def).to_vec() {
-            let rebound = self.rebind_generated_continuation(
-                capture,
-                old_root,
-                new_root,
-                destination,
-                cache,
-            )?;
-            mapping.insert(capture, rebound);
-        }
-        let rebound_op = self.clone_plain_op(def, &mut mapping)?;
-        self.ctx.push_op(destination, rebound_op);
-        let rebound = self.ctx.op_result(rebound_op, 0);
-        cache.insert(value, rebound);
-        Ok(rebound)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1850,38 +2248,21 @@ impl<'a> Converter<'a> {
         location: Location,
     ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
         let input_type = self.convert_type(input_type);
-        let done_k_type = self.done_k_type(flow.answer_type);
-        let block = self.make_block(location, &[done_k_type, input_type]);
-        let resume_done = self.ctx.block_args(block)[0];
-        let resume_input = self.ctx.block_args(block)[1];
+        let evidence_type = self.evidence_type();
+        let frame_type = self.frame_types(flow.answer_type).reference;
+        let block = self.make_block(location, &[evidence_type, frame_type, input_type]);
+        let resume_evidence = self.ctx.block_args(block)[0];
+        let resume_frame = self.ctx.block_args(block)[1];
+        let resume_input = self.ctx.block_args(block)[2];
         let mut body_mapping = mapping.clone();
         body_mapping.insert(source_result, resume_input);
         let mut suffix_flow = flow.clone();
-        let old_root = flow.root_exit_k.ok_or_else(|| {
-            TributeControlToCpsError::one(
-                POST_CPS_BOUNDARY,
-                None,
-                Some(location),
-                "resumptive computation has no root continuation",
-            )
-        })?;
-        let current_exit = flow.exit_k.ok_or_else(|| {
-            TributeControlToCpsError::one(
-                POST_CPS_BOUNDARY,
-                None,
-                Some(location),
-                "resumptive computation has no current continuation",
-            )
-        })?;
-        let rebound_exit = self.rebind_generated_continuation(
-            current_exit,
-            old_root,
-            resume_done,
-            block,
-            &mut HashMap::new(),
-        )?;
-        suffix_flow.exit_k = Some(rebound_exit);
-        suffix_flow.root_exit_k = Some(resume_done);
+        // A resumed suffix receives the dynamic frame directly. It carries
+        // both the completion and lexical-dispatch provenance, so no closure
+        // graph cloning or ambient-evidence reconstruction is permitted.
+        suffix_flow.evidence = Some(resume_evidence);
+        suffix_flow.exit_k = Some(resume_frame);
+        suffix_flow.root_exit_k = Some(resume_frame);
         self.convert_sequence(
             source_ops.to_vec(),
             start,
@@ -1897,13 +2278,331 @@ impl<'a> Converter<'a> {
         Ok((lambda.op_ref(), lambda.result(self.ctx)))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn build_exact_handler_token(
+        &mut self,
+        location: Location,
+        raw_resume: ValueRef,
+        input_type: TypeRef,
+        body_type: TypeRef,
+        answer_type: TypeRef,
+        completion: ValueRef,
+        dispatch_factory: Symbol,
+        dispatch_factory_args: DispatchFactoryArgs<'_>,
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
+        let evidence_type = self.evidence_type();
+        let frame_type = self.frame_types(answer_type).reference;
+        let block = self.make_block(location, &[evidence_type, frame_type, input_type]);
+        let args = self.ctx.block_args(block).to_vec();
+        let anyref = self.anyref_type();
+        let erased_input = core::unrealized_conversion_cast(self.ctx, location, args[2], anyref);
+        self.ctx.push_op(block, erased_input.op_ref());
+        let (rebound_op, rebound) = self.build_rebound_resume(
+            location,
+            body_type,
+            answer_type,
+            raw_resume,
+            completion,
+            dispatch_factory,
+            dispatch_factory_args,
+        )?;
+        self.ctx.push_op(block, rebound_op);
+        self.emit_cps_tail_call_indirect(
+            block,
+            location,
+            rebound,
+            [args[0], args[1], erased_input.result(self.ctx)],
+        )?;
+        let region = self.single_block_region(location, block);
+        let token_type = self.resumption_type(input_type, answer_type);
+        let lambda = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, region),
+            token_type,
+            region,
+        );
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        Ok((lambda.op_ref(), lambda.result(self.ctx)))
+    }
+
+    /// Build an immutable factory for one lexical handle dispatcher. Each
+    /// resumption calls this factory again with its current outer dispatcher,
+    /// so the resumed body retains this handle's arm-selection boundary.
+    fn build_local_dispatcher_factory(
+        &mut self,
+        location: Location,
+        arms: &[HandlerArmInfo],
+        body_type: TypeRef,
+        answer_type: TypeRef,
+    ) -> Result<Symbol, TributeControlToCpsError> {
+        let symbol = self.fresh_helper("make_local_dispatch");
+        let completion_type = self.completion_type(body_type, answer_type);
+        let i32_type = self.i32_type();
+        let parent_dispatch_type = self.frame_types(answer_type).dispatch;
+        let dispatch_type = self.frame_types(body_type).dispatch;
+        let mut params = vec![completion_type, parent_dispatch_type, i32_type];
+        params.extend(arms.iter().map(|arm| self.ctx.value_ty(arm.value)));
+        let factory_type = core::func(self.ctx, dispatch_type, params.clone()).as_type_ref();
+        let factory_block = self.make_block(location, &params);
+        let factory_args = self.ctx.block_args(factory_block).to_vec();
+        let mut factory_arms = arms.to_vec();
+        for (arm, value) in factory_arms
+            .iter_mut()
+            .zip(factory_args[3..].iter().copied())
+        {
+            arm.value = value;
+        }
+        let (dispatcher_op, dispatcher) = self.build_local_dispatcher_instance(
+            location,
+            &factory_arms,
+            body_type,
+            answer_type,
+            factory_args[0],
+            factory_args[1],
+            symbol,
+            factory_args[2],
+            factory_args[3..].to_vec(),
+        )?;
+        self.ctx.push_op(factory_block, dispatcher_op);
+        let ret = func::r#return(self.ctx, location, [dispatcher]);
+        self.ctx.push_op(factory_block, ret.op_ref());
+        let region = self.single_block_region(location, factory_block);
+        let factory = func::func(self.ctx, location, symbol, factory_type, region);
+        set_calling_convention(self.ctx, factory.op_ref(), CallingConvention::Direct);
+        self.ctx.push_op(self.module_block, factory.op_ref());
+        Ok(symbol)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_local_foreign_dispatch(
+        &mut self,
+        location: Location,
+        body_type: TypeRef,
+        answer_type: TypeRef,
+        completion: ValueRef,
+        parent_dispatch: ValueRef,
+        factory: Symbol,
+        factory_prefix_args: &[ValueRef],
+        factory_suffix_args: &[ValueRef],
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
+        let evidence_type = self.evidence_type();
+        let anyref = self.anyref_type();
+        let i32_type = self.i32_type();
+        let body_frame = self.frame_types(body_type).reference;
+        let resume_type = tribute_core::calling_convention::cps_resume_type(
+            self.ctx,
+            evidence_type,
+            body_frame,
+            anyref,
+        );
+        let block = self.make_block(
+            location,
+            &[
+                evidence_type,
+                resume_type,
+                i32_type,
+                i32_type,
+                i32_type,
+                anyref,
+            ],
+        );
+        let args = self.ctx.block_args(block).to_vec();
+        let (rebound_op, rebound) = self.build_rebound_resume(
+            location,
+            body_type,
+            answer_type,
+            args[1],
+            completion,
+            factory,
+            DispatchFactoryArgs {
+                prefix: factory_prefix_args,
+                suffix: factory_suffix_args,
+            },
+        )?;
+        self.ctx.push_op(block, rebound_op);
+        self.emit_cps_tail_call_indirect(
+            block,
+            location,
+            parent_dispatch,
+            [args[0], rebound, args[2], args[3], args[4], args[5]],
+        )?;
+        let region = self.single_block_region(location, block);
+        let dispatch_type = self.frame_types(body_type).dispatch;
+        let lambda = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, region),
+            dispatch_type,
+            region,
+        );
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        Ok((lambda.op_ref(), lambda.result(self.ctx)))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_local_dispatcher_instance(
+        &mut self,
+        location: Location,
+        arms: &[HandlerArmInfo],
+        body_type: TypeRef,
+        answer_type: TypeRef,
+        completion: ValueRef,
+        parent_dispatch: ValueRef,
+        factory: Symbol,
+        local_prompt: ValueRef,
+        factory_args: Vec<ValueRef>,
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
+        let evidence_type = self.evidence_type();
+        let anyref = self.anyref_type();
+        let i32_type = self.i32_type();
+        let body_frame = self.frame_types(body_type).reference;
+        let resume_type = tribute_core::calling_convention::cps_resume_type(
+            self.ctx,
+            evidence_type,
+            body_frame,
+            anyref,
+        );
+        let block = self.make_block(
+            location,
+            &[
+                evidence_type,
+                resume_type,
+                i32_type,
+                i32_type,
+                i32_type,
+                anyref,
+            ],
+        );
+        let args = self.ctx.block_args(block).to_vec();
+        let mut factory_suffix_args = vec![local_prompt];
+        factory_suffix_args.extend(factory_args.iter().copied());
+        let (foreign_op, foreign_dispatch) = self.build_local_foreign_dispatch(
+            location,
+            body_type,
+            answer_type,
+            completion,
+            parent_dispatch,
+            factory,
+            &[],
+            &factory_suffix_args,
+        )?;
+        self.ctx.push_op(block, foreign_op);
+        let switch_block = self.make_block(location, &[]);
+        let i1_type = self
+            .ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i1")).build());
+        for arm in arms.iter().filter(|arm| arm.kind == Symbol::new("op")) {
+            let case_block = self.make_block(location, &[]);
+            let same_prompt = arith::cmpi(
+                self.ctx,
+                location,
+                args[2],
+                local_prompt,
+                i1_type,
+                Symbol::new("eq"),
+            );
+            self.ctx.push_op(case_block, same_prompt.op_ref());
+
+            let local_block = self.make_block(location, &[]);
+            let mut call_args = vec![args[0]];
+            call_args.extend(self.unpack_handler_payload(local_block, location, args[5], arm));
+            if arm.has_resume_token {
+                let input_type = *arm.params.last().expect("resumptive arm has a token");
+                let token_input = cps_closure_function_type(self.ctx, input_type)
+                    .and_then(|function| core::Func::from_type_ref(self.ctx, function))
+                    .and_then(|function| function.params(self.ctx).get(2).copied())
+                    .ok_or_else(|| {
+                        TributeControlToCpsError::one(
+                            POST_CPS_BOUNDARY,
+                            None,
+                            Some(location),
+                            "handler resume token lacks an exact callable input",
+                        )
+                    })?;
+                let (token_op, token) = self.build_exact_handler_token(
+                    location,
+                    args[1],
+                    token_input,
+                    body_type,
+                    answer_type,
+                    completion,
+                    factory,
+                    DispatchFactoryArgs {
+                        prefix: &[],
+                        suffix: &factory_suffix_args,
+                    },
+                )?;
+                self.ctx.push_op(local_block, token_op);
+                call_args.push(token);
+            }
+            self.emit_cps_tail_call_indirect(local_block, location, arm.value, call_args)?;
+            let local_region = self.single_block_region(location, local_block);
+            let fallback_block = self.make_block(location, &[]);
+            self.emit_cps_tail_call_indirect(
+                fallback_block,
+                location,
+                foreign_dispatch,
+                [args[0], args[1], args[2], args[3], args[4], args[5]],
+            )?;
+            let fallback_region = self.single_block_region(location, fallback_block);
+            let never = self.never_type();
+            let choose = scf::r#if(
+                self.ctx,
+                location,
+                same_prompt.result(self.ctx),
+                never,
+                local_region,
+                fallback_region,
+            );
+            self.ctx.push_op(case_block, choose.op_ref());
+            let case_region = self.single_block_region(location, case_block);
+            let op_index = ability::compute_op_idx(
+                self.ctx.types.get(arm.ability_ref).attrs.get_symbol("name"),
+                Some(arm.op_name),
+            );
+            let case = scf::case(
+                self.ctx,
+                location,
+                Attribute::Int(op_index as i128),
+                case_region,
+            );
+            self.ctx.push_op(switch_block, case.op_ref());
+        }
+        let default_block = self.make_block(location, &[]);
+        self.emit_cps_tail_call_indirect(
+            default_block,
+            location,
+            foreign_dispatch,
+            [args[0], args[1], args[2], args[3], args[4], args[5]],
+        )?;
+        let foreign_region = self.single_block_region(location, default_block);
+        let default = scf::default(self.ctx, location, foreign_region);
+        self.ctx.push_op(switch_block, default.op_ref());
+        let switch_region = self.single_block_region(location, switch_block);
+        let switch = scf::switch(self.ctx, location, args[4], switch_region);
+        self.ctx.push_op(block, switch.op_ref());
+        let region = self.single_block_region(location, block);
+        let dispatch_type = self.frame_types(body_type).dispatch;
+        let lambda = closure::lambda(
+            self.ctx,
+            location,
+            ordered_external_values(self.ctx, region),
+            dispatch_type,
+            region,
+        );
+        set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
+        Ok((lambda.op_ref(), lambda.result(self.ctx)))
+    }
+
     fn build_one_shot_wrapper(
         &mut self,
         raw_continuation: ValueRef,
         input_type: TypeRef,
         answer_type: TypeRef,
         location: Location,
-    ) -> (Vec<OpRef>, ValueRef) {
+    ) -> Result<(Vec<OpRef>, ValueRef), TributeControlToCpsError> {
         let i1_type = self
             .ctx
             .types
@@ -1930,9 +2629,32 @@ impl<'a> Converter<'a> {
             state_type,
         );
 
-        let done_k_type = self.done_k_type(answer_type);
-        let block = self.make_block(location, &[done_k_type, input_type]);
+        let evidence_type = self.evidence_type();
+        let frame_type = self.frame_types(answer_type).reference;
+        let anyref = self.anyref_type();
+        // The dispatcher ABI is existential only at this boundary. Keep the
+        // captured continuation exact, recover this operation's declared input,
+        // then transfer in proper tail position.
+        let block = self.make_block(location, &[evidence_type, frame_type, anyref]);
         let args = self.ctx.block_args(block).to_vec();
+        let input = if type_is(self.ctx, input_type, "core", "nil") {
+            // Nil has no physical payload: its exact resumption receives the
+            // canonical unit instead of an erased runtime value.
+            let unit = arith::r#const(self.ctx, location, input_type, Attribute::Unit);
+            self.ctx.push_op(block, unit.op_ref());
+            unit.result(self.ctx)
+        } else if type_is(self.ctx, input_type, "adt", "typeref") {
+            // Dynamic effect values recover nominal references only through
+            // their declared type, preserving the typed ownership boundary.
+            let recovered = adt::ref_cast(self.ctx, location, args[2], input_type, input_type);
+            self.ctx.push_op(block, recovered.op_ref());
+            recovered.result(self.ctx)
+        } else {
+            let recovered =
+                core::unrealized_conversion_cast(self.ctx, location, args[2], input_type);
+            self.ctx.push_op(block, recovered.op_ref());
+            recovered.result(self.ctx)
+        };
         let consumed = adt::struct_get(
             self.ctx,
             location,
@@ -1960,10 +2682,12 @@ impl<'a> Converter<'a> {
             0,
         );
         self.ctx.push_op(enter_block, mark.op_ref());
-        let tail =
-            func::tail_call_indirect(self.ctx, location, raw_continuation, args.iter().copied());
-        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-        self.ctx.push_op(enter_block, tail.op_ref());
+        self.emit_cps_tail_call_indirect(
+            enter_block,
+            location,
+            raw_continuation,
+            [args[0], args[1], input],
+        )?;
         let enter_region = self.single_block_region(location, enter_block);
 
         let never = self.never_type();
@@ -1978,13 +2702,18 @@ impl<'a> Converter<'a> {
         self.ctx.push_op(block, guard.op_ref());
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
-        let closure_type = self.resumption_type(input_type, answer_type);
+        let closure_type = tribute_core::calling_convention::cps_resume_type(
+            self.ctx,
+            evidence_type,
+            frame_type,
+            anyref,
+        );
         let wrapper = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, wrapper.op_ref(), CallingConvention::Cps);
-        (
+        Ok((
             vec![not_consumed.op_ref(), state.op_ref(), wrapper.op_ref()],
             wrapper.result(self.ctx),
-        )
+        ))
     }
 
     fn build_reject_continuation(
@@ -1994,8 +2723,9 @@ impl<'a> Converter<'a> {
         location: Location,
     ) -> (OpRef, ValueRef) {
         let input_type = self.convert_type(input_type);
-        let done_k_type = self.done_k_type(answer_type);
-        let block = self.make_block(location, &[done_k_type, input_type]);
+        let evidence_type = self.evidence_type();
+        let frame_type = self.frame_types(answer_type).reference;
+        let block = self.make_block(location, &[evidence_type, frame_type, input_type]);
         let unreachable = func::unreachable(self.ctx, location);
         self.ctx.push_op(block, unreachable.op_ref());
         let region = self.single_block_region(location, block);
@@ -2049,7 +2779,7 @@ impl<'a> Converter<'a> {
             self.ctx.push_op(block, raw_op);
             let converted_input = self.convert_type(input_type);
             let (ops, one_shot) =
-                self.build_one_shot_wrapper(raw, converted_input, flow.answer_type, location);
+                self.build_one_shot_wrapper(raw, converted_input, flow.answer_type, location)?;
             for op in ops {
                 self.ctx.push_op(block, op);
             }
@@ -2061,7 +2791,6 @@ impl<'a> Converter<'a> {
             .iter()
             .map(|arg| mapping.get(arg).copied().unwrap_or(*arg))
             .collect();
-        let never = self.never_type();
         let ability_ref = self
             .ctx
             .op(source)
@@ -2074,12 +2803,29 @@ impl<'a> Converter<'a> {
             .attributes
             .get_symbol("op_name")
             .expect("pre-CPS validation checked perform operation");
+        let evidence = self.current_evidence(source, flow)?;
+        let frame = flow.exit_k.ok_or_else(|| {
+            TributeControlToCpsError::one(
+                POST_CPS_BOUNDARY,
+                Some(source),
+                Some(location),
+                "general operation has no verified Dispatch boundary",
+            )
+        })?;
+        let dispatch = match flow.dispatch {
+            Some(dispatch) => dispatch,
+            None => {
+                self.unpack_frame(block, location, flow.answer_type, frame)
+                    .1
+            }
+        };
         let perform = ability::perform(
             self.ctx,
             location,
+            evidence,
+            dispatch,
             continuation,
             args,
-            never,
             ability_ref,
             op_name,
         );
@@ -2125,9 +2871,14 @@ impl<'a> Converter<'a> {
             _ => unreachable!("suffix is produced by closure.lambda"),
         };
         self.ctx.push_op(block, suffix_op);
-        let tail = func::tail_call_indirect(self.ctx, location, token, [suffix, value]);
-        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-        self.ctx.push_op(block, tail.op_ref());
+        let resume_result = self.convert_type(result_type);
+        let resume_frame = self.frame_for_suffix(block, location, resume_result, flow, suffix)?;
+        self.emit_cps_tail_call_indirect(
+            block,
+            location,
+            token,
+            [self.current_evidence(source, flow)?, resume_frame, value],
+        )?;
         Ok(())
     }
 
@@ -2195,6 +2946,8 @@ impl<'a> Converter<'a> {
             evidence: Some(evidence),
             exit_k: (convention == CallingConvention::Cps).then_some(handle_exit),
             root_exit_k: (convention == CallingConvention::Cps).then_some(handle_exit),
+            void_exit_k: None,
+            dispatch: None,
             answer_type: handle_answer,
             preserve_scf_yield: false,
         };
@@ -2240,11 +2993,12 @@ impl<'a> Converter<'a> {
         } else {
             arm.params.as_slice()
         };
+        let anyref = self.anyref_type();
         let payload_type = ability::operation_payload_type_ref(
             self.ctx,
             arm.ability_ref,
             arm.op_name,
-            value_params.iter().copied(),
+            value_params.iter().map(|_| anyref),
         );
         let cast = core::unrealized_conversion_cast(self.ctx, location, payload, payload_type);
         self.ctx.push_op(block, cast.op_ref());
@@ -2257,12 +3011,15 @@ impl<'a> Converter<'a> {
                     self.ctx,
                     location,
                     cast.result(self.ctx),
-                    ty,
+                    anyref,
                     payload_type,
                     index as u32,
                 );
                 self.ctx.push_op(block, get.op_ref());
-                get.result(self.ctx)
+                let recovered =
+                    core::unrealized_conversion_cast(self.ctx, location, get.result(self.ctx), ty);
+                self.ctx.push_op(block, recovered.op_ref());
+                recovered.result(self.ctx)
             })
             .collect()
     }
@@ -2272,7 +3029,7 @@ impl<'a> Converter<'a> {
         location: Location,
         arms: &[HandlerArmInfo],
         general: bool,
-    ) -> (OpRef, ValueRef) {
+    ) -> Result<(OpRef, ValueRef), TributeControlToCpsError> {
         let evidence_type = self.evidence_type();
         let anyref = self.anyref_type();
         let i32_type = self
@@ -2315,9 +3072,7 @@ impl<'a> Converter<'a> {
                 call_args.push(token.result(self.ctx));
             }
             if general {
-                let tail = func::tail_call_indirect(self.ctx, location, arm.value, call_args);
-                set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-                self.ctx.push_op(case_block, tail.op_ref());
+                self.emit_cps_tail_call_indirect(case_block, location, arm.value, call_args)?;
             } else {
                 let call = func::call_indirect(
                     self.ctx,
@@ -2372,7 +3127,7 @@ impl<'a> Converter<'a> {
         let closure_type = physical_closure_type(self.ctx, function, convention);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), convention);
-        (lambda.op_ref(), lambda.result(self.ctx))
+        Ok((lambda.op_ref(), lambda.result(self.ctx)))
     }
 
     fn lower_handle(
@@ -2410,6 +3165,8 @@ impl<'a> Converter<'a> {
             _ => unreachable!("handle continuation is produced by closure.lambda"),
         };
         self.ctx.push_op(block, after_handle_op);
+        let handle_frame =
+            self.frame_for_suffix(block, location, handle_answer, flow, after_handle)?;
 
         let regions = self.ctx.op(source).regions.to_vec();
         let [body_source, completion_source, handlers_region] = regions.as_slice() else {
@@ -2421,7 +3178,7 @@ impl<'a> Converter<'a> {
         let mut handler_arms = Vec::new();
         let source_handlers = self.ctx.block(handlers_block).ops.to_vec();
         for handler in source_handlers {
-            let arm = self.lower_handler_arm(handler, mapping, after_handle, handle_answer)?;
+            let arm = self.lower_handler_arm(handler, mapping, handle_frame, handle_answer)?;
             self.ctx.push_op(block, arm.op);
             handler_arms.push(arm);
         }
@@ -2439,37 +3196,83 @@ impl<'a> Converter<'a> {
                 .filter(|arm| arm.ability_ref == ability_ref)
                 .cloned()
                 .collect::<Vec<_>>();
-            let (tr_op, tr_value) = self.build_handler_dispatcher(location, &ability_arms, false);
+            let (tr_op, tr_value) =
+                self.build_handler_dispatcher(location, &ability_arms, false)?;
             self.ctx.push_op(block, tr_op);
             dispatchers.push(tr_value);
             let (handler_op, handler_value) =
-                self.build_handler_dispatcher(location, &ability_arms, true);
+                self.build_handler_dispatcher(location, &ability_arms, true)?;
             self.ctx.push_op(block, handler_op);
             dispatchers.push(handler_value);
         }
 
         let evidence_type = self.evidence_type();
+        let i32_type = self.i32_type();
+        let prompt = effect::fresh_prompt_tag(self.ctx, location, i32_type);
+        self.ctx.push_op(block, prompt.op_ref());
         let body_block = self.make_block(location, &[evidence_type]);
         let extended_evidence = self.ctx.block_args(body_block)[0];
         let mut body_mapping = mapping.clone();
         let body_flow_base = Flow {
             convention: CallingConvention::Cps,
             evidence: Some(extended_evidence),
-            exit_k: Some(after_handle),
-            root_exit_k: Some(after_handle),
+            exit_k: Some(handle_frame),
+            root_exit_k: Some(handle_frame),
+            void_exit_k: None,
+            dispatch: None,
             answer_type: handle_answer,
             preserve_scf_yield: false,
         };
         let (completion_op, completion_k) = self.build_completion_continuation(
             completion_source,
-            after_handle,
             &body_mapping,
             &body_flow_base,
             location,
         )?;
         self.ctx.push_op(body_block, completion_op);
+        let completion_input = self.convert_type(
+            self.ctx.value_ty(
+                self.ctx
+                    .block_args(self.ctx.region(completion_source).blocks[0])[0],
+            ),
+        );
+        let completion_frame = self.frame_for_suffix(
+            body_block,
+            location,
+            completion_input,
+            &body_flow_base,
+            completion_k,
+        )?;
+        let (_, parent_dispatch) =
+            self.unpack_frame(body_block, location, handle_answer, handle_frame);
+        let local_dispatch_factory = self.build_local_dispatcher_factory(
+            location,
+            &handler_arms,
+            completion_input,
+            handle_answer,
+        )?;
+        let mut local_dispatch_args = vec![completion_k, parent_dispatch, prompt.result(self.ctx)];
+        local_dispatch_args.extend(handler_arms.iter().map(|arm| arm.value));
+        let local_dispatch_type = self.frame_types(completion_input).dispatch;
+        let local_dispatch_op = func::call(
+            self.ctx,
+            location,
+            local_dispatch_args,
+            local_dispatch_type,
+            local_dispatch_factory,
+        );
+        set_calling_convention(
+            self.ctx,
+            local_dispatch_op.op_ref(),
+            CallingConvention::Direct,
+        );
+        let local_dispatch = local_dispatch_op.result(self.ctx);
+        self.ctx.push_op(body_block, local_dispatch_op.op_ref());
         let body_flow = Flow {
-            exit_k: Some(completion_k),
+            exit_k: Some(completion_frame),
+            root_exit_k: Some(completion_frame),
+            dispatch: Some(local_dispatch),
+            answer_type: completion_input,
             ..body_flow_base
         };
         let source_body_block = self.ctx.region(body_source).blocks[0];
@@ -2486,6 +3289,7 @@ impl<'a> Converter<'a> {
             self.ctx,
             location,
             current_evidence,
+            prompt.result(self.ctx),
             dispatchers,
             Attribute::List(ability_refs.into_iter().map(Attribute::Type).collect()),
             body_region,
@@ -2607,7 +3411,15 @@ impl<'a> Converter<'a> {
                             _ => unreachable!("continuation is produced by closure.lambda"),
                         };
                         self.ctx.push_op(block, continuation_op);
-                        let mut args = vec![self.current_evidence(source, flow)?, continuation];
+                        let converted_result = self.convert_type(result_type);
+                        let frame = self.frame_for_suffix(
+                            block,
+                            location,
+                            converted_result,
+                            flow,
+                            continuation,
+                        )?;
+                        let mut args = vec![self.current_evidence(source, flow)?, frame];
                         args.extend(
                             self.ctx
                                 .op_operands(source)
@@ -2660,15 +3472,21 @@ impl<'a> Converter<'a> {
                             _ => unreachable!("continuation is produced by closure.lambda"),
                         };
                         self.ctx.push_op(block, continuation_op);
-                        let mut args = vec![self.current_evidence(source, flow)?, continuation];
+                        let converted_result = self.convert_type(result_type);
+                        let frame = self.frame_for_suffix(
+                            block,
+                            location,
+                            converted_result,
+                            flow,
+                            continuation,
+                        )?;
+                        let mut args = vec![self.current_evidence(source, flow)?, frame];
                         args.extend(
                             source_args
                                 .iter()
                                 .map(|arg| mapping.get(arg).copied().unwrap_or(*arg)),
                         );
-                        let tail = func::tail_call_indirect(self.ctx, location, callee, args);
-                        set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-                        self.ctx.push_op(block, tail.op_ref());
+                        self.emit_cps_tail_call_indirect(block, location, callee, args)?;
                         return Ok(());
                     }
                     let mut args = Vec::new();
@@ -2805,8 +3623,8 @@ impl<'a> Converter<'a> {
             .collect();
         let abi = CallableAbi::new(info.convention, source_params, source_result);
         let evidence_ty = self.evidence_type();
-        let done_k_ty = self.done_k_type(source_result);
-        let params = abi.lowered_params(evidence_ty, done_k_ty);
+        let frame_ty = self.frame_types(source_result).reference;
+        let params = abi.lowered_params(evidence_ty, frame_ty);
         let block = self.make_block(location, &params);
         let mut mapping = HashMap::new();
         for (old, new) in self.ctx.block_args(source_block).to_vec().into_iter().zip(
@@ -2829,6 +3647,8 @@ impl<'a> Converter<'a> {
             evidence,
             exit_k,
             root_exit_k: exit_k,
+            void_exit_k: None,
+            dispatch: None,
             answer_type: source_result,
             preserve_scf_yield: false,
         };
@@ -3039,6 +3859,7 @@ pub fn tribute_control_to_cps(
                 .iter()
                 .map(|(name, ty)| (*name, converter.convert_type(*ty))),
         );
+        converted_aliases.extend(converter.frame_layout_aliases.iter().copied());
     }
     let new_region = ctx.create_region(RegionData {
         location: ctx.region(source_region).location,
@@ -3126,6 +3947,75 @@ mod tests {
         (ctx, module)
     }
 
+    fn operation_declarations(
+        ctx: &IrContext,
+        operations: &[(&str, &str)],
+    ) -> Vec<tribute_control::OperationDeclaration> {
+        let i32_type = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .expect("test module declares core.i32");
+        operations
+            .iter()
+            .map(|&(ability_name, op_name)| {
+                let ability_ref = ctx
+                    .types
+                    .iter()
+                    .find_map(|(ty, data)| {
+                        (data.dialect == Symbol::new("core")
+                            && data.name == Symbol::new("ability_ref")
+                            && data.attrs.get_symbol("name")
+                                == Some(Symbol::from_dynamic(ability_name)))
+                        .then_some(ty)
+                    })
+                    .unwrap_or_else(|| panic!("test module declares {ability_name}"));
+                tribute_control::OperationDeclaration::new(
+                    ability_ref,
+                    Symbol::from_dynamic(op_name),
+                    Symbol::new("op"),
+                    [i32_type],
+                    i32_type,
+                )
+            })
+            .collect()
+    }
+
+    fn assert_nested_resume_frames(printed: &str) {
+        assert_eq!(
+            printed.matches("ability.handle_dispatch").count(),
+            2,
+            "{printed}"
+        );
+        assert_eq!(printed.matches("ability.perform").count(), 2, "{printed}");
+        assert!(
+            printed
+                .matches("tribute.cps_continuation_frame_result")
+                .count()
+                >= 2,
+            "{printed}"
+        );
+        assert!(
+            printed.matches("adt.struct_get").count() >= 6,
+            "dynamic frames must be unpacked to recover done and dispatch: {printed}"
+        );
+        assert!(
+            printed.matches("adt.struct_new").count() >= 4,
+            "suffixes and resumes must repack the lexical dispatcher with a new done target: {printed}"
+        );
+        assert!(
+            printed
+                .lines()
+                .filter(|line| line.contains("ability.perform"))
+                .all(|line| !line.contains(": core.i32")),
+            "final ability.perform must be resultless: {printed}"
+        );
+        assert!(!printed.contains("tribute_control."), "{printed}");
+    }
+
     fn collect_lambdas(ctx: &IrContext, op: OpRef, lambdas: &mut Vec<OpRef>) {
         if closure::Lambda::matches(ctx, op) {
             lambdas.push(op);
@@ -3135,6 +4025,21 @@ mod tests {
             for &block in &ctx.region(region).blocks {
                 for &child in &ctx.block(block).ops {
                     collect_lambdas(ctx, child, lambdas);
+                }
+            }
+        }
+    }
+
+    fn collect_cps_tail_calls(ctx: &IrContext, op: OpRef, tails: &mut Vec<OpRef>) {
+        if func::TailCallIndirect::matches(ctx, op)
+            && tribute_core::get_calling_convention(ctx, op) == Some(CallingConvention::Cps)
+        {
+            tails.push(op);
+        }
+        for &region in &ctx.op(op).regions {
+            for &block in &ctx.region(region).blocks {
+                for &child in &ctx.block(block).ops {
+                    collect_cps_tail_calls(ctx, child, tails);
                 }
             }
         }
@@ -3740,8 +4645,8 @@ mod tests {
   !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
   !tr = closure.closure(core.func(tribute_rt.anyref, !evidence, core.i32, tribute_rt.anyref))
   !general = closure.closure(core.func(core.never, !evidence, tribute_rt.anyref, core.i32, tribute_rt.anyref))
-  func.func @caller(%ev: !evidence, %tr: !tr, %general: !general) -> core.never attributes {tribute.calling_convention = 2} {
-    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+  func.func @caller(%ev: !evidence, %prompt: core.i32, %tr: !tr, %general: !general) -> core.never attributes {tribute.calling_convention = 2} {
+    ability.handle_dispatch %ev, %prompt, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }
@@ -3758,14 +4663,14 @@ mod tests {
 
         let wrong_abi_input = r#"core.module @test {
   !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  func.func @caller(%ev: !evidence) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @caller(%ev: !evidence, %prompt: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     %tr = closure.lambda(%inner: !evidence) -> tribute_rt.anyref {tribute.calling_convention = 1} {
       func.unreachable
     }
     %general = closure.lambda(%inner: !evidence) -> core.never {tribute.calling_convention = 2} {
       func.unreachable
     }
-    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+    ability.handle_dispatch %ev, %prompt, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }
@@ -3782,14 +4687,14 @@ mod tests {
 
         let wrong_metadata_input = r#"core.module @test {
   !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  func.func @caller(%ev: !evidence) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @caller(%ev: !evidence, %prompt: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     %tr = closure.lambda(%inner: !evidence, %op_idx: core.i32, %payload: tribute_rt.anyref) -> tribute_rt.anyref {tribute.calling_convention = 0} {
       func.unreachable
     }
     %general = closure.lambda(%inner: !evidence, %continuation: tribute_rt.anyref, %op_idx: core.i32, %payload: tribute_rt.anyref) -> core.never {tribute.calling_convention = 1} {
       func.unreachable
     }
-    ability.handle_dispatch %ev, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
+    ability.handle_dispatch %ev, %prompt, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
       ^body(%inner: !evidence):
         func.unreachable
     }
@@ -3871,6 +4776,47 @@ mod tests {
             i32_type,
         )];
         tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
+        let mut perform_resume = None;
+        fn find_perform_resume(ctx: &IrContext, op: OpRef, found: &mut Option<ValueRef>) {
+            if let Ok(perform) = ability::Perform::from_op(ctx, op) {
+                *found = Some(perform.resume(ctx));
+            }
+            for region in ctx.op(op).regions.iter().copied() {
+                for block in ctx.region(region).blocks.iter().copied() {
+                    for child in ctx.block(block).ops.iter().copied() {
+                        find_perform_resume(ctx, child, found);
+                    }
+                }
+            }
+        }
+        find_perform_resume(&ctx, module.op(), &mut perform_resume);
+        let perform_resume = perform_resume.expect("resumptive handler emits ability.perform");
+        let erased_function = cps_closure_function_type(&ctx, ctx.value_ty(perform_resume))
+            .expect("ability.perform resume has CPS callable provenance");
+        let erased = core::Func::from_type_ref(&ctx, erased_function)
+            .expect("ability.perform resume has a function signature");
+        assert_eq!(erased.params(&ctx).len(), 3);
+        assert!(
+            type_is(&ctx, erased.params(&ctx)[2], "tribute_rt", "anyref"),
+            "ability.perform must receive Resume<anyref, R>, not the exact continuation: {}",
+            print_module(&ctx, module.op())
+        );
+        let trunk_ir::ValueDef::OpResult(wrapper_op, _) = ctx.value_def(perform_resume) else {
+            panic!("ability.perform resume must be the one-shot adapter closure");
+        };
+        assert!(closure::Lambda::matches(&ctx, wrapper_op));
+        assert!(
+            ctx.op_operands(wrapper_op).iter().copied().any(|capture| {
+                cps_closure_function_type(&ctx, ctx.value_ty(capture))
+                    .and_then(|function| core::Func::from_type_ref(&ctx, function))
+                    .is_some_and(|function| {
+                        function.params(&ctx).len() == 3
+                            && type_is(&ctx, function.params(&ctx)[2], "core", "i32")
+                    })
+            }),
+            "the erased adapter must capture the declared ResumeExact<I, R>: {}",
+            print_module(&ctx, module.op())
+        );
         let mut consumed_get = None;
         let mut consumed_set = None;
         fn find_one_shot_state_ops(
@@ -3912,7 +4858,7 @@ mod tests {
         assert!(consumed_get.is_some(), "one-shot state was not emitted");
         let printed = print_module(&ctx, module.op());
         assert_eq!(printed.matches("ability.handle_dispatch").count(), 1);
-        assert!(!printed.contains("effect."));
+        assert!(printed.contains("effect.fresh_prompt_tag"));
         assert!(printed.contains("ability_refs = [core.ability_ref"));
         assert!(printed.contains("func.tail_call_indirect"));
         assert!(printed.contains("adt.struct_set"));
@@ -3999,7 +4945,7 @@ mod tests {
         let [delimiter] = delimiters.as_slice() else {
             panic!("expected one final delimiter");
         };
-        assert_eq!(ctx.op_operands(*delimiter).len(), 3);
+        assert_eq!(ctx.op_operands(*delimiter).len(), 4);
         let Some(Attribute::List(ability_refs)) = ctx.op(*delimiter).attributes.get("ability_refs")
         else {
             panic!("final delimiter must have ability_refs");
@@ -4008,7 +4954,29 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("value = 9"));
         assert!(printed.contains("func.tail_call_indirect"));
-        assert!(!printed.contains("effect."));
+        assert!(
+            printed.contains("@__tribute_make_dispatch_adapter_"),
+            "the dispatch-adapter factory must be present: {printed}"
+        );
+        let mut tails = Vec::new();
+        collect_cps_tail_calls(&ctx, module.op(), &mut tails);
+        assert!(
+            tails.len() >= 3,
+            "the dispatch adapter and separate handler paths must tail-transfer: {printed}"
+        );
+        for tail in tails {
+            let signature = tribute_core::get_indirect_call_signature(&ctx, tail)
+                .expect("every emitted CPS indirect tail has its exact closure contract");
+            let callable = core::Func::from_type_ref(&ctx, signature)
+                .expect("the indirect tail signature is a core.func");
+            assert_eq!(callable.r#return(&ctx), core::never(&mut ctx).as_type_ref());
+            assert_eq!(
+                callable.params(&ctx).len() + 1,
+                ctx.op_operands(tail).len(),
+                "the exact signature covers every tail operand: {printed}"
+            );
+        }
+        assert!(printed.contains("effect.fresh_prompt_tag"));
     }
 
     #[test]
@@ -4140,6 +5108,33 @@ mod tests {
         assert!(printed.contains("func.call") && printed.contains("func.tail_call_indirect"));
         assert!(!printed.contains("tribute_control."));
 
+        let mut tails = Vec::new();
+        collect_cps_tail_calls(&ctx, module.op(), &mut tails);
+        assert!(
+            tails.len() >= 3,
+            "the dispatch adapter and independent CPS exits must both tail-transfer: {printed}"
+        );
+        for tail in tails {
+            let signature = tribute_core::get_indirect_call_signature(&ctx, tail)
+                .expect("every emitted CPS indirect tail has its exact closure contract");
+            let callable = core::Func::from_type_ref(&ctx, signature)
+                .expect("the indirect tail signature is a core.func");
+            assert_eq!(callable.r#return(&ctx), core::never(&mut ctx).as_type_ref());
+            assert_eq!(
+                callable.params(&ctx).len() + 1,
+                ctx.op_operands(tail).len(),
+                "the exact signature covers every tail operand: {printed}"
+            );
+            assert!(
+                callable
+                    .params(&ctx)
+                    .iter()
+                    .zip(&ctx.op_operands(tail)[1..])
+                    .all(|(expected, actual)| *expected == ctx.value_ty(*actual)),
+                "the exact signature must not be inferred from erased operands: {printed}"
+            );
+        }
+
         let mut lambdas = Vec::new();
         collect_lambdas(&ctx, module.op(), &mut lambdas);
         let mut generated_param_counts = Vec::new();
@@ -4157,7 +5152,7 @@ mod tests {
                 .unwrap();
             generated_param_counts.push(callable.params(&ctx).len());
         }
-        assert!(generated_param_counts.contains(&0), "{printed}");
+        assert!(generated_param_counts.contains(&2), "{printed}");
 
         crate::lower_closure_lambda::lower_closure_lambda(&mut ctx, module);
         let lifted = print_module(&ctx, module.op());
@@ -4172,6 +5167,44 @@ mod tests {
         assert!(
             lowered.contains("func.indirect_call_signature"),
             "{lowered}"
+        );
+    }
+
+    #[test]
+    fn cps_indirect_tail_without_a_provenance_bearing_closure_fails_before_insertion() {
+        let (mut ctx, module) = parse(
+            r#"core.module @test {
+  func.func @caller() -> core.never {
+    func.unreachable
+  }
+}"#,
+        );
+        let module_block = ctx.region(module.body(&ctx).unwrap()).blocks[0];
+        let location = ctx.op(module.op()).location;
+        let never = core::never(&mut ctx).as_type_ref();
+        let raw_type = core::func(&mut ctx, never, []).as_type_ref();
+        let raw = func::constant(&mut ctx, location, raw_type, Symbol::new("raw"));
+        let before = ctx.block(module_block).ops.to_vec();
+        let mut converter = Converter::new(&mut ctx, module_block, HashMap::new(), module.op());
+
+        let error = converter
+            .emit_cps_tail_call_indirect(
+                module_block,
+                location,
+                raw.result(converter.ctx),
+                std::iter::empty(),
+            )
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("no exact provenance-bearing closure contract"),
+            "{error}"
+        );
+        assert_eq!(
+            converter.ctx.block(module_block).ops.as_slice(),
+            before.as_slice()
         );
     }
 
@@ -4358,11 +5391,88 @@ mod tests {
         tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert_eq!(printed.matches("ability.handle_dispatch").count(), 2);
-        assert!(!printed.contains("effect."));
+        assert!(printed.contains("effect.fresh_prompt_tag"));
         assert!(printed.matches("func.tail_call_indirect").count() >= 3);
         assert!(!printed.contains("__tribute_cps_control"));
     }
 
+    #[test]
+    fn nested_same_ability_resumes_rebuild_the_dynamic_frame_dispatcher() {
+        let input = r#"core.module @test {
+  tribute_control.func @nested_same(%input: core.i32) -> core.i32 convention(cps) {
+    %outer = tribute_control.handle : core.i32 {
+      %inner = tribute_control.handle : core.i32 {
+        %performed = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @State}, op_name = @get, operation_kind = @op} : core.i32
+        tribute_control.yield %performed
+      } {
+        ^inner_completion(%value: core.i32):
+          tribute_control.yield %value
+      } {
+        tribute_control.handler {ability_ref = core.ability_ref() {name = @State}, kind = @op, op_name = @get, operation_result_type = core.i32} {
+          ^inner_arm(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+            %resumed = tribute_control.resume %token, %argument : core.i32
+            tribute_control.yield %resumed
+        }
+      }
+      %performed = tribute_control.perform %inner {ability_ref = core.ability_ref() {name = @State}, op_name = @get, operation_kind = @op} : core.i32
+      tribute_control.yield %performed
+    } {
+      ^outer_completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @State}, kind = @op, op_name = @get, operation_result_type = core.i32} {
+        ^outer_arm(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+          %resumed = tribute_control.resume %token, %argument : core.i32
+          tribute_control.yield %resumed
+      }
+    }
+    tribute_control.return %outer
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let declarations = operation_declarations(&ctx, &[("State", "get")]);
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
+        assert_nested_resume_frames(&print_module(&ctx, module.op()));
+    }
+
+    #[test]
+    fn nested_cross_ability_resumes_rebuild_the_dynamic_frame_dispatcher() {
+        let input = r#"core.module @test {
+  tribute_control.func @nested_cross(%input: core.i32) -> core.i32 convention(cps) {
+    %outer = tribute_control.handle : core.i32 {
+      %inner = tribute_control.handle : core.i32 {
+        %performed = tribute_control.perform %input {ability_ref = core.ability_ref() {name = @Console}, op_name = @read, operation_kind = @op} : core.i32
+        tribute_control.yield %performed
+      } {
+        ^inner_completion(%value: core.i32):
+          tribute_control.yield %value
+      } {
+        tribute_control.handler {ability_ref = core.ability_ref() {name = @Console}, kind = @op, op_name = @read, operation_result_type = core.i32} {
+          ^inner_arm(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+            %resumed = tribute_control.resume %token, %argument : core.i32
+            tribute_control.yield %resumed
+        }
+      }
+      %performed = tribute_control.perform %inner {ability_ref = core.ability_ref() {name = @State}, op_name = @get, operation_kind = @op} : core.i32
+      tribute_control.yield %performed
+    } {
+      ^outer_completion(%value: core.i32):
+        tribute_control.yield %value
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @State}, kind = @op, op_name = @get, operation_result_type = core.i32} {
+        ^outer_arm(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+          %resumed = tribute_control.resume %token, %argument : core.i32
+          tribute_control.yield %resumed
+      }
+    }
+    tribute_control.return %outer
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let declarations = operation_declarations(&ctx, &[("State", "get"), ("Console", "read")]);
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
+        assert_nested_resume_frames(&print_module(&ctx, module.op()));
+    }
     #[test]
     fn op_to_never_uses_a_typed_zero_capture_reject_continuation() {
         let input = r#"core.module @test {

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -1492,6 +1492,25 @@ mod tests {
     }
 
     #[test]
+    fn multi_result_legacy_dispatch_remains_unchanged() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run(%ev: wasm.arrayref, %continuation: wasm.anyref, %payload: wasm.anyref) -> wasm.anyref {
+    %first, %second = effect.legacy_dispatch_cps %ev, %continuation, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : wasm.anyref, wasm.anyref
+    func.return %first
+  }
+}"#,
+        );
+        let before = print_module(&ctx, module.op());
+
+        rewrite_evidence_ops_in_scope(&mut ctx, module);
+
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
     fn result_bearing_final_dispatch_remains_unchanged() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -20,10 +20,12 @@
 //! binary search (O(log n)) since the evidence array is maintained in sorted order
 //! by ability_id.
 
+use tribute_core::{CallingConvention, set_calling_convention, set_indirect_call_signature};
 use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
+use trunk_ir::dialect::core;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
@@ -84,6 +86,7 @@ fn rewrite_evidence_ops_in_scope<S: RewriteScope>(ctx: &mut IrContext, scope: S)
     let applicator = PatternApplicator::new(TypeConverter::new())
         .add_pattern(EffectExtendPattern)
         .add_pattern(EffectDispatchTailPattern)
+        .add_pattern(LegacyEffectDispatchCpsPattern)
         .add_pattern(EffectDispatchCpsPattern)
         .add_pattern(EvidenceLookupPattern)
         .add_pattern(EvidenceExtendPattern);
@@ -139,6 +142,7 @@ fn evidence_helper_requirements(ctx: &IrContext, module: Module) -> (bool, bool)
             for &op in &ctx.block(block).ops {
                 *lookup |= ability::EvidenceLookup::from_op(ctx, op).is_ok()
                     || effect::DispatchTail::from_op(ctx, op).is_ok()
+                    || effect::LegacyDispatchCps::from_op(ctx, op).is_ok()
                     || effect::DispatchCps::from_op(ctx, op).is_ok();
                 *extend |= ability::EvidenceExtend::from_op(ctx, op).is_ok()
                     || effect::Extend::from_op(ctx, op).is_ok();
@@ -155,6 +159,100 @@ fn evidence_helper_requirements(ctx: &IrContext, module: Module) -> (bool, bool)
         visit(ctx, body, &mut lookup, &mut extend);
     }
     (lookup, extend)
+}
+
+/// Lower only the explicit carrier ABI to its historical ordinary call.
+struct LegacyEffectDispatchCpsPattern;
+
+impl RewritePattern for LegacyEffectDispatchCpsPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(dispatch_op) = effect::LegacyDispatchCps::from_op(ctx, op) else {
+            return false;
+        };
+        let result_types = ctx.op_result_types(op).to_vec();
+        let [result_ty] = result_types.as_slice() else {
+            return false;
+        };
+        let loc = ctx.op(op).location;
+        let ability_ref = dispatch_op.ability_ref(ctx);
+        let (dispatch, prompt) = insert_legacy_dispatch_closure_and_prompt(
+            ctx,
+            loc,
+            dispatch_op.evidence(ctx),
+            ability_ref,
+            rewriter,
+        );
+        let (table_idx, env) = insert_closure_parts(ctx, loc, dispatch, rewriter);
+        let op_idx = insert_op_idx_const(ctx, loc, ability_ref, dispatch_op.op_name(ctx), rewriter);
+        let call = wasm_dialect::call_indirect(
+            ctx,
+            loc,
+            [
+                table_idx,
+                dispatch_op.evidence(ctx),
+                env,
+                dispatch_op.continuation(ctx),
+                prompt,
+                op_idx,
+                dispatch_op.payload(ctx),
+            ],
+            [*result_ty],
+            0,
+            0,
+        );
+        let result = call.results(ctx)[0];
+        rewriter.insert_op(call.op_ref());
+        rewriter.erase_op(vec![result]);
+        true
+    }
+}
+
+fn insert_legacy_dispatch_closure_and_prompt(
+    ctx: &mut IrContext,
+    loc: Location,
+    evidence: ValueRef,
+    ability_ref_ty: TypeRef,
+    rewriter: &mut PatternRewriter<'_>,
+) -> (ValueRef, ValueRef) {
+    let i32_ty = intern_i32(ctx);
+    let marker_ty = ability::marker_adt_type_ref(ctx);
+    let closure_ty = crate::wasm::type_converter::closure_adt_type(ctx);
+    let ability_id =
+        wasm_dialect::i32_const(ctx, loc, i32_ty, compute_ability_id(ctx, ability_ref_ty));
+    let lookup = wasm_dialect::call(
+        ctx,
+        loc,
+        [evidence, ability_id.result(ctx)],
+        [marker_ty],
+        Symbol::new(evidence_abi::LOOKUP),
+    );
+    let marker = lookup.results(ctx)[0];
+    let dispatch = wasm_dialect::struct_get(
+        ctx,
+        loc,
+        marker,
+        closure_ty,
+        MARKER_IDX,
+        MarkerField::HandlerDispatch.index(),
+    );
+    let prompt = wasm_dialect::struct_get(
+        ctx,
+        loc,
+        marker,
+        i32_ty,
+        MARKER_IDX,
+        MarkerField::PromptTag.index(),
+    );
+    rewriter.insert_op(ability_id.op_ref());
+    rewriter.insert_op(lookup.op_ref());
+    rewriter.insert_op(dispatch.op_ref());
+    rewriter.insert_op(prompt.op_ref());
+    (dispatch.result(ctx), prompt.result(ctx))
 }
 
 /// Replace a top-level module operation with a new one.
@@ -348,37 +446,56 @@ impl RewritePattern for EffectDispatchCpsPattern {
         };
 
         let loc = ctx.op(op).location;
-        let result_ty = ctx.op_result_types(op)[0];
+        if !ctx.op_result_types(op).is_empty() {
+            return false;
+        }
         let ability_ref = dispatch_op.ability_ref(ctx);
-        let (dispatch_closure, owner_tag) = insert_dispatch_closure_and_owner(
+        let (table_idx, env) = insert_closure_parts(ctx, loc, dispatch_op.dispatch(ctx), rewriter);
+        let i32_ty = intern_i32(ctx);
+        let ability_id =
+            wasm_dialect::i32_const(ctx, loc, i32_ty, compute_ability_id(ctx, ability_ref));
+        let ability_id_value = ability_id.result(ctx);
+        rewriter.insert_op(ability_id.op_ref());
+        let marker_ty = ability::marker_adt_type_ref(ctx);
+        let marker = wasm_dialect::call(
             ctx,
             loc,
-            dispatch_op.evidence(ctx),
-            ability_ref,
-            rewriter,
+            [dispatch_op.evidence(ctx), ability_id_value],
+            [marker_ty],
+            Symbol::new(evidence_abi::LOOKUP),
         );
-        let (table_idx, env) = insert_closure_parts(ctx, loc, dispatch_closure, rewriter);
+        let prompt = wasm_dialect::struct_get(
+            ctx,
+            loc,
+            marker.results(ctx)[0],
+            i32_ty,
+            MARKER_IDX,
+            MarkerField::PromptTag.index(),
+        );
+        let prompt_value = prompt.result(ctx);
+        rewriter.insert_op(marker.op_ref());
+        rewriter.insert_op(prompt.op_ref());
         let op_idx = insert_op_idx_const(ctx, loc, ability_ref, dispatch_op.op_name(ctx), rewriter);
 
-        let call = wasm_dialect::call_indirect(
+        let tail = wasm_dialect::return_call_indirect(
             ctx,
             loc,
             [
                 table_idx,
                 dispatch_op.evidence(ctx),
                 env,
-                dispatch_op.continuation(ctx),
-                owner_tag,
+                dispatch_op.resume(ctx),
+                prompt_value,
+                ability_id_value,
                 op_idx,
                 dispatch_op.payload(ctx),
             ],
-            [result_ty],
             0,
             0,
         );
-        let call_result = call.results(ctx)[0];
-        rewriter.insert_op(call.op_ref());
-        rewriter.erase_op(vec![call_result]);
+        attach_exact_indirect_signature(ctx, tail.op_ref());
+        set_calling_convention(ctx, tail.op_ref(), CallingConvention::Cps);
+        rewriter.replace_op(tail.op_ref());
         true
     }
 
@@ -387,51 +504,14 @@ impl RewritePattern for EffectDispatchCpsPattern {
     }
 }
 
-/// Extract the general handler closure and its dynamic owner from one selected
-/// Marker. WasmGC keeps both fields in the same immutable Marker struct.
-fn insert_dispatch_closure_and_owner(
-    ctx: &mut IrContext,
-    loc: Location,
-    evidence: ValueRef,
-    ability_ref_ty: TypeRef,
-    rewriter: &mut PatternRewriter<'_>,
-) -> (ValueRef, ValueRef) {
-    let ability_id = compute_ability_id(ctx, ability_ref_ty);
-    let i32_ty = intern_i32(ctx);
-    let marker_ty = ability::marker_adt_type_ref(ctx);
-    let closure_ty = crate::wasm::type_converter::closure_adt_type(ctx);
-
-    let ability_id_const = wasm_dialect::i32_const(ctx, loc, i32_ty, ability_id);
-    let lookup = wasm_dialect::call(
-        ctx,
-        loc,
-        [evidence, ability_id_const.result(ctx)],
-        [marker_ty],
-        Symbol::new(evidence_abi::LOOKUP),
-    );
-    let marker = lookup.results(ctx)[0];
-    let closure_get = wasm_dialect::struct_get(
-        ctx,
-        loc,
-        marker,
-        closure_ty,
-        MARKER_IDX,
-        MarkerField::HandlerDispatch.index(),
-    );
-    let owner_get = wasm_dialect::struct_get(
-        ctx,
-        loc,
-        marker,
-        i32_ty,
-        MARKER_IDX,
-        MarkerField::PromptTag.index(),
-    );
-
-    rewriter.insert_op(ability_id_const.op_ref());
-    rewriter.insert_op(lookup.op_ref());
-    rewriter.insert_op(closure_get.op_ref());
-    rewriter.insert_op(owner_get.op_ref());
-    (closure_get.result(ctx), owner_get.result(ctx))
+fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
+    let parameters = ctx.op_operands(call)[1..]
+        .iter()
+        .map(|&value| ctx.value_ty(value))
+        .collect::<Vec<_>>();
+    let result = core::nil(ctx).as_type_ref();
+    let signature = core::func(ctx, result, parameters).as_type_ref();
+    set_indirect_call_signature(ctx, call, signature);
 }
 
 /// Pattern that matches `ability.evidence_extend` and replaces it with
@@ -1371,78 +1451,63 @@ mod tests {
     fn textual_dispatch_cps_lowers_to_wasm_indirect_call() {
         let output = lower_text(
             r#"core.module @test {
-  func.func @run(%ev: wasm.arrayref, %k: wasm.anyref, %payload: wasm.anyref) -> wasm.anyref {
-    %result = effect.dispatch_cps %ev, %k, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : wasm.anyref
-    func.return %result
+  func.func @run(%ev: wasm.arrayref, %dispatch: wasm.anyref, %resume: wasm.anyref, %payload: wasm.anyref) -> core.never {
+    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
   }
 }"#,
         );
 
         assert!(!output.contains("effect.dispatch_cps"), "{output}");
         assert!(output.contains("__tribute_evidence_lookup"), "{output}");
+        assert!(
+            output.contains("wasm.struct_get %1"),
+            "the Wasm tail must decompose the explicit dispatch operand: {output}"
+        );
+        assert!(
+            !output.contains("core.unrealized_conversion_cast"),
+            "the Wasm tail must not cast the explicit dispatch operand: {output}"
+        );
 
-        fn result_name(line: &str) -> &str {
-            line.split_whitespace()
-                .next()
-                .expect("lowered operation must have an SSA result")
-        }
-        fn struct_operand(line: &str) -> &str {
-            line.split("wasm.struct_get ")
-                .nth(1)
-                .expect("expected wasm.struct_get")
-                .split_whitespace()
-                .next()
-                .expect("wasm.struct_get must have a struct operand")
-        }
-        let handler_field = format!("field_idx = {}", MarkerField::HandlerDispatch.index());
-        let prompt_field = format!("field_idx = {}", MarkerField::PromptTag.index());
-        let handler_get = output
-            .lines()
-            .find(|line| line.contains("wasm.struct_get") && line.contains(&handler_field))
-            .expect("CPS dispatch must extract MarkerField::HandlerDispatch");
-        let marker = struct_operand(handler_get);
-        let handler = result_name(handler_get);
-        let owner_get = output
-            .lines()
-            .find(|line| {
-                line.contains("wasm.struct_get")
-                    && line.contains(&prompt_field)
-                    && struct_operand(line) == marker
-            })
-            .expect("CPS dispatch must extract MarkerField::PromptTag from the same Marker");
-        let owner = result_name(owner_get);
-        let table_get = output
-            .lines()
-            .find(|line| {
-                line.contains("wasm.struct_get")
-                    && struct_operand(line) == handler
-                    && line.contains("field_idx = 0")
-            })
-            .expect("CPS dispatch must unpack the handler closure table index");
-        let table = result_name(table_get);
-        let env_get = output
-            .lines()
-            .find(|line| {
-                line.contains("wasm.struct_get")
-                    && struct_operand(line) == handler
-                    && line.contains("field_idx = 1")
-            })
-            .expect("CPS dispatch must unpack the handler closure environment");
-        let env = result_name(env_get);
-        let indirect = output
-            .lines()
-            .find(|line| line.contains("wasm.call_indirect"))
-            .expect("CPS dispatch must lower to wasm.call_indirect");
+        assert!(output.contains("wasm.return_call_indirect"), "{output}");
         assert!(
-            indirect.contains(&format!(
-                "wasm.call_indirect {table}, %0, {env}, %1, {owner},"
-            )),
-            "CPS indirect call must pass the extracted owner after k:\n{output}"
+            output.contains("tribute.calling_convention = 2"),
+            "{output}"
         );
-        assert!(
-            indirect.contains(", %2 {table ="),
-            "CPS indirect call must retain the source payload as its final argument:\n{output}"
+        assert!(output.contains("func.indirect_call_signature"), "{output}");
+    }
+
+    #[test]
+    fn textual_legacy_dispatch_lowers_to_wasm_indirect_call() {
+        let output = lower_text(
+            r#"core.module @test {
+  func.func @run(%ev: wasm.arrayref, %continuation: wasm.anyref, %payload: wasm.anyref) -> wasm.anyref {
+    %result = effect.legacy_dispatch_cps %ev, %continuation, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : wasm.anyref
+    func.return %result
+  }
+}"#,
         );
+        assert!(!output.contains("effect.legacy_dispatch_cps"), "{output}");
+        assert!(output.contains("wasm.call_indirect"), "{output}");
+        assert!(!output.contains("wasm.return_call_indirect"), "{output}");
+    }
+
+    #[test]
+    fn result_bearing_final_dispatch_remains_unchanged() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run(%ev: wasm.arrayref, %continuation: wasm.anyref, %payload: wasm.anyref) -> wasm.anyref {
+    %result = effect.dispatch_cps %ev, %continuation, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : wasm.anyref
+    func.return %result
+  }
+}"#,
+        );
+        let before = print_module(&ctx, module.op());
+
+        rewrite_evidence_ops_in_scope(&mut ctx, module);
+
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -843,6 +843,7 @@ pub fn is_proper_tail_terminator(ctx: &IrContext, op: OpRef) -> bool {
                 data.name.with_str(|name| name.to_owned()).as_str(),
                 "perform" | "handle_dispatch"
             ))
+        || (data.dialect == Symbol::new("effect") && data.name == Symbol::new("dispatch_cps"))
         || (data.dialect == Symbol::new("scf")
             && matches!(
                 data.name.with_str(|name| name.to_owned()).as_str(),

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -54,7 +54,7 @@ core.module @mixed_nested {
       %7 = adt.struct_new %6, %5 {type = !_closure} : !_closure
       %8 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %9 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
-      %10 = effect.dispatch_cps %0, %9, %8 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %10 = effect.legacy_dispatch_cps %0, %9, %8 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %10
   }
 
@@ -187,7 +187,7 @@ core.module @mixed_nested {
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
       %11 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
       %12 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %13 = effect.dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %13 = effect.legacy_dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
       func.return %13
   }
 

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -49,7 +49,7 @@ core.module @resumptive_op {
       %4 = adt.struct_new %3, %2 {type = !_closure} : !_closure
       %5 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
       %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
-      %7 = effect.dispatch_cps %0, %6, %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
+      %7 = effect.legacy_dispatch_cps %0, %6, %5 {ability_ref = core.ability_ref() {name = @State}, op_name = @get} : tribute_rt.anyref
       func.return %7
   }
 
@@ -132,7 +132,7 @@ core.module @resumptive_op {
       %10 = adt.struct_new %9, %8 {type = !_closure} : !_closure
       %11 = core.unrealized_conversion_cast %7 : tribute_rt.anyref
       %12 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
-      %13 = effect.dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
+      %13 = effect.legacy_dispatch_cps %0, %12, %11 {ability_ref = core.ability_ref() {name = @State}, op_name = @set} : tribute_rt.anyref
       func.return %13
   }
 


### PR DESCRIPTION
Fixes #836.
Fixes #872.

This change carries result-indexed `ContinuationFrame<R>` values through the CPS callable graph so resumed handlers can rebuild the lexical dispatcher across same-ability shadowing and cross-ability nesting.

The final `ability.perform` and `effect.dispatch_cps` forms are resultless and lower to native and Wasm proper indirect tail transfers. The unchanged production carrier route is isolated behind the explicitly named, result-producing `effect.legacy_dispatch_cps`; its native and Wasm consumers remain ordinary indirect calls until #825 migrates production and #826 removes the compatibility path.

Validation:

- `cargo nextest run --workspace` (1,971 passed, 1 skipped)
- focused `tribute-ir`, `tribute-passes`, native, and Wasm lowering suites
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit dispatch and resume handling for ability and effect operations.
  * Added legacy dispatch support for result-producing workflows.
  * Improved continuation handling for nested resumes and prompt-based dispatch.

* **Bug Fixes**
  * Preserved typed call results and dynamic payload values.
  * Added validation for prompt tags and unsupported result-bearing dispatches.
  * Improved native and WebAssembly tail-call dispatch behavior.

* **Tests**
  * Expanded coverage for compatibility, prompt tags, typed results, nested resumes, and backend validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->