### PR TITLE
#844: Preserve explicit physical closure environment slots

### DIFF
--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -111,16 +111,39 @@ pub fn get_closure_callable_type(ctx: &IrContext, op: OpRef) -> Option<TypeRef> 
 }
 
 /// Build a closure type whose outer occurrence carries exact convention
-/// provenance. This is dormant until a producer selects the physical CPS path.
+/// provenance for physical callable producers and consumers.
 pub fn physical_closure_type(
     ctx: &mut IrContext,
     function: TypeRef,
     convention: CallingConvention,
 ) -> TypeRef {
+    physical_closure_type_with_environment_index(
+        ctx,
+        function,
+        convention,
+        convention.closure_environment_index(),
+    )
+}
+
+/// Build a convention-proven closure type with its exact environment slot.
+///
+/// Most callables use the convention's standard slot. Generated continuation
+/// closures may have a narrower physical entry shape, so their producer must
+/// record the slot explicitly instead of asking a later consumer to infer it.
+pub fn physical_closure_type_with_environment_index(
+    ctx: &mut IrContext,
+    function: TypeRef,
+    convention: CallingConvention,
+    environment_index: usize,
+) -> TypeRef {
     ctx.types.intern(
         TypeDataBuilder::new(Symbol::new("closure"), Symbol::new("closure"))
             .param(function)
             .attr(CALLING_CONVENTION_ATTR, Attribute::Int(convention as i128))
+            .attr(
+                CLOSURE_ENVIRONMENT_INDEX_ATTR,
+                Attribute::Int(environment_index as i128),
+            )
             .build(),
     )
 }
@@ -136,6 +159,19 @@ pub fn get_physical_closure_convention(
     }
     data.attrs
         .get_u8(CALLING_CONVENTION_ATTR)
+        .ok()??
+        .try_into()
+        .ok()
+}
+
+/// Read the exact environment slot from a convention-proven closure type.
+pub fn get_physical_closure_environment_index(ctx: &IrContext, closure: TypeRef) -> Option<usize> {
+    let data = ctx.types.get(closure);
+    if data.dialect != Symbol::new("closure") || data.name != Symbol::new("closure") {
+        return None;
+    }
+    data.attrs
+        .get_u32(CLOSURE_ENVIRONMENT_INDEX_ATTR)
         .ok()??
         .try_into()
         .ok()
@@ -171,6 +207,18 @@ mod tests {
         assert_eq!(
             get_physical_closure_convention(&ctx, cps),
             Some(CallingConvention::Cps)
+        );
+        assert_eq!(get_physical_closure_environment_index(&ctx, cps), Some(1));
+
+        let continuation = physical_closure_type_with_environment_index(
+            &mut ctx,
+            function,
+            CallingConvention::Cps,
+            0,
+        );
+        assert_eq!(
+            get_physical_closure_environment_index(&ctx, continuation),
+            Some(0)
         );
     }
 }

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -21,6 +21,7 @@
 
 use std::ops::ControlFlow;
 
+use tribute_core::calling_convention::get_physical_closure_environment_index;
 use tribute_core::{
     CallableAbi, CallingConvention, get_calling_convention, get_closure_callable_type,
     get_physical_closure_convention, set_closure_callable_type, set_indirect_call_signature,
@@ -474,7 +475,7 @@ fn exact_physical_call_contract(
             casts.push((index, *expected));
         }
     }
-    let environment_index = convention.closure_environment_index();
+    let environment_index = get_physical_closure_environment_index(ctx, closure_ty)?;
     if environment_index > args.len() {
         return None;
     }
@@ -950,7 +951,7 @@ mod tests {
             &mut ctx,
             &format!(
                 r#"core.module @test {{
-  !cps = closure.closure(core.func(core.never, {ev}, core.i32, core.i32, core.i32)) {{tribute.calling_convention = 2}}
+  !cps = closure.closure(core.func(core.never, {ev}, core.i32, core.i32, core.i32)) {{tribute.calling_convention = 2, tribute.closure_environment_index = 1}}
   func.func @run(%callee: !cps, %evidence: {ev}, %done: core.i32, %dispatch: core.i32, %value: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
     func.tail_call_indirect %callee, %evidence, %done, %dispatch, %value {{tribute.calling_convention = 2}}
   }}
@@ -958,7 +959,11 @@ mod tests {
             ),
         );
         let run = func_by_name(&ctx, module, "run");
-        let evidence = ctx.block_args(ctx.region(run.body(&ctx)).blocks[0])[1];
+        let entry_args = ctx.block_args(ctx.region(run.body(&ctx)).blocks[0]);
+        let evidence = entry_args[1];
+        let done = entry_args[2];
+        let dispatch = entry_args[3];
+        let value = entry_args[4];
 
         lower_closures_in_func(&mut ctx, run);
 
@@ -974,6 +979,13 @@ mod tests {
         assert_eq!(callable.params(&ctx).len(), 5);
         assert_eq!(ctx.op_operands(tail).len(), 6);
         assert_eq!(ctx.op_operands(tail)[1], evidence);
+        assert_eq!(
+            ctx.value_ty(ctx.op_operands(tail)[2]),
+            tribute_rt::anyref(&mut ctx).as_type_ref()
+        );
+        assert_eq!(ctx.op_operands(tail)[3], done);
+        assert_eq!(ctx.op_operands(tail)[4], dispatch);
+        assert_eq!(ctx.op_operands(tail)[5], value);
     }
 
     #[test]

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -24,22 +24,24 @@
 
 use std::collections::HashMap;
 
+use tribute_core::calling_convention::{
+    CLOSURE_ENVIRONMENT_INDEX_ATTR, get_physical_closure_environment_index,
+};
 use tribute_core::{
-    CallableAbi, CallingConvention, get_calling_convention, set_calling_convention,
+    get_calling_convention, get_physical_closure_convention, set_calling_convention,
 };
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, core, func};
 use trunk_ir::ir_mapping::IrMapping;
-use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{Module, erase_op};
 use trunk_ir::types::{Attribute, AttributeMap, TypeDataBuilder};
 
-use tribute_ir::dialect::ability;
-use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
+use tribute_ir::dialect::{ability, closure};
 
 /// Lower all `closure.lambda` ops in the module to `func.func` + `closure.new`.
 pub(crate) fn lower_closure_lambda(ctx: &mut IrContext, module: Module) {
@@ -60,8 +62,12 @@ pub(crate) fn lower_closure_lambda(ctx: &mut IrContext, module: Module) {
             break;
         }
 
+        let mut made_progress = false;
         for lambda_ref in lambdas {
-            lower_single_lambda(ctx, module_block, lambda_ref, &mut namer);
+            made_progress |= lower_single_lambda(ctx, module_block, lambda_ref, &mut namer);
+        }
+        if !made_progress {
+            break;
         }
     }
 }
@@ -120,9 +126,9 @@ fn lower_single_lambda(
     module_block: BlockRef,
     lambda_ref: OpRef,
     namer: &mut LambdaNamer,
-) {
+) -> bool {
     let Ok(lambda_op) = closure::Lambda::from_op(ctx, lambda_ref) else {
-        return;
+        return false;
     };
 
     let location = ctx.op(lambda_ref).location;
@@ -145,11 +151,43 @@ fn lower_single_lambda(
         .map(|i| ctx.block(orig_entry).args[i].ty)
         .collect();
 
-    // Determine function return type and effect from the closure result type.
+    // Convention-proven physical closures define the only legal environment
+    // insertion slot. Do not recover hidden operands from a lambda's shape.
     let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
     let convention = get_calling_convention(ctx, lambda_ref);
-    let func_result_ty = extract_return_type_from_closure(ctx, result_ty)
-        .expect("closure.lambda result type must be closure.closure<core.func<...>>");
+    let legacy_compatibility =
+        convention.is_none() && get_physical_closure_convention(ctx, result_ty).is_none();
+    let environment_index = match (convention, get_physical_closure_convention(ctx, result_ty)) {
+        (Some(convention), Some(provenance)) if provenance == convention => {
+            let Some(index) = get_physical_closure_environment_index(ctx, result_ty) else {
+                return false;
+            };
+            index
+        }
+        // Source lambdas predate exact outer-type provenance, but their
+        // operation metadata still fixes the existing environment slot.
+        (Some(convention), None) => convention.closure_environment_index(),
+        // The legacy frontend's untagged continuations have a fixed
+        // `(evidence, environment, source...)` compatibility ABI.
+        (None, None) => 1,
+        _ => return false,
+    };
+    let Some(callable) = closure::Closure::from_type_ref(ctx, result_ty)
+        .and_then(|closure| core::Func::from_type_ref(ctx, closure.func_type(ctx)))
+    else {
+        return false;
+    };
+    let func_result_ty = callable.r#return(ctx);
+    if callable.params(ctx) != orig_param_types.as_slice() {
+        return false;
+    }
+    if !legacy_compatibility && environment_index > orig_param_count {
+        return false;
+    }
+    let evidence_ty = legacy_compatibility.then(|| ability::evidence_adt_type_ref(ctx));
+    let implicit_evidence = evidence_ty
+        .and_then(|evidence_ty| nearest_physical_evidence_arg(ctx, lambda_ref, evidence_ty))
+        .filter(|evidence| !captures.contains(evidence));
 
     // Build env struct type for captures.
     let env_struct_ty = if captures.is_empty() {
@@ -165,12 +203,6 @@ fn lower_single_lambda(
     };
 
     // === Build the lifted function ===
-    let evidence_ty = ability::evidence_adt_type_ref(ctx);
-    let implicit_evidence = convention
-        .is_none()
-        .then(|| nearest_physical_evidence_arg(ctx, lambda_ref, evidence_ty))
-        .flatten()
-        .filter(|evidence| !captures.contains(evidence));
     let func_body_region = build_lifted_body(
         ctx,
         location,
@@ -180,36 +212,30 @@ fn lower_single_lambda(
             capture_types: &capture_types,
             env_struct_ty,
             orig_param_types: &orig_param_types,
-            convention,
-            evidence_ty,
+            environment_index,
+            legacy_compatibility,
             implicit_evidence,
             anyref_ty,
         },
     );
 
-    // Source lambdas carry explicit convention metadata. Synthetic legacy
-    // continuations still use the compatibility ABI `(evidence, env, args...)`.
-    let all_param_tys = if let Some(convention) = convention {
-        let source_offset =
-            usize::from(convention.needs_evidence()) + usize::from(convention.needs_done_k());
-        let abi = CallableAbi::new(
-            convention,
-            orig_param_types[source_offset..].iter().copied(),
-            func_result_ty,
-        );
-        abi.interpose_environment(&orig_param_types, anyref_ty)
-    } else {
-        let mut params = Vec::with_capacity(orig_param_types.len() + 2);
-        params.push(ability::evidence_adt_type_ref(ctx));
-        params.push(anyref_ty);
-        params.extend_from_slice(&orig_param_types);
-        params
-    };
+    let mut all_param_tys = orig_param_types.clone();
+    all_param_tys.insert(
+        environment_index - usize::from(legacy_compatibility),
+        anyref_ty,
+    );
+    if legacy_compatibility {
+        all_param_tys.insert(0, ability::evidence_adt_type_ref(ctx));
+    }
     let func_ty = core::func(ctx, func_result_ty, all_param_tys.iter().copied()).as_type_ref();
 
     let func_op = func::func(ctx, location, lifted_name, func_ty, func_body_region);
     if let Some(convention) = convention {
         set_calling_convention(ctx, func_op.op_ref(), convention);
+        ctx.op_mut(func_op.op_ref()).attributes.insert(
+            Symbol::new(CLOSURE_ENVIRONMENT_INDEX_ATTR),
+            Attribute::Int(environment_index as i128),
+        );
     }
     ctx.push_op(module_block, func_op.op_ref());
 
@@ -232,10 +258,7 @@ fn lower_single_lambda(
     };
 
     // Create closure.new replacing the lambda.
-    let closure_func_ty =
-        core::func(ctx, func_result_ty, orig_param_types.iter().copied()).as_type_ref();
-    let closure_ty = closure::closure(ctx, closure_func_ty).as_type_ref();
-    let closure_new_op = closure::new(ctx, location, closure_env, closure_ty, lifted_name);
+    let closure_new_op = closure::new(ctx, location, closure_env, result_ty, lifted_name);
     if let Some(convention) = convention {
         set_calling_convention(ctx, closure_new_op.op_ref(), convention);
     }
@@ -250,6 +273,7 @@ fn lower_single_lambda(
     // use-chains of the lambda and its (now-cloned) body subtree, not just
     // detaches it — see #710.
     erase_op(ctx, lambda_ref);
+    true
 }
 
 // ============================================================================
@@ -262,8 +286,8 @@ struct LiftBodyParams<'a> {
     capture_types: &'a [TypeRef],
     env_struct_ty: Option<TypeRef>,
     orig_param_types: &'a [TypeRef],
-    convention: Option<CallingConvention>,
-    evidence_ty: TypeRef,
+    environment_index: usize,
+    legacy_compatibility: bool,
     implicit_evidence: Option<ValueRef>,
     anyref_ty: TypeRef,
 }
@@ -280,8 +304,8 @@ fn build_lifted_body(
     let capture_types = params.capture_types;
     let env_struct_ty = params.env_struct_ty;
     let orig_param_types = params.orig_param_types;
-    let convention = params.convention;
-    let evidence_ty = params.evidence_ty;
+    let environment_index = params.environment_index;
+    let legacy_compatibility = params.legacy_compatibility;
     let implicit_evidence = params.implicit_evidence;
     let anyref_ty = params.anyref_ty;
     let orig_blocks: Vec<BlockRef> = ctx.region(orig_body).blocks.to_vec();
@@ -291,32 +315,30 @@ fn build_lifted_body(
     let mut mapping = IrMapping::new();
 
     // --- Pass 1: Create new entry block with the physical closure ABI. ---
-    let mut new_entry_args = Vec::new();
-    match convention {
-        Some(convention) if convention.needs_evidence() => {
-            new_entry_args.push(BlockArgData {
-                ty: orig_param_types[0],
-                attrs: ctx.block(orig_entry).args[0].attrs.clone(),
-            });
-        }
-        None => {
-            new_entry_args.push(BlockArgData {
-                ty: evidence_ty,
+    let mut new_entry_args: Vec<_> = orig_param_types
+        .iter()
+        .enumerate()
+        .map(|(index, &ty)| BlockArgData {
+            ty,
+            attrs: ctx.block(orig_entry).args[index].attrs.clone(),
+        })
+        .collect();
+    let logical_environment_index = environment_index - usize::from(legacy_compatibility);
+    new_entry_args.insert(
+        logical_environment_index,
+        BlockArgData {
+            ty: anyref_ty,
+            attrs: make_bind_name_attrs("__env"),
+        },
+    );
+    if legacy_compatibility {
+        new_entry_args.insert(
+            0,
+            BlockArgData {
+                ty: ability::evidence_adt_type_ref(ctx),
                 attrs: make_bind_name_attrs("__evidence"),
-            });
-        }
-        Some(_) => {}
-    }
-    new_entry_args.push(BlockArgData {
-        ty: anyref_ty,
-        attrs: make_bind_name_attrs("__env"),
-    });
-    let source_start = usize::from(convention.is_some_and(CallingConvention::needs_evidence));
-    for (i, &param_ty) in orig_param_types.iter().enumerate().skip(source_start) {
-        new_entry_args.push(BlockArgData {
-            ty: param_ty,
-            attrs: ctx.block(orig_entry).args[i].attrs.clone(),
-        });
+            },
+        );
     }
 
     let new_entry = ctx.create_block(BlockData {
@@ -331,27 +353,18 @@ fn build_lifted_body(
     // Map logical closure args around the inserted environment parameter.
     for i in 0..orig_param_count {
         let old_arg = ctx.block_arg(orig_entry, i as u32);
-        let new_index = match convention {
-            Some(convention) if convention.needs_evidence() && i == 0 => 0,
-            Some(_) => i + 1,
-            None => i + 2,
-        };
+        let new_index =
+            usize::from(legacy_compatibility) + i + usize::from(i >= logical_environment_index);
         let new_arg = ctx.block_arg(new_entry, new_index as u32);
         mapping.map_value(old_arg, new_arg);
     }
 
-    // Synthetic compatibility continuations receive evidence through their
-    // invocation ABI. Remap only the nearest physical function's exact entry
-    // value; an explicit capture has already taken precedence above.
-    if convention.is_none()
-        && let Some(outer_evidence) = implicit_evidence
-    {
+    if let Some(outer_evidence) = implicit_evidence {
         mapping.map_value(outer_evidence, ctx.block_arg(new_entry, 0));
     }
 
     // Insert env extraction ops at the start of the new entry block.
-    let env_index = u32::from(convention.is_none_or(CallingConvention::needs_evidence));
-    let raw_env_val = ctx.block_arg(new_entry, env_index);
+    let raw_env_val = ctx.block_arg(new_entry, environment_index as u32);
     if let Some(env_ty) = env_struct_ty {
         let cast_op = adt::ref_cast(ctx, location, raw_env_val, env_ty, env_ty);
         ctx.push_op(new_entry, cast_op.op_ref());
@@ -434,8 +447,8 @@ fn find_enclosing_func_name(ctx: &IrContext, op: OpRef) -> String {
     "<anon>".to_string()
 }
 
-/// Return the nearest physical function's evidence entry argument when its
-/// first ABI parameter is exactly the shared evidence type.
+/// Return the nearest physical function's evidence entry argument for the
+/// legacy frontend continuation ABI.
 fn nearest_physical_evidence_arg(
     ctx: &IrContext,
     op: OpRef,
@@ -475,28 +488,6 @@ impl LambdaNamer {
     }
 }
 
-/// Extract return type from `closure.closure<core.func<Return, Params...>>`.
-fn extract_return_type_from_closure(ctx: &IrContext, closure_ty: TypeRef) -> Option<TypeRef> {
-    let func_ty = extract_func_type_from_closure(ctx, closure_ty)?;
-    let func_data = ctx.types.get(func_ty);
-    // core.func params[0] = return type
-    func_data.params.first().copied()
-}
-
-/// Extract the `core.func` TypeRef from a `closure.closure<core.func<...>>`.
-fn extract_func_type_from_closure(ctx: &IrContext, closure_ty: TypeRef) -> Option<TypeRef> {
-    let data = ctx.types.get(closure_ty);
-    if data.dialect != Symbol::new("closure") || data.name != Symbol::new("closure") {
-        return None;
-    }
-    let func_ty = *data.params.first()?;
-    let func_data = ctx.types.get(func_ty);
-    if func_data.dialect != Symbol::new("core") || func_data.name != Symbol::new("func") {
-        return None;
-    }
-    Some(func_ty)
-}
-
 /// Create an `adt.struct` type with name and fields.
 fn make_adt_struct_type(
     ctx: &mut IrContext,
@@ -534,11 +525,14 @@ fn make_bind_name_attrs(name: &str) -> AttributeMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tribute_core::CallingConvention;
+    use tribute_ir::dialect::ability;
     use trunk_ir::context::RegionData;
     use trunk_ir::dialect::{arith, core};
+    use trunk_ir::printer::print_module;
     use trunk_ir::refs::PathRef;
     use trunk_ir::types::Location;
-    use trunk_ir::{Attribute, IrContext, OperationDataBuilder, Span, validation};
+    use trunk_ir::{Attribute, IrContext, OperationDataBuilder, Span};
 
     fn test_ctx() -> (IrContext, Location) {
         let ctx = IrContext::new();
@@ -612,7 +606,8 @@ mod tests {
 
         // closure type: closure.closure<core.func<i32, i32>>
         let func_ty = core::func(&mut ctx, i32_ty, [i32_ty]).as_type_ref();
-        let closure_ty = closure::closure(&mut ctx, func_ty).as_type_ref();
+        let closure_ty =
+            tribute_core::physical_closure_type(&mut ctx, func_ty, CallingConvention::Direct);
 
         // closure.lambda [] { ... } -> closure_ty
         let lambda_op = closure::lambda(
@@ -685,15 +680,14 @@ mod tests {
     }
 
     #[test]
-    fn test_synthetic_lambda_remaps_enclosing_evidence_to_its_abi_argument() {
+    fn missing_physical_environment_index_leaves_lambda_unchanged() {
         let (mut ctx, loc) = test_ctx();
         let (module, module_block) = make_module(&mut ctx, loc);
         let anyref_ty = make_anyref_ty(&mut ctx);
         let evidence_ty = ability::evidence_adt_type_ref(&mut ctx);
 
-        // A synthetic compatibility continuation has no convention metadata
-        // and no explicit captures, but its body uses the enclosing physical
-        // function's invocation-time evidence.
+        // A physical CPS closure without its exact environment slot must fail
+        // closed before the lambda body is mutated.
         let outer_entry = ctx.create_block(BlockData {
             location: loc,
             args: vec![BlockArgData {
@@ -723,7 +717,15 @@ mod tests {
         });
 
         let lambda_func_ty = core::func(&mut ctx, anyref_ty, std::iter::empty::<TypeRef>());
-        let lambda_ty = closure::closure(&mut ctx, lambda_func_ty.as_type_ref()).as_type_ref();
+        let lambda_ty = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("closure"), Symbol::new("closure"))
+                .param(lambda_func_ty.as_type_ref())
+                .attr(
+                    tribute_core::CALLING_CONVENTION_ATTR,
+                    Attribute::Int(CallingConvention::Cps as i128),
+                )
+                .build(),
+        );
         let lambda = closure::lambda(
             &mut ctx,
             loc,
@@ -731,6 +733,7 @@ mod tests {
             lambda_ty,
             lambda_body,
         );
+        set_calling_convention(&mut ctx, lambda.op_ref(), CallingConvention::Cps);
         ctx.push_op(outer_entry, lambda.op_ref());
 
         let outer_body = ctx.create_region(RegionData {
@@ -742,25 +745,9 @@ mod tests {
         let outer = func::func(&mut ctx, loc, Symbol::new("test_fn"), outer_ty, outer_body);
         ctx.push_op(module_block, outer.op_ref());
 
+        let before = print_module(&ctx, module.op());
         lower_closure_lambda(&mut ctx, module);
-
-        let validation = validation::validate_value_integrity(&ctx, module);
-        assert!(validation.is_ok(), "{validation}");
-
-        let lifted = func::Func::from_op(&ctx, module.ops(&ctx)[1]).unwrap();
-        let lifted_entry = ctx.region(lifted.body(&ctx)).blocks[0];
-        let lifted_cast = ctx
-            .block(lifted_entry)
-            .ops
-            .iter()
-            .copied()
-            .find(|op| core::UnrealizedConversionCast::matches(&ctx, *op))
-            .expect("lifted body must retain the evidence cast");
-        assert_eq!(
-            ctx.op_operands(lifted_cast)[0],
-            ctx.block_arg(lifted_entry, 0),
-            "synthetic evidence use must map to the lifted ABI argument"
-        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]
@@ -817,7 +804,8 @@ mod tests {
         });
 
         let func_ty = core::func(&mut ctx, i32_ty, [i32_ty]).as_type_ref();
-        let closure_ty = closure::closure(&mut ctx, func_ty).as_type_ref();
+        let closure_ty =
+            tribute_core::physical_closure_type(&mut ctx, func_ty, CallingConvention::Direct);
 
         // closure.lambda [%a] { ... }
         let lambda_op = closure::lambda(&mut ctx, loc, vec![a_val], closure_ty, lambda_body_region);

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -261,13 +261,7 @@ fn collect_functions(
         let identity = FunctionIdentity {
             signature,
             convention,
-            environment_index: environment_index(
-                ctx,
-                op,
-                callable.params(ctx),
-                convention,
-                anyref,
-            )?,
+            environment_index: environment_index(ctx, op, callable.params(ctx), anyref)?,
         };
         if functions.insert(key, identity).is_some() {
             return Err(TargetAbiError::new(
@@ -453,7 +447,6 @@ fn environment_index(
     ctx: &IrContext,
     function: OpRef,
     params: &[TypeRef],
-    convention: CallingConvention,
     anyref: TypeRef,
 ) -> Result<Option<usize>, TargetAbiError> {
     let attributes = &ctx.op(function).attributes;
@@ -471,7 +464,7 @@ fn environment_index(
         ));
     }
     if let Some(index) = declared {
-        validate_environment_slot(params, convention, anyref, index)?;
+        validate_environment_slot(params, anyref, index)?;
     }
 
     let Some(&region) = ctx.op(function).regions.first() else {
@@ -503,7 +496,7 @@ fn environment_index(
         )),
         [] => Ok(None),
         [index] => {
-            validate_environment_slot(params, convention, anyref, *index)?;
+            validate_environment_slot(params, anyref, *index)?;
             if declared.is_some_and(|declared| declared != *index) {
                 return Err(TargetAbiError::new(
                     "target ABI: closure environment index differs from `__env` parameter",
@@ -519,13 +512,12 @@ fn environment_index(
 
 fn validate_environment_slot(
     params: &[TypeRef],
-    convention: CallingConvention,
     anyref: TypeRef,
     index: usize,
 ) -> Result<(), TargetAbiError> {
-    if index != convention.closure_environment_index() {
+    if index >= params.len() {
         return Err(TargetAbiError::new(
-            "target ABI: closure environment index differs from calling convention",
+            "target ABI: closure environment index is outside function signature",
         ));
     }
     if params.get(index) != Some(&anyref) {
@@ -838,6 +830,45 @@ mod tests {
     }
 
     #[test]
+    fn physicalizes_explicit_generated_cps_environment_slots() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @generated_zero(%__env: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 0} {
+    func.unreachable
+  }
+  func.func @generated_one(%__env: tribute_rt.anyref, %value: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 0} {
+    func.unreachable
+  }
+  func.func @holder() -> core.i32 {
+    %zero = func.constant {func_ref = @generated_zero} : core.func(core.never)
+    %one = func.constant {func_ref = @generated_one} : core.func(core.never, core.i32)
+    func.unreachable
+  }
+}"#,
+        );
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+
+        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let nil = core::nil(&mut ctx).as_type_ref();
+        for (name, parameter_count) in [("generated_zero", 1), ("generated_one", 2)] {
+            let function = function(&ctx, module, name);
+            let signature = core::Func::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
+            assert_eq!(signature.r#return(&ctx), nil);
+            assert_eq!(signature.params(&ctx).len(), parameter_count);
+            assert_eq!(signature.params(&ctx)[0], anyref);
+        }
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains(": core.func(core.nil)"), "{printed}");
+        assert!(
+            printed.contains(": core.func(core.nil, core.i32)"),
+            "{printed}"
+        );
+    }
+
+    #[test]
     fn malformed_or_missing_environment_provenance_fails_before_mutation() {
         for (function, expected) in [
             (
@@ -845,8 +876,8 @@ mod tests {
                 "function reference differs",
             ),
             (
-                "func.func @external(%evidence: core.i32, %environment: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 0}",
-                "differs from calling convention",
+                "func.func @external(%evidence: core.i32, %environment: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 3}",
+                "outside function signature",
             ),
             (
                 "func.func @external(%evidence: core.i32, %environment: core.i32, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 1}",
@@ -855,6 +886,10 @@ mod tests {
             (
                 "func.func @external(%evidence: core.i32, %environment: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 1} { func.unreachable }",
                 "no matching `__env`",
+            ),
+            (
+                "func.func @external(%environment: tribute_rt.anyref, %__env: tribute_rt.anyref, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 0} { func.unreachable }",
+                "differs from `__env` parameter",
             ),
         ] {
             let mut ctx = IrContext::new();
@@ -877,6 +912,38 @@ mod tests {
             assert!(error.to_string().contains(expected), "{error}");
             assert_eq!(print_module(&ctx, module.op()), before);
         }
+    }
+
+    #[test]
+    fn duplicate_environment_provenance_fails_before_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @external(%__env: tribute_rt.anyref, %environment: tribute_rt.anyref) -> core.never attributes {tribute.calling_convention = 2, tribute.closure_environment_index = 0} {
+    func.unreachable
+  }
+  func.func @holder() -> core.i32 {
+    %function = func.constant {func_ref = @external} : core.func(core.never, tribute_rt.anyref)
+    func.unreachable
+  }
+}"#,
+        );
+        let external = function(&ctx, module, "external");
+        let entry = ctx.region(external.body(&ctx)).blocks[0];
+        ctx.block_mut(entry).args[1].attrs.insert(
+            Symbol::new("bind_name"),
+            Attribute::Symbol(Symbol::new("__env")),
+        );
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error.to_string().contains("multiple `__env` parameters"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -8,8 +8,10 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 
+use tribute_core::calling_convention::physical_closure_type_with_environment_index;
 use tribute_core::{
-    CALLING_CONVENTION_ATTR, CallableAbi, CallingConvention, set_calling_convention,
+    CALLING_CONVENTION_ATTR, CallableAbi, CallingConvention, physical_closure_type,
+    set_calling_convention,
 };
 use tribute_ir::dialect::{ability, closure, tribute_control, tribute_rt};
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
@@ -806,14 +808,18 @@ impl<'a> Converter<'a> {
     fn done_k_type(&mut self, answer: TypeRef) -> TypeRef {
         let never = self.never_type();
         let function = core::func(self.ctx, never, [answer]).as_type_ref();
-        closure::closure(self.ctx, function).as_type_ref()
+        self.generated_continuation_type(function)
     }
 
     fn resumption_type(&mut self, input: TypeRef, answer: TypeRef) -> TypeRef {
         let never = self.never_type();
         let done_k = self.done_k_type(answer);
         let function = core::func(self.ctx, never, [done_k, input]).as_type_ref();
-        closure::closure(self.ctx, function).as_type_ref()
+        self.generated_continuation_type(function)
+    }
+
+    fn generated_continuation_type(&mut self, function: TypeRef) -> TypeRef {
+        physical_closure_type_with_environment_index(self.ctx, function, CallingConvention::Cps, 0)
     }
 
     fn convert_attribute(&mut self, attribute: &Attribute) -> Attribute {
@@ -861,7 +867,7 @@ impl<'a> Converter<'a> {
                 result
             };
             let function = core::func(self.ctx, lowered_result, lowered_params).as_type_ref();
-            let converted = closure::closure(self.ctx, function).as_type_ref();
+            let converted = physical_closure_type(self.ctx, function, convention);
             self.converted_types.insert(ty, converted);
             return converted;
         }
@@ -1488,7 +1494,7 @@ impl<'a> Converter<'a> {
         let captures = ordered_external_values(self.ctx, region);
         let never = self.never_type();
         let function = core::func(self.ctx, never, std::iter::empty::<TypeRef>()).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let closure_type = self.generated_continuation_type(function);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok(lambda.result(self.ctx))
@@ -1624,7 +1630,7 @@ impl<'a> Converter<'a> {
         let captures = ordered_external_values(self.ctx, region);
         let never = self.never_type();
         let function = core::func(self.ctx, never, [result_type]).as_type_ref();
-        let closure_ty = closure::closure(self.ctx, function).as_type_ref();
+        let closure_ty = self.generated_continuation_type(function);
         let lambda = closure::lambda(self.ctx, location, captures, closure_ty, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok(lambda.result(self.ctx))
@@ -1787,7 +1793,7 @@ impl<'a> Converter<'a> {
         let captures = ordered_external_values(self.ctx, body);
         let never = self.never_type();
         let function = core::func(self.ctx, never, [arg_type]).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let closure_type = self.generated_continuation_type(function);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, body);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
         Ok((lambda.op_ref(), lambda.result(self.ctx)))
@@ -2206,7 +2212,7 @@ impl<'a> Converter<'a> {
             self.convert_type(operation_result)
         };
         let function = core::func(self.ctx, result, params).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let closure_type = physical_closure_type(self.ctx, function, convention);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), convention);
         Ok(HandlerArmInfo {
@@ -2357,17 +2363,14 @@ impl<'a> Converter<'a> {
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
         let function = core::func(self.ctx, result, params).as_type_ref();
-        let closure_type = closure::closure(self.ctx, function).as_type_ref();
+        let convention = if general {
+            CallingConvention::Cps
+        } else {
+            CallingConvention::EvidenceDirect
+        };
+        let closure_type = physical_closure_type(self.ctx, function, convention);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
-        set_calling_convention(
-            self.ctx,
-            lambda.op_ref(),
-            if general {
-                CallingConvention::Cps
-            } else {
-                CallingConvention::EvidenceDirect
-            },
-        );
+        set_calling_convention(self.ctx, lambda.op_ref(), convention);
         (lambda.op_ref(), lambda.result(self.ctx))
     }
 
@@ -3096,6 +3099,7 @@ impl Pass for TributeControlToCps {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trunk_ir::ops::DialectType;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
 
@@ -3103,6 +3107,20 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, input);
         (ctx, module)
+    }
+
+    fn collect_lambdas(ctx: &IrContext, op: OpRef, lambdas: &mut Vec<OpRef>) {
+        if closure::Lambda::matches(ctx, op) {
+            lambdas.push(op);
+            return;
+        }
+        for &region in &ctx.op(op).regions {
+            for &block in &ctx.region(region).blocks {
+                for &child in &ctx.block(block).ops {
+                    collect_lambdas(ctx, child, lambdas);
+                }
+            }
+        }
     }
 
     #[test]
@@ -3197,9 +3215,34 @@ mod tests {
         assert!(printed.contains("tribute.calling_convention = 2"));
         assert!(!printed.contains("tribute_control."), "{printed}");
 
-        let mut reparsed = IrContext::new();
-        let reparsed_module = parse_test_module(&mut reparsed, &printed);
-        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+        // `closure.lambda` assembly only preserves its callable shape. The
+        // exact outer closure convention remains canonical type provenance
+        // and is verified above before this printer/parser boundary.
+        let mut lambdas = Vec::new();
+        collect_lambdas(&ctx, module.op(), &mut lambdas);
+        let one_parameter_cps = lambdas.into_iter().find(|lambda| {
+            let closure_ty = ctx.op_result_types(*lambda)[0];
+            tribute_core::get_calling_convention(&ctx, *lambda) == Some(CallingConvention::Cps)
+                && closure::Closure::from_type_ref(&ctx, closure_ty)
+                    .and_then(|closure| core::Func::from_type_ref(&ctx, closure.func_type(&ctx)))
+                    .is_some_and(|callable| callable.params(&ctx).len() == 1)
+        });
+        let lambda =
+            one_parameter_cps.expect("conversion should produce a one-parameter CPS continuation");
+        let closure_ty = ctx.op_result_types(lambda)[0];
+        assert_eq!(
+            tribute_core::calling_convention::get_physical_closure_environment_index(
+                &ctx, closure_ty
+            ),
+            Some(0)
+        );
+        crate::lower_closure_lambda::lower_closure_lambda(&mut ctx, module);
+        crate::closure_lower::lower_closures(&mut ctx, module);
+        let lowered = print_module(&ctx, module.op());
+        assert!(
+            !lowered.contains("closure.lambda") && !lowered.contains("closure.new"),
+            "{lowered}"
+        );
     }
 
     #[test]
@@ -4080,9 +4123,39 @@ mod tests {
         assert!(printed.contains("func.call") && printed.contains("func.tail_call_indirect"));
         assert!(!printed.contains("tribute_control."));
 
-        let mut reparsed = IrContext::new();
-        let reparsed_module = parse_test_module(&mut reparsed, &printed);
-        verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+        let mut lambdas = Vec::new();
+        collect_lambdas(&ctx, module.op(), &mut lambdas);
+        let mut generated_param_counts = Vec::new();
+        for lambda in lambdas {
+            if tribute_core::get_calling_convention(&ctx, lambda) != Some(CallingConvention::Cps) {
+                continue;
+            }
+            let closure_ty = ctx.op_result_types(lambda)[0];
+            assert_eq!(
+                tribute_core::get_physical_closure_convention(&ctx, closure_ty),
+                Some(CallingConvention::Cps)
+            );
+            let callable = closure::Closure::from_type_ref(&ctx, closure_ty)
+                .and_then(|closure| core::Func::from_type_ref(&ctx, closure.func_type(&ctx)))
+                .unwrap();
+            generated_param_counts.push(callable.params(&ctx).len());
+        }
+        assert!(generated_param_counts.contains(&0), "{printed}");
+
+        crate::lower_closure_lambda::lower_closure_lambda(&mut ctx, module);
+        let lifted = print_module(&ctx, module.op());
+        assert!(!lifted.contains("closure.lambda"), "{lifted}");
+        assert!(
+            lifted.contains("tribute.closure_environment_index = 0"),
+            "{lifted}"
+        );
+        crate::closure_lower::lower_closures(&mut ctx, module);
+        let lowered = print_module(&ctx, module.op());
+        assert!(!lowered.contains("closure.new"), "{lowered}");
+        assert!(
+            lowered.contains("func.indirect_call_signature"),
+            "{lowered}"
+        );
     }
 
     #[test]

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -86,6 +86,15 @@ adapter의 최종 parameter 순서는 `Direct`에서 `environment, source...`,
 `evidence, environment, done_k, source...`다. `call_indirect`도 같은 순서로
 environment를 삽입한다.
 
+Convention-proven physical `closure.closure` type은 outer type에 exact
+`tribute.closure_environment_index`도 기록한다. Ordinary callable은
+`CallableAbi`의 convention slot을 사용하지만, generated continuation은 capture한
+evidence/`done_k`를 entry parameter로 다시 만들지 않는다. 따라서 producer가
+실제 physical entry slot을 type provenance에 명시하고 lambda lifting과 indirect
+call lowering은 그 slot을 그대로 cross-check/consume한다. Consumer가 arity,
+parameter type, body shape, 또는 calling-convention marker만으로 slot이나 hidden
+operand를 복원하는 것은 illegal이다.
+
 Environment-bearing `func.func`는 zero-based physical slot을
 `tribute.closure_environment_index`로 기록한다. Bodyless declaration은 이
 function-level provenance가 필수이며, definition은 entry block의 `__env` marker와

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -98,8 +98,9 @@ operand를 복원하는 것은 illegal이다.
 Environment-bearing `func.func`는 zero-based physical slot을
 `tribute.closure_environment_index`로 기록한다. Bodyless declaration은 이
 function-level provenance가 필수이며, definition은 entry block의 `__env` marker와
-같은 slot이어야 한다. Slot은 convention-defined `CallableAbi` 순서와 exact
-`tribute_rt.anyref` type에 일치해야 하며 type이나 arity로 추측하지 않는다.
+같은 slot이어야 한다. Slot은 outer convention-proven closure type이 기록한 exact
+physical order와 exact `tribute_rt.anyref` type에 일치해야 하며 type이나 arity로
+추측하지 않는다.
 
 생성한 physical definition, lambda, adapter, direct/indirect call에는 logical
 type의 convention을 기존 `tribute.calling_convention` attribute로 복사한다.


### PR DESCRIPTION
## Summary

- Preserve exact closure environment-slot provenance.
- Keep the producer, lambda lifter, and indirect-call lowering on the same contract.
- Retain narrow legacy compatibility for untyped legacy continuations.

## Validation

- Focused physical-closure pass tests.
- Normal hook and workspace suite.
- Final #854 overlay passed the former lambda/crash point and stopped at the independent residual ability.perform blocker.

Closes #844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit tracking of closure environment placement across calling conventions.
  - Improved support for CPS-generated closures, continuations, handlers, and dispatchers.

- **Bug Fixes**
  - Closure lowering now validates environment metadata and preserves intermediate results when metadata is inconsistent.
  - Improved reliability of captured-environment operand placement and callable parameter handling.
  - Added validation for environment slot bounds, types, and parameter consistency.

- **Documentation**
  - Updated CPS callable-shape guidance to define explicit closure environment slots and prevent ambiguous slot inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->