### PR TITLE
#879: Reserve nextest capacity for ability-handler regression

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,7 @@
 [profile.default]
 slow-timeout = { period = "30s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(tribute) & binary(e2e_ability_handler) & test(test_cps_control_carrier_preserves_read_outcome_and_nested_zero_resume)'
+slow-timeout = { period = "60s", terminate-after = 1 }
+threads-required = "num-test-threads"


### PR DESCRIPTION
Closes #879

Give the exact multi-profile ability-handler regression a 60-second slow timeout and reserve all nextest test threads while it runs. The global 30-second timeout remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for a specific end-to-end test to 60 seconds.
  * Configured the test to use all available test threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->