### PR TITLE
#886: Lower core.nil as zero-width in Cranelift

### DIFF
--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -46,10 +46,12 @@ fn has_physical_empty_result(ctx: &IrContext, signature: TypeRef) -> bool {
     let Some(&result) = signature.params.first() else {
         return false;
     };
-    let result = ctx.types.get(result);
-    result.dialect == Symbol::new("core")
-        && result.name == Symbol::new("nil")
-        && result.params.is_empty()
+    is_nil_type(ctx, result)
+}
+
+pub(crate) fn is_nil_type(ctx: &IrContext, ty: TypeRef) -> bool {
+    let ty = ctx.types.get(ty);
+    ty.dialect == Symbol::new("core") && ty.name == Symbol::new("nil") && ty.params.is_empty()
 }
 
 /// Parse a condition symbol into a Cranelift integer condition code.
@@ -169,6 +171,9 @@ pub(crate) fn translate_signature(
     let param_types = &td.params[1..];
 
     for &param_ty in param_types {
+        if is_nil_type(ctx, param_ty) {
+            continue;
+        }
         let cl_ty = translate_type(ctx, param_ty, ptr_ty)?;
         sig.params.push(cl_ir::AbiParam::new(cl_ty));
     }
@@ -254,9 +259,15 @@ impl<'a> FunctionTranslator<'a> {
 
     /// Check if a value has `core.nil` type.
     fn is_nil_typed(&self, val: ValueRef) -> bool {
-        let ty = self.ctx.value_ty(val);
-        let td = self.ctx.types.get(ty);
-        td.dialect == Symbol::new("core") && td.name == Symbol::new("nil")
+        is_nil_type(self.ctx, self.ctx.value_ty(val))
+    }
+
+    fn runtime_values(&self, values: &[ValueRef]) -> CompilationResult<Vec<cl_ir::Value>> {
+        values
+            .iter()
+            .filter(|&&value| !self.is_nil_typed(value))
+            .map(|&value| self.lookup(value))
+            .collect()
     }
 
     pub(crate) fn lookup_block(&self, ir_block: BlockRef) -> CompilationResult<cl_ir::Block> {
@@ -362,10 +373,7 @@ impl<'a> FunctionTranslator<'a> {
                 .ok_or_else(|| CompilationError::function_not_found(&callee_sym.to_string()))?;
 
             let operands = ctx.op_operands(op);
-            let args: Vec<cl_ir::Value> = operands
-                .iter()
-                .map(|v| self.lookup(*v))
-                .collect::<CompilationResult<_>>()?;
+            let args = self.runtime_values(operands)?;
 
             let inst = self.builder.ins().call(func_ref, &args);
             let results = self.builder.inst_results(inst);
@@ -399,10 +407,11 @@ impl<'a> FunctionTranslator<'a> {
             let ir_dest = op_data.successors[0];
             let cl_dest = self.lookup_block(ir_dest)?;
             let operands = ctx.op_operands(op);
-            let args: Vec<cl_ir::BlockArg> = operands
-                .iter()
-                .map(|v| self.lookup(*v).map(cl_ir::BlockArg::from))
-                .collect::<CompilationResult<_>>()?;
+            let args: Vec<cl_ir::BlockArg> = self
+                .runtime_values(operands)?
+                .into_iter()
+                .map(cl_ir::BlockArg::from)
+                .collect();
             let dest_param_count = self.builder.block_params(cl_dest).len();
             if args.len() != dest_param_count {
                 return Err(CompilationError::codegen(format!(
@@ -532,10 +541,7 @@ impl<'a> FunctionTranslator<'a> {
                 .ok_or_else(|| CompilationError::function_not_found(&callee_sym.to_string()))?;
 
             let operands = ctx.op_operands(op);
-            let args: Vec<cl_ir::Value> = operands
-                .iter()
-                .map(|v| self.lookup(*v))
-                .collect::<CompilationResult<_>>()?;
+            let args = self.runtime_values(operands)?;
 
             self.builder.ins().return_call(func_ref, &args);
             return Ok(());
@@ -545,10 +551,7 @@ impl<'a> FunctionTranslator<'a> {
         if let Ok(rci) = clif::ReturnCallIndirect::from_op(ctx, op) {
             let operands = ctx.op_operands(op);
             let callee = self.lookup(operands[0])?;
-            let args: Vec<cl_ir::Value> = operands[1..]
-                .iter()
-                .map(|v| self.lookup(*v))
-                .collect::<CompilationResult<_>>()?;
+            let args = self.runtime_values(&operands[1..])?;
 
             let sig_ty = rci.sig(ctx);
             let sig = translate_signature(ctx, sig_ty, CallConv::Tail, self.ptr_ty)?;
@@ -564,10 +567,7 @@ impl<'a> FunctionTranslator<'a> {
         if let Ok(call_ind) = clif::CallIndirect::from_op(ctx, op) {
             let operands = ctx.op_operands(op);
             let callee = self.lookup(operands[0])?;
-            let args: Vec<cl_ir::Value> = operands[1..]
-                .iter()
-                .map(|v| self.lookup(*v))
-                .collect::<CompilationResult<_>>()?;
+            let args = self.runtime_values(&operands[1..])?;
 
             let sig_ty = call_ind.sig(ctx);
             let call_conv = call_conv_for_cps_signature(
@@ -839,6 +839,32 @@ mod tests {
         assert_eq!(sig.params.len(), 1);
         assert_eq!(sig.params[0].value_type, cl_types::I64);
         assert_eq!(sig.returns.len(), 0);
+    }
+
+    #[test]
+    fn test_translate_signature_omits_nil_parameters_in_order() {
+        let mut ctx = IrContext::new();
+        let i32_ty = make_core_type(&mut ctx, "i32");
+        let i64_ty = make_core_type(&mut ctx, "i64");
+        let nil_ty = make_core_type(&mut ctx, "nil");
+
+        let func_ty = ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::new("func"),
+            params: trunk_ir::smallvec::smallvec![i32_ty, i32_ty, nil_ty, i64_ty],
+            attrs: Default::default(),
+        });
+
+        let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
+        assert_eq!(
+            sig.params
+                .iter()
+                .map(|param| param.value_type)
+                .collect::<Vec<_>>(),
+            vec![cl_types::I32, cl_types::I64]
+        );
+        assert_eq!(sig.returns.len(), 1);
+        assert_eq!(sig.returns[0].value_type, cl_types::I32);
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -24,7 +24,7 @@ use trunk_ir::rewrite::Module;
 
 use crate::function::{
     CPS_CALLING_CONVENTION, FunctionTranslator, TRIBUTE_CALLING_CONVENTION_ATTR,
-    call_conv_for_cps_signature, translate_signature, translate_type,
+    call_conv_for_cps_signature, is_nil_type, translate_signature, translate_type,
 };
 use crate::{CompilationError, CompilationResult, validate_clif_ir};
 
@@ -510,6 +510,9 @@ fn emit_module_impl(
                 let ir_args = ctx.block_args(ir_block);
                 for &arg_val in ir_args {
                     let arg_ty = ctx.value_ty(arg_val);
+                    if is_nil_type(ctx, arg_ty) {
+                        continue;
+                    }
                     let cl_ty = translate_type(ctx, arg_ty, ptr_ty)?;
                     translator.builder.append_block_param(cl_block, cl_ty);
                 }
@@ -524,10 +527,14 @@ fn emit_module_impl(
                 // Map block arguments to Cranelift block params
                 let cl_params: Vec<_> = translator.builder.block_params(cl_block).to_vec();
                 let ir_args = ctx.block_args(ir_block);
-                let ir_arg_count = ir_args.len();
-                if ir_arg_count != cl_params.len() {
+                let runtime_ir_args: Vec<_> = ir_args
+                    .iter()
+                    .copied()
+                    .filter(|&arg| !is_nil_type(ctx, ctx.value_ty(arg)))
+                    .collect();
+                if runtime_ir_args.len() != cl_params.len() {
                     let is_entry = ir_blocks.first() == Some(&ir_block);
-                    let ir_arg_types: Vec<String> = ir_args
+                    let ir_arg_types: Vec<String> = runtime_ir_args
                         .iter()
                         .map(|&a| {
                             let ty = ctx.value_ty(a);
@@ -546,7 +553,7 @@ fn emit_module_impl(
                         .collect();
                     return Err(CompilationError::codegen(format!(
                         "block arg count mismatch: TrunkIR block has {} args ({:?}) but Cranelift block has {} params (function: {}, entry: {}, func_type_params: {:?})",
-                        ir_arg_count,
+                        runtime_ir_args.len(),
                         ir_arg_types,
                         cl_params.len(),
                         name_sym,
@@ -554,8 +561,7 @@ fn emit_module_impl(
                         func_ty_params,
                     )));
                 }
-                for (i, &cl_param) in cl_params.iter().enumerate() {
-                    let ir_arg = ir_args[i];
+                for (&ir_arg, &cl_param) in runtime_ir_args.iter().zip(&cl_params) {
                     translator.values.insert(ir_arg, cl_param);
                 }
 
@@ -695,6 +701,38 @@ fn declare_runtime_functions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trunk_ir::parser::parse_test_module;
+
+    const NIL_ZERO_WIDTH_NATIVE: &str = r#"core.module @test {
+  clif.func {sym_name = @call_target, type = core.func(core.i32, core.i32, core.nil, core.i64)} {
+    ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
+      clif.return %value
+  }
+  clif.func {sym_name = @direct_call, type = core.func(core.i32, core.i32, core.nil, core.i64)} {
+    ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
+      %result = clif.call %value, %unit, %last {callee = @call_target} : core.i32
+      clif.return %result
+  }
+  clif.func {sym_name = @indirect_call, type = core.func(core.i32, core.ptr, core.i32, core.nil, core.i64)} {
+    ^entry(%callee: core.ptr, %value: core.i32, %unit: core.nil, %last: core.i64):
+      %result = clif.call_indirect %callee, %value, %unit, %last {sig = core.func(core.i32, core.i32, core.nil, core.i64)} : core.i32
+      clif.return %result
+  }
+  clif.func {sym_name = @direct_tail, tribute.calling_convention = 2, type = core.func(core.nil, core.i32, core.nil, core.i64)} {
+    ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
+      clif.return_call %value, %unit, %last {callee = @direct_tail}
+  }
+  clif.func {sym_name = @indirect_tail, tribute.calling_convention = 2, type = core.func(core.nil, core.ptr, core.i32, core.nil, core.i64)} {
+    ^entry(%callee: core.ptr, %value: core.i32, %unit: core.nil, %last: core.i64):
+      clif.return_call_indirect %callee, %value, %unit, %last {sig = core.func(core.nil, core.i32, core.nil, core.i64)}
+  }
+  clif.func {sym_name = @jump, type = core.func(core.nil, core.i32, core.nil, core.i64)} {
+    ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
+      clif.jump %value, %unit, %last [^merge]
+    ^merge(%next_value: core.i32, %next_unit: core.nil, %next_last: core.i64):
+      clif.return
+  }
+}"#;
 
     #[test]
     fn test_mangle_native_name() {
@@ -721,5 +759,13 @@ mod tests {
     #[test]
     fn native_isa_preserves_frame_pointers_for_tail_calls() {
         assert!(native_isa().unwrap().flags().preserve_frame_pointers());
+    }
+
+    #[test]
+    fn core_nil_is_zero_width_across_native_cfg_and_calls() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, NIL_ZERO_WIDTH_NATIVE);
+        let object = emit_module_to_native(&ctx, module, &[]).unwrap();
+        assert!(!object.is_empty());
     }
 }

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -136,6 +136,17 @@ Cranelift IR과 1:1 대응하는 저수준 연산. 전체 연산 목록은 [ir.m
 - **스택 할당**: stack_slot으로 로컬 메모리 할당 가능
 - **함수 포인터**: funcref 대신 symbol_addr로 함수 주소 획득
 
+### Zero-width `core.nil`
+
+`core.nil` is a logical TrunkIR `Unit` SSA value but has no runtime
+representation in Cranelift. The native emitter therefore omits nil values
+from function signatures, entry and non-entry block parameters, CFG edge
+operands, direct and indirect call operands, and direct and indirect tail-call
+operands. It preserves the ordering of all non-nil parameters and operands,
+including the non-nil indirect callee, while leaving logical TrunkIR
+unchanged. Nil returns, constants, and return operands follow the same
+zero-width convention.
+
 ---
 
 ## Effect 구현: CPS Tail-Call


### PR DESCRIPTION
Cranelift has no runtime value for shared TrunkIR core.nil, even though it is a genuine Unit SSA value. The native emitter now omits core.nil from signatures, block parameters, CFG edges, direct and indirect calls, and direct and indirect tail calls while preserving non-nil ordering and logical TrunkIR. Focused native regressions cover Unit parameters, merge and jump edges, mixed arguments, and tail transfers. Closes #886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native compilation support for zero-width `core.nil` values.
  * Nil values are now excluded from generated function parameters, calls, jumps, returns, and control-flow arguments while preserving other values.
  * Improved argument mismatch diagnostics by reporting only runtime-relevant arguments.

* **Documentation**
  * Added documentation describing how nil values are handled by the native backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->