### PR TITLE
Verify callable origins before CPS lowering

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -138,6 +138,8 @@ pub struct IrLoweringCtx<'db> {
     /// are built. This lets recursive and forward fields retain `adt.typeref`
     /// while their layout is still incomplete.
     logical_nominal_declarations: HashSet<Symbol>,
+    /// Exact compiler-owned prelude declaration ID to intrinsic identity.
+    compiler_intrinsics: HashMap<NodeId, Symbol>,
     /// Counter for generating unique prompt tags (per-module deterministic).
     prompt_tag_counter: u32,
     /// Stack of active prompt tags for nested handlers.
@@ -200,6 +202,7 @@ impl<'db> IrLoweringCtx<'db> {
             struct_fields: HashMap::new(),
             type_map: im::HashMap::new(),
             logical_nominal_declarations: HashSet::new(),
+            compiler_intrinsics: HashMap::new(),
             prompt_tag_counter: 0,
             active_prompt_tag_stack: Vec::new(),
 
@@ -216,6 +219,18 @@ impl<'db> IrLoweringCtx<'db> {
         debug_assert!(self.generated_functions.normal_done_k.is_none());
         self.options = options;
         self
+    }
+
+    pub(crate) fn with_compiler_intrinsics(
+        mut self,
+        compiler_intrinsics: HashMap<NodeId, Symbol>,
+    ) -> Self {
+        self.compiler_intrinsics = compiler_intrinsics;
+        self
+    }
+
+    pub(crate) fn compiler_intrinsic(&self, declaration: NodeId) -> Option<Symbol> {
+        self.compiler_intrinsics.get(&declaration).copied()
     }
 
     /// Get the current module path.

--- a/crates/tribute-front/src/ast_to_ir/lower/decl.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/decl.rs
@@ -267,6 +267,7 @@ impl<'db> TypedModule<'db> {
             perform_operations: _,
             lambda_signatures: _,
             exhaustive_cases: _,
+            compiler_intrinsics,
         } = self;
         let module_location = span_map.get_or_default(ast.id);
         let location = Location::new(path, module_location);
@@ -282,7 +283,8 @@ impl<'db> TypedModule<'db> {
             module_path,
             node_types,
         )
-        .with_options(options);
+        .with_options(options)
+        .with_compiler_intrinsics(compiler_intrinsics);
 
         prescan_definition_conventions(&mut ctx, &ast.decls, &mut String::new());
         promote_definition_conventions_to_fixed_point(&mut ctx, &ast.decls, &mut String::new());
@@ -587,6 +589,13 @@ fn lower_extern_function<'db>(
     });
 
     let func_op = func::func(ir, location, qualified_name, func_type, body_region);
+
+    if let Some(identity) = ctx.compiler_intrinsic(func_decl.id) {
+        ir.op_mut(func_op.op_ref()).attributes.insert(
+            Symbol::new(tribute_ir::dialect::tribute_control::COMPILER_INTRINSIC_ATTR),
+            Attribute::Symbol(identity),
+        );
+    }
 
     // Mark as extern so the backend treats it as Import linkage
     let abi_str = func_decl.abi.to_string();

--- a/crates/tribute-front/src/ast_to_ir/lower/logical.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/logical.rs
@@ -10,7 +10,7 @@ use salsa::Accumulator;
 use tribute_core::diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 use tribute_ir::dialect::{
     list,
-    tribute_control::{self, OperationDeclaration},
+    tribute_control::{self, CompilerIntrinsicDeclaration, OperationDeclaration},
 };
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, OperationDataBuilder, RegionData};
@@ -34,6 +34,7 @@ struct Declarations<'db> {
     // TypeRef is an arena index and therefore has deterministic total order only
     // through its debug representation.  Preserve first source use explicitly.
     values: Vec<OperationDeclaration>,
+    compiler_intrinsics: Vec<CompilerIntrinsicDeclaration>,
     schemas: std::collections::HashMap<crate::ast::AbilityId<'db>, crate::typeck::AbilityInfo<'db>>,
     handler_operations: std::collections::HashMap<
         crate::ast::NodeId,
@@ -152,6 +153,7 @@ pub(super) fn lower_module<'db>(
         lambda_signatures,
         exhaustive_cases,
         well_known_types,
+        compiler_intrinsics,
     } = typed;
     let location = Location::new(path, span_map.get_or_default(ast.id));
     let module_name = ast.name.unwrap_or_else(|| Symbol::new("main"));
@@ -163,7 +165,8 @@ pub(super) fn lower_module<'db>(
         ability_conventions,
         smallvec::smallvec![module_name],
         node_types,
-    );
+    )
+    .with_compiler_intrinsics(compiler_intrinsics);
     let module_block = ir.create_block(BlockData {
         location,
         args: vec![],
@@ -173,6 +176,7 @@ pub(super) fn lower_module<'db>(
     ctx.set_module_block(module_block);
     let mut declarations = Declarations {
         values: vec![],
+        compiler_intrinsics: vec![],
         schemas: ability_definitions,
         handler_operations,
         perform_operations,
@@ -207,6 +211,7 @@ pub(super) fn lower_module<'db>(
     FrontendIrModule {
         module: IrModule::new(ir, module.op_ref()).expect("valid core.module operation"),
         operation_declarations: declarations.values,
+        compiler_intrinsics: declarations.compiler_intrinsics,
     }
 }
 
@@ -319,7 +324,7 @@ fn lower_decl<'db>(
 ) {
     match declaration {
         Decl::Function(function) => lower_function(ctx, ir, top, function, declarations),
-        Decl::ExternFunction(function) => lower_extern(ctx, ir, top, function),
+        Decl::ExternFunction(function) => lower_extern(ctx, ir, top, function, declarations),
         Decl::Struct(declaration) => lower_struct_accessors(ctx, ir, top, declaration),
         Decl::Module(module) => {
             if let Some(body) = module.body {
@@ -752,6 +757,7 @@ fn lower_extern<'db>(
     ir: &mut IrContext,
     top: BlockRef,
     decl: ExternFuncDecl,
+    declarations: &mut Declarations<'db>,
 ) {
     let location = ctx.location(decl.id);
     let qualified = ctx.qualify_name(decl.name);
@@ -775,6 +781,18 @@ fn lower_extern<'db>(
     );
     let name = ctx.qualify_name(decl.name);
     let function = tribute_control::func_declaration(ir, location, name, callable);
+    if let Some(identity) = ctx.compiler_intrinsic(decl.id) {
+        ir.op_mut(function.op_ref()).attributes.insert(
+            Symbol::new(tribute_control::COMPILER_INTRINSIC_ATTR),
+            Attribute::Symbol(identity),
+        );
+        declarations
+            .compiler_intrinsics
+            .push(CompilerIntrinsicDeclaration::new(name, identity, callable));
+        declarations
+            .compiler_intrinsics
+            .sort_by_key(|declaration| (declaration.symbol, declaration.identity));
+    }
     ir.op_mut(function.op_ref())
         .attributes
         .insert(Symbol::new("abi"), Attribute::String(decl.abi.to_string()));
@@ -1710,15 +1728,6 @@ fn lower_call<'db>(
                 Some(builder.cast_if_needed(location, value, result_ty))
             }
             ResolvedRef::Function { id } => {
-                if let Some(value) = lower_arith_intrinsic(
-                    builder,
-                    location,
-                    id.qualified(builder.ctx.db),
-                    &values,
-                    result_ty,
-                ) {
-                    return Some(value);
-                }
                 let name = id.qualified(builder.ctx.db);
                 let signature = FuncSignature::lookup_logical(builder.ctx, builder.ir, name)
                     .unwrap_or_else(|| panic!("missing logical signature for call {name}"));
@@ -1807,35 +1816,6 @@ fn lower_call<'db>(
         let value = result(builder.ir, call);
         Some(builder.cast_if_needed(location, value, result_ty))
     }
-}
-
-fn lower_arith_intrinsic<'db>(
-    builder: &mut IrBuilder<'_, 'db>,
-    location: Location,
-    name: Symbol,
-    values: &[ValueRef],
-    result_ty: TypeRef,
-) -> Option<ValueRef> {
-    let [lhs, rhs] = values else {
-        return None;
-    };
-    let name = name.to_string();
-    let op = match name.as_str() {
-        "Int::+" | "Nat::+" => arith::addi(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Int::-" | "Nat::-" => arith::subi(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Int::*" | "Nat::*" => arith::muli(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Int::/" => arith::divsi(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Nat::/" => arith::divui(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Int::%" => arith::remsi(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Nat::%" => arith::remui(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Float::+" => arith::addf(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Float::-" => arith::subf(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Float::*" => arith::mulf(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        "Float::/" => arith::divf(builder.ir, location, *lhs, *rhs, result_ty).op_ref(),
-        _ => return None,
-    };
-    builder.ir.push_op(builder.block, op);
-    Some(result(builder.ir, op))
 }
 
 fn lower_lambda<'db>(

--- a/crates/tribute-front/src/ast_to_ir/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/mod.rs
@@ -33,9 +33,10 @@ mod context;
 mod lower;
 mod normalize;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
 
-use tribute_ir::dialect::tribute_control::OperationDeclaration;
+use tribute_ir::dialect::tribute_control::{CompilerIntrinsicDeclaration, OperationDeclaration};
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::rewrite::Module as IrModule;
@@ -54,6 +55,94 @@ pub use context::IrLoweringCtx;
 pub struct FrontendIrModule {
     pub module: IrModule,
     pub operation_declarations: Vec<OperationDeclaration>,
+    pub compiler_intrinsics: Vec<CompilerIntrinsicDeclaration>,
+}
+
+static SUPPORTED_COMPILER_INTRINSICS: LazyLock<HashSet<Symbol>> = LazyLock::new(|| {
+    [
+        "List::__tribute_list_prepend_intrinsic",
+        "Int::+",
+        "Int::-",
+        "Int::*",
+        "Int::/",
+        "Int::%",
+        "Int::==",
+        "Int::!=",
+        "Int::<",
+        "Int::<=",
+        "Int::>",
+        "Int::>=",
+        "Nat::+",
+        "Nat::-",
+        "Nat::*",
+        "Nat::/",
+        "Nat::%",
+        "Nat::==",
+        "Nat::!=",
+        "Nat::<",
+        "Nat::<=",
+        "Nat::>",
+        "Nat::>=",
+        "Float::+",
+        "Float::-",
+        "Float::*",
+        "Float::/",
+        "Float::==",
+        "Float::!=",
+        "Float::<",
+        "Float::<=",
+        "Float::>",
+        "Float::>=",
+    ]
+    .into_iter()
+    .map(Symbol::new)
+    .collect()
+});
+
+fn is_supported_compiler_intrinsic(identity: Symbol) -> bool {
+    SUPPORTED_COMPILER_INTRINSICS.contains(&identity)
+}
+
+/// Register compiler intrinsics from the canonical prelude AST.
+///
+/// Callers must invoke this only for the compiler-owned prelude module.  A
+/// user module with the same declarations must never be passed here.
+pub fn registered_compiler_intrinsics<V>(module: &AstModule<V>) -> HashMap<NodeId, Symbol>
+where
+    V: salsa::Update,
+{
+    fn collect<V>(
+        declarations: &[crate::ast::Decl<V>],
+        prefix: &mut String,
+        result: &mut HashMap<NodeId, Symbol>,
+    ) where
+        V: salsa::Update,
+    {
+        for declaration in declarations {
+            match declaration {
+                crate::ast::Decl::ExternFunction(function)
+                    if function.abi == Symbol::new("intrinsic") =>
+                {
+                    let symbol = crate::qualified_symbol(prefix, function.name);
+                    if is_supported_compiler_intrinsic(symbol) {
+                        result.insert(function.id, symbol);
+                    }
+                }
+                crate::ast::Decl::Module(module) => {
+                    if let Some(body) = &module.body {
+                        let saved = crate::push_prefix(prefix, module.name);
+                        collect(body, prefix, result);
+                        prefix.truncate(saved);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut result = HashMap::new();
+    collect(&module.decls, &mut String::new(), &mut result);
+    result
 }
 
 /// Policy for compiler-generated identity done continuations.
@@ -110,6 +199,8 @@ pub struct TypedModule<'db> {
     /// Case expressions whose source coverage is known to be exhaustive.
     pub exhaustive_cases: std::collections::HashSet<NodeId>,
     pub well_known_types: crate::typeck::WellKnownTypes<'db>,
+    /// Exact declaration IDs registered from the compiler-owned prelude.
+    pub compiler_intrinsics: HashMap<NodeId, Symbol>,
 }
 
 impl<'db> TypedModule<'db> {
@@ -151,6 +242,14 @@ mod tests {
 
     fn test_db() -> salsa::DatabaseImpl {
         salsa::DatabaseImpl::new()
+    }
+
+    #[test]
+    fn compiler_intrinsic_registry_is_explicit() {
+        assert!(is_supported_compiler_intrinsic(Symbol::new("Float::==")));
+        assert!(!is_supported_compiler_intrinsic(Symbol::new(
+            "user_intrinsic"
+        )));
     }
 
     #[test]

--- a/crates/tribute-front/tests/common/mod.rs
+++ b/crates/tribute-front/tests/common/mod.rs
@@ -108,6 +108,12 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
         result.handler_operations.into_iter().collect();
     let perform_operations: std::collections::HashMap<_, _> =
         result.perform_operations.into_iter().collect();
+    let compiler_intrinsics = prelude
+        .as_ref()
+        .map(|prelude| {
+            tribute_front::ast_to_ir::registered_compiler_intrinsics(&prelude.typed_module)
+        })
+        .unwrap_or_default();
     let mut ir = IrContext::new();
     let module = tribute_front::ast_to_ir::TypedModule {
         ast: tdnr_ast,
@@ -122,12 +128,14 @@ fn run_ast_pipeline_inner(db: &dyn salsa::Database, source: SourceCst) -> String
         lambda_signatures: result.lambda_signatures.into_iter().collect(),
         exhaustive_cases: result.exhaustive_cases.into_iter().collect(),
         well_known_types: result.well_known_types,
+        compiler_intrinsics,
     }
     .lower_to_ir(db, &mut ir, source.uri(db).as_str());
     let validation = tribute_ir::dialect::tribute_control::validate(
         &ir,
         module.module,
         &module.operation_declarations,
+        &module.compiler_intrinsics,
     );
     assert!(
         validation.is_ok(),

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -1864,18 +1864,34 @@ fn assert_sequential_performs_shape(function: &str) {
 fn assert_nested_argument_shape(function: &str) {
     assert_in_order(function, &["callee = @read", "callee = @add_one"]);
 }
+fn assert_exact_integer_addition(function: &str) -> &'static str {
+    let callee = ["callee = @\"Int::+\"", "callee = @\"Nat::+\""]
+        .into_iter()
+        .find(|callee| function.contains(callee))
+        .unwrap_or_else(|| {
+            panic!("missing exact integer intrinsic call in canonical IR:\n{function}")
+        });
+    assert_in_order(function, &["tribute_control.call", callee]);
+    assert!(
+        !function.contains("arith.addi"),
+        "source-logical lowering must preserve the exact intrinsic call instead of lowering by name:\n{function}"
+    );
+    callee
+}
 fn assert_indirect_lambda_shape(function: &str) {
+    let callee = assert_exact_integer_addition(function);
     assert_in_order(
         function,
         &[
             "tribute_control.lambda",
             "tribute_control.call_indirect",
-            "arith.addi",
+            callee,
         ],
     );
 }
 fn assert_case_arm_shape(function: &str) {
-    assert_in_order(function, &["scf.if", "callee = @read", "arith.addi"]);
+    let callee = assert_exact_integer_addition(function);
+    assert_in_order(function, &["scf.if", "callee = @read", callee]);
 }
 fn assert_short_circuit_shape(function: &str) {
     assert_in_order(function, &["scf.if", "callee = @read"]);
@@ -1949,16 +1965,14 @@ fn assert_nested_handle_shape(function: &str) {
     );
 }
 fn assert_resume_then_suffix_shape(function: &str) {
-    assert_in_order(function, &["tribute_control.resume", "arith.addi"]);
+    let callee = assert_exact_integer_addition(function);
+    assert_in_order(function, &["tribute_control.resume", callee]);
 }
 fn assert_resume_capture_shape(function: &str) {
+    let callee = assert_exact_integer_addition(function);
     assert_in_order(
         function,
-        &[
-            "tribute_control.lambda",
-            "tribute_control.resume",
-            "arith.addi",
-        ],
+        &["tribute_control.lambda", "tribute_control.resume", callee],
     );
 }
 fn assert_normalized_region_shape(function: &str) {

--- a/crates/tribute-front/tests/int_text.rs
+++ b/crates/tribute-front/tests/int_text.rs
@@ -170,6 +170,7 @@ fn generic_extern_specialization_has_a_logical_signature_inner(
         lambda_signatures: mono.metadata.lambda_signatures,
         exhaustive_cases: mono.metadata.exhaustive_cases,
         well_known_types: checked.well_known_types(db),
+        compiler_intrinsics: std::collections::HashMap::new(),
     }
     .lower_to_ir(db, &mut ir, source.uri(db).as_str());
     let ir_text = print_module(&ir, output.module.op());
@@ -239,6 +240,7 @@ fn generic_specialization_transports_direct_callee_metadata_inner(
         lambda_signatures: mono.metadata.lambda_signatures,
         exhaustive_cases: mono.metadata.exhaustive_cases,
         well_known_types: checked.well_known_types(db),
+        compiler_intrinsics: std::collections::HashMap::new(),
     }
     .lower_to_ir(db, &mut ir, source.uri(db).as_str());
     let ir_text = print_module(&ir, output.module.op());
@@ -287,6 +289,7 @@ fn public_logical_output_declarations_inner(db: &dyn salsa::Database, source: So
         lambda_signatures: checked.lambda_signatures(db).iter().cloned().collect(),
         exhaustive_cases: checked.exhaustive_cases(db).iter().copied().collect(),
         well_known_types: checked.well_known_types(db),
+        compiler_intrinsics: std::collections::HashMap::new(),
     }
     .lower_to_ir(db, &mut ir, source.uri(db).as_str());
     let declarations = &output.operation_declarations;
@@ -357,8 +360,12 @@ fn public_logical_output_declarations_inner(db: &dyn salsa::Database, source: So
             (Symbol::new("core"), Symbol::new("i1"))
         );
     }
-    let validation =
-        tribute_ir::dialect::tribute_control::validate(&ir, output.module, declarations);
+    let validation = tribute_ir::dialect::tribute_control::validate(
+        &ir,
+        output.module,
+        declarations,
+        &output.compiler_intrinsics,
+    );
     assert!(
         validation.is_ok(),
         "public logical frontend output must pass complete validation: {validation}"

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
@@ -9,10 +9,11 @@ core.module @test {
       %0 = tribute_control.perform {ability_ref = core.ability_ref() {name = @Counter}, op_name = @inc, operation_kind = @op} : core.i32
       tribute_control.return %0
   }
+  tribute_control.func @"Nat::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @use_counter() -> core.i32 convention(cps) {
       %0 = tribute_control.call {callee = @get_count} : core.i32
       %1 = tribute_control.call {callee = @get_count} : core.i32
-      %2 = arith.addi %0, %1 : core.i32
+      %2 = tribute_control.call %0, %1 {callee = @"Nat::+"} : core.i32
       tribute_control.return %2
   }
   tribute_control.func @main() -> core.nil convention(direct) {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -7,10 +7,11 @@ core.module @test {
   !t1 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
   !t2 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
+  tribute_control.func @"Int::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @counter() -> core.i32 convention(cps) {
       %0 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
       %1 = arith.const {value = 1} : core.i32
-      %2 = arith.addi %0, %1 : core.i32
+      %2 = tribute_control.call %0, %1 {callee = @"Int::+"} : core.i32
       %3 = tribute_control.perform %2 {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @set, operation_kind = @op} : core.nil
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -5,10 +5,11 @@ expression: ir_text
 core.module @test {
   !t0 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
 
+  tribute_control.func @"Int::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @counter() -> core.i32 convention(cps) {
       %0 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
       %1 = arith.const {value = 1} : core.i32
-      %2 = arith.addi %0, %1 : core.i32
+      %2 = tribute_control.call %0, %1 {callee = @"Int::+"} : core.i32
       %3 = tribute_control.perform %2 {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @set, operation_kind = @op} : core.nil
       tribute_control.return %0
   }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
@@ -28,11 +28,12 @@ core.module @test {
       }
       tribute_control.return %1
   }
+  tribute_control.func @"Nat::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
           %1 = tribute_control.perform {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @get, operation_kind = @op} : core.i32
           %2 = arith.const {value = 1} : core.i32
-          %3 = arith.addi %1, %2 : core.i32
+          %3 = tribute_control.call %1, %2 {callee = @"Nat::+"} : core.i32
           %4 = tribute_control.perform %3 {ability_ref = core.ability_ref(core.i32) {name = @State}, op_name = @set, operation_kind = @op} : core.nil
           tribute_control.return %1
       }

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
@@ -9,10 +9,11 @@ core.module @test {
       %2 = tribute_control.call_indirect %0, %1 : core.i32
       tribute_control.return %2
   }
+  tribute_control.func @"Int::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = tribute_control.lambda(%1: core.i32) -> core.i32 convention(cps) captures [] {
           %2 = arith.const {value = 1} : core.i32
-          %3 = arith.addi %1, %2 : core.i32
+          %3 = tribute_control.call %1, %2 {callee = @"Int::+"} : core.i32
           tribute_control.return %3
       }
       %4 = arith.const {value = 41} : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
@@ -9,10 +9,11 @@ core.module @test {
       %2 = tribute_control.call_indirect %0, %1 : core.i32
       tribute_control.return %2
   }
+  tribute_control.func @"Int::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @main() -> core.i32 convention(cps) attributes {tribute.root_export_convention = 0, tribute.root_source_result = core.i32} {
       %0 = arith.const {value = 10} : core.i32
       %1 = tribute_control.lambda(%2: core.i32) -> core.i32 convention(cps) captures [%0] {
-          %3 = arith.addi %2, %0 : core.i32
+          %3 = tribute_control.call %2, %0 {callee = @"Int::+"} : core.i32
           tribute_control.return %3
       }
       %4 = arith.const {value = 32} : core.i32

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_basic.snap
@@ -6,13 +6,14 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32]], name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_3_nat}
 
+  tribute_control.func @"Nat::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1
       %3 = adt.struct_get %2 {field = 0, type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : core.i32
       %4 = adt.struct_get %2 {field = 1, type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : core.i32
-      %5 = arith.addi %3, %4 : core.i32
+      %5 = tribute_control.call %3, %4 {callee = @"Nat::+"} : core.i32
       tribute_control.return %5
   }
 }

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_from_function.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_from_function.snap
@@ -10,13 +10,14 @@ core.module @test {
       %2 = adt.struct_new %0, %1 {type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1
       tribute_control.return %2
   }
+  tribute_control.func @"Nat::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 10} : core.i32
       %1 = arith.const {value = 20} : core.i32
       %2 = tribute_control.call %0, %1 {callee = @make_pair} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1
       %3 = adt.struct_get %2 {field = 0, type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : core.i32
       %4 = adt.struct_get %2 {field = 1, type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : core.i32
-      %5 = arith.addi %3, %4 : core.i32
+      %5 = tribute_control.call %3, %4 {callee = @"Nat::+"} : core.i32
       tribute_control.return %5
   }
 }

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_nested.snap
@@ -8,6 +8,7 @@ core.module @test {
   !__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1]], name = @__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat}
   !__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat}
 
+  tribute_control.func @"Nat::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
@@ -18,8 +19,8 @@ core.module @test {
       %6 = adt.struct_get %4 {field = 1, type = !__logical_tuple_tuple_3_1_2_3_nat_23_tuple_3_1_2_3_nat_3_nat} : !__logical_tuple_tuple_3_1_2_3_nat_3_nat_1
       %7 = adt.struct_get %6 {field = 0, type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : core.i32
       %8 = adt.struct_get %6 {field = 1, type = !__logical_tuple_tuple_3_1_2_3_nat_3_nat} : core.i32
-      %9 = arith.addi %5, %7 : core.i32
-      %10 = arith.addi %9, %8 : core.i32
+      %9 = tribute_control.call %5, %7 {callee = @"Nat::+"} : core.i32
+      %10 = tribute_control.call %9, %8 {callee = @"Nat::+"} : core.i32
       tribute_control.return %10
   }
 }

--- a/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
+++ b/crates/tribute-front/tests/snapshots/tuple_pattern__tuple_let_destructure_wildcard.snap
@@ -6,6 +6,7 @@ core.module @test {
   !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat = adt.struct() {fields = [[@0, core.i32], [@1, core.i32], [@2, core.i32]], name = @__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat}
   !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat_1 = adt.typeref() {name = @__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat}
 
+  tribute_control.func @"Nat::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @test() -> core.i32 convention(direct) {
       %0 = arith.const {value = 1} : core.i32
       %1 = arith.const {value = 2} : core.i32
@@ -14,7 +15,7 @@ core.module @test {
       %4 = adt.struct_get %3 {field = 0, type = !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat} : core.i32
       %5 = adt.struct_get %3 {field = 1, type = !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat} : core.i32
       %6 = adt.struct_get %3 {field = 2, type = !__logical_tuple_tuple_4_1_3_3_nat_3_nat_3_nat} : core.i32
-      %7 = arith.addi %4, %6 : core.i32
+      %7 = tribute_control.call %4, %6 {callee = @"Nat::+"} : core.i32
       tribute_control.return %7
   }
 }

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
@@ -36,12 +36,13 @@ core.module @test {
       %4 = adt.struct_new %2, %3, %1 {type = !Triple_1} : !Triple
       tribute_control.return %4
   }
+  tribute_control.func @"Nat::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @"Triple::sum"(%0: !Triple) -> core.i32 convention(direct) {
       %1 = tribute_control.call %0 {callee = @"Triple::x"} : core.i32
       %2 = tribute_control.call %0 {callee = @"Triple::y"} : core.i32
-      %3 = arith.addi %1, %2 : core.i32
+      %3 = tribute_control.call %1, %2 {callee = @"Nat::+"} : core.i32
       %4 = tribute_control.call %0 {callee = @"Triple::z"} : core.i32
-      %5 = arith.addi %3, %4 : core.i32
+      %5 = tribute_control.call %3, %4 {callee = @"Nat::+"} : core.i32
       tribute_control.return %5
   }
   tribute_control.func @test(%0: !Pair) -> core.i32 convention(direct) {

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -2037,7 +2037,9 @@ fn canonical_nominal_layouts(
 ) -> HashMap<Symbol, TypeRef> {
     let mut layouts = HashMap::new();
     let mut referenced_names = HashSet::new();
-    for ty in reachable_types.iter().copied() {
+    let mut sorted_reachable_types = reachable_types.iter().copied().collect::<Vec<_>>();
+    sorted_reachable_types.sort_unstable();
+    for ty in sorted_reachable_types {
         let data = ctx.types.get(ty);
         if is_adt_typeref(ctx, ty) {
             if let Some(name) = data.attrs.get_symbol("name") {
@@ -2053,13 +2055,17 @@ fn canonical_nominal_layouts(
         let Some(name) = data.attrs.get_symbol("name") else {
             continue;
         };
-        if let Some(previous) = layouts.insert(name, ty)
-            && previous != ty
-        {
-            push_type_error(
-                errors,
-                format!("nominal layout @{name} is declared more than once ({previous} and {ty})"),
-            );
+        if let Some(previous) = layouts.get(&name).copied() {
+            if previous != ty {
+                push_type_error(
+                    errors,
+                    format!(
+                        "nominal layout @{name} is declared more than once ({previous} and {ty})"
+                    ),
+                );
+            }
+        } else {
+            layouts.insert(name, ty);
         }
     }
     for name in referenced_names {
@@ -2178,27 +2184,11 @@ fn raw_pointer_cast_origin(
 fn validate_managed_reference_boundaries(
     ctx: &IrContext,
     body: RegionRef,
+    reachable_types: &HashSet<TypeRef>,
     nominal_layouts: &HashMap<Symbol, TypeRef>,
     errors: &mut Vec<ValidationError>,
 ) {
-    let mut reachable_types = HashSet::new();
-    walk_region_ops(ctx, body, &mut |op| {
-        for value in ctx.op_operands(op).iter().chain(ctx.op_results(op).iter()) {
-            collect_reachable_type(ctx, ctx.value_ty(*value), &mut reachable_types);
-        }
-        for attribute in ctx.op(op).attributes.values() {
-            collect_attribute_types(ctx, attribute, &mut reachable_types);
-        }
-        for region in ctx.op(op).regions.iter().copied() {
-            for block in ctx.region(region).blocks.iter().copied() {
-                for argument in ctx.block_args(block) {
-                    collect_reachable_type(ctx, ctx.value_ty(*argument), &mut reachable_types);
-                }
-            }
-        }
-    });
-
-    for ty in reachable_types {
+    for ty in reachable_types.iter().copied() {
         if !is_adt_typeref(ctx, ty) {
             continue;
         }
@@ -3125,7 +3115,13 @@ pub fn validate_whole_ir(
     let declarations = declaration_map(declarations, &mut errors);
     let reachable_types = collect_reachable_ir_types(ctx, module.op());
     let nominal_layouts = canonical_nominal_layouts(ctx, &reachable_types, &mut errors);
-    validate_managed_reference_boundaries(ctx, body, &nominal_layouts, &mut errors);
+    validate_managed_reference_boundaries(
+        ctx,
+        body,
+        &reachable_types,
+        &nominal_layouts,
+        &mut errors,
+    );
     validate_callable_origins(
         ctx,
         body,
@@ -5175,6 +5171,7 @@ mod tests {
         let result = validate(&ctx, module, &[], &[]);
         let diagnostics = messages(&result);
         assert!(diagnostics.contains("nominal layout @Tuple is declared more than once"));
+        assert!(diagnostics.contains("callable provenance"), "{result}");
     }
 
     #[test]

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -8,14 +8,20 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use itertools::Itertools;
+use trunk_ir::dialect::{adt, arith, core};
 use trunk_ir::ops::{DialectOp, DialectType};
-use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
+use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 use trunk_ir::rewrite::Module;
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 use trunk_ir::{IrContext, Symbol};
 
+use super::list;
+
 /// Exact type-attribute key used by logical callable types.
 pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
+
+/// Exact semantic identity copied from the trusted compiler-intrinsic registry.
+pub const COMPILER_INTRINSIC_ATTR: &str = "tribute.compiler_intrinsic";
 
 /// Source-logical callable convention.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -204,6 +210,15 @@ pub fn func_declaration(
     .build(ctx);
     let op = ctx.create_op(data);
     Func::from_op(ctx, op).expect("newly built tribute_control.func")
+}
+
+impl Func {
+    /// Return the optional semantic identity attached by the trusted frontend registry.
+    pub fn compiler_intrinsic_identity(&self, ctx: &IrContext) -> Option<Symbol> {
+        ctx.op(self.op_ref())
+            .attributes
+            .get_symbol(COMPILER_INTRINSIC_ATTR)
+    }
 }
 
 // Only the named function is isolated. Lambda intentionally remains
@@ -611,6 +626,28 @@ pub struct OperationDeclaration {
     pub kind: Symbol,
     pub parameter_types: Vec<TypeRef>,
     pub result_type: TypeRef,
+}
+
+/// One exact compiler-intrinsic declaration supplied by the typed frontend.
+///
+/// This metadata is deliberately kept outside textual TrunkIR.  The symbol and
+/// operation attribute are accepted only when they match this declaration's
+/// registered identity and complete logical callable type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompilerIntrinsicDeclaration {
+    pub symbol: Symbol,
+    pub identity: Symbol,
+    pub callable_type: TypeRef,
+}
+
+impl CompilerIntrinsicDeclaration {
+    pub fn new(symbol: Symbol, identity: Symbol, callable_type: TypeRef) -> Self {
+        Self {
+            symbol,
+            identity,
+            callable_type,
+        }
+    }
 }
 
 impl OperationDeclaration {
@@ -1942,6 +1979,737 @@ fn declaration_map<'a>(
     map
 }
 
+fn is_adt_typeref(ctx: &IrContext, ty: TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::new("adt") && data.name == Symbol::new("typeref")
+}
+
+fn contains_adt_typeref(ctx: &IrContext, ty: TypeRef, visiting: &mut HashSet<TypeRef>) -> bool {
+    if !visiting.insert(ty) {
+        return false;
+    }
+    let data = ctx.types.get(ty);
+    let contains = is_adt_typeref(ctx, ty)
+        || data
+            .params
+            .iter()
+            .copied()
+            .any(|param| contains_adt_typeref(ctx, param, visiting))
+        || data
+            .attrs
+            .values()
+            .any(|attribute| attribute_contains_adt_typeref(ctx, attribute, visiting));
+    visiting.remove(&ty);
+    contains
+}
+
+fn attribute_contains_adt_typeref(
+    ctx: &IrContext,
+    attribute: &Attribute,
+    visiting: &mut HashSet<TypeRef>,
+) -> bool {
+    match attribute {
+        Attribute::Type(ty) => contains_adt_typeref(ctx, *ty, visiting),
+        Attribute::List(values) => values
+            .iter()
+            .any(|value| attribute_contains_adt_typeref(ctx, value, visiting)),
+        _ => false,
+    }
+}
+
+fn nominal_identity(ctx: &IrContext, ty: TypeRef) -> Option<Symbol> {
+    let data = ctx.types.get(ty);
+    (data.dialect == Symbol::new("adt")
+        && matches!(
+            data.name,
+            name if name == Symbol::new("typeref")
+                || name == Symbol::new("struct")
+                || name == Symbol::new("enum")
+        ))
+    .then(|| data.attrs.get_symbol("name"))
+    .flatten()
+}
+
+fn canonical_nominal_layouts(
+    ctx: &IrContext,
+    reachable_types: &HashSet<TypeRef>,
+    errors: &mut Vec<ValidationError>,
+) -> HashMap<Symbol, TypeRef> {
+    let mut layouts = HashMap::new();
+    let mut referenced_names = HashSet::new();
+    for ty in reachable_types.iter().copied() {
+        let data = ctx.types.get(ty);
+        if is_adt_typeref(ctx, ty) {
+            if let Some(name) = data.attrs.get_symbol("name") {
+                referenced_names.insert(name);
+            }
+            continue;
+        }
+        if data.dialect != Symbol::new("adt")
+            || !(data.name == Symbol::new("struct") || data.name == Symbol::new("enum"))
+        {
+            continue;
+        }
+        let Some(name) = data.attrs.get_symbol("name") else {
+            continue;
+        };
+        if let Some(previous) = layouts.insert(name, ty)
+            && previous != ty
+        {
+            push_type_error(
+                errors,
+                format!("nominal layout @{name} is declared more than once ({previous} and {ty})"),
+            );
+        }
+    }
+    for name in referenced_names {
+        if layouts.contains_key(&name) {
+            continue;
+        }
+        let candidates = ctx
+            .types
+            .iter()
+            .filter_map(|(ty, data)| {
+                (data.dialect == Symbol::new("adt")
+                    && (data.name == Symbol::new("struct") || data.name == Symbol::new("enum"))
+                    && data.attrs.get_symbol("name") == Some(name))
+                .then_some(ty)
+            })
+            .collect::<Vec<_>>();
+        if let [layout] = candidates.as_slice() {
+            layouts.insert(name, *layout);
+        } else if let [first, second, ..] = candidates.as_slice() {
+            push_type_error(
+                errors,
+                format!("nominal layout @{name} is declared more than once ({first} and {second})"),
+            );
+        }
+    }
+    layouts
+}
+
+fn is_core_ptr(ctx: &IrContext, ty: TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::new("core") && data.name == Symbol::new("ptr")
+}
+
+fn collect_attribute_types(ctx: &IrContext, attribute: &Attribute, types: &mut HashSet<TypeRef>) {
+    match attribute {
+        Attribute::Type(ty) => collect_reachable_type(ctx, *ty, types),
+        Attribute::List(values) => {
+            for value in values {
+                collect_attribute_types(ctx, value, types);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_reachable_type(ctx: &IrContext, ty: TypeRef, types: &mut HashSet<TypeRef>) {
+    if !types.insert(ty) {
+        return;
+    }
+    let data = ctx.types.get(ty);
+    for parameter in data.params.iter().copied() {
+        collect_reachable_type(ctx, parameter, types);
+    }
+    for attribute in data.attrs.values() {
+        collect_attribute_types(ctx, attribute, types);
+    }
+}
+
+/// Collect semantic types reachable from a module operation and its nested IR.
+///
+/// Context-wide type aliases are printer/parser conveniences, not IR roots:
+/// an alias whose type is never used by an operation, operand, result, block
+/// argument, or type-bearing attribute must not affect validation of this
+/// module. A reachable `adt.typeref` may resolve one unique layout alias; an
+/// ambiguous nominal name remains invalid.
+fn collect_reachable_ir_types(ctx: &IrContext, module: OpRef) -> HashSet<TypeRef> {
+    fn collect_op_types(ctx: &IrContext, op: OpRef, types: &mut HashSet<TypeRef>) {
+        for value in ctx.op_operands(op).iter().chain(ctx.op_results(op).iter()) {
+            collect_reachable_type(ctx, ctx.value_ty(*value), types);
+        }
+        for attribute in ctx.op(op).attributes.values() {
+            collect_attribute_types(ctx, attribute, types);
+        }
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for argument in ctx.block_args(block) {
+                    collect_reachable_type(ctx, ctx.value_ty(*argument), types);
+                }
+            }
+        }
+    }
+
+    let mut types = HashSet::new();
+    collect_op_types(ctx, module, &mut types);
+    for region in ctx.op(module).regions.iter().copied() {
+        walk_region_ops(ctx, region, &mut |op| collect_op_types(ctx, op, &mut types));
+    }
+    types
+}
+
+fn raw_pointer_cast_origin(
+    ctx: &IrContext,
+    value: ValueRef,
+    visiting: &mut HashSet<ValueRef>,
+) -> bool {
+    if !visiting.insert(value) {
+        return false;
+    }
+    if is_core_ptr(ctx, ctx.value_ty(value)) {
+        return true;
+    }
+    let ValueDef::OpResult(producer, _) = ctx.value_def(value) else {
+        return false;
+    };
+    let transparent_cast = core::UnrealizedConversionCast::from_op(ctx, producer).is_ok()
+        || adt::RefCast::from_op(ctx, producer).is_ok()
+        || arith::Cast::from_op(ctx, producer).is_ok();
+    transparent_cast
+        && ctx
+            .op_operands(producer)
+            .first()
+            .copied()
+            .is_some_and(|operand| raw_pointer_cast_origin(ctx, operand, visiting))
+}
+
+fn validate_managed_reference_boundaries(
+    ctx: &IrContext,
+    body: RegionRef,
+    nominal_layouts: &HashMap<Symbol, TypeRef>,
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut reachable_types = HashSet::new();
+    walk_region_ops(ctx, body, &mut |op| {
+        for value in ctx.op_operands(op).iter().chain(ctx.op_results(op).iter()) {
+            collect_reachable_type(ctx, ctx.value_ty(*value), &mut reachable_types);
+        }
+        for attribute in ctx.op(op).attributes.values() {
+            collect_attribute_types(ctx, attribute, &mut reachable_types);
+        }
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for argument in ctx.block_args(block) {
+                    collect_reachable_type(ctx, ctx.value_ty(*argument), &mut reachable_types);
+                }
+            }
+        }
+    });
+
+    for ty in reachable_types {
+        if !is_adt_typeref(ctx, ty) {
+            continue;
+        }
+        let data = ctx.types.get(ty);
+        let Some(name) = data.attrs.get_symbol("name") else {
+            push_type_error(
+                errors,
+                format!("{ty}: adt.typeref requires nominal name metadata"),
+            );
+            continue;
+        };
+        if !data.params.is_empty() {
+            push_type_error(
+                errors,
+                format!("{ty}: adt.typeref cannot have type parameters"),
+            );
+        }
+        if !nominal_layouts.contains_key(&name) {
+            push_type_error(
+                errors,
+                format!("{ty}: adt.typeref @{name} has no verified nominal declaration"),
+            );
+        }
+    }
+
+    walk_region_ops(ctx, body, &mut |op| {
+        let data = ctx.op(op);
+        if data.dialect == Symbol::new("adt") && data.name == Symbol::new("ref_null") {
+            let ([], [result], Some(declared)) = (
+                ctx.op_operands(op),
+                ctx.op_result_types(op),
+                data.attributes.get_type("type"),
+            ) else {
+                push_op_error(ctx, op, errors, "adt.ref_null requires one typed result");
+                return;
+            };
+            if *result != declared || !is_adt_typeref(ctx, *result) {
+                push_op_error(
+                    ctx,
+                    op,
+                    errors,
+                    "adt.ref_null result and type attribute must be the same managed adt.typeref",
+                );
+            }
+        }
+        if data.dialect == Symbol::new("adt") && data.name == Symbol::new("ref_cast") {
+            let ([operand], [result], Some(declared)) = (
+                ctx.op_operands(op),
+                ctx.op_result_types(op),
+                data.attributes.get_type("type"),
+            ) else {
+                push_op_error(
+                    ctx,
+                    op,
+                    errors,
+                    "adt.ref_cast requires one typed operand and result",
+                );
+                return;
+            };
+            let operand_type = ctx.value_ty(*operand);
+            let source = nominal_identity(ctx, operand_type);
+            let target = nominal_identity(ctx, *result);
+            if declared != *result
+                || !is_adt_typeref(ctx, operand_type)
+                || !is_adt_typeref(ctx, *result)
+                || source.is_none()
+                || source != target
+            {
+                push_op_error(
+                    ctx,
+                    op,
+                    errors,
+                    "adt.ref_cast requires compatible managed nominal reference types",
+                );
+            }
+        }
+        for result in ctx.op_results(op) {
+            if is_adt_typeref(ctx, ctx.value_ty(*result))
+                && raw_pointer_cast_origin(ctx, *result, &mut HashSet::new())
+            {
+                push_op_error(
+                    ctx,
+                    op,
+                    errors,
+                    "core.ptr cast chain cannot produce a managed adt.typeref",
+                );
+            }
+        }
+    });
+}
+
+fn compiler_intrinsic_map<'a>(
+    ctx: &IrContext,
+    declarations: &'a [CompilerIntrinsicDeclaration],
+    errors: &mut Vec<ValidationError>,
+) -> HashMap<Symbol, &'a CompilerIntrinsicDeclaration> {
+    let mut map = HashMap::new();
+    let mut previous = None;
+    for declaration in declarations {
+        let key = (declaration.symbol, declaration.identity);
+        if previous.is_some_and(|previous| previous > key) {
+            push_type_error(
+                errors,
+                "compiler intrinsic declarations are not deterministically ordered",
+            );
+        }
+        previous = Some(key);
+        if callable_convention(ctx, declaration.callable_type) != Some(CallingConvention::Direct) {
+            push_type_error(
+                errors,
+                format!(
+                    "registered compiler intrinsic @{} must use Direct calling convention",
+                    declaration.symbol
+                ),
+            );
+        }
+        if map.insert(declaration.symbol, declaration).is_some() {
+            push_type_error(
+                errors,
+                format!(
+                    "duplicate compiler intrinsic declaration for @{}",
+                    declaration.symbol
+                ),
+            );
+        }
+    }
+    map
+}
+
+fn adt_projection_has_exact_callable_type(
+    ctx: &IrContext,
+    producer: OpRef,
+    result_type: TypeRef,
+    nominal_layouts: &HashMap<Symbol, TypeRef>,
+) -> bool {
+    if ctx.op_result_types(producer) != [result_type] {
+        return false;
+    }
+    if let Ok(get) = adt::StructGet::from_op(ctx, producer) {
+        let layout = get.r#type(ctx);
+        return projection_source_matches_layout(ctx, get.r#ref(ctx), layout, nominal_layouts)
+            && struct_field_type(ctx, layout, get.field(ctx)) == Some(result_type);
+    }
+    if let Ok(get) = adt::VariantGet::from_op(ctx, producer) {
+        let layout = get.r#type(ctx);
+        return projection_source_matches_layout(ctx, get.r#ref(ctx), layout, nominal_layouts)
+            && variant_field_type(ctx, layout, get.tag(ctx), get.field(ctx)) == Some(result_type);
+    }
+    false
+}
+
+fn projection_source_matches_layout(
+    ctx: &IrContext,
+    source: ValueRef,
+    layout: TypeRef,
+    nominal_layouts: &HashMap<Symbol, TypeRef>,
+) -> bool {
+    let layout_identity = nominal_identity(ctx, layout);
+    layout_identity.is_some_and(|identity| nominal_layouts.get(&identity) == Some(&layout))
+        && nominal_identity(ctx, ctx.value_ty(source)) == layout_identity
+}
+
+fn struct_field_type(ctx: &IrContext, layout: TypeRef, field: u32) -> Option<TypeRef> {
+    let data = ctx.types.get(layout);
+    if data.dialect != Symbol::new("adt") || data.name != Symbol::new("struct") {
+        return None;
+    }
+    let Attribute::List(fields) = data.attrs.get("fields")? else {
+        return None;
+    };
+    let Attribute::List(pair) = fields.get(field as usize)? else {
+        return None;
+    };
+    match pair.as_slice() {
+        [Attribute::Symbol(_), Attribute::Type(field_type)] => Some(*field_type),
+        _ => None,
+    }
+}
+
+fn variant_field_type(
+    ctx: &IrContext,
+    layout: TypeRef,
+    tag: Symbol,
+    field: u32,
+) -> Option<TypeRef> {
+    let data = ctx.types.get(layout);
+    if data.dialect != Symbol::new("adt") || data.name != Symbol::new("enum") {
+        return None;
+    }
+    let Attribute::List(variants) = data.attrs.get("variants")? else {
+        return None;
+    };
+    variants.iter().find_map(|variant| {
+        let Attribute::List(pair) = variant else {
+            return None;
+        };
+        let [Attribute::Symbol(variant_tag), Attribute::List(fields)] = pair.as_slice() else {
+            return None;
+        };
+        (*variant_tag == tag).then(|| match fields.get(field as usize) {
+            Some(Attribute::Type(field_type)) => Some(*field_type),
+            _ => None,
+        })?
+    })
+}
+
+struct CallableProvenance<'a> {
+    registered: &'a HashMap<Symbol, &'a CompilerIntrinsicDeclaration>,
+    declarations: &'a HashMap<(TypeRef, Symbol), &'a OperationDeclaration>,
+    nominal_layouts: &'a HashMap<Symbol, TypeRef>,
+}
+
+fn callable_block_arg_has_source_contract(
+    ctx: &IrContext,
+    block: BlockRef,
+    index: u32,
+    value: ValueRef,
+    provenance: &CallableProvenance<'_>,
+    visiting: &mut HashSet<ValueRef>,
+) -> bool {
+    let Some(region) = ctx.block(block).parent_region else {
+        return false;
+    };
+    let Some(owner) = ctx.region(region).parent_op else {
+        return false;
+    };
+    let value_type = ctx.value_ty(value);
+
+    let callable_type = if is_control_op(ctx, owner, "func") {
+        (ctx.op(owner).regions.as_slice() == [region])
+            .then(|| ctx.op(owner).attributes.get_type("type"))
+            .flatten()
+    } else if is_control_op(ctx, owner, "lambda") {
+        (ctx.op(owner).regions.as_slice() == [region])
+            .then(|| ctx.op_result_types(owner).first().copied())
+            .flatten()
+    } else {
+        None
+    };
+    if let Some((_, parameters, _)) = callable_type.and_then(|ty| callable_parts(ctx, ty)) {
+        return parameters.get(index as usize) == Some(&value_type);
+    }
+
+    if is_control_op(ctx, owner, "handler") && ctx.op(owner).regions.as_slice() == [region] {
+        let data = ctx.op(owner);
+        if let (Some(ability), Some(name), Some(kind)) = (
+            data.attributes.get_type("ability_ref"),
+            data.attributes.get_symbol("op_name"),
+            data.attributes.get_symbol("kind"),
+        ) {
+            return provenance
+                .declarations
+                .get(&(ability, name))
+                .is_some_and(|declaration| {
+                    declaration.kind == kind
+                        && declaration.parameter_types.get(index as usize) == Some(&value_type)
+                });
+        }
+    }
+
+    let [body_region, completion_region, _] = ctx.op(owner).regions.as_slice() else {
+        return false;
+    };
+    if !is_control_op(ctx, owner, "handle") || completion_region != &region || index != 0 {
+        return false;
+    }
+    let [body_block] = ctx.region(*body_region).blocks.as_slice() else {
+        return false;
+    };
+    let Some(body_yield) = ctx.block(*body_block).ops.last().copied() else {
+        return false;
+    };
+    let [body_value] = ctx.op_operands(body_yield) else {
+        return false;
+    };
+    is_control_op(ctx, body_yield, "yield")
+        && ctx.value_ty(*body_value) == value_type
+        && callable_has_semantic_provenance(ctx, *body_value, provenance, visiting)
+}
+
+fn callable_has_semantic_provenance(
+    ctx: &IrContext,
+    value: ValueRef,
+    provenance: &CallableProvenance<'_>,
+    visiting: &mut HashSet<ValueRef>,
+) -> bool {
+    if !visiting.insert(value) || Callable::from_type_ref(ctx, ctx.value_ty(value)).is_none() {
+        return false;
+    }
+    match ctx.value_def(value) {
+        ValueDef::BlockArg(block, index) => {
+            callable_block_arg_has_source_contract(ctx, block, index, value, provenance, visiting)
+        }
+        ValueDef::OpResult(producer, _) => {
+            is_control_op(ctx, producer, "lambda")
+                || ((is_control_op(ctx, producer, "func_ref")
+                    || is_control_op(ctx, producer, "call"))
+                    && ctx
+                        .op(producer)
+                        .attributes
+                        .get_symbol(if is_control_op(ctx, producer, "func_ref") {
+                            "func_ref"
+                        } else {
+                            "callee"
+                        })
+                        .and_then(|symbol| resolve_visible_function(ctx, producer, symbol))
+                        .is_some_and(|function| {
+                            verified_callable_declaration(ctx, function, provenance.registered)
+                        }))
+                || (is_control_op(ctx, producer, "call_indirect")
+                    && ctx.op_operands(producer).first().is_some_and(|callee| {
+                        callable_has_semantic_provenance(ctx, *callee, provenance, visiting)
+                    }))
+                || list::Head::from_op(ctx, producer).is_ok_and(|head| {
+                    head.element_type(ctx) == ctx.value_ty(value)
+                        && ctx.op_result_types(producer) == [ctx.value_ty(value)]
+                })
+                || adt_projection_has_exact_callable_type(
+                    ctx,
+                    producer,
+                    ctx.value_ty(value),
+                    provenance.nominal_layouts,
+                )
+        }
+    }
+}
+
+fn resolve_visible_function(ctx: &IrContext, use_op: OpRef, symbol: Symbol) -> Option<OpRef> {
+    let mut owner = Some(use_op);
+    let scope = loop {
+        let current = owner?;
+        if is_core_module(ctx, current) {
+            break current;
+        }
+        owner = parent_op(ctx, current);
+    };
+    let body = ctx.op(scope).regions.first().copied()?;
+    let mut resolved = None;
+    let mut duplicate = false;
+    walk_symbol_scope_ops(ctx, body, &mut |op| {
+        if is_control_op(ctx, op, "func")
+            && ctx.op(op).attributes.get_symbol("sym_name") == Some(symbol)
+        {
+            duplicate |= resolved.replace(op).is_some();
+        }
+    });
+    (!duplicate).then_some(resolved).flatten()
+}
+
+fn verified_callable_declaration(
+    ctx: &IrContext,
+    function: OpRef,
+    registered: &HashMap<Symbol, &CompilerIntrinsicDeclaration>,
+) -> bool {
+    let data = ctx.op(function);
+    if !data.regions.is_empty() {
+        return true;
+    }
+    let (Some(symbol), Some(identity), Some(callable_type)) = (
+        data.attributes.get_symbol("sym_name"),
+        Func::from_op(ctx, function)
+            .ok()
+            .and_then(|function| function.compiler_intrinsic_identity(ctx)),
+        data.attributes.get_type("type"),
+    ) else {
+        return false;
+    };
+    registered.get(&symbol).is_some_and(|declaration| {
+        declaration.identity == identity && declaration.callable_type == callable_type
+    })
+}
+
+fn validate_callable_origins(
+    ctx: &IrContext,
+    body: RegionRef,
+    declarations: &[CompilerIntrinsicDeclaration],
+    operation_declarations: &HashMap<(TypeRef, Symbol), &OperationDeclaration>,
+    nominal_layouts: &HashMap<Symbol, TypeRef>,
+    errors: &mut Vec<ValidationError>,
+) {
+    let registered = compiler_intrinsic_map(ctx, declarations, errors);
+    let provenance = CallableProvenance {
+        registered: &registered,
+        declarations: operation_declarations,
+        nominal_layouts,
+    };
+    let mut seen = HashSet::new();
+    walk_region_ops(ctx, body, &mut |op| {
+        if is_control_op(ctx, op, "func") {
+            let data = ctx.op(op);
+            let (Some(symbol), Some(callable_type)) = (
+                data.attributes.get_symbol("sym_name"),
+                data.attributes.get_type("type"),
+            ) else {
+                return;
+            };
+            let intrinsic_identity = Func::from_op(ctx, op)
+                .ok()
+                .and_then(|function| function.compiler_intrinsic_identity(ctx));
+            let bodyless = data.regions.is_empty();
+            if !bodyless && intrinsic_identity.is_some() {
+                push_op_error(
+                    ctx,
+                    op,
+                    errors,
+                    "defined Tribute function cannot claim compiler intrinsic identity",
+                );
+            }
+            if bodyless {
+                let exact_intrinsic = match (registered.get(&symbol), intrinsic_identity) {
+                    (Some(expected), Some(actual))
+                        if expected.identity == actual
+                            && expected.callable_type == callable_type =>
+                    {
+                        seen.insert(symbol);
+                        true
+                    }
+                    (Some(_), _) => {
+                        push_op_error(
+                            ctx,
+                            op,
+                            errors,
+                            "compiler intrinsic identity or complete signature does not match the registered declaration",
+                        );
+                        false
+                    }
+                    (None, Some(_)) => {
+                        push_op_error(
+                            ctx,
+                            op,
+                            errors,
+                            "unregistered declaration cannot claim compiler intrinsic identity",
+                        );
+                        false
+                    }
+                    (None, None) => false,
+                };
+                if !exact_intrinsic && contains_adt_typeref(ctx, callable_type, &mut HashSet::new())
+                {
+                    push_op_error(
+                        ctx,
+                        op,
+                        errors,
+                        "unclassified bodyless external declaration cannot use managed adt.typeref",
+                    );
+                }
+            }
+        } else if is_control_op(ctx, op, "call_indirect")
+            && let Some(callee) = ctx.op_operands(op).first().copied()
+            && !callable_has_semantic_provenance(ctx, callee, &provenance, &mut HashSet::new())
+        {
+            push_op_error(
+                ctx,
+                op,
+                errors,
+                "indirect callee lacks verified source-logical callable provenance",
+            );
+        }
+    });
+    for symbol in registered.keys() {
+        if !seen.contains(symbol) {
+            push_type_error(
+                errors,
+                format!(
+                    "registered compiler intrinsic @{symbol} has no exact bodyless declaration"
+                ),
+            );
+        }
+    }
+}
+
+fn validate_return_contracts(ctx: &IrContext, body: RegionRef, errors: &mut Vec<ValidationError>) {
+    walk_region_ops(ctx, body, &mut |op| {
+        if !is_control_op(ctx, op, "return") {
+            return;
+        }
+        let mut owner = parent_op(ctx, op);
+        let callable = loop {
+            let Some(current) = owner else {
+                push_op_error(
+                    ctx,
+                    op,
+                    errors,
+                    "return has no containing semantic callable",
+                );
+                return;
+            };
+            if is_control_op(ctx, current, "func") {
+                break ctx.op(current).attributes.get_type("type");
+            }
+            if is_control_op(ctx, current, "lambda") {
+                break ctx.op_result_types(current).first().copied();
+            }
+            owner = parent_op(ctx, current);
+        };
+        let Some((expected, _, _)) = callable.and_then(|ty| callable_parts(ctx, ty)) else {
+            return;
+        };
+        if let [value] = ctx.op_operands(op)
+            && ctx.value_ty(*value) != expected
+        {
+            push_op_error(
+                ctx,
+                op,
+                errors,
+                "return operand type does not match containing semantic callable",
+            );
+        }
+    });
+}
+
 fn validate_declaration_uses(
     ctx: &IrContext,
     body: RegionRef,
@@ -2346,6 +3114,7 @@ pub fn validate_whole_ir(
     ctx: &IrContext,
     module: Module,
     declarations: &[OperationDeclaration],
+    compiler_intrinsics: &[CompilerIntrinsicDeclaration],
 ) -> ValidationResult {
     let mut errors = Vec::new();
     let Some(body) = module.body(ctx) else {
@@ -2354,6 +3123,18 @@ pub fn validate_whole_ir(
     validate_module_symbol_scopes(ctx, module.op(), &mut errors);
     validate_lambda_captures(ctx, body, &mut errors);
     let declarations = declaration_map(declarations, &mut errors);
+    let reachable_types = collect_reachable_ir_types(ctx, module.op());
+    let nominal_layouts = canonical_nominal_layouts(ctx, &reachable_types, &mut errors);
+    validate_managed_reference_boundaries(ctx, body, &nominal_layouts, &mut errors);
+    validate_callable_origins(
+        ctx,
+        body,
+        compiler_intrinsics,
+        &declarations,
+        &nominal_layouts,
+        &mut errors,
+    );
+    validate_return_contracts(ctx, body, &mut errors);
     validate_declaration_uses(ctx, body, &declarations, &mut errors);
     validate_resume_ownership(ctx, body, &mut errors);
     validate_token_placements(ctx, body, &mut errors);
@@ -2368,11 +3149,12 @@ pub fn validate(
     ctx: &IrContext,
     module: Module,
     declarations: &[OperationDeclaration],
+    compiler_intrinsics: &[CompilerIntrinsicDeclaration],
 ) -> ValidationResult {
     let mut local = validate_local(ctx, module);
     local
         .errors
-        .extend(validate_whole_ir(ctx, module, declarations).errors);
+        .extend(validate_whole_ir(ctx, module, declarations, compiler_intrinsics).errors);
     local
 }
 
@@ -2835,7 +3617,7 @@ mod tests {
     #[test]
     fn generic_control_operations_round_trip_and_validate() {
         let fixture = valid_fixture();
-        let result = validate(&fixture.ctx, fixture.module, &fixture.declarations);
+        let result = validate(&fixture.ctx, fixture.module, &fixture.declarations, &[]);
         assert!(result.is_ok(), "{result}");
 
         let printed = assert_round_trip(&fixture.ctx, fixture.module);
@@ -3385,7 +4167,7 @@ mod tests {
   }
 }"#,
         );
-        let missing = validate_whole_ir(&missing_ctx, missing_module, &[]);
+        let missing = validate_whole_ir(&missing_ctx, missing_module, &[], &[]);
         assert!(messages(&missing).contains("capture list is missing external value"));
 
         let (excess_ctx, excess_module) = parse_fixture(
@@ -3399,7 +4181,7 @@ mod tests {
   }
 }"#,
         );
-        let excess = validate_whole_ir(&excess_ctx, excess_module, &[]);
+        let excess = validate_whole_ir(&excess_ctx, excess_module, &[], &[]);
         assert!(messages(&excess).contains("capture list contains unused external value"));
     }
 
@@ -3434,7 +4216,7 @@ mod tests {
 }"#,
         );
 
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         assert!(result.is_ok(), "{:?}", result.errors);
     }
 
@@ -3499,7 +4281,7 @@ mod tests {
             result_type: i32_ty,
         };
         let declarations = [declaration.clone(), declaration];
-        let result = validate_whole_ir(&ctx, module, &declarations);
+        let result = validate_whole_ir(&ctx, module, &declarations, &[]);
         assert_diagnostics(
             &result,
             &[
@@ -3563,7 +4345,7 @@ mod tests {
                 .get_type("operation_result_type")
                 .unwrap(),
         )];
-        let result = validate(&ctx, module, &declarations);
+        let result = validate(&ctx, module, &declarations, &[]);
         let messages = messages(&result);
         assert!(messages.contains("duplicate handler clause"));
         assert!(messages.contains("kind does not match the resolved declaration"));
@@ -3590,7 +4372,7 @@ mod tests {
   }
 }"#,
         );
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         assert!(messages(&result).contains("more than one tribute_control.resume"));
     }
 
@@ -3631,7 +4413,7 @@ mod tests {
   }
 }"#,
         );
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         assert_diagnostics(
             &result,
             &[
@@ -3668,7 +4450,7 @@ mod tests {
   }
 }"#,
         );
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         assert_diagnostics(
             &result,
             &["resume token is copied into multiple capture paths"],
@@ -3709,7 +4491,7 @@ mod tests {
   }
 }"#,
         );
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         let diagnostics = messages(&result);
         for forbidden in [
             "resume token is copied into multiple capture paths",
@@ -3745,7 +4527,7 @@ mod tests {
   }
 }"#,
         );
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         assert!(
             messages(&result).contains("multiple static terminal uses"),
             "{result}"
@@ -3771,7 +4553,7 @@ mod tests {
         );
         let local = validate_local(&ctx, module);
         assert!(messages(&local).contains("must not yield a resume token"));
-        let whole = validate_whole_ir(&ctx, module, &[]);
+        let whole = validate_whole_ir(&ctx, module, &[], &[]);
         assert!(messages(&whole).contains("forbidden use"));
 
         let (ctx, module) = parse_fixture(
@@ -3883,7 +4665,7 @@ mod tests {
   }
 }"#,
         );
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         assert!(
             messages(&result).contains("multiple static terminal uses"),
             "{result}"
@@ -3920,7 +4702,7 @@ mod tests {
   }
 }"#,
         );
-        let result = validate_whole_ir(&ctx, module, &[]);
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
         assert!(
             messages(&result).contains("crosses into a different handler"),
             "{result}"
@@ -3940,6 +4722,496 @@ mod tests {
 
         let result = validate_local(&ctx, module);
         assert!(messages(&result).contains("references external value"));
+    }
+
+    #[test]
+    fn exact_registered_intrinsic_is_accepted_but_spelling_and_abi_are_not() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  tribute_control.func @"Nat::+"(%left: core.i32, %right: core.i32) -> core.i32 convention(direct)
+    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"}
+}"#,
+        );
+        let function = control_op(&ctx, module, "func");
+        let callable_type = ctx.op(function).attributes.get_type("type").unwrap();
+        let exact = CompilerIntrinsicDeclaration::new(
+            Symbol::new("Nat::+"),
+            Symbol::new("Nat::+"),
+            callable_type,
+        );
+        assert!(validate(&ctx, module, &[], std::slice::from_ref(&exact)).is_ok());
+
+        let wrong_signature = CompilerIntrinsicDeclaration::new(
+            exact.symbol,
+            exact.identity,
+            ctx.types.get(callable_type).params[0],
+        );
+        let result = validate(&ctx, module, &[], &[wrong_signature]);
+        assert!(messages(&result).contains("complete signature"), "{result}");
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(
+            messages(&result).contains("unregistered declaration"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn registered_intrinsic_requires_direct_convention() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  tribute_control.func @read(%value: core.i32) -> core.i32 convention(evidence_direct)
+    attributes {tribute.compiler_intrinsic = @read}
+}"#,
+        );
+        let function = control_op(&ctx, module, "func");
+        let callable_type = ctx.op(function).attributes.get_type("type").unwrap();
+        let declaration = CompilerIntrinsicDeclaration::new(
+            Symbol::new("read"),
+            Symbol::new("read"),
+            callable_type,
+        );
+
+        let result = validate(&ctx, module, &[], &[declaration]);
+        assert!(
+            messages(&result).contains("must use Direct calling convention"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn exact_registered_intrinsic_has_indirect_callable_provenance() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32, core.i32) {tribute.calling_convention = 0}
+  tribute_control.func @"Nat::+"(%left: core.i32, %right: core.i32) -> core.i32 convention(direct)
+    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"}
+  tribute_control.func @caller(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) {
+    %callee = tribute_control.func_ref {func_ref = @"Nat::+"} : !F
+    %result = tribute_control.call_indirect %callee, %left, %right : core.i32
+    tribute_control.return %result
+  }
+}"#,
+        );
+        let intrinsic = control_ops(&ctx, module, "func")
+            .into_iter()
+            .find(|op| ctx.op(*op).attributes.get_symbol("sym_name") == Some(Symbol::new("Nat::+")))
+            .unwrap();
+        let callable_type = ctx.op(intrinsic).attributes.get_type("type").unwrap();
+        let declaration = CompilerIntrinsicDeclaration::new(
+            Symbol::new("Nat::+"),
+            Symbol::new("Nat::+"),
+            callable_type,
+        );
+
+        let result = validate(&ctx, module, &[], &[declaration]);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn intrinsic_registry_order_duplicates_and_defined_claims_fail_closed() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  tribute_control.func @"Int::+"(%left: core.i32, %right: core.i32) -> core.i32 convention(direct)
+    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Int::+"}
+  tribute_control.func @"Nat::+"(%left: core.i32, %right: core.i32) -> core.i32 convention(direct)
+    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"} {
+    tribute_control.return %left
+  }
+}"#,
+        );
+        let functions = control_ops(&ctx, module, "func");
+        let declaration = |symbol: Symbol| {
+            let function = functions
+                .iter()
+                .copied()
+                .find(|op| ctx.op(*op).attributes.get_symbol("sym_name") == Some(symbol))
+                .unwrap();
+            CompilerIntrinsicDeclaration::new(
+                symbol,
+                symbol,
+                ctx.op(function).attributes.get_type("type").unwrap(),
+            )
+        };
+        let nat = declaration(Symbol::new("Nat::+"));
+        let int = declaration(Symbol::new("Int::+"));
+
+        let result = validate(&ctx, module, &[], &[nat.clone(), int, nat]);
+        let diagnostics = messages(&result);
+        assert!(
+            diagnostics.contains("not deterministically ordered"),
+            "{result}"
+        );
+        assert!(
+            diagnostics.contains("duplicate compiler intrinsic"),
+            "{result}"
+        );
+        assert!(
+            diagnostics.contains("defined Tribute function cannot claim compiler intrinsic"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn managed_reference_metadata_and_return_contracts_fail_closed() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !S = adt.struct() {name = @S, fields = []}
+  !Unnamed = adt.typeref()
+  !Parameterized = adt.typeref(core.i32) {name = @S}
+  !Missing = adt.typeref() {name = @Missing}
+  tribute_control.func @unnamed(%value: !Unnamed) -> !Unnamed convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @parameterized(%value: !Parameterized) -> !Parameterized convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @missing(%value: !Missing) -> !Missing convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @wrong_return(%integer: core.i32, %flag: core.bool) -> core.i32 convention(direct) {
+    tribute_control.return %flag
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        let diagnostics = messages(&result);
+        assert!(
+            diagnostics.contains("requires nominal name metadata"),
+            "{result}"
+        );
+        assert!(
+            diagnostics.contains("cannot have type parameters"),
+            "{result}"
+        );
+        assert!(
+            diagnostics.contains("has no verified nominal declaration"),
+            "{result}"
+        );
+        assert!(
+            diagnostics.contains("return operand type does not match containing semantic callable"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn managed_defined_boundaries_null_and_compatible_cast_are_valid() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !S = adt.struct() {name = @S, fields = []}
+  !R = adt.typeref() {name = @S}
+  tribute_control.func @managed(%value: !R) -> !R convention(direct) {
+    %null = adt.ref_null {type = !R} : !R
+    %cast = adt.ref_cast %null {type = !R} : !R
+    tribute_control.return %cast
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn managed_bodyless_external_and_raw_pointer_cast_chain_fail_closed() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !S = adt.struct() {name = @S, fields = []}
+  !R = adt.typeref() {name = @S}
+  tribute_control.func @private_helper(%value: !R) -> !R convention(direct)
+    attributes {abi = "C"}
+  tribute_control.func @masquerade(%raw: core.ptr) -> !R convention(direct) {
+    %middle = arith.cast %raw : core.i64
+    %managed = core.unrealized_conversion_cast %middle : !R
+    tribute_control.return %managed
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        let diagnostics = messages(&result);
+        assert!(diagnostics.contains("bodyless external"), "{result}");
+        assert!(diagnostics.contains("core.ptr cast chain"), "{result}");
+    }
+
+    #[test]
+    fn managed_nested_aggregate_in_bodyless_external_fails_closed() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !S = adt.struct() {name = @S, fields = []}
+  !R = adt.typeref() {name = @S}
+  !Container = adt.struct() {name = @Container, fields = [[@managed, !R]]}
+  tribute_control.func @private_helper(%value: !Container) -> core.i32 convention(direct)
+    attributes {abi = "C"}
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(messages(&result).contains("bodyless external"), "{result}");
+    }
+
+    #[test]
+    fn primitive_external_remains_a_conservative_boundary() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  tribute_control.func @primitive(%buffer: core.ptr, %length: core.i32) -> core.ptr convention(direct)
+    attributes {abi = "C"}
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn ref_cast_rejects_distinct_nominal_managed_references() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !S = adt.struct() {name = @S, fields = []}
+  !T = adt.struct() {name = @T, fields = []}
+  !RS = adt.typeref() {name = @S}
+  !RT = adt.typeref() {name = @T}
+  tribute_control.func @incompatible(%value: !RS) -> !RT convention(direct) {
+    %cast = adt.ref_cast %value {type = !RT} : !RT
+    tribute_control.return %cast
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(
+            messages(&result).contains("compatible managed nominal reference types"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn indirect_call_rejects_typed_callable_cast_without_semantic_provenance() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  tribute_control.func @caller(%raw: core.ptr, %value: core.i32) -> core.i32 convention(direct) {
+    %callee = core.unrealized_conversion_cast %raw : tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+    %result = tribute_control.call_indirect %callee, %value : core.i32
+    tribute_control.return %result
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(
+            messages(&result).contains("callable provenance"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn indirect_call_rejects_callable_from_uncontracted_structured_block_argument() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  tribute_control.func @caller(%condition: core.i1, %value: core.i32) -> core.i32 convention(direct) {
+    %result = scf.if %condition : core.i32 {
+      ^then(%callee: !F):
+        %called = tribute_control.call_indirect %callee, %value : core.i32
+        scf.yield %called
+    } {
+      ^else:
+        scf.yield %value
+    }
+    tribute_control.return %result
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(
+            messages(&result).contains("callable provenance"),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn callable_handle_completion_argument_traces_the_body_yield() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+  tribute_control.func @caller(%value: core.i32) -> !F convention(direct) {
+    %callback = tribute_control.handle : !F {
+      %source = tribute_control.func_ref {func_ref = @id} : !F
+      tribute_control.yield %source
+    } {
+      ^completion(%callback: !F):
+        %ignored = tribute_control.call_indirect %callback, %value : core.i32
+        tribute_control.yield %callback
+    } {
+      ^handlers:
+    }
+    tribute_control.return %callback
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn callable_handler_parameter_requires_an_exact_operation_declaration() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  tribute_control.func @caller(%value: core.i32) -> core.i32 convention(direct) {
+    %handled = tribute_control.handle : core.i32 {
+      tribute_control.yield %value
+    } {
+      ^completion(%completed: core.i32):
+        tribute_control.yield %completed
+    } {
+      tribute_control.handler {ability_ref = core.ability_ref() {name = @Callback}, kind = @fn, op_name = @apply, operation_result_type = core.i32} {
+        ^handler(%callback: !F):
+          %called = tribute_control.call_indirect %callback, %value : core.i32
+          tribute_control.yield %called
+      }
+    }
+    tribute_control.return %handled
+  }
+}"#,
+        );
+        let handler = control_op(&ctx, module, "handler");
+        let handler_region = ctx.op(handler).regions[0];
+        let handler_block = ctx.region(handler_region).blocks[0];
+        let callback_type = ctx.value_ty(ctx.block_args(handler_block)[0]);
+        let ability = ctx.op(handler).attributes.get_type("ability_ref").unwrap();
+        let operation_result = ctx
+            .op(handler)
+            .attributes
+            .get_type("operation_result_type")
+            .unwrap();
+        let declaration = OperationDeclaration::new(
+            ability,
+            Symbol::new("apply"),
+            Symbol::new("fn"),
+            [callback_type],
+            operation_result,
+        );
+
+        let result = validate(&ctx, module, &[declaration], &[]);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn exact_adt_callable_projections_have_semantic_provenance() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !Tuple = adt.struct() {name = @Tuple, fields = [[@callee, !F]]}
+  !TupleRef = adt.typeref() {name = @Tuple}
+  !Choice = adt.enum() {name = @Choice, variants = [[@Some, [!F]]]}
+  !ChoiceRef = adt.typeref() {name = @Choice}
+  tribute_control.func @caller(%tuple: !TupleRef, %choice: !ChoiceRef, %value: core.i32) -> core.i32 convention(direct) {
+    %tuple_callee = adt.struct_get %tuple {type = !Tuple, field = 0} : !F
+    %tuple_result = tribute_control.call_indirect %tuple_callee, %value : core.i32
+    %some = adt.variant_cast %choice {type = !Choice, tag = @Some} : !Choice
+    %choice_callee = adt.variant_get %some {type = !Choice, tag = @Some, field = 0} : !F
+    %choice_result = tribute_control.call_indirect %choice_callee, %tuple_result : core.i32
+    tribute_control.return %choice_result
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn adt_callable_projection_requires_matching_declared_field_type() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !Tuple = adt.struct() {name = @Tuple, fields = [[@not_callable, core.i32]]}
+  !TupleRef = adt.typeref() {name = @Tuple}
+  !Choice = adt.enum() {name = @Choice, variants = [[@Some, [core.i32]]]}
+  !ChoiceRef = adt.typeref() {name = @Choice}
+  tribute_control.func @caller(%tuple: !TupleRef, %choice: !ChoiceRef, %value: core.i32) -> core.i32 convention(direct) {
+    %tuple_callee = adt.struct_get %tuple {type = !Tuple, field = 0} : !F
+    %tuple_result = tribute_control.call_indirect %tuple_callee, %value : core.i32
+    %some = adt.variant_cast %choice {type = !Choice, tag = @Some} : !Choice
+    %choice_callee = adt.variant_get %some {type = !Choice, tag = @Some, field = 0} : !F
+    %choice_result = tribute_control.call_indirect %choice_callee, %tuple_result : core.i32
+    tribute_control.return %choice_result
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert_eq!(
+            messages(&result).matches("callable provenance").count(),
+            2,
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn duplicate_nominal_layout_rejects_callable_projection_spoofing() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !Canonical = adt.struct() {name = @Tuple, fields = [[@value, core.i32]]}
+  !Spoofed = adt.struct() {name = @Tuple, fields = [[@callee, !F]]}
+  !TupleRef = adt.typeref() {name = @Tuple}
+  tribute_control.func @caller(%tuple: !TupleRef, %value: core.i32) -> core.i32 convention(direct) {
+    %canonical = adt.struct_new %value {type = !Canonical} : !TupleRef
+    %callee = adt.struct_get %tuple {type = !Spoofed, field = 0} : !F
+    %result = tribute_control.call_indirect %callee, %value : core.i32
+    tribute_control.return %result
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        let diagnostics = messages(&result);
+        assert!(diagnostics.contains("nominal layout @Tuple is declared more than once"));
+    }
+
+    #[test]
+    fn unreachable_nominal_layout_collision_does_not_affect_validation() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !UnusedStruct = adt.struct() {name = @Unused, fields = [[@value, core.i32]]}
+  !UnusedEnum = adt.enum() {name = @Unused, variants = [[@Value, [core.i32]]]}
+  tribute_control.func @caller(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(result.is_ok(), "{result}");
+    }
+
+    #[test]
+    fn indirect_call_rejects_callable_from_unclassified_external() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  tribute_control.func @factory() -> !F convention(direct) attributes {abi = "C"}
+  tribute_control.func @caller(%value: core.i32) -> core.i32 convention(direct) {
+    %callee = tribute_control.call {callee = @factory} : !F
+    %result = tribute_control.call_indirect %callee, %value : core.i32
+    tribute_control.return %result
+  }
+}"#,
+        );
+
+        let result = validate(&ctx, module, &[], &[]);
+        assert!(
+            messages(&result).contains("callable provenance"),
+            "{result}"
+        );
     }
 
     #[test]

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -5,7 +5,10 @@
 //! arithmetic and comparison intrinsics declared in the prelude for Int, Nat, and Float.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::rc::Rc;
 
+use tribute_ir::dialect::tribute_control::COMPILER_INTRINSIC_ATTR;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::arith;
@@ -28,11 +31,29 @@ use trunk_ir::types::Location;
 pub(crate) fn lower_intrinsic_to_arith(ctx: &mut IrContext, module: Module) {
     let pattern = ArithIntrinsicPattern::new();
     let intrinsic_map: HashMap<Symbol, ArithMapping> = pattern.map.clone();
+    let eligible: Rc<HashSet<Symbol>> = Rc::new(
+        module
+            .ops(ctx)
+            .into_iter()
+            .filter_map(|op| {
+                let function = func::Func::from_op(ctx, op).ok()?;
+                let symbol = function.sym_name(ctx);
+                (ctx.op(op).attributes.get_symbol(COMPILER_INTRINSIC_ATTR) == Some(symbol)
+                    && intrinsic_map.get(&symbol).is_some_and(|mapping| {
+                        exact_signature(ctx, function.r#type(ctx), symbol, mapping)
+                    }))
+                .then_some(symbol)
+            })
+            .collect(),
+    );
 
     let mut applicator = PatternApplicator::new(TypeConverter::new());
     applicator = applicator
-        .add_pattern(pattern)
-        .add_pattern(ArithIntrinsicFuncDeclPattern { intrinsic_map });
+        .add_pattern(pattern.with_eligible(Rc::clone(&eligible)))
+        .add_pattern(ArithIntrinsicFuncDeclPattern {
+            intrinsic_map,
+            eligible,
+        });
     applicator.apply_partial(ctx, module);
 }
 
@@ -67,6 +88,7 @@ enum ArithMapping {
 /// rewrites them to the corresponding `arith.*` dialect operations.
 struct ArithIntrinsicPattern {
     map: HashMap<Symbol, ArithMapping>,
+    eligible: Rc<HashSet<Symbol>>,
 }
 
 impl ArithIntrinsicPattern {
@@ -169,7 +191,15 @@ impl ArithIntrinsicPattern {
         cmpf!("Float::>", "ogt");
         cmpf!("Float::>=", "oge");
 
-        Self { map }
+        Self {
+            map,
+            eligible: Rc::new(HashSet::new()),
+        }
+    }
+
+    fn with_eligible(mut self, eligible: Rc<HashSet<Symbol>>) -> Self {
+        self.eligible = eligible;
+        self
     }
 }
 
@@ -185,6 +215,9 @@ impl RewritePattern for ArithIntrinsicPattern {
         };
         let callee = call_op.callee(ctx);
 
+        if !self.eligible.contains(&callee) {
+            return false;
+        }
         let Some(mapping) = self.map.get(&callee) else {
             return false;
         };
@@ -222,6 +255,7 @@ impl RewritePattern for ArithIntrinsicPattern {
 /// marker so the backend treats them as normal functions.
 struct ArithIntrinsicFuncDeclPattern {
     intrinsic_map: HashMap<Symbol, ArithMapping>,
+    eligible: Rc<HashSet<Symbol>>,
 }
 
 impl RewritePattern for ArithIntrinsicFuncDeclPattern {
@@ -235,15 +269,11 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
             return false;
         };
 
-        // Check if this function has abi = "intrinsic"
-        let attrs = &ctx.op(op).attributes;
-        let is_intrinsic = attrs.get_str("abi") == Some("intrinsic");
-        if !is_intrinsic {
-            return false;
-        }
-
         // Check if this is one of our known arithmetic intrinsics
         let sym_name = func_op.sym_name(ctx);
+        if !self.eligible.contains(&sym_name) {
+            return false;
+        }
         let Some(mapping) = self.intrinsic_map.get(&sym_name) else {
             return false;
         };
@@ -311,6 +341,45 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
     }
 }
 
+fn exact_signature(ctx: &IrContext, ty: TypeRef, symbol: Symbol, mapping: &ArithMapping) -> bool {
+    let data = ctx.types.get(ty);
+    let [result, left, right] = data.params.as_slice() else {
+        return false;
+    };
+    if left != right {
+        return false;
+    }
+    let operand = ctx.types.get(*left);
+    let result = ctx.types.get(*result);
+    let operand_is_i32 =
+        operand.dialect == Symbol::new("core") && operand.name == Symbol::new("i32");
+    let operand_is_f64 =
+        operand.dialect == Symbol::new("core") && operand.name == Symbol::new("f64");
+    match mapping {
+        ArithMapping::BinaryOp(_) => {
+            result.dialect == operand.dialect
+                && result.name == operand.name
+                && symbol.with_str(|symbol| {
+                    if symbol.starts_with("Float::") {
+                        operand_is_f64
+                    } else {
+                        operand_is_i32
+                    }
+                })
+        }
+        ArithMapping::CmpI(_) => {
+            operand_is_i32
+                && result.dialect == Symbol::new("core")
+                && result.name == Symbol::new("i1")
+        }
+        ArithMapping::CmpF(_) => {
+            operand_is_f64
+                && result.dialect == Symbol::new("core")
+                && result.name == Symbol::new("i1")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,7 +394,7 @@ mod tests {
             r#"
             core.module @test {
                 func.func @"Nat::+"(%0: core.i32, %1: core.i32) -> core.i32
-                    attributes {abi = "intrinsic"} {
+                    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"} {
                 ^bb0:
                     func.unreachable
                 }
@@ -365,7 +434,7 @@ mod tests {
             r#"
             core.module @test {
                 func.func @"Int::=="(%0: core.i32, %1: core.i32) -> core.i1
-                    attributes {abi = "intrinsic"} {
+                    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Int::=="} {
                 ^bb0:
                     func.unreachable
                 }
@@ -394,7 +463,7 @@ mod tests {
             r#"
             core.module @test {
                 func.func @"Nat::+"(%0: core.i32, %1: core.i32) -> core.i32
-                    attributes {abi = "intrinsic"}
+                    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"}
             }
         "#,
         );
@@ -407,7 +476,28 @@ mod tests {
     }
 
     #[test]
-    fn direct_calls_still_rewritten() {
+    fn same_identity_with_wrong_complete_signature_is_not_lowered() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"
+            core.module @test {
+                func.func @"Nat::+"(%0: core.f64, %1: core.f64) -> core.f64
+                    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"} {
+                ^bb0:
+                    func.unreachable
+                }
+            }
+        "#,
+        );
+
+        let before = print_module(&ctx, module.op());
+        lower_intrinsic_to_arith(&mut ctx, module);
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn same_spelled_unregistered_declaration_is_not_lowered() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
@@ -415,6 +505,32 @@ mod tests {
             core.module @test {
                 func.func @"Nat::+"(%0: core.i32, %1: core.i32) -> core.i32
                     attributes {abi = "intrinsic"} {
+                ^bb0:
+                    func.return %0
+                }
+                func.func @caller(%0: core.i32, %1: core.i32) -> core.i32 {
+                ^bb0:
+                    %2 = func.call %0, %1 {callee = @"Nat::+"} : core.i32
+                    func.return %2
+                }
+            }
+        "#,
+        );
+
+        let before = print_module(&ctx, module.op());
+        lower_intrinsic_to_arith(&mut ctx, module);
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn direct_calls_still_rewritten() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"
+            core.module @test {
+                func.func @"Nat::+"(%0: core.i32, %1: core.i32) -> core.i32
+                    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"} {
                 ^bb0:
                     func.unreachable
                 }

--- a/crates/tribute-passes/src/list_intrinsics.rs
+++ b/crates/tribute-passes/src/list_intrinsics.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 use tribute_ir::dialect::list;
+use tribute_ir::dialect::tribute_control::COMPILER_INTRINSIC_ATTR;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::{core, func};
@@ -54,7 +55,17 @@ impl Pass for LowerListIntrinsics {
             let name = function.sym_name(ctx);
             intrinsic_declarations.all.insert(name);
             if is_prepend_intrinsic(name)
-                && ctx.op(op).attributes.get_str("abi") == Some("intrinsic")
+                && ctx.op(op).attributes.get_symbol(COMPILER_INTRINSIC_ATTR)
+                    == Some(Symbol::new(PREPEND_INTRINSIC))
+                && {
+                    let data = ctx.types.get(function.r#type(ctx));
+                    matches!(data.params.as_slice(), [result, element, tail]
+                    if [result, element, tail].into_iter().all(|ty| {
+                        let data = ctx.types.get(*ty);
+                        data.dialect == Symbol::new("tribute_rt")
+                            && data.name == Symbol::new("anyref")
+                    }))
+                }
             {
                 intrinsic_declarations.eligible.insert(name);
             }
@@ -162,7 +173,7 @@ mod tests {
             r#"
             core.module @test {
                 func.func @"List::__tribute_list_prepend_intrinsic"(%0: tribute_rt.anyref, %1: tribute_rt.anyref) -> tribute_rt.anyref
-                    attributes {abi = "intrinsic"} {
+                    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"List::__tribute_list_prepend_intrinsic"} {
                 ^bb0:
                     func.unreachable
                 }
@@ -221,7 +232,8 @@ mod tests {
             &mut ctx,
             r#"
             core.module @test {
-                func.func @"List::__tribute_list_prepend_intrinsic"(%0: tribute_rt.int, %1: tribute_rt.int) -> tribute_rt.int {
+                func.func @"List::__tribute_list_prepend_intrinsic"(%0: tribute_rt.int, %1: tribute_rt.int) -> tribute_rt.int
+                    attributes {tribute.compiler_intrinsic = @"List::__tribute_list_prepend_intrinsic"} {
                 ^bb0:
                     func.return %0
                 }
@@ -253,7 +265,7 @@ mod tests {
             r#"
             core.module @test {
                 func.func @"List::__tribute_list_prepend_intrinsic"(%0: tribute_rt.anyref, %1: tribute_rt.anyref) -> tribute_rt.anyref
-                    attributes {abi = "intrinsic"} {
+                    attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"List::__tribute_list_prepend_intrinsic"} {
                 ^bb0:
                     func.unreachable
                 }

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -112,7 +112,7 @@ fn final_handle_dispatch_shape(
         )));
     }
     let mut dispatcher_pairs = Vec::with_capacity(ability_refs.len());
-    for (ability_ref, pair) in ability_refs.iter().zip(dispatchers.chunks_exact(2)) {
+    for (ability_ref, pair) in ability_refs.iter().zip(dispatchers.as_chunks::<2>().0) {
         let Attribute::Type(ability_ref) = ability_ref else {
             return Err(error("every ability_refs entry must be a type".into()));
         };

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -300,7 +300,7 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
             let operands = ctx.op_operands(op);
             if let Some((evidence, dispatchers)) = operands.split_first() {
                 let evidence_ty = ctx.value_ty(*evidence);
-                for pair in dispatchers.chunks_exact(2) {
+                for pair in dispatchers.as_chunks::<2>().0 {
                     check_dispatcher(ctx, op, pair[0], evidence_ty, false, failures);
                     check_dispatcher(ctx, op, pair[1], evidence_ty, true, failures);
                 }
@@ -603,9 +603,10 @@ pub fn verify_tribute_control_pre_cps(
     ctx: &IrContext,
     module: Module,
     declarations: &[tribute_control::OperationDeclaration],
+    compiler_intrinsics: &[tribute_control::CompilerIntrinsicDeclaration],
 ) -> Result<(), TributeControlToCpsError> {
     let mut failures = Vec::new();
-    let validation = tribute_control::validate(ctx, module, declarations);
+    let validation = tribute_control::validate(ctx, module, declarations, compiler_intrinsics);
     failures.extend(validation.errors.into_iter().map(|error| BoundaryFailure {
         op: error.op,
         location: error.location,
@@ -2983,8 +2984,9 @@ pub fn tribute_control_to_cps(
     ctx: &mut IrContext,
     module: Module,
     declarations: &[tribute_control::OperationDeclaration],
+    compiler_intrinsics: &[tribute_control::CompilerIntrinsicDeclaration],
 ) -> Result<(), TributeControlToCpsError> {
-    verify_tribute_control_pre_cps(ctx, module, declarations)?;
+    verify_tribute_control_pre_cps(ctx, module, declarations, compiler_intrinsics)?;
     let funcs_by_module = collect_callable_graph(ctx, module);
     let source_region = module.body(ctx).ok_or_else(|| {
         TributeControlToCpsError::one(
@@ -3071,6 +3073,7 @@ pub fn tribute_control_to_cps(
 /// Pass-manager wrapper carrying the verified source operation declarations.
 pub struct TributeControlToCps {
     declarations: Vec<tribute_control::OperationDeclaration>,
+    compiler_intrinsics: Vec<tribute_control::CompilerIntrinsicDeclaration>,
 }
 
 impl TributeControlToCps {
@@ -3079,7 +3082,16 @@ impl TributeControlToCps {
     ) -> Self {
         Self {
             declarations: declarations.into_iter().collect(),
+            compiler_intrinsics: Vec::new(),
         }
+    }
+
+    pub fn with_compiler_intrinsics(
+        mut self,
+        declarations: impl IntoIterator<Item = tribute_control::CompilerIntrinsicDeclaration>,
+    ) -> Self {
+        self.compiler_intrinsics = declarations.into_iter().collect();
+        self
     }
 }
 
@@ -3091,8 +3103,13 @@ impl Pass for TributeControlToCps {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
-        tribute_control_to_cps(ctx, target.into(), &self.declarations)
-            .map_err(|error| Box::new(error) as _)
+        tribute_control_to_cps(
+            ctx,
+            target.into(),
+            &self.declarations,
+            &self.compiler_intrinsics,
+        )
+        .map_err(|error| Box::new(error) as _)
     }
 }
 
@@ -3141,7 +3158,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         verify_tribute_control_post_cps(&ctx, module).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(!printed.contains("tribute_control.func "));
@@ -3204,7 +3221,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("func.call "));
         assert!(printed.contains("func.call_indirect"));
@@ -3255,7 +3272,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("core.module @inner"));
         assert!(printed.contains("func.func @nested"));
@@ -3288,7 +3305,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         verify_tribute_control_post_cps(&ctx, module).unwrap();
         let printed = print_module(&ctx, module.op());
         assert_eq!(printed.matches("func.func @same").count(), 2, "{printed}");
@@ -3312,7 +3329,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("name = @CallbackRecord"));
         assert!(printed.contains("closure.closure(core.func(core.i32, core.i32))"));
@@ -3333,7 +3350,7 @@ mod tests {
 }"#;
         let (mut ctx, module) = parse(input);
         let before = print_module(&ctx, module.op());
-        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
         assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
         assert!(error.to_string().contains("func.call"));
         assert_eq!(print_module(&ctx, module.op()), before);
@@ -3391,7 +3408,7 @@ mod tests {
         for (input, expected) in malformed {
             let (mut ctx, module) = parse(input);
             let before = print_module(&ctx, module.op());
-            let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+            let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
             assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
             assert!(error.to_string().contains(expected), "{error}");
             assert_eq!(print_module(&ctx, module.op()), before);
@@ -3407,7 +3424,7 @@ mod tests {
 }"#;
         let (mut ctx, module) = parse(input);
         let before = print_module(&ctx, module.op());
-        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
         assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
         assert!(
             error.to_string().contains("forbids block successors"),
@@ -3433,7 +3450,7 @@ mod tests {
 }"#;
         let (mut ctx, module) = parse(input);
         let before = print_module(&ctx, module.op());
-        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
         assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
         assert!(
             error.to_string().contains("scf.case requires a value"),
@@ -3559,7 +3576,7 @@ mod tests {
   }
 }"#;
         let (ctx, module) = parse(local_input);
-        let error = verify_tribute_control_pre_cps(&ctx, module, &[]).unwrap_err();
+        let error = verify_tribute_control_pre_cps(&ctx, module, &[], &[]).unwrap_err();
         assert!(error.to_string().contains("expects 1 operand"), "{error}");
 
         let core_input = r#"core.module @test {
@@ -3569,7 +3586,7 @@ mod tests {
   }
 }"#;
         let (ctx, module) = parse(core_input);
-        let error = verify_tribute_control_pre_cps(&ctx, module, &[]).unwrap_err();
+        let error = verify_tribute_control_pre_cps(&ctx, module, &[], &[]).unwrap_err();
         assert!(error.to_string().contains("requires a callee"), "{error}");
 
         let post_input = r#"core.module @test {
@@ -3853,7 +3870,7 @@ mod tests {
             vec![i32_type],
             i32_type,
         )];
-        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
         let mut consumed_get = None;
         let mut consumed_set = None;
         fn find_one_shot_state_ops(
@@ -3963,7 +3980,7 @@ mod tests {
                 i32_type,
             ),
         ];
-        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
 
         let mut delimiters = Vec::new();
         fn collect_delimiters(ctx: &IrContext, op: OpRef, found: &mut Vec<OpRef>) {
@@ -4035,7 +4052,7 @@ mod tests {
             vec![i32_type],
             i32_type,
         )];
-        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("scf.if"));
         assert!(printed.contains(" : core.never"));
@@ -4104,7 +4121,7 @@ mod tests {
                 i32_type,
             ),
         ];
-        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         let scf_ifs: Vec<_> = printed
             .lines()
@@ -4196,7 +4213,7 @@ mod tests {
             [i32_type],
             i32_type,
         )];
-        let error = tribute_control_to_cps(&mut ctx, module, &declarations).unwrap_err();
+        let error = tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap_err();
         assert_eq!(error.boundary, POST_CPS_BOUNDARY);
         assert!(
             error.to_string().contains("requires zero or one result"),
@@ -4219,7 +4236,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("__tribute_func_ref_adapter"));
         assert!(printed.contains("closure.new"));
@@ -4257,7 +4274,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         verify_tribute_control_post_cps(&ctx, module).unwrap();
         let printed = print_module(&ctx, module.op());
         assert_eq!(
@@ -4284,7 +4301,7 @@ mod tests {
 }"#;
         let (mut ctx, module) = parse(input);
         let before = print_module(&ctx, module.op());
-        let error = tribute_control_to_cps(&mut ctx, module, &[]).unwrap_err();
+        let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
         assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
         assert!(
             error
@@ -4292,6 +4309,25 @@ mod tests {
                 .contains("result convention must be at least as strong"),
             "{error}"
         );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn raw_pointer_managed_masquerade_is_rejected_before_mutation() {
+        let input = r#"core.module @test {
+  !S = adt.struct() {name = @S, fields = []}
+  !R = adt.typeref() {name = @S}
+  tribute_control.func @broken(%raw: core.ptr) -> !R convention(direct) {
+    %middle = arith.cast %raw : core.i64
+    %managed = core.unrealized_conversion_cast %middle : !R
+    tribute_control.return %managed
+  }
+}"#;
+        let (mut ctx, module) = parse(input);
+        let before = print_module(&ctx, module.op());
+        let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
+        assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+        assert!(error.to_string().contains("core.ptr cast chain"), "{error}");
         assert_eq!(print_module(&ctx, module.op()), before);
     }
 
@@ -4319,7 +4355,7 @@ mod tests {
   }
 }"#;
         let (mut ctx, module) = parse(input);
-        tribute_control_to_cps(&mut ctx, module, &[]).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert_eq!(printed.matches("ability.handle_dispatch").count(), 2);
         assert!(!printed.contains("effect."));
@@ -4380,7 +4416,7 @@ mod tests {
             vec![i32_type],
             never_type,
         )];
-        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("ability.perform"));
         assert!(printed.contains("func.unreachable"));
@@ -4433,7 +4469,7 @@ mod tests {
             vec![i32_type],
             i32_type,
         )];
-        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("ability.call"));
         assert!(!printed.contains("ability.perform"));
@@ -4483,7 +4519,7 @@ mod tests {
             vec![i32_type],
             i32_type,
         )];
-        tribute_control_to_cps(&mut ctx, module, &declarations).unwrap();
+        tribute_control_to_cps(&mut ctx, module, &declarations, &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("scf.switch"));
         assert!(printed.contains("scf.case"));

--- a/crates/trunk-ir/src/context.rs
+++ b/crates/trunk-ir/src/context.rs
@@ -173,7 +173,7 @@ impl IrContext {
 
     /// Take all collected diagnostics, leaving the internal buffer empty.
     pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
-        self.diagnostics.get_mut().drain(..).collect()
+        std::mem::take(self.diagnostics.get_mut())
     }
 
     /// Return a reference to the collected diagnostics.

--- a/new-plans/capabilities.md
+++ b/new-plans/capabilities.md
@@ -73,13 +73,13 @@ asserted. The current two Wasm ability tests are **compile-only**.
 | Byte-wise `String` equality (`==` and `!=`) | **compile-only** | **native-run** | **wasm-run** | `test_string_equality_operators` verifies frontend resolution and lowering in [`expr_coverage.rs`](../crates/tribute-front/tests/expr_coverage.rs). `test_native_string_equality` and `test_execute_string_equality` execute shape-independent leaf-span comparison, mismatched leaf boundaries, empty leaves, shared/repeated subtrees, Unicode, length mismatch, and early/middle/late byte mismatch in [`e2e_native.rs`](../tests/e2e_native.rs) and [`wasm_compilation.rs`](../tests/wasm_compilation.rs). The structural prelude test fixes the direct Leaf/Leaf span path and rejects the former equality-only flatten/index loop. |
 | `Bytes` literals, concatenation, and `String::from_bytes` | **compile-only** | **native-run** | **wasm-run** | Native literal, concat, length, indexing, and slicing tests are in [`e2e_native.rs`](../tests/e2e_native.rs); `test_native_bytes_get_safe` asserts both the in-range `Some` and out-of-range `None` paths. Wasm execution is limited to concatenation/output in `test_execute_dynamic_bytes_write_boundary` and to concatenation plus `String::from_bytes` in `test_execute_string_literals_and_dynamic_bytes`, which asserts the converted `dynamic bytes` and `shared bytes` output. Other Wasm `Bytes` APIs are **not-yet-verified**. |
 | `Nat` and `Int` arithmetic/comparison | **compile-only** | **native-run** | **compile-only** | Native execution is in [`e2e_native.rs`](../tests/e2e_native.rs) and [`e2e_add.rs`](../tests/e2e_add.rs). `test_compile_arithmetic_expr` emits Wasm but does not run it. |
-| `Int::parse` and `Int::to_string` decimal text conversion | **compile-only** | **native-run** | **not-yet-verified** | `canonical_int_text_api_resolves_through_prelude` verifies the public signatures and canonical `Int::ParseError` identity in [`int_text.rs`](../crates/tribute-front/tests/int_text.rs). `public_int_text_api_covers_decimal_contract_and_boundaries` uses only public source APIs and executes signs, zero, invalid syntax, whitespace/data rejection, overflow, signed 32-bit boundaries, formatting, and round trips in [`e2e_int_text.rs`](../tests/e2e_int_text.rs). M1 accepts only `-2147483648` through `2147483647`; syntactically valid values outside that range return `OutOfRange` until the Fixnum/BigInt representation is implemented. No focused Wasm evidence was added. |
+| `Int::parse` and `Int::to_string` decimal text conversion | **compile-only** | **native-run** | **not-yet-verified** | `canonical_int_text_api_resolves_through_prelude` verifies the public signatures and canonical `Int::ParseError` identity in [`int_text.rs`](../crates/tribute-front/tests/int_text.rs). `public_int_text_api_covers_decimal_contract_and_boundaries` uses only public source APIs and executes signs, zero, invalid syntax, whitespace/data rejection, overflow, signed 32-bit boundaries, formatting, and round trips in [`e2e_int_text.rs`](../tests/e2e_int_text.rs). The current representation accepts only `-2147483648` through `2147483647`; syntactically valid values outside that range return `OutOfRange` until the Fixnum/BigInt representation is implemented. No focused Wasm evidence was added. |
 | `Float` arithmetic, comparison, and NaN behavior | **compile-only** | **native-run** | **not-yet-verified** | The native suite, including `test_float_comparison_nan_semantics`, is in [`e2e_float.rs`](../tests/e2e_float.rs). No Wasm float execution or focused emission test was found. |
 | Tuple collection-like grouping | **compile-only** | **native-run** | **not-yet-verified** | See tuple construction and pattern evidence above. |
-| General collection APIs beyond M1 list literals/patterns/prepend (`List` algorithms, map/set APIs) | **unsupported** | **unsupported** | **unsupported** | The M1 public surface is intentionally limited to literals, `List::prepend`, and sequence patterns. No broader collection implementation is exported by [`prelude.trb`](../lib/std/prelude.trb). |
+| General collection APIs beyond list literals/patterns/prepend (`List` algorithms, map/set APIs) | **unsupported** | **unsupported** | **unsupported** | The current public surface is intentionally limited to literals, `List::prepend`, and sequence patterns. No broader collection implementation is exported by [`prelude.trb`](../lib/std/prelude.trb). |
 | `std::io::print` and `print_line` | **compile-only** | **native-run** | **wasm-run** | Native output behavior is tested in [`e2e_native.rs`](../tests/e2e_native.rs). Wasm output execution is covered by the two execution tests in [`wasm_compilation.rs`](../tests/wasm_compilation.rs). The Wasm lowering implements `tribute_io.write` in [`wasm/io.rs`](../crates/tribute-passes/src/wasm/io.rs). |
 | `std::io::read_line` | **compile-only** | **native-run** | **unsupported** | Native line endings, empty/partial input, EOF, invalid UTF-8, and system errors execute in the `test_native_std_io_read_line_*` tests in [`e2e_native.rs`](../tests/e2e_native.rs). Native lowering is in [`native/io.rs`](../crates/tribute-passes/src/native/io.rs). Wasm I/O lowering has only a `WritePattern` and rejects residual `tribute_io` operations in [`wasm/io.rs`](../crates/tribute-passes/src/wasm/io.rs). |
-| Canonical M1 calculator REPL | **compile-only** | **native-run** | **not-yet-verified** | [`native_calculator.trb`](../lang-examples/native_calculator.trb) is compiled through the public CLI and its exact scripted and EOF stdout fixtures are asserted by [`canonical_calculator.rs`](../tests/canonical_calculator.rs). That product test also executes NUL-leading valid UTF-8 malformed input and invalid UTF-8, requiring a clean exit and exactly one input-failure line. The scripted session runs under AddressSanitizer locally and in the Ubuntu `canonical-native` CI matrix. Its exact source opens with empty LSP diagnostics and has `Int::parse` hover plus imported `Io` completion protocol evidence in [`lsp/server.rs`](../src/lsp/server.rs). No Wasm calculator execution claim is made. |
+| Canonical calculator REPL | **compile-only** | **native-run** | **not-yet-verified** | [`native_calculator.trb`](../lang-examples/native_calculator.trb) is compiled through the public CLI and its exact scripted and EOF stdout fixtures are asserted by [`canonical_calculator.rs`](../tests/canonical_calculator.rs). That product test also executes NUL-leading valid UTF-8 malformed input and invalid UTF-8, requiring a clean exit and exactly one input-failure line. The scripted session runs under AddressSanitizer locally and in the Ubuntu `canonical-native` CI matrix. Its exact source opens with empty LSP diagnostics and has `Int::parse` hover plus imported `Io` completion protocol evidence in [`lsp/server.rs`](../src/lsp/server.rs). No Wasm calculator execution claim is made. |
 
 The current **wasm-run** language-level claims in this table are String/Bytes
 output through `std::io::print_line` and byte-wise String equality. That
@@ -100,19 +100,19 @@ These compiler/tooling statuses are independent of a target runtime.
 | Package/project compilation and manifests | **unsupported** | The CLI accepts a source file rather than a package root or manifest in [`cli.rs`](../src/cli.rs). No package graph or manifest loader is present in the active pipeline. |
 | Separate compilation/linking of Tribute modules | **unsupported** | Native linking consumes one object generated from one `SourceCst` in [`main.rs`](../src/main.rs) and [`pipeline.rs`](../src/pipeline.rs); it does not link independently compiled Tribute modules. |
 
-## Canonical M1 Preview and M0 Artifacts
+## Canonical and Retained Artifacts
 
 ### User-Facing Canonical Artifacts
 
-Issue #806 adds the M1 native preview. Issue #797 owns the retained M0
-artifacts and their documentation:
+The repository keeps the following user-facing artifacts and their
+documentation:
 
-1. `lang-examples/native_calculator.trb` is the canonical M1 **native-run**
+1. `lang-examples/native_calculator.trb` is the canonical **native-run**
    example. Its scripted and EOF stdin/stdout contracts are checked in under
    `tests/fixtures/` and `tests/expected/`; the scripted session also has
    AddressSanitizer and LSP protocol evidence. The product test additionally
    covers NUL-leading valid UTF-8 malformed input and invalid UTF-8.
-2. `lang-examples/native_effects.trb` is a retained M0 **native-run** artifact.
+2. `lang-examples/native_effects.trb` is a retained **native-run** artifact.
    Its expected stdout is `Recovered: the failure was handled`.
 3. `lang-examples/wasm_dynamic_output.trb` is the canonical **wasm-run**
    example. Wasmtime execution must assert its expected String/Bytes output.
@@ -125,7 +125,7 @@ these artifacts and their expected results.
 
 ### Internal Regression Selection
 
-The user-facing artifacts above are the canonical examples. Separately, M0 CI
+The user-facing artifacts above are the canonical examples. Separately, CI
 should keep this broader internal regression selection to cross important
 compiler boundaries without treating every compile test as a runtime test:
 

--- a/new-plans/capabilities.md
+++ b/new-plans/capabilities.md
@@ -112,20 +112,23 @@ documentation:
    `tests/fixtures/` and `tests/expected/`; the scripted session also has
    AddressSanitizer and LSP protocol evidence. The product test additionally
    covers NUL-leading valid UTF-8 malformed input and invalid UTF-8.
-2. `lang-examples/native_effects.trb` is a retained **native-run** artifact.
-   Its expected stdout is `Recovered: the failure was handled`.
-3. `lang-examples/wasm_dynamic_output.trb` is the canonical **wasm-run**
+2. `lang-examples/wasm_dynamic_output.trb` is the canonical **wasm-run**
    example. Wasmtime execution must assert its expected String/Bytes output.
-4. `lang-examples/invalid_unresolved_name.trb` is the canonical frontend
+3. `lang-examples/invalid_unresolved_name.trb` is the canonical frontend
    failure example. Its diagnostic must include
    `` unresolved name `missing_value` ``.
 
+### Retained User-Facing Artifacts
+
+`lang-examples/native_effects.trb` is a retained **native-run** artifact. Its
+expected stdout is `Recovered: the failure was handled`.
+
 `lang-examples/README.md` is the companion catalog that records how to run
-these artifacts and their expected results.
+the canonical and retained artifacts and their expected results.
 
 ### Internal Regression Selection
 
-The user-facing artifacts above are the canonical examples. Separately, CI
+The canonical artifacts above are the required examples. Separately, CI
 should keep this broader internal regression selection to cross important
 compiler boundaries without treating every compile test as a runtime test:
 

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -163,6 +163,11 @@ ability 연산을 handler_dispatch 클로저 호출로 변환한다.
 
 상세 내용은 [implementation.md](implementation.md#cranelift-reference-counting)를 참조.
 
+Private native runtime helper는 target stage에서 exact physical callable ABI로만
+선언한다. 이 helper의 parameter와 result는 `core.ptr` 또는 scalar physical type이며
+`adt.typeref`를 사용할 수 없다. Source-logical managed reference와 private runtime
+pointer 사이의 경계는 이름, `abi` 문자열 또는 symbol 위치로 추론하지 않는다.
+
 ### ADT 메모리 레이아웃
 
 ```text

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -64,19 +64,21 @@ hand-written or text-round-tripped IR from silently selecting a user lookalike.
 ### Private List layout
 
 The native backend must eliminate shared `list.*` operations before the
-backend-ready boundary. M1 may use a private immutable singly linked node:
+backend-ready boundary. It lowers them to a private immutable RC-managed RRB
+tree. A representative physical shape is:
 
 ```text
-empty       = null
-non-empty   = RC object [element, tail]
+root          = RC object [length, depth, root_node, tail_leaf]
+internal node = RC object [child_count, cumulative_sizes, children...]
+leaf node     = RC object [element_count, elements...]
 ```
 
-This is a target-private lowering choice, not an `adt.enum List` contract.
-Frontend/shared IR never names node fields or `Empty`/`Cons`. Node allocation
-uses the standard RC header, RTTI, retain/release insertion, and deep-release
-path. A node owns reference-typed elements and its tail; tail observation
-preserves order and persistence. Later replacement with an RRB representation
-must not require source or shared-IR changes.
+The exact branching factor, packing, and empty sentinel are target-private and
+are not an `adt.enum List` contract. Frontend/shared IR never names RRB node
+fields. Node allocation uses the standard RC header, RTTI, retain/release
+insertion, and deep-release path. Internal nodes own their children and leaves
+own reference-typed elements. Sequence observations preserve order and
+persistence without exposing this layout.
 
 ### Native 타겟
 

--- a/new-plans/design.md
+++ b/new-plans/design.md
@@ -385,8 +385,6 @@ Cranelift 타겟에서는 **Reference Counting**을 채택한다.
 
 - [Binaryen](https://github.com/WebAssembly/binaryen) - WasmGC 최적화
 - [Cranelift](https://cranelift.dev/) - 네이티브 코드 생성
-- [WASM Stack Switching](https://github.com/WebAssembly/stack-switching) -
-  Continuation proposal
 
 ### 논문
 

--- a/new-plans/design.md
+++ b/new-plans/design.md
@@ -47,7 +47,7 @@ fn describe(value: Option(Int)) -> Text {
     }
 }
 
-// Post-M1 illustrative List algorithms; M1은 이 API를 보장하지 않는다.
+// Illustrative List algorithms; 별도 public API 절에서 확정되기 전까지 예시다.
 // UFCS 체이닝 (인자 없으면 괄호 생략)
 fn process(data: List(Int)) -> Int {
     data
@@ -99,7 +99,7 @@ pub mod Option {
     pub fn map(value: Option(a), f: fn(a) -> b) -> Option(b) { ... }
 }
 
-// M1 List construction과 UFCS 사용
+// List construction과 UFCS 사용
 let xs = [1, 2, 3]
 let prefixed = List::prepend(0, xs)
 let option = Option::Some(1)
@@ -107,11 +107,11 @@ let mapped = option.map(fn(x) x + 1)  // Option::map(option, ...) 로 해석
 ```
 
 `List(a)`는 compiler-owned canonical identity를 가진 opaque nominal immutable
-persistent sequence다. `[]`와 `[a, b, c]`가 유일한 M1 construction syntax이며,
-원소 표현식은 왼쪽에서 오른쪽으로 정확히 한 번 평가된다. `Empty`/`Cons` 같은
-representation constructor는 source API가 아니다. List의 shared IR operation과
-source-visible observation은 sequence 의미만 표현하고, native와 Wasm backend는 서로
-다른 private layout을 선택할 수 있다.
+persistent RRB tree다. List literal과 canonical persistent operation은 원소 표현식을
+왼쪽에서 오른쪽으로 정확히 한 번 평가한다. `Empty`/`Cons` 같은 representation
+constructor나 RRB node shape은 source API가 아니다. List의 shared IR operation과
+source-visible observation은 sequence 의미만 표현하고, native와 Wasm backend는 같은
+RRB invariant를 만족하는 target-private physical layout을 사용한다.
 
 ---
 
@@ -383,8 +383,6 @@ Cranelift 타겟에서는 **Reference Counting**을 채택한다.
 
 ### 구현
 
-- [libmprompt](https://github.com/koka-lang/libmprompt) -
-  Delimited continuation 런타임
 - [Binaryen](https://github.com/WebAssembly/binaryen) - WasmGC 최적화
 - [Cranelift](https://cranelift.dev/) - 네이티브 코드 생성
 - [WASM Stack Switching](https://github.com/WebAssembly/stack-switching) -

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -82,6 +82,24 @@ tribute        -> tribute-front + tribute-passes
   검증한다. 성공한 경계에는 residual `tribute_control` operation/type이 없고
   backend-ready 경계에는 `tribute_control.*`, `ability.*`, `effect.*`이 없다.
 
+Typed frontend output은 operation declaration metadata와 같은 out-of-band 경계에
+compiler intrinsic declaration metadata를 둔다. 각 entry는 canonical semantic
+identity, module-local symbol, complete logical callable type을 포함하고 deterministic
+order로 전달된다. Pre-CPS verifier는 bodyless function과 metadata를 exact-match한 뒤에만
+intrinsic identity attribute를 lowering에 맡긴다. 이후 intrinsic lowering은 이 verified
+identity와 signature를 소비하며 이름이나 `abi` 문자열을 fallback으로 사용하지 않는다.
+
+같은 pre-CPS 검사에서 `adt.typeref` callable boundary, `adt.ref_null`,
+`adt.ref_cast`, direct/indirect call과 return을 모두 검사한다. `core.ptr`에서 시작해
+unrealized cast 또는 reference cast를 거쳐 managed nominal reference가 되는 경로는
+전체 validation 실패이며 conversion은 시작하지 않는다. Defined Tribute function은
+managed logical parameter/result를 사용할 수 있지만, 등록되지 않은 bodyless external과
+private target runtime helper는 사용할 수 없다.
+
+기존 source-visible bytes/runtime bridge는 새 semantic callable origin을 만들지 않고
+현재의 conservative barrier로 남긴다. 이 경계가 별도 typed representation을 갖기
+전까지 새 bridge symbol이나 managed signature를 추가하지 않는다.
+
 Logical CPS result는 `core.never`, physical CPS ABI는 empty result다. 모든 CPS
 이전은 direct/indirect proper tail call이며 backend-ready IR은 CPS control-result
 `anyref`, private control enum, `Step`과 trampoline을 거부한다. Boxed source

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -11,9 +11,9 @@
 | 의미론 | 동적 (호출 시점 핸들러) | 정적 (생성 시점 캡처) |
 | 핸들러 디스패치 | Evidence passing | 런타임 스택 탐색 |
 | Continuation | One-shot, scoped | Multi-shot |
-| Polymorphic 함수 | Evidence 전달 | Monomorphization, 전면 CPS |
+| Polymorphic 함수 | Monomorphization + 필요한 Evidence/CPS convention | Uniform erasure, dictionary passing |
 | Evidence 구조 | 포인터 전달 + 정렬된 slice | bitmap, HashMap, 연결 리스트 |
-| GC (Cranelift) | Boehm GC (초기) | Custom tracing GC |
+| 메모리 관리 (Cranelift) | Reference counting | Tracing GC |
 | GC (WasmGC) | 런타임 내장 GC | - |
 
 ---
@@ -163,24 +163,23 @@ violates that precondition; they never synthesize a fallback element or tail.
 
 The prelude declares `List::prepend(value, tail)` as the minimal public dynamic
 construction API. Its source wrapper delegates to a private compiler intrinsic,
-and the shared pipeline replaces only that private ABI-marked call with
+and the shared pipeline replaces only that registry-verified private call with
 `list.prepend`. An ordinary source function with the same public qualified name
 is not an intrinsic. User code depends only on the public function signature and
 canonical `List(a)` contract; the private intrinsic, shared operation, and native
 node layout are not separately addressable collection APIs.
 
-Native may lower the operations to private immutable singly linked
-RC-managed nodes with empty represented by a private null sentinel. Each
-non-empty node owns its element when reference-typed and its tail. Existing RTTI,
-RC insertion, deep release, and borrowed-field rules apply after the private
-node operations become native ADT/load/store operations. Returning or binding a
-tail must keep it alive independently of the original list. Mutation based on a
-uniqueness proof is an optional optimization and cannot change semantics.
+Native lowers the operations to private immutable RC-managed RRB nodes. Internal
+nodes own their child references, leaves own their reference-typed elements, and
+the root owns the reachable tree. Existing RTTI, RC insertion, deep release, and
+borrowed-field rules apply after private RRB operations become native
+ADT/load/store operations. Returning a sequence view must keep the referenced
+tree alive independently of the original value.
 
-WasmGC selects its own private GC layout. Native layout choices are not shared
-IR conventions and do not establish Wasm execution parity. Full RRB trees,
-efficient concatenation, slicing, and transients are outside the canonical
-`List` contract.
+WasmGC uses its own private RRB-node layout. Concrete branching factors and node
+packing are target details rather than shared IR conventions. Efficient
+concatenation and slicing are required RRB properties; transient mutation based
+on a uniqueness proof is an optional optimization and cannot change semantics.
 
 ## Canonical Native Calculator
 
@@ -439,7 +438,7 @@ cell을 읽는다. Shared `func.call`에 zero-result 형상을 추가하지 않�
 nested-module `main`은 특별하지 않다.
 
 기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
-Frontend shared lowering은 private intrinsic stub을 `tribute_io.write`와
+Frontend shared lowering은 private runtime bridge stub을 `tribute_io.write`와
 `tribute_io.read_line` operation으로 바꾼다. 이 boundary는 rope 표현 대신 `Bytes`와
 target-independent `ReadLineResult`를 사용한다. Native와 Wasm pipeline은 이후 각자의
 runtime ABI 또는 host import로 operation을 완전히 lower해야 한다.

--- a/new-plans/io.md
+++ b/new-plans/io.md
@@ -179,7 +179,8 @@ Embedded `std::io` source는 `String::to_bytes`로 rope를 flatten한 뒤 `write
 `tribute_io.*`는 shared IR operation이며 public source symbol이 아니다. Embedded source가
 사용하는 private runtime bridge stub은 frontend lowering에서 이 operation으로 즉시 바뀌고,
 target pipeline 이전에는 제거된다. Shared contract는 target ABI를 포함하지 않으며,
-native와 Wasm lowering이 각 target boundary에서 operation을 완전히 소비한다.
+지원하는 native와 Wasm operation만 각 target boundary에서 완전히 소비된다. Wasm
+`read_line`은 해당 lowering이 구현되기 전까지 지원하지 않으며 검증에서 거부한다.
 
 - Native lowering은 `tribute-runtime`의 stdin/stdout ABI로 변환한다.
 - Wasm lowering은 현재 backend가 지원하는 WASI 또는 custom host import로 변환한다.

--- a/new-plans/io.md
+++ b/new-plans/io.md
@@ -115,8 +115,8 @@ main(ev) -> Nil
 ```
 
 `read_line`은 실패 시 `Throw(Error)`를 수행하므로 CPS 규약을 사용한다. 논리적
-ABI에서 `done_k`와 함수의 control result는 `Never`이며, 현재 compatibility
-lowering만 이를 `anyref` carrier로 표현한다.
+ABI에서 `done_k`와 함수의 control result는 `Never`다. Physical lowering은 이를
+empty-result callable과 proper tail transfer로 바꾸며 control carrier를 만들지 않는다.
 
 ```text
 read_line(ev, done_k: fn(String) -> Never) -> Never
@@ -177,9 +177,9 @@ Embedded `std::io` source는 `String::to_bytes`로 rope를 flatten한 뒤 `write
 `std::io::Error`로 변환하여 `Throw(Error)` operation을 호출한다.
 
 `tribute_io.*`는 shared IR operation이며 public source symbol이 아니다. Embedded source가
-사용하는 private intrinsic stub은 frontend lowering에서 이 operation으로 즉시 바뀌고,
-target pipeline 이전에는 제거된다. #770은 이 shared contract까지 구현하고, 실제 native와
-Wasm lowering은 각각 #772와 #771이 담당한다.
+사용하는 private runtime bridge stub은 frontend lowering에서 이 operation으로 즉시 바뀌고,
+target pipeline 이전에는 제거된다. Shared contract는 target ABI를 포함하지 않으며,
+native와 Wasm lowering이 각 target boundary에서 operation을 완전히 소비한다.
 
 - Native lowering은 `tribute-runtime`의 stdin/stdout ABI로 변환한다.
 - Wasm lowering은 현재 backend가 지원하는 WASI 또는 custom host import로 변환한다.

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -245,7 +245,9 @@ tribute_control.func {sym_name = @id, type = !Callable} (%x: T) { ... }
 Named callable의 origin은 symbol이나 `abi` 문자열과 별개인 typed frontend
 metadata다. Source 정의는 body를 가진 Tribute callable이고, compiler intrinsic은
 canonical registry가 부여한 semantic identity와 완전한 logical signature를 함께
-가진다. Private runtime helper는 target stage에서만 physical signature로 만들며
+가진다. 등록된 compiler intrinsic의 logical callable convention은 항상 `Direct`이며,
+이 조건은 identity와 signature 대조와 함께 mutation 전에 검증한다. Private runtime
+helper는 target stage에서만 physical signature로 만들며
 source-logical `adt.typeref`를 받을 수 없다. 아직 별도 user FFI 계약이 없는 bodyless
 declaration은 managed semantic parameter나 result를 사용할 수 없다. Textual attribute,
 symbol spelling, 위치 또는 printed IR만으로 origin을 복구하거나 승격하지 않는다.

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -619,10 +619,10 @@ non-emptiness before executing either operation. A backend must trap if the
 precondition is violated; it must not return a type-default head, a null tail,
 or any other fallback value.
 The public `List::prepend(value, tail)` prelude wrapper delegates to a private
-ABI-marked compiler intrinsic, whose calls lower to the same `list.prepend`
-operation. A source-defined function merely spelled `List::prepend` remains an
-ordinary call. The private intrinsic ABI is a compiler/prelude boundary, not an
-additional public symbol or a layout contract.
+registry-verified compiler intrinsic, whose calls lower to the same
+`list.prepend` operation. A source-defined function merely spelled
+`List::prepend` remains an ordinary call. The private intrinsic declaration is a
+compiler/prelude boundary, not an additional public symbol or a layout contract.
 
 List patterns lower to sequence observations. Exact-length patterns require an
 empty remainder; prefix-rest patterns return the remainder as the same canonical

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -242,6 +242,20 @@ tribute_control.func {sym_name = @id, type = !Callable} (%x: T) { ... }
   block argument로 들어온다.
 - **위치:** source function 또는 extern declaration 전체 span이다.
 
+Named callable의 origin은 symbol이나 `abi` 문자열과 별개인 typed frontend
+metadata다. Source 정의는 body를 가진 Tribute callable이고, compiler intrinsic은
+canonical registry가 부여한 semantic identity와 완전한 logical signature를 함께
+가진다. Private runtime helper는 target stage에서만 physical signature로 만들며
+source-logical `adt.typeref`를 받을 수 없다. 아직 별도 user FFI 계약이 없는 bodyless
+declaration은 managed semantic parameter나 result를 사용할 수 없다. Textual attribute,
+symbol spelling, 위치 또는 printed IR만으로 origin을 복구하거나 승격하지 않는다.
+
+Frontend 경계 verifier는 metadata 전체와 module의 callable graph를 mutation 전에
+대조한다. Direct call은 module-local symbol을 유일하게 resolve하고 완전한 signature를
+맞춰야 한다. Indirect call은 exact `tribute_control.callable` signature와 source-logical
+callable producer를 요구한다. Return은 enclosing callable의 logical result와 일치해야
+한다. Body가 없는 declaration도 body traversal 없이 같은 검사를 받는다.
+
 #### `tribute_control.lambda`
 
 ```text
@@ -580,6 +594,15 @@ native uses function pointers plus heap environments.
 
 `adt.*` represents target-independent product, sum, array, reference, and
 literal operations.
+
+`adt.typeref`는 nominal managed reference type이다. 유효한 값은 이 type 자체로
+managed이며 pointer provenance로 managed 여부를 다시 판정하지 않는다.
+`adt.ref_null`은 정확히 지정한 `adt.typeref`의 null inhabitant이고 retain/release는
+null에 대해 no-op이다. `adt.ref_cast`는 확인된 같은 nominal identity의 managed
+reference 사이에서만 허용한다. `core.ptr`는 항상 unmanaged이므로 raw pointer,
+allocator result, code address, Evidence, borrowed buffer와 이를 통과하는 cast chain은
+`adt.typeref`가 될 수 없다. 이 규칙은 typed frontend 경계에서 reachable IR을 바꾸기
+전에 검사한다.
 
 `list.*` represents the opaque canonical `List(a)` sequence contract. It uses
 `list.empty`, `list.prepend`, `list.is_empty`, `list.head`, and `list.tail`.

--- a/new-plans/modules.md
+++ b/new-plans/modules.md
@@ -60,17 +60,18 @@ syntax-owned semantics를 바꾸지 않는다. 예를 들어 로컬 `List`는 an
 ```rust
 // List(a)는 compiler-owned opaque nominal type이다.
 // Empty/Cons constructor나 backend layout은 이 namespace에 export하지 않는다.
-// M1 source-visible dynamic construction is specified as a sequence operation.
+// Source-visible dynamic construction is specified as a sequence operation.
 pub mod List {
     pub fn prepend(value: a, tail: List(a)) -> List(a) { ... }
 }
 ```
 
-M1 List public surface는 literal, sequence-view pattern,
+현재 List public surface는 literal, sequence-view pattern,
 `List::prepend(value, tail) -> List(a)`로 제한된다. Prelude의 public wrapper는
-private ABI-marked compiler intrinsic을 호출하고, shared pipeline은 그 private
-call만 `list.prepend`로 lower한다. 같은 public qualified name을 가진 일반 source
-function은 intrinsic이 아니다. Private intrinsic ABI는 별도 source API가 아니다.
+registry-verified private compiler intrinsic을 호출하고, shared pipeline은 그
+private call만 `list.prepend`로 lower한다. 같은 public qualified name을 가진 일반
+source function은 intrinsic이 아니다. Private intrinsic declaration은 별도 source
+API가 아니다.
 Compiler lowering에 필요한 `list.empty`, `list.prepend`, `list.is_empty`,
 `list.head`, `list.tail`도 shared IR operation이며 source API가 아니다. 이
 operation들은 sequence 의미만 갖고 target layout이나 variant tag를 노출하지
@@ -199,8 +200,9 @@ UFCS와 pipe는 같은 문제(함수 체이닝)를 해결한다. 둘 다 지원�
 
 ### 기존 예제 업데이트
 
-다음 pipe/UFCS 비교는 post-M1 illustrative collection API를 사용한다.
-`List::filter`, `List::map`, `List::fold`는 M1 public API 계약이 아니다.
+다음 pipe/UFCS 비교는 illustrative collection API를 사용한다.
+`List::filter`, `List::map`, `List::fold`는 별도 public API 절에서 확정되기 전까지
+예시에 불과하다.
 
 ```rust
 // Before (pipe 스타일, 더 이상 사용하지 않음)
@@ -227,8 +229,8 @@ fn process(data: List(Int)) -> Int {
 ### Type-Directed Resolution
 
 함수 이름이 여러 모듈에서 use된 경우, 첫 번째 인자의 타입으로 해소한다.
-이 절의 `List::map`은 해소 규칙만 설명하는 post-M1 illustrative API이며 M1에서
-보장되지 않는다.
+이 절의 `List::map`은 해소 규칙만 설명하는 illustrative API이며 별도 public API
+절에서 확정되지 않았다.
 
 ```rust
 use std::collections::List
@@ -331,7 +333,7 @@ fn sort_by(xs: List(a), key: fn(a) -> k, compare: fn(k, k) -> Ordering) -> List(
 ## Complete Example
 
 다음 예제의 `List::of`, `filter`, `map`, `fold`, `sort`, `each`는 전체 module/UFCS
-구성을 보여 주기 위한 post-M1 illustrative API이며 M1에서 보장되지 않는다.
+구성을 보여 주기 위한 illustrative API이며 별도 public API 절에서 확정되지 않았다.
 
 ```rust
 // app/main.trb

--- a/new-plans/modules.md
+++ b/new-plans/modules.md
@@ -76,6 +76,11 @@ Compiler lowering에 필요한 `list.empty`, `list.prepend`, `list.is_empty`,
 operation들은 sequence 의미만 갖고 target layout이나 variant tag를 노출하지
 않는다. Native와 Wasm은 각자 private layout으로 lower한다.
 
+Compiler intrinsic은 canonical prelude declaration identity와 typechecked complete
+signature가 registry에서 함께 확인될 때만 intrinsic이다. 같은 qualified symbol이나
+같은 `abi` 문자열을 사용한 source declaration은 ordinary external callable이며
+intrinsic 권한을 상속하지 않는다.
+
 ### Use 문법
 
 ```rust

--- a/new-plans/numeric-types.md
+++ b/new-plans/numeric-types.md
@@ -147,7 +147,7 @@ digits, base prefixes, separators, embedded whitespace, surrounding
 whitespace, and trailing data return `InvalidSyntax`. Whitespace normalization
 belongs to a separate `String` operation; parsing never trims implicitly.
 
-The M1 representation is a signed 32-bit integer with the inclusive range
+The current representation is a signed 32-bit integer with the inclusive range
 `-2147483648` through `2147483647`. A syntactically valid decimal outside that
 range returns `OutOfRange`. The implementation must detect overflow before an
 arithmetic operation would exceed the range; it must not wrap, trap, truncate,

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -133,11 +133,15 @@ materialize한 `tribute_rt.retain`과 `tribute_rt.release`만 RC 의미를 보�
 
 ```text
 // tribute_rt.retain(ptr):
+if ptr == null:
+    return ptr
 refcount = load(ptr - 8)
 refcount = refcount + 1
 store(refcount, ptr - 8)
 
 // tribute_rt.release(ptr):
+if ptr == null:
+    return
 refcount = load(ptr - 8)
 refcount = refcount - 1
 store(refcount, ptr - 8)
@@ -145,8 +149,10 @@ if refcount == 0:
     call @__tribute_dealloc(ptr - 8, size + 8)
 ```
 
-The abbreviated sequence above omits null handling and type-specific field
-destruction. The complete release path uses RTTI dispatch as described below.
+The abbreviated sequence above omits type-specific field destruction. Every
+complete retain and release path returns for a null managed reference before
+accessing its header, refcount, or RTTI. The complete release path uses RTTI
+dispatch as described below.
 
 ---
 
@@ -415,6 +421,7 @@ dependencies separately govern field-derived temporaries.
 
 ```text
 tribute_rt.retain(ptr) ->
+    if ptr == null: return ptr
     %rc_addr = clif.iadd(ptr, clif.iconst(-8))
     %rc = clif.load(%rc_addr)
     %new_rc = clif.iadd(%rc, clif.iconst(1))
@@ -422,6 +429,7 @@ tribute_rt.retain(ptr) ->
     // result: ptr (unchanged)
 
 tribute_rt.release(ptr) ->
+    if ptr == null: jump continue_block
     %rc_addr = clif.iadd(ptr, clif.iconst(-8))
     %rc = clif.load(%rc_addr)
     %new_rc = clif.isub(%rc, clif.iconst(1))
@@ -483,6 +491,8 @@ __tribute_release_Point(ptr):
 
 ```text
 tribute_rt.release(ptr) ->
+    if ptr == null:
+        return
     %rc = decrement_refcount(ptr)
     if %rc == 0:
         %rtti_idx = load(ptr - 4)

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -15,7 +15,7 @@ The native backend uses **reference counting** for heap-allocated objects
 - **libc only** — depends solely on `malloc`/`free` (via allocator indirection)
 - **Dialect-based** — RC operations are `tribute_rt.retain`/`tribute_rt.release`
   dialect ops, lowered to inline code
-- **Phased rollout** — Phase 3a (shallow), 3b (deep release), 4 (continuations)
+- **Typed planning** — ownership and RTTI decisions precede type erasure
 
 ## Allocator Interface
 
@@ -57,7 +57,7 @@ with user code and to clearly mark compiler-generated functions.
 
 ## Memory Layout
 
-### Object Header (Phase 3a+)
+### Object Header
 
 Every heap-allocated RC object has an 8-byte header prepended before the
 payload. Compiled code always sees the pointer at offset 0 (first field);
@@ -68,10 +68,6 @@ header access uses `ptr - 8`.
 [-4] rtti_idx: u32   — runtime type info index
 [ 0] payload...      — first field (naturally aligned)
 ```
-
-> **Current state (pre-RC):** Struct allocation via `adt_to_clif` and
-> boxing via `tribute_rt_to_clif` do NOT include the header yet. The
-> header will be added when the RC insertion pass (PR 3) lands.
 
 ### Struct Layout
 
@@ -96,13 +92,13 @@ Boxed primitives are the simplest heap objects — just the raw value:
 
 ### Private native List nodes
 
-The M1 native `List(a)` representation may use the ordinary RC object header
-with a target-private immutable payload `[element, tail]`; empty is a private
-null sentinel. A non-empty node owns every reference-typed field, including its
-tail. Sequence observation may borrow fields transiently, but a tail that
-escapes the observation or outlives the original list must be retained by the
-normal ownership rules. The representation is replaceable and is not visible
-as public `Empty`/`Cons` constructors or shared-IR field indices.
+The native `List(a)` representation uses immutable RRB nodes with the ordinary
+RC object header. Internal nodes own their child references, leaves own their
+reference-typed elements, and the root owns the reachable tree. Sequence views
+may borrow nodes transiently, but a view that escapes or outlives the original
+root must retain the referenced structure under the normal ownership rules.
+Branching factor, node packing, and the empty representation are target-private
+and are not visible as source constructors or shared-IR field indices.
 
 ---
 
@@ -127,7 +123,13 @@ operand position 또는 pointer provenance로 managed 성질을 얻을 수 없�
 release는 이 값에 대해 no-op이어야 한다. Callable과 managed-reference validation은
 ownership plan 또는 IR mutation이 이 분류를 사용하기 전에 완료된다.
 
-### Inline Lowering (Phase 3a)
+Type erasure가 managed reference를 `core.ptr`로 바꾼 뒤에는 pointer type 자체가
+ownership을 증명하지 않는다. Pre-erasure ownership plan이 물리 IR에 명시적으로
+materialize한 `tribute_rt.retain`과 `tribute_rt.release`만 RC 의미를 보존한다. 따라서
+이 operation의 `core.ptr` operand가 RC allocation을 가리킬 수 있다는 사실과
+`core.ptr` 자체가 unmanaged라는 규칙은 모순되지 않는다.
+
+### Inline Lowering
 
 ```text
 // tribute_rt.retain(ptr):
@@ -143,8 +145,8 @@ if refcount == 0:
     call @__tribute_dealloc(ptr - 8, size + 8)
 ```
 
-Phase 3b will replace the simple dealloc with type-specific destructors
-via RTTI dispatch.
+The abbreviated sequence above omits null handling and type-specific field
+destruction. The complete release path uses RTTI dispatch as described below.
 
 ---
 
@@ -441,40 +443,27 @@ continue_block:
 
 ---
 
-## Phasing
+## Ownership and Lowering Order
 
-RC is implemented in three phases:
+RC lowering follows a semantic-to-physical order:
 
-### Phase 3a: Shallow Free (Current PR + Next PR)
+1. Validate callable origins and managed-reference boundaries on typed IR.
+2. Compute ownership actions and RTTI field information while `adt.typeref`
+   identity is still available.
+3. Materialize explicit `tribute_rt.retain` and `tribute_rt.release` operations.
+4. Erase managed references to `core.ptr` and lower the explicit RC operations
+   to physical refcount updates and type-specific destruction.
 
-**Goal:** Basic RC infrastructure without deep release.
+No later pass may reconstruct managedness from a raw pointer, symbol spelling,
+ABI marker, operand position, or erased provenance. A shallow release may be
+used only as an explicitly documented intermediate implementation stage; the
+semantic contract requires type-specific release of owned managed fields.
 
-**Components:**
+### Type-specific release
 
-- ✅ **PR 1:** Allocator indirection (`__tribute_alloc`, `__tribute_dealloc`)
-- ✅ **PR 2:** Boxing/unboxing + `retain`/`release` ops (this PR)
-- ⏳ **PR 3:** RC insertion pass (SSA-based liveness)
-- ⏳ **PR 4:** RC lowering pass (inline refcount ops)
-
-**State after Phase 3a:**
-
-- All heap objects have 8-byte headers (refcount + rtti_idx)
-- Boxing/unboxing work for primitives
-- `retain`/`release` inserted and lowered to inline code
-- **Limitation:** `release` only does shallow free (no recursive release of fields)
-- Leak detection: Use Valgrind/AddressSanitizer to verify no double-frees
-
-### Phase 3b: Deep Release (Deferred)
-
-**Goal:** Recursive release of pointer fields.
-
-**New components:**
-
-- **Type-specific release functions:** Compiler generates
-  `__tribute_release_T(ptr)` for each struct type
-- **RTTI table:** Maps `rtti_idx` to release function pointer
-- **Deep release logic:** Release function calls `tribute_rt.release` on
-  pointer fields before dealloc
+The compiler generates a release function for each managed aggregate type. When
+the refcount reaches zero, RTTI dispatch selects that function, which releases
+owned managed fields before deallocating the object.
 
 **Example (struct with pointer field):**
 
@@ -501,96 +490,19 @@ tribute_rt.release(ptr) ->
         call %release_fn(ptr)
 ```
 
-### Phase 4a: Continuation RC Protection (Implemented)
+### Continuation ownership
 
-**Goal:** Prevent use-after-free when handlers release RC pointers that
-live across `mp_yield` boundaries.
+Tail-call CPS represents a continuation as a typed closure with an explicit
+ContinuationFrame. Capturing a managed value into that frame creates an
+independent owned reference and therefore materializes a retain. Destroying an
+unresumed one-shot continuation releases every owned frame field through the
+ordinary type-specific destructor. Resuming transfers the frame-owned values
+according to the continuation callable contract.
 
-**Problem:** When `mp_yield` captures a continuation, the stack segment is
-copied to the heap. If the handler releases a pointer that was live on the
-captured stack, resuming the continuation accesses freed memory.
-
-**Solution — three components:**
-
-1. **`insert_rc` extension (Phase 2.8):** At each `__tribute_yield` call site,
-   inserts extra `retain` for all live RC pointers before yield, and matching
-   `release` after yield returns (resume path). Also stores the RC roots in
-   TLS via `__tribute_yield_set_rc_roots`.
-
-2. **`TributeContinuation` wrapper (runtime):** Opaque wrapper around the raw
-   `mp_resume` pointer that carries an array of `RcRoot` captured at
-   yield time. Created by `__tribute_cont_wrap_from_tls`.
-
-3. **`cont_rc` rewrite pass (Phase 2.85):** Wraps raw resume pointers by
-   inserting `__tribute_cont_wrap_from_tls` after each
-   `__tribute_get_yield_continuation()`. The existing `__tribute_resume`
-   and `__tribute_resume_drop` functions accept the wrapped
-   `TributeContinuation*` directly.
-
-**RC flow:**
-
-```text
-Before yield:  retain(ptr)     → refcount + 1 (capture protection)
-               store ptr in TLS RC roots
-               __tribute_yield(...)
-
-Resume path:   yield returns
-               release(ptr)    → refcount - 1 (cancel extra retain)
-               body continues with normal release path
-
-Drop path:     __tribute_resume_drop(wrapped_k)
-               runtime: release each rc_root → refcount - 1
-               runtime: mp_resume_drop → discard captured stack
-```
-
-**Drop path cleanup (Phase 4b):** On the drop path, the body's normal
-`release` calls do not execute (the captured stack is discarded). Phase 4b
-mitigates this via double `release_deep` per RC root in
-`__tribute_resume_drop`: the first cancels the extra retain, the
-second replaces the body's missing normal release.
-
-### Phase 4b: Continuation Cleanup on Drop Path (Implemented)
-
-**Goal:** Eliminate resource leaks on the drop path when a captured
-continuation is discarded without being resumed.
-
-**Two problems solved:**
-
-1. **Roots buffer leak:** The temporary roots array (heap-allocated by
-   `insert_rc` via `__tribute_alloc`) was freed only on the resume path
-   by post-yield `__tribute_dealloc`, but leaked on the drop path.
-   **Fix:** `__tribute_cont_wrap_from_tls` now frees the original buffer
-   after copying its contents. The post-yield dealloc was removed to
-   prevent double-free.
-
-2. **Lost normal releases:** When `mp_resume_drop` discards a captured
-   continuation, the body's remaining `release` calls never execute,
-   leaking objects. **Fix:** `__tribute_resume_drop` now performs
-   **two** deep releases per RC root:
-   - 1st: cancel the extra retain (refcount N+1 → N)
-   - 2nd: replace the body's missing normal release (refcount N → N-1)
-
-**Implementation details:**
-
-- **Roots array layout changed** from `[ptr, ...]` (8 bytes/entry) to
-  `[(ptr, alloc_size), ...]` (16 bytes/entry). The `alloc_size` is
-  determined at compile time by `infer_alloc_size()`.
-
-- **`RcRoot` struct** replaces `RcObject` in the runtime:
-  `RcRoot { ptr: NonNull<u8>, alloc_size: u64 }`
-
-- **`__tribute_deep_release`** is now exported (`Linkage::Export`) from
-  compiled code, allowing the runtime to call it for RTTI-dispatched
-  recursive field release when refcount reaches 0.
-
-- **`release_deep()`**: decrements refcount; if 0, calls
-  `__tribute_deep_release(ptr, alloc_size)` for full cleanup.
-
-**Known limitation:** When `infer_alloc_size()` returns 0 (e.g., for block
-arguments with unknown provenance), the deep release's shallow path calls
-`__tribute_dealloc(raw, 0)` which is a no-op — the object leaks. This is
-the same constraint as normal release paths. Adding size info to the RTTI
-table would fix this (separate future work).
+There is no stack-copying continuation runtime, TLS root buffer, `mp_yield`, or
+special double-release protocol. Proper-tail lowering emits releases for dying,
+non-transferred values before `func.tail_call` or
+`func.tail_call_indirect`; no RC operation may follow the tail terminator.
 
 ---
 
@@ -620,10 +532,7 @@ static TRIBUTE_RTTI_TABLE: [TypeInfo; N] = [...];
   - `2` = boxed i32 (Bool/Nat)
   - `3+` = user-defined structs/enums
 
-**Phase 3a behavior:** `rtti_idx` is recorded but not used (all objects
-use shallow free).
-
-**Phase 3b behavior:** `release` dispatch via RTTI table for deep release.
+`release` uses the stored RTTI index to select the type-specific destructor.
 
 ---
 
@@ -696,6 +605,5 @@ for both sides of the optimization comparison.
 
 - **Cycle detection:** Weak references? Tracing GC fallback?
 - **Thread-safety:** Atomic refcount for multi-threaded code?
-- **Continuation cleanup:** ~~Phase 4b cleanup functions for drop-path leaks~~ (implemented)
 - **FFI boundaries:** How to handle RC objects at C FFI boundaries?
 - **Optimization:** Compile-time escape analysis to elide RC?

--- a/new-plans/rc.md
+++ b/new-plans/rc.md
@@ -120,6 +120,13 @@ These are dialect-level operations that will be:
 1. **Inserted** by the RC insertion pass (SSA-based liveness analysis)
 2. **Lowered** to inline code by the RC lowering pass
 
+Type erasure 전 RC planning은 검증된 모든 `adt.typeref`를 semantic type에 따라
+managed로 취급한다. `core.ptr`는 항상 unmanaged이며 cast, symbol, ABI spelling,
+operand position 또는 pointer provenance로 managed 성질을 얻을 수 없다.
+`adt.ref_null`은 nominal managed reference type의 null 값이고, 생성된 retain과
+release는 이 값에 대해 no-op이어야 한다. Callable과 managed-reference validation은
+ownership plan 또는 IR mutation이 이 분류를 사용하기 전에 완료된다.
+
 ### Inline Lowering (Phase 3a)
 
 ```text

--- a/new-plans/syntax.md
+++ b/new-plans/syntax.md
@@ -651,7 +651,7 @@ ResumeExpr ::= 'resume' Expression?            // op handler body 전용 (affine
 List literal은 canonical opaque `List(a)`를 만든다. 각 element expression은 source
 순서대로 왼쪽에서 오른쪽으로 정확히 한 번 평가되며, 내부 persistent representation을
 구성하기 위한 reverse fold가 이 evaluation order를 바꾸거나 재평가해서는 안 된다.
-Runtime value를 기존 tail 앞에 붙이는 M1 public API는
+Runtime value를 기존 tail 앞에 붙이는 최소 public API는
 `List::prepend(value, tail)`이다. 이 함수는 새 canonical List를 반환하며 tail을
 변경하지 않는다. `Empty`와 `Cons`는 List syntax의 constructor가 아니다.
 
@@ -1032,7 +1032,7 @@ let x = 1; let y = 2; x + y
 ## Complete Example
 
 이 예제의 `List::filter`, `List::map`, `List::each`는 complete-program 구성을
-보여 주기 위한 post-M1 illustrative API이며 M1에서 보장되지 않는다.
+보여 주기 위한 illustrative API이며 별도 public API 절에서 확정되지 않았다.
 
 ```rust
 use std::collections::{List, Option}

--- a/new-plans/types.md
+++ b/new-plans/types.md
@@ -152,9 +152,9 @@ identity is compiler-owned and distinct from every source declaration, including
 a user declaration also spelled `List`. Name-based equality is not sufficient
 for named types: type checking and lowering compare declaration identities.
 
-The representation is not a source contract. In particular, `Empty` and `Cons`
-are not public constructors or patterns. M1 construction uses list literals and
-the canonical persistent prepend operation:
+The concrete RRB-node layout is not a source contract. In particular, `Empty`
+and `Cons` are not public constructors or patterns. Construction uses list
+literals and the canonical persistent prepend operation:
 
 ```rust
 let empty: List(Int) = []
@@ -168,10 +168,10 @@ order. Lists are immutable and persistent: observing a tail never changes the
 original list, and a tail retains the original element order.
 `List::prepend(value, tail)` returns a new canonical `List(a)` whose first
 element is `value` and whose remaining sequence is `tail`; it does not mutate or
-expose the representation of `tail`. This is the only general source-level List
-construction operation required by M1.
+expose the representation of `tail`. This is the minimal general source-level
+List construction operation.
 
-M1 exposes sequence-view patterns:
+List patterns use sequence views:
 
 ```rust
 []                    // exactly empty
@@ -184,10 +184,11 @@ Exact patterns require the stated length. Prefix-rest patterns require at least
 the prefix length and bind the remaining sequence without copying or mutation.
 Element subpatterns are matched left to right.
 
-The initial backend representation may be a simpler persistent linked sequence.
-Full RRB-tree layout, logarithmic concatenation, and transient/uniqueness
-optimization are future work. Those changes must not alter source syntax,
-`List(a)` identity, or shared `list.*` IR contracts.
+Every backend represents `List(a)` as an RRB tree. The branching factor, node
+packing, and allocation layout are target-private, while persistence, logarithmic
+concatenation, and efficient slicing are representation requirements. A
+transient or uniqueness optimization is optional and must not alter source
+syntax, `List(a)` identity, or shared `list.*` IR contracts.
 
 ### Shorthand Syntax
 

--- a/plans/02.04-wasm-translation.md
+++ b/plans/02.04-wasm-translation.md
@@ -1,59 +1,17 @@
-# Wasm Translation (TrunkIR → Wasm)
+# Wasm Translation (Superseded Plan)
 
-Goal: compile Tribute end-to-end to WebAssembly (including WasmGC).
+This implementation plan is retained only as a historical index. Its crate
+layout, pass inventory, issue list, and stack-switching assumptions no longer
+describe the active compiler.
 
-## Current State
+The current design and implementation boundaries are documented in:
 
-### Implemented
+- [`new-plans/wasm-backend.md`](../new-plans/wasm-backend.md) for the shared
+  tail-call CPS to WasmGC lowering and emission architecture;
+- [`new-plans/ir.md`](../new-plans/ir.md) for backend-ready validation; and
+- [`new-plans/capabilities.md`](../new-plans/capabilities.md) for evidence-backed
+  current target support.
 
-**Lowering Passes** (`crates/tribute-wasm-backend/src/passes/`):
-
-- `adt_to_wasm` - ADT operations → WasmGC structs
-- `arith_to_wasm` - Arithmetic → Wasm numeric ops
-- `const_to_wasm` - Constants → Wasm const ops
-- `func_to_wasm` - Functions → Wasm functions
-- `intrinsic_to_wasm` - WASI intrinsics
-- `scf_to_wasm` - Structured control flow
-
-**Wasm Dialect** (`crates/trunk-ir/src/dialect/wasm.rs`):
-
-- Control flow: `block`, `loop`, `if`, `br`, `br_if`, `return`, `call`, `call_indirect`
-- Module items: `func`, `import_func`, `export_func`, `memory`, `data`
-- Numerics: Full i32/i64/f32/f64 arithmetic, comparison, bitwise
-- Locals: `local_get`, `local_set`, `local_tee`
-- WasmGC: `struct_new`, `struct_get`, `struct_set`, `ref_null`, `ref_cast`, etc.
-
-**Emitter** (`emit.rs`): Converts wasm dialect → binary via `wasm_encoder`
-
-### Remaining Work
-
-| Issue | Description |
-| ----- | ----------- |
-| #38 | Add `wasm.table` and `wasm.elem` operations |
-| #39 | Add `wasm.global` operations |
-| #40 | Add memory load/store operations |
-| #41 | Implement closure lowering to Wasm |
-
-## Architecture
-
-```text
-TrunkIR Module
-    │
-    ├─▶ adt_to_wasm
-    ├─▶ arith_to_wasm
-    ├─▶ const_to_wasm
-    ├─▶ func_to_wasm
-    ├─▶ intrinsic_to_wasm
-    └─▶ scf_to_wasm
-    │
-    ▼
-Wasm Dialect Module
-    │
-    ▼ emit_wasm()
-WebAssembly Binary
-```
-
-## References
-
-- `new-plans/lowering.md` - Lowering pass architecture
-- `02.03-wasm-runtime-research.md` - Runtime research (Wasmtime recommended)
+Historical runtime research remains in
+[`02.03-wasm-runtime-research.md`](02.03-wasm-runtime-research.md) and is not a
+current implementation contract.

--- a/plans/05-standard-library.md
+++ b/plans/05-standard-library.md
@@ -207,7 +207,7 @@ mod List {
 1. **Ability-first**: I/O and errors expressed as abilities
 2. **Explicit effects**: Effects visible in types
 3. **Handler composability**: Various execution strategies via handler composition
-4. **GC-managed memory**: No explicit memory management required
+4. **Compiler-managed memory**: No explicit source-level memory management required
 5. **Persistent by default**: Collections use persistent data structures
 
 ## Success Criteria

--- a/plans/README.md
+++ b/plans/README.md
@@ -29,8 +29,8 @@ See **[../new-plans/](../new-plans/)** directory:
 
 | Plan | Description | Priority |
 | ---- | ----------- | -------- |
-| [02.04-wasm-translation.md](02.04-wasm-translation.md) | Wasm backend (see #38-41 for remaining work) | High |
-| Cranelift backend | Native backend via libmprompt + RC (see [cranelift-backend.md](../new-plans/cranelift-backend.md)) | High |
+| Wasm backend | Shared tail-call CPS to WasmGC (see [wasm-backend.md](../new-plans/wasm-backend.md)) | High |
+| Cranelift backend | Native tail-call CPS backend with RC (see [cranelift-backend.md](../new-plans/cranelift-backend.md)) | High |
 
 ### Future
 
@@ -46,6 +46,7 @@ See **[../new-plans/](../new-plans/)** directory:
 | Document | Description |
 | -------- | ----------- |
 | [02.03-wasm-runtime-research.md](02.03-wasm-runtime-research.md) | WebAssembly runtime research (WasmGC + WASI) |
+| [02.04-wasm-translation.md](02.04-wasm-translation.md) | Superseded Wasm implementation plan |
 
 ---
 
@@ -58,7 +59,7 @@ See **[../new-plans/](../new-plans/)** directory:
 
 ### Future Phases
 
-1. **Ability System**: Algebraic effects via evidence passing (see #23-26)
-2. **Cranelift Backend**: libmprompt + Boehm GC integration
-3. **WasmGC Backend**: Stack Switching support
+1. **Ability System**: Algebraic effects via evidence passing and tail-call CPS
+2. **Cranelift Backend**: Native lowering with reference counting
+3. **Wasm Backend**: Emit the shared tail-call CPS representation
 4. **Developer Tools**: LSP (see #31-37), package manager, documentation

--- a/plans/README.md
+++ b/plans/README.md
@@ -20,6 +20,7 @@ See **[../new-plans/](../new-plans/)** directory:
 | [ir.md](../new-plans/ir.md) | TrunkIR multi-level dialect IR |
 | [implementation.md](../new-plans/implementation.md) | Ability implementation strategy |
 | [cranelift-backend.md](../new-plans/cranelift-backend.md) | Cranelift native backend architecture |
+| [wasm-backend.md](../new-plans/wasm-backend.md) | WasmGC backend architecture |
 
 ---
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -390,8 +390,10 @@ fn merge_and_lower_to_ir_with<'db, M>(
         merged_call_callee_types,
         merged_ability_conventions,
         merged_span_map,
+        compiler_intrinsics,
     ) = if let Some(prelude) = prelude_module(db) {
         let prelude_module_ast = prelude.module(db);
+        let compiler_intrinsics = ast_to_ir::registered_compiler_intrinsics(prelude_module_ast);
         let prelude_fn_types = prelude.function_types(db);
         let prelude_node_types = &prelude.expression_types(db).node_types;
         let prelude_call_callee_types = &prelude.expression_types(db).call_callee_types;
@@ -436,6 +438,7 @@ fn merge_and_lower_to_ir_with<'db, M>(
             call_callee_types,
             ability_conventions,
             merged_span_map,
+            compiler_intrinsics,
         )
     } else {
         let fn_types: std::collections::HashMap<_, _> = user_fn_types.iter().cloned().collect();
@@ -451,6 +454,7 @@ fn merge_and_lower_to_ir_with<'db, M>(
             call_callee_types,
             ability_conventions,
             user_span_map.clone(),
+            std::collections::HashMap::new(),
         )
     };
 
@@ -492,6 +496,7 @@ fn merge_and_lower_to_ir_with<'db, M>(
             lambda_signatures: mono_result.metadata.lambda_signatures,
             exhaustive_cases: mono_result.metadata.exhaustive_cases,
             well_known_types: typed.well_known_types(db),
+            compiler_intrinsics,
         },
         db,
         &mut ir,
@@ -2161,6 +2166,96 @@ fn main() {
                 "specialized List body must not retain generic intrinsic binders:\n{ast}"
             );
         });
+    }
+
+    #[salsa_test]
+    fn frontend_registers_only_compiler_owned_intrinsic_origins(db: &salsa::DatabaseImpl) {
+        let source = source_from_str(
+            "intrinsic_origin.trb",
+            r#"
+extern "intrinsic" fn user_intrinsic(value: Int) -> Int
+
+fn comparison(left: Float, right: Float) -> Bool { left == right }
+"#,
+        );
+        let typed = parse_and_lower_ast(db, source).expect("frontend output");
+        let (_, registered) = merge_and_lower_to_ir_with(db, &typed, source, |typed, _, _, _| {
+            typed.compiler_intrinsics
+        });
+
+        assert!(
+            registered
+                .values()
+                .any(|identity| *identity == trunk_ir::Symbol::new("Float::==")),
+            "canonical prelude intrinsic must retain exact identity"
+        );
+        assert!(
+            registered
+                .values()
+                .all(|identity| *identity != trunk_ir::Symbol::new("user_intrinsic")),
+            "user abi spelling must not register an intrinsic"
+        );
+
+        let (mut logical_ctx, logical) =
+            merge_and_lower_to_ir_with(db, &typed, source, |mut typed, db, ir, uri| {
+                typed.ast.decls.retain(|declaration| match declaration {
+                    tribute_front::ast::Decl::Module(module) => {
+                        module.name == trunk_ir::Symbol::new("Float")
+                    }
+                    tribute_front::ast::Decl::ExternFunction(declaration) => {
+                        declaration.name == trunk_ir::Symbol::new("user_intrinsic")
+                    }
+                    tribute_front::ast::Decl::Function(declaration) => {
+                        declaration.name == trunk_ir::Symbol::new("comparison")
+                    }
+                    _ => false,
+                });
+                typed.lower_to_ir(db, ir, uri)
+            });
+        let source_logical_ir = trunk_ir::printer::print_module(&logical_ctx, logical.module.op());
+        assert!(
+            source_logical_ir.contains("tribute_control.call"),
+            "logical lowering must preserve the call for exact declaration-based lowering:\n{source_logical_ir}"
+        );
+        assert!(
+            !source_logical_ir.contains("arith.cmpf"),
+            "logical lowering must not trust an intrinsic name alone:\n{source_logical_ir}"
+        );
+        let validation = tribute_ir::dialect::tribute_control::validate(
+            &logical_ctx,
+            logical.module,
+            &logical.operation_declarations,
+            &logical.compiler_intrinsics,
+        );
+        assert!(validation.is_ok(), "{validation}");
+        tribute_passes::tribute_control_to_cps::tribute_control_to_cps(
+            &mut logical_ctx,
+            logical.module,
+            &logical.operation_declarations,
+            &logical.compiler_intrinsics,
+        )
+        .unwrap();
+        let logical_ir = trunk_ir::printer::print_module(&logical_ctx, logical.module.op());
+        assert!(
+            logical_ir.contains("tribute.compiler_intrinsic = @\"Float::==\""),
+            "verified identity must cross the logical boundary:\n{logical_ir}"
+        );
+        assert!(
+            !logical_ir.contains("tribute.compiler_intrinsic = @user_intrinsic"),
+            "source ABI spelling must remain untrusted logically:\n{logical_ir}"
+        );
+
+        let (ctx, module) =
+            merge_and_lower_to_ir(db, &typed, source, OptimizationOptions::production());
+        let converted = trunk_ir::printer::print_module(&ctx, module.op());
+        assert!(
+            converted.contains("tribute.compiler_intrinsic = @\"Float::==\""),
+            "verified identity must cross the current frontend boundary:\n{converted}"
+        );
+        assert!(
+            !converted.contains("tribute.compiler_intrinsic = @user_intrinsic"),
+            "unregistered source declaration must remain ordinary:\n{converted}"
+        );
     }
 
     #[salsa_test]


### PR DESCRIPTION
## Summary

- Carry exact compiler-owned callable identity and signature to physical intrinsic lowering; source-logical arithmetic intentionally remains `tribute_control.call`.
- Validate managed-reference boundaries and callable provenance before mutation, including structured-region contracts, handler completion provenance, and exact nominal layouts.
- Keep bytes/array/I/O/FFI handling conservative and out of scope.

## Validation

- Focused frontend snapshots, `cps_lowering` (48/48), `tribute_control` (47/47), and root origin regression passed.
- `cargo nextest run --workspace` passed: 1,951 tests, 1 skipped.
- `cargo clippy -p tribute-front -p tribute-ir -p tribute --all-targets -- -D warnings`, `cargo fmt --all`, and `git diff --check` passed.

Fixes #898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compiler-provided arithmetic and list operations now use verified declarations and exact signatures.
  * Intrinsic metadata is preserved throughout compilation and lowering.
* **Bug Fixes**
  * User-defined declarations are no longer treated as compiler intrinsics based only on names or ABI labels.
  * Expanded validation covers callable boundaries, managed references, return contracts, and resume-token behavior.
* **Documentation**
  * Updated compiler intrinsic, IR, runtime, list, and reference-counting guidance.
* **Tests**
  * Added coverage for intrinsic registration, invalid signatures, callable provenance, and ownership safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->