### PR TITLE
Fix RC ownership across proper tail calls

### DIFF
--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -659,7 +659,10 @@ fn collect_validated_call_contracts(
                 let expected = trusted.get(&id).ok_or(OwnershipContractError(
                     "call ownership contract identity is untrusted",
                 ))?;
-                let args = &ctx.op_operands(op)[usize::from(is_indirect)..];
+                let args = ctx
+                    .op_operands(op)
+                    .get(usize::from(is_indirect)..)
+                    .unwrap_or_default();
                 let argument_count = ctx
                     .op_operands(op)
                     .len()
@@ -732,7 +735,10 @@ fn collect_validated_call_contracts(
                     "call ownership actions have no trusted identity",
                 ));
             } else if is_tail
-                && ctx.op_operands(op)[usize::from(is_indirect)..]
+                && ctx
+                    .op_operands(op)
+                    .get(usize::from(is_indirect)..)
+                    .unwrap_or_default()
                     .iter()
                     .any(|&argument| is_anyref_value(ctx, argument))
             {

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -1,18 +1,70 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 
+use tribute_core::{CallingConvention, get_calling_convention, get_indirect_call_signature};
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{adt, arith, clif, core, func, mem};
-use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::rewrite::{Module, TypeConverter};
 use trunk_ir::transforms::call_graph::{build_call_graph, recursive_functions};
-use trunk_ir::{Attribute, OpRef, RegionRef, Symbol, ValueRef};
+use trunk_ir::{Attribute, OpRef, RegionRef, Symbol, TypeRef, ValueRef};
 
 pub const PARAMETER_OWNERSHIP_ATTR: &str = "tribute.rc.parameter_ownership_v1";
+pub const PARAMETER_ENTRY_OWNERSHIP_ATTR: &str = "tribute.rc.parameter_entry_ownership_v1";
+pub const CALL_ARGUMENT_OWNERSHIP_ATTR: &str = "tribute.rc.call_argument_ownership_v1";
+pub const OWNERSHIP_CONTRACT_ID_ATTR: &str = "tribute.rc.ownership_contract_id_v1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParameterOwnership {
     Borrowed,
     Owned,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RcOwnership {
+    Plain,
+    Borrowed,
+    Retained,
+    Consumed,
+    Acquire,
+    Transfer,
+}
+
+impl RcOwnership {
+    fn as_attribute(self) -> Attribute {
+        Attribute::Symbol(Symbol::new(match self {
+            Self::Plain => "plain",
+            Self::Borrowed => "borrowed",
+            Self::Retained => "retained",
+            Self::Consumed => "consumed",
+            Self::Acquire => "acquire",
+            Self::Transfer => "transfer",
+        }))
+    }
+
+    fn list_attribute(entries: &[Self]) -> Attribute {
+        Attribute::List(entries.iter().copied().map(Self::as_attribute).collect())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnershipContractError(&'static str);
+
+impl fmt::Display for OwnershipContractError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "native RC ownership contract: {}", self.0)
+    }
+}
+
+impl std::error::Error for OwnershipContractError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedCallContract {
+    pub actions: Vec<RcOwnership>,
+    pub is_tail: bool,
+    pub is_indirect: bool,
+    direct_callee: Option<Symbol>,
+    indirect_signature: Option<TypeRef>,
 }
 
 impl ParameterOwnership {
@@ -26,22 +78,31 @@ impl ParameterOwnership {
 
 pub struct TrustedOwnershipSummaries {
     summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
+    entry_contracts: HashMap<Symbol, Vec<RcOwnership>>,
+    call_contracts: HashMap<i128, TrustedCallContract>,
+}
+
+pub struct ValidatedOwnershipContracts {
+    pub summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
+    pub entry_contracts: HashMap<Symbol, Vec<RcOwnership>>,
+    pub call_contracts: HashMap<OpRef, TrustedCallContract>,
 }
 
 pub fn compute_and_attach(
     ctx: &mut IrContext,
     module: Module,
     type_converter: &TypeConverter,
-) -> TrustedOwnershipSummaries {
+) -> Result<TrustedOwnershipSummaries, OwnershipContractError> {
     let Some(module_block) = module.first_block(ctx) else {
-        return TrustedOwnershipSummaries {
+        return Ok(TrustedOwnershipSummaries {
             summaries: HashMap::new(),
-        };
+            entry_contracts: HashMap::new(),
+            call_contracts: HashMap::new(),
+        });
     };
     let module_ops = ctx.block(module_block).ops.to_vec();
     let mut definitions: HashMap<Symbol, Vec<OpRef>> = HashMap::new();
     for &op in &module_ops {
-        ctx.op_mut(op).attributes.remove(PARAMETER_OWNERSHIP_ATTR);
         if let Ok(function) = func::Func::from_op(ctx, op) {
             definitions
                 .entry(function.sym_name(ctx))
@@ -105,6 +166,44 @@ pub fn compute_and_attach(
         }
     }
 
+    let mut entry_contracts = HashMap::new();
+    for (&symbol, &op) in &unique_functions {
+        let function = func::Func::from_op(ctx, op).expect("collected func.func");
+        let consuming_cps = is_defined_physical_cps_function(ctx, op);
+        let entries = entry_parameters(ctx, function.body(ctx))
+            .into_iter()
+            .enumerate()
+            .map(|(index, parameter)| {
+                if !lowers_to_anyref(ctx, parameter, type_converter) {
+                    RcOwnership::Plain
+                } else if consuming_cps {
+                    RcOwnership::Consumed
+                } else if summaries[&symbol][index] == ParameterOwnership::Borrowed {
+                    RcOwnership::Borrowed
+                } else {
+                    RcOwnership::Retained
+                }
+            })
+            .collect();
+        entry_contracts.insert(symbol, entries);
+    }
+
+    let mut pending_calls = Vec::new();
+    let mut next_contract_id = 1i128;
+    for &op in unique_functions.values() {
+        let function = func::Func::from_op(ctx, op).expect("collected func.func");
+        collect_call_contracts(
+            ctx,
+            function.body(ctx),
+            type_converter,
+            &entry_contracts,
+            &mut next_contract_id,
+            &mut pending_calls,
+        )?;
+    }
+
+    strip_contract_metadata(ctx, module.op());
+
     for (&symbol, &op) in &unique_functions {
         let entries = summaries[&symbol]
             .iter()
@@ -115,9 +214,222 @@ pub fn compute_and_attach(
             Symbol::new(PARAMETER_OWNERSHIP_ATTR),
             Attribute::List(entries),
         );
+        ctx.op_mut(op).attributes.insert(
+            Symbol::new(PARAMETER_ENTRY_OWNERSHIP_ATTR),
+            RcOwnership::list_attribute(&entry_contracts[&symbol]),
+        );
     }
 
-    TrustedOwnershipSummaries { summaries }
+    let mut call_contracts = HashMap::new();
+    for (op, id, contract) in pending_calls {
+        ctx.op_mut(op)
+            .attributes
+            .insert(Symbol::new(OWNERSHIP_CONTRACT_ID_ATTR), Attribute::Int(id));
+        ctx.op_mut(op).attributes.insert(
+            Symbol::new(CALL_ARGUMENT_OWNERSHIP_ATTR),
+            RcOwnership::list_attribute(&contract.actions),
+        );
+        call_contracts.insert(id, contract);
+    }
+
+    Ok(TrustedOwnershipSummaries {
+        summaries,
+        entry_contracts,
+        call_contracts,
+    })
+}
+
+fn strip_contract_metadata(ctx: &mut IrContext, op: OpRef) {
+    let regions = ctx.op(op).regions.to_vec();
+    let attributes = &mut ctx.op_mut(op).attributes;
+    attributes.remove(PARAMETER_OWNERSHIP_ATTR);
+    attributes.remove(PARAMETER_ENTRY_OWNERSHIP_ATTR);
+    attributes.remove(CALL_ARGUMENT_OWNERSHIP_ATTR);
+    attributes.remove(OWNERSHIP_CONTRACT_ID_ATTR);
+    for region in regions {
+        let blocks = ctx.region(region).blocks.clone();
+        for block in blocks {
+            let ops = ctx.block(block).ops.clone();
+            for nested in ops {
+                strip_contract_metadata(ctx, nested);
+            }
+        }
+    }
+}
+
+fn is_defined_physical_cps_function(ctx: &IrContext, op: OpRef) -> bool {
+    if get_calling_convention(ctx, op) != Some(CallingConvention::Cps)
+        || ctx.op(op).attributes.contains_key("abi")
+        || ctx
+            .op(op)
+            .regions
+            .first()
+            .is_none_or(|region| ctx.region(*region).blocks.is_empty())
+    {
+        return false;
+    }
+    let Some(signature) = ctx.op(op).attributes.get_type("type") else {
+        return false;
+    };
+    let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
+        return false;
+    };
+    let result = ctx.types.get(callable.r#return(ctx));
+    result.dialect == Symbol::new("core") && result.name == Symbol::new("nil")
+}
+
+fn type_lowers_to_anyref(ctx: &mut IrContext, ty: TypeRef, type_converter: &TypeConverter) -> bool {
+    let converted = type_converter.convert_type_or_identity(ctx, ty);
+    let data = ctx.types.get(converted);
+    data.dialect == Symbol::new("tribute_rt") && data.name == Symbol::new("anyref")
+}
+
+fn collect_call_contracts(
+    ctx: &mut IrContext,
+    region: RegionRef,
+    type_converter: &TypeConverter,
+    entries: &HashMap<Symbol, Vec<RcOwnership>>,
+    next_id: &mut i128,
+    pending: &mut Vec<(OpRef, i128, TrustedCallContract)>,
+) -> Result<(), OwnershipContractError> {
+    let blocks = ctx.region(region).blocks.clone();
+    for block in blocks {
+        let ops = ctx.block(block).ops.clone();
+        for op in ops {
+            let direct = func::Call::matches(ctx, op) || func::TailCall::matches(ctx, op);
+            let indirect =
+                func::CallIndirect::matches(ctx, op) || func::TailCallIndirect::matches(ctx, op);
+            let is_tail =
+                func::TailCall::matches(ctx, op) || func::TailCallIndirect::matches(ctx, op);
+            if is_tail && get_calling_convention(ctx, op) != Some(CallingConvention::Cps) {
+                let arguments = ctx.op_operands(op)[usize::from(indirect)..].to_vec();
+                if arguments
+                    .into_iter()
+                    .any(|argument| lowers_to_anyref(ctx, argument, type_converter))
+                {
+                    return Err(OwnershipContractError(
+                        "RC proper-tail call lacks exact CPS provenance",
+                    ));
+                }
+                continue;
+            }
+            if direct || indirect {
+                let actions = if direct {
+                    let callee = ctx.op(op).attributes.get_symbol("callee").ok_or(
+                        OwnershipContractError("direct call lacks exact callee symbol"),
+                    )?;
+                    let Some(parameter_entries) = entries.get(&callee) else {
+                        if is_tail {
+                            return Err(OwnershipContractError(
+                                "proper-tail direct callee has no trusted local entry contract",
+                            ));
+                        }
+                        continue;
+                    };
+                    let operands = ctx.op_operands(op);
+                    if operands.len() != parameter_entries.len() {
+                        return Err(OwnershipContractError(
+                            "direct call arity differs from callee entry contract",
+                        ));
+                    }
+                    parameter_entries
+                        .iter()
+                        .copied()
+                        .map(|entry| action_for_entry(entry, is_tail))
+                        .collect::<Result<Vec<_>, _>>()?
+                } else {
+                    if !is_tail {
+                        continue;
+                    }
+                    if get_calling_convention(ctx, op) != Some(CallingConvention::Cps) {
+                        return Err(OwnershipContractError(
+                            "indirect proper-tail call lacks exact CPS provenance",
+                        ));
+                    }
+                    let signature =
+                        get_indirect_call_signature(ctx, op).ok_or(OwnershipContractError(
+                            "indirect proper-tail call lacks exact callable signature",
+                        ))?;
+                    let callable = core::Func::from_type_ref(ctx, signature).ok_or(
+                        OwnershipContractError("indirect proper-tail signature is not core.func"),
+                    )?;
+                    let result = ctx.types.get(callable.r#return(ctx));
+                    if result.dialect != Symbol::new("core") || result.name != Symbol::new("nil") {
+                        return Err(OwnershipContractError(
+                            "indirect proper-tail signature is not physically empty",
+                        ));
+                    }
+                    let args = ctx.op_operands(op).get(1..).unwrap_or_default();
+                    if args.len() != callable.params(ctx).len() {
+                        return Err(OwnershipContractError(
+                            "indirect proper-tail arity differs from exact signature",
+                        ));
+                    }
+                    let parameters = callable.params(ctx).to_vec();
+                    parameters
+                        .iter()
+                        .map(|&ty| {
+                            if type_lowers_to_anyref(ctx, ty, type_converter) {
+                                RcOwnership::Transfer
+                            } else {
+                                RcOwnership::Plain
+                            }
+                        })
+                        .collect()
+                };
+                let id = *next_id;
+                *next_id += 1;
+                pending.push((
+                    op,
+                    id,
+                    TrustedCallContract {
+                        actions,
+                        is_tail,
+                        is_indirect: indirect,
+                        direct_callee: direct.then(|| {
+                            ctx.op(op)
+                                .attributes
+                                .get_symbol("callee")
+                                .expect("validated direct callee")
+                        }),
+                        indirect_signature: if indirect {
+                            get_indirect_call_signature(ctx, op)
+                        } else {
+                            None
+                        },
+                    },
+                ));
+            }
+            let nested_regions = ctx.op(op).regions.clone();
+            for nested in nested_regions {
+                collect_call_contracts(ctx, nested, type_converter, entries, next_id, pending)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn action_for_entry(
+    entry: RcOwnership,
+    is_tail: bool,
+) -> Result<RcOwnership, OwnershipContractError> {
+    if is_tail {
+        return match entry {
+            RcOwnership::Plain => Ok(RcOwnership::Plain),
+            RcOwnership::Consumed => Ok(RcOwnership::Transfer),
+            RcOwnership::Borrowed | RcOwnership::Retained => Err(OwnershipContractError(
+                "proper-tail RC parameter is not consumed by its callee",
+            )),
+            RcOwnership::Acquire | RcOwnership::Transfer => unreachable!("entry mode"),
+        };
+    }
+    Ok(match entry {
+        RcOwnership::Plain => RcOwnership::Plain,
+        RcOwnership::Borrowed => RcOwnership::Borrowed,
+        RcOwnership::Retained => RcOwnership::Retained,
+        RcOwnership::Consumed => RcOwnership::Acquire,
+        RcOwnership::Acquire | RcOwnership::Transfer => unreachable!("entry mode"),
+    })
 }
 
 impl TrustedOwnershipSummaries {
@@ -125,7 +437,7 @@ impl TrustedOwnershipSummaries {
         &self,
         ctx: &IrContext,
         module_ops: &[OpRef],
-    ) -> HashMap<Symbol, Vec<ParameterOwnership>> {
+    ) -> Result<ValidatedOwnershipContracts, OwnershipContractError> {
         let mut definitions: HashMap<Symbol, Vec<OpRef>> = HashMap::new();
         for &op in module_ops {
             if let Ok(function) = clif::Func::from_op(ctx, op) {
@@ -136,7 +448,8 @@ impl TrustedOwnershipSummaries {
             }
         }
 
-        self.summaries
+        let summaries = self
+            .summaries
             .iter()
             .filter_map(|(&symbol, expected)| {
                 let ops = definitions.get(&symbol)?;
@@ -181,7 +494,71 @@ impl TrustedOwnershipSummaries {
                 }
                 Some((symbol, actual))
             })
-            .collect()
+            .collect();
+
+        let mut entry_contracts = HashMap::new();
+        for (&symbol, expected) in &self.entry_contracts {
+            let ops = definitions.get(&symbol).ok_or(OwnershipContractError(
+                "trusted function disappeared during func_to_clif",
+            ))?;
+            if ops.len() != 1 {
+                return Err(OwnershipContractError(
+                    "trusted function is not unique after func_to_clif",
+                ));
+            }
+            let function = clif::Func::from_op(ctx, ops[0]).map_err(|_| {
+                OwnershipContractError("trusted function did not lower to clif.func")
+            })?;
+            let parameters = entry_parameters(ctx, function.body(ctx));
+            if parameters.len() != expected.len() {
+                return Err(OwnershipContractError(
+                    "parameter entry contract arity changed during func_to_clif",
+                ));
+            }
+            if ctx
+                .op(ops[0])
+                .attributes
+                .get(PARAMETER_ENTRY_OWNERSHIP_ATTR)
+                != Some(&RcOwnership::list_attribute(expected))
+                || (expected.iter().any(|entry| *entry != RcOwnership::Plain)
+                    && (expected.contains(&RcOwnership::Consumed)
+                        != is_defined_physical_cps_function(ctx, ops[0])))
+                || expected.iter().zip(parameters).any(|(entry, parameter)| {
+                    matches!(entry, RcOwnership::Plain) == is_anyref_value(ctx, parameter)
+                })
+            {
+                return Err(OwnershipContractError(
+                    "parameter entry contract changed during func_to_clif",
+                ));
+            }
+            entry_contracts.insert(symbol, expected.clone());
+        }
+
+        let mut call_contracts = HashMap::new();
+        let mut seen_ids = HashSet::new();
+        for &function_op in module_ops {
+            let Ok(function) = clif::Func::from_op(ctx, function_op) else {
+                continue;
+            };
+            collect_validated_call_contracts(
+                ctx,
+                function.body(ctx),
+                &self.call_contracts,
+                &mut seen_ids,
+                &mut call_contracts,
+            )?;
+        }
+        if seen_ids.len() != self.call_contracts.len() {
+            return Err(OwnershipContractError(
+                "trusted call contract disappeared during func_to_clif",
+            ));
+        }
+
+        Ok(ValidatedOwnershipContracts {
+            summaries,
+            entry_contracts,
+            call_contracts,
+        })
     }
 
     #[cfg(test)]
@@ -189,9 +566,12 @@ impl TrustedOwnershipSummaries {
         let Some(module_block) = module.first_block(ctx) else {
             return Self {
                 summaries: HashMap::new(),
+                entry_contracts: HashMap::new(),
+                call_contracts: HashMap::new(),
             };
         };
         let mut summaries = HashMap::new();
+        let mut entry_contracts = HashMap::new();
         let op_count = ctx.block(module_block).ops.len();
         for index in 0..op_count {
             let op = ctx.block(module_block).ops[index];
@@ -218,10 +598,114 @@ impl TrustedOwnershipSummaries {
                 Symbol::new(PARAMETER_OWNERSHIP_ATTR),
                 Attribute::List(entries),
             );
+            let entry_contract: Vec<_> = entry_parameters(ctx, function.body(ctx))
+                .into_iter()
+                .map(|parameter| {
+                    if is_anyref_value(ctx, parameter) {
+                        RcOwnership::Borrowed
+                    } else {
+                        RcOwnership::Plain
+                    }
+                })
+                .collect();
+            ctx.op_mut(op).attributes.insert(
+                Symbol::new(PARAMETER_ENTRY_OWNERSHIP_ATTR),
+                RcOwnership::list_attribute(&entry_contract),
+            );
+            entry_contracts.insert(symbol, entry_contract);
             summaries.insert(symbol, summary);
         }
-        Self { summaries }
+        Self {
+            summaries,
+            entry_contracts,
+            call_contracts: HashMap::new(),
+        }
     }
+}
+
+fn collect_validated_call_contracts(
+    ctx: &IrContext,
+    region: RegionRef,
+    trusted: &HashMap<i128, TrustedCallContract>,
+    seen_ids: &mut HashSet<i128>,
+    validated: &mut HashMap<OpRef, TrustedCallContract>,
+) -> Result<(), OwnershipContractError> {
+    for &block in &ctx.region(region).blocks {
+        for (index, &op) in ctx.block(block).ops.iter().enumerate() {
+            let is_tail =
+                clif::ReturnCall::matches(ctx, op) || clif::ReturnCallIndirect::matches(ctx, op);
+            let is_indirect =
+                clif::CallIndirect::matches(ctx, op) || clif::ReturnCallIndirect::matches(ctx, op);
+            if is_tail && index + 1 != ctx.block(block).ops.len() {
+                return Err(OwnershipContractError("proper-tail call is not final"));
+            }
+            let id = match ctx.op(op).attributes.get(OWNERSHIP_CONTRACT_ID_ATTR) {
+                None => None,
+                Some(Attribute::Int(id)) => Some(*id),
+                Some(_) => {
+                    return Err(OwnershipContractError(
+                        "call ownership contract identity is malformed",
+                    ));
+                }
+            };
+            if let Some(id) = id {
+                if !seen_ids.insert(id) {
+                    return Err(OwnershipContractError(
+                        "call ownership contract identity is duplicated",
+                    ));
+                }
+                let expected = trusted.get(&id).ok_or(OwnershipContractError(
+                    "call ownership contract identity is untrusted",
+                ))?;
+                let args = &ctx.op_operands(op)[usize::from(is_indirect)..];
+                let argument_count = ctx
+                    .op_operands(op)
+                    .len()
+                    .saturating_sub(usize::from(is_indirect));
+                if ctx.op(op).attributes.get(CALL_ARGUMENT_OWNERSHIP_ATTR)
+                    != Some(&RcOwnership::list_attribute(&expected.actions))
+                    || is_tail != expected.is_tail
+                    || is_indirect != expected.is_indirect
+                    || expected.direct_callee != ctx.op(op).attributes.get_symbol("callee")
+                    || expected.indirect_signature
+                        != (is_indirect
+                            .then(|| ctx.op(op).attributes.get_type("sig"))
+                            .flatten())
+                    || expected.actions.len() != argument_count
+                    || (is_tail
+                        && args
+                            .iter()
+                            .zip(&expected.actions)
+                            .any(|(&argument, action)| {
+                                is_anyref_value(ctx, argument) != (*action == RcOwnership::Transfer)
+                            }))
+                {
+                    return Err(OwnershipContractError(
+                        "call ownership contract changed during func_to_clif",
+                    ));
+                }
+                validated.insert(op, expected.clone());
+            } else if ctx
+                .op(op)
+                .attributes
+                .contains_key(CALL_ARGUMENT_OWNERSHIP_ATTR)
+            {
+                return Err(OwnershipContractError(
+                    "call ownership actions have no trusted identity",
+                ));
+            } else if is_tail
+                && ctx.op_operands(op)[usize::from(is_indirect)..]
+                    .iter()
+                    .any(|&argument| is_anyref_value(ctx, argument))
+            {
+                return Err(OwnershipContractError("proper-tail transfer is untrusted"));
+            }
+            for &nested in &ctx.op(op).regions {
+                collect_validated_call_contracts(ctx, nested, trusted, seen_ids, validated)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn entry_parameters(ctx: &IrContext, body: RegionRef) -> Vec<ValueRef> {
@@ -421,7 +905,15 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
         let type_converter = TypeConverter::new();
-        compute_and_attach(&mut ctx, module, &type_converter);
+        compute_and_attach(&mut ctx, module, &type_converter).expect("ownership contracts");
+        if let Some(block) = module.first_block(&ctx) {
+            let ops = ctx.block(block).ops.clone();
+            for op in ops {
+                ctx.op_mut(op)
+                    .attributes
+                    .remove(PARAMETER_ENTRY_OWNERSHIP_ATTR);
+            }
+        }
         print_module(&ctx, module.op())
             .lines()
             .filter(|line| line.contains(PARAMETER_OWNERSHIP_ATTR))
@@ -473,7 +965,8 @@ mod tests {
   }
 }"#,
         );
-        let summaries = compute_and_attach(&mut ctx, module, &TypeConverter::new());
+        let summaries = compute_and_attach(&mut ctx, module, &TypeConverter::new())
+            .expect("ownership contracts");
 
         assert_eq!(
             summaries.summaries.get(&Symbol::new("constant_target")),
@@ -548,7 +1041,8 @@ mod tests {
 }"#,
         );
         let type_converter = TypeConverter::new();
-        let trusted = compute_and_attach(&mut ctx, module, &type_converter);
+        let trusted =
+            compute_and_attach(&mut ctx, module, &type_converter).expect("ownership contracts");
         let module_block = module.first_block(&ctx).expect("module body");
         let caller = ctx.block(module_block).ops[1];
         mutate(&mut ctx, caller);
@@ -559,7 +1053,8 @@ mod tests {
             module,
             BorrowedParameterPolicy::ElideProvenBorrowed,
             &trusted,
-        );
+        )
+        .expect("RC insertion");
         print_module(&ctx, module.op())
             .lines()
             .filter(|line| line.contains("tribute_rt.retain"))
@@ -587,5 +1082,69 @@ mod tests {
             );
         });
         assert_eq!(retains.matches("tribute_rt.retain").count(), 1, "{retains}");
+    }
+
+    #[test]
+    fn cps_entry_and_direct_indirect_edge_contracts_are_positional() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @direct(%0: tribute_rt.anyref, %1: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %0, %1 {callee = @target, tribute.calling_convention = 2}
+  }
+  func.func @indirect(%0: core.ptr, %1: tribute_rt.anyref, %2: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1, %2 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref, core.i32), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let trusted = compute_and_attach(&mut ctx, module, &TypeConverter::new())
+            .expect("exact CPS contracts");
+
+        assert_eq!(
+            trusted.entry_contracts[&Symbol::new("target")],
+            [RcOwnership::Consumed, RcOwnership::Plain]
+        );
+        assert_eq!(trusted.call_contracts.len(), 2);
+        assert!(trusted.call_contracts.values().all(|contract| {
+            contract.actions == [RcOwnership::Transfer, RcOwnership::Plain] && contract.is_tail
+        }));
+        assert_eq!(
+            trusted.summaries[&Symbol::new("target")],
+            [ParameterOwnership::Owned, ParameterOwnership::Owned]
+        );
+    }
+
+    #[test]
+    fn missing_direct_or_indirect_provenance_fails_before_mutation() {
+        for ir in [
+            r#"core.module @test {
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %0 {callee = @missing, tribute.calling_convention = 2}
+  }
+}"#,
+            r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1 {tribute.calling_convention = 2}
+  }
+}"#,
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref) -> core.nil {
+    func.unreachable
+  }
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil {
+    func.tail_call %0 {callee = @target}
+  }
+}"#,
+        ] {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, ir);
+            let before = print_module(&ctx, module.op());
+            assert!(compute_and_attach(&mut ctx, module, &TypeConverter::new()).is_err());
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
     }
 }

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -544,6 +544,7 @@ impl TrustedOwnershipSummaries {
                 ctx,
                 function.body(ctx),
                 &self.call_contracts,
+                &entry_contracts,
                 &mut seen_ids,
                 &mut call_contracts,
             )?;
@@ -627,6 +628,7 @@ fn collect_validated_call_contracts(
     ctx: &IrContext,
     region: RegionRef,
     trusted: &HashMap<i128, TrustedCallContract>,
+    entry_contracts: &HashMap<Symbol, Vec<RcOwnership>>,
     seen_ids: &mut HashSet<i128>,
     validated: &mut HashMap<OpRef, TrustedCallContract>,
 ) -> Result<(), OwnershipContractError> {
@@ -662,8 +664,50 @@ fn collect_validated_call_contracts(
                     .op_operands(op)
                     .len()
                     .saturating_sub(usize::from(is_indirect));
-                if ctx.op(op).attributes.get(CALL_ARGUMENT_OWNERSHIP_ATTR)
-                    != Some(&RcOwnership::list_attribute(&expected.actions))
+                let expected_call_family = match (expected.is_tail, expected.is_indirect) {
+                    (false, false) => clif::Call::matches(ctx, op),
+                    (false, true) => clif::CallIndirect::matches(ctx, op),
+                    (true, false) => clif::ReturnCall::matches(ctx, op),
+                    (true, true) => clif::ReturnCallIndirect::matches(ctx, op),
+                };
+                // Direct operands may be ABI-equivalent `core.ptr` values after conversion;
+                // the already-validated callee entry contract is the exact parameter type proof.
+                let actions_match_types = if !expected.is_tail && !expected.is_indirect {
+                    expected
+                        .direct_callee
+                        .and_then(|callee| entry_contracts.get(&callee))
+                        .is_some_and(|entries| {
+                            entries.len() == expected.actions.len()
+                                && entries
+                                    .iter()
+                                    .zip(&expected.actions)
+                                    .all(|(entry, action)| match action {
+                                        RcOwnership::Plain => *entry == RcOwnership::Plain,
+                                        RcOwnership::Borrowed
+                                        | RcOwnership::Retained
+                                        | RcOwnership::Acquire => *entry != RcOwnership::Plain,
+                                        RcOwnership::Consumed | RcOwnership::Transfer => false,
+                                    })
+                        })
+                } else {
+                    args.iter()
+                        .zip(&expected.actions)
+                        .all(|(&argument, action)| match (expected.is_tail, action) {
+                            (true, RcOwnership::Plain) => !is_anyref_value(ctx, argument),
+                            (true, RcOwnership::Transfer) => is_anyref_value(ctx, argument),
+                            (false, RcOwnership::Plain) => !is_anyref_value(ctx, argument),
+                            (
+                                false,
+                                RcOwnership::Borrowed
+                                | RcOwnership::Retained
+                                | RcOwnership::Acquire,
+                            ) => is_anyref_value(ctx, argument),
+                            _ => false,
+                        })
+                };
+                if !expected_call_family
+                    || ctx.op(op).attributes.get(CALL_ARGUMENT_OWNERSHIP_ATTR)
+                        != Some(&RcOwnership::list_attribute(&expected.actions))
                     || is_tail != expected.is_tail
                     || is_indirect != expected.is_indirect
                     || expected.direct_callee != ctx.op(op).attributes.get_symbol("callee")
@@ -672,13 +716,7 @@ fn collect_validated_call_contracts(
                             .then(|| ctx.op(op).attributes.get_type("sig"))
                             .flatten())
                     || expected.actions.len() != argument_count
-                    || (is_tail
-                        && args
-                            .iter()
-                            .zip(&expected.actions)
-                            .any(|(&argument, action)| {
-                                is_anyref_value(ctx, argument) != (*action == RcOwnership::Transfer)
-                            }))
+                    || !actions_match_types
                 {
                     return Err(OwnershipContractError(
                         "call ownership contract changed during func_to_clif",
@@ -701,7 +739,14 @@ fn collect_validated_call_contracts(
                 return Err(OwnershipContractError("proper-tail transfer is untrusted"));
             }
             for &nested in &ctx.op(op).regions {
-                collect_validated_call_contracts(ctx, nested, trusted, seen_ids, validated)?;
+                collect_validated_call_contracts(
+                    ctx,
+                    nested,
+                    trusted,
+                    entry_contracts,
+                    seen_ids,
+                    validated,
+                )?;
             }
         }
     }
@@ -897,9 +942,11 @@ fn borrowed_use_kind(ctx: &IrContext, op: OpRef) -> BorrowedUseKind {
 mod tests {
     use super::*;
     use crate::native::rc_insertion::{BorrowedParameterPolicy, insert_rc_with_trusted_summaries};
+    use crate::native::type_converter::native_type_converter;
     use insta::assert_snapshot;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
+    use trunk_ir_cranelift_backend::passes::func_to_clif;
 
     fn summarize(ir: &str) -> String {
         let mut ctx = IrContext::new();
@@ -1022,6 +1069,91 @@ mod tests {
                     lower_func_ops_to_clif(ctx, nested);
                 }
             }
+        }
+    }
+
+    fn lowered_ordinary_call_contract()
+    -> (IrContext, Module, TrustedOwnershipSummaries, OpRef, i128) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref, %1: core.i32) -> core.i32 {
+    %2 = clif.load %0 {offset = 0} : core.i32
+    func.return %1
+  }
+  func.func @caller(%0: tribute_rt.anyref, %1: core.i32) -> core.i32 {
+    %2 = func.call %0, %1 {callee = @target} : core.i32
+    func.return %2
+  }
+}"#,
+        );
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let trusted =
+            compute_and_attach(&mut ctx, module, &type_converter).expect("ordinary call contract");
+        func_to_clif::lower(&mut ctx, module, type_converter).expect("func_to_clif");
+        let module_block = module.first_block(&ctx).expect("module body");
+        let caller =
+            clif::Func::from_op(&ctx, ctx.block(module_block).ops[1]).expect("lowered caller");
+        let call = ctx
+            .region(caller.body(&ctx))
+            .blocks
+            .iter()
+            .flat_map(|&block| ctx.block(block).ops.iter().copied())
+            .find(|&op| clif::Call::matches(&ctx, op))
+            .expect("ordinary direct call");
+        let id = match ctx.op(call).attributes.get(OWNERSHIP_CONTRACT_ID_ATTR) {
+            Some(Attribute::Int(id)) => *id,
+            _ => panic!("trusted contract identity"),
+        };
+        (ctx, module, trusted, call, id)
+    }
+
+    fn assert_rc_rejects_unchanged(
+        ctx: &mut IrContext,
+        module: Module,
+        trusted: &TrustedOwnershipSummaries,
+    ) {
+        let before = print_module(ctx, module.op());
+        assert!(
+            insert_rc_with_trusted_summaries(
+                ctx,
+                module,
+                BorrowedParameterPolicy::ElideProvenBorrowed,
+                trusted,
+            )
+            .is_err()
+        );
+        assert_eq!(print_module(ctx, module.op()), before);
+    }
+
+    #[test]
+    fn ordinary_direct_contract_on_non_call_fails_before_mutation() {
+        let (mut ctx, module, trusted, call, _) = lowered_ordinary_call_contract();
+        ctx.op_mut(call).name = Symbol::new("load");
+
+        assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
+    }
+
+    #[test]
+    fn ordinary_direct_action_type_mismatch_fails_before_mutation() {
+        for (argument_index, action) in [
+            (0, RcOwnership::Plain),
+            (1, RcOwnership::Borrowed),
+            (1, RcOwnership::Retained),
+            (1, RcOwnership::Acquire),
+            (0, RcOwnership::Consumed),
+            (0, RcOwnership::Transfer),
+        ] {
+            let (mut ctx, module, mut trusted, call, id) = lowered_ordinary_call_contract();
+            let contract = trusted.call_contracts.get_mut(&id).expect("trusted call");
+            contract.actions[argument_index] = action;
+            ctx.op_mut(call).attributes.insert(
+                Symbol::new(CALL_ARGUMENT_OWNERSHIP_ATTR),
+                RcOwnership::list_attribute(&contract.actions),
+            );
+
+            assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
         }
     }
 

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -2356,6 +2356,41 @@ mod tests {
     }
 
     #[test]
+    fn zero_operand_indirect_tail_fails_before_rc_mutation() {
+        for keep_metadata in [true, false] {
+            let (mut ctx, module, trusted) = lowered_trusted_cps(
+                r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+}"#,
+            );
+            let tail = first_tail_call(&ctx, module, true);
+            while !ctx.op_operands(tail).is_empty() {
+                ctx.remove_op_operand(tail, 0);
+            }
+            if !keep_metadata {
+                ctx.op_mut(tail)
+                    .attributes
+                    .remove(OWNERSHIP_CONTRACT_ID_ATTR);
+                ctx.op_mut(tail)
+                    .attributes
+                    .remove(CALL_ARGUMENT_OWNERSHIP_ATTR);
+            }
+            let before = print_module(&ctx, module.op());
+            let _: OwnershipContractError = insert_rc_with_policies_and_trusted_summaries(
+                &mut ctx,
+                module,
+                BorrowedParameterPolicy::ElideProvenBorrowed,
+                TemporaryBorrowPolicy::Preserve,
+                &trusted,
+            )
+            .expect_err("zero-operand indirect tail must fail closed");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
     fn nonfinal_tail_placement_fails_before_rc_mutation() {
         let (mut ctx, module, trusted) = lowered_trusted_cps(
             r#"core.module @test {

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -34,7 +34,6 @@
 //! | Value dies in block (live-in but not live-out) | `release` at appropriate point |
 
 use std::collections::{HashMap, HashSet};
-
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::clif;
@@ -47,9 +46,13 @@ use trunk_ir::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 use tribute_ir::dialect::tribute_rt;
 
 use super::ownership_summary::{
-    BorrowedUse, BorrowedUseKind, ParameterOwnership, TrustedOwnershipSummaries,
+    BorrowedUse, BorrowedUseKind, CALL_ARGUMENT_OWNERSHIP_ATTR, OWNERSHIP_CONTRACT_ID_ATTR,
+    OwnershipContractError, PARAMETER_ENTRY_OWNERSHIP_ATTR, ParameterOwnership, RcOwnership,
+    TrustedCallContract, TrustedOwnershipSummaries, ValidatedOwnershipContracts,
     classify_borrowed_use,
 };
+
+pub type RcInsertionError = OwnershipContractError;
 
 /// Policy for eliding RC ownership of proven borrowed function parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -85,6 +88,7 @@ fn is_terminator_op(ctx: &IrContext, op: OpRef) -> bool {
         || clif::Brif::matches(ctx, op)
         || clif::Trap::matches(ctx, op)
         || clif::ReturnCall::matches(ctx, op)
+        || clif::ReturnCallIndirect::matches(ctx, op)
         || clif::BrTable::matches(ctx, op)
 }
 
@@ -415,7 +419,8 @@ pub fn insert_rc(ctx: &mut IrContext, module: Module) {
         module,
         BorrowedParameterPolicy::Preserve,
         TemporaryBorrowPolicy::Preserve,
-    );
+    )
+    .expect("legacy RC insertion without trusted CPS transfers");
 }
 
 /// Insert reference counting operations with an explicit borrowed-parameter
@@ -430,7 +435,8 @@ pub fn insert_rc_with_policy(
         module,
         borrowed_parameters,
         TemporaryBorrowPolicy::Preserve,
-    );
+    )
+    .expect("legacy RC insertion without trusted CPS transfers");
 }
 
 pub fn insert_rc_with_trusted_summaries(
@@ -438,14 +444,14 @@ pub fn insert_rc_with_trusted_summaries(
     module: Module,
     borrowed_parameters: BorrowedParameterPolicy,
     trusted_summaries: &TrustedOwnershipSummaries,
-) {
+) -> Result<(), RcInsertionError> {
     insert_rc_with_policies_and_trusted_summaries(
         ctx,
         module,
         borrowed_parameters,
         TemporaryBorrowPolicy::Preserve,
         trusted_summaries,
-    );
+    )
 }
 
 /// Insert reference counting operations with independently selectable borrow
@@ -459,8 +465,8 @@ pub fn insert_rc_with_policies(
     module: Module,
     borrowed_parameters: BorrowedParameterPolicy,
     temporary_borrows: TemporaryBorrowPolicy,
-) {
-    insert_rc_impl(ctx, module, borrowed_parameters, temporary_borrows, None);
+) -> Result<(), RcInsertionError> {
+    insert_rc_impl(ctx, module, borrowed_parameters, temporary_borrows, None)
 }
 
 pub fn insert_rc_with_policies_and_trusted_summaries(
@@ -469,14 +475,14 @@ pub fn insert_rc_with_policies_and_trusted_summaries(
     borrowed_parameters: BorrowedParameterPolicy,
     temporary_borrows: TemporaryBorrowPolicy,
     trusted_summaries: &TrustedOwnershipSummaries,
-) {
+) -> Result<(), RcInsertionError> {
     insert_rc_impl(
         ctx,
         module,
         borrowed_parameters,
         temporary_borrows,
         Some(trusted_summaries),
-    );
+    )
 }
 
 fn insert_rc_impl(
@@ -485,14 +491,20 @@ fn insert_rc_impl(
     borrowed_parameters: BorrowedParameterPolicy,
     temporary_borrows: TemporaryBorrowPolicy,
     trusted_summaries: Option<&TrustedOwnershipSummaries>,
-) {
+) -> Result<(), RcInsertionError> {
     let Some(first_block) = module.first_block(ctx) else {
-        return;
+        return Ok(());
     };
     let module_ops: Vec<OpRef> = ctx.block(first_block).ops.to_vec();
-    let trusted_summaries = trusted_summaries
-        .map(|summaries| summaries.validated_for_clif(ctx, &module_ops))
-        .unwrap_or_default();
+    let trusted = if let Some(summaries) = trusted_summaries {
+        summaries.validated_for_clif(ctx, &module_ops)?
+    } else {
+        ValidatedOwnershipContracts {
+            summaries: HashMap::new(),
+            entry_contracts: HashMap::new(),
+            call_contracts: HashMap::new(),
+        }
+    };
     let borrow_safe_functions = borrow_safe_functions(ctx, &module_ops);
 
     for op in &module_ops {
@@ -513,14 +525,36 @@ fn insert_rc_impl(
                 body,
                 function_policy,
                 temporary_borrows,
-                &trusted_summaries,
+                &trusted.summaries,
+                trusted.entry_contracts.get(&sym).map(Vec::as_slice),
+                &trusted.call_contracts,
             );
         }
     }
 
+    clear_contract_metadata(ctx, module.op());
+
     // After RC insertion, lower all remaining `tribute_rt.anyref` types to `core.ptr`.
     // This ensures anyref doesn't survive past RC insertion into the Cranelift emit phase.
     lower_anyref_to_ptr(ctx, module);
+    Ok(())
+}
+
+fn clear_contract_metadata(ctx: &mut IrContext, op: OpRef) {
+    let regions = ctx.op(op).regions.to_vec();
+    let attributes = &mut ctx.op_mut(op).attributes;
+    attributes.remove(PARAMETER_ENTRY_OWNERSHIP_ATTR);
+    attributes.remove(CALL_ARGUMENT_OWNERSHIP_ATTR);
+    attributes.remove(OWNERSHIP_CONTRACT_ID_ATTR);
+    for region in regions {
+        let blocks = ctx.region(region).blocks.clone();
+        for block in blocks {
+            let ops = ctx.block(block).ops.clone();
+            for nested in ops {
+                clear_contract_metadata(ctx, nested);
+            }
+        }
+    }
 }
 
 /// Functions whose callers are guaranteed to keep an owning frame alive for
@@ -728,6 +762,7 @@ fn rewrite_type_anyref(
 }
 
 /// Insert RC in a function body.
+#[allow(clippy::too_many_arguments)]
 fn insert_rc_in_function(
     ctx: &mut IrContext,
     function: Symbol,
@@ -735,6 +770,8 @@ fn insert_rc_in_function(
     borrowed_parameter_policy: BorrowedParameterPolicy,
     temporary_borrow_policy: TemporaryBorrowPolicy,
     trusted_summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
+    entry_contract: Option<&[RcOwnership]>,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) {
     let mut ptr_values = collect_ptr_values(ctx, body);
 
@@ -746,7 +783,7 @@ fn insert_rc_in_function(
     let temporary_borrows = match temporary_borrow_policy {
         TemporaryBorrowPolicy::Preserve => TemporaryBorrowInfo::default(),
         TemporaryBorrowPolicy::ElideProvenFieldBorrows => {
-            analyze_temporary_borrows(ctx, body, &ptr_values, &ptr_alias_map)
+            analyze_temporary_borrows(ctx, body, &ptr_values, &ptr_alias_map, call_contracts)
         }
     };
     let liveness = compute_liveness(
@@ -756,12 +793,23 @@ fn insert_rc_in_function(
         &ptr_alias_map,
         &temporary_borrows.lifetime_dependencies,
     );
-    let borrowed_parameters = match borrowed_parameter_policy {
+    let mut borrowed_parameters = match borrowed_parameter_policy {
         BorrowedParameterPolicy::Preserve => HashSet::new(),
         BorrowedParameterPolicy::ElideProvenBorrowed => {
             analyze_borrowed_parameters(ctx, function, body, trusted_summaries)
         }
     };
+    let consumed_parameters: HashSet<ValueRef> = entry_contract
+        .into_iter()
+        .flat_map(|entries| entries.iter().enumerate())
+        .filter_map(|(index, entry)| {
+            (*entry == RcOwnership::Consumed)
+                .then(|| ctx.region(body).blocks.first())
+                .flatten()
+                .and_then(|&entry_block| ctx.block_args(entry_block).get(index).copied())
+        })
+        .collect();
+    borrowed_parameters.retain(|parameter| !consumed_parameters.contains(parameter));
 
     let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
     let borrow_info = RcBorrowInfo {
@@ -778,6 +826,8 @@ fn insert_rc_in_function(
             &liveness,
             &ptr_alias_map,
             &borrow_info,
+            &consumed_parameters,
+            call_contracts,
         );
     }
 }
@@ -787,6 +837,7 @@ fn analyze_temporary_borrows(
     body: RegionRef,
     ptr_values: &HashSet<ValueRef>,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) -> TemporaryBorrowInfo {
     let dominance = DominatorTree::compute(ctx, body);
     if !dominance.is_valid() {
@@ -818,9 +869,15 @@ fn analyze_temporary_borrows(
             ) else {
                 continue;
             };
-            if let Some(aliases) =
-                temporary_is_proven_borrowed(ctx, body, op, temporary, owner, &dominance)
-            {
+            if let Some(aliases) = temporary_is_proven_borrowed(
+                ctx,
+                body,
+                op,
+                temporary,
+                owner,
+                &dominance,
+                call_contracts,
+            ) {
                 info.borrowed.insert(temporary);
                 info.lifetime_dependencies.insert(temporary, owner);
                 for alias in aliases {
@@ -867,6 +924,7 @@ fn temporary_is_proven_borrowed(
     temporary: ValueRef,
     owner: ValueRef,
     dominance: &DominatorTree,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) -> Option<Vec<ValueRef>> {
     let load_block = ctx.op(load).parent_block?;
     if !value_dominates_op(ctx, body, owner, load, dominance) {
@@ -883,6 +941,7 @@ fn temporary_is_proven_borrowed(
         visited: HashSet::new(),
         use_blocks: &mut use_blocks,
         aliases: &mut aliases,
+        call_contracts,
     };
     if !collector.collect(temporary) {
         return None;
@@ -926,6 +985,7 @@ struct TemporaryUseCollector<'a> {
     visited: HashSet<ValueRef>,
     use_blocks: &'a mut Vec<BlockRef>,
     aliases: &'a mut Vec<ValueRef>,
+    call_contracts: &'a HashMap<OpRef, TrustedCallContract>,
 }
 
 impl TemporaryUseCollector<'_> {
@@ -956,7 +1016,7 @@ impl TemporaryUseCollector<'_> {
                 if !self.collect(alias) {
                     return false;
                 }
-            } else if !is_proven_temporary_use(self.ctx, user, operand_index) {
+            } else if !is_proven_temporary_use(self.ctx, user, operand_index, self.call_contracts) {
                 return false;
             }
         }
@@ -1003,12 +1063,23 @@ fn op_dominates_op(
         .is_some_and(|(defining, use_)| defining < use_)
 }
 
-fn is_proven_temporary_use(ctx: &IrContext, op: OpRef, operand_index: usize) -> bool {
+fn is_proven_temporary_use(
+    ctx: &IrContext,
+    op: OpRef,
+    operand_index: usize,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
+) -> bool {
     if clif::Load::matches(ctx, op) {
         return operand_index == 0;
     }
     if clif::Store::matches(ctx, op) {
         return operand_index == 1;
+    }
+    if let Some(contract) = call_contracts.get(&op)
+        && contract.is_tail
+        && let Some(action_index) = operand_index.checked_sub(usize::from(contract.is_indirect))
+    {
+        return contract.actions.get(action_index) == Some(&RcOwnership::Transfer);
     }
     clif::Icmp::matches(ctx, op)
 }
@@ -1116,6 +1187,7 @@ fn borrowed_use_kind(ctx: &IrContext, op: OpRef) -> BorrowedUseKind {
 }
 
 /// Insert RC ops in a single block.
+#[allow(clippy::too_many_arguments)]
 fn insert_rc_in_block(
     ctx: &mut IrContext,
     block: BlockRef,
@@ -1124,6 +1196,8 @@ fn insert_rc_in_block(
     liveness: &LivenessInfo,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
     borrow_info: &RcBorrowInfo<'_>,
+    consumed_parameters: &HashSet<ValueRef>,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) {
     let ops: Vec<OpRef> = ctx.block(block).ops.to_vec();
     let loc = ctx.block(block).location;
@@ -1164,6 +1238,50 @@ fn insert_rc_in_block(
     }
 
     let mut plan = InsertionPlan::default();
+    let mut transferred_values = HashSet::new();
+
+    for (op_idx, &op) in ops.iter().enumerate() {
+        let Some(contract) = call_contracts.get(&op) else {
+            continue;
+        };
+        let operands = ctx.op_operands(op).to_vec();
+        let args = operands
+            .get(usize::from(contract.is_indirect)..)
+            .unwrap_or_default();
+        if contract.is_tail {
+            let mut transfers: HashMap<ValueRef, (ValueRef, usize)> = HashMap::new();
+            for (&argument, action) in args.iter().zip(&contract.actions) {
+                if *action != RcOwnership::Transfer {
+                    continue;
+                }
+                let owned = ptr_alias_map.get(&argument).copied().unwrap_or(argument);
+                transferred_values.insert(argument);
+                transferred_values.insert(owned);
+                transfers
+                    .entry(owned)
+                    .and_modify(|(_, count)| *count += 1)
+                    .or_insert((argument, 1));
+            }
+            for (owned, (argument, count)) in transfers {
+                let borrowed = borrow_info.parameters.contains(&owned)
+                    || borrow_info.parameters.contains(&argument)
+                    || borrow_info.temporaries.contains(&owned)
+                    || borrow_info.temporaries.contains(&argument);
+                let retain_count = count.saturating_sub(usize::from(!borrowed));
+                for _ in 0..retain_count {
+                    let retain = tribute_rt::retain(ctx, ctx.op(op).location, argument, ptr_ty);
+                    plan.before.entry(op_idx).or_default().push(retain.op_ref());
+                }
+            }
+        } else {
+            for (&argument, action) in args.iter().zip(&contract.actions) {
+                if *action == RcOwnership::Acquire {
+                    let retain = tribute_rt::retain(ctx, ctx.op(op).location, argument, ptr_ty);
+                    plan.before.entry(op_idx).or_default().push(retain.op_ref());
+                }
+            }
+        }
+    }
 
     // --- Retain insertions ---
 
@@ -1173,6 +1291,7 @@ fn insert_rc_in_block(
         for arg_val in args {
             if is_anyref_type(ctx, ctx.value_ty(arg_val))
                 && !borrow_info.parameters.contains(&arg_val)
+                && !consumed_parameters.contains(&arg_val)
             {
                 let retain_op = tribute_rt::retain(ctx, loc, arg_val, ptr_ty);
                 plan.at_start.push(retain_op.op_ref());
@@ -1222,6 +1341,7 @@ fn insert_rc_in_block(
     for v in &live_in {
         if !live_out.contains(v)
             && !returned_values.contains(v)
+            && !transferred_values.contains(v)
             && !borrow_info.parameters.contains(v)
             && !borrow_info.temporaries.contains(v)
         {
@@ -1231,6 +1351,7 @@ fn insert_rc_in_block(
     for v in &defs_in_block {
         if !live_out.contains(v)
             && !returned_values.contains(v)
+            && !transferred_values.contains(v)
             && !is_alloc_intermediate(ctx, *v)
             && !borrow_info.parameters.contains(v)
             && !borrow_info.temporaries.contains(v)
@@ -1337,10 +1458,14 @@ fn apply_insertion_plan(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native::ownership_summary::compute_and_attach;
+    use crate::native::type_converter::native_type_converter;
+    use trunk_ir::Attribute;
     use trunk_ir::context::IrContext;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
     use trunk_ir::validation::validate_use_chains;
+    use trunk_ir_cranelift_backend::passes::func_to_clif;
 
     fn run_pass(ir: &str) -> String {
         run_pass_with_policy(ir, BorrowedParameterPolicy::Preserve)
@@ -1378,9 +1503,11 @@ mod tests {
                 parameter_policy,
                 temporary_policy,
                 &trusted,
-            );
+            )
+            .expect("trusted RC insertion");
         } else {
-            insert_rc_with_policies(&mut ctx, module, parameter_policy, temporary_policy);
+            insert_rc_with_policies(&mut ctx, module, parameter_policy, temporary_policy)
+                .expect("legacy RC insertion");
         }
         let validation = validate_use_chains(&ctx, module);
         assert!(
@@ -1388,6 +1515,55 @@ mod tests {
             "RC insertion must preserve SSA use chains: {validation}"
         );
         print_module(&ctx, module.op())
+    }
+
+    fn run_trusted_cps_pass(
+        ir: &str,
+        temporary_policy: TemporaryBorrowPolicy,
+    ) -> Result<String, String> {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let trusted = compute_and_attach(&mut ctx, module, &type_converter)
+            .map_err(|error| error.to_string())?;
+        func_to_clif::lower(&mut ctx, module, type_converter).map_err(|error| error.to_string())?;
+        insert_rc_with_policies_and_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            temporary_policy,
+            &trusted,
+        )
+        .map_err(|error| error.to_string())?;
+        Ok(print_module(&ctx, module.op()))
+    }
+
+    fn lowered_trusted_cps(ir: &str) -> (IrContext, Module, TrustedOwnershipSummaries) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let trusted = compute_and_attach(&mut ctx, module, &type_converter)
+            .expect("ownership contract production");
+        func_to_clif::lower(&mut ctx, module, type_converter).expect("func_to_clif");
+        (ctx, module, trusted)
+    }
+
+    fn first_tail_call(ctx: &IrContext, module: Module, indirect: bool) -> OpRef {
+        let block = module.first_block(ctx).expect("module body");
+        ctx.block(block)
+            .ops
+            .iter()
+            .filter_map(|&op| clif::Func::from_op(ctx, op).ok())
+            .flat_map(|function| ctx.region(function.body(ctx)).blocks.iter().copied())
+            .flat_map(|block| ctx.block(block).ops.iter().copied())
+            .find(|&op| {
+                if indirect {
+                    clif::ReturnCallIndirect::matches(ctx, op)
+                } else {
+                    clif::ReturnCall::matches(ctx, op)
+                }
+            })
+            .expect("tail call")
     }
 
     fn focused_rc_ops(output: &str) -> String {
@@ -1933,28 +2109,277 @@ mod tests {
     }
 
     #[test]
-    fn tail_call_target_preserves_owned_rc() {
-        let output = run_pass_with_policy(
+    fn direct_and_indirect_cps_tails_transfer_without_caller_cleanup() {
+        let output = run_trusted_cps_pass(
             r#"core.module @test {
-  clif.func @f(%0: tribute_rt.anyref) -> core.i32 {
-    %1 = clif.load %0 {offset = 0} : core.i32
-    clif.return %1
+  func.func @target(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
   }
-  clif.func @caller(%0: tribute_rt.anyref) -> core.i32 {
-    clif.return_call %0 {callee = @f}
+  func.func @direct(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %0 {callee = @target, tribute.calling_convention = 2}
+  }
+  func.func @indirect(%0: core.ptr, %1: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
   }
 }"#,
-            BorrowedParameterPolicy::ElideProvenBorrowed,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("trusted CPS transfer");
+        assert_eq!(output.matches("tribute_rt.retain").count(), 0, "{output}");
+        assert_eq!(output.matches("tribute_rt.release").count(), 1, "{output}");
+        assert!(
+            output.contains("clif.return_call %0 {callee = @target"),
+            "{output}"
         );
-        assert_focused_rc(
-            &output,
-            concat!(
-                "%1 = tribute_rt.retain %0 : core.ptr\n",
-                "tribute_rt.release %0 {alloc_size = 0}\n",
-                "%1 = tribute_rt.retain %0 : core.ptr\n",
-                "tribute_rt.release %0 {alloc_size = 0}"
-            ),
+        assert!(
+            output.contains("clif.return_call_indirect %0, %1"),
+            "{output}"
         );
+        for body in output.split("clif.func").skip(1) {
+            if body.contains("return_call") {
+                assert_eq!(
+                    body.lines()
+                        .rfind(|line| !line.trim().is_empty())
+                        .unwrap()
+                        .trim(),
+                    "}"
+                );
+                assert!(
+                    !body
+                        .split("return_call")
+                        .nth(1)
+                        .unwrap()
+                        .contains("tribute_rt."),
+                    "{body}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn consumed_cps_entry_owns_even_when_borrow_summary_is_eligible() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    %1 = clif.load %0 {offset = 0} : core.i32
+    func.unreachable
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("consumed CPS entry");
+        assert!(!output.contains("tribute_rt.retain"), "{output}");
+        assert_eq!(
+            output.matches("tribute_rt.release %0").count(),
+            1,
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn tail_transfer_multiplicity_acquires_only_additional_units() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref, %1: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %0, %0 {callee = @target, tribute.calling_convention = 2}
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("trusted duplicate transfer");
+        assert_eq!(output.matches("tribute_rt.retain").count(), 1, "{output}");
+        assert_eq!(output.matches("tribute_rt.release").count(), 2, "{output}");
+        let caller = output
+            .split("sym_name = @caller")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        assert!(
+            caller.find("tribute_rt.retain").unwrap() < caller.find("clif.return_call").unwrap(),
+            "{caller}"
+        );
+        assert!(!caller.contains("tribute_rt.release"), "{caller}");
+    }
+
+    #[test]
+    fn borrowed_tail_operand_is_acquired_before_untransferred_owner_cleanup() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    clif.store %0, %0 {offset = 16}
+    %1 = clif.load %0 {offset = 8} : tribute_rt.anyref
+    func.tail_call %1 {callee = @target, tribute.calling_convention = 2}
+  }
+}"#,
+            TemporaryBorrowPolicy::ElideProvenFieldBorrows,
+        )
+        .expect("borrowed tail acquisition");
+        let caller = output
+            .split("sym_name = @caller")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let retain = caller
+            .find("tribute_rt.retain %2")
+            .unwrap_or_else(|| panic!("{caller}"));
+        let release = caller
+            .find("tribute_rt.release %0")
+            .unwrap_or_else(|| panic!("{caller}"));
+        let tail = caller
+            .find("clif.return_call %2")
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert!(retain < release && release < tail, "{caller}");
+        assert!(!caller[tail..].contains("tribute_rt."), "{caller}");
+    }
+
+    #[test]
+    fn ordinary_call_acquires_for_consumed_callee_and_return_still_transfers() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%0: tribute_rt.anyref) -> tribute_rt.anyref {
+    %1 = func.call %0 {callee = @target} : core.nil
+    func.return %0
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("ordinary acquisition");
+        let caller = output.split("sym_name = @caller").nth(1).unwrap();
+        assert_eq!(
+            caller.matches("tribute_rt.retain %0").count(),
+            2,
+            "{caller}"
+        );
+        assert!(
+            caller.rfind("tribute_rt.retain %0").unwrap() < caller.find("clif.call %0").unwrap(),
+            "{caller}"
+        );
+        assert!(!caller.contains("tribute_rt.release %0"), "{caller}");
+        assert!(caller.contains("clif.return %0"), "{caller}");
+    }
+
+    #[test]
+    fn malformed_trust_fails_before_rc_mutation() {
+        let (mut ctx, module, trusted) = lowered_trusted_cps(
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @other(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %0 {callee = @target, tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let tail = first_tail_call(&ctx, module, false);
+        let original_id = ctx
+            .op(tail)
+            .attributes
+            .get(OWNERSHIP_CONTRACT_ID_ATTR)
+            .cloned()
+            .expect("contract identity");
+        ctx.op_mut(tail)
+            .attributes
+            .insert(Symbol::new(OWNERSHIP_CONTRACT_ID_ATTR), Attribute::Int(999));
+        let before = print_module(&ctx, module.op());
+        assert!(
+            insert_rc_with_policies_and_trusted_summaries(
+                &mut ctx,
+                module,
+                BorrowedParameterPolicy::ElideProvenBorrowed,
+                TemporaryBorrowPolicy::Preserve,
+                &trusted,
+            )
+            .is_err()
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+
+        ctx.op_mut(tail)
+            .attributes
+            .insert(Symbol::new(OWNERSHIP_CONTRACT_ID_ATTR), original_id);
+        ctx.op_mut(tail).attributes.insert(
+            Symbol::new("callee"),
+            Attribute::Symbol(Symbol::new("other")),
+        );
+        let before = print_module(&ctx, module.op());
+        assert!(
+            insert_rc_with_policies_and_trusted_summaries(
+                &mut ctx,
+                module,
+                BorrowedParameterPolicy::ElideProvenBorrowed,
+                TemporaryBorrowPolicy::Preserve,
+                &trusted,
+            )
+            .is_err()
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn indirect_signature_mismatch_fails_before_rc_mutation() {
+        let (mut ctx, module, trusted) = lowered_trusted_cps(
+            r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: tribute_rt.anyref, %2: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1, %2 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref, core.i32), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let tail = first_tail_call(&ctx, module, true);
+        let nil = core::nil(&mut ctx).as_type_ref();
+        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let ptr = core::ptr(&mut ctx).as_type_ref();
+        let changed_signature = core::func(&mut ctx, nil, [anyref, ptr]).as_type_ref();
+        ctx.op_mut(tail)
+            .attributes
+            .insert(Symbol::new("sig"), Attribute::Type(changed_signature));
+        let before = print_module(&ctx, module.op());
+        assert!(
+            insert_rc_with_policies_and_trusted_summaries(
+                &mut ctx,
+                module,
+                BorrowedParameterPolicy::ElideProvenBorrowed,
+                TemporaryBorrowPolicy::Preserve,
+                &trusted,
+            )
+            .is_err()
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn nonfinal_tail_placement_fails_before_rc_mutation() {
+        let (mut ctx, module, trusted) = lowered_trusted_cps(
+            r#"core.module @test {
+  func.func @target(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call %0 {callee = @target, tribute.calling_convention = 2}
+    func.unreachable
+  }
+}"#,
+        );
+        let before = print_module(&ctx, module.op());
+        assert!(
+            insert_rc_with_policies_and_trusted_summaries(
+                &mut ctx,
+                module,
+                BorrowedParameterPolicy::ElideProvenBorrowed,
+                TemporaryBorrowPolicy::Preserve,
+                &trusted,
+            )
+            .is_err()
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -293,6 +293,60 @@ occur before unrealized cast resolution and RC lowering, which keeps alias
 handling conservative and makes the inserted and optimized RC boundaries
 directly observable in tests.
 
+#### Proper-tail ownership transfer
+
+Native RC distinguishes a callable's parameter-entry contract from the action
+at one call site. The existing `borrowed`/`owned` summary remains a borrow
+optimization and does not encode proper-tail transfer.
+
+Each RC-managed physical parameter has one exact entry mode:
+
+- **borrowed:** the callee receives no ownership unit, performs no entry retain,
+  and must neither release nor transfer the parameter;
+- **retained:** the callee acquires its own unit with an entry retain and must
+  release or return that unit; this is the existing ordinary owned-parameter
+  behavior; or
+- **consumed:** the caller supplies one ownership unit, the callee performs no
+  entry retain, and the callee must eventually release, return, or proper-tail
+  transfer that unit.
+
+Physically empty CPS callables use `consumed` for every parameter whose exact
+native conversion is RC-managed. Non-RC parameters have no RC action. This is
+a native callable contract, not a conclusion inferred by RC insertion from a
+name, operand type, body shape, or calling-convention integer alone.
+
+An ordinary call to a consumed parameter acquires a new unit with `retain`
+immediately before the call, leaving the caller's existing unit live. A
+non-returning proper-tail call transfers the caller's existing unit without a
+caller-side release. When the caller only borrows the value, it first retains
+once to create the transferred unit. If the same underlying value is supplied
+to `N` consumed parameters, the edge supplies `N` units: an owned value
+transfers one existing unit and retains `N - 1`, while a borrowed value retains
+`N`. Alias-transparent casts count as the same underlying ownership unit.
+
+Every RC-managed proper-tail operand must target a consumed parameter. A tail
+edge to a borrowed parameter would outlive the caller dynamic extent; a tail
+edge to a retained parameter would require cleanup after the terminator. Both
+are rejected. Dying RC values not transferred by the edge are released before
+the tail terminator. No RC operation may follow `clif.return_call` or
+`clif.return_call_indirect`.
+
+The native ownership producer runs after target-ABI validation and immediately
+before `func_to_clif`. It records versioned, positional parameter-entry and
+call-edge actions plus a fresh contract identity, and returns an opaque
+in-memory trust token. Direct edges must resolve one exact module-local symbol.
+Indirect edges additionally require the exact physical callable signature and
+explicit CPS provenance already carried by the transfer. `func_to_clif`
+preserves this metadata; RC insertion cross-checks it against the trust token
+after lowering. Textual metadata is never trusted.
+
+RC insertion validates the complete module before applying any mutation. Once
+that preflight succeeds, insertion planning has no remaining failure path.
+Missing, malformed, duplicate, external, stale, or inconsistent contracts; an
+indirect signature mismatch; and a tail operation that is not the final block
+operation all fail before mutation. The contract metadata is removed after
+successful consumption and does not become part of the emitted ABI.
+
 #### Trusted ownership summaries across `func_to_clif`
 
 Borrowed forwarding uses explicit pre-lowering metadata rather than rebuilding

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1065,7 +1065,10 @@ fn prepare_module_to_native(
             ctx,
             module,
             &type_converter,
-        );
+        )
+        .map_err(|error| {
+            trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string())
+        })?;
         func_to_clif::lower(ctx, module, type_converter).map_err(native_conversion_failure)?;
     }
 
@@ -1155,7 +1158,10 @@ fn prepare_module_to_native(
             borrowed_parameters,
             temporary_borrows,
             &ownership_summaries,
-        );
+        )
+        .map_err(|error| {
+            trunk_ir_cranelift_backend::CompilationError::ir_validation(error.to_string())
+        })?;
     }
 
     if stop_after == Some(NativePipelineStage::AfterRcInsertion) {


### PR DESCRIPTION
## Summary

- define the consumed CPS callee-entry and proper-tail transfer ownership contract
- preserve transferred RC operands while cleaning untransferred dying values before the tail terminator
- validate exact direct/indirect call provenance, Clif call families, and ordinary call action types before RC mutation

## Testing

- focused ownership-summary and RC-insertion tests
- workspace nextest and clippy with warnings denied
- cargo fmt and diff checks

Closes #891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ownership contracts for native reference-counted calls, including borrowed, retained, consumed, acquired, and transferred values.
  * Added ownership transfers for proper tail calls and acquisitions during ordinary calls.
  * Added validation for direct and indirect call contracts, including positional and CPS-based contracts.

* **Bug Fixes**
  * Compilation now reports invalid or missing ownership metadata instead of proceeding silently.
  * Prevented unsafe tail-call provenance and contract tampering.
  * Ensured validation completes before changes are applied and ownership metadata is removed afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->