### PR TITLE
Fix native indirect-tail ownership validation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,5 +2,5 @@
 slow-timeout = { period = "30s", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = "package(tribute) & binary(optimization_conformance) & (test(trusted_ownership_forwarding_preserves_native_execution) | test(temporary_field_borrows_preserve_native_execution_with_sanitizer))"
+filter = "package(tribute) & binary(optimization_conformance) & test(/_slow$/)"
 slow-timeout = { period = "60s", terminate-after = 1 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,6 @@
 [profile.default]
 slow-timeout = { period = "30s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter = "package(tribute) & binary(optimization_conformance) & (test(trusted_ownership_forwarding_preserves_native_execution) | test(temporary_field_borrows_preserve_native_execution_with_sanitizer))"
+slow-timeout = { period = "60s", terminate-after = 1 }

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -713,6 +713,21 @@ fn collect_validated_call_contracts(
                                         RcOwnership::Consumed | RcOwnership::Transfer => false,
                                     })
                         })
+                } else if expected.is_tail && expected.is_indirect {
+                    expected
+                        .indirect_signature
+                        .and_then(|signature| core::Func::from_type_ref(ctx, signature))
+                        .is_some_and(|callable| {
+                            let parameters = callable.params(ctx);
+                            parameters.len() == expected.actions.len()
+                                && parameters.iter().zip(&expected.actions).all(
+                                    |(&parameter, action)| match action {
+                                        RcOwnership::Plain => !is_anyref_type(ctx, parameter),
+                                        RcOwnership::Transfer => is_anyref_type(ctx, parameter),
+                                        _ => false,
+                                    },
+                                )
+                        })
                 } else {
                     args.iter()
                         .zip(&expected.actions)
@@ -789,7 +804,11 @@ fn entry_parameters(ctx: &IrContext, body: RegionRef) -> Vec<ValueRef> {
 }
 
 fn is_anyref_value(ctx: &IrContext, value: ValueRef) -> bool {
-    let ty = ctx.types.get(ctx.value_ty(value));
+    is_anyref_type(ctx, ctx.value_ty(value))
+}
+
+fn is_anyref_type(ctx: &IrContext, ty: TypeRef) -> bool {
+    let ty = ctx.types.get(ty);
     ty.dialect == Symbol::new("tribute_rt") && ty.name == Symbol::new("anyref")
 }
 
@@ -1162,17 +1181,11 @@ mod tests {
         assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
     }
 
-    fn lowered_indirect_tail_contract()
-    -> (IrContext, Module, TrustedOwnershipSummaries, OpRef, i128) {
+    fn lowered_indirect_tail_contract_with(
+        ir: &str,
+    ) -> (IrContext, Module, TrustedOwnershipSummaries, OpRef, i128) {
         let mut ctx = IrContext::new();
-        let module = parse_test_module(
-            &mut ctx,
-            r#"core.module @test {
-  func.func @caller(%0: core.ptr, %1: tribute_rt.intref) -> core.nil attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %0, %1 {func.indirect_call_signature = core.func(core.nil, tribute_rt.intref), tribute.calling_convention = 2}
-  }
-}"#,
-        );
+        let module = parse_test_module(&mut ctx, ir);
         let (type_converter, _) = native_type_converter(&mut ctx);
         let trusted =
             compute_and_attach(&mut ctx, module, &type_converter).expect("indirect tail contract");
@@ -1192,6 +1205,17 @@ mod tests {
             _ => panic!("trusted contract identity"),
         };
         (ctx, module, trusted, call, id)
+    }
+
+    fn lowered_indirect_tail_contract()
+    -> (IrContext, Module, TrustedOwnershipSummaries, OpRef, i128) {
+        lowered_indirect_tail_contract_with(
+            r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: tribute_rt.intref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1 {func.indirect_call_signature = core.func(core.nil, tribute_rt.intref), tribute.calling_convention = 2}
+  }
+}"#,
+        )
     }
 
     #[test]
@@ -1215,6 +1239,50 @@ mod tests {
             &trusted,
         )
         .expect("converted indirect tail contract");
+    }
+
+    #[test]
+    fn indirect_tail_transfer_accepts_an_adapted_ptr_for_an_anyref_signature() {
+        let (mut ctx, module, trusted, call, _) = lowered_indirect_tail_contract_with(
+            r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: core.ptr) -> core.nil attributes {tribute.calling_convention = 2} {
+    %2 = core.unrealized_conversion_cast %1 : core.ptr
+    func.tail_call_indirect %0, %2 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let signature = ctx
+            .op(call)
+            .attributes
+            .get_type("sig")
+            .expect("lowered indirect signature");
+        let callable = core::Func::from_type_ref(&ctx, signature).expect("core.func signature");
+        assert!(is_anyref_type(&ctx, callable.params(&ctx)[0]));
+        assert!(!is_anyref_value(&ctx, ctx.op_operands(call)[1]));
+
+        insert_rc_with_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            &trusted,
+        )
+        .expect("adapted indirect tail transfer");
+    }
+
+    #[test]
+    fn indirect_tail_plain_signature_cannot_masquerade_as_transfer() {
+        let (mut ctx, module, mut trusted, call, id) = lowered_indirect_tail_contract();
+        let actions = {
+            let contract = trusted.call_contracts.get_mut(&id).expect("trusted call");
+            contract.actions[0] = RcOwnership::Transfer;
+            contract.actions.clone()
+        };
+        ctx.op_mut(call).attributes.insert(
+            Symbol::new(CALL_ARGUMENT_OWNERSHIP_ATTR),
+            RcOwnership::list_attribute(&actions),
+        );
+
+        assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
     }
 
     #[test]

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -92,6 +92,7 @@ pub struct TrustedOwnershipSummaries {
 pub struct ValidatedOwnershipContracts {
     pub summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
     pub entry_contracts: HashMap<Symbol, Vec<RcOwnership>>,
+    pub(crate) entry_physical_closures: HashMap<Symbol, Vec<Option<TypeRef>>>,
     pub call_contracts: HashMap<OpRef, TrustedCallContract>,
 }
 
@@ -584,6 +585,7 @@ impl TrustedOwnershipSummaries {
             .collect();
 
         let mut entry_contracts = HashMap::new();
+        let mut entry_physical_closures = HashMap::new();
         for (&symbol, expected) in &self.entry_contracts {
             let physical_closures =
                 self.entry_physical_closures
@@ -632,6 +634,7 @@ impl TrustedOwnershipSummaries {
                 ));
             }
             entry_contracts.insert(symbol, expected.clone());
+            entry_physical_closures.insert(symbol, physical_closures.clone());
         }
 
         let mut call_contracts = HashMap::new();
@@ -658,6 +661,7 @@ impl TrustedOwnershipSummaries {
         Ok(ValidatedOwnershipContracts {
             summaries,
             entry_contracts,
+            entry_physical_closures,
             call_contracts,
         })
     }
@@ -1413,6 +1417,37 @@ mod tests {
             .get_mut(&id)
             .expect("trusted call")
             .indirect_physical_closures = None;
+
+        assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
+    }
+
+    #[test]
+    fn retained_physical_entry_without_provenance_fails_closed() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.never, tribute_rt.anyref)) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  func.func @factory(%handler: !handler) -> core.nil attributes {tribute.calling_convention = 0} {
+    %size = clif.iconst {value = 32} : core.i64
+    %env = clif.call %size {callee = @__tribute_alloc} : core.ptr
+    clif.store %handler, %env {offset = 24}
+    func.unreachable
+  }
+}"#,
+        );
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let mut trusted = compute_and_attach(&mut ctx, module, &type_converter)
+            .expect("retained physical entry contract");
+        assert_eq!(
+            trusted.entry_contracts[&Symbol::new("factory")],
+            [RcOwnership::Retained]
+        );
+        func_to_clif::lower(&mut ctx, module, type_converter).expect("func_to_clif");
+        trusted
+            .entry_physical_closures
+            .get_mut(&Symbol::new("factory"))
+            .expect("physical entry provenance")[0] = None;
 
         assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
     }

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -18,6 +18,8 @@ pub const PARAMETER_OWNERSHIP_ATTR: &str = "tribute.rc.parameter_ownership_v1";
 pub const PARAMETER_ENTRY_OWNERSHIP_ATTR: &str = "tribute.rc.parameter_entry_ownership_v1";
 pub const CALL_ARGUMENT_OWNERSHIP_ATTR: &str = "tribute.rc.call_argument_ownership_v1";
 pub const OWNERSHIP_CONTRACT_ID_ATTR: &str = "tribute.rc.ownership_contract_id_v1";
+pub(crate) const PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR: &str =
+    "tribute.rc.physical_closure_value_provenance_v1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParameterOwnership {
@@ -86,6 +88,7 @@ pub struct TrustedOwnershipSummaries {
     summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
     entry_contracts: HashMap<Symbol, Vec<RcOwnership>>,
     entry_physical_closures: HashMap<Symbol, Vec<Option<TypeRef>>>,
+    physical_closure_values: HashMap<i128, TypeRef>,
     call_contracts: HashMap<i128, TrustedCallContract>,
 }
 
@@ -93,6 +96,7 @@ pub struct ValidatedOwnershipContracts {
     pub summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
     pub entry_contracts: HashMap<Symbol, Vec<RcOwnership>>,
     pub(crate) entry_physical_closures: HashMap<Symbol, Vec<Option<TypeRef>>>,
+    pub(crate) physical_closure_values: HashMap<i128, ValueRef>,
     pub call_contracts: HashMap<OpRef, TrustedCallContract>,
 }
 
@@ -106,6 +110,7 @@ pub fn compute_and_attach(
             summaries: HashMap::new(),
             entry_contracts: HashMap::new(),
             entry_physical_closures: HashMap::new(),
+            physical_closure_values: HashMap::new(),
             call_contracts: HashMap::new(),
         });
     };
@@ -225,6 +230,15 @@ pub fn compute_and_attach(
 
     strip_contract_metadata(ctx, module.op());
 
+    let mut physical_closure_values = HashMap::new();
+    let mut next_physical_closure_value_id = 1i128;
+    collect_physical_closure_values(
+        ctx,
+        module.op(),
+        &mut next_physical_closure_value_id,
+        &mut physical_closure_values,
+    );
+
     for (&symbol, &op) in &unique_functions {
         let entries = summaries[&symbol]
             .iter()
@@ -257,6 +271,7 @@ pub fn compute_and_attach(
         summaries,
         entry_contracts,
         entry_physical_closures,
+        physical_closure_values,
         call_contracts,
     })
 }
@@ -268,12 +283,44 @@ fn strip_contract_metadata(ctx: &mut IrContext, op: OpRef) {
     attributes.remove(PARAMETER_ENTRY_OWNERSHIP_ATTR);
     attributes.remove(CALL_ARGUMENT_OWNERSHIP_ATTR);
     attributes.remove(OWNERSHIP_CONTRACT_ID_ATTR);
+    attributes.remove(PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR);
     for region in regions {
         let blocks = ctx.region(region).blocks.clone();
         for block in blocks {
             let ops = ctx.block(block).ops.clone();
             for nested in ops {
                 strip_contract_metadata(ctx, nested);
+            }
+        }
+    }
+}
+
+fn collect_physical_closure_values(
+    ctx: &mut IrContext,
+    op: OpRef,
+    next_id: &mut i128,
+    values: &mut HashMap<i128, TypeRef>,
+) {
+    if adt::StructGet::matches(ctx, op) && ctx.op_results(op).len() == 1 {
+        let result = ctx.op_result(op, 0);
+        let ty = ctx.value_ty(result);
+        if type_is_proven_physical_closure(ctx, ty) {
+            let id = *next_id;
+            *next_id += 1;
+            values.insert(id, ty);
+            ctx.op_mut(op).attributes.insert(
+                Symbol::new(PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR),
+                Attribute::Int(id),
+            );
+        }
+    }
+    let regions = ctx.op(op).regions.to_vec();
+    for region in regions {
+        let blocks = ctx.region(region).blocks.clone();
+        for block in blocks {
+            let ops = ctx.block(block).ops.clone();
+            for nested in ops {
+                collect_physical_closure_values(ctx, nested, next_id, values);
             }
         }
     }
@@ -658,10 +705,31 @@ impl TrustedOwnershipSummaries {
             ));
         }
 
+        let mut physical_closure_values = HashMap::new();
+        let mut seen_physical_closure_values = HashSet::new();
+        for &function_op in module_ops {
+            let Ok(function) = clif::Func::from_op(ctx, function_op) else {
+                continue;
+            };
+            collect_validated_physical_closure_values(
+                ctx,
+                function.body(ctx),
+                &self.physical_closure_values,
+                &mut seen_physical_closure_values,
+                &mut physical_closure_values,
+            )?;
+        }
+        if seen_physical_closure_values.len() != self.physical_closure_values.len() {
+            return Err(OwnershipContractError(
+                "trusted physical closure value disappeared during func_to_clif",
+            ));
+        }
+
         Ok(ValidatedOwnershipContracts {
             summaries,
             entry_contracts,
             entry_physical_closures,
+            physical_closure_values,
             call_contracts,
         })
     }
@@ -673,6 +741,7 @@ impl TrustedOwnershipSummaries {
                 summaries: HashMap::new(),
                 entry_contracts: HashMap::new(),
                 entry_physical_closures: HashMap::new(),
+                physical_closure_values: HashMap::new(),
                 call_contracts: HashMap::new(),
             };
         };
@@ -727,9 +796,53 @@ impl TrustedOwnershipSummaries {
             summaries,
             entry_contracts,
             entry_physical_closures,
+            physical_closure_values: HashMap::new(),
             call_contracts: HashMap::new(),
         }
     }
+}
+
+fn collect_validated_physical_closure_values(
+    ctx: &IrContext,
+    region: RegionRef,
+    trusted: &HashMap<i128, TypeRef>,
+    seen: &mut HashSet<i128>,
+    validated: &mut HashMap<i128, ValueRef>,
+) -> Result<(), OwnershipContractError> {
+    for &block in &ctx.region(region).blocks {
+        for &op in &ctx.block(block).ops {
+            if let Some(attribute) = ctx
+                .op(op)
+                .attributes
+                .get(PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR)
+            {
+                let Attribute::Int(id) = attribute else {
+                    return Err(OwnershipContractError(
+                        "physical closure value provenance is malformed",
+                    ));
+                };
+                if !clif::Load::matches(ctx, op)
+                    || ctx.op_results(op).len() != 1
+                    || !is_core_ptr_type(ctx, ctx.value_ty(ctx.op_result(op, 0)))
+                    || !seen.insert(*id)
+                {
+                    return Err(OwnershipContractError(
+                        "physical closure value provenance changed during func_to_clif",
+                    ));
+                }
+                if !trusted.contains_key(id) {
+                    return Err(OwnershipContractError(
+                        "physical closure value provenance is untrusted",
+                    ));
+                }
+                validated.insert(*id, ctx.op_result(op, 0));
+            }
+            for &nested in &ctx.op(op).regions {
+                collect_validated_physical_closure_values(ctx, nested, trusted, seen, validated)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn collect_validated_call_contracts(
@@ -1096,7 +1209,7 @@ mod tests {
     use insta::assert_snapshot;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
-    use trunk_ir_cranelift_backend::passes::func_to_clif;
+    use trunk_ir_cranelift_backend::passes::{adt_to_clif, func_to_clif};
 
     fn summarize(ir: &str) -> String {
         let mut ctx = IrContext::new();
@@ -1448,6 +1561,70 @@ mod tests {
             .entry_physical_closures
             .get_mut(&Symbol::new("factory"))
             .expect("physical entry provenance")[0] = None;
+
+        assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
+    }
+
+    #[test]
+    fn physical_closure_field_value_without_provenance_fails_closed() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.never, tribute_rt.anyref)) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  !frame = adt.struct(!handler) {fields = [[@dispatch, !handler]], name = @Frame}
+  func.func @factory(%frame: !frame) -> core.nil attributes {tribute.calling_convention = 0} {
+    %dispatch = adt.struct_get %frame {field = 0, type = !frame} : !handler
+    func.unreachable
+  }
+}"#,
+        );
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let mut trusted = compute_and_attach(&mut ctx, module, &type_converter)
+            .expect("physical closure field contract");
+        assert_eq!(trusted.physical_closure_values.len(), 1);
+        func_to_clif::lower(&mut ctx, module, type_converter).expect("func_to_clif");
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        adt_to_clif::lower(&mut ctx, module, type_converter).expect("adt_to_clif");
+        trusted.physical_closure_values.clear();
+
+        assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
+    }
+
+    #[test]
+    fn forged_physical_closure_field_value_provenance_fails_closed() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.never, tribute_rt.anyref)) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  !frame = adt.struct(!handler) {fields = [[@dispatch, !handler]], name = @Frame}
+  func.func @factory(%frame: !frame) -> core.nil attributes {tribute.calling_convention = 0} {
+    %dispatch = adt.struct_get %frame {field = 0, type = !frame} : !handler
+    func.unreachable
+  }
+}"#,
+        );
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let trusted = compute_and_attach(&mut ctx, module, &type_converter)
+            .expect("physical closure field contract");
+        func_to_clif::lower(&mut ctx, module, type_converter).expect("func_to_clif");
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        adt_to_clif::lower(&mut ctx, module, type_converter).expect("adt_to_clif");
+        let module_block = module.first_block(&ctx).expect("module body");
+        let factory =
+            clif::Func::from_op(&ctx, ctx.block(module_block).ops[0]).expect("lowered factory");
+        let load = ctx
+            .region(factory.body(&ctx))
+            .blocks
+            .iter()
+            .flat_map(|&block| ctx.block(block).ops.iter().copied())
+            .find(|&op| clif::Load::matches(&ctx, op))
+            .expect("proven field load");
+        ctx.op_mut(load).attributes.insert(
+            Symbol::new(PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR),
+            Attribute::Int(999),
+        );
 
         assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
     }

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -96,7 +96,7 @@ pub struct ValidatedOwnershipContracts {
     pub summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
     pub entry_contracts: HashMap<Symbol, Vec<RcOwnership>>,
     pub(crate) entry_physical_closures: HashMap<Symbol, Vec<Option<TypeRef>>>,
-    pub(crate) physical_closure_values: HashMap<i128, ValueRef>,
+    pub(crate) physical_closure_values: HashMap<Symbol, HashSet<ValueRef>>,
     pub call_contracts: HashMap<OpRef, TrustedCallContract>,
 }
 
@@ -711,13 +711,17 @@ impl TrustedOwnershipSummaries {
             let Ok(function) = clif::Func::from_op(ctx, function_op) else {
                 continue;
             };
+            let mut function_values = HashSet::new();
             collect_validated_physical_closure_values(
                 ctx,
                 function.body(ctx),
                 &self.physical_closure_values,
                 &mut seen_physical_closure_values,
-                &mut physical_closure_values,
+                &mut function_values,
             )?;
+            if !function_values.is_empty() {
+                physical_closure_values.insert(function.sym_name(ctx), function_values);
+            }
         }
         if seen_physical_closure_values.len() != self.physical_closure_values.len() {
             return Err(OwnershipContractError(
@@ -807,7 +811,7 @@ fn collect_validated_physical_closure_values(
     region: RegionRef,
     trusted: &HashMap<i128, TypeRef>,
     seen: &mut HashSet<i128>,
-    validated: &mut HashMap<i128, ValueRef>,
+    validated: &mut HashSet<ValueRef>,
 ) -> Result<(), OwnershipContractError> {
     for &block in &ctx.region(region).blocks {
         for &op in &ctx.block(block).ops {
@@ -835,7 +839,7 @@ fn collect_validated_physical_closure_values(
                         "physical closure value provenance is untrusted",
                     ));
                 }
-                validated.insert(*id, ctx.op_result(op, 0));
+                validated.insert(ctx.op_result(op, 0));
             }
             for &nested in &ctx.op(op).regions {
                 collect_validated_physical_closure_values(ctx, nested, trusted, seen, validated)?;

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -284,6 +284,23 @@ fn type_lowers_to_anyref(ctx: &mut IrContext, ty: TypeRef, type_converter: &Type
     data.dialect == Symbol::new("tribute_rt") && data.name == Symbol::new("anyref")
 }
 
+fn lowered_indirect_signature(
+    ctx: &mut IrContext,
+    signature: TypeRef,
+    type_converter: &TypeConverter,
+) -> Result<TypeRef, OwnershipContractError> {
+    let callable = core::Func::from_type_ref(ctx, signature).ok_or(OwnershipContractError(
+        "indirect proper-tail signature is not core.func",
+    ))?;
+    let return_type = type_converter.convert_type_or_identity(ctx, callable.r#return(ctx));
+    let parameter_types: Vec<_> = callable
+        .params(ctx)
+        .iter()
+        .map(|&parameter| type_converter.convert_type_or_identity(ctx, parameter))
+        .collect();
+    Ok(core::func(ctx, return_type, parameter_types.iter().copied()).as_type_ref())
+}
+
 fn collect_call_contracts(
     ctx: &mut IrContext,
     region: RegionRef,
@@ -394,6 +411,10 @@ fn collect_call_contracts(
                         }),
                         indirect_signature: if indirect {
                             get_indirect_call_signature(ctx, op)
+                                .map(|signature| {
+                                    lowered_indirect_signature(ctx, signature, type_converter)
+                                })
+                                .transpose()?
                         } else {
                             None
                         },
@@ -1137,6 +1158,73 @@ mod tests {
     fn ordinary_direct_contract_on_non_call_fails_before_mutation() {
         let (mut ctx, module, trusted, call, _) = lowered_ordinary_call_contract();
         ctx.op_mut(call).name = Symbol::new("load");
+
+        assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
+    }
+
+    fn lowered_indirect_tail_contract()
+    -> (IrContext, Module, TrustedOwnershipSummaries, OpRef, i128) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: tribute_rt.intref) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1 {func.indirect_call_signature = core.func(core.nil, tribute_rt.intref), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let trusted =
+            compute_and_attach(&mut ctx, module, &type_converter).expect("indirect tail contract");
+        func_to_clif::lower(&mut ctx, module, type_converter).expect("func_to_clif");
+        let module_block = module.first_block(&ctx).expect("module body");
+        let caller =
+            clif::Func::from_op(&ctx, ctx.block(module_block).ops[0]).expect("lowered caller");
+        let call = ctx
+            .region(caller.body(&ctx))
+            .blocks
+            .iter()
+            .flat_map(|&block| ctx.block(block).ops.iter().copied())
+            .find(|&op| clif::ReturnCallIndirect::matches(&ctx, op))
+            .expect("indirect tail call");
+        let id = match ctx.op(call).attributes.get(OWNERSHIP_CONTRACT_ID_ATTR) {
+            Some(Attribute::Int(id)) => *id,
+            _ => panic!("trusted contract identity"),
+        };
+        (ctx, module, trusted, call, id)
+    }
+
+    #[test]
+    fn indirect_tail_contract_uses_the_converted_callable_signature() {
+        let (mut ctx, module, trusted, call, _) = lowered_indirect_tail_contract();
+        let signature = ctx
+            .op(call)
+            .attributes
+            .get_type("sig")
+            .expect("lowered indirect signature");
+        let callable = core::Func::from_type_ref(&ctx, signature).expect("core.func signature");
+        assert!(callable.params(&ctx).iter().all(|&parameter| {
+            let ty = ctx.types.get(parameter);
+            ty.dialect == Symbol::new("core") && ty.name == Symbol::new("ptr")
+        }));
+
+        insert_rc_with_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            &trusted,
+        )
+        .expect("converted indirect tail contract");
+    }
+
+    #[test]
+    fn indirect_tail_signature_mutation_fails_before_rc_mutation() {
+        let (mut ctx, module, trusted, call, _) = lowered_indirect_tail_contract();
+        let nil = core::nil(&mut ctx).as_type_ref();
+        let malformed = core::func(&mut ctx, nil, [nil]).as_type_ref();
+        ctx.op_mut(call)
+            .attributes
+            .insert(Symbol::new("sig"), Attribute::Type(malformed));
 
         assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
     }

--- a/crates/tribute-passes/src/native/ownership_summary.rs
+++ b/crates/tribute-passes/src/native/ownership_summary.rs
@@ -1,7 +1,12 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use tribute_core::{CallingConvention, get_calling_convention, get_indirect_call_signature};
+use tribute_core::calling_convention::get_physical_closure_environment_index;
+use tribute_core::{
+    CallingConvention, get_calling_convention, get_indirect_call_signature,
+    get_physical_closure_convention,
+};
+use tribute_ir::dialect::closure;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{adt, arith, clif, core, func, mem};
 use trunk_ir::ops::{DialectOp, DialectType};
@@ -65,6 +70,7 @@ pub struct TrustedCallContract {
     pub is_indirect: bool,
     direct_callee: Option<Symbol>,
     indirect_signature: Option<TypeRef>,
+    indirect_physical_closures: Option<Vec<Option<TypeRef>>>,
 }
 
 impl ParameterOwnership {
@@ -79,6 +85,7 @@ impl ParameterOwnership {
 pub struct TrustedOwnershipSummaries {
     summaries: HashMap<Symbol, Vec<ParameterOwnership>>,
     entry_contracts: HashMap<Symbol, Vec<RcOwnership>>,
+    entry_physical_closures: HashMap<Symbol, Vec<Option<TypeRef>>>,
     call_contracts: HashMap<i128, TrustedCallContract>,
 }
 
@@ -97,6 +104,7 @@ pub fn compute_and_attach(
         return Ok(TrustedOwnershipSummaries {
             summaries: HashMap::new(),
             entry_contracts: HashMap::new(),
+            entry_physical_closures: HashMap::new(),
             call_contracts: HashMap::new(),
         });
     };
@@ -131,7 +139,8 @@ pub fn compute_and_attach(
         let initial: Vec<ParameterOwnership> = parameters
             .iter()
             .map(|&parameter| {
-                if !ineligible.contains(&symbol) && lowers_to_anyref(ctx, parameter, type_converter)
+                if !ineligible.contains(&symbol)
+                    && lowers_to_rc_managed(ctx, parameter, type_converter)
                 {
                     ParameterOwnership::Borrowed
                 } else {
@@ -167,14 +176,17 @@ pub fn compute_and_attach(
     }
 
     let mut entry_contracts = HashMap::new();
+    let mut entry_physical_closures = HashMap::new();
     for (&symbol, &op) in &unique_functions {
         let function = func::Func::from_op(ctx, op).expect("collected func.func");
         let consuming_cps = is_defined_physical_cps_function(ctx, op);
-        let entries = entry_parameters(ctx, function.body(ctx))
-            .into_iter()
+        let parameters = entry_parameters(ctx, function.body(ctx));
+        let entries = parameters
+            .iter()
+            .copied()
             .enumerate()
             .map(|(index, parameter)| {
-                if !lowers_to_anyref(ctx, parameter, type_converter) {
+                if !lowers_to_rc_managed(ctx, parameter, type_converter) {
                     RcOwnership::Plain
                 } else if consuming_cps {
                     RcOwnership::Consumed
@@ -185,7 +197,15 @@ pub fn compute_and_attach(
                 }
             })
             .collect();
+        let physical_closures = parameters
+            .iter()
+            .map(|&parameter| {
+                let ty = ctx.value_ty(parameter);
+                type_is_proven_physical_closure(ctx, ty).then_some(ty)
+            })
+            .collect();
         entry_contracts.insert(symbol, entries);
+        entry_physical_closures.insert(symbol, physical_closures);
     }
 
     let mut pending_calls = Vec::new();
@@ -235,6 +255,7 @@ pub fn compute_and_attach(
     Ok(TrustedOwnershipSummaries {
         summaries,
         entry_contracts,
+        entry_physical_closures,
         call_contracts,
     })
 }
@@ -284,6 +305,30 @@ fn type_lowers_to_anyref(ctx: &mut IrContext, ty: TypeRef, type_converter: &Type
     data.dialect == Symbol::new("tribute_rt") && data.name == Symbol::new("anyref")
 }
 
+fn type_is_proven_physical_closure(ctx: &IrContext, ty: TypeRef) -> bool {
+    let Some(environment_index) = get_physical_closure_environment_index(ctx, ty) else {
+        return false;
+    };
+    if get_physical_closure_convention(ctx, ty).is_none() {
+        return false;
+    }
+    let Some(closure) = closure::Closure::from_type_ref(ctx, ty) else {
+        return false;
+    };
+    let Some(callable) = core::Func::from_type_ref(ctx, closure.func_type(ctx)) else {
+        return false;
+    };
+    environment_index <= callable.params(ctx).len()
+}
+
+fn type_lowers_to_rc_managed(
+    ctx: &mut IrContext,
+    ty: TypeRef,
+    type_converter: &TypeConverter,
+) -> bool {
+    type_lowers_to_anyref(ctx, ty, type_converter) || type_is_proven_physical_closure(ctx, ty)
+}
+
 fn lowered_indirect_signature(
     ctx: &mut IrContext,
     signature: TypeRef,
@@ -299,6 +344,20 @@ fn lowered_indirect_signature(
         .map(|&parameter| type_converter.convert_type_or_identity(ctx, parameter))
         .collect();
     Ok(core::func(ctx, return_type, parameter_types.iter().copied()).as_type_ref())
+}
+
+fn indirect_physical_closures(
+    ctx: &IrContext,
+    signature: TypeRef,
+) -> Result<Vec<Option<TypeRef>>, OwnershipContractError> {
+    let callable = core::Func::from_type_ref(ctx, signature).ok_or(OwnershipContractError(
+        "indirect proper-tail signature is not core.func",
+    ))?;
+    Ok(callable
+        .params(ctx)
+        .iter()
+        .map(|&parameter| type_is_proven_physical_closure(ctx, parameter).then_some(parameter))
+        .collect())
 }
 
 fn collect_call_contracts(
@@ -322,7 +381,7 @@ fn collect_call_contracts(
                 let arguments = ctx.op_operands(op)[usize::from(indirect)..].to_vec();
                 if arguments
                     .into_iter()
-                    .any(|argument| lowers_to_anyref(ctx, argument, type_converter))
+                    .any(|argument| lowers_to_rc_managed(ctx, argument, type_converter))
                 {
                     return Err(OwnershipContractError(
                         "RC proper-tail call lacks exact CPS provenance",
@@ -386,7 +445,7 @@ fn collect_call_contracts(
                     parameters
                         .iter()
                         .map(|&ty| {
-                            if type_lowers_to_anyref(ctx, ty, type_converter) {
+                            if type_lowers_to_rc_managed(ctx, ty, type_converter) {
                                 RcOwnership::Transfer
                             } else {
                                 RcOwnership::Plain
@@ -414,6 +473,13 @@ fn collect_call_contracts(
                                 .map(|signature| {
                                     lowered_indirect_signature(ctx, signature, type_converter)
                                 })
+                                .transpose()?
+                        } else {
+                            None
+                        },
+                        indirect_physical_closures: if indirect {
+                            get_indirect_call_signature(ctx, op)
+                                .map(|signature| indirect_physical_closures(ctx, signature))
                                 .transpose()?
                         } else {
                             None
@@ -519,6 +585,12 @@ impl TrustedOwnershipSummaries {
 
         let mut entry_contracts = HashMap::new();
         for (&symbol, expected) in &self.entry_contracts {
+            let physical_closures =
+                self.entry_physical_closures
+                    .get(&symbol)
+                    .ok_or(OwnershipContractError(
+                        "trusted physical entry provenance disappeared during func_to_clif",
+                    ))?;
             let ops = definitions.get(&symbol).ok_or(OwnershipContractError(
                 "trusted function disappeared during func_to_clif",
             ))?;
@@ -531,7 +603,7 @@ impl TrustedOwnershipSummaries {
                 OwnershipContractError("trusted function did not lower to clif.func")
             })?;
             let parameters = entry_parameters(ctx, function.body(ctx));
-            if parameters.len() != expected.len() {
+            if parameters.len() != expected.len() || physical_closures.len() != expected.len() {
                 return Err(OwnershipContractError(
                     "parameter entry contract arity changed during func_to_clif",
                 ));
@@ -544,9 +616,16 @@ impl TrustedOwnershipSummaries {
                 || (expected.iter().any(|entry| *entry != RcOwnership::Plain)
                     && (expected.contains(&RcOwnership::Consumed)
                         != is_defined_physical_cps_function(ctx, ops[0])))
-                || expected.iter().zip(parameters).any(|(entry, parameter)| {
-                    matches!(entry, RcOwnership::Plain) == is_anyref_value(ctx, parameter)
-                })
+                || expected.iter().zip(parameters).zip(physical_closures).any(
+                    |((entry, parameter), physical_closure)| match entry {
+                        RcOwnership::Plain => is_anyref_value(ctx, parameter),
+                        _ if is_anyref_value(ctx, parameter) => false,
+                        _ => {
+                            physical_closure.is_none()
+                                || !is_core_ptr_type(ctx, ctx.value_ty(parameter))
+                        }
+                    },
+                )
             {
                 return Err(OwnershipContractError(
                     "parameter entry contract changed during func_to_clif",
@@ -589,11 +668,13 @@ impl TrustedOwnershipSummaries {
             return Self {
                 summaries: HashMap::new(),
                 entry_contracts: HashMap::new(),
+                entry_physical_closures: HashMap::new(),
                 call_contracts: HashMap::new(),
             };
         };
         let mut summaries = HashMap::new();
         let mut entry_contracts = HashMap::new();
+        let mut entry_physical_closures = HashMap::new();
         let op_count = ctx.block(module_block).ops.len();
         for index in 0..op_count {
             let op = ctx.block(module_block).ops[index];
@@ -635,11 +716,13 @@ impl TrustedOwnershipSummaries {
                 RcOwnership::list_attribute(&entry_contract),
             );
             entry_contracts.insert(symbol, entry_contract);
+            entry_physical_closures.insert(symbol, vec![None; summary.len()]);
             summaries.insert(symbol, summary);
         }
         Self {
             summaries,
             entry_contracts,
+            entry_physical_closures,
             call_contracts: HashMap::new(),
         }
     }
@@ -717,16 +800,27 @@ fn collect_validated_call_contracts(
                     expected
                         .indirect_signature
                         .and_then(|signature| core::Func::from_type_ref(ctx, signature))
-                        .is_some_and(|callable| {
+                        .zip(expected.indirect_physical_closures.as_deref())
+                        .is_some_and(|(callable, physical_closures)| {
                             let parameters = callable.params(ctx);
                             parameters.len() == expected.actions.len()
-                                && parameters.iter().zip(&expected.actions).all(
-                                    |(&parameter, action)| match action {
-                                        RcOwnership::Plain => !is_anyref_type(ctx, parameter),
-                                        RcOwnership::Transfer => is_anyref_type(ctx, parameter),
+                                && physical_closures.len() == expected.actions.len()
+                                && parameters
+                                    .iter()
+                                    .zip(&expected.actions)
+                                    .zip(physical_closures)
+                                    .all(|((&parameter, action), physical_closure)| match action {
+                                        RcOwnership::Plain => {
+                                            !is_anyref_type(ctx, parameter)
+                                                && physical_closure.is_none()
+                                        }
+                                        RcOwnership::Transfer => {
+                                            is_anyref_type(ctx, parameter)
+                                                || (physical_closure.is_some()
+                                                    && is_core_ptr_type(ctx, parameter))
+                                        }
                                         _ => false,
-                                    },
-                                )
+                                    })
                         })
                 } else {
                     args.iter()
@@ -812,11 +906,17 @@ fn is_anyref_type(ctx: &IrContext, ty: TypeRef) -> bool {
     ty.dialect == Symbol::new("tribute_rt") && ty.name == Symbol::new("anyref")
 }
 
-fn lowers_to_anyref(ctx: &mut IrContext, value: ValueRef, type_converter: &TypeConverter) -> bool {
-    let original = ctx.value_ty(value);
-    let converted = type_converter.convert_type_or_identity(ctx, original);
-    let ty = ctx.types.get(converted);
-    ty.dialect == Symbol::new("tribute_rt") && ty.name == Symbol::new("anyref")
+fn is_core_ptr_type(ctx: &IrContext, ty: TypeRef) -> bool {
+    let ty = ctx.types.get(ty);
+    ty.dialect == Symbol::new("core") && ty.name == Symbol::new("ptr")
+}
+
+fn lowers_to_rc_managed(
+    ctx: &mut IrContext,
+    value: ValueRef,
+    type_converter: &TypeConverter,
+) -> bool {
+    type_lowers_to_rc_managed(ctx, ctx.value_ty(value), type_converter)
 }
 
 fn collect_escaping_function_symbols(
@@ -1267,6 +1367,54 @@ mod tests {
             &trusted,
         )
         .expect("adapted indirect tail transfer");
+    }
+
+    #[test]
+    fn indirect_tail_transfer_accepts_a_proven_closure_ptr_signature() {
+        let (mut ctx, module, trusted, call, id) = lowered_indirect_tail_contract_with(
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.nil)) {tribute.calling_convention = 2, tribute.closure_environment_index = 0}
+  func.func @caller(%0: core.ptr, %1: !handler) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1 {func.indirect_call_signature = core.func(core.nil, !handler), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let contract = trusted.call_contracts.get(&id).expect("trusted call");
+        assert_eq!(contract.actions, [RcOwnership::Transfer]);
+        let signature = ctx
+            .op(call)
+            .attributes
+            .get_type("sig")
+            .expect("lowered indirect signature");
+        let callable = core::Func::from_type_ref(&ctx, signature).expect("core.func signature");
+        assert!(is_core_ptr_type(&ctx, callable.params(&ctx)[0]));
+
+        insert_rc_with_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            &trusted,
+        )
+        .expect("proven closure indirect tail transfer");
+    }
+
+    #[test]
+    fn indirect_tail_closure_transfer_without_provenance_fails_closed() {
+        let (mut ctx, module, mut trusted, _call, id) = lowered_indirect_tail_contract_with(
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.nil)) {tribute.calling_convention = 2, tribute.closure_environment_index = 0}
+  func.func @caller(%0: core.ptr, %1: !handler) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %0, %1 {func.indirect_call_signature = core.func(core.nil, !handler), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        trusted
+            .call_contracts
+            .get_mut(&id)
+            .expect("trusted call")
+            .indirect_physical_closures = None;
+
+        assert_rc_rejects_unchanged(&mut ctx, module, &trusted);
     }
 
     #[test]

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -2135,6 +2135,10 @@ mod tests {
             output.contains("clif.return_call_indirect %0, %1"),
             "{output}"
         );
+        assert!(
+            output.contains("sig = core.func(core.nil, core.ptr)"),
+            "{output}"
+        );
         for body in output.split("clif.func").skip(1) {
             if body.contains("return_call") {
                 assert_eq!(

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -3,8 +3,9 @@
 //! Automatically inserts `tribute_rt.retain` and `tribute_rt.release` operations
 //! for `tribute_rt.anyref`-typed values in the native backend pipeline.
 //!
-//! Only `tribute_rt.anyref` values are RC-managed. Plain `core.ptr` values
-//! (function pointers, continuations, null sentinels) are not affected.
+//! `tribute_rt.anyref` values and convention-proven physical closures are
+//! RC-managed. Plain `core.ptr` values (function pointers, continuations,
+//! null sentinels) are not affected.
 //!
 //! ## Pipeline Position
 //!
@@ -79,6 +80,11 @@ fn is_anyref_type(ctx: &IrContext, ty: TypeRef) -> bool {
 /// Check if a value is an anyref type (RC-managed).
 fn is_anyref_value(ctx: &IrContext, value: ValueRef) -> bool {
     is_anyref_type(ctx, ctx.value_ty(value))
+}
+
+fn is_core_ptr_value(ctx: &IrContext, value: ValueRef) -> bool {
+    let data = ctx.types.get(ctx.value_ty(value));
+    data.dialect == Symbol::new("core") && data.name == Symbol::new("ptr")
 }
 
 /// Check if an op is a block terminator.
@@ -179,6 +185,23 @@ struct LivenessInfo {
 struct TemporaryBorrowInfo {
     borrowed: HashSet<ValueRef>,
     lifetime_dependencies: HashMap<ValueRef, ValueRef>,
+}
+
+impl TemporaryBorrowInfo {
+    fn extend(&mut self, other: Self) -> bool {
+        let changed = other
+            .borrowed
+            .iter()
+            .any(|value| !self.borrowed.contains(value))
+            || other
+                .lifetime_dependencies
+                .iter()
+                .any(|(value, owner)| self.lifetime_dependencies.get(value) != Some(owner));
+        self.borrowed.extend(other.borrowed);
+        self.lifetime_dependencies
+            .extend(other.lifetime_dependencies);
+        changed
+    }
 }
 
 struct RcBorrowInfo<'a> {
@@ -300,7 +323,7 @@ fn compute_use_def_sets(
         let mut defs = HashSet::new();
 
         for &arg_val in ctx.block_args(block) {
-            if is_anyref_type(ctx, ctx.value_ty(arg_val)) {
+            if ptr_values.contains(&arg_val) {
                 defs.insert(arg_val);
             }
         }
@@ -322,10 +345,7 @@ fn compute_use_def_sets(
                 });
             }
             for &result_val in ctx.op_results(op) {
-                if is_anyref_type(ctx, ctx.value_ty(result_val))
-                    && !is_static_ptr(ctx, result_val)
-                    && ptr_values.contains(&result_val)
-                {
+                if ptr_values.contains(&result_val) {
                     defs.insert(result_val);
                 }
             }
@@ -773,19 +793,49 @@ fn insert_rc_in_function(
     entry_contract: Option<&[RcOwnership]>,
     call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) {
+    let consumed_parameters: HashSet<ValueRef> = entry_contract
+        .into_iter()
+        .flat_map(|entries| entries.iter().enumerate())
+        .filter_map(|(index, entry)| {
+            (*entry == RcOwnership::Consumed)
+                .then(|| ctx.region(body).blocks.first())
+                .flatten()
+                .and_then(|&entry_block| ctx.block_args(entry_block).get(index).copied())
+        })
+        .collect();
     let mut ptr_values = collect_ptr_values(ctx, body);
+    // `func_to_clif` erases convention-proven physical closures to `core.ptr`.
+    // Their consumed entry contract is the exact provenance that keeps them in
+    // RC accounting; arbitrary pointer block arguments remain unmanaged.
+    ptr_values.extend(consumed_parameters.iter().copied());
 
     if ptr_values.is_empty() {
         return;
     }
 
+    let initial_ptr_alias_map = build_ptr_alias_map(ctx, body, &mut ptr_values);
+    let promoted_ptr_values = collect_adapted_tail_store_escapes(
+        ctx,
+        body,
+        &ptr_values,
+        &initial_ptr_alias_map,
+        call_contracts,
+    );
+    ptr_values.extend(promoted_ptr_values.iter().copied());
     let ptr_alias_map = build_ptr_alias_map(ctx, body, &mut ptr_values);
-    let temporary_borrows = match temporary_borrow_policy {
+    let mut temporary_borrows = match temporary_borrow_policy {
         TemporaryBorrowPolicy::Preserve => TemporaryBorrowInfo::default(),
         TemporaryBorrowPolicy::ElideProvenFieldBorrows => {
             analyze_temporary_borrows(ctx, body, &ptr_values, &ptr_alias_map, call_contracts)
         }
     };
+    temporary_borrows.extend(analyze_abi_adapted_indirect_tail_transfer_borrows(
+        ctx,
+        body,
+        &ptr_values,
+        &ptr_alias_map,
+        call_contracts,
+    ));
     let liveness = compute_liveness(
         ctx,
         body,
@@ -799,16 +849,6 @@ fn insert_rc_in_function(
             analyze_borrowed_parameters(ctx, function, body, trusted_summaries)
         }
     };
-    let consumed_parameters: HashSet<ValueRef> = entry_contract
-        .into_iter()
-        .flat_map(|entries| entries.iter().enumerate())
-        .filter_map(|(index, entry)| {
-            (*entry == RcOwnership::Consumed)
-                .then(|| ctx.region(body).blocks.first())
-                .flatten()
-                .and_then(|&entry_block| ctx.block_args(entry_block).get(index).copied())
-        })
-        .collect();
     borrowed_parameters.retain(|parameter| !consumed_parameters.contains(parameter));
 
     let blocks: Vec<BlockRef> = ctx.region(body).blocks.to_vec();
@@ -823,6 +863,7 @@ fn insert_rc_in_function(
             block,
             block_idx == 0,
             &ptr_values,
+            &promoted_ptr_values,
             &liveness,
             &ptr_alias_map,
             &borrow_info,
@@ -832,12 +873,152 @@ fn insert_rc_in_function(
     }
 }
 
+/// Promote only physical closure loads that are proven to feed a trusted
+/// indirect-tail transfer and whose otherwise-safe use chain stores that
+/// closure as a value. The store receives its own RC unit; arbitrary pointers
+/// and other escaping uses remain outside ownership accounting.
+fn collect_adapted_tail_store_escapes(
+    ctx: &IrContext,
+    body: RegionRef,
+    ptr_values: &HashSet<ValueRef>,
+    ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
+) -> HashSet<ValueRef> {
+    let dominance = DominatorTree::compute(ctx, body);
+    if !dominance.is_valid() {
+        return HashSet::new();
+    }
+
+    let known_owners = HashMap::new();
+    let mut promoted = HashSet::new();
+    for &block in &ctx.region(body).blocks {
+        if !dominance.is_reachable(block) {
+            continue;
+        }
+        for &op in &ctx.block(block).ops {
+            if !clif::Load::matches(ctx, op) || ctx.op_results(op).len() != 1 {
+                continue;
+            }
+            let loaded = ctx.op_result(op, 0);
+            if !is_core_ptr_value(ctx, loaded)
+                || !is_abi_adapted_indirect_tail_transfer(ctx, loaded, call_contracts)
+                || !has_store_value_use(ctx, loaded, &mut HashSet::new())
+            {
+                continue;
+            }
+            let Some(&address) = ctx.op_operands(op).first() else {
+                continue;
+            };
+            let Some(owner) = resolve_temporary_owner(
+                ctx,
+                address,
+                ptr_values,
+                ptr_alias_map,
+                &known_owners,
+                &mut HashSet::new(),
+            ) else {
+                continue;
+            };
+            if temporary_is_proven_borrowed(
+                ctx,
+                body,
+                op,
+                loaded,
+                owner,
+                &dominance,
+                call_contracts,
+                true,
+                true,
+            )
+            .is_some()
+            {
+                promoted.insert(loaded);
+            }
+        }
+    }
+    promoted
+}
+
+fn has_store_value_use(ctx: &IrContext, value: ValueRef, visited: &mut HashSet<ValueRef>) -> bool {
+    if !visited.insert(value) {
+        return false;
+    }
+    ctx.uses(value).iter().any(|use_| {
+        let op = use_.user;
+        let operand_index = use_.operand_index as usize;
+        (clif::Store::matches(ctx, op) && operand_index == 0)
+            || (core::UnrealizedConversionCast::matches(ctx, op)
+                && operand_index == 0
+                && ctx.op_operands(op).len() == 1
+                && ctx.op_results(op).len() == 1
+                && has_store_value_use(ctx, ctx.op_result(op, 0), visited))
+    })
+}
+
 fn analyze_temporary_borrows(
     ctx: &IrContext,
     body: RegionRef,
     ptr_values: &HashSet<ValueRef>,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
     call_contracts: &HashMap<OpRef, TrustedCallContract>,
+) -> TemporaryBorrowInfo {
+    let known_owners = HashMap::new();
+    analyze_eligible_temporary_borrows(
+        ctx,
+        body,
+        ptr_values,
+        ptr_alias_map,
+        call_contracts,
+        &known_owners,
+        is_anyref_value,
+        false,
+        false,
+    )
+}
+
+/// Analyze only physical pointer loads whose trusted indirect-tail contract
+/// requires a transferred RC unit. This correctness path is independent of
+/// optional field-borrow elision.
+fn analyze_abi_adapted_indirect_tail_transfer_borrows(
+    ctx: &IrContext,
+    body: RegionRef,
+    ptr_values: &HashSet<ValueRef>,
+    ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
+) -> TemporaryBorrowInfo {
+    let mut info = TemporaryBorrowInfo::default();
+    loop {
+        let discovered = analyze_eligible_temporary_borrows(
+            ctx,
+            body,
+            ptr_values,
+            ptr_alias_map,
+            call_contracts,
+            &info.lifetime_dependencies,
+            |ctx, temporary| {
+                !is_anyref_value(ctx, temporary)
+                    && is_abi_adapted_indirect_tail_transfer(ctx, temporary, call_contracts)
+            },
+            true,
+            false,
+        );
+        if !info.extend(discovered) {
+            return info;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_eligible_temporary_borrows(
+    ctx: &IrContext,
+    body: RegionRef,
+    ptr_values: &HashSet<ValueRef>,
+    ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
+    known_owners: &HashMap<ValueRef, ValueRef>,
+    is_eligible: impl Fn(&IrContext, ValueRef) -> bool,
+    follow_descendant_loads: bool,
+    allow_store_value: bool,
 ) -> TemporaryBorrowInfo {
     let dominance = DominatorTree::compute(ctx, body);
     if !dominance.is_valid() {
@@ -854,7 +1035,7 @@ fn analyze_temporary_borrows(
                 continue;
             }
             let temporary = ctx.op_result(op, 0);
-            if !is_anyref_value(ctx, temporary) {
+            if !is_eligible(ctx, temporary) {
                 continue;
             }
             let Some(&address) = ctx.op_operands(op).first() else {
@@ -865,6 +1046,7 @@ fn analyze_temporary_borrows(
                 address,
                 ptr_values,
                 ptr_alias_map,
+                known_owners,
                 &mut HashSet::new(),
             ) else {
                 continue;
@@ -877,10 +1059,13 @@ fn analyze_temporary_borrows(
                 owner,
                 &dominance,
                 call_contracts,
+                follow_descendant_loads,
+                allow_store_value,
             ) {
                 info.borrowed.insert(temporary);
                 info.lifetime_dependencies.insert(temporary, owner);
                 for alias in aliases {
+                    info.borrowed.insert(alias);
                     info.lifetime_dependencies.insert(alias, owner);
                 }
             }
@@ -889,11 +1074,69 @@ fn analyze_temporary_borrows(
     info
 }
 
+/// A physical `core.ptr` load may still carry an RC-managed value when the
+/// exact trusted indirect-tail signature classifies that operand as a transfer.
+/// Do not extend this exception to arbitrary pointer uses.
+fn is_abi_adapted_indirect_tail_transfer(
+    ctx: &IrContext,
+    value: ValueRef,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
+) -> bool {
+    fn reaches_transfer(
+        ctx: &IrContext,
+        value: ValueRef,
+        call_contracts: &HashMap<OpRef, TrustedCallContract>,
+        visited: &mut HashSet<ValueRef>,
+    ) -> bool {
+        if !visited.insert(value) {
+            return false;
+        }
+        ctx.uses(value).iter().any(|use_| {
+            let op = use_.user;
+            let operand_index = use_.operand_index as usize;
+            if core::UnrealizedConversionCast::matches(ctx, op)
+                && operand_index == 0
+                && ctx.op_operands(op).len() == 1
+                && ctx.op_results(op).len() == 1
+            {
+                return reaches_transfer(ctx, ctx.op_result(op, 0), call_contracts, visited);
+            }
+            if clif::Load::matches(ctx, op) && operand_index == 0 && ctx.op_results(op).len() == 1 {
+                let descendant = ctx.op_result(op, 0);
+                return (is_anyref_value(ctx, descendant) || is_core_ptr_value(ctx, descendant))
+                    && reaches_transfer(ctx, descendant, call_contracts, visited);
+            }
+            let Some(contract) = call_contracts.get(&op) else {
+                return false;
+            };
+            contract.is_tail
+                && contract.is_indirect
+                && operand_index
+                    .checked_sub(usize::from(contract.is_indirect))
+                    .and_then(|index| contract.actions.get(index))
+                    == Some(&RcOwnership::Transfer)
+        })
+    }
+
+    reaches_transfer(ctx, value, call_contracts, &mut HashSet::new())
+}
+
+fn is_trusted_indirect_tail_callee(
+    op: OpRef,
+    operand_index: usize,
+    call_contracts: &HashMap<OpRef, TrustedCallContract>,
+) -> bool {
+    call_contracts
+        .get(&op)
+        .is_some_and(|contract| contract.is_tail && contract.is_indirect && operand_index == 0)
+}
+
 fn resolve_temporary_owner(
     ctx: &IrContext,
     value: ValueRef,
     ptr_values: &HashSet<ValueRef>,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
+    known_owners: &HashMap<ValueRef, ValueRef>,
     visited: &mut HashSet<ValueRef>,
 ) -> Option<ValueRef> {
     if !visited.insert(value) {
@@ -902,8 +1145,18 @@ fn resolve_temporary_owner(
     if ptr_values.contains(&value) {
         return Some(value);
     }
+    if let Some(&owner) = known_owners.get(&value) {
+        return Some(owner);
+    }
     if let Some(&owner) = ptr_alias_map.get(&value) {
-        return resolve_temporary_owner(ctx, owner, ptr_values, ptr_alias_map, visited);
+        return resolve_temporary_owner(
+            ctx,
+            owner,
+            ptr_values,
+            ptr_alias_map,
+            known_owners,
+            visited,
+        );
     }
     let ValueDef::OpResult(defining_op, _) = ctx.value_def(value) else {
         return None;
@@ -912,11 +1165,19 @@ fn resolve_temporary_owner(
         || clif::Iadd::matches(ctx, defining_op)
     {
         let input = *ctx.op_operands(defining_op).first()?;
-        return resolve_temporary_owner(ctx, input, ptr_values, ptr_alias_map, visited);
+        return resolve_temporary_owner(
+            ctx,
+            input,
+            ptr_values,
+            ptr_alias_map,
+            known_owners,
+            visited,
+        );
     }
     None
 }
 
+#[allow(clippy::too_many_arguments)]
 fn temporary_is_proven_borrowed(
     ctx: &IrContext,
     body: RegionRef,
@@ -925,6 +1186,8 @@ fn temporary_is_proven_borrowed(
     owner: ValueRef,
     dominance: &DominatorTree,
     call_contracts: &HashMap<OpRef, TrustedCallContract>,
+    follow_descendant_loads: bool,
+    allow_store_value: bool,
 ) -> Option<Vec<ValueRef>> {
     let load_block = ctx.op(load).parent_block?;
     if !value_dominates_op(ctx, body, owner, load, dominance) {
@@ -942,6 +1205,8 @@ fn temporary_is_proven_borrowed(
         use_blocks: &mut use_blocks,
         aliases: &mut aliases,
         call_contracts,
+        follow_descendant_loads,
+        allow_store_value,
     };
     if !collector.collect(temporary) {
         return None;
@@ -986,6 +1251,8 @@ struct TemporaryUseCollector<'a> {
     use_blocks: &'a mut Vec<BlockRef>,
     aliases: &'a mut Vec<ValueRef>,
     call_contracts: &'a HashMap<OpRef, TrustedCallContract>,
+    follow_descendant_loads: bool,
+    allow_store_value: bool,
 }
 
 impl TemporaryUseCollector<'_> {
@@ -1016,7 +1283,26 @@ impl TemporaryUseCollector<'_> {
                 if !self.collect(alias) {
                     return false;
                 }
-            } else if !is_proven_temporary_use(self.ctx, user, operand_index, self.call_contracts) {
+            } else if self.follow_descendant_loads
+                && clif::Load::matches(self.ctx, user)
+                && operand_index == 0
+                && self.ctx.op_results(user).len() == 1
+            {
+                let descendant = self.ctx.op_result(user, 0);
+                if is_anyref_value(self.ctx, descendant) || is_core_ptr_value(self.ctx, descendant)
+                {
+                    self.aliases.push(descendant);
+                    if !self.collect(descendant) {
+                        return false;
+                    }
+                }
+            } else if !(self.allow_store_value
+                && clif::Store::matches(self.ctx, user)
+                && operand_index == 0)
+                && !(self.follow_descendant_loads
+                    && is_trusted_indirect_tail_callee(user, operand_index, self.call_contracts))
+                && !is_proven_temporary_use(self.ctx, user, operand_index, self.call_contracts)
+            {
                 return false;
             }
         }
@@ -1193,6 +1479,7 @@ fn insert_rc_in_block(
     block: BlockRef,
     is_entry: bool,
     ptr_values: &HashSet<ValueRef>,
+    promoted_ptr_values: &HashSet<ValueRef>,
     liveness: &LivenessInfo,
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
     borrow_info: &RcBorrowInfo<'_>,
@@ -1304,8 +1591,12 @@ fn insert_rc_in_block(
         if let Ok(_store_op) = clif::Store::from_op(ctx, op) {
             let operands = ctx.op_operands(op).to_vec();
             if let Some(&stored_val) = operands.first()
-                && is_anyref_value(ctx, stored_val)
-                && !is_static_ptr(ctx, stored_val)
+                && ((is_anyref_value(ctx, stored_val) && !is_static_ptr(ctx, stored_val))
+                    || promoted_ptr_values.contains(&stored_val)
+                    || consumed_parameters.contains(&stored_val)
+                    || ptr_alias_map.get(&stored_val).is_some_and(|owner| {
+                        promoted_ptr_values.contains(owner) || consumed_parameters.contains(owner)
+                    }))
             {
                 let op_loc = ctx.op(op).location;
                 let retain_op = tribute_rt::retain(ctx, op_loc, stored_val, ptr_ty);
@@ -1316,13 +1607,12 @@ fn insert_rc_in_block(
             }
         }
 
-        if clif::Load::matches(ctx, op) {
-            let result_ty = ctx.op_result_types(op).first().copied();
-            if result_ty.is_some_and(|ty| is_anyref_type(ctx, ty)) {
-                let load_result = ctx.op_result(op, 0);
-                if borrow_info.temporaries.contains(&load_result) {
-                    continue;
-                }
+        if clif::Load::matches(ctx, op) && ctx.op_results(op).len() == 1 {
+            let load_result = ctx.op_result(op, 0);
+            if ((is_anyref_value(ctx, load_result) && !is_static_ptr(ctx, load_result))
+                || promoted_ptr_values.contains(&load_result))
+                && !borrow_info.temporaries.contains(&load_result)
+            {
                 let op_loc = ctx.op(op).location;
                 let retain_op = tribute_rt::retain(ctx, op_loc, load_result, ptr_ty);
                 plan.after
@@ -2181,6 +2471,75 @@ mod tests {
     }
 
     #[test]
+    fn consumed_physical_entry_retain_per_owning_store() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.nil)) {tribute.calling_convention = 2, tribute.closure_environment_index = 0}
+  func.func @producer(%0: core.i64, %1: core.i64, %2: core.i64, %3: core.i64, %4: !handler) -> core.nil attributes {tribute.calling_convention = 2} {
+    %5 = clif.iconst {value = 32} : core.i64
+    %6 = clif.call %5 {callee = @__tribute_alloc} : core.ptr
+    clif.store %4, %6 {offset = 24}
+    %7 = clif.call %5 {callee = @__tribute_alloc} : core.ptr
+    clif.store %4, %7 {offset = 24}
+    %8 = core.unrealized_conversion_cast %6 : !handler
+    clif.store %8, %7 {offset = 40}
+    func.unreachable
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("consumed physical entry stores");
+        let producer = output
+            .split("sym_name = @producer")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let stores: Vec<_> = producer
+            .match_indices("clif.store %4,")
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(stores.len(), 2, "{producer}");
+        assert_eq!(producer.matches("offset = 40").count(), 1, "{producer}");
+        let retains: Vec<_> = producer
+            .match_indices("tribute_rt.retain %4")
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(retains.len(), 2, "{producer}");
+        assert!(
+            retains[0] < stores[0] && stores[0] < retains[1] && retains[1] < stores[1],
+            "{producer}"
+        );
+        let release = producer
+            .find("tribute_rt.release %4")
+            .unwrap_or_else(|| panic!("{producer}"));
+        assert!(stores[1] < release, "{producer}");
+    }
+
+    #[test]
+    fn plain_physical_entry_store_does_not_retain_core_ptr() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @producer(%0: core.i64, %1: core.i64, %2: core.i64, %3: core.i64, %4: core.ptr) -> core.nil attributes {tribute.calling_convention = 2} {
+    %5 = clif.iconst {value = 32} : core.i64
+    %6 = clif.call %5 {callee = @__tribute_alloc} : core.ptr
+    clif.store %4, %6 {offset = 24}
+    %7 = clif.call %5 {callee = @__tribute_alloc} : core.ptr
+    clif.store %4, %7 {offset = 24}
+    clif.store %6, %7 {offset = 40}
+    func.unreachable
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("plain physical entry stores");
+        let producer = output
+            .split("sym_name = @producer")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        assert!(!producer.contains("tribute_rt.retain %4"), "{producer}");
+        assert!(!producer.contains("tribute_rt.release %4"), "{producer}");
+    }
+
+    #[test]
     fn tail_transfer_multiplicity_acquires_only_additional_units() {
         let output = run_trusted_cps_pass(
             r#"core.module @test {
@@ -2237,6 +2596,227 @@ mod tests {
             .find("clif.return_call %2")
             .unwrap_or_else(|| panic!("{caller}"));
         assert!(retain < release && release < tail, "{caller}");
+        assert!(!caller[tail..].contains("tribute_rt."), "{caller}");
+    }
+
+    #[test]
+    fn borrowed_indirect_tail_alias_operand_is_acquired_before_untransferred_owner_cleanup() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    clif.store %1, %1 {offset = 16}
+    %2 = core.unrealized_conversion_cast %1 : core.ptr
+    %3 = clif.load %2 {offset = 8} : core.ptr
+    func.tail_call_indirect %0, %3 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("borrowed indirect tail acquisition");
+        let caller = output
+            .split("sym_name = @caller")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let load = caller
+            .lines()
+            .find(|line| line.contains("clif.load"))
+            .unwrap_or_else(|| panic!("{caller}"));
+        let loaded = load
+            .split_once(" = ")
+            .map(|(value, _)| value.trim())
+            .unwrap_or_else(|| panic!("{caller}"));
+        let retain_op = format!("tribute_rt.retain {loaded}");
+        let retain = caller
+            .find(&retain_op)
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert_eq!(caller.matches(&retain_op).count(), 1, "{caller}");
+        let release = caller
+            .find("tribute_rt.release %1")
+            .unwrap_or_else(|| panic!("{caller}"));
+        let tail_op = format!("clif.return_call_indirect %0, {loaded}");
+        let tail = caller.find(&tail_op).unwrap_or_else(|| panic!("{caller}"));
+        let load = caller
+            .find("clif.load")
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert!(
+            load < retain && retain < release && release < tail,
+            "{caller}"
+        );
+        assert!(!caller[tail..].contains("tribute_rt."), "{caller}");
+    }
+
+    #[test]
+    fn nested_borrowed_indirect_tail_operand_keeps_dispatcher_alive() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    clif.store %0, %0 {offset = 24}
+    %1 = core.unrealized_conversion_cast %0 : core.ptr
+    %2 = clif.load %1 {offset = 16} : core.ptr
+    %3 = core.unrealized_conversion_cast %2 : core.ptr
+    %4 = clif.load %3 {offset = 0} : core.ptr
+    %5 = clif.load %3 {offset = 8} : core.ptr
+    func.tail_call_indirect %4, %5 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("nested borrowed indirect tail acquisition");
+        let caller = output
+            .split("sym_name = @caller")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let loaded_value = |offset| {
+            caller
+                .lines()
+                .find(|line| line.contains("clif.load") && line.contains(offset))
+                .and_then(|line| line.split_once(" = ").map(|(value, _)| value.trim()))
+                .unwrap_or_else(|| panic!("{caller}"))
+        };
+        let dispatcher = loaded_value("offset = 16");
+        let code = loaded_value("offset = 0");
+        let environment = loaded_value("offset = 8");
+        let retain_op = format!("tribute_rt.retain {environment}");
+        let retain = caller
+            .find(&retain_op)
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert_eq!(caller.matches(&retain_op).count(), 1, "{caller}");
+        assert!(
+            !caller.contains(&format!("tribute_rt.retain {dispatcher}")),
+            "{caller}"
+        );
+        let release = caller
+            .find("tribute_rt.release %0")
+            .unwrap_or_else(|| panic!("{caller}"));
+        let tail_op = format!("clif.return_call_indirect {code}, {environment}");
+        let tail = caller.find(&tail_op).unwrap_or_else(|| panic!("{caller}"));
+        let environment_load = caller
+            .find("offset = 8")
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert!(
+            environment_load < retain && retain < release && release < tail,
+            "{caller}"
+        );
+        assert!(!caller[tail..].contains("tribute_rt."), "{caller}");
+    }
+
+    #[test]
+    fn stored_borrowed_dispatcher_keeps_nested_tail_operands_alive() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    %1 = clif.load %0 {offset = 24} : core.ptr
+    %2 = clif.iconst {value = 32} : core.i64
+    %3 = clif.call %2 {callee = @__tribute_alloc} : core.ptr
+    clif.store %1, %3 {offset = 24}
+    %4 = clif.load %1 {offset = 0} : core.i64
+    %5 = clif.load %1 {offset = 8} : core.ptr
+    func.tail_call_indirect %4, %5 {func.indirect_call_signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("stored borrowed dispatcher acquisition");
+        let caller = output
+            .split("sym_name = @caller")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let loaded_value = |offset| {
+            caller
+                .lines()
+                .find(|line| line.contains("clif.load") && line.contains(offset))
+                .and_then(|line| line.split_once(" = ").map(|(value, _)| value.trim()))
+                .unwrap_or_else(|| panic!("{caller}"))
+        };
+        let dispatcher = loaded_value("offset = 24");
+        let code = loaded_value("offset = 0");
+        let environment = loaded_value("offset = 8");
+        let dispatcher_retain = format!("tribute_rt.retain {dispatcher}");
+        let dispatcher_load = caller
+            .find("offset = 24")
+            .unwrap_or_else(|| panic!("{caller}"));
+        let root_release = caller
+            .find("tribute_rt.release %0")
+            .unwrap_or_else(|| panic!("{caller}"));
+        let environment_retain = format!("tribute_rt.retain {environment}");
+        let environment_retain = caller
+            .find(&environment_retain)
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert_eq!(caller.matches(&dispatcher_retain).count(), 2, "{caller}");
+        let first_dispatcher_retain = caller
+            .find(&dispatcher_retain)
+            .unwrap_or_else(|| panic!("{caller}"));
+        let dispatcher_release = caller
+            .find(&format!("tribute_rt.release {dispatcher}"))
+            .unwrap_or_else(|| panic!("{caller}"));
+        let tail_op = format!("clif.return_call_indirect {code}, {environment}");
+        let tail = caller.find(&tail_op).unwrap_or_else(|| panic!("{caller}"));
+        assert!(
+            dispatcher_load < first_dispatcher_retain
+                && first_dispatcher_retain < root_release
+                && environment_retain < dispatcher_release
+                && dispatcher_release < tail,
+            "{caller}"
+        );
+        assert!(!caller[tail..].contains("tribute_rt."), "{caller}");
+    }
+
+    #[test]
+    fn plain_indirect_tail_store_does_not_promote_core_ptr() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @caller(%0: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    %1 = clif.load %0 {offset = 24} : core.ptr
+    %2 = clif.iconst {value = 32} : core.i64
+    %3 = clif.call %2 {callee = @__tribute_alloc} : core.ptr
+    clif.store %1, %3 {offset = 24}
+    %4 = clif.load %1 {offset = 0} : core.i64
+    %5 = clif.load %1 {offset = 8} : core.ptr
+    func.tail_call_indirect %4, %5 {func.indirect_call_signature = core.func(core.nil, core.ptr), tribute.calling_convention = 2}
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("plain stored dispatcher stays unmanaged");
+        let caller = output
+            .split("sym_name = @caller")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let dispatcher = caller
+            .lines()
+            .find(|line| line.contains("clif.load") && line.contains("offset = 24"))
+            .and_then(|line| line.split_once(" = ").map(|(value, _)| value.trim()))
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert!(
+            !caller.contains(&format!("tribute_rt.retain {dispatcher}")),
+            "{caller}"
+        );
+    }
+
+    #[test]
+    fn indirect_tail_plain_ptr_operand_preserves_loaded_anyref_ownership() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @caller(%0: core.ptr, %1: tribute_rt.anyref) -> core.nil attributes {tribute.calling_convention = 2} {
+    %2 = clif.load %1 {offset = 8} : tribute_rt.anyref
+    %3 = core.unrealized_conversion_cast %2 : core.ptr
+    func.tail_call_indirect %0, %3 {func.indirect_call_signature = core.func(core.nil, core.ptr), tribute.calling_convention = 2}
+  }
+}"#,
+            TemporaryBorrowPolicy::ElideProvenFieldBorrows,
+        )
+        .expect("plain indirect tail preserves loaded ownership");
+        let caller = output
+            .split("sym_name = @caller")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let load = caller
+            .find("clif.load")
+            .unwrap_or_else(|| panic!("{caller}"));
+        let tail = caller
+            .find("clif.return_call_indirect")
+            .unwrap_or_else(|| panic!("{caller}"));
+        assert!(caller[load..tail].contains("tribute_rt.retain"), "{caller}");
         assert!(!caller[tail..].contains("tribute_rt."), "{caller}");
     }
 

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -527,8 +527,6 @@ fn insert_rc_impl(
             call_contracts: HashMap::new(),
         }
     };
-    let physical_closure_values: HashSet<ValueRef> =
-        trusted.physical_closure_values.values().copied().collect();
     let borrow_safe_functions = borrow_safe_functions(ctx, &module_ops);
 
     for op in &module_ops {
@@ -543,6 +541,11 @@ fn insert_rc_impl(
             } else {
                 BorrowedParameterPolicy::Preserve
             };
+            let physical_closure_values = trusted
+                .physical_closure_values
+                .get(&sym)
+                .cloned()
+                .unwrap_or_default();
             insert_rc_in_function(
                 ctx,
                 sym,
@@ -2653,6 +2656,72 @@ mod tests {
             .unwrap_or_else(|| panic!("{factory}"));
         assert!(store < release, "{factory}");
         assert!(!factory.contains("return_call"), "{factory}");
+    }
+
+    #[test]
+    fn proven_physical_closure_field_values_stay_in_their_function() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.never, tribute_rt.anyref)) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  !frame = adt.struct(!handler) {fields = [[@dispatch, !handler]], name = @Frame}
+  func.func @capture(%0: !frame) -> core.nil attributes {tribute.calling_convention = 0} {
+    %1 = adt.struct_get %0 {field = 0, type = !frame} : !handler
+    %2 = clif.iconst {value = 32} : core.i64
+    %3 = clif.call %2 {callee = @__tribute_alloc} : core.ptr
+    clif.store %1, %3 {offset = 24}
+    func.unreachable
+  }
+  func.func @unrelated(%0: core.ptr) -> core.nil attributes {tribute.calling_convention = 0} {
+    func.unreachable
+  }
+}"#,
+        );
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let trusted = compute_and_attach(&mut ctx, module, &type_converter)
+            .expect("physical closure field contract");
+        func_to_clif::lower(&mut ctx, module, type_converter).expect("func_to_clif");
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        adt_to_clif::lower(&mut ctx, module, type_converter).expect("adt_to_clif");
+        let module_ops = ctx
+            .block(module.first_block(&ctx).expect("module body"))
+            .ops
+            .to_vec();
+        let validated = trusted
+            .validated_for_clif(&ctx, &module_ops)
+            .expect("validated physical field contract");
+        assert_eq!(validated.physical_closure_values.len(), 1);
+        assert_eq!(
+            validated.physical_closure_values[&Symbol::new("capture")].len(),
+            1
+        );
+        assert!(
+            !validated
+                .physical_closure_values
+                .contains_key(&Symbol::new("unrelated"))
+        );
+
+        insert_rc_with_policies_and_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            TemporaryBorrowPolicy::Preserve,
+            &trusted,
+        )
+        .expect("function-local physical closure accounting");
+        let output = print_module(&ctx, module.op());
+        let capture = output
+            .split("sym_name = @capture")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        assert_eq!(capture.matches("tribute_rt.retain").count(), 2, "{capture}");
+        let unrelated = output
+            .split("sym_name = @unrelated")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        assert!(!unrelated.contains("tribute_rt.retain"), "{unrelated}");
+        assert!(!unrelated.contains("tribute_rt.release"), "{unrelated}");
     }
 
     #[test]

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -522,6 +522,7 @@ fn insert_rc_impl(
         ValidatedOwnershipContracts {
             summaries: HashMap::new(),
             entry_contracts: HashMap::new(),
+            entry_physical_closures: HashMap::new(),
             call_contracts: HashMap::new(),
         }
     };
@@ -547,6 +548,7 @@ fn insert_rc_impl(
                 temporary_borrows,
                 &trusted.summaries,
                 trusted.entry_contracts.get(&sym).map(Vec::as_slice),
+                trusted.entry_physical_closures.get(&sym).map(Vec::as_slice),
                 &trusted.call_contracts,
             );
         }
@@ -791,6 +793,7 @@ fn insert_rc_in_function(
     temporary_borrow_policy: TemporaryBorrowPolicy,
     trusted_summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
     entry_contract: Option<&[RcOwnership]>,
+    entry_physical_closures: Option<&[Option<TypeRef>]>,
     call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) {
     let consumed_parameters: HashSet<ValueRef> = entry_contract
@@ -803,11 +806,25 @@ fn insert_rc_in_function(
                 .and_then(|&entry_block| ctx.block_args(entry_block).get(index).copied())
         })
         .collect();
+    let retained_physical_parameters: HashSet<ValueRef> = entry_contract
+        .zip(entry_physical_closures)
+        .into_iter()
+        .flat_map(|(entries, physical_closures)| entries.iter().zip(physical_closures).enumerate())
+        .filter_map(|(index, (entry, physical_closure))| {
+            (*entry == RcOwnership::Retained && physical_closure.is_some())
+                .then(|| ctx.region(body).blocks.first())
+                .flatten()
+                .and_then(|&entry_block| ctx.block_args(entry_block).get(index).copied())
+                .filter(|&parameter| is_core_ptr_value(ctx, parameter))
+        })
+        .collect();
     let mut ptr_values = collect_ptr_values(ctx, body);
     // `func_to_clif` erases convention-proven physical closures to `core.ptr`.
-    // Their consumed entry contract is the exact provenance that keeps them in
-    // RC accounting; arbitrary pointer block arguments remain unmanaged.
+    // Their validated consumed or retained entry contract is the exact
+    // provenance that keeps them in RC accounting; arbitrary pointer block
+    // arguments remain unmanaged.
     ptr_values.extend(consumed_parameters.iter().copied());
+    ptr_values.extend(retained_physical_parameters.iter().copied());
 
     if ptr_values.is_empty() {
         return;
@@ -868,6 +885,7 @@ fn insert_rc_in_function(
             &ptr_alias_map,
             &borrow_info,
             &consumed_parameters,
+            &retained_physical_parameters,
             call_contracts,
         );
     }
@@ -1484,6 +1502,7 @@ fn insert_rc_in_block(
     ptr_alias_map: &HashMap<ValueRef, ValueRef>,
     borrow_info: &RcBorrowInfo<'_>,
     consumed_parameters: &HashSet<ValueRef>,
+    retained_physical_parameters: &HashSet<ValueRef>,
     call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) {
     let ops: Vec<OpRef> = ctx.block(block).ops.to_vec();
@@ -1576,9 +1595,10 @@ fn insert_rc_in_block(
     if is_entry {
         let args: Vec<ValueRef> = ctx.block_args(block).to_vec();
         for arg_val in args {
-            if is_anyref_type(ctx, ctx.value_ty(arg_val))
+            if (is_anyref_type(ctx, ctx.value_ty(arg_val))
                 && !borrow_info.parameters.contains(&arg_val)
-                && !consumed_parameters.contains(&arg_val)
+                && !consumed_parameters.contains(&arg_val))
+                || retained_physical_parameters.contains(&arg_val)
             {
                 let retain_op = tribute_rt::retain(ctx, loc, arg_val, ptr_ty);
                 plan.at_start.push(retain_op.op_ref());
@@ -1594,8 +1614,11 @@ fn insert_rc_in_block(
                 && ((is_anyref_value(ctx, stored_val) && !is_static_ptr(ctx, stored_val))
                     || promoted_ptr_values.contains(&stored_val)
                     || consumed_parameters.contains(&stored_val)
+                    || retained_physical_parameters.contains(&stored_val)
                     || ptr_alias_map.get(&stored_val).is_some_and(|owner| {
-                        promoted_ptr_values.contains(owner) || consumed_parameters.contains(owner)
+                        promoted_ptr_values.contains(owner)
+                            || consumed_parameters.contains(owner)
+                            || retained_physical_parameters.contains(owner)
                     }))
             {
                 let op_loc = ctx.op(op).location;
@@ -2515,10 +2538,58 @@ mod tests {
     }
 
     #[test]
-    fn plain_physical_entry_store_does_not_retain_core_ptr() {
+    fn retained_physical_entry_retain_per_owning_store() {
         let output = run_trusted_cps_pass(
             r#"core.module @test {
-  func.func @producer(%0: core.i64, %1: core.i64, %2: core.i64, %3: core.i64, %4: core.ptr) -> core.nil attributes {tribute.calling_convention = 2} {
+  !completion = closure.closure(core.func(core.nil)) {tribute.calling_convention = 2, tribute.closure_environment_index = 0}
+  !handler = closure.closure(core.func(core.never, tribute_rt.anyref)) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  !dispatch = closure.closure(core.func(core.never, tribute_rt.anyref)) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  func.func @producer(%0: tribute_rt.anyref, %1: core.ptr, %2: core.i32, %3: !completion, %4: !handler) -> !dispatch attributes {tribute.calling_convention = 0} {
+    %5 = clif.iconst {value = 32} : core.i64
+    %6 = clif.call %5 {callee = @__tribute_alloc} : core.ptr
+    clif.store %4, %6 {offset = 24}
+    %7 = clif.call %5 {callee = @__tribute_alloc} : core.ptr
+    clif.store %4, %7 {offset = 24}
+    %8 = core.unrealized_conversion_cast %6 : !handler
+    clif.store %8, %7 {offset = 40}
+    func.unreachable
+  }
+}"#,
+            TemporaryBorrowPolicy::Preserve,
+        )
+        .expect("retained physical entry stores");
+        let producer = output
+            .split("sym_name = @producer")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let stores: Vec<_> = producer
+            .match_indices("clif.store %4,")
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(stores.len(), 2, "{producer}");
+        let retains: Vec<_> = producer
+            .match_indices("tribute_rt.retain %4")
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(retains.len(), 3, "{producer}");
+        assert!(
+            retains[0] < retains[1]
+                && retains[1] < stores[0]
+                && stores[0] < retains[2]
+                && retains[2] < stores[1],
+            "{producer}"
+        );
+        let release = producer
+            .find("tribute_rt.release %4")
+            .unwrap_or_else(|| panic!("{producer}"));
+        assert!(stores[1] < release, "{producer}");
+    }
+
+    #[test]
+    fn plain_direct_entry_store_does_not_retain_core_ptr() {
+        let output = run_trusted_cps_pass(
+            r#"core.module @test {
+  func.func @producer(%0: core.i64, %1: core.i64, %2: core.i64, %3: core.i64, %4: core.ptr) -> core.nil attributes {tribute.calling_convention = 0} {
     %5 = clif.iconst {value = 32} : core.i64
     %6 = clif.call %5 {callee = @__tribute_alloc} : core.ptr
     clif.store %4, %6 {offset = 24}
@@ -2530,7 +2601,7 @@ mod tests {
 }"#,
             TemporaryBorrowPolicy::Preserve,
         )
-        .expect("plain physical entry stores");
+        .expect("plain direct entry stores");
         let producer = output
             .split("sym_name = @producer")
             .nth(1)

--- a/crates/tribute-passes/src/native/rc_insertion.rs
+++ b/crates/tribute-passes/src/native/rc_insertion.rs
@@ -48,9 +48,9 @@ use tribute_ir::dialect::tribute_rt;
 
 use super::ownership_summary::{
     BorrowedUse, BorrowedUseKind, CALL_ARGUMENT_OWNERSHIP_ATTR, OWNERSHIP_CONTRACT_ID_ATTR,
-    OwnershipContractError, PARAMETER_ENTRY_OWNERSHIP_ATTR, ParameterOwnership, RcOwnership,
-    TrustedCallContract, TrustedOwnershipSummaries, ValidatedOwnershipContracts,
-    classify_borrowed_use,
+    OwnershipContractError, PARAMETER_ENTRY_OWNERSHIP_ATTR, PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR,
+    ParameterOwnership, RcOwnership, TrustedCallContract, TrustedOwnershipSummaries,
+    ValidatedOwnershipContracts, classify_borrowed_use,
 };
 
 pub type RcInsertionError = OwnershipContractError;
@@ -523,9 +523,12 @@ fn insert_rc_impl(
             summaries: HashMap::new(),
             entry_contracts: HashMap::new(),
             entry_physical_closures: HashMap::new(),
+            physical_closure_values: HashMap::new(),
             call_contracts: HashMap::new(),
         }
     };
+    let physical_closure_values: HashSet<ValueRef> =
+        trusted.physical_closure_values.values().copied().collect();
     let borrow_safe_functions = borrow_safe_functions(ctx, &module_ops);
 
     for op in &module_ops {
@@ -549,6 +552,7 @@ fn insert_rc_impl(
                 &trusted.summaries,
                 trusted.entry_contracts.get(&sym).map(Vec::as_slice),
                 trusted.entry_physical_closures.get(&sym).map(Vec::as_slice),
+                &physical_closure_values,
                 &trusted.call_contracts,
             );
         }
@@ -568,6 +572,7 @@ fn clear_contract_metadata(ctx: &mut IrContext, op: OpRef) {
     attributes.remove(PARAMETER_ENTRY_OWNERSHIP_ATTR);
     attributes.remove(CALL_ARGUMENT_OWNERSHIP_ATTR);
     attributes.remove(OWNERSHIP_CONTRACT_ID_ATTR);
+    attributes.remove(PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR);
     for region in regions {
         let blocks = ctx.region(region).blocks.clone();
         for block in blocks {
@@ -794,6 +799,7 @@ fn insert_rc_in_function(
     trusted_summaries: &HashMap<Symbol, Vec<ParameterOwnership>>,
     entry_contract: Option<&[RcOwnership]>,
     entry_physical_closures: Option<&[Option<TypeRef>]>,
+    physical_closure_values: &HashSet<ValueRef>,
     call_contracts: &HashMap<OpRef, TrustedCallContract>,
 ) {
     let consumed_parameters: HashSet<ValueRef> = entry_contract
@@ -825,19 +831,21 @@ fn insert_rc_in_function(
     // arguments remain unmanaged.
     ptr_values.extend(consumed_parameters.iter().copied());
     ptr_values.extend(retained_physical_parameters.iter().copied());
+    ptr_values.extend(physical_closure_values.iter().copied());
 
     if ptr_values.is_empty() {
         return;
     }
 
     let initial_ptr_alias_map = build_ptr_alias_map(ctx, body, &mut ptr_values);
-    let promoted_ptr_values = collect_adapted_tail_store_escapes(
+    let mut promoted_ptr_values = collect_adapted_tail_store_escapes(
         ctx,
         body,
         &ptr_values,
         &initial_ptr_alias_map,
         call_contracts,
     );
+    promoted_ptr_values.extend(physical_closure_values.iter().copied());
     ptr_values.extend(promoted_ptr_values.iter().copied());
     let ptr_alias_map = build_ptr_alias_map(ctx, body, &mut ptr_values);
     let mut temporary_borrows = match temporary_borrow_policy {
@@ -1778,7 +1786,7 @@ mod tests {
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
     use trunk_ir::validation::validate_use_chains;
-    use trunk_ir_cranelift_backend::passes::func_to_clif;
+    use trunk_ir_cranelift_backend::passes::{adt_to_clif, func_to_clif};
 
     fn run_pass(ir: &str) -> String {
         run_pass_with_policy(ir, BorrowedParameterPolicy::Preserve)
@@ -1845,6 +1853,26 @@ mod tests {
             module,
             BorrowedParameterPolicy::ElideProvenBorrowed,
             temporary_policy,
+            &trusted,
+        )
+        .map_err(|error| error.to_string())?;
+        Ok(print_module(&ctx, module.op()))
+    }
+
+    fn run_trusted_native_rc_pass(ir: &str) -> Result<String, String> {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        let trusted = compute_and_attach(&mut ctx, module, &type_converter)
+            .map_err(|error| error.to_string())?;
+        func_to_clif::lower(&mut ctx, module, type_converter).map_err(|error| error.to_string())?;
+        let (type_converter, _) = native_type_converter(&mut ctx);
+        adt_to_clif::lower(&mut ctx, module, type_converter).map_err(|error| error.to_string())?;
+        insert_rc_with_policies_and_trusted_summaries(
+            &mut ctx,
+            module,
+            BorrowedParameterPolicy::ElideProvenBorrowed,
+            TemporaryBorrowPolicy::Preserve,
             &trusted,
         )
         .map_err(|error| error.to_string())?;
@@ -2583,6 +2611,71 @@ mod tests {
             .find("tribute_rt.release %4")
             .unwrap_or_else(|| panic!("{producer}"));
         assert!(stores[1] < release, "{producer}");
+    }
+
+    #[test]
+    fn proven_physical_closure_field_load_retain_per_owning_store() {
+        let output = run_trusted_native_rc_pass(
+            r#"core.module @test {
+  !handler = closure.closure(core.func(core.never, tribute_rt.anyref)) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+  !frame = adt.struct(!handler) {fields = [[@dispatch, !handler]], name = @Frame}
+  func.func @factory(%0: !frame) -> core.nil attributes {tribute.calling_convention = 0} {
+    %1 = adt.struct_get %0 {field = 0, type = !frame} : !handler
+    %2 = clif.iconst {value = 32} : core.i64
+    %3 = clif.call %2 {callee = @__tribute_alloc} : core.ptr
+    clif.store %1, %3 {offset = 24}
+    func.unreachable
+  }
+}"#,
+        )
+        .expect("proven physical closure field capture");
+        let factory = output
+            .split("sym_name = @factory")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        let load = factory
+            .find("clif.load")
+            .unwrap_or_else(|| panic!("{factory}"));
+        let store = factory
+            .find("clif.store")
+            .unwrap_or_else(|| panic!("{factory}"));
+        let retains: Vec<_> = factory
+            .match_indices("tribute_rt.retain")
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(retains.len(), 2, "{factory}");
+        assert!(
+            load < retains[0] && retains[0] < retains[1] && retains[1] < store,
+            "{factory}"
+        );
+        let release = factory
+            .find("tribute_rt.release")
+            .unwrap_or_else(|| panic!("{factory}"));
+        assert!(store < release, "{factory}");
+        assert!(!factory.contains("return_call"), "{factory}");
+    }
+
+    #[test]
+    fn plain_core_ptr_field_load_capture_remains_unmanaged() {
+        let output = run_trusted_native_rc_pass(
+            r#"core.module @test {
+  !frame = adt.struct(core.ptr) {fields = [[@dispatch, core.ptr]], name = @Frame}
+  func.func @factory(%0: !frame) -> core.nil attributes {tribute.calling_convention = 0} {
+    %1 = adt.struct_get %0 {field = 0, type = !frame} : core.ptr
+    %2 = clif.iconst {value = 32} : core.i64
+    %3 = clif.call %2 {callee = @__tribute_alloc} : core.ptr
+    clif.store %1, %3 {offset = 24}
+    func.unreachable
+  }
+}"#,
+        )
+        .expect("plain pointer field capture");
+        let factory = output
+            .split("sym_name = @factory")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{output}"));
+        assert!(!factory.contains("tribute_rt.retain"), "{factory}");
+        assert!(!factory.contains("tribute_rt.release"), "{factory}");
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/adt_to_clif.rs
@@ -39,6 +39,9 @@ use trunk_ir::rewrite::{
 };
 use trunk_ir::types::TypeDataBuilder;
 
+const PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR: &str =
+    "tribute.rc.physical_closure_value_provenance_v1";
+
 /// Lower ADT operations to clif dialect.
 ///
 /// This is a partial lowering: struct access and reference operations are converted.
@@ -131,6 +134,17 @@ impl RewritePattern for StructGetPattern {
         let result_ty = tc.convert_type_or_identity(ctx, result_ty);
 
         let load_op = clif::load(ctx, loc, ref_val, result_ty, offset);
+        if let Some(provenance) = ctx
+            .op(op)
+            .attributes
+            .get(PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR)
+            .cloned()
+        {
+            ctx.op_mut(load_op.op_ref()).attributes.insert(
+                Symbol::new(PHYSICAL_CLOSURE_VALUE_PROVENANCE_ATTR),
+                provenance,
+            );
+        }
         rewriter.replace_op(load_op.op_ref());
         true
     }

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -342,6 +342,19 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         if callable.r#return(ctx) != core::nil(ctx).as_type_ref() {
             return false;
         }
+        let return_type = rewriter
+            .type_converter()
+            .convert_type_or_identity(ctx, callable.r#return(ctx));
+        let parameter_types: Vec<_> = callable
+            .params(ctx)
+            .iter()
+            .map(|&parameter| {
+                rewriter
+                    .type_converter()
+                    .convert_type_or_identity(ctx, parameter)
+            })
+            .collect();
+        let signature = core::func(ctx, return_type, parameter_types.iter().copied()).as_type_ref();
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -316,8 +316,8 @@ a native callable contract, not a conclusion inferred by RC insertion from a
 name, operand type, body shape, or calling-convention integer alone.
 Convention-proven physical closure types are RC-managed even after their
 representation is erased to `core.ptr`; a bare `core.ptr` remains plain.
-Entry and indirect-tail contracts retain that positional provenance through RC
-insertion.
+Entry, trusted physical field-load, and indirect-tail contracts retain that
+positional provenance through RC insertion.
 
 An ordinary call to a consumed parameter acquires a new unit with `retain`
 immediately before the call, leaving the caller's existing unit live. A

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -316,8 +316,8 @@ a native callable contract, not a conclusion inferred by RC insertion from a
 name, operand type, body shape, or calling-convention integer alone.
 Convention-proven physical closure types are RC-managed even after their
 representation is erased to `core.ptr`; a bare `core.ptr` remains plain.
-Entry and indirect-tail contracts retain that positional provenance until RC
-validation.
+Entry and indirect-tail contracts retain that positional provenance through RC
+insertion.
 
 An ordinary call to a consumed parameter acquires a new unit with `retain`
 immediately before the call, leaving the caller's existing unit live. A

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -314,6 +314,10 @@ Physically empty CPS callables use `consumed` for every parameter whose exact
 native conversion is RC-managed. Non-RC parameters have no RC action. This is
 a native callable contract, not a conclusion inferred by RC insertion from a
 name, operand type, body shape, or calling-convention integer alone.
+Convention-proven physical closure types are RC-managed even after their
+representation is erased to `core.ptr`; a bare `core.ptr` remains plain.
+Entry and indirect-tail contracts retain that positional provenance until RC
+validation.
 
 An ordinary call to a consumed parameter acquires a new unit with `retain`
 immediately before the call, leaving the caller's existing unit live. A

--- a/tests/optimization_conformance.rs
+++ b/tests/optimization_conformance.rs
@@ -209,7 +209,7 @@ fn borrowed_parameters_preserve_native_execution() {
 }
 
 #[test]
-fn trusted_ownership_forwarding_preserves_native_execution() {
+fn trusted_ownership_forwarding_preserves_native_execution_slow() {
     for sanitize_address in [false, true] {
         let preserved = compile_and_run_native_with_borrowed_parameters(
             "trusted_ownership_forwarding_preserved.trb",
@@ -239,7 +239,7 @@ fn trusted_ownership_forwarding_preserves_native_execution() {
 }
 
 #[test]
-fn temporary_field_borrows_preserve_native_execution_with_sanitizer() {
+fn temporary_field_borrows_preserve_native_execution_with_sanitizer_slow() {
     for sanitize_address in [false, true] {
         let preserved = compile_and_run_native_with_temporary_borrows(
             "temporary_field_borrows_preserved.trb",


### PR DESCRIPTION
Historical context: #891 was superseded by #897. This PR does not close either issue.

Trusted native ownership contracts normalize indirect proper-tail signatures through lowering and retain exact physical-closure provenance. Transfer actions are validated from that trusted signature and provenance even when an ABI-adapted operand is `core.ptr`; untrusted or Plain pointers remain rejected. RC insertion also carries validated entry and field-load provenance, so Direct factories and separately lifted environment captures retain convention-proven physical closures after ABI erasure.

Discriminating regressions cover converted signatures, trusted and forged closure provenance, nested adapted tail borrows, duplicate owning stores, Direct `Retained` entries, proven field-load captures, and Plain pointer paths.

The #836/#872 integration advanced past these ownership defects and now stops at a distinct native-Evidence capture/release-layout issue owned by that integration.

Checks: focused ownership-summary, RC-insertion, and func-to-Clif tests; warnings-denied clippy; formatting and diff checks; normal workspace hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reference-counting accuracy for physical closures, including converted and indirectly called closures.
  - Prevented unmanaged pointers from being incorrectly reference-counted.
  - Fixed ownership tracking across nested loads, transfers, aliases, and function boundaries.
  - Improved validation to reject missing, duplicated, altered, or untrusted ownership information.
  - Improved lowering of indirect calls with converted parameter and return types.

- **Reliability**
  - Preserved closure ownership information through lowered operations for more consistent runtime behavior.

- **Tests**
  - Expanded coverage for closure ownership, indirect calls, pointer handling, and slow optimization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->