### PR TITLE
#878: Preserve bodyless declarations in SCF-to-CF lowering

### DIFF
--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -36,12 +36,6 @@ fn i32_type_ref(ctx: &mut IrContext) -> TypeRef {
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
 }
 
-/// Return a function body when the `func.func` operation is a definition.
-/// External declarations intentionally have no body region.
-fn func_body_if_present(ctx: &IrContext, func_op: func::Func) -> Option<RegionRef> {
-    ctx.op(func_op.op_ref()).regions.first().copied()
-}
-
 #[derive(Debug)]
 pub(crate) struct ResolveEvidenceError {
     op: OpRef,
@@ -377,7 +371,7 @@ fn collect_handler_root_functions(
             if fns_with_evidence.contains(&func_name) {
                 continue;
             }
-            let Some(body) = func_body_if_present(ctx, func_op) else {
+            let Some(body) = func_op.body_if_present(ctx) else {
                 continue;
             };
             if region_contains_handle_dispatch(ctx, body) {
@@ -501,7 +495,7 @@ fn transform_handler_roots(
             continue;
         }
 
-        let Some(body) = func_body_if_present(ctx, func_op) else {
+        let Some(body) = func_op.body_if_present(ctx) else {
             continue;
         };
         let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
@@ -591,7 +585,7 @@ fn update_calls_to_newly_evidenced(
             continue;
         }
 
-        let Some(body) = func_body_if_present(ctx, func_op) else {
+        let Some(body) = func_op.body_if_present(ctx) else {
             continue;
         };
         update_calls_in_region(ctx, body, newly_evidenced, evidence_ty, i32_ty);
@@ -689,7 +683,7 @@ fn transform_shifts_in_module(
             continue;
         }
 
-        let Some(body) = func_body_if_present(ctx, func_op) else {
+        let Some(body) = func_op.body_if_present(ctx) else {
             continue;
         };
         let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -34,6 +34,13 @@ mod func {
     fn unreachable() {}
 }
 
+impl Func {
+    /// Return the function body when this declaration has one.
+    pub fn body_if_present(&self, ctx: &crate::IrContext) -> Option<crate::RegionRef> {
+        ctx.op(self.op_ref()).regions.first().copied()
+    }
+}
+
 // === Custom assembly format for func.func ===
 
 /// Print func.func with decomposed signature:

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -53,7 +53,10 @@ pub fn lower_scf_to_cf(ctx: &mut IrContext, module: Module) {
 
 /// Lower all `scf` operations in one function to `cf` operations.
 pub fn lower_scf_to_cf_func(ctx: &mut IrContext, func: func::Func) {
-    transform_region(ctx, func.body(ctx));
+    let Some(body) = func.body_if_present(ctx) else {
+        return;
+    };
+    transform_region(ctx, body);
 }
 
 /// Build a function-anchored SCF-to-CF lowering pass.
@@ -796,6 +799,26 @@ mod tests {
             untouched_names.iter().any(|n| n.starts_with("scf.")),
             "untouched function should retain scf ops: {untouched_names:?}"
         );
+    }
+
+    #[test]
+    fn scf_to_cf_pass_leaves_bodyless_func_unchanged() {
+        let (mut ctx, loc) = test_ctx();
+        let fn_ty = fn_type(&mut ctx);
+        let func_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
+            .attr("sym_name", Attribute::Symbol(Symbol::new("external")))
+            .attr("type", Attribute::Type(fn_ty))
+            .build(&mut ctx);
+        let func_op = ctx.create_op(func_data);
+        let module = build_module(&mut ctx, loc, vec![func_op]);
+        let before = crate::printer::print_module(&ctx, module.op());
+        let func = func::Func::from_op(&ctx, func_op).unwrap();
+
+        scf_to_cf_pass().run(&mut ctx, func).unwrap();
+
+        assert!(func.body_if_present(&ctx).is_none());
+        assert!(ctx.op(func_op).regions.is_empty());
+        assert_eq!(crate::printer::print_module(&ctx, module.op()), before);
     }
 
     #[test]


### PR DESCRIPTION
Regionless `func.func` declarations are skipped before the generated body accessor is called. Body-bearing functions continue through the existing SCF-to-CF lowering. A focused regression verifies that a bodyless declaration remains unchanged.

Closes #878