### PR TITLE
#851: Promote logical worker calling conventions

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -464,6 +464,12 @@ impl<'db> IrLoweringCtx<'db> {
     /// - `["test", "String"]` + `"to_bytes"` → `"String::to_bytes"`
     /// - `["test"]` + `"print_line"` → `"print_line"` (top-level, unchanged)
     pub fn qualify_name(&self, name: Symbol) -> Symbol {
+        // Synthetic monomorphized declarations already carry their resolved
+        // source path. Adding the current module again would change the
+        // identity used by convention lookup and logical declaration emission.
+        if name.with_str(|text| text.contains("::")) {
+            return name;
+        }
         // Skip the first segment (top-level module name from filename).
         // Only nested module segments contribute to the qualified name.
         let nested: Vec<_> = self.module_path.iter().skip(1).collect();

--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -463,6 +463,8 @@ impl<'db> IrLoweringCtx<'db> {
     ///
     /// - `["test", "String"]` + `"to_bytes"` → `"String::to_bytes"`
     /// - `["test"]` + `"print_line"` → `"print_line"` (top-level, unchanged)
+    /// - `"Nested::Box::value"` → `"Nested::Box::value"` (already qualified,
+    ///   returned unchanged)
     pub fn qualify_name(&self, name: Symbol) -> Symbol {
         // Synthetic monomorphized declarations already carry their resolved
         // source path. Adding the current module again would change the

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -914,6 +914,15 @@ pub(super) fn evaluation_control_class<'db>(
     evaluation_control_class_with_handle_propagation(ctx, expr, false)
 }
 
+/// Classify a source-logical worker before shared CPS legalization. A handled
+/// computation remains CPS until that later pass creates its continuation.
+pub(super) fn logical_evaluation_control_class<'db>(
+    ctx: &super::super::context::IrLoweringCtx<'db>,
+    expr: &Expr<TypedRef<'db>>,
+) -> EvaluationControlClass {
+    evaluation_control_class_with_handle_propagation(ctx, expr, true)
+}
+
 /// Classify evaluation with an explicit nested-handle propagation policy.
 ///
 /// Source convention selection treats handles as source delimiters. Ambient

--- a/crates/tribute-front/src/ast_to_ir/lower/logical.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/logical.rs
@@ -21,13 +21,14 @@ use trunk_ir::rewrite::Module as IrModule;
 use trunk_ir::types::{Attribute, Location};
 
 use crate::ast::{
-    Arm, CallingConvention, CtorId, Decl, Expr, ExprKind, ExternFuncDecl, FuncDecl, HandlerArm,
-    HandlerKind, OpDeclKind, Pattern, PatternKind, ResolvedRef, Stmt, TypeKind, TypedRef,
+    Arm, CallingConvention, CtorId, Decl, EffectRow, Expr, ExprKind, ExternFuncDecl, FuncDecl,
+    HandlerArm, HandlerKind, OpDeclKind, Pattern, PatternKind, ResolvedRef, Stmt, TypeKind,
+    TypedRef,
 };
 
 use super::super::context::IrLoweringCtx;
 use super::super::{FrontendIrModule, TypedModule};
-use super::{FuncSignature, IrBuilder};
+use super::{FuncSignature, IrBuilder, expr};
 
 struct Declarations<'db> {
     // TypeRef is an arena index and therefore has deterministic total order only
@@ -124,6 +125,14 @@ fn callable_type(
     tribute_control::callable(ir, result, params, control_convention(convention)).as_type_ref()
 }
 
+fn declaration_name(prefix: &mut String, name: Symbol) -> Symbol {
+    if name.with_str(|text| text.contains("::")) {
+        name
+    } else {
+        crate::qualified_symbol(prefix, name)
+    }
+}
+
 pub(super) fn lower_module<'db>(
     typed: TypedModule<'db>,
     db: &'db dyn salsa::Database,
@@ -170,6 +179,8 @@ pub(super) fn lower_module<'db>(
         lambda_signatures,
         exhaustive_cases,
     };
+    prescan_definition_conventions(&mut ctx, &ast.decls, &mut String::new());
+    promote_definition_conventions_to_fixed_point(&mut ctx, &ast.decls, &mut String::new());
     let mut well_known_type_prescan = super::decl::WellKnownTypePrescan::new(well_known_types);
     collect_logical_nominal_identities(&mut ctx, &ast.decls, &mut String::new());
     prescan_logical_nominal_layouts(
@@ -196,6 +207,95 @@ pub(super) fn lower_module<'db>(
     FrontendIrModule {
         module: IrModule::new(ir, module.op_ref()).expect("valid core.module operation"),
         operation_declarations: declarations.values,
+    }
+}
+
+/// Seed worker conventions from each body's concrete residual effects. The
+/// semantic function type remains untouched: an omitted annotation can still
+/// expose an open-row callable at a first-class call site.
+fn prescan_definition_conventions<'db>(
+    ctx: &mut IrLoweringCtx<'db>,
+    declarations: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+) {
+    for declaration in declarations {
+        match declaration {
+            Decl::Function(function) => {
+                let name = declaration_name(prefix, function.name);
+                let Some(scheme) = ctx.lookup_function_type(name).copied() else {
+                    continue;
+                };
+                let body = scheme.body(ctx.db);
+                let Some(mut convention) = ctx.calling_convention_for_type(body) else {
+                    continue;
+                };
+                if (function.effects.is_none()
+                    || crate::is_root_main(function.name, prefix.is_empty()))
+                    && let TypeKind::Func { effect, .. } = body.kind(ctx.db)
+                {
+                    convention = ctx.calling_convention_for_effect_row(EffectRow::new(
+                        ctx.db,
+                        effect.effects(ctx.db).clone(),
+                        None,
+                    ));
+                }
+                ctx.register_definition_convention(name, convention);
+            }
+            Decl::Module(module) => {
+                if let Some(body) = &module.body {
+                    let saved = crate::push_prefix(prefix, module.name);
+                    prescan_definition_conventions(ctx, body, prefix);
+                    prefix.truncate(saved);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Strengthen workers until direct calls and structured logical evaluation no
+/// longer leave a Direct/EvidenceDirect worker responsible for CPS control.
+fn promote_definition_conventions_to_fixed_point<'db>(
+    ctx: &mut IrLoweringCtx<'db>,
+    declarations: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+) {
+    loop {
+        let mut changed = false;
+        promote_definition_conventions_pass(ctx, declarations, prefix, &mut changed);
+        if !changed {
+            return;
+        }
+    }
+}
+
+fn promote_definition_conventions_pass<'db>(
+    ctx: &mut IrLoweringCtx<'db>,
+    declarations: &[Decl<TypedRef<'db>>],
+    prefix: &mut String,
+    changed: &mut bool,
+) {
+    for declaration in declarations {
+        match declaration {
+            Decl::Function(function) => {
+                let name = declaration_name(prefix, function.name);
+                if ctx.function_calling_convention(name) != Some(CallingConvention::Cps)
+                    && expr::logical_evaluation_control_class(ctx, &function.body)
+                        == expr::EvaluationControlClass::Cps
+                {
+                    ctx.register_definition_convention(name, CallingConvention::Cps);
+                    *changed = true;
+                }
+            }
+            Decl::Module(module) => {
+                if let Some(body) = &module.body {
+                    let saved = crate::push_prefix(prefix, module.name);
+                    promote_definition_conventions_pass(ctx, body, prefix, changed);
+                    prefix.truncate(saved);
+                }
+            }
+            _ => {}
+        }
     }
 }
 
@@ -541,20 +641,24 @@ fn function_signature<'db>(
     function: &FuncDecl<TypedRef<'db>>,
 ) -> FuncSignature {
     let qualified = ctx.qualify_name(function.name);
-    let signature = if qualified == function.name {
+    let mut signature = (if qualified == function.name {
         FuncSignature::lookup_logical(ctx, ir, function.name)
     } else {
         // Nested declarations are exported under their qualified identity; a
         // short-name lookup can silently select an unrelated root declaration.
         FuncSignature::lookup_logical(ctx, ir, qualified)
             .or_else(|| FuncSignature::lookup_logical(ctx, ir, function.name))
-    };
-    signature.unwrap_or_else(|| {
+    })
+    .unwrap_or_else(|| {
         panic!(
             "missing typechecked signature for function {}",
             function.name
         )
-    })
+    });
+    signature.convention = ctx
+        .function_calling_convention(qualified)
+        .unwrap_or(signature.convention);
+    signature
 }
 
 fn lower_function<'db>(
@@ -565,6 +669,15 @@ fn lower_function<'db>(
     declarations: &mut Declarations<'db>,
 ) {
     let location = ctx.location(function.id);
+    let root_export_convention = crate::is_root_main(function.name, ctx.module_path().len() == 1)
+        .then(|| {
+            let name = ctx.qualify_name(function.name);
+            let scheme = ctx
+                .lookup_function_type(name)
+                .expect("root main has a typechecked logical signature");
+            ctx.calling_convention_for_type(scheme.body(ctx.db))
+                .expect("root main has a function type")
+        });
     let signature = function_signature(ctx, ir, &function);
     let callable = callable_type(
         ir,
@@ -618,6 +731,19 @@ fn lower_function<'db>(
     let function = tribute_control::func_declaration(ir, location, name, callable);
     ir.op_mut(function.op_ref()).regions.push(body);
     ir.region_mut(body).parent_op = Some(function.op_ref());
+    if let Some(convention) = root_export_convention
+        && convention != signature.convention
+    {
+        assert_ne!(convention, CallingConvention::Cps);
+        ir.op_mut(function.op_ref()).attributes.insert(
+            Symbol::new("tribute.root_export_convention"),
+            Attribute::Int(convention as i128),
+        );
+        ir.op_mut(function.op_ref()).attributes.insert(
+            Symbol::new("tribute.root_source_result"),
+            Attribute::Type(signature.return_type),
+        );
+    }
     ir.push_op(top, function.op_ref());
 }
 
@@ -898,10 +1024,14 @@ fn lower_expr<'db>(
             ),
             ResolvedRef::Function { id } => {
                 let name = id.qualified(builder.ctx.db);
-                let signature = FuncSignature::lookup_logical(builder.ctx, builder.ir, name)
+                let mut signature = FuncSignature::lookup_logical(builder.ctx, builder.ir, name)
                     .unwrap_or_else(|| {
                         panic!("missing logical signature for function reference {name}")
                     });
+                signature.convention = builder
+                    .ctx
+                    .function_calling_convention(name)
+                    .unwrap_or(signature.convention);
                 ensure_prelude_declaration(builder, location, name, &signature);
                 let ty = callable_type(
                     builder.ir,

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -708,21 +708,38 @@ fn main() {
     let main = checked_logical_function(&ir_text, "main");
     let main_header = main.lines().next().expect("logical function has a header");
     assert!(
-        main_header.contains("convention(cps)")
-            && main_header.contains("tribute.root_export_convention = 0")
-            && main_header.contains("tribute.root_source_result = core.nil")
-            && main.contains("tribute_control.call")
-            && main.contains("callee = @forward_open"),
-        "pure root export must keep Direct metadata while its worker calls CPS:\n{main}"
+        main_header.contains("convention(cps)"),
+        "root main worker must be promoted to Cps:\n{main_header}"
     );
     assert!(
-        !ir_text.contains("Nested::Nested::")
-            && logical_function(&ir_text, "Nested::unwrap")
-                .contains("callee = @\"Nested::Box::value\"")
-            && ir_text.lines().any(|line| line
-                .trim_start()
-                .starts_with("tribute_control.func @\"Box::value\"")),
-        "nested specialized workers must keep their exact qualified identities:\n{ir_text}"
+        main_header.contains("tribute.root_export_convention = 0"),
+        "pure root export must stay Direct:\n{main_header}"
+    );
+    assert!(
+        main_header.contains("tribute.root_source_result = core.nil"),
+        "root source result must stay core.nil:\n{main_header}"
+    );
+    assert!(
+        main.contains("tribute_control.call"),
+        "root main must contain the direct worker call:\n{main}"
+    );
+    assert!(
+        main.contains("callee = @forward_open"),
+        "root main must call the promoted forward_open worker:\n{main}"
+    );
+    assert!(
+        !ir_text.contains("Nested::Nested::"),
+        "nested workers must not be requalified:\n{ir_text}"
+    );
+    assert!(
+        logical_function(&ir_text, "Nested::unwrap").contains("callee = @\"Nested::Box::value\""),
+        "nested worker must call the exact qualified accessor:\n{ir_text}"
+    );
+    assert!(
+        ir_text.lines().any(|line| line
+            .trim_start()
+            .starts_with("tribute_control.func @\"Box::value\"")),
+        "specialized accessor must keep its exact root identity:\n{ir_text}"
     );
 }
 

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -642,8 +642,21 @@ fn apply_closed(value: Int, callback: fn(Int) ->{} Int) ->{} Int {
     callback(value)
 }
 
+fn evidence() ->{std::io::Io} Nil { Nil }
+
+struct Box(a) { value: a }
+fn unwrap(value: Box(a)) ->{} a { value.value }
+
+mod Nested {
+    struct Box(a) { value: a }
+    fn unwrap(value: Box(a)) ->{} a { value.value }
+    fn use_nested() ->{} Int { unwrap(Box { value: +41 }) }
+}
+
 fn main() {
     let _ = forward_open(+41, fn(value) { value })
+    let _ = unwrap(Box { value: +1 })
+    let _ = Nested::use_nested()
 }
 "#,
     );
@@ -670,23 +683,51 @@ fn main() {
         pure_header.contains("convention(direct)"),
         "pure worker must remain Direct:\n{pure_header}"
     );
-    for name in ["apply_closed", "main"] {
-        let header = ir_text
-            .lines()
-            .find(|line| {
-                line.trim_start()
-                    .starts_with(&format!("tribute_control.func @{name}("))
-            })
-            .unwrap_or_else(|| panic!("missing lowered worker {name}"));
-        assert!(
-            header.contains("convention(direct)"),
-            "{name} must stay Direct:\n{header}"
-        );
-    }
+    let apply_closed_header = ir_text
+        .lines()
+        .find(|line| {
+            line.trim_start()
+                .starts_with("tribute_control.func @apply_closed(")
+        })
+        .expect("missing lowered apply_closed worker");
+    assert!(
+        apply_closed_header.contains("convention(direct)"),
+        "apply_closed must stay Direct:\n{apply_closed_header}"
+    );
+    let evidence_header = ir_text
+        .lines()
+        .find(|line| {
+            line.trim_start()
+                .starts_with("tribute_control.func @evidence(")
+        })
+        .expect("missing lowered evidence worker");
+    assert!(
+        evidence_header.contains("convention(evidence_direct)"),
+        "evidence worker must stay EvidenceDirect:\n{evidence_header}"
+    );
+    let main = checked_logical_function(&ir_text, "main");
+    let main_header = main.lines().next().expect("logical function has a header");
+    assert!(
+        main_header.contains("convention(cps)")
+            && main_header.contains("tribute.root_export_convention = 0")
+            && main_header.contains("tribute.root_source_result = core.nil")
+            && main.contains("tribute_control.call")
+            && main.contains("callee = @forward_open"),
+        "pure root export must keep Direct metadata while its worker calls CPS:\n{main}"
+    );
+    assert!(
+        !ir_text.contains("Nested::Nested::")
+            && logical_function(&ir_text, "Nested::unwrap")
+                .contains("callee = @\"Nested::Box::value\"")
+            && ir_text.lines().any(|line| line
+                .trim_start()
+                .starts_with("tribute_control.func @\"Box::value\"")),
+        "nested specialized workers must keep their exact qualified identities:\n{ir_text}"
+    );
 }
 
-/// An `Io` root keeps its EvidenceDirect ABI while the frontend delimiter
-/// closes the CPS implementation convention of an open callback worker.
+/// An `Io` root retains EvidenceDirect export metadata while its worker is
+/// promoted for an open-callback call.
 #[salsa_test]
 fn test_open_callback_evidence_root_main_stays_evidence_direct(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -710,8 +751,9 @@ fn main() ->{std::io::Io} Nil {
         .find(|line| line.trim_start().starts_with("tribute_control.func @main("))
         .expect("missing lowered root main");
     assert!(
-        main_header.contains("convention(evidence_direct)"),
-        "Io root main must remain EvidenceDirect, not Cps:\n{main_header}"
+        main_header.contains("convention(cps)")
+            && main_header.contains("tribute.root_export_convention = 1"),
+        "Io root export must remain EvidenceDirect while its worker is Cps:\n{main_header}"
     );
 }
 

--- a/crates/tribute-front/tests/snapshots/block_scope__block_let_binding_accessible_inside.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__block_let_binding_accessible_inside.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 42} : core.i32
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/block_scope__block_with_case_pattern_binding.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__block_with_case_pattern_binding.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Option = adt.enum() {name = @Option, variants = [[@Some, [tribute_rt.anyref]], [@None, []]]}
 
-  tribute_control.func @example(%0: adt.typeref() {name = @Option}) -> core.i32 convention(cps) {
+  tribute_control.func @example(%0: adt.typeref() {name = @Option}) -> core.i32 convention(direct) {
       %1 = adt.variant_is %0 {tag = @Some, type = !Option} : core.i1
       %2 = scf.if %1 : core.i1 {
           %3 = adt.variant_cast %0 {tag = @Some, type = !Option} : !Option

--- a/crates/tribute-front/tests/snapshots/block_scope__nested_blocks_separate_scopes.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__nested_blocks_separate_scopes.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       tribute_control.return %1

--- a/crates/tribute-front/tests/snapshots/block_scope__outer_scope_accessible_in_inner_block.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__outer_scope_accessible_in_inner_block.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 10} : core.i32
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/block_scope__sequential_blocks_independent_scopes.snap
+++ b/crates/tribute-front/tests/snapshots/block_scope__sequential_blocks_independent_scopes.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/block_scope.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @example() -> core.i32 convention(cps) {
+  tribute_control.func @example() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       tribute_control.return %0

--- a/crates/tribute-front/tests/snapshots/case_type__case_bool_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_bool_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @invert(%0: core.i1) -> core.i1 convention(cps) {
+  tribute_control.func @invert(%0: core.i1) -> core.i1 convention(direct) {
       %1 = arith.const {value = true} : core.i1
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i1 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_enum_variant.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_enum_variant.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Option = adt.enum() {name = @Option, variants = [[@Some, [tribute_rt.anyref]], [@None, []]]}
 
-  tribute_control.func @unwrap_or(%0: adt.typeref() {name = @Option}, %1: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @unwrap_or(%0: adt.typeref() {name = @Option}, %1: core.i32) -> core.i32 convention(direct) {
       %2 = adt.variant_is %0 {tag = @Some, type = !Option} : core.i1
       %3 = scf.if %2 : core.i1 {
           %4 = adt.variant_cast %0 {tag = @Some, type = !Option} : !Option

--- a/crates/tribute-front/tests/snapshots/case_type__case_int_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_int_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @sign(%0: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @sign(%0: core.i32) -> core.i32 convention(direct) {
       %1 = arith.const {value = -1} : core.i32
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_nat_literal.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_nat_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @classify(%0: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @classify(%0: core.i32) -> core.i32 convention(direct) {
       %1 = arith.const {value = 0} : core.i32
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_nested.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_nested.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @nested(%0: core.i32, %1: core.i1) -> core.i32 convention(cps) {
+  tribute_control.func @nested(%0: core.i32, %1: core.i1) -> core.i32 convention(direct) {
       %2 = arith.const {value = 0} : core.i32
       %3 = arith.cmpi %0, %2 {predicate = @eq} : core.i1
       %4 = scf.if %3 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/case_type__case_result_type_unification.snap
+++ b/crates/tribute-front/tests/snapshots/case_type__case_result_type_unification.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/case_type.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @to_nat(%0: core.i1) -> core.i32 convention(cps) {
+  tribute_control.func @to_nat(%0: core.i1) -> core.i32 convention(direct) {
       %1 = arith.const {value = true} : core.i1
       %2 = arith.cmpi %0, %1 {predicate = @eq} : core.i1
       %3 = scf.if %2 : core.i32 {

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__pure_context_creates_null_evidence.snap
@@ -7,7 +7,7 @@ core.module @test {
       %0 = tribute_control.perform {ability_ref = core.ability_ref() {name = @Ask}, op_name = @ask, operation_kind = @op} : core.i32
       tribute_control.return %0
   }
-  tribute_control.func @main() -> core.nil convention(direct) {
+  tribute_control.func @main() -> core.nil convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
       %0 = tribute_control.handle : core.i32 {
           %1 = tribute_control.call {callee = @use_ask} : core.i32
           tribute_control.yield %1

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_false.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_false.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @no() -> core.i1 convention(cps) {
+  tribute_control.func @no() -> core.i1 convention(direct) {
       %0 = arith.const {value = false} : core.i1
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_true.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bool_literal_true.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @yes() -> core.i1 convention(cps) {
+  tribute_control.func @yes() -> core.i1 convention(direct) {
       %0 = arith.const {value = true} : core.i1
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__boolean_operators.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @logic(%0: core.i1, %1: core.i1) -> core.i1 convention(cps) {
+  tribute_control.func @logic(%0: core.i1, %1: core.i1) -> core.i1 convention(direct) {
       %2 = scf.if %0 : core.i1 {
           %3 = arith.const {value = true} : core.i1
           scf.yield %3

--- a/crates/tribute-front/tests/snapshots/expr_coverage__bytes_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__bytes_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @data() -> core.bytes convention(cps) {
+  tribute_control.func @data() -> core.bytes convention(direct) {
       %0 = adt.bytes_const {value = b"payload"} : core.bytes
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
@@ -13,7 +13,7 @@ core.module @test {
   tribute_control.func @"Float::<="(%arg0: core.f64, %arg1: core.f64) -> core.i1 convention(direct)
   tribute_control.func @"Float::>"(%arg0: core.f64, %arg1: core.f64) -> core.i1 convention(direct)
   tribute_control.func @"Float::>="(%arg0: core.f64, %arg1: core.f64) -> core.i1 convention(direct)
-  tribute_control.func @comparisons(%0: core.f64, %1: core.f64) -> !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool_1 convention(cps) {
+  tribute_control.func @comparisons(%0: core.f64, %1: core.f64) -> !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool_1 convention(direct) {
       %2 = tribute_control.call %0, %1 {callee = @"Float::=="} : core.i1
       %3 = tribute_control.call %0, %1 {callee = @"Float::!="} : core.i1
       %4 = tribute_control.call %0, %1 {callee = @"Float::<"} : core.i1

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @pi() -> core.f64 convention(cps) {
+  tribute_control.func @pi() -> core.f64 convention(direct) {
       %0 = arith.const {value = 3.14} : core.f64
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
@@ -3,9 +3,9 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
 
-  tribute_control.func @id(%0: core.i32) -> core.i32 convention(cps) {
+  tribute_control.func @id(%0: core.i32) -> core.i32 convention(direct) {
       tribute_control.return %0
   }
   tribute_control.func @test_ref() -> core.i32 convention(cps) {

--- a/crates/tribute-front/tests/snapshots/expr_coverage__list_literals_use_shared_sequence_ops.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__list_literals_use_shared_sequence_ops.snap
@@ -3,13 +3,13 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
+  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 0}
 
-  tribute_control.func @empty() -> tribute_rt.anyref convention(cps) {
+  tribute_control.func @empty() -> tribute_rt.anyref convention(direct) {
       %0 = list.empty {element_type = tribute_rt.anyref} : tribute_rt.anyref
       tribute_control.return %0
   }
-  tribute_control.func @numbers() -> tribute_rt.anyref convention(cps) {
+  tribute_control.func @numbers() -> tribute_rt.anyref convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32

--- a/crates/tribute-front/tests/snapshots/expr_coverage__list_sequence_patterns_use_shared_observation_ops.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__list_sequence_patterns_use_shared_observation_ops.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @observe(%0: tribute_rt.anyref) -> core.i32 convention(cps) {
+  tribute_control.func @observe(%0: tribute_rt.anyref) -> core.i32 convention(direct) {
       %1 = list.is_empty %0 {element_type = core.i32} : core.i1
       %2 = scf.if %1 : core.i32 {
           %3 = arith.const {value = 0} : core.i32

--- a/crates/tribute-front/tests/snapshots/expr_coverage__nil_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__nil_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @nothing() -> core.nil convention(cps) {
+  tribute_control.func @nothing() -> core.nil convention(direct) {
       %0 = arith.const {value = unit} : core.nil
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__rune_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__rune_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @letter() -> core.i32 convention(cps) {
+  tribute_control.func @letter() -> core.i32 convention(direct) {
       %0 = arith.const {value = 97} : core.i32
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__string_literal.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__string_literal.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  tribute_control.func @greeting() -> tribute_rt.anyref convention(cps) {
+  tribute_control.func @greeting() -> tribute_rt.anyref convention(direct) {
       %0 = adt.string_const {value = "hello"} : tribute_rt.anyref
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/expr_coverage__tuple_construction.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__tuple_construction.snap
@@ -6,7 +6,7 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_4_bool = adt.struct() {fields = [[@0, core.i32], [@1, core.i1]], name = @__logical_tuple_tuple_3_1_2_3_nat_4_bool}
   !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_4_bool}
 
-  tribute_control.func @pair() -> !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1 convention(cps) {
+  tribute_control.func @pair() -> !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1 convention(direct) {
       %0 = arith.const {value = 42} : core.i32
       %1 = arith.const {value = true} : core.i1
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_4_bool} : !__logical_tuple_tuple_3_1_2_3_nat_4_bool_1

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -44,7 +44,7 @@ core.module @test {
       }
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.call {callee = @counter} : core.i32
           %2 = tribute_control.call {callee = @counter} : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
@@ -28,7 +28,7 @@ core.module @test {
       }
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
           %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -35,7 +35,7 @@ core.module @test {
       }
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.call {callee = @counter} : core.i32
           tribute_control.return %1

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
@@ -28,7 +28,7 @@ core.module @test {
       }
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
           %2 = arith.const {value = 1} : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -4,7 +4,8 @@ expression: ir_text
 ---
 core.module @test {
   !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
-  !t1 = core.ability_ref(tribute_rt.anyref) {name = @State}
+  !t1 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t2 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
   tribute_control.func @with_state(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref convention(cps) {
       %2 = tribute_control.handle : tribute_rt.anyref {
@@ -14,7 +15,7 @@ core.module @test {
         ^bb2(%4: tribute_rt.anyref):
           tribute_control.yield %4
       } {
-          tribute_control.handler {ability_ref = !t1, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
+          tribute_control.handler {ability_ref = !t2, kind = @op, op_name = @get, operation_result_type = tribute_rt.anyref} {
             ^bb4(%5: tribute_control.resume_token(tribute_rt.anyref, tribute_rt.anyref)):
               %6 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%1, %5] {
                   %7 = tribute_control.resume %5, %1 : tribute_rt.anyref
@@ -23,7 +24,7 @@ core.module @test {
               %8 = tribute_control.call %6, %1 {callee = @with_state} : tribute_rt.anyref
               tribute_control.yield %8
           }
-          tribute_control.handler {ability_ref = !t1, kind = @op, op_name = @set, operation_result_type = core.nil} {
+          tribute_control.handler {ability_ref = !t2, kind = @op, op_name = @set, operation_result_type = core.nil} {
             ^bb6(%9: tribute_rt.anyref, %10: tribute_control.resume_token(core.nil, tribute_rt.anyref)):
               %11 = tribute_control.lambda() -> tribute_rt.anyref convention(cps) captures [%10] {
                   %12 = arith.const {value = unit} : core.nil
@@ -36,7 +37,7 @@ core.module @test {
       }
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
           %2 = core.unrealized_conversion_cast %1 : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
@@ -27,7 +27,7 @@ core.module @test {
       %1 = tribute_control.call_indirect %0 : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
               %2 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
@@ -9,7 +9,7 @@ core.module @test {
       %2 = tribute_control.call_indirect %0, %1 : core.i32
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda(%1: core.i32) -> core.i32 convention(cps) captures [] {
           %2 = arith.const {value = 1} : core.i32
           %3 = arith.addi %1, %2 : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
@@ -9,7 +9,7 @@ core.module @test {
       %2 = tribute_control.call_indirect %0, %1 : core.i32
       tribute_control.return %2
   }
-  tribute_control.func @main() -> core.i32 convention(direct) {
+  tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = arith.const {value = 10} : core.i32
       %1 = tribute_control.lambda(%2: core.i32) -> core.i32 convention(cps) captures [%0] {
           %3 = arith.addi %2, %0 : core.i32

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Point} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @make_point() -> !Point_1 convention(cps) {
+  tribute_control.func @make_point() -> !Point_1 convention(direct) {
       %0 = arith.const {value = 10} : core.i32
       %1 = arith.const {value = 20} : core.i32
       %2 = adt.struct_new %0, %1 {type = !Point} : !Point_1

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Pair} : tribute_rt.anyref
       tribute_control.return %1
   }
-  tribute_control.func @make_pair() -> !Pair_1 convention(cps) {
+  tribute_control.func @make_pair() -> !Pair_1 convention(direct) {
       %0 = arith.const {value = 42} : core.i32
       %1 = arith.const {value = true} : core.i1
       %2 = adt.struct_new %0, %1 {type = !Pair} : !Pair_1

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Point} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @update_x(%0: !Point_1) -> !Point_1 convention(cps) {
+  tribute_control.func @update_x(%0: !Point_1) -> !Point_1 convention(direct) {
       %1 = arith.const {value = 100} : core.i32
       %2 = adt.struct_get %0 {field = 1, type = !Point} : core.i32
       %3 = adt.struct_new %1, %2 {type = !Point} : !Point_1

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Point_1} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @replace_all(%0: !Point) -> !Point convention(cps) {
+  tribute_control.func @replace_all(%0: !Point) -> !Point convention(direct) {
       %1 = arith.const {value = 1} : core.i32
       %2 = arith.const {value = 2} : core.i32
       %3 = adt.struct_new %1, %2 {type = !Point_1} : !Point

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
@@ -15,7 +15,7 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 1, type = !Config} : core.i1
       tribute_control.return %1
   }
-  tribute_control.func @copy_config(%0: !Config_1) -> !Config_1 convention(cps) {
+  tribute_control.func @copy_config(%0: !Config_1) -> !Config_1 convention(direct) {
       %1 = adt.struct_get %0 {field = 0, type = !Config} : core.i1
       %2 = adt.struct_get %0 {field = 1, type = !Config} : core.i1
       %3 = adt.struct_new %1, %2 {type = !Config} : !Config_1

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
@@ -6,7 +6,7 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32]], name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
 
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_from_function.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_from_function.snap
@@ -6,11 +6,11 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32]], name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
 
-  tribute_control.func @make_pair(%0: core.i32, %1: core.i32) -> !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 convention(cps) {
+  tribute_control.func @make_pair(%0: core.i32, %1: core.i32) -> !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 convention(direct) {
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1
       tribute_control.return %2
   }
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 10} : core.i32
       %1 = arith.const {value = 20} : core.i32
       %2 = tribute_control.call %0, %1 {callee = @make_pair} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
@@ -8,7 +8,7 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1]], name = @__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat}
 
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
@@ -6,7 +6,7 @@ core.module @test {
   !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32], [@2, core.i32]], name = @__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat}
   !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat}
 
-  tribute_control.func @test() -> core.i32 convention(cps) {
+  tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = arith.const {value = 3} : core.i32

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
@@ -4,9 +4,9 @@ expression: ir_text
 ---
 core.module @test {
   !Triple = adt.typeref() {name = @Triple}
+  !t0 = tribute_control.callable(core.i32, !Triple) {tribute.calling_convention = 0}
   !Triple_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32], [@z, core.i32]], name = @Triple}
   !Pair = adt.typeref() {name = @Pair}
-  !t0 = tribute_control.callable(core.i32, !Triple) {tribute.calling_convention = 0}
   !t1 = tribute_control.callable(core.i32, !Pair) {tribute.calling_convention = 0}
   !Pair_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32]], name = @Pair}
 
@@ -30,13 +30,13 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 2, type = !Triple_1} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(cps) {
+  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(direct) {
       %2 = tribute_control.call %0 {callee = @"Pair::x"} : core.i32
       %3 = tribute_control.call %0 {callee = @"Pair::y"} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple_1} : !Triple
       tribute_control.return %4
   }
-  tribute_control.func @"Triple::sum"(%0: !Triple) -> core.i32 convention(cps) {
+  tribute_control.func @"Triple::sum"(%0: !Triple) -> core.i32 convention(direct) {
       %1 = tribute_control.call %0 {callee = @"Triple::x"} : core.i32
       %2 = tribute_control.call %0 {callee = @"Triple::y"} : core.i32
       %3 = arith.addi %1, %2 : core.i32
@@ -44,7 +44,7 @@ core.module @test {
       %5 = arith.addi %3, %4 : core.i32
       tribute_control.return %5
   }
-  tribute_control.func @test(%0: !Pair) -> core.i32 convention(cps) {
+  tribute_control.func @test(%0: !Pair) -> core.i32 convention(direct) {
       %1 = arith.const {value = 3} : core.i32
       %2 = tribute_control.call %0, %1 {callee = @"Pair::extend"} : !Triple
       %3 = tribute_control.call %2 {callee = @"Triple::sum"} : core.i32

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
@@ -30,13 +30,13 @@ core.module @test {
       %1 = adt.struct_get %0 {field = 2, type = !Triple_1} : core.i32
       tribute_control.return %1
   }
-  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(cps) {
+  tribute_control.func @"Pair::extend"(%0: !Pair, %1: core.i32) -> !Triple convention(direct) {
       %2 = tribute_control.call %0 {callee = @"Pair::x"} : core.i32
       %3 = tribute_control.call %0 {callee = @"Pair::y"} : core.i32
       %4 = adt.struct_new %2, %3, %1 {type = !Triple_1} : !Triple
       tribute_control.return %4
   }
-  tribute_control.func @test(%0: !Pair) -> !Triple convention(cps) {
+  tribute_control.func @test(%0: !Pair) -> !Triple convention(direct) {
       %1 = arith.const {value = 3} : core.i32
       %2 = tribute_control.call %0, %1 {callee = @"Pair::extend"} : !Triple
       tribute_control.return %2


### PR DESCRIPTION
Closes #851

Promotes source-logical worker calling conventions to a fixed point before lowering. A worker that directly calls or structurally evaluates CPS control is emitted as Cps, while a root preserves its source export convention and result metadata. First-class function references use the promoted worker convention, and qualified/specialized identities remain exact.

Updates 44 canonical frontend snapshots: 21 header-only Cps-to-Direct worker baselines and 12 expected convention/export or canonical callable effects, plus the 11 previously audited header baselines.

Validation: cargo fmt --all -- --check; tribute-front (617); tribute-passes (205); tribute root tests (468); clippy -D warnings; native and Wasm legacy-route witnesses; workspace Nextest (1,891 passed, 1 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested and generated declarations to prevent duplicate qualification.
  * Corrected logical evaluation and callback handling across direct, evidence-direct, and CPS execution conventions.
  * Preserved root entry-point metadata while allowing internal CPS implementations.
  * Improved wiring for logical calls and nested-module identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->