### PR TITLE
Preserve bodyless declarations during evidence resolution

### DIFF
--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -36,6 +36,12 @@ fn i32_type_ref(ctx: &mut IrContext) -> TypeRef {
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
 }
 
+/// Return a function body when the `func.func` operation is a definition.
+/// External declarations intentionally have no body region.
+fn func_body_if_present(ctx: &IrContext, func_op: func::Func) -> Option<RegionRef> {
+    ctx.op(func_op.op_ref()).regions.first().copied()
+}
+
 #[derive(Debug)]
 pub(crate) struct ResolveEvidenceError {
     op: OpRef,
@@ -371,7 +377,7 @@ fn collect_handler_root_functions(
             if fns_with_evidence.contains(&func_name) {
                 continue;
             }
-            let Some(&body) = ctx.op(op).regions.first() else {
+            let Some(body) = func_body_if_present(ctx, func_op) else {
                 continue;
             };
             if region_contains_handle_dispatch(ctx, body) {
@@ -495,7 +501,7 @@ fn transform_handler_roots(
             continue;
         }
 
-        let Some(&body) = ctx.op(func_op_ref).regions.first() else {
+        let Some(body) = func_body_if_present(ctx, func_op) else {
             continue;
         };
         let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
@@ -585,7 +591,7 @@ fn update_calls_to_newly_evidenced(
             continue;
         }
 
-        let Some(&body) = ctx.op(func_op_ref).regions.first() else {
+        let Some(body) = func_body_if_present(ctx, func_op) else {
             continue;
         };
         update_calls_in_region(ctx, body, newly_evidenced, evidence_ty, i32_ty);
@@ -683,7 +689,7 @@ fn transform_shifts_in_module(
             continue;
         }
 
-        let Some(&body) = ctx.op(func_op_ref).regions.first() else {
+        let Some(body) = func_body_if_present(ctx, func_op) else {
             continue;
         };
         let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -371,7 +371,10 @@ fn collect_handler_root_functions(
             if fns_with_evidence.contains(&func_name) {
                 continue;
             }
-            if region_contains_handle_dispatch(ctx, func_op.body(ctx)) {
+            let Some(&body) = ctx.op(op).regions.first() else {
+                continue;
+            };
+            if region_contains_handle_dispatch(ctx, body) {
                 handler_roots.insert(func_name);
             }
         }
@@ -492,7 +495,9 @@ fn transform_handler_roots(
             continue;
         }
 
-        let body = func_op.body(ctx);
+        let Some(&body) = ctx.op(func_op_ref).regions.first() else {
+            continue;
+        };
         let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
         let Some(&entry_block) = blocks.first() else {
             continue;
@@ -580,7 +585,9 @@ fn update_calls_to_newly_evidenced(
             continue;
         }
 
-        let body = func_op.body(ctx);
+        let Some(&body) = ctx.op(func_op_ref).regions.first() else {
+            continue;
+        };
         update_calls_in_region(ctx, body, newly_evidenced, evidence_ty, i32_ty);
     }
 }
@@ -676,7 +683,9 @@ fn transform_shifts_in_module(
             continue;
         }
 
-        let body = func_op.body(ctx);
+        let Some(&body) = ctx.op(func_op_ref).regions.first() else {
+            continue;
+        };
         let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
         let Some(&entry_block) = blocks.first() else {
             continue;
@@ -1342,6 +1351,42 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, &input);
         validate_final_handle_dispatches(&ctx, module).unwrap();
+    }
+
+    #[test]
+    fn bodyless_declarations_are_preserved_during_evidence_resolution() {
+        let input = r#"core.module @test {
+  !marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
+  !evidence = core.array(!marker)
+  func.func @plain_external() -> core.i32
+  func.func @evidence_external(%ev: !evidence) -> !marker
+  func.func @body(%ev: !evidence) -> !marker {
+    %marker = ability.evidence_lookup %ev {ability_ref = core.ability_ref() {name = @State}} : !marker
+    func.return %marker
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+
+        resolve_evidence_dispatch(&mut ctx, module).unwrap();
+
+        let resolved = print_module(&ctx, module.op());
+        assert!(
+            resolved.contains("func.func @plain_external() -> core.i32\n"),
+            "plain external declaration changed or disappeared:\n{resolved}"
+        );
+        assert!(
+            resolved.contains("func.func @evidence_external(%arg0: !evidence) -> !marker\n"),
+            "evidence-bearing external declaration changed or disappeared:\n{resolved}"
+        );
+        assert!(
+            !resolved.contains("ability.evidence_lookup"),
+            "body-bearing function was not processed:\n{resolved}"
+        );
+        assert!(
+            resolved.contains("func.call") && resolved.contains("__tribute_evidence_lookup"),
+            "body-bearing evidence lookup was not resolved:\n{resolved}"
+        );
     }
 
     // Note: CPS-specific evidence resolution (ability.evidence_lookup,


### PR DESCRIPTION
Fixes #853

`resolve_evidence` keeps module-level declarations available for signature and evidence classification, while its four body-only loops now skip functions with no region instead of calling `Func::body()` unconditionally. The focused textual regression verifies that plain and evidence-bearing declarations remain unchanged and that a body-bearing evidence lookup is still processed.

Checks:
- `cargo nextest run -p tribute-passes 'resolve_evidence::tests::'`
- `cargo nextest run -p tribute-passes`
- `cargo clippy -p tribute-passes --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Commit hook: workspace nextest 1,891 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved external and bodyless function declarations during evidence resolution.
  * Continued lowering evidence lookups for functions that include bodies.
  * Added regression coverage to verify both bodyless and body-bearing declarations behave correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->