### PR TITLE
#836: Define the ContinuationFrame CPS ABI

### DIFF
--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -7,8 +7,8 @@ use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
 pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
-/// Result type carried by a private immutable CPS parent frame.
-pub const CPS_PARENT_RESULT_ATTR: &str = "tribute.cps_parent_result";
+/// Result type carried by a private immutable CPS continuation frame.
+pub const CPS_CONTINUATION_FRAME_RESULT_ATTR: &str = "tribute.cps_continuation_frame_result";
 pub const INDIRECT_CALL_SIGNATURE_ATTR: &str =
     trunk_ir::dialect::func::INDIRECT_CALL_SIGNATURE_ATTR;
 pub const CLOSURE_CALLABLE_TYPE_ATTR: &str = "tribute.closure_callable_type";
@@ -94,29 +94,33 @@ pub fn cps_done_type(ctx: &mut IrContext, result: TypeRef) -> TypeRef {
     generated_cps_closure_type(ctx, function)
 }
 
-/// Make the nominal reference for one private immutable `Parent<R>` frame.
+/// Make the nominal reference for one private immutable `ContinuationFrame<R>`.
 ///
 /// Its paired layout may recursively use this reference.
-pub fn cps_parent_ref_type(ctx: &mut IrContext, name: Symbol, result: TypeRef) -> TypeRef {
+pub fn cps_continuation_frame_ref_type(
+    ctx: &mut IrContext,
+    name: Symbol,
+    result: TypeRef,
+) -> TypeRef {
     ctx.types.intern(
         TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("typeref"))
             .attr("name", Attribute::Symbol(name))
-            .attr(CPS_PARENT_RESULT_ATTR, Attribute::Type(result))
+            .attr(CPS_CONTINUATION_FRAME_RESULT_ATTR, Attribute::Type(result))
             .build(),
     )
 }
 
-/// Read result-index metadata only from an explicit parent-frame type.
-pub fn cps_parent_result_type(ctx: &IrContext, parent: TypeRef) -> Option<TypeRef> {
-    let data = ctx.types.get(parent);
+/// Read result-index metadata only from an explicit continuation-frame type.
+pub fn cps_continuation_frame_result_type(ctx: &IrContext, frame: TypeRef) -> Option<TypeRef> {
+    let data = ctx.types.get(frame);
     (data.dialect == Symbol::new("adt")
         && matches!(data.name, name if name == Symbol::new("typeref") || name == Symbol::new("struct")))
-    .then(|| data.attrs.get_type(CPS_PARENT_RESULT_ATTR))
+    .then(|| data.attrs.get_type(CPS_CONTINUATION_FRAME_RESULT_ATTR))
     .flatten()
 }
 
-/// Make the exact immutable layout for [`cps_parent_ref_type`].
-pub fn cps_parent_layout_type(
+/// Make the exact immutable layout for [`cps_continuation_frame_ref_type`].
+pub fn cps_continuation_frame_layout_type(
     ctx: &mut IrContext,
     name: Symbol,
     result: TypeRef,
@@ -126,7 +130,7 @@ pub fn cps_parent_layout_type(
     ctx.types.intern(
         TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("struct"))
             .attr("name", Attribute::Symbol(name))
-            .attr(CPS_PARENT_RESULT_ATTR, Attribute::Type(result))
+            .attr(CPS_CONTINUATION_FRAME_RESULT_ATTR, Attribute::Type(result))
             .attr(
                 "fields",
                 Attribute::List(vec![
@@ -144,48 +148,48 @@ pub fn cps_parent_layout_type(
     )
 }
 
-/// Strict suffix continuation `Completion<X, R> = (Evidence, Parent<R>, X) -> never`.
+/// Strict suffix continuation `Completion<X, R> = (Evidence, ContinuationFrame<R>, X) -> never`.
 pub fn cps_completion_type(
     ctx: &mut IrContext,
     evidence: TypeRef,
     value: TypeRef,
-    parent: TypeRef,
+    frame: TypeRef,
 ) -> TypeRef {
     let never = core::never(ctx).as_type_ref();
-    let function = core::func(ctx, never, [evidence, parent, value]).as_type_ref();
+    let function = core::func(ctx, never, [evidence, frame, value]).as_type_ref();
     generated_cps_closure_type(ctx, function)
 }
 
-/// Exact operation resumption `ResumeExact<I, R> = (Evidence, Parent<R>, I) -> never`.
+/// Exact operation resumption `ResumeExact<I, R> = (Evidence, ContinuationFrame<R>, I) -> never`.
 pub fn cps_resume_exact_type(
     ctx: &mut IrContext,
     evidence: TypeRef,
     input: TypeRef,
-    parent: TypeRef,
+    frame: TypeRef,
 ) -> TypeRef {
-    cps_completion_type(ctx, evidence, input, parent)
+    cps_completion_type(ctx, evidence, input, frame)
 }
 
-/// Erased-input resumption `Resume<R> = (Evidence, Parent<R>, anyref) -> never`.
+/// Erased-input resumption `Resume<R> = (Evidence, ContinuationFrame<R>, anyref) -> never`.
 pub fn cps_resume_type(
     ctx: &mut IrContext,
     evidence: TypeRef,
-    parent: TypeRef,
+    frame: TypeRef,
     anyref: TypeRef,
 ) -> TypeRef {
-    cps_completion_type(ctx, evidence, anyref, parent)
+    cps_completion_type(ctx, evidence, anyref, frame)
 }
 
 /// Result-indexed general-operation dispatcher.
 pub fn cps_dispatch_type(
     ctx: &mut IrContext,
     evidence: TypeRef,
-    parent: TypeRef,
+    frame: TypeRef,
     anyref: TypeRef,
     i32_type: TypeRef,
 ) -> TypeRef {
     let never = core::never(ctx).as_type_ref();
-    let resume = cps_resume_type(ctx, evidence, parent, anyref);
+    let resume = cps_resume_type(ctx, evidence, frame, anyref);
     let function = core::func(
         ctx,
         never,
@@ -358,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn result_indexed_parent_builders_preserve_exact_types_and_provenance() {
+    fn result_indexed_continuation_frame_builders_preserve_exact_types_and_provenance() {
         let mut ctx = IrContext::new();
         let evidence = ctx
             .types
@@ -369,18 +373,30 @@ mod tests {
         let anyref = ctx
             .types
             .intern(TypeDataBuilder::new(Symbol::new("tribute_rt"), Symbol::new("anyref")).build());
-        let parent = cps_parent_ref_type(&mut ctx, Symbol::new("ParentI32"), i32_ty);
+        let frame =
+            cps_continuation_frame_ref_type(&mut ctx, Symbol::new("ContinuationFrameI32"), i32_ty);
         let done = cps_done_type(&mut ctx, i32_ty);
-        let dispatch = cps_dispatch_type(&mut ctx, evidence, parent, anyref, i32_ty);
-        let layout =
-            cps_parent_layout_type(&mut ctx, Symbol::new("ParentI32"), i32_ty, done, dispatch);
-        let completion = cps_completion_type(&mut ctx, evidence, i32_ty, parent);
-        let resume_exact = cps_resume_exact_type(&mut ctx, evidence, i32_ty, parent);
-        let resume = cps_resume_type(&mut ctx, evidence, parent, anyref);
+        let dispatch = cps_dispatch_type(&mut ctx, evidence, frame, anyref, i32_ty);
+        let layout = cps_continuation_frame_layout_type(
+            &mut ctx,
+            Symbol::new("ContinuationFrameI32"),
+            i32_ty,
+            done,
+            dispatch,
+        );
+        let completion = cps_completion_type(&mut ctx, evidence, i32_ty, frame);
+        let resume_exact = cps_resume_exact_type(&mut ctx, evidence, i32_ty, frame);
+        let resume = cps_resume_type(&mut ctx, evidence, frame, anyref);
         let never = core::never(&mut ctx).as_type_ref();
 
-        assert_eq!(cps_parent_result_type(&ctx, parent), Some(i32_ty));
-        assert_eq!(cps_parent_result_type(&ctx, layout), Some(i32_ty));
+        assert_eq!(
+            cps_continuation_frame_result_type(&ctx, frame),
+            Some(i32_ty)
+        );
+        assert_eq!(
+            cps_continuation_frame_result_type(&ctx, layout),
+            Some(i32_ty)
+        );
         assert_eq!(
             ctx.types.get(layout).attrs.get("fields"),
             Some(&Attribute::List(vec![
@@ -397,9 +413,9 @@ mod tests {
 
         for (closure, environment_index, expected) in [
             (done, 0, vec![never, i32_ty]),
-            (completion, 0, vec![never, evidence, parent, i32_ty]),
-            (resume_exact, 0, vec![never, evidence, parent, i32_ty]),
-            (resume, 0, vec![never, evidence, parent, anyref]),
+            (completion, 0, vec![never, evidence, frame, i32_ty]),
+            (resume_exact, 0, vec![never, evidence, frame, i32_ty]),
+            (resume, 0, vec![never, evidence, frame, anyref]),
             (
                 dispatch,
                 1,
@@ -419,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn parent_and_cps_closure_readers_fail_closed_on_malformed_metadata() {
+    fn continuation_frame_and_cps_closure_readers_fail_closed_on_malformed_metadata() {
         let mut ctx = IrContext::new();
         let never = core::never(&mut ctx).as_type_ref();
         let function = core::func(&mut ctx, never, []).as_type_ref();
@@ -453,9 +469,9 @@ mod tests {
                 .attr(CLOSURE_ENVIRONMENT_INDEX_ATTR, Attribute::Int(1))
                 .build(),
         );
-        let unmarked_parent = ctx.types.intern(
+        let unmarked_frame = ctx.types.intern(
             TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("typeref"))
-                .attr("name", Attribute::Symbol(Symbol::new("Parent")))
+                .attr("name", Attribute::Symbol(Symbol::new("ContinuationFrame")))
                 .build(),
         );
 
@@ -465,7 +481,13 @@ mod tests {
             cps_closure_function_type(&ctx, out_of_range_environment),
             None
         );
-        assert_eq!(cps_parent_result_type(&ctx, unmarked_parent), None);
-        assert_eq!(cps_parent_result_type(&ctx, missing_environment), None);
+        assert_eq!(
+            cps_continuation_frame_result_type(&ctx, unmarked_frame),
+            None
+        );
+        assert_eq!(
+            cps_continuation_frame_result_type(&ctx, missing_environment),
+            None
+        );
     }
 }

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -28,11 +28,11 @@ Effect row, convention 순서, 실행 region 내부의 ANF invariant는 바뀌�
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="pre-cps-callable-shape"></a>
 
-### CPS 변환 전 호출 대상 형상
+### CPS 변환의 호출 대상 형상
 
 입력 형상은 [ir.md](ir.md#direct-style-control)의 operation/type 계약을 따른다.
 모든 callable은 exact `tribute.calling_convention` code 0/1/2를 가진 logical
-type과 source parameter/result만 사용하며 evidence, environment, `done_k`는
+type과 source parameter/result만 사용하며 evidence, environment, `ContinuationFrame<R>`는
 아직 없다.
 
 `tribute_control_to_cps`는 closure extraction 전에 전체 callable graph를 하나의
@@ -42,11 +42,14 @@ type과 source parameter/result만 사용하며 evidence, environment, `done_k`�
 | ---- | ---- | ---- |
 | `Direct` | 소스 parameter | 소스 result |
 | `EvidenceDirect` | evidence 뒤 소스 parameter | 소스 result |
-| `Cps` | evidence, `done_k`, source parameter 순서 | logical `core.never`, physical empty result |
+| `Cps` | evidence, `ContinuationFrame<R>`, source parameter 순서 | logical `core.never`, physical empty result |
 
-Parameter 순서는 기존 `CallableAbi` 순서다. `Cps`의 `done_k`는 source result를
-받고 logical `core.never`를 반환한다. Control lowering 뒤 worker와 continuation은
-result vector가 비어 있으며 제어 값을 반환하지 않는다.
+Parameter 순서는 기존 `CallableAbi` 순서다. `ContinuationFrame<R>`는 CPS callable이
+전달하는 continuation/control frame이며 `Done<R>`와 내부의 어휘적 `Dispatch<R>`를
+함께 보존한다. `Completion<X, R>`와 `ResumeExact<I, R>`는 각각
+`(Evidence, ContinuationFrame<R>, X)`와 `(Evidence, ContinuationFrame<R>, I)`를 받아
+logical `core.never`로 끝난다. Control lowering
+뒤 worker와 continuation은 result vector가 비어 있으며 제어 값을 반환하지 않는다.
 
 Conversion은 먼저 모든 logical callable type, definition, lambda, `func_ref`,
 direct/indirect call, return의 대응 관계를 검증하고 physical symbol과 type을
@@ -65,15 +68,15 @@ direct/indirect call, return의 대응 관계를 검증하고 physical symbol과
   closure struct로 바꾼다.
 - `Direct`/`EvidenceDirect`의 `tribute_control.call`과 `call_indirect`는 각각
   physical `func.call`과 `func.call_indirect`가 된다. `Cps` call은 suffix를
-  `done_k`로 전달하고 named target에는 `func.tail_call`, dynamic target에는
-  `func.tail_call_indirect`를 쓴다. Evidence와 environment는 `CallableAbi`
+  담은 `ContinuationFrame<R>`를 전달하고 named target에는 `func.tail_call`, dynamic target에는
+  `func.tail_call_indirect`를 쓴다. Evidence, ContinuationFrame과 environment는 `CallableAbi`
   순서로 삽입한다.
 - `tribute_control.return`은 `Direct`/`EvidenceDirect`에서 `func.return`이 된다.
-  `Cps`에서는 `done_k(value)`로 `func.tail_call_indirect`하며 뒤에
+  `Cps`에서는 ContinuationFrame의 `Done<R>`으로 `value`를 이전하며 뒤에
   `func.return`이나 result가 없다.
 
 알려진 CPS target으로의 최종 이전은 `func.tail_call`, closure, continuation,
-`done_k`처럼 동적인 target으로의 이전은 `func.tail_call_indirect`를 사용한다.
+ContinuationFrame의 `Done<R>`처럼 동적인 target으로의 이전은 `func.tail_call_indirect`를 사용한다.
 Shared IR의 caller/callee result는 `core.never`이고 target signature의 result
 vector는 비어 있어야 한다.
 생성한 continuation, `done_k`, handler-dispatch function에도
@@ -83,13 +86,13 @@ vector는 비어 있어야 한다.
 기존 `CallableAbi::interpose_environment`에 따라 extracted lambda와 `func_ref`
 adapter의 최종 parameter 순서는 `Direct`에서 `environment, source...`,
 `EvidenceDirect`에서 `evidence, environment, source...`, `Cps`에서
-`evidence, environment, done_k, source...`다. `call_indirect`도 같은 순서로
+`evidence, environment, ContinuationFrame<R>, source...`다. `call_indirect`도 같은 순서로
 environment를 삽입한다.
 
 Convention-proven physical `closure.closure` type은 outer type에 exact
-`tribute.closure_environment_index`도 기록한다. Ordinary callable은
-`CallableAbi`의 convention slot을 사용하지만, generated continuation은 capture한
-evidence/`done_k`를 entry parameter로 다시 만들지 않는다. 따라서 producer가
+`tribute.closure_environment_index`도 기록한다. 일반 callable과 생성된
+continuation은 `CallableAbi`가 정한 Evidence와 ContinuationFrame entry parameter를 사용한다.
+따라서 producer가
 실제 physical entry slot을 type provenance에 명시하고 lambda lifting과 indirect
 call lowering은 그 slot을 그대로 cross-check/consume한다. Consumer가 arity,
 parameter type, body shape, 또는 calling-convention marker만으로 slot이나 hidden
@@ -165,7 +168,9 @@ branch, guard, 오른쪽 항만 실행한다.
    performed-computation suffix와 completion region을 건너뛴다.
 5. Nested handle은 같은 delimiter를 재귀적으로 만든다. Resumed path는 perform과
    handler 사이에서 capture된 모든 case/conditional/short-circuit/nested-handle
-   frame에 다시 진입한다. Non-resumed path는 해당 frame을 포기한다.
+   frame에 다시 진입한다. Resume은 동적 `ContinuationFrame<R>`에서 새 불변 어휘적
+   dispatcher를 만들고, 그 ContinuationFrame을 다음 suffix와 resume에 전달한다. Non-resumed
+   path는 해당 frame을 포기한다.
 
 Converter는 region, block suffix, `tribute_control.yield`, 검증된
 `operation_kind`, callable convention metadata에서 모든 continuation을
@@ -206,8 +211,8 @@ location에서 conversion failure가 된다. 이 경계에는 일관된 physical
 Backend-ready Tribute boundary는 남은 `tribute_control.*`, `ability.*`,
 `effect.*`를 각각 독립적으로 거부한다.
 
-논리적 CPS 함수는 source result를 직접 반환하지 않는다. 완료 값은 `done_k`의
-인자로만 전달되고 logical control result는 `core.never`다. Physical control
+논리적 CPS 함수는 source result를 직접 반환하지 않는다. 완료 값은 ContinuationFrame의
+`Done<R>`에만 전달되고 logical control result는 `core.never`다. Physical control
 lowering은 이를 empty-result 함수와 proper tail transfer로 바꾸며 반환되는
 control value를 만들지 않는다. Resume하지 않는 handler arm도
 `Escape`를 반환하는 대신 해당 handle의 exit continuation으로 직접 tail
@@ -289,6 +294,25 @@ tail-calls it:
 func.tail_call_indirect %fn(
   %ev, %env, %continuation_anyref, %op_idx, %arg_anyref)
 ```
+
+<!-- markdownlint-disable-next-line MD033 -->
+<a id="dispatch-layers"></a>
+
+### Dispatch 계층
+
+여기에는 서로 다른 세 dispatch 계층이 있다.
+
+1. `ContinuationFrame<R>`의 내부 `Dispatch<R>`는 resume에서 어휘적 dispatcher를 재구성하는
+   CPS closure이며 `(evidence, resume, prompt, ability_id, op_id, payload)`를 받는다.
+2. `effect.dispatch_cps(evidence, continuation, payload)`는 대상 독립적이고
+   result가 없는 effect operation이다.
+3. 대상 handler tail ABI는
+   `(evidence, env, continuation, op_idx, payload)`이며 handler closure를 직접
+   호출한다.
+
+정의, lambda, adapter, direct/indirect call, return, suffix, resume, handle은
+ContinuationFrame을 같은 callable provenance로 전달한다. 내부 Dispatch를 effect operation이나
+target handler ABI로 대체하지 않는다.
 
 Effect point 이후의 코드는 이미 `%continuation` closure 안에 있으므로,
 `ability.perform` 이후의 같은 function-body ops는 dead code가 된다.

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -62,7 +62,9 @@ tribute        -> tribute-front + tribute-passes
   verifier와 Tribute-specific whole-IR verifier를 소유한다.
 - `tribute-passes`는
   [atomic callable/control conversion](cps-effects.md#pre-cps-callable-shape)과
-  post-CPS legality, generic `func.tail_call_indirect`를 소유한다.
+  post-CPS legality, generic `func.tail_call_indirect`를 소유한다. 이 변환은
+  Cps 정의, lambda, adapter, call, return, suffix, resume, handle에
+  Evidence와 ContinuationFrame을 같은 callable contract로 전달한다.
 - Root `tribute` crate는 frontend emission과 shared conversion을 조합한다.
   Target-independent root bridge는 completion cell과 terminal continuation의 추상
   조합 계약만 정한다.
@@ -310,7 +312,8 @@ struct Marker {
 Operation table 대신 handler boundary에서 두 종류의 dispatch closure를 만든다:
 
 - `tr_dispatch_fn`: `fn` operation 전용. `(op_idx, value) -> anyref`
-- `handler_dispatch`: `op` operation 전용. `(k, op_idx, value) -> ()`
+- `handler_dispatch`: `op` operation 전용 대상 proper-tail closure.
+  `(evidence, env, continuation, op_idx, payload) -> empty result`
 
 `op_idx`는 ability 이름과 operation 이름의 stable hash로 계산한다. 호출 지점과
 handler dispatch closure가 같은 hash 함수를 사용하므로, handler arm 등록 순서에
@@ -390,7 +393,7 @@ fn state_get(ev: Evidence) -> s {
    `fn(a) ->{e} b`이지만, 정의에서 발견된 concrete residual effect가 없다면
    worker 자체도 Direct일 수 있다
 2. **EvidenceDirect 함수**는 evidence를 받지만 `done_k` 없이 source result를 직접 반환한다
-3. **CPS 함수**는 evidence와 `done_k`를 받고 source result를 직접 반환하지 않는다
+3. **CPS 함수**는 evidence와 `ContinuationFrame<R>`를 받고 source result를 직접 반환하지 않는다
 4. **Handler 설치** 시 새 evidence를 할당한다
 5. **Handled ability operation** 시 evidence에서 marker를 조회한다
 
@@ -423,16 +426,18 @@ Frontend shared lowering은 private intrinsic stub을 `tribute_io.write`와
 target-independent `ReadLineResult`를 사용한다. Native와 Wasm pipeline은 이후 각자의
 runtime ABI 또는 host import로 operation을 완전히 lower해야 한다.
 
-논리적인 CPS ABI에서 함수와 `done_k`의 control result는 `Never`다:
+논리적인 CPS ABI에서 함수와 ContinuationFrame의 `Done<R>` transfer의 control result는
+`Never`다:
 
 ```text
-fn cps(ev: Evidence, done_k: fn(T) -> Never, args...) -> Never
+fn cps(ev: Evidence, frame: ContinuationFrame<R>, args...) -> Never
 ```
 
 최종 physical ABI는 empty result를 쓰고 direct transfer는 `func.tail_call`,
-closure/continuation/`done_k` transfer는 `func.tail_call_indirect`를 쓴다. CPS
-control carrier로 `anyref`를 사용할 수 없다. Boxed source value, payload, closure
-environment 같은 일반 reference erasure에는 사용할 수 있다.
+closure/continuation/ContinuationFrame의 `Done<R>` transfer는
+`func.tail_call_indirect`를 쓴다. CPS control carrier로 `anyref`를 사용할 수 없다.
+Boxed source value, payload, closure environment 같은 일반 reference erasure에는
+`anyref`를 사용할 수 있다.
 
 ### 런타임 함수
 
@@ -509,8 +514,8 @@ effect-polymorphic `add`는 Direct worker를 가질 수 있으며, first-class f
 boundary에서는 contextual convention에 맞는 adapter를 사용한다. 명시적인 `->{}`도
 닫힌 빈 row이므로 Direct를 사용한다.
 
-여기서 `Cps`는 source result를 직접 반환하지 않고 `done_k`로 전달한다는
-논리적 convention이다. Lowering은 `core.never`를 empty-result proper tail
+여기서 `Cps`는 source result를 직접 반환하지 않고 ContinuationFrame의 `Done<R>`으로
+전달한다는 논리적 convention이다. Lowering은 `core.never`를 empty-result proper tail
 transfer로 바꾸며 대체 carrier를 선택하지 않는다.
 
 따라서 `fn`과 `op`를 함께 선언한 ability는 함수 ABI를 정할 때 `Cps`로
@@ -580,7 +585,7 @@ fn map(xs: List(a), f: fn(a) ->{e} b) ->{e} List(b)
 `f`가 순수인지 effectful인지 컴파일 타임에 모를 수 있다. 전략:
 
 1. **열린 row는 Cps**: 구체화 전에는 더 강한 convention을 요구할 가능성을
-   배제할 수 없으므로 `done_k`를 포함하는 ABI를 사용한다
+   배제할 수 없으므로 `ContinuationFrame<R>`를 포함하는 ABI를 사용한다
 2. **Evidence는 항상 전달**: effectful polymorphic 호출은 동일한 evidence를 전달한다
 3. **Tail-resumptive 최적화**: 구체적인 `fn` operation call-site에서는 실제 shift가
    필요 없다
@@ -770,6 +775,9 @@ Effect handling은 tail-call CPS로 구현한다.
 `lower_handle_dispatch`는 runtime dispatch loop가 아니라 body result에 `done`
 handler를 적용하는 정리 pass이다. Backend-specific lowering이 이후 `effect.*`를
 native runtime call 또는 Wasm evidence helper와 indirect call로 제거한다.
+
+내부 ContinuationFrame dispatcher와 resultless `effect.dispatch_cps`, target handler
+tail ABI의 구분과 순서는 [cps-effects.md](cps-effects.md#dispatch-layers)를 따른다.
 
 상세 내용은 [cps-effects.md](cps-effects.md)를 참조.
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -461,7 +461,7 @@ tribute_control.handler {
   terminator, token 위치/parameter, 위 yield 규칙을 확인한다.
   `operation_result_type`이 `Never`인 general handler는 token argument가 없어야
   하며 nested region을 포함한 body 어디에도 `tribute_control.resume`이 없어야
-  한다. Parent placement, uniqueness와 `op -> Never` yield를 포함한 enclosing
+  한다. ContinuationFrame placement, uniqueness와 `op -> Never` yield를 포함한 enclosing
   handle result와의 equality는 containing handle의 local verifier가 확인하고,
   converter도 rewrite 전에 같은 equality와 resume 부재를 검사해 위반을
   conversion failure로 보고한다. Symbol-aware frontend 적합성 검사는 참조된
@@ -551,6 +551,12 @@ logical continuation으로 region을 lower한다:
    handler 중 가장 가까운 일치 handler가 처리한다. Resume하면 perform과 해당
    handler 사이에서 선택된 모든 structured frame에 다시 진입한다. Resume하지
    않고 완료하면 그 frame을 포기한다.
+
+CPS 변환 뒤 Cps callable은 `Evidence, ContinuationFrame<R>, source args`를 받고
+`core.never`로 끝난다. 생성된 completion과 exact resume도 Evidence와
+ContinuationFrame을 명시적으로 받는다. Resume은 동적 ContinuationFrame에서 불변 어휘적 dispatcher를
+재구성한 뒤 suffix와 nested handle을 계속 실행한다. 세 dispatch 계층의 정확한
+형상은 [cps-effects.md](cps-effects.md#dispatch-layers)를 따른다.
 
 이 단일 region/suffix 규칙은 case arm과 guard, conditional, short-circuit
 오른쪽 항, nested handle body와 arm, resume path, 그리고 이들을 감싸는 strict


### PR DESCRIPTION
Defines the shared CPS contract needed by #836 and #872.

## Summary

- Rename the newly introduced, unconsumed `Parent<R>` metadata and builders to `ContinuationFrame<R>`.
- Define CPS callables as receiving `Evidence` and `ContinuationFrame<R>` before source arguments.
- Define completion and exact-resume continuations with explicit evidence and frame inputs.
- Distinguish the internal frame dispatcher, resultless `effect.dispatch_cps`, and the target handler tail ABI.
- Clarify immutable lexical dispatcher reconstruction during resumption and the durable lowering order.

`ContinuationFrame` describes the value's ABI role directly; no compatibility alias is needed because the metadata has no existing consumer.

## Validation

- Focused `tribute-core`: 9 passed
- Markdownlint and `git diff --check`
- Workspace Clippy and formatting
- Workspace nextest: 1,895 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CPS and handler dispatch guidance to use continuation frames instead of completion callbacks.
  * Clarified continuation-frame placement, provenance validation, dispatch behavior, and callable signatures.

* **Refactor**
  * Renamed CPS terminology and APIs to consistently reference continuation frames.
  * Updated completion, resumption, and dispatch interfaces to accept continuation-frame metadata.

* **Bug Fixes**
  * Added validation to safely reject malformed or unmarked continuation-frame metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->