### PR TITLE
Skip bodyless function declarations in rewrite scopes

### DIFF
--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -248,6 +248,12 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
             return false;
         };
 
+        // External declarations have no body region and must remain
+        // untouched. `Func::body` asserts that the region exists.
+        let Some(old_body) = ctx.op(op).regions.first().copied() else {
+            return false;
+        };
+
         let loc = ctx.op(op).location;
         let func_ty = func_op.r#type(ctx);
 
@@ -296,7 +302,6 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
         });
 
         // Detach old body region before replacing
-        let old_body = func_op.body(ctx);
         ctx.detach_region(old_body);
 
         let new_func = func::func(ctx, loc, sym_name, func_ty, body).op_ref();
@@ -379,6 +384,26 @@ mod tests {
             !output.contains("func.unreachable"),
             "func.unreachable should be gone:\n{output}"
         );
+    }
+
+    #[test]
+    fn bodyless_intrinsic_decl_is_unchanged() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"
+            core.module @test {
+                func.func @"Nat::+"(%0: core.i32, %1: core.i32) -> core.i32
+                    attributes {abi = "intrinsic"}
+            }
+        "#,
+        );
+
+        let before = print_module(&ctx, module.op());
+        lower_intrinsic_to_arith(&mut ctx, module);
+        let after = print_module(&ctx, module.op());
+
+        assert_eq!(after, before, "bodyless declaration must remain unchanged");
     }
 
     #[test]

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -42,10 +42,10 @@ impl RewriteScope for Module {
 }
 
 impl RewriteScope for func::Func {
-    type Regions = std::iter::Once<RegionRef>;
+    type Regions = std::option::IntoIter<RegionRef>;
 
     fn regions(self, ctx: &IrContext) -> Self::Regions {
-        std::iter::once(self.body(ctx))
+        ctx.op(self.op_ref()).regions.first().copied().into_iter()
     }
 
     fn module_first_block(self, _ctx: &IrContext) -> Option<BlockRef> {
@@ -54,10 +54,10 @@ impl RewriteScope for func::Func {
 }
 
 impl RewriteScope for wasm::Func {
-    type Regions = std::iter::Once<RegionRef>;
+    type Regions = std::option::IntoIter<RegionRef>;
 
     fn regions(self, ctx: &IrContext) -> Self::Regions {
-        std::iter::once(self.body(ctx))
+        ctx.op(self.op_ref()).regions.first().copied().into_iter()
     }
 
     fn module_first_block(self, _ctx: &IrContext) -> Option<BlockRef> {
@@ -393,9 +393,10 @@ impl PatternApplicator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dialect::func;
+    use crate::dialect::{func, wasm};
     use crate::location::Span;
     use crate::ops::DialectOp;
+    use crate::printer::print_module;
     use crate::rewrite::conversion_target::ConversionTarget;
     use crate::symbol::Symbol;
     use crate::*;
@@ -488,6 +489,46 @@ mod tests {
             .build(ctx);
         let func_op = ctx.create_op(func_data);
         func::Func::from_op(ctx, func_op).expect("test func should be valid")
+    }
+
+    fn make_wasm_func_container(
+        ctx: &mut IrContext,
+        loc: Location,
+        name: &'static str,
+        nested_ops: Vec<OpRef>,
+    ) -> wasm::Func {
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for op in nested_ops {
+            ctx.push_op(block, op);
+        }
+        let region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+        let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
+        let func_ty = crate::dialect::core::func(ctx, nil_ty, []).as_type_ref();
+        wasm::func(ctx, loc, Symbol::new(name), func_ty, region)
+    }
+
+    fn make_bodyless_func(
+        ctx: &mut IrContext,
+        loc: Location,
+        dialect: &'static str,
+        name: &'static str,
+    ) -> OpRef {
+        let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
+        let func_ty = crate::dialect::core::func(ctx, nil_ty, []).as_type_ref();
+        let op_data = OperationDataBuilder::new(loc, Symbol::new(dialect), Symbol::new("func"))
+            .attr("sym_name", Attribute::Symbol(Symbol::new(name)))
+            .attr("type", Attribute::Type(func_ty))
+            .build(ctx);
+        ctx.create_op(op_data)
     }
 
     fn first_nested_op(ctx: &IrContext, op: OpRef) -> OpRef {
@@ -729,6 +770,66 @@ mod tests {
         assert_eq!(
             ctx.op(first_nested_op(&ctx, sibling_func.op_ref())).name,
             Symbol::new("source")
+        );
+    }
+
+    #[test]
+    fn func_scope_skips_bodyless_and_visits_body() {
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+        let bodyless = make_bodyless_func(&mut ctx, loc, "func", "extern");
+        let nested_data =
+            OperationDataBuilder::new(loc, Symbol::new("test"), Symbol::new("source"))
+                .result(i32_ty)
+                .build(&mut ctx);
+        let nested = ctx.create_op(nested_data);
+        let bodyful = make_func_container(&mut ctx, loc, "defined", vec![nested]);
+        let module = make_module(&mut ctx, loc, vec![bodyless, bodyful.op_ref()]);
+
+        let before = print_module(&ctx, module.op());
+        let bodyless = func::Func::from_op(&ctx, bodyless).unwrap();
+        PatternApplicator::new(TypeConverter::new())
+            .add_pattern(RenamePattern)
+            .apply_partial(&mut ctx, bodyless);
+        assert_eq!(print_module(&ctx, module.op()), before);
+
+        let result = PatternApplicator::new(TypeConverter::new())
+            .add_pattern(RenamePattern)
+            .apply_partial(&mut ctx, bodyful);
+        assert_eq!(result.total_changes, 1);
+        assert_eq!(
+            ctx.op(first_nested_op(&ctx, bodyful.op_ref())).name,
+            Symbol::new("target")
+        );
+    }
+
+    #[test]
+    fn wasm_scope_skips_bodyless_and_visits_body() {
+        let (mut ctx, loc) = test_ctx();
+        let i32_ty = i32_type(&mut ctx);
+        let bodyless = make_bodyless_func(&mut ctx, loc, "wasm", "extern");
+        let nested_data =
+            OperationDataBuilder::new(loc, Symbol::new("test"), Symbol::new("source"))
+                .result(i32_ty)
+                .build(&mut ctx);
+        let nested = ctx.create_op(nested_data);
+        let bodyful = make_wasm_func_container(&mut ctx, loc, "defined", vec![nested]);
+        let module = make_module(&mut ctx, loc, vec![bodyless, bodyful.op_ref()]);
+
+        let before = print_module(&ctx, module.op());
+        let bodyless = wasm::Func::from_op(&ctx, bodyless).unwrap();
+        PatternApplicator::new(TypeConverter::new())
+            .add_pattern(RenamePattern)
+            .apply_partial(&mut ctx, bodyless);
+        assert_eq!(print_module(&ctx, module.op()), before);
+
+        let result = PatternApplicator::new(TypeConverter::new())
+            .add_pattern(RenamePattern)
+            .apply_partial(&mut ctx, bodyful);
+        assert_eq!(result.total_changes, 1);
+        assert_eq!(
+            ctx.op(first_nested_op(&ctx, bodyful.op_ref())).name,
+            Symbol::new("target")
         );
     }
 


### PR DESCRIPTION
## Summary

Bodyless `func.func` and `wasm.func` declarations now expose zero nested rewrite regions instead of calling the asserting `Func::body()` accessor. `LowerIntrinsicToArith` also preserves bodyless intrinsic declarations unchanged.

Focused regressions cover unchanged bodyless declarations and traversal of body-bearing functions in both dialect scopes, plus intrinsic lowering behavior.

Checks: focused applicator and intrinsic suites, affected-package Clippy with `-D warnings`, formatting, diff/artifact checks, and full workspace nextest (1,841 passed, 0 skipped) with `--test-threads 2`.

Closes #852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved intrinsic declarations that do not contain a body, preventing unintended modifications.
  * Improved rewrite handling for functions and WebAssembly functions without bodies.
  * Ensured functions with bodies continue to be rewritten correctly.
  * Added regression coverage to verify bodyless declarations and scopes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->