### PR TITLE
Lower proper tail transfers through the Wasm backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,8 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -646,8 +644,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1730,10 +1726,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.10.0",
- "hashbrown 0.17.0",
  "indexmap",
  "semver",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -644,6 +646,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1619,9 +1623,11 @@ version = "0.1.0"
 dependencies = [
  "derive_more",
  "insta",
+ "tempfile",
  "tracing",
  "trunk-ir",
  "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1724,8 +1730,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.10.0",
+ "hashbrown 0.17.0",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ trunk-ir-cranelift-backend = { path = "crates/trunk-ir-cranelift-backend" }
 trunk-ir-wasm-backend = { path = "crates/trunk-ir-wasm-backend" }
 unsynn = "0.3.0"
 wasm-encoder = "0.251.0"
-wasmparser = "0.251.0"
+wasmparser = { version = "0.251.0", default-features = false, features = ["std", "validate", "features"] }
 winnow = "1.0"
 zmij = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ trunk-ir-cranelift-backend = { path = "crates/trunk-ir-cranelift-backend" }
 trunk-ir-wasm-backend = { path = "crates/trunk-ir-wasm-backend" }
 unsynn = "0.3.0"
 wasm-encoder = "0.251.0"
+wasmparser = "0.251.0"
 winnow = "1.0"
 zmij = "1"
 

--- a/crates/trunk-ir-wasm-backend/Cargo.toml
+++ b/crates/trunk-ir-wasm-backend/Cargo.toml
@@ -14,3 +14,5 @@ wasm-encoder.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+tempfile.workspace = true
+wasmparser.workspace = true

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -1169,7 +1169,9 @@ fn should_adjust_handler_return_to_i32(ctx: &IrContext, region: RegionRef) -> bo
 fn region_contains_call_indirect(ctx: &IrContext, region: RegionRef) -> bool {
     for &block_ref in &ctx.region(region).blocks {
         for &op in &ctx.block(block_ref).ops {
-            if wasm_dialect::CallIndirect::matches(ctx, op) {
+            if wasm_dialect::CallIndirect::matches(ctx, op)
+                || wasm_dialect::ReturnCallIndirect::matches(ctx, op)
+            {
                 return true;
             }
             for &nested_region in &ctx.op(op).regions {
@@ -1274,6 +1276,33 @@ mod tests {
             )),
             "missing return_call_indirect in {instructions:?}"
         );
+    }
+
+    #[test]
+    fn region_contains_call_indirect_recognizes_return_call_indirect() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @tail_indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+  }
+  wasm.func @tail_direct(%value: core.i32) -> core.nil {
+    wasm.return_call %value {callee = @target}
+  }
+}"#,
+        );
+
+        let tail_indirect = module.ops(&ctx)[0];
+        let tail_direct = module.ops(&ctx)[1];
+        assert!(region_contains_call_indirect(
+            &ctx,
+            ctx.op(tail_indirect).regions[0]
+        ));
+        assert!(!region_contains_call_indirect(
+            &ctx,
+            ctx.op(tail_direct).regions[0]
+        ));
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -1279,13 +1279,56 @@ mod tests {
     }
 
     #[test]
+    fn collects_and_encodes_tableless_return_call_indirect_exact_signature() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+  }
+}"#,
+        );
+        let info = collect_module_info(&mut ctx, module).expect("collect module info");
+        let [(type_index, _)] = info.call_indirect_types.as_slice() else {
+            panic!("expected one collected exact signature")
+        };
+        assert_eq!(info.tables.len(), 1, "implicit function table");
+
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("valid tail-transfer module")
+            .bytes;
+        let encoded = Parser::new(0)
+            .parse_all(&bytes)
+            .filter_map(Result::ok)
+            .filter_map(|payload| match payload {
+                Payload::CodeSectionEntry(body) => Some(body),
+                _ => None,
+            })
+            .flat_map(|body| body.get_operators_reader().expect("operators").into_iter())
+            .find_map(
+                |instruction| match instruction.expect("decode instruction") {
+                    Operator::ReturnCallIndirect {
+                        type_index,
+                        table_index,
+                    } => Some((type_index, table_index)),
+                    _ => None,
+                },
+            )
+            .expect("encoded return_call_indirect");
+        assert_eq!(encoded, (*type_index, 0));
+    }
+
+    #[test]
     fn region_contains_call_indirect_recognizes_return_call_indirect() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
   wasm.func @tail_indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.block {
+      wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    }
   }
   wasm.func @tail_direct(%value: core.i32) -> core.nil {
     wasm.return_call %value {callee = @target}

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -25,7 +25,8 @@ use handlers::{
     handle_i64_store, handle_i64_store8, handle_i64_store16, handle_i64_store32, handle_if,
     handle_local_get, handle_local_set, handle_local_tee, handle_loop, handle_memory_grow,
     handle_memory_size, handle_ref_cast, handle_ref_func, handle_ref_null, handle_ref_test,
-    handle_return_call, handle_struct_get, handle_struct_new, handle_struct_set,
+    handle_return_call, handle_return_call_indirect, handle_struct_get, handle_struct_new,
+    handle_struct_set,
 };
 use helpers::*;
 use value_emission::*;
@@ -1003,6 +1004,8 @@ fn emit_op_nested(
         handle_call_indirect(ctx, op, emit_ctx, module_info, function)
     } else if let Ok(return_call_op) = wasm_dialect::ReturnCall::from_op(ctx, op) {
         handle_return_call(ctx, return_call_op, emit_ctx, module_info, function)
+    } else if wasm_dialect::ReturnCallIndirect::matches(ctx, op) {
+        handle_return_call_indirect(ctx, op, emit_ctx, module_info, function)
     } else if let Ok(local_op) = wasm_dialect::LocalGet::from_op(ctx, op) {
         handle_local_get(ctx, local_op, emit_ctx, function)
     } else if let Ok(local_op) = wasm_dialect::LocalSet::from_op(ctx, op) {
@@ -1207,4 +1210,89 @@ fn intern_simple_type(ctx: &mut IrContext, dialect: &'static str, name: &'static
         params: Default::default(),
         attrs: Default::default(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::process::Command;
+
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use wasmparser::{Operator, Parser, Payload, Validator, WasmFeatures};
+
+    fn return_call_indirect_module(ctx: &mut IrContext) -> IrModule {
+        parse_test_module(
+            ctx,
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.elem {table = 0, offset = 0} {
+    wasm.ref_func {func_name = @target} : wasm.funcref
+  }
+  wasm.func @target(%value: core.i32) -> core.nil {
+    wasm.return
+  }
+  wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+  }
+  wasm.export_func {name = "caller", func = @caller}
+}"#,
+        )
+    }
+
+    #[test]
+    fn encodes_and_validates_return_call_indirect_with_exact_signature() {
+        let mut ctx = IrContext::new();
+        let module = return_call_indirect_module(&mut ctx);
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("valid tail-transfer module")
+            .bytes;
+
+        let mut validator =
+            Validator::new_with_features(WasmFeatures::default() | WasmFeatures::TAIL_CALL);
+        validator
+            .validate_all(&bytes)
+            .expect("encoded return_call_indirect must validate");
+
+        let instructions = Parser::new(0)
+            .parse_all(&bytes)
+            .filter_map(Result::ok)
+            .filter_map(|payload| match payload {
+                Payload::CodeSectionEntry(body) => Some(body),
+                _ => None,
+            })
+            .flat_map(|body| body.get_operators_reader().expect("operators").into_iter())
+            .collect::<Result<Vec<_>, _>>()
+            .expect("decode encoded instructions");
+        assert!(
+            instructions.iter().any(|instruction| matches!(
+                instruction,
+                Operator::ReturnCallIndirect {
+                    type_index: _,
+                    table_index: 0,
+                }
+            )),
+            "missing return_call_indirect in {instructions:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires the Wasmtime CLI runtime"]
+    fn return_call_indirect_executes_in_wasmtime() {
+        let mut ctx = IrContext::new();
+        let module = return_call_indirect_module(&mut ctx);
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("valid tail-transfer module")
+            .bytes;
+        let file = tempfile::NamedTempFile::new().expect("temporary Wasm file");
+        fs::write(file.path(), bytes).expect("write Wasm module");
+
+        let status = Command::new("wasmtime")
+            .args(["-W", "gc=y", "-W", "tail-call=y", "--invoke", "caller"])
+            .arg(file.path())
+            .args(["0", "42"])
+            .status()
+            .expect("run Wasmtime");
+        assert!(status.success(), "Wasmtime returned {status}");
+    }
 }

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -129,7 +129,24 @@ pub(crate) fn collect_call_indirect_types(
                     )?;
                 }
 
-                // Check if this is a call_indirect
+                // `return_call_indirect` carries the exact physical callable
+                // contract from the shared ABI pass. Validate and register it
+                // before handling ordinary calls, whose historical path still
+                // derives a signature from their result-producing operation.
+                if wasm_dialect::ReturnCallIndirect::matches(ctx, op) {
+                    let func_type = helpers::exact_return_call_indirect_signature(ctx, op)?;
+                    if let std::collections::hash_map::Entry::Vacant(entry) =
+                        type_idx_by_type.entry(func_type)
+                    {
+                        let index = *next_type_idx;
+                        *next_type_idx += 1;
+                        entry.insert(index);
+                        new_types.push((index, func_type));
+                    }
+                    continue;
+                }
+
+                // Check if this is a result-producing call_indirect.
                 if wasm_dialect::CallIndirect::matches(ctx, op) {
                     // Build function type from operands and results
                     let operands: Vec<_> = ctx.op_operands(op).to_vec();
@@ -316,7 +333,7 @@ pub(crate) fn collect_ref_funcs(ctx: &IrContext, module: Module) -> HashSet<Symb
     ref_funcs
 }
 
-/// Check if the module contains any call_indirect operations.
+/// Check if the module contains any table-based indirect transfer.
 pub(crate) fn has_call_indirect(ctx: &IrContext, module: Module) -> bool {
     fn check_region(ctx: &IrContext, region_ref: RegionRef) -> bool {
         for &block_ref in &ctx.region(region_ref).blocks {
@@ -328,8 +345,9 @@ pub(crate) fn has_call_indirect(ctx: &IrContext, module: Module) -> bool {
                     }
                 }
 
-                // Check if this is a call_indirect
-                if wasm_dialect::CallIndirect::matches(ctx, op) {
+                if wasm_dialect::CallIndirect::matches(ctx, op)
+                    || wasm_dialect::ReturnCallIndirect::matches(ctx, op)
+                {
                     return true;
                 }
             }

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -3,7 +3,7 @@
 //! This module handles WebAssembly function call operations:
 //! - wasm.call (direct function call)
 //! - wasm.call_indirect (indirect function call via i32 table index)
-//! - wasm.return_call (tail call)
+//! - wasm.return_call / wasm.return_call_indirect (tail calls)
 
 use tracing::debug;
 use trunk_ir::IrContext;
@@ -260,6 +260,45 @@ pub(crate) fn handle_return_call(
     emit_operands(ctx, operands, emit_ctx, function)?;
 
     function.instruction(&Instruction::ReturnCall(target));
+    Ok(())
+}
+
+/// Handle `wasm.return_call_indirect` using its exact physical signature.
+pub(crate) fn handle_return_call_indirect(
+    ctx: &IrContext,
+    op: OpRef,
+    emit_ctx: &FunctionEmitContext,
+    module_info: &ModuleInfo,
+    function: &mut Function,
+) -> CompilationResult<()> {
+    let signature = helpers::exact_return_call_indirect_signature(ctx, op)?;
+    let type_index = module_info
+        .type_idx_by_type
+        .get(&signature)
+        .copied()
+        .ok_or_else(|| {
+            CompilationError::invalid_module(
+                "wasm.return_call_indirect function type not registered in type section",
+            )
+        })?;
+    let table_index = ctx
+        .op(op)
+        .attributes
+        .get("table")
+        .map(|_| attr_u32(&ctx.op(op).attributes, Symbol::new("table")))
+        .transpose()?
+        .unwrap_or(0);
+    let operands = ctx.op_operands(op);
+
+    // WebAssembly evaluates arguments before the table index.
+    for &arg in operands.iter().skip(1) {
+        emit_value(ctx, arg, emit_ctx, function)?;
+    }
+    emit_value(ctx, operands[0], emit_ctx, function)?;
+    function.instruction(&Instruction::ReturnCallIndirect {
+        type_index,
+        table_index,
+    });
     Ok(())
 }
 

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/mod.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/mod.rs
@@ -16,7 +16,9 @@ pub(super) use array_handlers::{
     handle_array_copy, handle_array_get, handle_array_get_s, handle_array_get_u, handle_array_new,
     handle_array_new_default, handle_array_set,
 };
-pub(super) use call_handlers::{handle_call, handle_call_indirect, handle_return_call};
+pub(super) use call_handlers::{
+    handle_call, handle_call_indirect, handle_return_call, handle_return_call_indirect,
+};
 pub(super) use const_handlers::{
     handle_f32_const, handle_f64_const, handle_i32_const, handle_i64_const,
 };

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::refs::{TypeRef, ValueRef};
+use trunk_ir::dialect::func;
+use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, AttributeMap};
 use wasm_encoder::{AbstractHeapType, HeapType, RefType, ValType};
 
@@ -102,6 +103,54 @@ pub(crate) fn func_type_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef
     }
     let (ret, params) = data.params.split_first()?;
     Some((params, *ret))
+}
+
+/// Read and validate the exact physical function type required by an indirect
+/// proper tail transfer. This backend deliberately does not infer the type
+/// from the runtime table index and operands.
+pub(crate) fn exact_return_call_indirect_signature(
+    ctx: &IrContext,
+    op: OpRef,
+) -> CompilationResult<TypeRef> {
+    let signature = ctx
+        .op(op)
+        .attributes
+        .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
+        .ok_or_else(|| {
+            CompilationError::invalid_module(
+                "wasm.return_call_indirect lacks func.indirect_call_signature",
+            )
+        })?;
+    let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.return_call_indirect signature must be core.func")
+    })?;
+    if !is_nil_type(ctx, result) {
+        return Err(CompilationError::invalid_module(
+            "wasm.return_call_indirect signature must have an empty result",
+        ));
+    }
+    let operands = ctx.op_operands(op);
+    let Some((&table_index, args)) = operands.split_first() else {
+        return Err(CompilationError::invalid_module(
+            "wasm.return_call_indirect requires a table index operand",
+        ));
+    };
+    if !is_type(ctx, value_type(ctx, table_index), "core", "i32") {
+        return Err(CompilationError::invalid_module(
+            "wasm.return_call_indirect first operand must be an i32 table index",
+        ));
+    }
+    if params.len() != args.len()
+        || params
+            .iter()
+            .zip(args)
+            .any(|(param, arg)| *param != value_type(ctx, *arg))
+    {
+        return Err(CompilationError::invalid_module(
+            "wasm.return_call_indirect operands do not match its exact signature",
+        ));
+    }
+    Ok(signature)
 }
 
 /// Convert an IR type to a WebAssembly value type.

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -469,6 +469,10 @@ mod tests {
   func.func @indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
     func.tail_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32)}
   }
+  func.func @ordinary(%table_index: core.i32, %value: core.i32) -> core.i32 {
+    %result = func.call_indirect %table_index, %value : core.i32
+    func.return %result
+  }
 }"#,
         );
 
@@ -483,6 +487,7 @@ mod tests {
             output.contains("wasm.return_call_indirect %0, %1"),
             "{output}"
         );
+        assert!(output.contains(" = wasm.call_indirect "), "{output}");
         assert!(
             output.contains("func.indirect_call_signature = core.func(core.nil, core.i32)"),
             "{output}"

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -6,6 +6,7 @@
 //! - `func.call_indirect` -> `wasm.call_indirect`
 //! - `func.return` -> `wasm.return`
 //! - `func.tail_call` -> `wasm.return_call`
+//! - `func.tail_call_indirect` -> `wasm.return_call_indirect`
 //! - `func.unreachable` -> `wasm.unreachable`
 //! - `func.constant` -> `wasm.i32_const` (function table index)
 //!
@@ -46,6 +47,7 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
             .add_pattern(FuncCallIndirectPattern)
             .add_pattern(FuncReturnPattern)
             .add_pattern(FuncTailCallPattern)
+            .add_pattern(FuncTailCallIndirectPattern)
             .add_pattern(FuncUnreachablePattern)
             .add_pattern(FuncConstantPattern {
                 table_indices: HashMap::new(),
@@ -73,6 +75,7 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
         .add_pattern(FuncCallIndirectPattern)
         .add_pattern(FuncReturnPattern)
         .add_pattern(FuncTailCallPattern)
+        .add_pattern(FuncTailCallIndirectPattern)
         .add_pattern(FuncUnreachablePattern)
         .add_pattern(FuncConstantPattern {
             table_indices: table_indices.clone(),
@@ -302,6 +305,47 @@ impl RewritePattern for FuncTailCallPattern {
     }
 }
 
+/// Pattern for `func.tail_call_indirect` -> `wasm.return_call_indirect`.
+///
+/// The shared physical-ABI boundary retains the precise callee signature in
+/// `func.indirect_call_signature` after closure lowering has replaced the
+/// typed closure with a table index.  This backend must carry that metadata
+/// through instead of rebuilding a signature from the runtime operands.
+struct FuncTailCallIndirectPattern;
+
+impl RewritePattern for FuncTailCallIndirectPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        if func::TailCallIndirect::from_op(ctx, op).is_err() {
+            return false;
+        }
+
+        // This is intentionally checked before creating any replacement.
+        // Missing or malformed metadata remains a residual `func.*` op and is
+        // rejected by the Wasm readiness boundary rather than guessed from
+        // table-index and argument values.
+        if crate::emit::helpers::exact_return_call_indirect_signature(ctx, op).is_err() {
+            return false;
+        }
+
+        let operands: Vec<_> = ctx.op_operands(op).to_vec();
+        if operands.is_empty() || !ctx.op_result_types(op).is_empty() {
+            return false;
+        }
+
+        let loc = ctx.op(op).location;
+        let attrs = ctx.op(op).attributes.clone();
+        let new_op = wasm_dialect::return_call_indirect(ctx, loc, operands, 0, 0);
+        ctx.op_mut(new_op.op_ref()).attributes.extend(attrs);
+        rewriter.replace_op(new_op.op_ref());
+        true
+    }
+}
+
 /// Pattern for `func.unreachable` -> `wasm.unreachable`
 struct FuncUnreachablePattern;
 
@@ -381,6 +425,7 @@ fn intern_funcref_type(ctx: &mut IrContext) -> TypeRef {
 mod tests {
     use super::*;
     use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
     use trunk_ir::types::Attribute;
 
     #[test]
@@ -407,5 +452,95 @@ mod tests {
             ctx.op(lowered).attributes.get("custom"),
             Some(&Attribute::Int(7))
         );
+    }
+
+    #[test]
+    fn lowers_direct_and_indirect_proper_tail_transfers() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @target(%value: core.i32) -> core.nil {
+    func.return
+  }
+  func.func @direct(%value: core.i32) -> core.nil {
+    func.tail_call %value {callee = @target}
+  }
+  func.func @indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32)}
+  }
+}"#,
+        );
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let output = print_module(&ctx, module.op());
+        assert!(
+            output.contains("wasm.return_call %0 {callee = @target}"),
+            "{output}"
+        );
+        assert!(
+            output.contains("wasm.return_call_indirect %0, %1"),
+            "{output}"
+        );
+        assert!(
+            output.contains("func.indirect_call_signature = core.func(core.nil, core.i32)"),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn lowers_indirect_tail_transfer_with_a_function_table_entry() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @target(%value: core.i32) -> core.nil {
+    func.return
+  }
+  func.func @caller(%value: core.i32) -> core.nil {
+    %table_index = func.constant {func_ref = @target} : core.i32
+    func.tail_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32)}
+  }
+}"#,
+        );
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let output = print_module(&ctx, module.op());
+        assert!(output.contains("wasm.table"), "{output}");
+        assert!(output.contains("wasm.elem"), "{output}");
+        assert!(
+            output.contains("wasm.ref_func {func_name = @target}"),
+            "{output}"
+        );
+        assert!(output.contains("wasm.i32_const {value = 0}"), "{output}");
+        assert!(output.contains("wasm.return_call_indirect"), "{output}");
+    }
+
+    #[test]
+    fn leaves_indirect_tail_transfers_without_an_exact_empty_signature_unconverted() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %table_index, %value
+  }
+  func.func @malformed(%table_index: core.i32, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.i32, core.i32)}
+  }
+}"#,
+        );
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let output = print_module(&ctx, module.op());
+        assert_eq!(
+            output.matches("func.tail_call_indirect").count(),
+            2,
+            "{output}"
+        );
+        assert!(!output.contains("wasm.return_call_indirect"), "{output}");
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -114,37 +114,66 @@ mod tests {
     use trunk_ir::parser::parse_test_module;
 
     #[test]
-    fn rejects_return_call_indirect_without_an_exact_empty_signature() {
-        let mut ctx = IrContext::new();
-        let missing = parse_test_module(
-            &mut ctx,
+    fn rejects_invalid_return_call_indirect_exact_contracts() {
+        let rejects = |source: &str, diagnostic: &str| {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, source);
+            let error = validate_wasm_ir(&ctx, module).unwrap_err();
+            assert!(error.to_string().contains(diagnostic), "{error}");
+        };
+
+        rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
     wasm.return_call_indirect %table_index, %value {table = 0, type_idx = 0}
   }
 }"#,
-        );
-        let error = validate_wasm_ir(&ctx, missing).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("lacks func.indirect_call_signature"),
-            "{error}"
+            "lacks func.indirect_call_signature",
         );
 
-        let mut ctx = IrContext::new();
-        let malformed = parse_test_module(
-            &mut ctx,
+        rejects(
+            r#"core.module @test {
+  wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.i32, table = 0, type_idx = 0}
+  }
+}"#,
+            "signature must be core.func",
+        );
+
+        rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
     wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.i32, core.i32), table = 0, type_idx = 0}
   }
 }"#,
+            "must have an empty result",
         );
-        let error = validate_wasm_ir(&ctx, malformed).unwrap_err();
-        assert!(
-            error.to_string().contains("must have an empty result"),
-            "{error}"
+
+        rejects(
+            r#"core.module @test {
+  wasm.func @caller() -> core.nil {
+    wasm.return_call_indirect {func.indirect_call_signature = core.func(core.nil), table = 0, type_idx = 0}
+  }
+}"#,
+            "requires a table index operand",
+        );
+
+        rejects(
+            r#"core.module @test {
+  wasm.func @caller(%table_index: core.i64, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+  }
+}"#,
+            "first operand must be an i32 table index",
+        );
+
+        rejects(
+            r#"core.module @test {
+  wasm.func @caller(%table_index: core.i32, %value: core.i64) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+  }
+}"#,
+            "operands do not match its exact signature",
         );
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -8,6 +8,8 @@
 use trunk_ir::IrContext;
 use trunk_ir::Module;
 use trunk_ir::Symbol;
+use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef};
 
 use crate::{CompilationError, CompilationResult};
@@ -69,10 +71,22 @@ fn validate_operation(ctx: &IrContext, op: OpRef, depth: usize, errors: &mut Vec
     if !is_allowed_dialect(ctx, op, depth) {
         errors.push(format!("Non-wasm operation found: {}.{}", dialect, name));
     }
+    validate_return_call_indirect(ctx, op, errors);
 
     // Recursively validate nested regions
     for &region in &op_data.regions {
         validate_region(ctx, region, depth + 1, errors);
+    }
+}
+
+/// Validate the source-of-truth signature needed for a proper indirect tail
+/// transfer before emission has a chance to construct a type section.
+fn validate_return_call_indirect(ctx: &IrContext, op: OpRef, errors: &mut Vec<String>) {
+    if !wasm_dialect::ReturnCallIndirect::matches(ctx, op) {
+        return;
+    }
+    if let Err(error) = crate::emit::helpers::exact_return_call_indirect_signature(ctx, op) {
+        errors.push(error.to_string());
     }
 }
 
@@ -92,4 +106,45 @@ fn is_allowed_dialect(ctx: &IrContext, op: OpRef, depth: usize) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+
+    #[test]
+    fn rejects_return_call_indirect_without_an_exact_empty_signature() {
+        let mut ctx = IrContext::new();
+        let missing = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {table = 0, type_idx = 0}
+  }
+}"#,
+        );
+        let error = validate_wasm_ir(&ctx, missing).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("lacks func.indirect_call_signature"),
+            "{error}"
+        );
+
+        let mut ctx = IrContext::new();
+        let malformed = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.i32, core.i32), table = 0, type_idx = 0}
+  }
+}"#,
+        );
+        let error = validate_wasm_ir(&ctx, malformed).unwrap_err();
+        assert!(
+            error.to_string().contains("must have an empty result"),
+            "{error}"
+        );
+    }
 }

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -53,6 +53,9 @@ mod wasm {
     #[attr(callee: Symbol)]
     fn return_call(#[rest] args: ()) {}
 
+    #[attr(type_idx: u32, table: u32)]
+    fn return_call_indirect(#[rest] args: ()) {}
+
     fn unreachable() {}
     fn nop() -> result {}
 


### PR DESCRIPTION
Closes #846.

Lowers direct and indirect CPS tail transfers through the Wasm backend, consuming exact `func.indirect_call_signature` metadata. Emits `wasm.return_call` and `wasm.return_call_indirect`, including function/table collection and fail-closed signature validation.

Validated with focused Wasm/backend and pass suites, an indirect-tail Wasmtime witness, formatting, clippy, and canonical Wasm compile/run output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for indirect tail calls in WebAssembly output.
  - Indirect tail calls can now use function tables and preserve their declared signatures.
  - Added support for validating and lowering indirect tail-call operations.

- **Bug Fixes**
  - Improved detection and handling of indirect control-flow transfers.
  - Invalid signatures, table indexes, operands, and result types now produce clear validation errors instead of generating invalid modules.

- **Tests**
  - Added coverage for encoding, validation, nested regions, tableless modules, and optional runtime execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->