### PR TITLE
Preserve local callable metadata after solving

### DIFF
--- a/crates/tribute-front/src/ast/types.rs
+++ b/crates/tribute-front/src/ast/types.rs
@@ -86,6 +86,13 @@ pub enum TypeKind<'db> {
     /// Index 0 refers to the innermost binder, following De Bruijn convention.
     BoundVar { index: u32 },
 
+    /// Type variable quantified by a local `let` binding.
+    ///
+    /// Local binders have no enclosing `TypeScheme`, so their owner must remain
+    /// part of typed-body metadata instead of being confused with a function
+    /// scheme's `BoundVar`.
+    LocalBoundVar { scope: NodeId, index: u32 },
+
     /// Unification variable (unknown during inference).
     ///
     /// These are created during type checking and resolved by unification.
@@ -230,6 +237,7 @@ impl fmt::Display for TypeKind<'_> {
                 write!(f, "#({elems})")
             }
             Self::BoundVar { index } => write!(f, "_{}", index),
+            Self::LocalBoundVar { index, .. } => write!(f, "_local{}", index),
             Self::UniVar { .. } => f.write_str("_"),
             Self::App { ctor, args } => {
                 let args = args

--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -624,7 +624,7 @@ impl<'db> IrLoweringCtx<'db> {
                 // Legacy frontend CPS has no logical bottom representation.
                 self.anyref_type(ir)
             }
-            TypeKind::BoundVar { .. } => {
+            TypeKind::BoundVar { .. } | TypeKind::LocalBoundVar { .. } => {
                 // Quantified type variable in TypeScheme body → type-erased any
                 self.anyref_type(ir)
             }
@@ -660,7 +660,9 @@ impl<'db> IrLoweringCtx<'db> {
             TypeKind::Bytes => self.bytes_type(ir),
             TypeKind::Nil | TypeKind::Error => self.nil_type(ir),
             TypeKind::Never => core::never(ir).as_type_ref(),
-            TypeKind::BoundVar { .. } | TypeKind::UniVar { .. } => self.anyref_type(ir),
+            TypeKind::BoundVar { .. }
+            | TypeKind::LocalBoundVar { .. }
+            | TypeKind::UniVar { .. } => self.anyref_type(ir),
             TypeKind::Named { name, .. }
                 if self.get_type(*name).is_some()
                     || self.logical_nominal_declarations.contains(name) =>
@@ -746,6 +748,9 @@ impl<'db> IrLoweringCtx<'db> {
             TypeKind::Never => "never".into(),
             TypeKind::Error => "error".into(),
             TypeKind::BoundVar { index } => logical_key("bound", [index.to_string()]),
+            TypeKind::LocalBoundVar { scope, index } => {
+                logical_key("local_bound", [scope.raw().to_string(), index.to_string()])
+            }
             TypeKind::UniVar { id } => self.logical_univar_key(*id),
             TypeKind::Named { id, name, args } => {
                 let mut parts = vec![self.logical_nominal_key(*id, *name)];

--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -395,7 +395,10 @@ fn collect_from_type<'db>(
 ) {
     match ty.kind(db) {
         TypeKind::Named { id, args, .. } => {
-            if !args.is_empty() && generic_types.contains(id) {
+            if !args.is_empty()
+                && generic_types.contains(id)
+                && args.iter().all(|arg| is_concrete_type(db, *arg))
+            {
                 result.entry(*id).or_default().insert(args.clone());
             }
             // Recurse into type arguments (e.g., List(Option(Int)) → collect Option(Int))
@@ -559,7 +562,7 @@ impl<'a, 'db> TypeInstantiationVisitor<'a, 'db> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{AbilityId, Effect, EffectRow, EffectVar, TypeParam, TypeScheme};
+    use crate::ast::{AbilityId, Effect, EffectRow, EffectVar, NodeId, TypeParam, TypeScheme};
     use trunk_ir::Symbol;
 
     use super::*;
@@ -859,7 +862,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_collect_type_from_named() {
+    fn test_collect_type_retains_concrete_specialization() {
         let db = TestDb::default();
         let int = Type::new(&db, TypeKind::Int);
         let option_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option"));
@@ -881,6 +884,87 @@ mod tests {
         assert_eq!(result.len(), 1);
         let option_insts = result.get(&option_id).unwrap();
         assert!(option_insts.contains(&vec![int]));
+    }
+
+    #[test]
+    fn test_collect_type_skips_bound_var_specialization() {
+        let db = TestDb::default();
+        let option_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option"));
+        let option_bound = Type::new(
+            &db,
+            TypeKind::Named {
+                id: option_id,
+                name: trunk_ir::Symbol::new("Option"),
+                args: vec![Type::new(&db, TypeKind::BoundVar { index: 0 })],
+            },
+        );
+
+        let mut generic_types = HashSet::new();
+        generic_types.insert(option_id);
+
+        let mut result = HashMap::new();
+        collect_from_type(&db, option_bound, &generic_types, &mut result);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_collect_type_skips_local_bound_var_specialization() {
+        let db = TestDb::default();
+        let option_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option"));
+        let option_bound = Type::new(
+            &db,
+            TypeKind::Named {
+                id: option_id,
+                name: trunk_ir::Symbol::new("Option"),
+                args: vec![Type::new(
+                    &db,
+                    TypeKind::LocalBoundVar {
+                        scope: NodeId::from_raw(0),
+                        index: 0,
+                    },
+                )],
+            },
+        );
+
+        let mut generic_types = HashSet::new();
+        generic_types.insert(option_id);
+
+        let mut result = HashMap::new();
+        collect_from_type(&db, option_bound, &generic_types, &mut result);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_collect_type_retains_concrete_child_below_skipped_parent() {
+        let db = TestDb::default();
+        let result_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Result"));
+        let option_id = crate::ast::TypeDefId::synthetic(&db, trunk_ir::Symbol::new("Option"));
+        let int = Type::new(&db, TypeKind::Int);
+        let option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                id: option_id,
+                name: trunk_ir::Symbol::new("Option"),
+                args: vec![int],
+            },
+        );
+        let result_bound_option_int = Type::new(
+            &db,
+            TypeKind::Named {
+                id: result_id,
+                name: trunk_ir::Symbol::new("Result"),
+                args: vec![Type::new(&db, TypeKind::BoundVar { index: 0 }), option_int],
+            },
+        );
+
+        let generic_types = HashSet::from([result_id, option_id]);
+        let mut result = HashMap::new();
+        collect_from_type(&db, result_bound_option_int, &generic_types, &mut result);
+
+        assert!(!result.contains_key(&result_id));
+        assert_eq!(result[&option_id], HashSet::from([vec![int]]));
     }
 
     #[test]

--- a/crates/tribute-front/src/monomorphize/collect.rs
+++ b/crates/tribute-front/src/monomorphize/collect.rs
@@ -297,6 +297,7 @@ fn is_concrete_type(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
         | TypeKind::Nil
         | TypeKind::Never => true,
         TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
         | TypeKind::UniVar { .. }
         | TypeKind::App { .. }
         | TypeKind::Error => false,

--- a/crates/tribute-front/src/monomorphize/mangle.rs
+++ b/crates/tribute-front/src/monomorphize/mangle.rs
@@ -79,6 +79,10 @@ fn write_type_mangled(
             f.write_str("$1")
         }
         TypeKind::BoundVar { index } => write!(f, "T{index}"),
+        // Local binders are source-body metadata. Monomorphization retains the
+        // existing uniform representation boundary, where both kinds of
+        // quantified variables use their index only.
+        TypeKind::LocalBoundVar { index, .. } => write!(f, "T{index}"),
         TypeKind::UniVar { .. } | TypeKind::App { .. } | TypeKind::Continuation { .. } => {
             panic!("mangle_name requires fully-resolved concrete types");
         }

--- a/crates/tribute-front/src/monomorphize/rewrite.rs
+++ b/crates/tribute-front/src/monomorphize/rewrite.rs
@@ -416,6 +416,7 @@ pub fn rewrite_type<'db>(
         | TypeKind::Nil
         | TypeKind::Never
         | TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
         | TypeKind::UniVar { .. }
         | TypeKind::Error => ty,
     }

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -707,6 +707,33 @@ impl<'db> TypeChecker<'db> {
                     self.infer_call_with_ctx(ctx, ctor_ty, &arg_types, expr.id)
                 }
             }
+            ExprKind::Record {
+                type_name,
+                fields,
+                spread,
+            } => {
+                let ctor_ty = self.infer_var_with_ctx(ctx, type_name);
+                let struct_ty = if let TypeKind::Func { result, .. } = ctor_ty.kind(self.db()) {
+                    *result
+                } else {
+                    ctor_ty
+                };
+
+                for (field_name, field_expr) in fields {
+                    let field_ty = self.infer_expr_type_with_ctx(ctx, field_expr);
+                    if let Some(expected_field_ty) =
+                        self.lookup_struct_field_type(ctx, struct_ty, *field_name)
+                    {
+                        ctx.constrain_eq(field_ty, expected_field_ty);
+                    }
+                }
+                if let Some(spread_expr) = spread {
+                    let spread_ty = self.infer_expr_type_with_ctx(ctx, spread_expr);
+                    ctx.constrain_eq(spread_ty, struct_ty);
+                }
+
+                struct_ty
+            }
             ExprKind::Block { stmts, value } => {
                 ctx.push_scope();
                 for stmt in stmts {

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -112,6 +112,9 @@ impl<'db> TypeChecker<'db> {
             ExprKind::Nil => ctx.nil_type(),
             ExprKind::RuneLit(_) => ctx.rune_type(),
 
+            ExprKind::Var(resolved @ ResolvedRef::Local { .. }) => {
+                self.infer_local_reference_with_ctx(ctx, expr.id, resolved)
+            }
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
@@ -639,6 +642,9 @@ impl<'db> TypeChecker<'db> {
             ExprKind::BytesLit(_) => ctx.bytes_type(),
             ExprKind::Nil => ctx.nil_type(),
             ExprKind::RuneLit(_) => ctx.rune_type(),
+            ExprKind::Var(resolved @ ResolvedRef::Local { .. }) => {
+                self.infer_local_reference_with_ctx(ctx, expr.id, resolved)
+            }
             ExprKind::Var(resolved) => self.infer_var_with_ctx(ctx, resolved),
             ExprKind::Call { callee, args } => {
                 let callee_ty = self.infer_expr_type_with_ctx(ctx, callee);
@@ -821,8 +827,9 @@ impl<'db> TypeChecker<'db> {
                 } else {
                     ctx.lookup_local(*id)
                 };
-                let by_name = ctx.lookup_local_by_name(*name);
-                by_id.or(by_name).unwrap_or_else(|| ctx.fresh_type_var())
+                by_id
+                    .or_else(|| ctx.lookup_local_by_name(*name))
+                    .unwrap_or_else(|| ctx.fresh_type_var())
             }
             ResolvedRef::Function { id } => ctx
                 .instantiate_function(*id)
@@ -896,6 +903,19 @@ impl<'db> TypeChecker<'db> {
                 ctx.error_type()
             }
         }
+    }
+
+    fn infer_local_reference_with_ctx(
+        &self,
+        ctx: &mut FunctionInferenceContext<'_, 'db>,
+        node: NodeId,
+        resolved: &ResolvedRef<'db>,
+    ) -> Type<'db> {
+        let ResolvedRef::Local { id, name } = resolved else {
+            unreachable!("local-reference inference requires a local reference");
+        };
+        ctx.lookup_local_reference(node, *id, *name)
+            .unwrap_or_else(|| ctx.fresh_type_var())
     }
 
     /// Infer the result type of a function call.
@@ -1340,13 +1360,21 @@ impl<'db> TypeChecker<'db> {
                 // Bind lambda parameters so that references to them in the body
                 // resolve to their concrete types (not fresh UniVars). Without this,
                 // TDNR cannot determine receiver types for method calls inside lambdas.
-                let param_types: Vec<Type<'db>> = params
-                    .iter()
-                    .map(|p| match &p.ty {
-                        Some(ann) => self.annotation_to_type_with_ctx(ctx, ann),
-                        None => ctx.fresh_type_var(),
+                let param_types = ctx
+                    .get_node_type(expr_id)
+                    .and_then(|ty| match ty.kind(self.db()) {
+                        TypeKind::Func { params, .. } => Some(params.clone()),
+                        _ => None,
                     })
-                    .collect();
+                    .unwrap_or_else(|| {
+                        params
+                            .iter()
+                            .map(|p| match &p.ty {
+                                Some(ann) => self.annotation_to_type_with_ctx(ctx, ann),
+                                None => ctx.fresh_type_var(),
+                            })
+                            .collect()
+                    });
                 ctx.push_scope();
                 for (param, ty) in params.iter().zip(param_types.iter()) {
                     tracing::debug!(
@@ -1418,9 +1446,16 @@ impl<'db> TypeChecker<'db> {
         node_id: Option<crate::ast::NodeId>,
         resolved: ResolvedRef<'db>,
     ) -> TypedRef<'db> {
-        let ty = node_id
-            .and_then(|node| ctx.get_call_callee_type(node))
-            .unwrap_or_else(|| self.infer_var_with_ctx(ctx, &resolved));
+        let ty = match (node_id, &resolved) {
+            (Some(node), ResolvedRef::Local { id, name }) => ctx
+                .lookup_local_reference(node, *id, *name)
+                .unwrap_or_else(|| ctx.fresh_type_var()),
+            (Some(node), _) => ctx
+                .get_call_callee_type(node)
+                .or_else(|| ctx.get_node_type(node))
+                .unwrap_or_else(|| self.infer_var_with_ctx(ctx, &resolved)),
+            (None, _) => self.infer_var_with_ctx(ctx, &resolved),
+        };
         TypedRef { resolved, ty }
     }
 

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -192,36 +192,7 @@ impl<'db> TypeChecker<'db> {
                 type_name,
                 fields,
                 spread,
-            } => {
-                // Get the struct constructor type and extract return type
-                let ctor_ty = self.infer_var_with_ctx(ctx, type_name);
-                let struct_ty = if let TypeKind::Func { result, .. } = ctor_ty.kind(self.db()) {
-                    // Constructor has function type: fn(fields...) -> StructType
-                    *result
-                } else {
-                    // Fallback: use constructor type directly (shouldn't happen)
-                    ctor_ty
-                };
-
-                // Validate each field expression against the declared field type
-                for (field_name, field_expr) in fields {
-                    let expr_ty = self.infer_expr_type_with_ctx(ctx, field_expr);
-                    if let Some(expected_field_ty) =
-                        self.lookup_struct_field_type(ctx, struct_ty, *field_name)
-                    {
-                        ctx.constrain_eq(expr_ty, expected_field_ty);
-                    }
-                    // If field not found, we'll let later phases handle the error
-                }
-
-                // Validate spread expression if present
-                if let Some(spread_expr) = spread {
-                    let spread_ty = self.infer_expr_type_with_ctx(ctx, spread_expr);
-                    ctx.constrain_eq(spread_ty, struct_ty);
-                }
-
-                struct_ty
-            }
+            } => self.infer_record_type_with_ctx(ctx, type_name, fields, spread.as_ref()),
             ExprKind::MethodCall {
                 receiver,
                 method,
@@ -719,29 +690,7 @@ impl<'db> TypeChecker<'db> {
                 type_name,
                 fields,
                 spread,
-            } => {
-                let ctor_ty = self.infer_var_with_ctx(ctx, type_name);
-                let struct_ty = if let TypeKind::Func { result, .. } = ctor_ty.kind(self.db()) {
-                    *result
-                } else {
-                    ctor_ty
-                };
-
-                for (field_name, field_expr) in fields {
-                    let field_ty = self.infer_expr_type_with_ctx(ctx, field_expr);
-                    if let Some(expected_field_ty) =
-                        self.lookup_struct_field_type(ctx, struct_ty, *field_name)
-                    {
-                        ctx.constrain_eq(field_ty, expected_field_ty);
-                    }
-                }
-                if let Some(spread_expr) = spread {
-                    let spread_ty = self.infer_expr_type_with_ctx(ctx, spread_expr);
-                    ctx.constrain_eq(spread_ty, struct_ty);
-                }
-
-                struct_ty
-            }
+            } => self.infer_record_type_with_ctx(ctx, type_name, fields, spread.as_ref()),
             ExprKind::Block { stmts, value } => {
                 ctx.push_scope();
                 for stmt in stmts {
@@ -846,6 +795,37 @@ impl<'db> TypeChecker<'db> {
             }
             _ => ctx.fresh_type_var(),
         }
+    }
+
+    /// Infer a record literal's nominal type and constrain its fields and spread.
+    fn infer_record_type_with_ctx(
+        &self,
+        ctx: &mut FunctionInferenceContext<'_, 'db>,
+        type_name: &ResolvedRef<'db>,
+        fields: &[(Symbol, Expr<ResolvedRef<'db>>)],
+        spread: Option<&Expr<ResolvedRef<'db>>>,
+    ) -> Type<'db> {
+        let ctor_ty = self.infer_var_with_ctx(ctx, type_name);
+        let struct_ty = if let TypeKind::Func { result, .. } = ctor_ty.kind(self.db()) {
+            *result
+        } else {
+            ctor_ty
+        };
+
+        for (field_name, field_expr) in fields {
+            let field_ty = self.infer_expr_type_with_ctx(ctx, field_expr);
+            if let Some(expected_field_ty) =
+                self.lookup_struct_field_type(ctx, struct_ty, *field_name)
+            {
+                ctx.constrain_eq(field_ty, expected_field_ty);
+            }
+        }
+        if let Some(spread_expr) = spread {
+            let spread_ty = self.infer_expr_type_with_ctx(ctx, spread_expr);
+            ctx.constrain_eq(spread_ty, struct_ty);
+        }
+
+        struct_ty
     }
 
     /// Infer the type of a variable reference.

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -32,6 +32,14 @@ struct HandlerOperationRequest<'a, 'db> {
     handle_ctx: &'a super::super::func_context::HandleContext<'db>,
 }
 
+/// One local introduced by a pattern, together with its resolved binding type.
+struct PatternBinding<'db> {
+    name: Symbol,
+    local_id: Option<LocalId>,
+    scope: NodeId,
+    ty: Type<'db>,
+}
+
 /// Check if a type contains any unification variables (UniVar).
 ///
 /// This is used to determine if it's safe to use Mode::Check with the type.
@@ -1638,23 +1646,29 @@ impl<'db> TypeChecker<'db> {
             &mut bindings,
         );
 
-        for (name, local_id, binding_scope, binding_ty) in bindings {
+        for PatternBinding {
+            name,
+            local_id,
+            scope,
+            ty,
+        } in bindings
+        {
             let scheme = if should_generalize {
                 let (generalized, type_params, mapping) = type_subst
                     .generalize_excluding_with_mapping(
                         self.db(),
-                        binding_ty,
+                        ty,
                         &row_subst,
                         &environment_type_vars,
                     );
-                ctx.record_local_generalization(binding_scope, mapping);
+                ctx.record_local_generalization(scope, mapping);
                 let effect_params: Vec<_> = collect_effect_vars(self.db(), generalized)
                     .into_iter()
                     .filter(|var| !environment_effect_vars.contains(var))
                     .collect();
                 TypeScheme::new(self.db(), type_params, effect_params, generalized)
             } else {
-                TypeScheme::mono(self.db(), binding_ty)
+                TypeScheme::mono(self.db(), ty)
             };
             if let Some(local_id) = local_id {
                 ctx.bind_local_scheme(local_id, scheme);
@@ -1670,12 +1684,17 @@ impl<'db> TypeChecker<'db> {
         ty: Type<'db>,
         type_subst: &TypeSubst<'db>,
         row_subst: &RowSubst<'db>,
-        bindings: &mut Vec<(Symbol, Option<LocalId>, NodeId, Type<'db>)>,
+        bindings: &mut Vec<PatternBinding<'db>>,
     ) {
         let resolve = |ty| type_subst.apply_with_rows(self.db(), ty, row_subst);
         match &*pattern.kind {
             PatternKind::Bind { name, local_id } => {
-                bindings.push((*name, *local_id, pattern.id, resolve(ty)));
+                bindings.push(PatternBinding {
+                    name: *name,
+                    local_id: *local_id,
+                    scope: pattern.id,
+                    ty: resolve(ty),
+                });
             }
             PatternKind::Tuple(patterns)
             | PatternKind::Variant {
@@ -1707,7 +1726,12 @@ impl<'db> TypeChecker<'db> {
                             ctx, pattern, field_ty, type_subst, row_subst, bindings,
                         );
                     } else {
-                        bindings.push((field.name, None, field.id, field_ty));
+                        bindings.push(PatternBinding {
+                            name: field.name,
+                            local_id: None,
+                            scope: field.id,
+                            ty: field_ty,
+                        });
                     }
                 }
             }
@@ -1726,7 +1750,12 @@ impl<'db> TypeChecker<'db> {
                     );
                 }
                 if let Some(name) = rest {
-                    bindings.push((*name, *rest_local_id, pattern.id, resolve(ty)));
+                    bindings.push(PatternBinding {
+                        name: *name,
+                        local_id: *rest_local_id,
+                        scope: pattern.id,
+                        ty: resolve(ty),
+                    });
                 }
             }
             PatternKind::As {
@@ -1735,7 +1764,12 @@ impl<'db> TypeChecker<'db> {
                 local_id,
             } => {
                 let resolved_ty = resolve(ty);
-                bindings.push((*name, *local_id, pattern.id, resolved_ty));
+                bindings.push(PatternBinding {
+                    name: *name,
+                    local_id: *local_id,
+                    scope: pattern.id,
+                    ty: resolved_ty,
+                });
                 self.collect_pattern_bindings_with_ctx(
                     ctx,
                     pattern,

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -73,6 +73,7 @@ fn type_contains_univar<'db>(db: &'db dyn salsa::Database, ty: Type<'db>) -> boo
         | TypeKind::Nil
         | TypeKind::Never
         | TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
         | TypeKind::Error => false,
     }
 }
@@ -1575,14 +1576,16 @@ impl<'db> TypeChecker<'db> {
             &mut bindings,
         );
 
-        for (name, local_id, binding_ty) in bindings {
+        for (name, local_id, binding_scope, binding_ty) in bindings {
             let scheme = if should_generalize {
-                let (generalized, type_params) = type_subst.generalize_excluding(
-                    self.db(),
-                    binding_ty,
-                    &row_subst,
-                    &environment_type_vars,
-                );
+                let (generalized, type_params, mapping) = type_subst
+                    .generalize_excluding_with_mapping(
+                        self.db(),
+                        binding_ty,
+                        &row_subst,
+                        &environment_type_vars,
+                    );
+                ctx.record_local_generalization(binding_scope, mapping);
                 let effect_params: Vec<_> = collect_effect_vars(self.db(), generalized)
                     .into_iter()
                     .filter(|var| !environment_effect_vars.contains(var))
@@ -1605,12 +1608,12 @@ impl<'db> TypeChecker<'db> {
         ty: Type<'db>,
         type_subst: &TypeSubst<'db>,
         row_subst: &RowSubst<'db>,
-        bindings: &mut Vec<(Symbol, Option<LocalId>, Type<'db>)>,
+        bindings: &mut Vec<(Symbol, Option<LocalId>, NodeId, Type<'db>)>,
     ) {
         let resolve = |ty| type_subst.apply_with_rows(self.db(), ty, row_subst);
         match &*pattern.kind {
             PatternKind::Bind { name, local_id } => {
-                bindings.push((*name, *local_id, resolve(ty)));
+                bindings.push((*name, *local_id, pattern.id, resolve(ty)));
             }
             PatternKind::Tuple(patterns)
             | PatternKind::Variant {
@@ -1642,7 +1645,7 @@ impl<'db> TypeChecker<'db> {
                             ctx, pattern, field_ty, type_subst, row_subst, bindings,
                         );
                     } else {
-                        bindings.push((field.name, None, field_ty));
+                        bindings.push((field.name, None, field.id, field_ty));
                     }
                 }
             }
@@ -1661,7 +1664,7 @@ impl<'db> TypeChecker<'db> {
                     );
                 }
                 if let Some(name) = rest {
-                    bindings.push((*name, *rest_local_id, resolve(ty)));
+                    bindings.push((*name, *rest_local_id, pattern.id, resolve(ty)));
                 }
             }
             PatternKind::As {
@@ -1670,7 +1673,7 @@ impl<'db> TypeChecker<'db> {
                 local_id,
             } => {
                 let resolved_ty = resolve(ty);
-                bindings.push((*name, *local_id, resolved_ty));
+                bindings.push((*name, *local_id, pattern.id, resolved_ty));
                 self.collect_pattern_bindings_with_ctx(
                     ctx,
                     pattern,

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -132,6 +132,7 @@ impl<'db> TypeChecker<'db> {
         let func_handler_operations = ctx.take_handler_operations();
         let func_perform_operations = ctx.take_perform_operations();
         let func_lambda_signatures = ctx.take_lambda_signatures();
+        let local_generalizations = ctx.take_local_generalizations();
         let func_exhaustive_cases = ctx.take_exhaustive_cases();
         // Save the accumulated effect row from the body before dropping ctx
         let body_effect_row = ctx.current_effect();
@@ -139,6 +140,7 @@ impl<'db> TypeChecker<'db> {
         let deferred_methods = ctx.take_deferred_methods();
         // Drop ctx now to release the borrow of self.env
         drop(ctx);
+        self.local_generalizations = local_generalizations;
 
         let mut solver = TypeSolver::new(self.db());
 
@@ -161,9 +163,10 @@ impl<'db> TypeChecker<'db> {
         let type_subst = solver.type_subst();
         let row_subst = solver.row_subst();
 
-        // First, collect ALL unresolved UniVars from the function type, body, and deferred
-        // method callee types. This ensures that UniVars created during body type checking
-        // or post-solve deferred method resolution are included in the generalization mapping.
+        // Keep the established body conversion mapping for non-local
+        // inference artifacts. Local generalizations are selected first when
+        // materializing types, so they cannot become phantom function scheme
+        // parameters.
         let mut all_univars = Vec::new();
         type_subst.collect_univars_from_type(
             self.db(),
@@ -178,12 +181,10 @@ impl<'db> TypeChecker<'db> {
             row_subst,
             &mut all_univars,
         );
-
-        // Create a comprehensive mapping from all UniVars to BoundVars
         let var_to_index: HashMap<UniVarId<'db>, u32> = all_univars
             .into_iter()
             .enumerate()
-            .map(|(i, id)| (id, i as u32))
+            .map(|(index, id)| (id, index as u32))
             .collect();
 
         // Only the exact root `main` is an entrypoint. Its omitted effect
@@ -237,6 +238,20 @@ impl<'db> TypeChecker<'db> {
 
         // Apply substitution and generalization to the function type.
         let substituted_ty = type_subst.apply_with_rows(self.db(), inferred_func_ty, row_subst);
+
+        // Solver aliases can point at a representative created after a local
+        // scheme was generalized. Preserve both spellings before finalizing
+        // typed references and callable metadata.
+        for (var, binding) in self.local_generalizations.clone() {
+            let resolved = type_subst.apply_with_rows(
+                self.db(),
+                Type::new(self.db(), TypeKind::UniVar { id: var }),
+                row_subst,
+            );
+            if let TypeKind::UniVar { id } = resolved.kind(self.db()) {
+                self.local_generalizations.entry(*id).or_insert(binding);
+            }
+        }
 
         // Validate that root `main` returns Nil.
         if is_root_main
@@ -362,7 +377,7 @@ impl<'db> TypeChecker<'db> {
         // These entries describe concrete expression storage for lowering; the
         // source-logical operation metadata is carried separately on TypedRef.
         for (node_id, ty) in func_node_types {
-            let substituted = type_subst.apply_with_rows(self.db(), ty, row_subst);
+            let substituted = self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index);
             self.node_types.insert(node_id, substituted);
         }
         for (callee_id, ty) in func_call_callee_types {
@@ -377,15 +392,24 @@ impl<'db> TypeChecker<'db> {
                     ability_args: operation
                         .ability_args
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
                     kind: operation.kind,
                     params: operation
                         .params
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
-                    result: type_subst.apply_with_rows(self.db(), operation.result, row_subst),
+                    result: self.apply_subst_to_type(
+                        operation.result,
+                        type_subst,
+                        row_subst,
+                        &var_to_index,
+                    ),
                 },
             );
         }
@@ -397,15 +421,24 @@ impl<'db> TypeChecker<'db> {
                     ability_args: operation
                         .ability_args
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
                     kind: operation.kind,
                     params: operation
                         .params
                         .into_iter()
-                        .map(|ty| type_subst.apply_with_rows(self.db(), ty, row_subst))
+                        .map(|ty| {
+                            self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index)
+                        })
                         .collect(),
-                    result: type_subst.apply_with_rows(self.db(), operation.result, row_subst),
+                    result: self.apply_subst_to_type(
+                        operation.result,
+                        type_subst,
+                        row_subst,
+                        &var_to_index,
+                    ),
                 },
             );
         }
@@ -415,8 +448,12 @@ impl<'db> TypeChecker<'db> {
             .into_iter()
             .collect::<HashMap<_, _>>();
         for (lambda_id, signature) in func_lambda_signatures {
-            let function_type =
-                type_subst.apply_with_rows(self.db(), signature.function_type, row_subst);
+            let function_type = self.apply_subst_to_type(
+                signature.function_type,
+                type_subst,
+                row_subst,
+                &var_to_index,
+            );
             let convention = crate::ast::calling_convention_for_function_type(
                 self.db(),
                 function_type,
@@ -938,7 +975,13 @@ impl<'db> TypeChecker<'db> {
         // First apply the substitution to resolve UniVars
         let substituted = type_subst.apply_with_rows(self.db(), ty, row_subst);
         // Then apply the generalization mapping to convert remaining UniVars to BoundVars
-        type_subst.apply_generalization(self.db(), substituted, row_subst, var_to_index)
+        type_subst.apply_generalization_with_local_vars(
+            self.db(),
+            substituted,
+            row_subst,
+            var_to_index,
+            &self.local_generalizations,
+        )
     }
 
     /// Apply substitution to a statement.

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -163,30 +163,6 @@ impl<'db> TypeChecker<'db> {
         let type_subst = solver.type_subst();
         let row_subst = solver.row_subst();
 
-        // Keep the established body conversion mapping for non-local
-        // inference artifacts. Local generalizations are selected first when
-        // materializing types, so they cannot become phantom function scheme
-        // parameters.
-        let mut all_univars = Vec::new();
-        type_subst.collect_univars_from_type(
-            self.db(),
-            instantiated_func_ty,
-            row_subst,
-            &mut all_univars,
-        );
-        self.collect_univars_from_body(&body, type_subst, row_subst, &mut all_univars);
-        self.collect_univars_from_deferred_resolutions(
-            &deferred_resolutions,
-            type_subst,
-            row_subst,
-            &mut all_univars,
-        );
-        let var_to_index: HashMap<UniVarId<'db>, u32> = all_univars
-            .into_iter()
-            .enumerate()
-            .map(|(index, id)| (id, index as u32))
-            .collect();
-
         // Only the exact root `main` is an entrypoint. Its omitted effect
         // annotation is closed over the effects actually performed by its body:
         // pure roots remain Direct and ambient-Io roots EvidenceDirect.  The
@@ -236,12 +212,9 @@ impl<'db> TypeChecker<'db> {
             instantiated_func_ty
         };
 
-        // Apply substitution and generalization to the function type.
-        let substituted_ty = type_subst.apply_with_rows(self.db(), inferred_func_ty, row_subst);
-
         // Solver aliases can point at a representative created after a local
-        // scheme was generalized. Preserve both spellings before finalizing
-        // typed references and callable metadata.
+        // scheme was generalized. Preserve both spellings before collecting
+        // body and deferred metadata variables for finalization.
         for (var, binding) in self.local_generalizations.clone() {
             let resolved = type_subst.apply_with_rows(
                 self.db(),
@@ -252,6 +225,33 @@ impl<'db> TypeChecker<'db> {
                 self.local_generalizations.entry(*id).or_insert(binding);
             }
         }
+
+        // Preserve the established whole-body and deferred-resolution mapping
+        // for non-local inference artifacts. Locally generalized variables are
+        // excluded below so they cannot become phantom function binders.
+        let mut all_univars = Vec::new();
+        type_subst.collect_univars_from_type(
+            self.db(),
+            instantiated_func_ty,
+            row_subst,
+            &mut all_univars,
+        );
+        self.collect_univars_from_body(&body, type_subst, row_subst, &mut all_univars);
+        self.collect_univars_from_deferred_resolutions(
+            &deferred_resolutions,
+            type_subst,
+            row_subst,
+            &mut all_univars,
+        );
+        all_univars.retain(|id| !self.local_generalizations.contains_key(id));
+        let var_to_index: HashMap<UniVarId<'db>, u32> = all_univars
+            .into_iter()
+            .enumerate()
+            .map(|(index, id)| (id, index as u32))
+            .collect();
+
+        // Apply substitution and generalization to the function type.
+        let substituted_ty = type_subst.apply_with_rows(self.db(), inferred_func_ty, row_subst);
 
         // Validate that root `main` returns Nil.
         if is_root_main

--- a/crates/tribute-front/src/typeck/checker/mod.rs
+++ b/crates/tribute-front/src/typeck/checker/mod.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use trunk_ir::{Span, Symbol};
 
 use crate::ast::{
-    Decl, FuncDefId, Module, NodeId, ResolvedRef, SpanMap, Type, TypeScheme, TypedRef,
+    Decl, FuncDefId, Module, NodeId, ResolvedRef, SpanMap, Type, TypeScheme, TypedRef, UniVarId,
 };
 
 use super::context::ModuleTypeEnv;
@@ -100,6 +100,9 @@ pub struct TypeChecker<'db> {
     handler_operations: HashMap<NodeId, crate::typeck::InstantiatedHandlerOperation<'db>>,
     perform_operations: HashMap<NodeId, crate::typeck::InstantiatedPerformOperation<'db>>,
     lambda_signatures: HashMap<NodeId, crate::typeck::LambdaSignature<'db>>,
+    /// Quantifiers owned by generalized local schemes in the function currently
+    /// being finalized. They remain separate from exported function schemes.
+    local_generalizations: HashMap<UniVarId<'db>, (NodeId, u32)>,
     exhaustive_cases: Vec<NodeId>,
     /// Source origins for concrete effects in each collected function signature.
     effect_annotation_origins: HashMap<FuncDefId<'db>, crate::ast::EffectAnnotationOrigins>,
@@ -138,6 +141,7 @@ impl<'db> TypeChecker<'db> {
             handler_operations: HashMap::new(),
             perform_operations: HashMap::new(),
             lambda_signatures: HashMap::new(),
+            local_generalizations: HashMap::new(),
             exhaustive_cases: Vec::new(),
             effect_annotation_origins: HashMap::new(),
         }

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -71,6 +71,11 @@ pub struct FunctionInferenceContext<'a, 'db> {
     /// Types of AST nodes (for TypedRef construction).
     node_types: HashMap<NodeId, Type<'db>>,
 
+    /// Function-local quantifiers introduced by pure `let` generalization.
+    /// These are distinct from the enclosing function scheme's binders when
+    /// the solved typed body and callable metadata are materialized.
+    local_generalizations: HashMap<UniVarId<'db>, (NodeId, u32)>,
+
     /// The solved function type selected for each direct call callee.
     call_callee_types: HashMap<NodeId, Type<'db>>,
 
@@ -161,6 +166,7 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             local_scopes: vec![HashMap::new()],
             name_scopes: vec![HashMap::new()],
             node_types: HashMap::new(),
+            local_generalizations: HashMap::new(),
             call_callee_types: HashMap::new(),
             handler_operations: HashMap::new(),
             perform_operations: HashMap::new(),
@@ -351,6 +357,23 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     /// Used for collecting all node types after type checking a function.
     pub fn take_node_types(&mut self) -> HashMap<NodeId, Type<'db>> {
         std::mem::take(&mut self.node_types)
+    }
+
+    /// Record the quantifier provenance of one generalized local scheme.
+    pub fn record_local_generalization(
+        &mut self,
+        scope: NodeId,
+        mapping: HashMap<UniVarId<'db>, u32>,
+    ) {
+        self.local_generalizations.extend(
+            mapping
+                .into_iter()
+                .map(|(var, index)| (var, (scope, index))),
+        );
+    }
+
+    pub fn take_local_generalizations(&mut self) -> HashMap<UniVarId<'db>, (NodeId, u32)> {
+        std::mem::take(&mut self.local_generalizations)
     }
 
     pub fn record_call_callee_type(&mut self, callee: NodeId, ty: Type<'db>) {

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use trunk_ir::Symbol;
 
 use super::{InstantiatedHandlerOperation, InstantiatedPerformOperation, LambdaSignature};
+
 use crate::ast::{
     CtorId, Effect, EffectRow, EffectVar, FuncDefId, LocalId, NodeId, Type, TypeKind, TypeScheme,
     UniVarId, UniVarSource,
@@ -78,6 +79,11 @@ pub struct FunctionInferenceContext<'a, 'db> {
 
     /// The solved function type selected for each direct call callee.
     call_callee_types: HashMap<NodeId, Type<'db>>,
+
+    /// Inference-time instances for quantified local reference occurrences.
+    /// Conversion reuses only these polymorphic instances; monomorphic locals
+    /// are deliberately looked up again.
+    quantified_local_reference_types: HashMap<NodeId, Type<'db>>,
 
     /// Fully instantiated operation metadata for handler arms.
     handler_operations: HashMap<NodeId, InstantiatedHandlerOperation<'db>>,
@@ -168,6 +174,7 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             node_types: HashMap::new(),
             local_generalizations: HashMap::new(),
             call_callee_types: HashMap::new(),
+            quantified_local_reference_types: HashMap::new(),
             handler_operations: HashMap::new(),
             perform_operations: HashMap::new(),
             ability_op_callee_types: HashMap::new(),
@@ -280,12 +287,15 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     ///
     /// Searches from innermost to outermost scope.
     pub fn lookup_local(&mut self, local: LocalId) -> Option<Type<'db>> {
-        for scope in self.local_scopes.iter().rev() {
-            if let Some(scheme) = scope.get(&local).copied() {
-                return Some(self.instantiate_scheme(scheme));
-            }
-        }
-        None
+        self.local_scheme(local)
+            .map(|scheme| self.instantiate_scheme(scheme))
+    }
+
+    fn local_scheme(&self, local: LocalId) -> Option<TypeScheme<'db>> {
+        self.local_scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.get(&local).copied())
     }
 
     /// Bind a local variable by name in the current scope.
@@ -304,12 +314,15 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     ///
     /// Searches from innermost to outermost scope.
     pub fn lookup_local_by_name(&mut self, name: Symbol) -> Option<Type<'db>> {
-        for scope in self.name_scopes.iter().rev() {
-            if let Some(scheme) = scope.get(&name).copied() {
-                return Some(self.instantiate_scheme(scheme));
-            }
-        }
-        None
+        self.local_scheme_by_name(name)
+            .map(|scheme| self.instantiate_scheme(scheme))
+    }
+
+    fn local_scheme_by_name(&self, name: Symbol) -> Option<TypeScheme<'db>> {
+        self.name_scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.get(&name).copied())
     }
 
     // =========================================================================
@@ -386,6 +399,30 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
 
     pub fn get_call_callee_type(&self, callee: NodeId) -> Option<Type<'db>> {
         self.call_callee_types.get(&callee).copied()
+    }
+
+    pub(crate) fn lookup_local_reference(
+        &mut self,
+        node: NodeId,
+        local: LocalId,
+        name: Symbol,
+    ) -> Option<Type<'db>> {
+        let scheme = if local.is_unresolved() {
+            None
+        } else {
+            self.local_scheme(local)
+        }
+        .or_else(|| self.local_scheme_by_name(name))?;
+        if !scheme.type_params(self.db).is_empty() || !scheme.effect_params(self.db).is_empty() {
+            if let Some(ty) = self.quantified_local_reference_types.get(&node).copied() {
+                return Some(ty);
+            }
+            let ty = self.instantiate_scheme(scheme);
+            self.quantified_local_reference_types.insert(node, ty);
+            Some(ty)
+        } else {
+            Some(self.instantiate_scheme(scheme))
+        }
     }
 
     /// Record the exact semantic operation selected for a handler arm.

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -302,6 +302,20 @@ impl<'db> TypeSubst<'db> {
         row_subst: &RowSubst<'db>,
         excluded: &[UniVarId<'db>],
     ) -> (Type<'db>, Vec<TypeParam>) {
+        let (generalized, type_params, _) =
+            self.generalize_excluding_with_mapping(db, ty, row_subst, excluded);
+        (generalized, type_params)
+    }
+
+    /// Generalize unresolved variables except those free in the environment,
+    /// retaining the variable-to-local-scheme mapping for typed-body metadata.
+    pub fn generalize_excluding_with_mapping(
+        &self,
+        db: &'db dyn salsa::Database,
+        ty: Type<'db>,
+        row_subst: &RowSubst<'db>,
+        excluded: &[UniVarId<'db>],
+    ) -> (Type<'db>, Vec<TypeParam>, HashMap<UniVarId<'db>, u32>) {
         let mut univars = Vec::new();
         self.collect_unresolved_univars(db, ty, row_subst, &mut univars);
         univars.retain(|id| !excluded.contains(id));
@@ -313,7 +327,7 @@ impl<'db> TypeSubst<'db> {
             .collect();
         let generalized = self.replace_univars_with_bound(db, ty, row_subst, &var_to_index);
         let type_params = univars.iter().map(|_| TypeParam::anonymous()).collect();
-        (generalized, type_params)
+        (generalized, type_params, var_to_index)
     }
 
     /// Generalize a type and return the UniVar → BoundVar index mapping.
@@ -362,6 +376,192 @@ impl<'db> TypeSubst<'db> {
         var_to_index: &HashMap<UniVarId<'db>, u32>,
     ) -> Type<'db> {
         self.replace_univars_with_bound(db, ty, row_subst, var_to_index)
+    }
+
+    /// Finalize a typed body or its semantic metadata.
+    ///
+    /// Function-interface variables become `BoundVar`; variables owned by a
+    /// local generalized scheme become `LocalBoundVar`.
+    pub fn apply_generalization_with_local_vars(
+        &self,
+        db: &'db dyn salsa::Database,
+        ty: Type<'db>,
+        row_subst: &RowSubst<'db>,
+        var_to_index: &HashMap<UniVarId<'db>, u32>,
+        local_vars: &HashMap<UniVarId<'db>, (crate::ast::NodeId, u32)>,
+    ) -> Type<'db> {
+        self.replace_univars_with_bound_and_local(db, ty, row_subst, var_to_index, local_vars)
+    }
+
+    fn replace_univars_with_bound_and_local(
+        &self,
+        db: &'db dyn salsa::Database,
+        ty: Type<'db>,
+        row_subst: &RowSubst<'db>,
+        var_to_index: &HashMap<UniVarId<'db>, u32>,
+        local_vars: &HashMap<UniVarId<'db>, (crate::ast::NodeId, u32)>,
+    ) -> Type<'db> {
+        match ty.kind(db) {
+            TypeKind::UniVar { id } => {
+                if let Some(&(scope, index)) = local_vars.get(id) {
+                    Type::new(db, TypeKind::LocalBoundVar { scope, index })
+                } else if let Some(&index) = var_to_index.get(id) {
+                    Type::new(db, TypeKind::BoundVar { index })
+                } else if let Some(subst_ty) = self.get(*id) {
+                    self.replace_univars_with_bound_and_local(
+                        db,
+                        subst_ty,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                    )
+                } else {
+                    ty
+                }
+            }
+            TypeKind::Named { id, name, args } => Type::new(
+                db,
+                TypeKind::Named {
+                    id: *id,
+                    name: *name,
+                    args: args
+                        .iter()
+                        .map(|arg| {
+                            self.replace_univars_with_bound_and_local(
+                                db,
+                                *arg,
+                                row_subst,
+                                var_to_index,
+                                local_vars,
+                            )
+                        })
+                        .collect(),
+                },
+            ),
+            TypeKind::Func {
+                params,
+                result,
+                effect,
+                minimum_convention,
+            } => Type::new(
+                db,
+                TypeKind::Func {
+                    params: params
+                        .iter()
+                        .map(|param| {
+                            self.replace_univars_with_bound_and_local(
+                                db,
+                                *param,
+                                row_subst,
+                                var_to_index,
+                                local_vars,
+                            )
+                        })
+                        .collect(),
+                    result: self.replace_univars_with_bound_and_local(
+                        db,
+                        *result,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                    ),
+                    effect: map_effect_row_type_args(db, row_subst.apply(db, *effect), |arg| {
+                        self.replace_univars_with_bound_and_local(
+                            db,
+                            arg,
+                            row_subst,
+                            var_to_index,
+                            local_vars,
+                        )
+                    }),
+                    minimum_convention: *minimum_convention,
+                },
+            ),
+            TypeKind::Tuple(elements) => Type::new(
+                db,
+                TypeKind::Tuple(
+                    elements
+                        .iter()
+                        .map(|element| {
+                            self.replace_univars_with_bound_and_local(
+                                db,
+                                *element,
+                                row_subst,
+                                var_to_index,
+                                local_vars,
+                            )
+                        })
+                        .collect(),
+                ),
+            ),
+            TypeKind::App { ctor, args } => Type::new(
+                db,
+                TypeKind::App {
+                    ctor: self.replace_univars_with_bound_and_local(
+                        db,
+                        *ctor,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                    ),
+                    args: args
+                        .iter()
+                        .map(|arg| {
+                            self.replace_univars_with_bound_and_local(
+                                db,
+                                *arg,
+                                row_subst,
+                                var_to_index,
+                                local_vars,
+                            )
+                        })
+                        .collect(),
+                },
+            ),
+            TypeKind::Continuation {
+                arg,
+                result,
+                effect,
+            } => Type::new(
+                db,
+                TypeKind::Continuation {
+                    arg: self.replace_univars_with_bound_and_local(
+                        db,
+                        *arg,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                    ),
+                    result: self.replace_univars_with_bound_and_local(
+                        db,
+                        *result,
+                        row_subst,
+                        var_to_index,
+                        local_vars,
+                    ),
+                    effect: map_effect_row_type_args(db, row_subst.apply(db, *effect), |entry| {
+                        self.replace_univars_with_bound_and_local(
+                            db,
+                            entry,
+                            row_subst,
+                            var_to_index,
+                            local_vars,
+                        )
+                    }),
+                },
+            ),
+            TypeKind::BoundVar { .. }
+            | TypeKind::LocalBoundVar { .. }
+            | TypeKind::Int
+            | TypeKind::Nat
+            | TypeKind::Float
+            | TypeKind::Bool
+            | TypeKind::Bytes
+            | TypeKind::Rune
+            | TypeKind::Nil
+            | TypeKind::Never
+            | TypeKind::Error => ty,
+        }
     }
 
     /// Collect unresolved UniVarIds from a type in appearance (left-to-right) order.
@@ -811,7 +1011,10 @@ impl<'db> TypeSolver<'db> {
             }
 
             // BoundVar should never reach the solver — it must be instantiated first
-            (TypeKind::BoundVar { .. }, _) | (_, TypeKind::BoundVar { .. }) => {
+            (TypeKind::BoundVar { .. }, _)
+            | (_, TypeKind::BoundVar { .. })
+            | (TypeKind::LocalBoundVar { .. }, _)
+            | (_, TypeKind::LocalBoundVar { .. }) => {
                 debug_assert!(
                     false,
                     "BoundVar reached solver — should have been instantiated"

--- a/crates/tribute-front/src/typeck/solver.rs
+++ b/crates/tribute-front/src/typeck/solver.rs
@@ -382,7 +382,7 @@ impl<'db> TypeSubst<'db> {
     ///
     /// Function-interface variables become `BoundVar`; variables owned by a
     /// local generalized scheme become `LocalBoundVar`.
-    pub fn apply_generalization_with_local_vars(
+    pub(crate) fn apply_generalization_with_local_vars(
         &self,
         db: &'db dyn salsa::Database,
         ty: Type<'db>,
@@ -659,104 +659,7 @@ impl<'db> TypeSubst<'db> {
         row_subst: &RowSubst<'db>,
         var_to_index: &HashMap<UniVarId<'db>, u32>,
     ) -> Type<'db> {
-        match ty.kind(db) {
-            TypeKind::UniVar { id } => {
-                // Check mapping first: if this UniVar should become a BoundVar,
-                // do so immediately without following the substitution chain.
-                // This is important because when unification binds UniVar(X) -> UniVar(Y),
-                // we want to generalize X (which is in the mapping), not Y (which may not be).
-                if let Some(&index) = var_to_index.get(id) {
-                    Type::new(db, TypeKind::BoundVar { index })
-                } else if let Some(subst_ty) = self.get(*id) {
-                    self.replace_univars_with_bound(db, subst_ty, row_subst, var_to_index)
-                } else {
-                    ty
-                }
-            }
-            TypeKind::Named { id, name, args } => {
-                let new_args: Vec<_> = args
-                    .iter()
-                    .map(|a| self.replace_univars_with_bound(db, *a, row_subst, var_to_index))
-                    .collect();
-                Type::new(
-                    db,
-                    TypeKind::Named {
-                        id: *id,
-                        name: *name,
-                        args: new_args,
-                    },
-                )
-            }
-            TypeKind::Func {
-                params,
-                result,
-                effect,
-                minimum_convention,
-            } => {
-                let new_params: Vec<_> = params
-                    .iter()
-                    .map(|p| self.replace_univars_with_bound(db, *p, row_subst, var_to_index))
-                    .collect();
-                let new_result =
-                    self.replace_univars_with_bound(db, *result, row_subst, var_to_index);
-                let applied_row = row_subst.apply(db, *effect);
-                let new_effect = map_effect_row_type_args(db, applied_row, |a| {
-                    self.replace_univars_with_bound(db, a, row_subst, var_to_index)
-                });
-                Type::new(
-                    db,
-                    TypeKind::Func {
-                        params: new_params,
-                        result: new_result,
-                        effect: new_effect,
-                        minimum_convention: *minimum_convention,
-                    },
-                )
-            }
-            TypeKind::Tuple(elems) => {
-                let new_elems: Vec<_> = elems
-                    .iter()
-                    .map(|e| self.replace_univars_with_bound(db, *e, row_subst, var_to_index))
-                    .collect();
-                Type::new(db, TypeKind::Tuple(new_elems))
-            }
-            TypeKind::App { ctor, args } => {
-                let new_ctor = self.replace_univars_with_bound(db, *ctor, row_subst, var_to_index);
-                let new_args: Vec<_> = args
-                    .iter()
-                    .map(|a| self.replace_univars_with_bound(db, *a, row_subst, var_to_index))
-                    .collect();
-                Type::new(
-                    db,
-                    TypeKind::App {
-                        ctor: new_ctor,
-                        args: new_args,
-                    },
-                )
-            }
-            TypeKind::Continuation {
-                arg,
-                result,
-                effect,
-            } => {
-                let new_arg = self.replace_univars_with_bound(db, *arg, row_subst, var_to_index);
-                let new_result =
-                    self.replace_univars_with_bound(db, *result, row_subst, var_to_index);
-                let applied_row = row_subst.apply(db, *effect);
-                let new_effect = map_effect_row_type_args(db, applied_row, |a| {
-                    self.replace_univars_with_bound(db, a, row_subst, var_to_index)
-                });
-                Type::new(
-                    db,
-                    TypeKind::Continuation {
-                        arg: new_arg,
-                        result: new_result,
-                        effect: new_effect,
-                    },
-                )
-            }
-            _ => ty,
-        }
+        self.replace_univars_with_bound_and_local(db, ty, row_subst, var_to_index, &HashMap::new())
     }
 }
 
@@ -1010,14 +913,14 @@ impl<'db> TypeSolver<'db> {
                 Ok(())
             }
 
-            // BoundVar should never reach the solver — it must be instantiated first
+            // BoundVar and LocalBoundVar should never reach the solver — they must be instantiated first.
             (TypeKind::BoundVar { .. }, _)
             | (_, TypeKind::BoundVar { .. })
             | (TypeKind::LocalBoundVar { .. }, _)
             | (_, TypeKind::LocalBoundVar { .. }) => {
                 debug_assert!(
                     false,
-                    "BoundVar reached solver — should have been instantiated"
+                    "quantified type variable (BoundVar or LocalBoundVar) reached solver — should have been instantiated"
                 );
                 Err(SolveError::TypeMismatch {
                     expected: t1,
@@ -2478,9 +2381,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "BoundVar reached solver")]
+    #[should_panic(
+        expected = "quantified type variable (BoundVar or LocalBoundVar) reached solver"
+    )]
     fn test_bound_var_panics_in_debug() {
-        // BoundVar should never reach the solver — it must be instantiated first.
+        // BoundVar and LocalBoundVar should never reach the solver — they must be instantiated first.
         // In debug mode, this triggers a debug_assert panic.
         let db = test_db();
         let mut solver = TypeSolver::new(&db);

--- a/crates/tribute-front/src/typeck/subst.rs
+++ b/crates/tribute-front/src/typeck/subst.rs
@@ -397,6 +397,7 @@ fn freshen_effect_vars_inner<'db>(
             },
         ),
         TypeKind::BoundVar { .. }
+        | TypeKind::LocalBoundVar { .. }
         | TypeKind::UniVar { .. }
         | TypeKind::Int
         | TypeKind::Nat

--- a/crates/tribute-front/tests/let_generalization.rs
+++ b/crates/tribute-front/tests/let_generalization.rs
@@ -1,6 +1,54 @@
 use salsa_test_macros::salsa_test;
 use tribute_core::{CompilationPhase, Diagnostic, DiagnosticSeverity};
-use tribute_front::SourceCst;
+use tribute_front::{
+    SourceCst,
+    ast::{Type, TypeKind},
+};
+
+fn type_contains_univar(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+    match ty.kind(db) {
+        TypeKind::UniVar { .. } => true,
+        TypeKind::Named { args, .. } => args.iter().any(|arg| type_contains_univar(db, *arg)),
+        TypeKind::Func { params, result, .. } => {
+            params.iter().any(|param| type_contains_univar(db, *param))
+                || type_contains_univar(db, *result)
+        }
+        TypeKind::Tuple(elements) => elements
+            .iter()
+            .any(|element| type_contains_univar(db, *element)),
+        TypeKind::App { ctor, args } => {
+            type_contains_univar(db, *ctor) || args.iter().any(|arg| type_contains_univar(db, *arg))
+        }
+        TypeKind::Continuation { arg, result, .. } => {
+            type_contains_univar(db, *arg) || type_contains_univar(db, *result)
+        }
+        _ => false,
+    }
+}
+
+fn type_contains_local_bound(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+    match ty.kind(db) {
+        TypeKind::LocalBoundVar { .. } => true,
+        TypeKind::Named { args, .. } => args.iter().any(|arg| type_contains_local_bound(db, *arg)),
+        TypeKind::Func { params, result, .. } => {
+            params
+                .iter()
+                .any(|param| type_contains_local_bound(db, *param))
+                || type_contains_local_bound(db, *result)
+        }
+        TypeKind::Tuple(elements) => elements
+            .iter()
+            .any(|element| type_contains_local_bound(db, *element)),
+        TypeKind::App { ctor, args } => {
+            type_contains_local_bound(db, *ctor)
+                || args.iter().any(|arg| type_contains_local_bound(db, *arg))
+        }
+        TypeKind::Continuation { arg, result, .. } => {
+            type_contains_local_bound(db, *arg) || type_contains_local_bound(db, *result)
+        }
+        _ => false,
+    }
+}
 
 fn phase_errors(
     db: &dyn salsa::Database,
@@ -29,13 +77,44 @@ fn pure_local_identity_is_polymorphic(db: &salsa::DatabaseImpl) {
         r#"
 fn pair() -> #(Nat, Bool) {
     let identity = fn(value) value
-    #(identity(1), identity(true))
+    #(identity(1), identity(True))
 }
 "#,
     );
 
     let errors = type_errors(db, source);
     assert!(errors.is_empty(), "unexpected type errors: {errors:#?}");
+}
+
+#[salsa_test]
+fn local_callable_metadata_has_no_raw_solver_variables(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn pair() -> #(Nat, Bool) {
+    let identity = fn(value) value
+    #(identity(1), identity(True))
+}
+"#,
+    );
+
+    let output = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    assert!(
+        output
+            .lambda_signatures(db)
+            .iter()
+            .all(|(_, signature)| !type_contains_univar(db, signature.function_type)),
+        "locally generalized callable metadata leaked a raw solver variable"
+    );
+    assert!(
+        output
+            .lambda_signatures(db)
+            .iter()
+            .any(|(_, signature)| type_contains_local_bound(db, signature.function_type)),
+        "locally generalized callable metadata lost its lexical quantifier owner"
+    );
 }
 
 #[salsa_test]
@@ -50,7 +129,7 @@ enum Wrapped(a) {
 
 fn pair() -> #(Nat, Bool) {
     let Wrapped(identity) = Wrapped(fn(value) value)
-    #(identity(1), identity(true))
+    #(identity(1), identity(True))
 }
 "#,
     );
@@ -67,7 +146,7 @@ fn as_pattern_alias_preserves_polymorphism(db: &salsa::DatabaseImpl) {
         r#"
 fn pair() -> #(Nat, Bool) {
     let _ as identity = fn(value) value
-    #(identity(1), identity(true))
+    #(identity(1), identity(True))
 }
 "#,
     );

--- a/crates/tribute-front/tests/let_generalization.rs
+++ b/crates/tribute-front/tests/let_generalization.rs
@@ -2,52 +2,174 @@ use salsa_test_macros::salsa_test;
 use tribute_core::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 use tribute_front::{
     SourceCst,
-    ast::{Type, TypeKind},
+    ast::{
+        AbilityId, CallingConvention, Decl, Effect, EffectRow, Expr, ExprKind, Module, NodeId,
+        Type, TypeKind, TypedRef, UniVarId, UniVarSource,
+    },
 };
+use trunk_ir::Symbol;
 
-fn type_contains_univar(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+fn type_contains<'db>(
+    db: &'db dyn salsa::Database,
+    ty: Type<'db>,
+    predicate: impl Fn(Type<'db>) -> bool + Copy,
+) -> bool {
+    if predicate(ty) {
+        return true;
+    }
     match ty.kind(db) {
-        TypeKind::UniVar { .. } => true,
-        TypeKind::Named { args, .. } => args.iter().any(|arg| type_contains_univar(db, *arg)),
-        TypeKind::Func { params, result, .. } => {
-            params.iter().any(|param| type_contains_univar(db, *param))
-                || type_contains_univar(db, *result)
+        TypeKind::Named { args, .. } => args.iter().any(|arg| type_contains(db, *arg, predicate)),
+        TypeKind::Func {
+            params,
+            result,
+            effect,
+            ..
+        } => {
+            params
+                .iter()
+                .any(|param| type_contains(db, *param, predicate))
+                || type_contains(db, *result, predicate)
+                || effect
+                    .effects(db)
+                    .iter()
+                    .flat_map(|effect| effect.args.iter())
+                    .any(|arg| type_contains(db, *arg, predicate))
         }
         TypeKind::Tuple(elements) => elements
             .iter()
-            .any(|element| type_contains_univar(db, *element)),
+            .any(|element| type_contains(db, *element, predicate)),
         TypeKind::App { ctor, args } => {
-            type_contains_univar(db, *ctor) || args.iter().any(|arg| type_contains_univar(db, *arg))
+            type_contains(db, *ctor, predicate)
+                || args.iter().any(|arg| type_contains(db, *arg, predicate))
         }
-        TypeKind::Continuation { arg, result, .. } => {
-            type_contains_univar(db, *arg) || type_contains_univar(db, *result)
+        TypeKind::Continuation {
+            arg,
+            result,
+            effect,
+        } => {
+            type_contains(db, *arg, predicate)
+                || type_contains(db, *result, predicate)
+                || effect
+                    .effects(db)
+                    .iter()
+                    .flat_map(|effect| effect.args.iter())
+                    .any(|arg| type_contains(db, *arg, predicate))
         }
         _ => false,
     }
 }
 
-fn type_contains_local_bound(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
-    match ty.kind(db) {
-        TypeKind::LocalBoundVar { .. } => true,
-        TypeKind::Named { args, .. } => args.iter().any(|arg| type_contains_local_bound(db, *arg)),
-        TypeKind::Func { params, result, .. } => {
-            params
-                .iter()
-                .any(|param| type_contains_local_bound(db, *param))
-                || type_contains_local_bound(db, *result)
+fn type_contains_univar(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+    type_contains(db, ty, |ty| matches!(ty.kind(db), TypeKind::UniVar { .. }))
+}
+
+fn type_contains_out_of_scope_bound(db: &dyn salsa::Database, ty: Type<'_>, arity: u32) -> bool {
+    type_contains(
+        db,
+        ty,
+        |ty| matches!(ty.kind(db), TypeKind::BoundVar { index } if *index >= arity),
+    )
+}
+
+fn local_call_callee_types<'db>(body: &Expr<TypedRef<'db>>) -> Vec<Type<'db>> {
+    let ExprKind::Block { value, .. } = &*body.kind else {
+        panic!("test function body must be a block");
+    };
+    let calls: &[Expr<TypedRef<'db>>] = match &*value.kind {
+        ExprKind::Tuple(calls) => calls,
+        ExprKind::Call { .. } => std::slice::from_ref(value),
+        _ => panic!("test function body must end in local calls"),
+    };
+    calls
+        .iter()
+        .map(|call| match &*call.kind {
+            ExprKind::Call { callee, .. } => match &*callee.kind {
+                ExprKind::Var(typed_ref) => typed_ref.ty,
+                _ => panic!("test call callee must be a local reference"),
+            },
+            _ => panic!("test body must contain calls"),
+        })
+        .collect()
+}
+
+fn body_node_ids(expr: &Expr<TypedRef<'_>>, ids: &mut Vec<NodeId>) {
+    ids.push(expr.id);
+    match &*expr.kind {
+        ExprKind::Block { stmts, value } => {
+            for stmt in stmts {
+                match stmt {
+                    tribute_front::ast::Stmt::Let { value, .. }
+                    | tribute_front::ast::Stmt::Expr { expr: value, .. } => {
+                        body_node_ids(value, ids);
+                    }
+                }
+            }
+            body_node_ids(value, ids);
         }
-        TypeKind::Tuple(elements) => elements
-            .iter()
-            .any(|element| type_contains_local_bound(db, *element)),
-        TypeKind::App { ctor, args } => {
-            type_contains_local_bound(db, *ctor)
-                || args.iter().any(|arg| type_contains_local_bound(db, *arg))
+        ExprKind::Lambda { body, .. } => body_node_ids(body, ids),
+        ExprKind::Tuple(elements) | ExprKind::List(elements) => {
+            for element in elements {
+                body_node_ids(element, ids);
+            }
         }
-        TypeKind::Continuation { arg, result, .. } => {
-            type_contains_local_bound(db, *arg) || type_contains_local_bound(db, *result)
+        ExprKind::Call { callee, args } => {
+            body_node_ids(callee, ids);
+            for arg in args {
+                body_node_ids(arg, ids);
+            }
         }
-        _ => false,
+        _ => {}
     }
+}
+
+fn func_ref_has_param_and_result(
+    db: &dyn salsa::Database,
+    ty: Type<'_>,
+    expected: Type<'_>,
+) -> bool {
+    matches!(ty.kind(db), TypeKind::Func { params, result, .. }
+        if params.as_slice() == [expected] && *result == expected)
+}
+
+fn is_local_identity_signature(db: &dyn salsa::Database, ty: Type<'_>) -> bool {
+    local_identity_scope(db, ty).is_some()
+}
+
+fn local_identity_scope(db: &dyn salsa::Database, ty: Type<'_>) -> Option<NodeId> {
+    let TypeKind::Func { params, result, .. } = ty.kind(db) else {
+        return None;
+    };
+    let [param] = params.as_slice() else {
+        return None;
+    };
+    matches!(
+        (param.kind(db), result.kind(db)),
+        (
+            TypeKind::LocalBoundVar { scope, index: 0 },
+            TypeKind::LocalBoundVar {
+                scope: result_scope,
+                index: 0,
+            },
+        ) if scope == result_scope
+    )
+    .then(|| match param.kind(db) {
+        TypeKind::LocalBoundVar { scope, .. } => *scope,
+        _ => unreachable!(),
+    })
+}
+
+fn typed_function_body<'a, 'db>(
+    module: &'a Module<TypedRef<'db>>,
+    name: Symbol,
+) -> &'a Expr<TypedRef<'db>> {
+    module
+        .decls
+        .iter()
+        .find_map(|decl| match decl {
+            Decl::Function(function) if function.name == name => Some(&function.body),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("missing typed function body for {name}"))
 }
 
 fn phase_errors(
@@ -87,7 +209,7 @@ fn pair() -> #(Nat, Bool) {
 }
 
 #[salsa_test]
-fn local_callable_metadata_has_no_raw_solver_variables(db: &salsa::DatabaseImpl) {
+fn local_callable_instantiations_keep_their_owner_after_solving(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,
         "test.trb",
@@ -96,25 +218,213 @@ fn pair() -> #(Nat, Bool) {
     let identity = fn(value) value
     #(identity(1), identity(True))
 }
+
+fn pass(value: a) -> a {
+    let identity = fn(other) other
+    identity(value)
+}
 "#,
     );
 
     let output = tribute_front::query::type_check_output(db, source)
         .expect("type checking should produce output");
-    assert!(
+    let scheme = |name| {
         output
-            .lambda_signatures(db)
+            .function_types(db)
             .iter()
-            .all(|(_, signature)| !type_contains_univar(db, signature.function_type)),
-        "locally generalized callable metadata leaked a raw solver variable"
+            .find_map(|(candidate, scheme)| (*candidate == Symbol::new(name)).then_some(*scheme))
+            .unwrap_or_else(|| panic!("missing function scheme for {name}"))
+    };
+
+    let pair_scheme = scheme("pair");
+    let pass_scheme = scheme("pass");
+    assert_eq!(pair_scheme.type_params(db).len(), 0);
+    assert_eq!(pass_scheme.type_params(db).len(), 1);
+    assert!(
+        !type_contains_out_of_scope_bound(db, pair_scheme.body(db), 0),
+        "pair must not acquire enclosing function binders"
+    );
+    assert!(
+        !type_contains_out_of_scope_bound(db, pass_scheme.body(db), 1),
+        "pass scheme must not contain phantom binders"
+    );
+    assert!(matches!(
+        pass_scheme.body(db).kind(db),
+        TypeKind::Func { params, result, .. }
+            if matches!(params.as_slice(), [param] if matches!(param.kind(db), TypeKind::BoundVar { index: 0 }))
+                && matches!(result.kind(db), TypeKind::BoundVar { index: 0 })
+    ));
+    for ty in output
+        .function_types(db)
+        .iter()
+        .map(|(_, scheme)| scheme.body(db))
+        .chain(
+            output
+                .expression_types(db)
+                .node_types
+                .iter()
+                .map(|(_, ty)| *ty),
+        )
+        .chain(
+            output
+                .expression_types(db)
+                .call_callee_types
+                .iter()
+                .map(|(_, ty)| *ty),
+        )
+        .chain(
+            output
+                .lambda_signatures(db)
+                .iter()
+                .map(|(_, signature)| signature.function_type),
+        )
+    {
+        assert!(
+            !type_contains_univar(db, ty),
+            "typed body and metadata must not retain raw solver variables: {ty:?}"
+        );
+    }
+
+    let module = output.module(db);
+    for (function, name, arity) in [
+        (Symbol::new("pair"), "pair", 0),
+        (Symbol::new("pass"), "pass", 1),
+    ] {
+        let mut nodes = Vec::new();
+        body_node_ids(typed_function_body(module, function), &mut nodes);
+        for node in &nodes {
+            let ty = output
+                .expression_types(db)
+                .node_types
+                .iter()
+                .find_map(|(candidate, ty)| (*candidate == *node).then_some(*ty))
+                .unwrap_or_else(|| panic!("missing typed metadata for {name} node {node:?}"));
+            assert!(
+                !type_contains_out_of_scope_bound(db, ty, arity),
+                "{name} node metadata exceeds its scheme arity {arity}: {ty:?}"
+            );
+        }
+        for (lambda, signature) in output.lambda_signatures(db) {
+            if nodes.contains(lambda) {
+                assert!(
+                    !type_contains_out_of_scope_bound(db, signature.function_type, arity),
+                    "{name} lambda metadata exceeds its scheme arity {arity}"
+                );
+            }
+        }
+    }
+    let pair_identities = local_call_callee_types(typed_function_body(module, Symbol::new("pair")));
+    assert!(
+        pair_identities
+            .iter()
+            .any(|ty| func_ref_has_param_and_result(db, *ty, Type::new(db, TypeKind::Nat))),
+        "identity(1) must have a concrete Nat callable type"
+    );
+    assert!(
+        pair_identities
+            .iter()
+            .any(|ty| func_ref_has_param_and_result(db, *ty, Type::new(db, TypeKind::Bool))),
+        "identity(True) must have a concrete Bool callable type"
+    );
+    let pass_identities = local_call_callee_types(typed_function_body(module, Symbol::new("pass")));
+    assert!(
+        pass_identities.iter().any(|ty| {
+            matches!(ty.kind(db), TypeKind::Func { params, result, .. }
+                if matches!(params.as_slice(), [param] if matches!(param.kind(db), TypeKind::BoundVar { index: 0 }))
+                    && matches!(result.kind(db), TypeKind::BoundVar { index: 0 }))
+        }),
+        "identity(value) must alias the enclosing function binder"
     );
     assert!(
         output
             .lambda_signatures(db)
             .iter()
-            .any(|(_, signature)| type_contains_local_bound(db, signature.function_type)),
-        "locally generalized callable metadata lost its lexical quantifier owner"
+            .all(|(_, signature)| is_local_identity_signature(db, signature.function_type)),
+        "each identity definition must retain one LocalBoundVar owner"
     );
+}
+
+#[salsa_test]
+fn effectful_local_callable_metadata_generalizes_effect_arguments(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+ability Source(s) {
+    op get() -> s
+}
+
+fn pair() -> Nil {
+    let read = fn() Source::get()
+    Nil
+}
+"#,
+    );
+
+    let output = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    let (scope, signature) = output
+        .lambda_signatures(db)
+        .iter()
+        .find(|(_, signature)| {
+            matches!(signature.function_type.kind(db), TypeKind::Func { effect, .. } if !effect.effects(db).is_empty())
+        })
+        .expect("effectful local lambda signature should be present");
+    let TypeKind::Func { effect, .. } = signature.function_type.kind(db) else {
+        unreachable!("selected lambda signature must be a function");
+    };
+    assert!(
+        effect
+            .effects(db)
+            .iter()
+            .flat_map(|effect| effect.args.iter())
+            .any(|arg| matches!(arg.kind(db), TypeKind::LocalBoundVar { .. })),
+        "the lambda effect row must retain its local quantifier provenance"
+    );
+    let local = Type::new(
+        db,
+        TypeKind::LocalBoundVar {
+            scope: *scope,
+            index: 0,
+        },
+    );
+    let univar = Type::new(
+        db,
+        TypeKind::UniVar {
+            id: UniVarId::new(db, UniVarSource::Anonymous(1), 0),
+        },
+    );
+    let effect = EffectRow::single(
+        db,
+        Effect {
+            ability_id: AbilityId::source(db, Symbol::new("Source")),
+            args: vec![local, univar],
+        },
+    );
+    let nil = Type::new(db, TypeKind::Nil);
+    let function = Type::new(
+        db,
+        TypeKind::Func {
+            params: vec![],
+            result: nil,
+            effect,
+            minimum_convention: CallingConvention::Direct,
+        },
+    );
+    let continuation = Type::new(
+        db,
+        TypeKind::Continuation {
+            arg: nil,
+            result: nil,
+            effect,
+        },
+    );
+    for ty in [function, continuation] {
+        assert!(type_contains_univar(db, ty));
+        assert!(type_contains(db, ty, |entry| {
+            matches!(entry.kind(db), TypeKind::LocalBoundVar { .. })
+        }));
+    }
 }
 
 #[salsa_test]

--- a/crates/tribute-front/tests/ufcs_method_call.rs
+++ b/crates/tribute-front/tests/ufcs_method_call.rs
@@ -333,6 +333,48 @@ fn score_b(thing: B::Thing) -> Nat { thing.score() }
 }
 
 #[salsa_test]
+fn test_tdnr_resolves_nested_generic_nominal_receivers(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "nested_generic_nominal_identity.trb",
+        r#"
+pub mod A {
+    pub struct Token(a) {}
+    pub fn tag(_value: Token(Nat)) -> Nat { 1 }
+}
+
+pub mod B {
+    pub struct Token(a) {}
+    pub fn tag(_value: Token(Nat)) -> Nat { 12 }
+}
+
+fn test() -> #(Nat, Nat) {
+    let a = A::Token {}
+    let b = B::Token {}
+    #(a.tag(), b.tag())
+}
+"#,
+    );
+
+    assert_eq!(
+        tdnr_function_summary(db, source, "test"),
+        TdnrSummary {
+            method_calls: vec![],
+            calls: vec![
+                TdnrCall {
+                    target: "A::tag".to_owned(),
+                    arg_count: 1,
+                },
+                TdnrCall {
+                    target: "B::tag".to_owned(),
+                    arg_count: 1,
+                },
+            ],
+        }
+    );
+}
+
+#[salsa_test]
 fn string_literal_method_uses_prelude_identity_when_shadowed(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -5,9 +5,9 @@ expression: ir_text
 core.module @direct_fn {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t2 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !t1 = closure.closure(!t2)
@@ -17,20 +17,11 @@ core.module @direct_fn {
   !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !t4 = core.ability_ref() {name = @"abilities::Throw"}
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
   !t3 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
 
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
@@ -4,33 +4,24 @@ expression: ir_text
 ---
 core.module @float_comparisons {
   !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !"Result::map_err::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map_err::__clam_0::env"}
   !"Option::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Option::map::__clam_0::env"}
   !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !t3 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !t1 = closure.closure(!t3)
   !t4 = core.ability_ref() {name = @"abilities::Throw"}
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
   !t2 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !__tuple_i1_i1_i1_i1_i1_i1_1 = adt.typeref() {name = @__tuple_i1_i1_i1_i1_i1_i1}
 
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -5,9 +5,9 @@ expression: ir_text
 core.module @mixed_nested {
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
   !t1 = core.func(tribute_rt.anyref, tribute_rt.anyref)
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
@@ -21,21 +21,12 @@ core.module @mixed_nested {
   !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !t4 = core.ability_ref() {name = @"abilities::Throw"}
   !t5 = core.func(tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref)
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
   !t3 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
 
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -5,9 +5,9 @@ expression: ir_text
 core.module @resumptive_op {
   !"String::Cursor" = adt.enum() {name = @"String::Cursor", variants = [[@CursorDone, []], [@CursorPending, [tribute_rt.anyref, tribute_rt.anyref]], [@CursorChunk, [core.bytes, core.i32, core.i32, tribute_rt.anyref]]]}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  !Result = adt.enum() {name = @Result, variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
-  !"Result$T0$T1" = adt.enum() {name = @"Result$T0$T1", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T0" = adt.enum() {name = @"Option$T0", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
+  !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t2 = core.func(tribute_rt.anyref, tribute_rt.anyref)
@@ -21,20 +21,11 @@ core.module @resumptive_op {
   !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !"Result$T1$T0" = adt.enum() {name = @"Result$T1$T0", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
   !t4 = core.ability_ref() {name = @"abilities::Throw"}
-  !"Result$T3$T4" = adt.enum() {name = @"Result$T3$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T6$T5" = adt.enum() {name = @"Result$T6$T5", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T2" = adt.enum() {name = @"Option$T2", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
   !t3 = closure.closure(core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, tribute_rt.anyref))
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
-  !"Result$T2$T3" = adt.enum() {name = @"Result$T2$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T4$T3" = adt.enum() {name = @"Result$T4$T3", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Result$T5$T4" = adt.enum() {name = @"Result$T5$T4", variants = [[@Ok, [tribute_rt.anyref]], [@Error, [tribute_rt.anyref]]]}
-  !"Option$T1" = adt.enum() {name = @"Option$T1", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
-  !"Option$T3" = adt.enum() {name = @"Option$T3", variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
 
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
       func.unreachable


### PR DESCRIPTION
Fixes #835.

Stacked on #840 (`codex/issue-834-generic-metadata`).

Preserves generalized local callable type/effect metadata through solving and typed-AST conversion, while keeping evaluation effects separate from latent callable effects and retaining solved lambda metadata.

Checks:
- `cargo nextest run -p tribute-front` (604 passed)
- `cargo nextest run -p tribute --test e2e_add test_generic_struct_argument`
- `cargo fmt --check`
- `cargo clippy -p tribute-front -- -D warnings`

The full-workspace native closure crash reproduces on the unchanged #840 base; it is not introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for polymorphic types introduced by local `let` bindings.
  * Preserved distinctions between locally scoped type variables during type checking and compilation.
  * Improved generalized type handling across functions, lambdas, handlers, operations, and effects.

* **Bug Fixes**
  * Prevented local generalized types from becoming unintended function parameters.
  * Improved resolution of same-name local bindings and nested generic method calls.
  * Ensured unresolved local type variables are handled safely.

* **Tests**
  * Added coverage for local polymorphism, nested types, lexical scoping, and specialized calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->