### PR TITLE
Lower logical CPS signatures to shared physical ABI

### DIFF
--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -9,6 +9,7 @@ pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
 pub const INDIRECT_CALL_SIGNATURE_ATTR: &str =
     trunk_ir::dialect::func::INDIRECT_CALL_SIGNATURE_ATTR;
 pub const CLOSURE_CALLABLE_TYPE_ATTR: &str = "tribute.closure_callable_type";
+pub const CLOSURE_ENVIRONMENT_INDEX_ATTR: &str = "tribute.closure_environment_index";
 
 /// The ABI strength required to call a function.
 ///
@@ -46,6 +47,11 @@ impl CallingConvention {
     /// Whether the convention carries a done continuation.
     pub fn needs_done_k(self) -> bool {
         self == Self::Cps
+    }
+
+    /// Physical closure environment slot for this convention.
+    pub fn closure_environment_index(self) -> usize {
+        usize::from(self.needs_evidence())
     }
 }
 
@@ -158,6 +164,10 @@ mod tests {
         let cps = physical_closure_type(&mut ctx, function, CallingConvention::Cps);
 
         assert_ne!(direct, cps);
+        assert_eq!(
+            get_physical_closure_convention(&ctx, direct),
+            Some(CallingConvention::Direct)
+        );
         assert_eq!(
             get_physical_closure_convention(&ctx, cps),
             Some(CallingConvention::Cps)

--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -2,10 +2,13 @@
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::refs::OpRef;
-use trunk_ir::types::Attribute;
+use trunk_ir::refs::{OpRef, TypeRef};
+use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
+pub const INDIRECT_CALL_SIGNATURE_ATTR: &str =
+    trunk_ir::dialect::func::INDIRECT_CALL_SIGNATURE_ATTR;
+pub const CLOSURE_CALLABLE_TYPE_ATTR: &str = "tribute.closure_callable_type";
 
 /// The ABI strength required to call a function.
 ///
@@ -75,6 +78,63 @@ pub fn get_calling_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConve
     code.try_into().ok()
 }
 
+/// Attach the exact callable signature to an indirect transfer.
+pub fn set_indirect_call_signature(ctx: &mut IrContext, op: OpRef, signature: TypeRef) {
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
+        Attribute::Type(signature),
+    );
+}
+
+/// Read the exact callable signature retained on an indirect transfer.
+pub fn get_indirect_call_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
+    ctx.op(op).attributes.get_type(INDIRECT_CALL_SIGNATURE_ATTR)
+}
+
+/// Retain a typed closure contract on its canonical runtime pair.
+pub fn set_closure_callable_type(ctx: &mut IrContext, op: OpRef, closure: TypeRef) {
+    ctx.op_mut(op).attributes.insert(
+        Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR),
+        Attribute::Type(closure),
+    );
+}
+
+/// Read typed closure provenance from a canonical runtime pair.
+pub fn get_closure_callable_type(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
+    ctx.op(op).attributes.get_type(CLOSURE_CALLABLE_TYPE_ATTR)
+}
+
+/// Build a closure type whose outer occurrence carries exact convention
+/// provenance. This is dormant until a producer selects the physical CPS path.
+pub fn physical_closure_type(
+    ctx: &mut IrContext,
+    function: TypeRef,
+    convention: CallingConvention,
+) -> TypeRef {
+    ctx.types.intern(
+        TypeDataBuilder::new(Symbol::new("closure"), Symbol::new("closure"))
+            .param(function)
+            .attr(CALLING_CONVENTION_ATTR, Attribute::Int(convention as i128))
+            .build(),
+    )
+}
+
+/// Read exact convention provenance from an outer physical closure type.
+pub fn get_physical_closure_convention(
+    ctx: &IrContext,
+    closure: TypeRef,
+) -> Option<CallingConvention> {
+    let data = ctx.types.get(closure);
+    if data.dialect != Symbol::new("closure") || data.name != Symbol::new("closure") {
+        return None;
+    }
+    data.attrs
+        .get_u8(CALLING_CONVENTION_ATTR)
+        .ok()??
+        .try_into()
+        .ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,5 +147,20 @@ mod tests {
         }
 
         assert_eq!(CallingConvention::try_from(3), Err(3));
+    }
+
+    #[test]
+    fn physical_closure_convention_is_exact_type_identity() {
+        let mut ctx = IrContext::new();
+        let never = trunk_ir::dialect::core::never(&mut ctx).as_type_ref();
+        let function = trunk_ir::dialect::core::func(&mut ctx, never, []).as_type_ref();
+        let direct = physical_closure_type(&mut ctx, function, CallingConvention::Direct);
+        let cps = physical_closure_type(&mut ctx, function, CallingConvention::Cps);
+
+        assert_ne!(direct, cps);
+        assert_eq!(
+            get_physical_closure_convention(&ctx, cps),
+            Some(CallingConvention::Cps)
+        );
     }
 }

--- a/crates/tribute-core/src/lib.rs
+++ b/crates/tribute-core/src/lib.rs
@@ -7,7 +7,10 @@ pub mod target;
 
 pub use callable_abi::CallableAbi;
 pub use calling_convention::{
-    CALLING_CONVENTION_ATTR, CallingConvention, get_calling_convention, set_calling_convention,
+    CALLING_CONVENTION_ATTR, CLOSURE_CALLABLE_TYPE_ATTR, CallingConvention,
+    INDIRECT_CALL_SIGNATURE_ATTR, get_calling_convention, get_closure_callable_type,
+    get_indirect_call_signature, get_physical_closure_convention, physical_closure_type,
+    set_calling_convention, set_closure_callable_type, set_indirect_call_signature,
 };
 pub use diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 pub use target::*;

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -19,7 +19,10 @@
 //!
 //! Uses `RewritePattern` + `PatternApplicator` for declarative transformation.
 
-use tribute_core::{CallableAbi, get_calling_convention};
+use tribute_core::{
+    CallableAbi, CallingConvention, get_calling_convention, get_closure_callable_type,
+    get_physical_closure_convention, set_closure_callable_type, set_indirect_call_signature,
+};
 use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
@@ -166,6 +169,9 @@ impl RewritePattern for LowerClosureNewArena {
         // Generate: %closure = adt.struct_new(%funcref, %env) : closure_struct_type
         let struct_ty = closure_struct_type_ref(ctx);
         let struct_new_op = adt::struct_new(ctx, loc, vec![funcref, env], struct_ty, struct_ty);
+        if get_physical_closure_convention(ctx, result_ty).is_some() {
+            set_closure_callable_type(ctx, struct_new_op.op_ref(), result_ty);
+        }
 
         rewriter.insert_op(constant_op.op_ref());
         rewriter.replace_op(struct_new_op.op_ref());
@@ -207,10 +213,11 @@ impl RewritePattern for LowerClosureCallArena {
             // Already lowered closure struct
             true
         } else if core::Func::matches(ctx, callee_ty) {
-            // core.func in func.call_indirect is always a closure value.
-            // Direct function calls use func.call; call_indirect operates on
-            // closure values (block args, env captures, etc.).
-            true
+            !matches!(
+                ctx.value_def(callee),
+                trunk_ir::refs::ValueDef::OpResult(defining_op, _)
+                    if func::Constant::from_op(ctx, defining_op).is_ok()
+            )
         } else {
             // Fallback: check if result of closure.new
             if let trunk_ir::refs::ValueDef::OpResult(def_op, _) = ctx.value_def(callee) {
@@ -232,6 +239,24 @@ impl RewritePattern for LowerClosureCallArena {
             .types
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
         let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+        let exact_contract = if physical_closure_type_for_callee(ctx, callee).is_some() {
+            let Some(convention) = get_calling_convention(ctx, op) else {
+                return false;
+            };
+            let Some(contract) = exact_physical_call_contract(
+                ctx,
+                callee,
+                convention,
+                &args,
+                caller_result_ty,
+                anyref_ty,
+            ) else {
+                return false;
+            };
+            Some(contract)
+        } else {
+            None
+        };
 
         // Determine actual return type from the closure's func type.
         // Effectful lambdas may return anyref even if the caller's
@@ -247,10 +272,22 @@ impl RewritePattern for LowerClosureCallArena {
         let env_op = closure::env(ctx, loc, callee, anyref_ty);
         let env = ctx.op_result(env_op.op_ref(), 0);
 
-        let new_args = if let Some(convention) = get_calling_convention(ctx, op) {
+        let new_args = if let Some(contract) = &exact_contract {
+            let mut args = args;
+            for &(index, expected) in &contract.argument_casts {
+                let cast = core::unrealized_conversion_cast(ctx, loc, args[index], expected);
+                rewriter.insert_op(cast.op_ref());
+                args[index] = cast.result(ctx);
+            }
+            args.insert(contract.environment_index, env);
+            args
+        } else if let Some(convention) = get_calling_convention(ctx, op) {
             let hidden =
                 usize::from(convention.needs_evidence()) + usize::from(convention.needs_done_k());
-            let abi = CallableAbi::new(convention, args[hidden..].iter().copied(), env);
+            let Some(source_args) = args.get(hidden..) else {
+                return false;
+            };
+            let abi = CallableAbi::new(convention, source_args.iter().copied(), env);
             abi.interpose_environment(&args, env)
         } else {
             // Compatibility for hand-written legacy IR without metadata.
@@ -267,6 +304,11 @@ impl RewritePattern for LowerClosureCallArena {
             legacy
         };
         let new_call = func::call_indirect(ctx, loc, table_idx, new_args, callee_return_ty);
+        if let Some(contract) = exact_contract {
+            let attributes = ctx.op(op).attributes.clone();
+            ctx.op_mut(new_call.op_ref()).attributes.extend(attributes);
+            set_indirect_call_signature(ctx, new_call.op_ref(), contract.signature);
+        }
 
         rewriter.insert_op(table_idx_op.op_ref());
         rewriter.insert_op(env_op.op_ref());
@@ -287,6 +329,159 @@ impl RewritePattern for LowerClosureCallArena {
     fn name(&self) -> &'static str {
         "LowerClosureCallArena"
     }
+}
+
+/// Lower a convention-proven closure-valued proper tail transfer. Untagged
+/// legacy closure values remain on their existing route.
+struct LowerClosureTailCallArena;
+
+impl RewritePattern for LowerClosureTailCallArena {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if func::TailCallIndirect::from_op(ctx, op).is_err() {
+            return false;
+        }
+        let operands = ctx.op_operands(op).to_vec();
+        let Some((&callee, args)) = operands.split_first() else {
+            return false;
+        };
+        let Some(convention) = get_calling_convention(ctx, op) else {
+            return false;
+        };
+        if convention != CallingConvention::Cps
+            || physical_closure_type_for_callee(ctx, callee).is_none()
+        {
+            return false;
+        }
+
+        let location = ctx.op(op).location;
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
+        let never = core::never(ctx).as_type_ref();
+        let Some(contract) =
+            exact_physical_call_contract(ctx, callee, convention, args, never, anyref_ty)
+        else {
+            return false;
+        };
+        let func_ref = closure::func(ctx, location, callee, i32_ty);
+        let environment = closure::env(ctx, location, callee, anyref_ty);
+        let mut args = args.to_vec();
+        for (index, expected) in contract.argument_casts {
+            let cast = core::unrealized_conversion_cast(ctx, location, args[index], expected);
+            rewriter.insert_op(cast.op_ref());
+            args[index] = cast.result(ctx);
+        }
+        args.insert(contract.environment_index, environment.result(ctx));
+        let tail = func::tail_call_indirect(ctx, location, func_ref.result(ctx), args);
+        let attributes = ctx.op(op).attributes.clone();
+        ctx.op_mut(tail.op_ref()).attributes.extend(attributes);
+        set_indirect_call_signature(ctx, tail.op_ref(), contract.signature);
+
+        rewriter.insert_op(func_ref.op_ref());
+        rewriter.insert_op(environment.op_ref());
+        rewriter.replace_op(tail.op_ref());
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "LowerClosureTailCallArena"
+    }
+}
+
+fn physical_closure_type_for_callee(ctx: &IrContext, callee: ValueRef) -> Option<TypeRef> {
+    let ty = ctx.value_ty(callee);
+    if get_physical_closure_convention(ctx, ty).is_some() {
+        return Some(ty);
+    }
+    let trunk_ir::refs::ValueDef::OpResult(pack, _) = ctx.value_def(callee) else {
+        return None;
+    };
+    let closure_ty = get_closure_callable_type(ctx, pack)?;
+    (get_physical_closure_convention(ctx, closure_ty).is_some()
+        && is_lowered_closure_pack(ctx, pack, closure_ty))
+    .then_some(closure_ty)
+}
+
+fn is_lowered_closure_pack(ctx: &IrContext, op: OpRef, closure_ty: TypeRef) -> bool {
+    if adt::StructNew::from_op(ctx, op).is_err() {
+        return false;
+    }
+    let [result] = ctx.op_results(op) else {
+        return false;
+    };
+    if !is_closure_struct_type_ref(ctx, ctx.value_ty(*result)) {
+        return false;
+    }
+    let [function, _environment] = ctx.op_operands(op) else {
+        return false;
+    };
+    let trunk_ir::refs::ValueDef::OpResult(constant, _) = ctx.value_def(*function) else {
+        return false;
+    };
+    if func::Constant::from_op(ctx, constant).is_err() {
+        return false;
+    }
+    let Some(closure) = closure::Closure::from_type_ref(ctx, closure_ty) else {
+        return false;
+    };
+    ctx.value_ty(*function) == closure.func_type(ctx)
+}
+
+struct PhysicalCallContract {
+    environment_index: usize,
+    signature: TypeRef,
+    argument_casts: Vec<(usize, TypeRef)>,
+}
+
+fn exact_physical_call_contract(
+    ctx: &mut IrContext,
+    callee: ValueRef,
+    convention: CallingConvention,
+    args: &[ValueRef],
+    result: TypeRef,
+    environment: TypeRef,
+) -> Option<PhysicalCallContract> {
+    let closure_ty = physical_closure_type_for_callee(ctx, callee)?;
+    (get_physical_closure_convention(ctx, closure_ty) == Some(convention)).then_some(())?;
+    let function = closure::Closure::from_type_ref(ctx, closure_ty)?.func_type(ctx);
+    let callable = core::Func::from_type_ref(ctx, function)?;
+    if callable.r#return(ctx) != result || callable.params(ctx).len() != args.len() {
+        return None;
+    }
+    let mut casts = Vec::new();
+    for (index, (argument, expected)) in args.iter().zip(callable.params(ctx)).enumerate() {
+        let actual = ctx.value_ty(*argument);
+        if actual != *expected {
+            if !is_closure_struct_type_ref(ctx, actual) {
+                return None;
+            }
+            if closure::Closure::matches(ctx, *expected) {
+                if physical_closure_type_for_callee(ctx, *argument) != Some(*expected) {
+                    return None;
+                }
+            } else if *expected != environment {
+                return None;
+            }
+            casts.push((index, *expected));
+        }
+    }
+    let environment_index = usize::from(convention.needs_evidence());
+    if environment_index > args.len() {
+        return None;
+    }
+    let mut params = callable.params(ctx).to_vec();
+    params.insert(environment_index, environment);
+    Some(PhysicalCallContract {
+        environment_index,
+        signature: core::func(ctx, result, params).as_type_ref(),
+        argument_casts: casts,
+    })
 }
 
 /// Lower `closure.func` to `adt.struct_get` field 0.
@@ -408,6 +603,9 @@ pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
 /// Closure calls already carry convention-specific hidden operands. This pass
 /// only interposes the physical closure environment.
 pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
+    if ctx.op(func_op.op_ref()).regions.is_empty() {
+        return;
+    }
     let legacy_evidence = evidence_param_for_func(ctx, func_op);
     let applicator = PatternApplicator::new(TypeConverter::new())
         .with_target(
@@ -416,6 +614,7 @@ pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
                 .recursive_legal_op("func", "func"),
         )
         .add_pattern(LowerClosureCallArena { legacy_evidence })
+        .add_pattern(LowerClosureTailCallArena)
         .add_pattern(LowerClosureNewArena)
         .add_pattern(LowerClosureFuncArena)
         .add_pattern(LowerClosureEnvArena);
@@ -650,6 +849,7 @@ mod tests {
             !ir.contains("closure.func") && !ir.contains("closure.env"),
             "module entrypoint should lower closure accessors:\n{ir}"
         );
+        assert!(!ir.contains("func.indirect_call_signature"), "{ir}");
 
         for name in ["selected", "untouched"] {
             let func_op = func_by_name(&ctx, module, name);
@@ -691,5 +891,111 @@ mod tests {
             entry_evidence_arg(&ctx, inner),
             "nested function pass should use the nested function's own evidence argument"
         );
+    }
+
+    #[test]
+    fn tagged_dispatch_aware_tail_retains_exact_physical_signature() {
+        let mut ctx = IrContext::new();
+        let ev = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  !cps = closure.closure(core.func(core.never, {ev}, core.i32, core.i32, core.i32)) {{tribute.calling_convention = 2}}
+  func.func @run(%callee: !cps, %evidence: {ev}, %done: core.i32, %dispatch: core.i32, %value: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
+    func.tail_call_indirect %callee, %evidence, %done, %dispatch, %value {{tribute.calling_convention = 2}}
+  }}
+}}"#
+            ),
+        );
+        let run = func_by_name(&ctx, module, "run");
+        let evidence = ctx.block_args(ctx.region(run.body(&ctx)).blocks[0])[1];
+
+        lower_closures_in_func(&mut ctx, run);
+
+        let tail = ctx
+            .block(ctx.region(run.body(&ctx)).blocks[0])
+            .ops
+            .iter()
+            .copied()
+            .find(|op| func::TailCallIndirect::from_op(&ctx, *op).is_ok())
+            .unwrap();
+        let signature = tribute_core::get_indirect_call_signature(&ctx, tail).unwrap();
+        let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
+        assert_eq!(callable.params(&ctx).len(), 5);
+        assert_eq!(ctx.op_operands(tail).len(), 6);
+        assert_eq!(ctx.op_operands(tail)[1], evidence);
+    }
+
+    #[test]
+    fn bodyless_declaration_remains_unchanged() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @external(%value: core.i32) -> core.i32
+}"#,
+        );
+        let external = func_by_name(&ctx, module, "external");
+        let before = print_module(&ctx, module.op());
+
+        lower_closures_in_func(&mut ctx, external);
+
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn raw_function_constant_indirect_call_remains_unchanged() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @external(%value: core.i32) -> core.i32
+  func.func @caller(%value: core.i32) -> core.i32 {
+    %callee = func.constant {func_ref = @external} : core.func(core.i32, core.i32)
+    %result = func.call_indirect %callee, %value : core.i32
+    func.return %result
+  }
+}"#,
+        );
+        let caller = func_by_name(&ctx, module, "caller");
+        let before = print_module(&ctx, module.op());
+
+        lower_closures_in_func(&mut ctx, caller);
+
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn differently_typed_tagged_closure_pack_fails_closed() {
+        let mut ctx = IrContext::new();
+        let evidence = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {{name = @_closure}}
+  !expected = closure.closure(core.func(core.never, {evidence}, core.i32, core.i32)) {{tribute.calling_convention = 2}}
+  !actual = closure.closure(core.func(core.never, {evidence}, core.i32, core.bool)) {{tribute.calling_convention = 2}}
+  !outer = closure.closure(core.func(core.never, {evidence}, core.i32, !expected)) {{tribute.calling_convention = 2}}
+
+  func.func @actual_fn(%evidence: {evidence}, %done: core.i32, %value: core.bool) -> core.never attributes {{tribute.calling_convention = 2}} {{
+    func.unreachable
+  }}
+  func.func @run(%callee: !outer, %evidence: {evidence}, %done: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
+    %function = func.constant {{func_ref = @actual_fn}} : core.func(core.never, {evidence}, core.i32, core.bool)
+    %environment = adt.ref_null {{type = tribute_rt.anyref}} : tribute_rt.anyref
+    %argument = adt.struct_new %function, %environment {{type = !_closure, tribute.closure_callable_type = !actual}} : !_closure
+    func.tail_call_indirect %callee, %evidence, %done, %argument {{tribute.calling_convention = 2}}
+  }}
+}}"#
+            ),
+        );
+        let run = func_by_name(&ctx, module, "run");
+        let before = print_module(&ctx, module.op());
+
+        lower_closures_in_func(&mut ctx, run);
+
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 }

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -19,6 +19,8 @@
 //!
 //! Uses `RewritePattern` + `PatternApplicator` for declarative transformation.
 
+use std::ops::ControlFlow;
+
 use tribute_core::{
     CallableAbi, CallingConvention, get_calling_convention, get_closure_callable_type,
     get_physical_closure_convention, set_closure_callable_type, set_indirect_call_signature,
@@ -37,6 +39,7 @@ use trunk_ir::rewrite::{
     ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
+use trunk_ir::walk::{WalkAction, walk_region};
 
 /// Create the unified closure struct type in arena: `{ table_idx: i32, env: anyref }`.
 pub fn closure_struct_type_ref(ctx: &mut IrContext) -> TypeRef {
@@ -471,7 +474,7 @@ fn exact_physical_call_contract(
             casts.push((index, *expected));
         }
     }
-    let environment_index = usize::from(convention.needs_evidence());
+    let environment_index = convention.closure_environment_index();
     if environment_index > args.len() {
         return None;
     }
@@ -572,6 +575,50 @@ fn evidence_param_for_func(ctx: &IrContext, func_op: func::Func) -> Option<Value
     ctx.block_args(entry).first().copied()
 }
 
+fn tagged_closure_transfers_are_legal(ctx: &mut IrContext, func_op: func::Func) -> bool {
+    let Some(&body) = ctx.op(func_op.op_ref()).regions.first() else {
+        return true;
+    };
+    let mut transfers = Vec::new();
+    let _ = walk_region::<()>(ctx, body, &mut |op| {
+        if func::Func::matches(ctx, op) {
+            return ControlFlow::Continue(WalkAction::Skip);
+        }
+        if func::CallIndirect::matches(ctx, op) || func::TailCallIndirect::matches(ctx, op) {
+            transfers.push(op);
+        }
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    if transfers.is_empty() {
+        return true;
+    }
+
+    let anyref = tribute_rt::anyref(ctx).as_type_ref();
+    let never = core::never(ctx).as_type_ref();
+    transfers.into_iter().all(|op| {
+        let operands = ctx.op_operands(op).to_vec();
+        let Some((&callee, args)) = operands.split_first() else {
+            return false;
+        };
+        if physical_closure_type_for_callee(ctx, callee).is_none() {
+            return true;
+        }
+        let Some(convention) = get_calling_convention(ctx, op) else {
+            return false;
+        };
+        if func::CallIndirect::matches(ctx, op) {
+            let Some(&result) = ctx.op_result_types(op).first() else {
+                return false;
+            };
+            exact_physical_call_contract(ctx, callee, convention, args, result, anyref).is_some()
+        } else {
+            convention == CallingConvention::Cps
+                && exact_physical_call_contract(ctx, callee, convention, args, never, anyref)
+                    .is_some()
+        }
+    })
+}
+
 /// Lower closures using arena IR.
 ///
 /// This compatibility entry point prepares module-level function signatures,
@@ -604,6 +651,9 @@ pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
 /// only interposes the physical closure environment.
 pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
     if ctx.op(func_op.op_ref()).regions.is_empty() {
+        return;
+    }
+    if !tagged_closure_transfers_are_legal(ctx, func_op) {
         return;
     }
     let legacy_evidence = evidence_param_for_func(ctx, func_op);
@@ -672,7 +722,6 @@ impl Pass for LowerClosuresInFunc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ops::ControlFlow;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
     use trunk_ir::walk::{WalkAction, walk_op};
@@ -925,6 +974,34 @@ mod tests {
         assert_eq!(callable.params(&ctx).len(), 5);
         assert_eq!(ctx.op_operands(tail).len(), 6);
         assert_eq!(ctx.op_operands(tail)[1], evidence);
+    }
+
+    #[test]
+    fn metadata_less_tagged_closure_transfer_leaves_function_unchanged() {
+        let mut ctx = IrContext::new();
+        let evidence = evidence_type_str();
+        let module = parse_test_module(
+            &mut ctx,
+            &format!(
+                r#"core.module @test {{
+  !cps = closure.closure(core.func(core.never, {evidence}, core.i32)) {{tribute.calling_convention = 2}}
+  func.func @callee(%evidence: {evidence}, %env: tribute_rt.anyref, %done: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
+    func.unreachable
+  }}
+  func.func @run(%evidence: {evidence}, %done: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
+    %environment = adt.ref_null {{type = tribute_rt.anyref}} : tribute_rt.anyref
+    %callee = closure.new %environment {{func_ref = @callee}} : !cps
+    func.tail_call_indirect %callee, %evidence, %done
+  }}
+}}"#
+            ),
+        );
+        let run = func_by_name(&ctx, module, "run");
+        let before = print_module(&ctx, module.op());
+
+        lower_closures_in_func(&mut ctx, run);
+
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/tribute-passes/src/lib.rs
+++ b/crates/tribute-passes/src/lib.rs
@@ -24,6 +24,7 @@ pub mod lower_handle_dispatch;
 pub mod native;
 pub mod resolve_evidence;
 pub mod tail_resumptive;
+pub mod target_abi;
 pub mod tribute_control_to_cps;
 pub mod type_converter;
 pub mod wasm;

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -1,0 +1,795 @@
+//! Shared target-neutral physicalization of convention-proven CPS signatures.
+//!
+//! The pass is intentionally not wired into the production pipeline here. It
+//! consumes exact callable metadata, validates the whole transfer surface, and
+//! only then maps logical CPS `core.never` results to the shared empty-result
+//! marker used by target backends.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::ops::ControlFlow;
+
+use tribute_core::{
+    CALLING_CONVENTION_ATTR, CallingConvention, INDIRECT_CALL_SIGNATURE_ATTR,
+    get_calling_convention, get_indirect_call_signature, get_physical_closure_convention,
+};
+use trunk_ir::Symbol;
+use trunk_ir::context::IrContext;
+use trunk_ir::dialect::{core, func};
+use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
+use trunk_ir::rewrite::Module;
+use trunk_ir::types::{Attribute, TypeData};
+use trunk_ir::walk::{WalkAction, walk_op};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetAbiError(String);
+
+impl TargetAbiError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for TargetAbiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for TargetAbiError {}
+
+#[derive(Clone, Copy)]
+struct FunctionIdentity {
+    signature: TypeRef,
+    convention: CallingConvention,
+    environment_index: Option<usize>,
+}
+
+/// Physicalize exact CPS callables without selecting target instructions.
+///
+/// Validation and conversion planning finish before existing IR is mutated, so
+/// rejected modules remain textually unchanged.
+pub fn lower_cps_signatures_to_physical(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), TargetAbiError> {
+    let ops = collect_ops(ctx, module.op());
+    let never = core::never(ctx).as_type_ref();
+    let nil = core::nil(ctx).as_type_ref();
+    let functions = collect_functions(ctx, &ops, never)?;
+    validate_transfers(ctx, &ops, &functions, never)?;
+
+    let aliases = ctx.type_aliases().to_vec();
+    let mut converter = PhysicalTypeConverter::new(ctx, never, nil);
+    let mut alias_updates = Vec::new();
+    let mut function_types = Vec::new();
+    let mut result_types = Vec::new();
+    let mut attributes = Vec::new();
+    let mut block_args = Vec::new();
+
+    for (name, ty) in aliases {
+        let converted = converter.convert_embedded(ty)?;
+        if converted != ty {
+            alias_updates.push((name, converted));
+        }
+    }
+
+    for &op in &ops {
+        if let Ok(function) = func::Func::from_op(converter.ctx, op) {
+            let signature = function.r#type(converter.ctx);
+            let converted = match exact_convention(converter.ctx, op)? {
+                Some(convention) => converter.convert_callable(signature, convention)?,
+                None => converter.convert_embedded(signature)?,
+            };
+            if converted != signature {
+                function_types.push((op, converted));
+            }
+        }
+
+        for (index, ty) in converter
+            .ctx
+            .op_result_types(op)
+            .to_vec()
+            .into_iter()
+            .enumerate()
+        {
+            let converted = if let Ok(constant) = func::Constant::from_op(converter.ctx, op) {
+                if let Some(identity) = function_for_symbol_optional(
+                    converter.ctx,
+                    op,
+                    constant.func_ref(converter.ctx),
+                    &functions,
+                )? {
+                    validate_constant(converter.ctx, constant, identity, never)?;
+                    converter.convert_callable(ty, identity.convention)?
+                } else {
+                    converter.convert_embedded(ty)?
+                }
+            } else {
+                converter.convert_embedded(ty)?
+            };
+            if converted != ty {
+                result_types.push((op, index as u32, converted));
+            }
+        }
+
+        let op_attributes: Vec<_> = converter
+            .ctx
+            .op(op)
+            .attributes
+            .iter()
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
+        for (name, value) in op_attributes {
+            if func::Func::matches(converter.ctx, op) && name == Symbol::new("type") {
+                continue;
+            }
+            let converted = if name == Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR) {
+                let Attribute::Type(signature) = value else {
+                    return Err(TargetAbiError::new(
+                        "target ABI: indirect callable signature must be a type attribute",
+                    ));
+                };
+                let convention = exact_convention(converter.ctx, op)?.ok_or_else(|| {
+                    TargetAbiError::new(
+                        "target ABI: indirect callable signature has no convention metadata",
+                    )
+                })?;
+                Attribute::Type(converter.convert_callable(signature, convention)?)
+            } else {
+                converter.convert_attribute(value.clone())?
+            };
+            if converted != value {
+                attributes.push((op, name, converted));
+            }
+        }
+
+        let regions = converter.ctx.op(op).regions.to_vec();
+        for region in regions {
+            let block_count = converter.ctx.region(region).blocks.len();
+            for block_index in 0..block_count {
+                let block = converter.ctx.region(region).blocks[block_index];
+                for (index, argument) in converter
+                    .ctx
+                    .block(block)
+                    .args
+                    .clone()
+                    .into_iter()
+                    .enumerate()
+                {
+                    let converted = converter.convert_embedded(argument.ty)?;
+                    if converted != argument.ty {
+                        block_args.push((block, index as u32, converted));
+                    }
+                }
+            }
+        }
+    }
+
+    drop(converter);
+    for (name, ty) in alias_updates {
+        ctx.register_type_alias(name, ty);
+    }
+    for (op, ty) in function_types {
+        ctx.op_mut(op)
+            .attributes
+            .insert(Symbol::new("type"), Attribute::Type(ty));
+    }
+    for (op, index, ty) in result_types {
+        ctx.set_op_result_type(op, index, ty);
+    }
+    for (op, name, value) in attributes {
+        ctx.op_mut(op).attributes.insert(name, value);
+    }
+    for (block, index, ty) in block_args {
+        ctx.set_block_arg_type(block, index, ty);
+    }
+    Ok(())
+}
+
+fn exact_convention(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<Option<CallingConvention>, TargetAbiError> {
+    let present = ctx
+        .op(op)
+        .attributes
+        .get(Symbol::new(CALLING_CONVENTION_ATTR))
+        .is_some();
+    let convention = get_calling_convention(ctx, op);
+    if present && convention.is_none() {
+        return Err(TargetAbiError::new(
+            "target ABI: malformed calling-convention metadata",
+        ));
+    }
+    Ok(convention)
+}
+
+fn collect_functions(
+    ctx: &IrContext,
+    ops: &[OpRef],
+    never: TypeRef,
+) -> Result<HashMap<(OpRef, Symbol), FunctionIdentity>, TargetAbiError> {
+    let mut functions = HashMap::new();
+    for &op in ops {
+        let Ok(function) = func::Func::from_op(ctx, op) else {
+            continue;
+        };
+        let Some(convention) = exact_convention(ctx, op)? else {
+            continue;
+        };
+        let signature = function.r#type(ctx);
+        let callable = core::Func::from_type_ref(ctx, signature).ok_or_else(|| {
+            TargetAbiError::new("target ABI: tagged function must have a core.func signature")
+        })?;
+        if convention == CallingConvention::Cps && callable.r#return(ctx) != never {
+            return Err(TargetAbiError::new(format!(
+                "target ABI: Cps function `{}` must have logical core.never result",
+                function.sym_name(ctx)
+            )));
+        }
+        let key = (symbol_scope(ctx, op)?, function.sym_name(ctx));
+        let identity = FunctionIdentity {
+            signature,
+            convention,
+            environment_index: environment_index(ctx, op, callable.params(ctx))?,
+        };
+        if functions.insert(key, identity).is_some() {
+            return Err(TargetAbiError::new(
+                "target ABI: duplicate tagged function symbol",
+            ));
+        }
+    }
+    Ok(functions)
+}
+
+fn validate_transfers(
+    ctx: &IrContext,
+    ops: &[OpRef],
+    functions: &HashMap<(OpRef, Symbol), FunctionIdentity>,
+    never: TypeRef,
+) -> Result<(), TargetAbiError> {
+    for &op in ops {
+        if func::Call::matches(ctx, op) || func::TailCall::matches(ctx, op) {
+            let Some(convention) = exact_convention(ctx, op)? else {
+                continue;
+            };
+            let callee = ctx.op(op).attributes.get_symbol("callee").ok_or_else(|| {
+                TargetAbiError::new("target ABI: direct transfer lacks callee metadata")
+            })?;
+            let identity = function_for_symbol(ctx, op, callee, functions)?;
+            if identity.convention != convention {
+                return Err(TargetAbiError::new(
+                    "target ABI: direct transfer convention differs from callee",
+                ));
+            }
+            let callable = core::Func::from_type_ref(ctx, identity.signature).unwrap();
+            if !operands_match(ctx, ctx.op_operands(op), callable.params(ctx)) {
+                return Err(TargetAbiError::new(
+                    "target ABI: direct transfer operands differ from callee signature",
+                ));
+            }
+            if func::Call::matches(ctx, op) {
+                if convention == CallingConvention::Cps {
+                    return Err(TargetAbiError::new(
+                        "target ABI: Cps direct transfer must use func.tail_call",
+                    ));
+                }
+                if ctx.op_result_types(op) != [callable.r#return(ctx)] {
+                    return Err(TargetAbiError::new(
+                        "target ABI: direct call result differs from callee signature",
+                    ));
+                }
+            } else if convention != CallingConvention::Cps
+                || callable.r#return(ctx) != never
+                || !is_cps_never_caller(ctx, op, never)?
+            {
+                return Err(TargetAbiError::new(
+                    "target ABI: direct tail call must be a Cps core.never transfer",
+                ));
+            }
+            continue;
+        }
+
+        if !func::CallIndirect::matches(ctx, op) && !func::TailCallIndirect::matches(ctx, op) {
+            continue;
+        }
+        let signature = get_indirect_call_signature(ctx, op);
+        let convention = exact_convention(ctx, op)?;
+        if signature.is_none() && convention.is_none() {
+            continue;
+        }
+        let convention = convention.ok_or_else(|| {
+            TargetAbiError::new("target ABI: indirect signature has no convention metadata")
+        })?;
+        let signature = signature.ok_or_else(|| {
+            TargetAbiError::new("target ABI: indirect transfer lacks exact callable signature")
+        })?;
+        let callable = core::Func::from_type_ref(ctx, signature).ok_or_else(|| {
+            TargetAbiError::new("target ABI: indirect callable signature is not core.func")
+        })?;
+        let args = ctx.op_operands(op).get(1..).unwrap_or_default();
+        if !operands_match(ctx, args, callable.params(ctx)) {
+            return Err(TargetAbiError::new(
+                "target ABI: indirect transfer operands differ from exact callable signature",
+            ));
+        }
+        if func::CallIndirect::matches(ctx, op) {
+            if convention == CallingConvention::Cps {
+                return Err(TargetAbiError::new(
+                    "target ABI: Cps indirect transfer must use func.tail_call_indirect",
+                ));
+            }
+            if ctx.op_result_types(op) != [callable.r#return(ctx)] {
+                return Err(TargetAbiError::new(
+                    "target ABI: indirect call result differs from exact callable signature",
+                ));
+            }
+        } else if convention != CallingConvention::Cps
+            || callable.r#return(ctx) != never
+            || !is_cps_never_caller(ctx, op, never)?
+        {
+            return Err(TargetAbiError::new(
+                "target ABI: indirect tail call must be a Cps core.never transfer",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn operands_match(ctx: &IrContext, operands: &[ValueRef], params: &[TypeRef]) -> bool {
+    operands.len() == params.len()
+        && operands
+            .iter()
+            .zip(params)
+            .all(|(operand, expected)| ctx.value_ty(*operand) == *expected)
+}
+
+fn is_cps_never_caller(ctx: &IrContext, op: OpRef, never: TypeRef) -> Result<bool, TargetAbiError> {
+    let mut current = Some(op);
+    while let Some(candidate) = current {
+        if let Ok(function) = func::Func::from_op(ctx, candidate) {
+            let callable =
+                core::Func::from_type_ref(ctx, function.r#type(ctx)).ok_or_else(|| {
+                    TargetAbiError::new("target ABI: enclosing function is not core.func")
+                })?;
+            return Ok(
+                exact_convention(ctx, candidate)? == Some(CallingConvention::Cps)
+                    && callable.r#return(ctx) == never,
+            );
+        }
+        current = parent_op(ctx, candidate);
+    }
+    Err(TargetAbiError::new(
+        "target ABI: tail transfer has no enclosing function",
+    ))
+}
+
+fn function_for_symbol(
+    ctx: &IrContext,
+    op: OpRef,
+    symbol: Symbol,
+    functions: &HashMap<(OpRef, Symbol), FunctionIdentity>,
+) -> Result<FunctionIdentity, TargetAbiError> {
+    function_for_symbol_optional(ctx, op, symbol, functions)?
+        .ok_or_else(|| TargetAbiError::new(format!("target ABI: unknown callable `{symbol}`")))
+}
+
+fn function_for_symbol_optional(
+    ctx: &IrContext,
+    op: OpRef,
+    symbol: Symbol,
+    functions: &HashMap<(OpRef, Symbol), FunctionIdentity>,
+) -> Result<Option<FunctionIdentity>, TargetAbiError> {
+    Ok(functions.get(&(symbol_scope(ctx, op)?, symbol)).copied())
+}
+
+fn validate_constant(
+    ctx: &mut IrContext,
+    constant: func::Constant,
+    identity: FunctionIdentity,
+    never: TypeRef,
+) -> Result<(), TargetAbiError> {
+    let target = core::Func::from_type_ref(ctx, identity.signature).unwrap();
+    if identity.convention == CallingConvention::Cps && target.r#return(ctx) != never {
+        return Err(TargetAbiError::new(
+            "target ABI: Cps function reference must have logical core.never result",
+        ));
+    }
+    let mut params = target.params(ctx).to_vec();
+    if let Some(index) = identity.environment_index {
+        if index >= params.len() {
+            return Err(TargetAbiError::new(
+                "target ABI: closure environment index is outside target signature",
+            ));
+        }
+        params.remove(index);
+    }
+    let expected = core::func(ctx, target.r#return(ctx), params).as_type_ref();
+    if ctx.op_result_types(constant.op_ref()) != [expected] {
+        return Err(TargetAbiError::new(
+            "target ABI: function reference differs from target signature",
+        ));
+    }
+    Ok(())
+}
+
+fn environment_index(
+    ctx: &IrContext,
+    function: OpRef,
+    params: &[TypeRef],
+) -> Result<Option<usize>, TargetAbiError> {
+    let Some(&region) = ctx.op(function).regions.first() else {
+        return Ok(None);
+    };
+    let Some(&entry) = ctx.region(region).blocks.first() else {
+        return Ok(None);
+    };
+    let arguments = &ctx.block(entry).args;
+    if arguments.len() != params.len() {
+        return Err(TargetAbiError::new(
+            "target ABI: function signature and entry block arity differ",
+        ));
+    }
+    let indices: Vec<_> = arguments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, argument)| {
+            (argument.attrs.get_symbol("bind_name") == Some(Symbol::new("__env"))).then_some(index)
+        })
+        .collect();
+    match indices.as_slice() {
+        [] => Ok(None),
+        [index] => {
+            let data = ctx.types.get(params[*index]);
+            if data.dialect != Symbol::new("tribute_rt") || data.name != Symbol::new("anyref") {
+                return Err(TargetAbiError::new(
+                    "target ABI: `__env` must have exact tribute_rt.anyref type",
+                ));
+            }
+            Ok(Some(*index))
+        }
+        _ => Err(TargetAbiError::new(
+            "target ABI: function has multiple `__env` parameters",
+        )),
+    }
+}
+
+fn symbol_scope(ctx: &IrContext, op: OpRef) -> Result<OpRef, TargetAbiError> {
+    let mut current = Some(op);
+    while let Some(candidate) = current {
+        if core::Module::matches(ctx, candidate) {
+            return Ok(candidate);
+        }
+        current = parent_op(ctx, candidate);
+    }
+    Err(TargetAbiError::new(
+        "target ABI: operation has no enclosing module",
+    ))
+}
+
+fn parent_op(ctx: &IrContext, op: OpRef) -> Option<OpRef> {
+    ctx.op(op).parent_block.and_then(|block| {
+        ctx.block(block)
+            .parent_region
+            .and_then(|region| ctx.region(region).parent_op)
+    })
+}
+
+struct PhysicalTypeConverter<'a> {
+    ctx: &'a mut IrContext,
+    never: TypeRef,
+    nil: TypeRef,
+    embedded: HashMap<TypeRef, TypeRef>,
+    callable: HashMap<(TypeRef, CallingConvention), TypeRef>,
+}
+
+impl<'a> PhysicalTypeConverter<'a> {
+    fn new(ctx: &'a mut IrContext, never: TypeRef, nil: TypeRef) -> Self {
+        Self {
+            ctx,
+            never,
+            nil,
+            embedded: HashMap::new(),
+            callable: HashMap::new(),
+        }
+    }
+
+    fn convert_callable(
+        &mut self,
+        ty: TypeRef,
+        convention: CallingConvention,
+    ) -> Result<TypeRef, TargetAbiError> {
+        if let Some(&converted) = self.callable.get(&(ty, convention)) {
+            return Ok(converted);
+        }
+        let mut data = self.ctx.types.get(ty).clone();
+        if data.dialect != Symbol::new("core")
+            || data.name != Symbol::new("func")
+            || data.params.is_empty()
+        {
+            return Err(TargetAbiError::new(
+                "target ABI: proven callable is not core.func",
+            ));
+        }
+        if convention == CallingConvention::Cps && data.params[0] != self.never {
+            return Err(TargetAbiError::new(
+                "target ABI: Cps callable must have logical core.never result",
+            ));
+        }
+        data.params[0] = if convention == CallingConvention::Cps {
+            self.nil
+        } else {
+            self.convert_embedded(data.params[0])?
+        };
+        for parameter in &mut data.params[1..] {
+            *parameter = self.convert_embedded(*parameter)?;
+        }
+        self.convert_type_attributes(&mut data)?;
+        let converted = self.intern_if_changed(ty, data);
+        self.callable.insert((ty, convention), converted);
+        Ok(converted)
+    }
+
+    fn convert_embedded(&mut self, ty: TypeRef) -> Result<TypeRef, TargetAbiError> {
+        if let Some(&converted) = self.embedded.get(&ty) {
+            return Ok(converted);
+        }
+        let data = self.ctx.types.get(ty).clone();
+        if data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure") {
+            let [function] = data.params.as_slice() else {
+                return Err(TargetAbiError::new(
+                    "target ABI: closure type must contain one callable",
+                ));
+            };
+            let convention = get_physical_closure_convention(self.ctx, ty).ok_or_else(|| {
+                TargetAbiError::new("target ABI: closure callable has no exact convention metadata")
+            })?;
+            let mut converted = data.clone();
+            converted.params[0] = self.convert_callable(*function, convention)?;
+            self.convert_type_attributes(&mut converted)?;
+            let converted = self.intern_if_changed(ty, converted);
+            self.embedded.insert(ty, converted);
+            return Ok(converted);
+        }
+        if data.dialect == Symbol::new("core") && data.name == Symbol::new("func") {
+            let callable = core::Func::from_type_ref(self.ctx, ty).unwrap();
+            if callable.r#return(self.ctx) == self.never {
+                return Err(TargetAbiError::new(
+                    "target ABI: untagged nested core.func<core.never, ...>",
+                ));
+            }
+        }
+        let mut converted = data.clone();
+        for parameter in &mut converted.params {
+            *parameter = self.convert_embedded(*parameter)?;
+        }
+        self.convert_type_attributes(&mut converted)?;
+        let converted = self.intern_if_changed(ty, converted);
+        self.embedded.insert(ty, converted);
+        Ok(converted)
+    }
+
+    fn convert_type_attributes(&mut self, data: &mut TypeData) -> Result<(), TargetAbiError> {
+        let attributes: Vec<_> = data
+            .attrs
+            .iter()
+            .map(|(name, value)| (*name, value.clone()))
+            .collect();
+        for (name, value) in attributes {
+            data.attrs.insert(name, self.convert_attribute(value)?);
+        }
+        Ok(())
+    }
+
+    fn convert_attribute(&mut self, attribute: Attribute) -> Result<Attribute, TargetAbiError> {
+        match attribute {
+            Attribute::Type(ty) => Ok(Attribute::Type(self.convert_embedded(ty)?)),
+            Attribute::List(values) => Ok(Attribute::List(
+                values
+                    .into_iter()
+                    .map(|value| self.convert_attribute(value))
+                    .collect::<Result<_, _>>()?,
+            )),
+            other => Ok(other),
+        }
+    }
+
+    fn intern_if_changed(&mut self, original: TypeRef, data: TypeData) -> TypeRef {
+        if data == *self.ctx.types.get(original) {
+            original
+        } else {
+            self.ctx.types.intern(data)
+        }
+    }
+}
+
+fn collect_ops(ctx: &IrContext, root: OpRef) -> Vec<OpRef> {
+    let mut operations = Vec::new();
+    let _ = walk_op::<()>(ctx, root, &mut |op| {
+        operations.push(op);
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    operations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    fn function(ctx: &IrContext, module: Module, name: &str) -> func::Func {
+        module
+            .ops(ctx)
+            .into_iter()
+            .find_map(|op| {
+                let function = func::Func::from_op(ctx, op).ok()?;
+                (function.sym_name(ctx) == Symbol::from_dynamic(name)).then_some(function)
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn physicalizes_dispatch_aware_exact_cps_contracts_only() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !cps = closure.closure(core.func(core.never, core.i32, core.i32, core.i32, core.i32)) {tribute.calling_convention = 2}
+  func.func @direct() -> core.never attributes {tribute.calling_convention = 0} { func.unreachable }
+  func.func @evidence() -> core.never attributes {tribute.calling_convention = 1} { func.unreachable }
+  func.func @cps() -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
+  func.func @run(%callee: core.i32, %evidence: core.i32, %env: tribute_rt.anyref, %done: core.i32, %dispatch: core.i32, %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %evidence, %env, %done, %dispatch, %value {func.indirect_call_signature = core.func(core.never, core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+
+        let never = core::never(&mut ctx).as_type_ref();
+        let nil = core::nil(&mut ctx).as_type_ref();
+        for (name, expected) in [
+            ("direct", never),
+            ("evidence", never),
+            ("cps", nil),
+            ("run", nil),
+        ] {
+            let signature = function(&ctx, module, name).r#type(&ctx);
+            assert_eq!(
+                core::Func::from_type_ref(&ctx, signature)
+                    .unwrap()
+                    .r#return(&ctx),
+                expected
+            );
+        }
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            printed.contains("func.indirect_call_signature = core.func(core.nil"),
+            "{printed}"
+        );
+        assert!(
+            printed.contains("closure.closure(core.func(core.nil"),
+            "{printed}"
+        );
+    }
+
+    #[test]
+    fn malformed_transfers_and_ambiguous_nested_never_leave_ir_unchanged() {
+        for (input, expected) in [
+            (
+                r#"core.module @test {
+  func.func @run(%callee: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee {tribute.calling_convention = 2}
+  }
+}"#,
+                "lacks exact callable signature",
+            ),
+            (
+                r#"core.module @test {
+  func.func @callee(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
+  func.func @run(%value: core.bool) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @callee, tribute.calling_convention = 2}
+  }
+}"#,
+                "operands differ",
+            ),
+            (
+                r#"core.module @test {
+  !ambiguous = closure.closure(core.func(core.never))
+}"#,
+                "no exact convention metadata",
+            ),
+        ] {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, input);
+            let before = print_module(&ctx, module.op());
+
+            let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+            assert!(error.to_string().contains(expected), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
+    fn bodyless_cps_function_constant_physicalizes_without_a_body() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @external(%evidence: core.i32, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2}
+  func.func @holder() -> core.i32 {
+    %function = func.constant {func_ref = @external} : core.func(core.never, core.i32, core.i32)
+    func.unreachable
+  }
+}"#,
+        );
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            printed.contains("func.func @external(%arg0: core.i32, %arg1: core.i32) -> core.nil")
+        );
+        assert!(printed.contains("func.constant {func_ref = @external} : core.func(core.nil"));
+    }
+
+    #[test]
+    fn raw_constant_is_unchanged_and_malformed_tagged_constant_fails_closed() {
+        let mut ctx = IrContext::new();
+        let raw = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @external(%value: core.i32) -> core.i32
+  func.func @holder() -> core.i32 {
+    %function = func.constant {func_ref = @external} : core.func(core.i32, core.i32)
+    func.unreachable
+  }
+}"#,
+        );
+        let before = print_module(&ctx, raw.op());
+
+        lower_cps_signatures_to_physical(&mut ctx, raw).unwrap();
+
+        assert_eq!(print_module(&ctx, raw.op()), before);
+
+        let mut ctx = IrContext::new();
+        let malformed = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @external(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2}
+  func.func @holder() -> core.i32 {
+    %function = func.constant {func_ref = @external} : core.func(core.never, core.bool)
+    func.unreachable
+  }
+}"#,
+        );
+        let before = print_module(&ctx, malformed.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, malformed).unwrap_err();
+
+        assert!(error.to_string().contains("function reference differs"));
+        assert_eq!(print_module(&ctx, malformed.op()), before);
+    }
+
+    #[test]
+    fn malformed_calling_convention_is_rejected_before_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @broken() -> core.never attributes {tribute.calling_convention = 9} { func.unreachable }
+}"#,
+        );
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+        assert!(error.to_string().contains("malformed calling-convention"));
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+}

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -10,10 +10,12 @@ use std::error::Error;
 use std::fmt;
 use std::ops::ControlFlow;
 
+use tribute_core::calling_convention::CLOSURE_ENVIRONMENT_INDEX_ATTR;
 use tribute_core::{
     CALLING_CONVENTION_ATTR, CallingConvention, INDIRECT_CALL_SIGNATURE_ATTR,
     get_calling_convention, get_indirect_call_signature, get_physical_closure_convention,
 };
+use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{core, func};
@@ -58,7 +60,8 @@ pub fn lower_cps_signatures_to_physical(
     let ops = collect_ops(ctx, module.op());
     let never = core::never(ctx).as_type_ref();
     let nil = core::nil(ctx).as_type_ref();
-    let functions = collect_functions(ctx, &ops, never)?;
+    let anyref = tribute_rt::anyref(ctx).as_type_ref();
+    let functions = collect_functions(ctx, &ops, never, anyref)?;
     validate_transfers(ctx, &ops, &functions, never)?;
 
     let aliases = ctx.type_aliases().to_vec();
@@ -79,12 +82,35 @@ pub fn lower_cps_signatures_to_physical(
     for &op in &ops {
         if let Ok(function) = func::Func::from_op(converter.ctx, op) {
             let signature = function.r#type(converter.ctx);
-            let converted = match exact_convention(converter.ctx, op)? {
+            let convention = exact_convention(converter.ctx, op)?;
+            let converted = match convention {
                 Some(convention) => converter.convert_callable(signature, convention)?,
                 None => converter.convert_embedded(signature)?,
             };
             if converted != signature {
                 function_types.push((op, converted));
+            }
+            if convention.is_some() {
+                let identity = function_for_symbol(
+                    converter.ctx,
+                    op,
+                    function.sym_name(converter.ctx),
+                    &functions,
+                )?;
+                if let Some(index) = identity.environment_index
+                    && converter
+                        .ctx
+                        .op(op)
+                        .attributes
+                        .get(Symbol::new(CLOSURE_ENVIRONMENT_INDEX_ATTR))
+                        .is_none()
+                {
+                    attributes.push((
+                        op,
+                        Symbol::new(CLOSURE_ENVIRONMENT_INDEX_ATTR),
+                        Attribute::Int(index as i128),
+                    ));
+                }
             }
         }
 
@@ -211,6 +237,7 @@ fn collect_functions(
     ctx: &IrContext,
     ops: &[OpRef],
     never: TypeRef,
+    anyref: TypeRef,
 ) -> Result<HashMap<(OpRef, Symbol), FunctionIdentity>, TargetAbiError> {
     let mut functions = HashMap::new();
     for &op in ops {
@@ -234,7 +261,13 @@ fn collect_functions(
         let identity = FunctionIdentity {
             signature,
             convention,
-            environment_index: environment_index(ctx, op, callable.params(ctx))?,
+            environment_index: environment_index(
+                ctx,
+                op,
+                callable.params(ctx),
+                convention,
+                anyref,
+            )?,
         };
         if functions.insert(key, identity).is_some() {
             return Err(TargetAbiError::new(
@@ -420,12 +453,36 @@ fn environment_index(
     ctx: &IrContext,
     function: OpRef,
     params: &[TypeRef],
+    convention: CallingConvention,
+    anyref: TypeRef,
 ) -> Result<Option<usize>, TargetAbiError> {
+    let attributes = &ctx.op(function).attributes;
+    let present = attributes
+        .get(Symbol::new(CLOSURE_ENVIRONMENT_INDEX_ATTR))
+        .is_some();
+    let declared = attributes
+        .get_u32(CLOSURE_ENVIRONMENT_INDEX_ATTR)
+        .ok()
+        .flatten()
+        .map(|index| index as usize);
+    if present && declared.is_none() {
+        return Err(TargetAbiError::new(
+            "target ABI: malformed closure environment index metadata",
+        ));
+    }
+    if let Some(index) = declared {
+        validate_environment_slot(params, convention, anyref, index)?;
+    }
+
     let Some(&region) = ctx.op(function).regions.first() else {
-        return Ok(None);
+        return Ok(declared);
     };
     let Some(&entry) = ctx.region(region).blocks.first() else {
-        return Ok(None);
+        return declared.map_or(Ok(None), |_| {
+            Err(TargetAbiError::new(
+                "target ABI: closure environment provenance has no entry block",
+            ))
+        });
     };
     let arguments = &ctx.block(entry).args;
     if arguments.len() != params.len() {
@@ -441,12 +498,15 @@ fn environment_index(
         })
         .collect();
     match indices.as_slice() {
+        [] if declared.is_some() => Err(TargetAbiError::new(
+            "target ABI: closure environment provenance has no matching `__env` parameter",
+        )),
         [] => Ok(None),
         [index] => {
-            let data = ctx.types.get(params[*index]);
-            if data.dialect != Symbol::new("tribute_rt") || data.name != Symbol::new("anyref") {
+            validate_environment_slot(params, convention, anyref, *index)?;
+            if declared.is_some_and(|declared| declared != *index) {
                 return Err(TargetAbiError::new(
-                    "target ABI: `__env` must have exact tribute_rt.anyref type",
+                    "target ABI: closure environment index differs from `__env` parameter",
                 ));
             }
             Ok(Some(*index))
@@ -455,6 +515,25 @@ fn environment_index(
             "target ABI: function has multiple `__env` parameters",
         )),
     }
+}
+
+fn validate_environment_slot(
+    params: &[TypeRef],
+    convention: CallingConvention,
+    anyref: TypeRef,
+    index: usize,
+) -> Result<(), TargetAbiError> {
+    if index != convention.closure_environment_index() {
+        return Err(TargetAbiError::new(
+            "target ABI: closure environment index differs from calling convention",
+        ));
+    }
+    if params.get(index) != Some(&anyref) {
+        return Err(TargetAbiError::new(
+            "target ABI: closure environment must have exact tribute_rt.anyref type",
+        ));
+    }
+    Ok(())
 }
 
 fn symbol_scope(ctx: &IrContext, op: OpRef) -> Result<OpRef, TargetAbiError> {
@@ -555,6 +634,11 @@ impl<'a> PhysicalTypeConverter<'a> {
             return Ok(converted);
         }
         if data.dialect == Symbol::new("core") && data.name == Symbol::new("func") {
+            if data.params.is_empty() {
+                return Err(TargetAbiError::new(
+                    "target ABI: core.func type has no result parameter",
+                ));
+            }
             let callable = core::Func::from_type_ref(self.ctx, ty).unwrap();
             if callable.r#return(self.ctx) == self.never {
                 return Err(TargetAbiError::new(
@@ -716,14 +800,18 @@ mod tests {
     }
 
     #[test]
-    fn bodyless_cps_function_constant_physicalizes_without_a_body() {
+    fn bodied_and_bodyless_closure_targets_share_environment_provenance() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @external(%evidence: core.i32, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2}
+  func.func @external(%evidence: core.i32, %environment: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  func.func @defined(%evidence: core.i32, %__env: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 1} {
+    func.unreachable
+  }
   func.func @holder() -> core.i32 {
-    %function = func.constant {func_ref = @external} : core.func(core.never, core.i32, core.i32)
+    %external = func.constant {func_ref = @external} : core.func(core.never, core.i32, core.i32)
+    %defined = func.constant {func_ref = @defined} : core.func(core.never, core.i32, core.i32)
     func.unreachable
   }
 }"#,
@@ -733,9 +821,84 @@ mod tests {
 
         let printed = print_module(&ctx, module.op());
         assert!(
-            printed.contains("func.func @external(%arg0: core.i32, %arg1: core.i32) -> core.nil")
+            printed.contains(
+                "func.func @external(%arg0: core.i32, %arg1: tribute_rt.anyref, %arg2: core.i32) -> core.nil"
+            ),
+            "{printed}"
         );
-        assert!(printed.contains("func.constant {func_ref = @external} : core.func(core.nil"));
+        assert!(
+            printed.contains("func.func @defined")
+                && printed.matches("func.constant").count() == 2
+                && printed
+                    .matches("core.func(core.nil, core.i32, core.i32)")
+                    .count()
+                    == 2,
+            "{printed}"
+        );
+    }
+
+    #[test]
+    fn malformed_or_missing_environment_provenance_fails_before_mutation() {
+        for (function, expected) in [
+            (
+                "func.func @external(%evidence: core.i32, %environment: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2}",
+                "function reference differs",
+            ),
+            (
+                "func.func @external(%evidence: core.i32, %environment: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 0}",
+                "differs from calling convention",
+            ),
+            (
+                "func.func @external(%evidence: core.i32, %environment: core.i32, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 1}",
+                "exact tribute_rt.anyref",
+            ),
+            (
+                "func.func @external(%evidence: core.i32, %environment: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 1} { func.unreachable }",
+                "no matching `__env`",
+            ),
+        ] {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    r#"core.module @test {{
+  {function}
+  func.func @holder() -> core.i32 {{
+    %function = func.constant {{func_ref = @external}} : core.func(core.never, core.i32, core.i32)
+    func.unreachable
+  }}
+}}"#
+                ),
+            );
+            let before = print_module(&ctx, module.op());
+
+            let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+            assert!(error.to_string().contains(expected), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
+    fn malformed_zero_parameter_core_func_fails_without_panicking() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, "core.module @test {}");
+        let malformed = ctx.types.intern(
+            trunk_ir::types::TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func")).build(),
+        );
+        ctx.op_mut(module.op()).attributes.insert(
+            Symbol::new("malformed_callable"),
+            Attribute::Type(malformed),
+        );
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error.to_string().contains("has no result parameter"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -1,5 +1,9 @@
 //! Arena-based func dialect.
 
+/// Exact callable signature retained after a typed indirect callee becomes a
+/// runtime function or table index.
+pub const INDIRECT_CALL_SIGNATURE_ATTR: &str = "func.indirect_call_signature";
+
 // === Operation registrations ===
 crate::register_pure_op!(func.constant);
 crate::register_isolated_op!(func.func);

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -86,6 +86,12 @@ adapter의 최종 parameter 순서는 `Direct`에서 `environment, source...`,
 `evidence, environment, done_k, source...`다. `call_indirect`도 같은 순서로
 environment를 삽입한다.
 
+Environment-bearing `func.func`는 zero-based physical slot을
+`tribute.closure_environment_index`로 기록한다. Bodyless declaration은 이
+function-level provenance가 필수이며, definition은 entry block의 `__env` marker와
+같은 slot이어야 한다. Slot은 convention-defined `CallableAbi` 순서와 exact
+`tribute_rt.anyref` type에 일치해야 하며 type이나 arity로 추측하지 않는다.
+
 생성한 physical definition, lambda, adapter, direct/indirect call에는 logical
 type의 convention을 기존 `tribute.calling_convention` attribute로 복사한다.
 Metadata/type/symbol 불일치는 conversion failure이며 hidden operand를 추측하지


### PR DESCRIPTION
## Summary

- Add dormant exact callable and closure provenance metadata for shared indirect-call lowering.
- Add target-neutral CPS physicalization that maps convention-proven logical core.never results to empty physical result vectors.
- Validate direct and indirect signatures, conventions, tagged closure packs, hidden operands, and proper-tail transfers before mutation; malformed IR fails closed and remains unchanged.

## Scope

No production routing, handler rebinding, native or Wasm instruction lowering, compatibility operation, root wrapper, or trampoline is included.

## Validation

- Focused closure and target-ABI tests: 13/13 passed.
- Affected tribute-core, tribute-passes, and trunk-ir suite: 582/582 passed.
- Workspace pre-commit suite: 1,868/1,868 passed.
- Strict affected Clippy, formatting, and diff checks passed.
- Exact-main canonical comparison produced identical shared IR and native output.

Fixes #844. This supplies the additive shared boundary for #845 and #846 below the final route and dispatcher switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added target-neutral ABI validation and lowering for convention-aware CPS signatures and transfers.
  * Improved closure and indirect-call handling with preserved callable metadata and signatures.
  * Added support for converting CPS results to physical representations while preserving compatible callables.
  * Exported new ABI utilities and compiler pass functionality.

* **Bug Fixes**
  * Added validation for malformed calls, closures, metadata, operands, and tail transfers.
  * Invalid modules now fail without partial modification.
  * Improved handling of bodyless functions, raw function constants, and mismatched closure environments.

* **Documentation**
  * Updated CPS conversion guidance for closure environment metadata and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->