### PR TITLE
Lower Cranelift CPS tail transfers

### DIFF
--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -17,6 +17,41 @@ use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 
 use crate::{CompilationError, CompilationResult};
 
+pub(crate) const TRIBUTE_CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
+pub(crate) const CPS_CALLING_CONVENTION: u8 = 2;
+
+/// Select Cranelift's tail-call convention only for the physical CPS ABI.
+///
+/// The convention attribute is also present on pre-physical logical CPS
+/// callables, whose non-empty signatures must retain the platform convention.
+pub(crate) fn call_conv_for_cps_signature(
+    ctx: &IrContext,
+    signature: TypeRef,
+    is_cps: bool,
+    default: CallConv,
+) -> CallConv {
+    if is_cps && has_physical_empty_result(ctx, signature) {
+        CallConv::Tail
+    } else {
+        default
+    }
+}
+
+fn has_physical_empty_result(ctx: &IrContext, signature: TypeRef) -> bool {
+    let signature = ctx.types.get(signature);
+    if signature.dialect != Symbol::new("core") || signature.name != Symbol::new("func") {
+        return false;
+    }
+
+    let Some(&result) = signature.params.first() else {
+        return false;
+    };
+    let result = ctx.types.get(result);
+    result.dialect == Symbol::new("core")
+        && result.name == Symbol::new("nil")
+        && result.params.is_empty()
+}
+
 /// Parse a condition symbol into a Cranelift integer condition code.
 fn parse_int_cc(sym: Symbol) -> CompilationResult<cl_ir::condcodes::IntCC> {
     use cl_ir::condcodes::IntCC;
@@ -535,12 +570,15 @@ impl<'a> FunctionTranslator<'a> {
                 .collect::<CompilationResult<_>>()?;
 
             let sig_ty = call_ind.sig(ctx);
-            let call_conv =
-                if ctx.op(op).attributes.get_u8("tribute.calling_convention") == Ok(Some(2)) {
-                    CallConv::Tail
-                } else {
-                    self.default_call_conv
-                };
+            let call_conv = call_conv_for_cps_signature(
+                ctx,
+                sig_ty,
+                ctx.op(op)
+                    .attributes
+                    .get_u8(TRIBUTE_CALLING_CONVENTION_ATTR)
+                    == Ok(Some(CPS_CALLING_CONVENTION)),
+                self.default_call_conv,
+            );
             let sig = translate_signature(ctx, sig_ty, call_conv, self.ptr_ty)?;
             let sig_ref = self.builder.import_signature(sig);
 
@@ -819,5 +857,33 @@ mod tests {
         assert_eq!(sig.params.len(), 0);
         assert_eq!(sig.returns.len(), 1);
         assert_eq!(sig.returns[0].value_type, cl_types::I64);
+    }
+
+    #[test]
+    fn logical_cps_indirect_signature_keeps_default_call_conv() {
+        let mut ctx = IrContext::new();
+        let i32_ty = make_core_type(&mut ctx, "i32");
+        let nil_ty = make_core_type(&mut ctx, "nil");
+        let logical_signature = ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::new("func"),
+            params: trunk_ir::smallvec::smallvec![i32_ty, i32_ty],
+            attrs: Default::default(),
+        });
+        let physical_signature = ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::new("func"),
+            params: trunk_ir::smallvec::smallvec![nil_ty, i32_ty],
+            attrs: Default::default(),
+        });
+
+        assert_eq!(
+            call_conv_for_cps_signature(&ctx, logical_signature, true, CallConv::SystemV),
+            CallConv::SystemV,
+        );
+        assert_eq!(
+            call_conv_for_cps_signature(&ctx, physical_signature, true, CallConv::SystemV),
+            CallConv::Tail,
+        );
     }
 }

--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -161,8 +161,8 @@ pub(crate) struct FunctionTranslator<'a> {
     data_refs: &'a HashMap<Symbol, cl_ir::GlobalValue>,
     /// Maps TrunkIR block refs to Cranelift blocks.
     pub(crate) block_map: HashMap<BlockRef, cl_ir::Block>,
-    /// The ISA calling convention (used for indirect calls).
-    call_conv: CallConv,
+    /// The platform's ordinary calling convention for non-CPS indirect calls.
+    default_call_conv: CallConv,
     /// The platform pointer type (e.g. I64 on 64-bit).
     ptr_ty: cl_types::Type,
 }
@@ -173,7 +173,7 @@ impl<'a> FunctionTranslator<'a> {
         builder: FunctionBuilder<'a>,
         func_refs: &'a HashMap<Symbol, cl_ir::FuncRef>,
         data_refs: &'a HashMap<Symbol, cl_ir::GlobalValue>,
-        call_conv: CallConv,
+        default_call_conv: CallConv,
         ptr_ty: cl_types::Type,
     ) -> Self {
         Self {
@@ -183,7 +183,7 @@ impl<'a> FunctionTranslator<'a> {
             func_refs,
             data_refs,
             block_map: HashMap::new(),
-            call_conv,
+            default_call_conv,
             ptr_ty,
         }
     }
@@ -516,7 +516,7 @@ impl<'a> FunctionTranslator<'a> {
                 .collect::<CompilationResult<_>>()?;
 
             let sig_ty = rci.sig(ctx);
-            let sig = translate_signature(ctx, sig_ty, self.call_conv, self.ptr_ty)?;
+            let sig = translate_signature(ctx, sig_ty, CallConv::Tail, self.ptr_ty)?;
             let sig_ref = self.builder.import_signature(sig);
 
             self.builder
@@ -535,7 +535,13 @@ impl<'a> FunctionTranslator<'a> {
                 .collect::<CompilationResult<_>>()?;
 
             let sig_ty = call_ind.sig(ctx);
-            let sig = translate_signature(ctx, sig_ty, self.call_conv, self.ptr_ty)?;
+            let call_conv =
+                if ctx.op(op).attributes.get_u8("tribute.calling_convention") == Ok(Some(2)) {
+                    CallConv::Tail
+                } else {
+                    self.default_call_conv
+                };
+            let sig = translate_signature(ctx, sig_ty, call_conv, self.ptr_ty)?;
             let sig_ref = self.builder.import_signature(sig);
 
             let inst = self.builder.ins().call_indirect(sig_ref, callee, &args);

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -546,7 +546,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value
+    func.tail_call_indirect %callee, %value {tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -565,7 +565,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.i32, core.i32)}
+    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.i32, core.i32), tribute.calling_convention = 2}
   }
 }"#,
         );

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -4,6 +4,8 @@
 //! - `func.func` -> `clif.func`
 //! - `func.call` -> `clif.call`
 //! - `func.call_indirect` -> `clif.call_indirect`
+//! - `func.tail_call` -> `clif.return_call`
+//! - `func.tail_call_indirect` -> `clif.return_call_indirect`
 //! - `func.return` -> `clif.return`
 //! - `func.unreachable` -> `clif.trap`
 //! - `func.constant` -> `clif.symbol_addr`
@@ -13,7 +15,7 @@ use trunk_ir::context::IrContext;
 use trunk_ir::dialect::clif;
 use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
-use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern,
@@ -38,6 +40,7 @@ pub fn lower(
         .add_pattern(FuncCallIndirectPattern)
         .add_pattern(FuncReturnPattern)
         .add_pattern(FuncTailCallPattern)
+        .add_pattern(FuncTailCallIndirectPattern)
         .add_pattern(FuncUnreachablePattern)
         .add_pattern(FuncConstantPattern)
         .with_target(func_to_clif_target());
@@ -297,6 +300,53 @@ impl RewritePattern for FuncTailCallPattern {
     }
 }
 
+/// Pattern: `func.tail_call_indirect` -> `clif.return_call_indirect`.
+///
+/// The physical closure lowering boundary records the exact callable ABI on
+/// the transfer.  Do not infer a signature from the function pointer: after
+/// closure lowering it is untyped at the TrunkIR level.
+struct FuncTailCallIndirectPattern;
+
+impl RewritePattern for FuncTailCallIndirectPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if func::TailCallIndirect::from_op(ctx, op).is_err() {
+            return false;
+        }
+
+        let signature = match ctx
+            .op(op)
+            .attributes
+            .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
+        {
+            Some(signature) => signature,
+            None => return false,
+        };
+        let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
+            return false;
+        };
+        if callable.r#return(ctx) != core::nil(ctx).as_type_ref() {
+            return false;
+        }
+
+        let new_op = crate::passes::cf_to_clif::rebuild_op_as(
+            ctx,
+            op,
+            Symbol::new("clif"),
+            Symbol::new("return_call_indirect"),
+        );
+        let attributes = &mut ctx.op_mut(new_op).attributes;
+        attributes.remove(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR));
+        attributes.insert(Symbol::new("sig"), Attribute::Type(signature));
+        rewriter.replace_op(new_op);
+        true
+    }
+}
+
 /// Pattern: `func.unreachable` -> `clif.trap`
 struct FuncUnreachablePattern;
 
@@ -416,6 +466,18 @@ mod tests {
     use trunk_ir::printer::print_module;
     use trunk_ir::rewrite::TypeConverter;
 
+    const TAIL_TRANSFERS: &str = r#"core.module @test {
+  func.func @direct_target(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.return
+  }
+  func.func @direct_caller(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %value {callee = @direct_target, tribute.calling_convention = 2}
+  }
+  func.func @indirect_caller(%callee: core.ptr, %value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.nil, core.i32), tribute.calling_convention = 2}
+  }
+}"#;
+
     fn run_pass(ir: &str) -> String {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
@@ -449,6 +511,60 @@ mod tests {
 }"#,
         );
         insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn test_tail_transfers_to_clif() {
+        let result = run_pass(TAIL_TRANSFERS);
+        insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn tail_transfers_emit_native_object() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, TAIL_TRANSFERS);
+        super::lower(&mut ctx, module, TypeConverter::new()).unwrap();
+
+        let object = crate::emit_module_to_native(&ctx, module, &[]).unwrap();
+        assert!(!object.is_empty());
+    }
+
+    #[test]
+    fn tail_call_indirect_without_exact_signature_is_rejected() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %value
+  }
+}"#,
+        );
+
+        let error = super::lower(&mut ctx, module, TypeConverter::new()).unwrap_err();
+        assert!(
+            error.to_string().contains("func.tail_call_indirect"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn tail_call_indirect_with_nonempty_signature_is_rejected() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.i32, core.i32)}
+  }
+}"#,
+        );
+
+        let error = super::lower(&mut ctx, module, TypeConverter::new()).unwrap_err();
+        assert!(
+            error.to_string().contains("func.tail_call_indirect"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -23,6 +23,8 @@ use trunk_ir::rewrite::{
 };
 use trunk_ir::types::Attribute;
 
+use crate::function::{CPS_CALLING_CONVENTION, TRIBUTE_CALLING_CONVENTION_ATTR};
+
 /// Lower func dialect to clif dialect.
 pub fn lower(
     ctx: &mut IrContext,
@@ -317,6 +319,14 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         if func::TailCallIndirect::from_op(ctx, op).is_err() {
             return false;
         }
+        if ctx
+            .op(op)
+            .attributes
+            .get_u8(TRIBUTE_CALLING_CONVENTION_ATTR)
+            != Ok(Some(CPS_CALLING_CONVENTION))
+        {
+            return false;
+        }
 
         let signature = match ctx
             .op(op)
@@ -565,6 +575,48 @@ mod tests {
             error.to_string().contains("func.tail_call_indirect"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn tail_call_indirect_without_cps_metadata_is_rejected_before_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.nil, core.i32)}
+  }
+}"#,
+        );
+        let error = super::lower(&mut ctx, module, TypeConverter::new()).unwrap_err();
+        assert!(
+            error.to_string().contains("func.tail_call_indirect"),
+            "{error}"
+        );
+        let after = print_module(&ctx, module.op());
+        assert!(after.contains("func.tail_call_indirect"), "{after}");
+        assert!(!after.contains("clif.return_call_indirect"), "{after}");
+    }
+
+    #[test]
+    fn tail_call_indirect_with_non_cps_metadata_is_rejected_before_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.nil, core.i32), tribute.calling_convention = 0}
+  }
+}"#,
+        );
+        let error = super::lower(&mut ctx, module, TypeConverter::new()).unwrap_err();
+        assert!(
+            error.to_string().contains("func.tail_call_indirect"),
+            "{error}"
+        );
+        let after = print_module(&ctx, module.op());
+        assert!(after.contains("func.tail_call_indirect"), "{after}");
+        assert!(!after.contains("clif.return_call_indirect"), "{after}");
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
@@ -1,0 +1,18 @@
+---
+source: crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+expression: result
+---
+core.module @test {
+  clif.func {sym_name = @direct_target, tribute.calling_convention = 2, type = core.func(core.nil, core.i32)} {
+    ^bb0(%0: core.i32):
+      clif.return
+  }
+  clif.func {sym_name = @direct_caller, tribute.calling_convention = 2, type = core.func(core.nil, core.i32)} {
+    ^bb0(%0: core.i32):
+      clif.return_call %0 {callee = @direct_target, tribute.calling_convention = 2}
+  }
+  clif.func {sym_name = @indirect_caller, tribute.calling_convention = 2, type = core.func(core.nil, core.ptr, core.i32)} {
+    ^bb0(%0: core.ptr, %1: core.i32):
+      clif.return_call_indirect %0, %1 {sig = core.func(core.nil, core.i32), tribute.calling_convention = 2}
+  }
+}

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -366,15 +366,7 @@ fn emit_module_impl(
     rodata: &[RodataEntry],
 ) -> CompilationResult<Vec<u8>> {
     // 1. ISA setup — use host triple
-    let triple = host_object_triple();
-    let mut flag_builder = settings::builder();
-    flag_builder
-        .set("is_pic", "true")
-        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
-    let isa_builder = isa::lookup(triple).map_err(|e| CompilationError::codegen(format!("{e}")))?;
-    let isa = isa_builder
-        .finish(settings::Flags::new(flag_builder))
-        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    let isa = native_isa()?;
     let call_conv = isa.default_call_conv();
 
     // 2. ObjectModule creation
@@ -604,6 +596,21 @@ fn emit_module_impl(
     Ok(bytes)
 }
 
+fn native_isa() -> CompilationResult<isa::OwnedTargetIsa> {
+    let mut flag_builder = settings::builder();
+    flag_builder
+        .set("is_pic", "true")
+        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    flag_builder
+        .set("preserve_frame_pointers", "true")
+        .map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    let isa_builder =
+        isa::lookup(host_object_triple()).map_err(|e| CompilationError::codegen(format!("{e}")))?;
+    isa_builder
+        .finish(settings::Flags::new(flag_builder))
+        .map_err(|e| CompilationError::codegen(format!("{e}")))
+}
+
 fn host_object_triple() -> Triple {
     let mut triple = Triple::host();
     if let OperatingSystem::Darwin(version) = triple.operating_system {
@@ -709,5 +716,10 @@ mod tests {
                 OperatingSystem::MacOSX(_)
             ));
         }
+    }
+
+    #[test]
+    fn native_isa_preserves_frame_pointers_for_tail_calls() {
+        assert!(native_isa().unwrap().flags().preserve_frame_pointers());
     }
 }

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -25,6 +25,23 @@ use trunk_ir::rewrite::Module;
 use crate::function::{FunctionTranslator, translate_signature, translate_type};
 use crate::{CompilationError, CompilationResult, validate_clif_ir};
 
+const TRIBUTE_CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
+const CPS_CALLING_CONVENTION: u8 = 2;
+
+/// CPS functions use Cranelift's internal tail-call convention.  The
+/// convention marker is part of the physical callable contract and is kept as
+/// an attribute so this language-agnostic backend does not depend on Tribute.
+fn function_call_conv(ctx: &IrContext, func_op: OpRef, default: isa::CallConv) -> isa::CallConv {
+    match ctx
+        .op(func_op)
+        .attributes
+        .get_u8(TRIBUTE_CALLING_CONVENTION_ATTR)
+    {
+        Ok(Some(CPS_CALLING_CONVENTION)) => isa::CallConv::Tail,
+        _ => default,
+    }
+}
+
 /// Mangle a TrunkIR symbol name for native linking.
 ///
 /// Produces a fixed-length hash format inspired by Rust's name mangling:
@@ -373,6 +390,7 @@ fn emit_module_impl(
             .map_err(|_| CompilationError::codegen("expected clif.func op"))?;
         let name_sym = func_wrapped.sym_name(ctx);
         let func_type_ref = func_wrapped.r#type(ctx);
+        let func_call_conv = function_call_conv(ctx, func_op, call_conv);
 
         let op_data = ctx.op(func_op);
         let has_abi = op_data.attributes.contains_key("abi");
@@ -386,7 +404,7 @@ fn emit_module_impl(
 
         // Skip imported functions whose types can't be translated to Cranelift
         // (e.g., prelude extern functions using core.bytes that are never called).
-        let sig = match translate_signature(ctx, func_type_ref, call_conv, ptr_ty) {
+        let sig = match translate_signature(ctx, func_type_ref, func_call_conv, ptr_ty) {
             Ok(sig) => sig,
             Err(_) if has_abi => continue,
             Err(e) => return Err(e),
@@ -446,8 +464,9 @@ fn emit_module_impl(
             .map_err(|_| CompilationError::codegen("expected clif.func op"))?;
         let name_sym = func_wrapped.sym_name(ctx);
         let func_type_ref = func_wrapped.r#type(ctx);
+        let func_call_conv = function_call_conv(ctx, func_op, call_conv);
 
-        let sig = translate_signature(ctx, func_type_ref, call_conv, ptr_ty)?;
+        let sig = translate_signature(ctx, func_type_ref, func_call_conv, ptr_ty)?;
         let func_id = func_ids[&name_sym];
 
         let mut cl_func =

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -22,24 +22,30 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef};
 use trunk_ir::rewrite::Module;
 
-use crate::function::{FunctionTranslator, translate_signature, translate_type};
+use crate::function::{
+    CPS_CALLING_CONVENTION, FunctionTranslator, TRIBUTE_CALLING_CONVENTION_ATTR,
+    call_conv_for_cps_signature, translate_signature, translate_type,
+};
 use crate::{CompilationError, CompilationResult, validate_clif_ir};
-
-const TRIBUTE_CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
-const CPS_CALLING_CONVENTION: u8 = 2;
 
 /// CPS functions use Cranelift's internal tail-call convention.  The
 /// convention marker is part of the physical callable contract and is kept as
 /// an attribute so this language-agnostic backend does not depend on Tribute.
-fn function_call_conv(ctx: &IrContext, func_op: OpRef, default: isa::CallConv) -> isa::CallConv {
-    match ctx
-        .op(func_op)
-        .attributes
-        .get_u8(TRIBUTE_CALLING_CONVENTION_ATTR)
-    {
-        Ok(Some(CPS_CALLING_CONVENTION)) => isa::CallConv::Tail,
-        _ => default,
-    }
+fn function_call_conv(
+    ctx: &IrContext,
+    func_op: OpRef,
+    func_type: trunk_ir::refs::TypeRef,
+    default: isa::CallConv,
+) -> isa::CallConv {
+    call_conv_for_cps_signature(
+        ctx,
+        func_type,
+        ctx.op(func_op)
+            .attributes
+            .get_u8(TRIBUTE_CALLING_CONVENTION_ATTR)
+            == Ok(Some(CPS_CALLING_CONVENTION)),
+        default,
+    )
 }
 
 /// Mangle a TrunkIR symbol name for native linking.
@@ -390,7 +396,7 @@ fn emit_module_impl(
             .map_err(|_| CompilationError::codegen("expected clif.func op"))?;
         let name_sym = func_wrapped.sym_name(ctx);
         let func_type_ref = func_wrapped.r#type(ctx);
-        let func_call_conv = function_call_conv(ctx, func_op, call_conv);
+        let func_call_conv = function_call_conv(ctx, func_op, func_type_ref, call_conv);
 
         let op_data = ctx.op(func_op);
         let has_abi = op_data.attributes.contains_key("abi");
@@ -464,7 +470,7 @@ fn emit_module_impl(
             .map_err(|_| CompilationError::codegen("expected clif.func op"))?;
         let name_sym = func_wrapped.sym_name(ctx);
         let func_type_ref = func_wrapped.r#type(ctx);
-        let func_call_conv = function_call_conv(ctx, func_op, call_conv);
+        let func_call_conv = function_call_conv(ctx, func_op, func_type_ref, call_conv);
 
         let sig = translate_signature(ctx, func_type_ref, func_call_conv, ptr_ty)?;
         let func_id = func_ids[&name_sym];


### PR DESCRIPTION
Fixes #845.

Lowers direct and indirect physical CPS proper-tail transfers to Cranelift return-call forms, consuming #847 exact callable metadata and preserving empty-result signatures.

Validated with focused tail-transfer, calling-convention, target-ABI, Cranelift backend, and affected pass suites. Excludes shared ABI redesign, production routing, handler/effect changes, wrappers or trampolines, and Wasm changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for indirect tail calls using CPS calling conventions.
  * Function signatures now select the appropriate calling convention based on CPS metadata and return types.
  * Added validation requiring compatible signatures and empty (`core.nil`) returns.
  * Improved native output for supported indirect tail calls.
  * Native code generation now preserves frame pointers.

* **Bug Fixes**
  * Prevented invalid indirect tail calls from being lowered when metadata or signatures are missing, or when return values are non-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->