### PR TITLE
Add structured control-flow interfaces to TrunkIR

### DIFF
--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -9,6 +9,7 @@ use std::fmt;
 
 use itertools::Itertools;
 use trunk_ir::dialect::{adt, arith, core};
+use trunk_ir::op_interface::{RegionBranchOps, RegionBranchPoint, RegionSuccessor};
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 use trunk_ir::rewrite::Module;
@@ -3024,21 +3025,23 @@ fn ops_are_mutually_exclusive(ctx: &IrContext, left: OpRef, right: OpRef) -> boo
     while let Some(current) = region {
         let owner = ctx.region(current).parent_op;
         if let Some(owner) = owner
-            && ctx.op(owner).dialect == Symbol::new("scf")
-            && ctx.op(owner).name == Symbol::new("if")
-            && let Some(left_index) = ctx
-                .op(owner)
-                .regions
-                .iter()
-                .position(|candidate| *candidate == current)
-            && let Some(right_index) = ctx
-                .op(owner)
-                .regions
-                .iter()
-                .position(|candidate| op_is_within_region(ctx, right, *candidate))
-            && left_index != right_index
+            && let Some(interface) = RegionBranchOps::get(ctx, owner)
+            && let Ok(successors) = interface.successors(ctx, owner, RegionBranchPoint::Parent)
         {
-            return true;
+            let containing_region = |candidate: OpRef| {
+                successors.as_slice().iter().find_map(|successor| {
+                    let RegionSuccessor::Region(region) = successor else {
+                        return None;
+                    };
+                    op_is_within_region(ctx, candidate, *region).then_some(*region)
+                })
+            };
+            if let (Some(left_region), Some(right_region)) =
+                (containing_region(left), containing_region(right))
+                && left_region != right_region
+            {
+                return true;
+            }
         }
         region = owner.and_then(|owner| parent_region(ctx, owner));
     }

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -4503,6 +4503,72 @@ mod tests {
     }
 
     #[test]
+    fn whole_ir_allows_mutually_exclusive_switch_capture_paths_without_default() {
+        let (ctx, module) = parse_fixture(
+            r#"core.module @test {
+  %handled = tribute_control.handle : core.i32 {
+    %body = arith.const {value = 0} : core.i32
+    tribute_control.yield %body
+  } {
+    ^completion(%value: core.i32):
+      tribute_control.yield %value
+  } {
+    tribute_control.handler {ability_ref = core.ability_ref() {name = @State}, kind = @op, op_name = @get, operation_result_type = core.i32} {
+      ^clause(%argument: core.i32, %token: tribute_control.resume_token(core.i32, core.i32)):
+        %choice = arith.const {value = 0} : core.i32
+        scf.switch %choice {
+          scf.case {value = 0} {
+            %left = tribute_control.lambda() -> core.i32 convention(direct) captures [%token, %argument] {
+              %left_resumed = tribute_control.resume %token, %argument : core.i32
+              tribute_control.return %left_resumed
+            }
+            %left_called = tribute_control.call_indirect %left : core.i32
+            scf.yield
+          }
+          scf.case {value = 1} {
+            %right = tribute_control.lambda() -> core.i32 convention(direct) captures [%token, %argument] {
+              %right_resumed = tribute_control.resume %token, %argument : core.i32
+              tribute_control.return %right_resumed
+            }
+            %right_called = tribute_control.call_indirect %right : core.i32
+            scf.yield
+          }
+        }
+        tribute_control.yield %argument
+    }
+  }
+}"#,
+        );
+        let result = validate_whole_ir(&ctx, module, &[], &[]);
+        let diagnostics = messages(&result);
+        for forbidden in [
+            "resume token is copied into multiple capture paths",
+            "resume token capture does not form a single path to resume",
+            "resume-token carrier branches into multiple lambda captures",
+            "resume-token carrier has multiple static terminal uses",
+        ] {
+            assert!(!diagnostics.contains(forbidden), "{result}");
+        }
+
+        let mut branch_lambda = None;
+        let mut switch = None;
+        walk_region_ops(&ctx, module.body(&ctx).unwrap(), &mut |op| {
+            let data = ctx.op(op);
+            if data.dialect == Symbol::new("tribute_control") && data.name == Symbol::new("lambda")
+            {
+                branch_lambda.get_or_insert(op);
+            } else if data.dialect == Symbol::new("scf") && data.name == Symbol::new("switch") {
+                switch = Some(op);
+            }
+        });
+        assert!(!ops_are_mutually_exclusive(
+            &ctx,
+            branch_lambda.unwrap(),
+            switch.unwrap(),
+        ));
+    }
+
+    #[test]
     fn whole_ir_rejects_same_path_lambda_carrier_terminals() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {

--- a/crates/trunk-ir/src/dialect/cf.rs
+++ b/crates/trunk-ir/src/dialect/cf.rs
@@ -17,50 +17,42 @@ mod cf {
 
 use crate::IrContext;
 use crate::op_interface::{
-    BranchOps, BranchSuccessor, BranchSuccessors, ControlFlowInterfaceError,
+    BranchModel, BranchOps, BranchSuccessor, BranchSuccessors, ControlFlowInterfaceError,
 };
-use crate::ops::DialectOp;
-use crate::refs::OpRef;
 
-fn br_successors(
-    ctx: &IrContext,
-    op: OpRef,
-) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
-    if ctx.op(op).successors.len() != 1 {
-        return Err(ControlFlowInterfaceError::new(
-            "cf.br requires exactly one successor",
-        ));
+impl BranchModel for Br {
+    fn successors(self, ctx: &IrContext) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+        if ctx.op(self.op_ref()).successors.len() != 1 {
+            return Err(ControlFlowInterfaceError::new(
+                "cf.br requires exactly one successor",
+            ));
+        }
+        Ok(BranchSuccessors::new([BranchSuccessor::new(
+            self.dest(ctx),
+            self.args(ctx).iter().copied(),
+        )]))
     }
-    let branch = Br::from_op(ctx, op)
-        .map_err(|error| ControlFlowInterfaceError::new(format!("malformed cf.br: {error:?}")))?;
-    Ok(BranchSuccessors::new([BranchSuccessor::new(
-        branch.dest(ctx),
-        branch.args(ctx).iter().copied(),
-    )]))
 }
 
-fn cond_br_successors(
-    ctx: &IrContext,
-    op: OpRef,
-) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
-    if ctx.op_operands(op).len() != 1 || ctx.op(op).successors.len() != 2 {
-        return Err(ControlFlowInterfaceError::new(
-            "cf.cond_br requires one condition and exactly two successors",
-        ));
+impl BranchModel for CondBr {
+    fn successors(self, ctx: &IrContext) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+        let op = self.op_ref();
+        if ctx.op_operands(op).len() != 1 || ctx.op(op).successors.len() != 2 {
+            return Err(ControlFlowInterfaceError::new(
+                "cf.cond_br requires one condition and exactly two successors",
+            ));
+        }
+        Ok(BranchSuccessors::new([
+            BranchSuccessor::new(self.then_dest(ctx), []),
+            BranchSuccessor::new(self.else_dest(ctx), []),
+        ]))
     }
-    let branch = CondBr::from_op(ctx, op).map_err(|error| {
-        ControlFlowInterfaceError::new(format!("malformed cf.cond_br: {error:?}"))
-    })?;
-    Ok(BranchSuccessors::new([
-        BranchSuccessor::new(branch.then_dest(ctx), []),
-        BranchSuccessor::new(branch.else_dest(ctx), []),
-    ]))
 }
 
 inventory::submit! {
-    BranchOps::register("cf", "br", br_successors)
+    BranchOps::register::<Br>()
 }
 
 inventory::submit! {
-    BranchOps::register("cf", "cond_br", cond_br_successors)
+    BranchOps::register::<CondBr>()
 }

--- a/crates/trunk-ir/src/dialect/cf.rs
+++ b/crates/trunk-ir/src/dialect/cf.rs
@@ -14,3 +14,53 @@ mod cf {
         {}
     }
 }
+
+use crate::IrContext;
+use crate::op_interface::{
+    BranchOps, BranchSuccessor, BranchSuccessors, ControlFlowInterfaceError,
+};
+use crate::ops::DialectOp;
+use crate::refs::OpRef;
+
+fn br_successors(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+    if ctx.op(op).successors.len() != 1 {
+        return Err(ControlFlowInterfaceError::new(
+            "cf.br requires exactly one successor",
+        ));
+    }
+    let branch = Br::from_op(ctx, op)
+        .map_err(|error| ControlFlowInterfaceError::new(format!("malformed cf.br: {error:?}")))?;
+    Ok(BranchSuccessors::new([BranchSuccessor::new(
+        branch.dest(ctx),
+        branch.args(ctx).iter().copied(),
+    )]))
+}
+
+fn cond_br_successors(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+    if ctx.op_operands(op).len() != 1 || ctx.op(op).successors.len() != 2 {
+        return Err(ControlFlowInterfaceError::new(
+            "cf.cond_br requires one condition and exactly two successors",
+        ));
+    }
+    let branch = CondBr::from_op(ctx, op).map_err(|error| {
+        ControlFlowInterfaceError::new(format!("malformed cf.cond_br: {error:?}"))
+    })?;
+    Ok(BranchSuccessors::new([
+        BranchSuccessor::new(branch.then_dest(ctx), []),
+        BranchSuccessor::new(branch.else_dest(ctx), []),
+    ]))
+}
+
+inventory::submit! {
+    BranchOps::register("cf", "br", br_successors)
+}
+
+inventory::submit! {
+    BranchOps::register("cf", "cond_br", cond_br_successors)
+}

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -38,6 +38,380 @@ mod scf {
 }
 
 // =========================================================================
+// Control-flow interfaces
+// =========================================================================
+
+use crate::op_interface::{
+    ControlFlowInterfaceError, ForwardedValues, RegionBranchOps, RegionBranchPoint,
+    RegionBranchTerminatorOps, RegionSuccessor, RegionSuccessors,
+};
+
+fn interface_error(detail: impl Into<String>) -> ControlFlowInterfaceError {
+    ControlFlowInterfaceError::new(detail)
+}
+
+fn not_applicable(detail: impl Into<String>) -> ControlFlowInterfaceError {
+    ControlFlowInterfaceError::not_applicable(detail)
+}
+
+fn op_parent_region(ctx: &IrContext, op: OpRef) -> Option<crate::refs::RegionRef> {
+    ctx.op(op)
+        .parent_block
+        .and_then(|block| ctx.block(block).parent_region)
+}
+
+fn nearest_enclosing_loop(ctx: &IrContext, op: OpRef) -> Option<OpRef> {
+    let mut region = op_parent_region(ctx, op);
+    while let Some(current) = region {
+        let owner = ctx.region(current).parent_op?;
+        if Loop::matches(ctx, owner) {
+            return Some(owner);
+        }
+        region = op_parent_region(ctx, owner);
+    }
+    None
+}
+
+fn immediate_region_owner(ctx: &IrContext, op: OpRef) -> Option<OpRef> {
+    op_parent_region(ctx, op).and_then(|region| ctx.region(region).parent_op)
+}
+
+fn if_successors(
+    ctx: &IrContext,
+    op: OpRef,
+    point: RegionBranchPoint,
+) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+    if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 2 {
+        return Err(interface_error(
+            "scf.if requires one condition and exactly two regions",
+        ));
+    }
+    let if_op = If::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.if: {error:?}")))?;
+    match point {
+        RegionBranchPoint::Parent => Ok(RegionSuccessors::new([
+            RegionSuccessor::Region(if_op.then_region(ctx)),
+            RegionSuccessor::Region(if_op.else_region(ctx)),
+        ])),
+        RegionBranchPoint::Terminator(terminator)
+            if Yield::matches(ctx, terminator)
+                && immediate_region_owner(ctx, terminator) == Some(op) =>
+        {
+            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+        }
+        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
+            "{terminator} is not an scf.if region yield"
+        ))),
+    }
+}
+
+fn if_entry_operands(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 2 {
+        return Err(interface_error(
+            "scf.if requires one condition and exactly two regions",
+        ));
+    }
+    let if_op = If::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.if: {error:?}")))?;
+    match successor {
+        RegionSuccessor::Region(region)
+            if region == if_op.then_region(ctx) || region == if_op.else_region(ctx) =>
+        {
+            Ok(ForwardedValues::default())
+        }
+        _ => Err(interface_error("successor is not an scf.if entry region")),
+    }
+}
+
+fn loop_successors(
+    ctx: &IrContext,
+    op: OpRef,
+    point: RegionBranchPoint,
+) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+    if ctx.op(op).regions.len() != 1 {
+        return Err(interface_error("scf.loop requires exactly one body region"));
+    }
+    let loop_op = Loop::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.loop: {error:?}")))?;
+    match point {
+        RegionBranchPoint::Parent => Ok(RegionSuccessors::new([RegionSuccessor::Region(
+            loop_op.body(ctx),
+        )])),
+        RegionBranchPoint::Terminator(terminator)
+            if nearest_enclosing_loop(ctx, terminator) == Some(op)
+                && Continue::matches(ctx, terminator) =>
+        {
+            Ok(RegionSuccessors::new([RegionSuccessor::Region(
+                loop_op.body(ctx),
+            )]))
+        }
+        RegionBranchPoint::Terminator(terminator)
+            if nearest_enclosing_loop(ctx, terminator) == Some(op)
+                && Break::matches(ctx, terminator) =>
+        {
+            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+        }
+        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
+            "{terminator} is not a continue or break for this scf.loop"
+        ))),
+    }
+}
+
+fn loop_entry_operands(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    if ctx.op(op).regions.len() != 1 {
+        return Err(interface_error("scf.loop requires exactly one body region"));
+    }
+    let loop_op = Loop::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.loop: {error:?}")))?;
+    match successor {
+        RegionSuccessor::Region(region) if region == loop_op.body(ctx) => {
+            Ok(ForwardedValues::new(loop_op.init(ctx).iter().copied()))
+        }
+        _ => Err(interface_error("successor is not the scf.loop body")),
+    }
+}
+
+fn case_regions(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<Vec<crate::refs::RegionRef>, ControlFlowInterfaceError> {
+    if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 1 {
+        return Err(interface_error(
+            "scf.switch requires one discriminant and exactly one body region",
+        ));
+    }
+    let switch = Switch::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.switch: {error:?}")))?;
+    let body = ctx.region(switch.body(ctx));
+    let [block] = body.blocks.as_slice() else {
+        return Err(interface_error(format!(
+            "scf.switch body must contain one block, found {}",
+            body.blocks.len()
+        )));
+    };
+    let mut regions = Vec::new();
+    let mut default_count = 0usize;
+    for &child in &ctx.block(*block).ops {
+        if let Ok(case) = Case::from_op(ctx, child) {
+            regions.push(case.body(ctx));
+        } else if let Ok(default) = Default::from_op(ctx, child) {
+            default_count += 1;
+            regions.push(default.body(ctx));
+        } else {
+            return Err(interface_error(format!(
+                "scf.switch body contains unsupported operation {child}"
+            )));
+        }
+    }
+    if default_count > 1 {
+        return Err(interface_error(
+            "scf.switch contains multiple default regions",
+        ));
+    }
+    Ok(regions)
+}
+
+fn switch_successors(
+    ctx: &IrContext,
+    op: OpRef,
+    point: RegionBranchPoint,
+) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+    let regions = case_regions(ctx, op)?;
+    match point {
+        RegionBranchPoint::Parent => {
+            let mut successors: Vec<_> = regions
+                .iter()
+                .copied()
+                .map(RegionSuccessor::Region)
+                .collect();
+            let has_default = regions.iter().any(|region| {
+                ctx.region(*region)
+                    .parent_op
+                    .is_some_and(|parent| Default::matches(ctx, parent))
+            });
+            if !has_default {
+                successors.push(RegionSuccessor::Parent);
+            }
+            Ok(RegionSuccessors::new(successors))
+        }
+        RegionBranchPoint::Terminator(terminator)
+            if Yield::matches(ctx, terminator)
+                && op_parent_region(ctx, terminator)
+                    .is_some_and(|region| regions.contains(&region)) =>
+        {
+            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+        }
+        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
+            "{terminator} is not a yield from this scf.switch"
+        ))),
+    }
+}
+
+fn switch_entry_operands(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    let regions = case_regions(ctx, op)?;
+    match successor {
+        RegionSuccessor::Region(region) if regions.contains(&region) => {
+            Ok(ForwardedValues::default())
+        }
+        RegionSuccessor::Parent
+            if !regions.iter().any(|region| {
+                ctx.region(*region)
+                    .parent_op
+                    .is_some_and(|parent| Default::matches(ctx, parent))
+            }) =>
+        {
+            Ok(ForwardedValues::default())
+        }
+        _ => Err(interface_error(
+            "successor is not an scf.switch entry target",
+        )),
+    }
+}
+
+fn wrapper_successors(
+    ctx: &IrContext,
+    op: OpRef,
+    point: RegionBranchPoint,
+) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+    if ctx.op(op).regions.len() != 1 {
+        return Err(interface_error(
+            "scf.case/default requires exactly one body region",
+        ));
+    }
+    let body = if let Ok(case) = Case::from_op(ctx, op) {
+        case.body(ctx)
+    } else {
+        Default::from_op(ctx, op)
+            .map_err(|error| interface_error(format!("malformed switch arm: {error:?}")))?
+            .body(ctx)
+    };
+    match point {
+        RegionBranchPoint::Parent => Ok(RegionSuccessors::new([RegionSuccessor::Region(body)])),
+        RegionBranchPoint::Terminator(terminator)
+            if Yield::matches(ctx, terminator)
+                && immediate_region_owner(ctx, terminator) == Some(op) =>
+        {
+            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+        }
+        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
+            "{terminator} is not a yield from this switch arm"
+        ))),
+    }
+}
+
+fn wrapper_entry_operands(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    if ctx.op(op).regions.len() != 1 {
+        return Err(interface_error(
+            "scf.case/default requires exactly one body region",
+        ));
+    }
+    let body = if let Ok(case) = Case::from_op(ctx, op) {
+        case.body(ctx)
+    } else {
+        Default::from_op(ctx, op)
+            .map_err(|error| interface_error(format!("malformed switch arm: {error:?}")))?
+            .body(ctx)
+    };
+    match successor {
+        RegionSuccessor::Region(region) if region == body => Ok(ForwardedValues::default()),
+        _ => Err(interface_error("successor is not this switch arm's body")),
+    }
+}
+
+fn yield_operands(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    let yield_op = Yield::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.yield: {error:?}")))?;
+    match successor {
+        RegionSuccessor::Parent => Ok(ForwardedValues::new(yield_op.values(ctx).iter().copied())),
+        RegionSuccessor::Region(_) => Err(interface_error("scf.yield can only return to a parent")),
+    }
+}
+
+fn continue_operands(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    let continue_op = Continue::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.continue: {error:?}")))?;
+    match successor {
+        RegionSuccessor::Region(_) => Ok(ForwardedValues::new(
+            continue_op.values(ctx).iter().copied(),
+        )),
+        RegionSuccessor::Parent => Err(interface_error("scf.continue cannot exit its loop")),
+    }
+}
+
+fn break_operands(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    if ctx.op_operands(op).len() != 1 {
+        return Err(interface_error("scf.break requires exactly one value"));
+    }
+    let break_op = Break::from_op(ctx, op)
+        .map_err(|error| interface_error(format!("malformed scf.break: {error:?}")))?;
+    match successor {
+        RegionSuccessor::Parent => {
+            let owner = nearest_enclosing_loop(ctx, op)
+                .ok_or_else(|| interface_error("scf.break has no enclosing scf.loop"))?;
+            if ctx.op_results(owner).is_empty() {
+                Ok(ForwardedValues::default())
+            } else {
+                Ok(ForwardedValues::new([break_op.value(ctx)]))
+            }
+        }
+        RegionSuccessor::Region(_) => Err(interface_error("scf.break cannot enter a region")),
+    }
+}
+
+inventory::submit! {
+    RegionBranchOps::register("scf", "if", if_successors, if_entry_operands)
+}
+inventory::submit! {
+    RegionBranchOps::register("scf", "switch", switch_successors, switch_entry_operands)
+}
+inventory::submit! {
+    RegionBranchOps::register("scf", "case", wrapper_successors, wrapper_entry_operands)
+}
+inventory::submit! {
+    RegionBranchOps::register("scf", "default", wrapper_successors, wrapper_entry_operands)
+}
+inventory::submit! {
+    RegionBranchOps::register("scf", "loop", loop_successors, loop_entry_operands)
+}
+inventory::submit! {
+    RegionBranchTerminatorOps::register("scf", "yield", yield_operands)
+}
+inventory::submit! {
+    RegionBranchTerminatorOps::register("scf", "continue", continue_operands)
+}
+inventory::submit! {
+    RegionBranchTerminatorOps::register("scf", "break", break_operands)
+}
+
+// =========================================================================
 // Canonicalization folds
 // =========================================================================
 

--- a/crates/trunk-ir/src/dialect/scf.rs
+++ b/crates/trunk-ir/src/dialect/scf.rs
@@ -42,17 +42,10 @@ mod scf {
 // =========================================================================
 
 use crate::op_interface::{
-    ControlFlowInterfaceError, ForwardedValues, RegionBranchOps, RegionBranchPoint,
-    RegionBranchTerminatorOps, RegionSuccessor, RegionSuccessors,
+    ControlFlowInterfaceError, ForwardedValues, RegionBranchModel, RegionBranchOps,
+    RegionBranchPoint, RegionBranchTerminatorModel, RegionBranchTerminatorOps, RegionSuccessor,
+    RegionSuccessors,
 };
-
-fn interface_error(detail: impl Into<String>) -> ControlFlowInterfaceError {
-    ControlFlowInterfaceError::new(detail)
-}
-
-fn not_applicable(detail: impl Into<String>) -> ControlFlowInterfaceError {
-    ControlFlowInterfaceError::not_applicable(detail)
-}
 
 fn op_parent_region(ctx: &IrContext, op: OpRef) -> Option<crate::refs::RegionRef> {
     ctx.op(op)
@@ -60,355 +53,438 @@ fn op_parent_region(ctx: &IrContext, op: OpRef) -> Option<crate::refs::RegionRef
         .and_then(|block| ctx.block(block).parent_region)
 }
 
-fn nearest_enclosing_loop(ctx: &IrContext, op: OpRef) -> Option<OpRef> {
-    let mut region = op_parent_region(ctx, op);
-    while let Some(current) = region {
-        let owner = ctx.region(current).parent_op?;
-        if Loop::matches(ctx, owner) {
-            return Some(owner);
+impl Loop {
+    fn enclosing(ctx: &IrContext, op: OpRef) -> Option<Self> {
+        let mut region = op_parent_region(ctx, op);
+        while let Some(current) = region {
+            let owner = ctx.region(current).parent_op?;
+            if let Ok(loop_op) = Self::from_op(ctx, owner) {
+                return Some(loop_op);
+            }
+            region = op_parent_region(ctx, owner);
         }
-        region = op_parent_region(ctx, owner);
+        None
     }
-    None
 }
 
 fn immediate_region_owner(ctx: &IrContext, op: OpRef) -> Option<OpRef> {
     op_parent_region(ctx, op).and_then(|region| ctx.region(region).parent_op)
 }
 
-fn if_successors(
-    ctx: &IrContext,
-    op: OpRef,
-    point: RegionBranchPoint,
-) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
-    if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 2 {
-        return Err(interface_error(
-            "scf.if requires one condition and exactly two regions",
-        ));
-    }
-    let if_op = If::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.if: {error:?}")))?;
-    match point {
-        RegionBranchPoint::Parent => Ok(RegionSuccessors::new([
-            RegionSuccessor::Region(if_op.then_region(ctx)),
-            RegionSuccessor::Region(if_op.else_region(ctx)),
-        ])),
-        RegionBranchPoint::Terminator(terminator)
-            if Yield::matches(ctx, terminator)
-                && immediate_region_owner(ctx, terminator) == Some(op) =>
-        {
-            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+impl If {
+    fn validate_region_shape(self, ctx: &IrContext) -> Result<(), ControlFlowInterfaceError> {
+        let op = self.op_ref();
+        if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 2 {
+            return Err(ControlFlowInterfaceError::new(
+                "scf.if requires one condition and exactly two regions",
+            ));
         }
-        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
-            "{terminator} is not an scf.if region yield"
-        ))),
+        Ok(())
     }
 }
 
-fn if_entry_operands(
-    ctx: &IrContext,
-    op: OpRef,
-    successor: RegionSuccessor,
-) -> Result<ForwardedValues, ControlFlowInterfaceError> {
-    if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 2 {
-        return Err(interface_error(
-            "scf.if requires one condition and exactly two regions",
-        ));
-    }
-    let if_op = If::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.if: {error:?}")))?;
-    match successor {
-        RegionSuccessor::Region(region)
-            if region == if_op.then_region(ctx) || region == if_op.else_region(ctx) =>
-        {
-            Ok(ForwardedValues::default())
-        }
-        _ => Err(interface_error("successor is not an scf.if entry region")),
-    }
-}
-
-fn loop_successors(
-    ctx: &IrContext,
-    op: OpRef,
-    point: RegionBranchPoint,
-) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
-    if ctx.op(op).regions.len() != 1 {
-        return Err(interface_error("scf.loop requires exactly one body region"));
-    }
-    let loop_op = Loop::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.loop: {error:?}")))?;
-    match point {
-        RegionBranchPoint::Parent => Ok(RegionSuccessors::new([RegionSuccessor::Region(
-            loop_op.body(ctx),
-        )])),
-        RegionBranchPoint::Terminator(terminator)
-            if nearest_enclosing_loop(ctx, terminator) == Some(op)
-                && Continue::matches(ctx, terminator) =>
-        {
-            Ok(RegionSuccessors::new([RegionSuccessor::Region(
-                loop_op.body(ctx),
-            )]))
-        }
-        RegionBranchPoint::Terminator(terminator)
-            if nearest_enclosing_loop(ctx, terminator) == Some(op)
-                && Break::matches(ctx, terminator) =>
-        {
-            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
-        }
-        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
-            "{terminator} is not a continue or break for this scf.loop"
-        ))),
-    }
-}
-
-fn loop_entry_operands(
-    ctx: &IrContext,
-    op: OpRef,
-    successor: RegionSuccessor,
-) -> Result<ForwardedValues, ControlFlowInterfaceError> {
-    if ctx.op(op).regions.len() != 1 {
-        return Err(interface_error("scf.loop requires exactly one body region"));
-    }
-    let loop_op = Loop::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.loop: {error:?}")))?;
-    match successor {
-        RegionSuccessor::Region(region) if region == loop_op.body(ctx) => {
-            Ok(ForwardedValues::new(loop_op.init(ctx).iter().copied()))
-        }
-        _ => Err(interface_error("successor is not the scf.loop body")),
-    }
-}
-
-fn case_regions(
-    ctx: &IrContext,
-    op: OpRef,
-) -> Result<Vec<crate::refs::RegionRef>, ControlFlowInterfaceError> {
-    if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 1 {
-        return Err(interface_error(
-            "scf.switch requires one discriminant and exactly one body region",
-        ));
-    }
-    let switch = Switch::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.switch: {error:?}")))?;
-    let body = ctx.region(switch.body(ctx));
-    let [block] = body.blocks.as_slice() else {
-        return Err(interface_error(format!(
-            "scf.switch body must contain one block, found {}",
-            body.blocks.len()
-        )));
-    };
-    let mut regions = Vec::new();
-    let mut default_count = 0usize;
-    for &child in &ctx.block(*block).ops {
-        if let Ok(case) = Case::from_op(ctx, child) {
-            regions.push(case.body(ctx));
-        } else if let Ok(default) = Default::from_op(ctx, child) {
-            default_count += 1;
-            regions.push(default.body(ctx));
-        } else {
-            return Err(interface_error(format!(
-                "scf.switch body contains unsupported operation {child}"
-            )));
-        }
-    }
-    if default_count > 1 {
-        return Err(interface_error(
-            "scf.switch contains multiple default regions",
-        ));
-    }
-    Ok(regions)
-}
-
-fn switch_successors(
-    ctx: &IrContext,
-    op: OpRef,
-    point: RegionBranchPoint,
-) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
-    let regions = case_regions(ctx, op)?;
-    match point {
-        RegionBranchPoint::Parent => {
-            let mut successors: Vec<_> = regions
-                .iter()
-                .copied()
-                .map(RegionSuccessor::Region)
-                .collect();
-            let has_default = regions.iter().any(|region| {
-                ctx.region(*region)
-                    .parent_op
-                    .is_some_and(|parent| Default::matches(ctx, parent))
-            });
-            if !has_default {
-                successors.push(RegionSuccessor::Parent);
+impl RegionBranchModel for If {
+    fn successors(
+        self,
+        ctx: &IrContext,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+        self.validate_region_shape(ctx)?;
+        match point {
+            RegionBranchPoint::Parent => Ok(RegionSuccessors::new([
+                RegionSuccessor::Region(self.then_region(ctx)),
+                RegionSuccessor::Region(self.else_region(ctx)),
+            ])),
+            RegionBranchPoint::Terminator(terminator)
+                if Yield::matches(ctx, terminator)
+                    && immediate_region_owner(ctx, terminator) == Some(self.op_ref()) =>
+            {
+                Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
             }
-            Ok(RegionSuccessors::new(successors))
+            RegionBranchPoint::Terminator(terminator) => {
+                Err(ControlFlowInterfaceError::not_applicable(format!(
+                    "{terminator} is not an scf.if region yield"
+                )))
+            }
         }
-        RegionBranchPoint::Terminator(terminator)
-            if Yield::matches(ctx, terminator)
-                && op_parent_region(ctx, terminator)
-                    .is_some_and(|region| regions.contains(&region)) =>
-        {
-            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
-        }
-        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
-            "{terminator} is not a yield from this scf.switch"
-        ))),
     }
-}
 
-fn switch_entry_operands(
-    ctx: &IrContext,
-    op: OpRef,
-    successor: RegionSuccessor,
-) -> Result<ForwardedValues, ControlFlowInterfaceError> {
-    let regions = case_regions(ctx, op)?;
-    match successor {
-        RegionSuccessor::Region(region) if regions.contains(&region) => {
-            Ok(ForwardedValues::default())
-        }
-        RegionSuccessor::Parent
-            if !regions.iter().any(|region| {
-                ctx.region(*region)
-                    .parent_op
-                    .is_some_and(|parent| Default::matches(ctx, parent))
-            }) =>
-        {
-            Ok(ForwardedValues::default())
-        }
-        _ => Err(interface_error(
-            "successor is not an scf.switch entry target",
-        )),
-    }
-}
-
-fn wrapper_successors(
-    ctx: &IrContext,
-    op: OpRef,
-    point: RegionBranchPoint,
-) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
-    if ctx.op(op).regions.len() != 1 {
-        return Err(interface_error(
-            "scf.case/default requires exactly one body region",
-        ));
-    }
-    let body = if let Ok(case) = Case::from_op(ctx, op) {
-        case.body(ctx)
-    } else {
-        Default::from_op(ctx, op)
-            .map_err(|error| interface_error(format!("malformed switch arm: {error:?}")))?
-            .body(ctx)
-    };
-    match point {
-        RegionBranchPoint::Parent => Ok(RegionSuccessors::new([RegionSuccessor::Region(body)])),
-        RegionBranchPoint::Terminator(terminator)
-            if Yield::matches(ctx, terminator)
-                && immediate_region_owner(ctx, terminator) == Some(op) =>
-        {
-            Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
-        }
-        RegionBranchPoint::Terminator(terminator) => Err(not_applicable(format!(
-            "{terminator} is not a yield from this switch arm"
-        ))),
-    }
-}
-
-fn wrapper_entry_operands(
-    ctx: &IrContext,
-    op: OpRef,
-    successor: RegionSuccessor,
-) -> Result<ForwardedValues, ControlFlowInterfaceError> {
-    if ctx.op(op).regions.len() != 1 {
-        return Err(interface_error(
-            "scf.case/default requires exactly one body region",
-        ));
-    }
-    let body = if let Ok(case) = Case::from_op(ctx, op) {
-        case.body(ctx)
-    } else {
-        Default::from_op(ctx, op)
-            .map_err(|error| interface_error(format!("malformed switch arm: {error:?}")))?
-            .body(ctx)
-    };
-    match successor {
-        RegionSuccessor::Region(region) if region == body => Ok(ForwardedValues::default()),
-        _ => Err(interface_error("successor is not this switch arm's body")),
-    }
-}
-
-fn yield_operands(
-    ctx: &IrContext,
-    op: OpRef,
-    successor: RegionSuccessor,
-) -> Result<ForwardedValues, ControlFlowInterfaceError> {
-    let yield_op = Yield::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.yield: {error:?}")))?;
-    match successor {
-        RegionSuccessor::Parent => Ok(ForwardedValues::new(yield_op.values(ctx).iter().copied())),
-        RegionSuccessor::Region(_) => Err(interface_error("scf.yield can only return to a parent")),
-    }
-}
-
-fn continue_operands(
-    ctx: &IrContext,
-    op: OpRef,
-    successor: RegionSuccessor,
-) -> Result<ForwardedValues, ControlFlowInterfaceError> {
-    let continue_op = Continue::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.continue: {error:?}")))?;
-    match successor {
-        RegionSuccessor::Region(_) => Ok(ForwardedValues::new(
-            continue_op.values(ctx).iter().copied(),
-        )),
-        RegionSuccessor::Parent => Err(interface_error("scf.continue cannot exit its loop")),
-    }
-}
-
-fn break_operands(
-    ctx: &IrContext,
-    op: OpRef,
-    successor: RegionSuccessor,
-) -> Result<ForwardedValues, ControlFlowInterfaceError> {
-    if ctx.op_operands(op).len() != 1 {
-        return Err(interface_error("scf.break requires exactly one value"));
-    }
-    let break_op = Break::from_op(ctx, op)
-        .map_err(|error| interface_error(format!("malformed scf.break: {error:?}")))?;
-    match successor {
-        RegionSuccessor::Parent => {
-            let owner = nearest_enclosing_loop(ctx, op)
-                .ok_or_else(|| interface_error("scf.break has no enclosing scf.loop"))?;
-            if ctx.op_results(owner).is_empty() {
+    fn entry_successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        self.validate_region_shape(ctx)?;
+        match successor {
+            RegionSuccessor::Region(region)
+                if region == self.then_region(ctx) || region == self.else_region(ctx) =>
+            {
                 Ok(ForwardedValues::default())
-            } else {
-                Ok(ForwardedValues::new([break_op.value(ctx)]))
+            }
+            _ => Err(ControlFlowInterfaceError::new(
+                "successor is not an scf.if entry region",
+            )),
+        }
+    }
+}
+
+impl Loop {
+    fn validate_region_shape(self, ctx: &IrContext) -> Result<(), ControlFlowInterfaceError> {
+        if ctx.op(self.op_ref()).regions.len() != 1 {
+            return Err(ControlFlowInterfaceError::new(
+                "scf.loop requires exactly one body region",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl RegionBranchModel for Loop {
+    fn successors(
+        self,
+        ctx: &IrContext,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+        self.validate_region_shape(ctx)?;
+        match point {
+            RegionBranchPoint::Parent => Ok(RegionSuccessors::new([RegionSuccessor::Region(
+                self.body(ctx),
+            )])),
+            RegionBranchPoint::Terminator(terminator)
+                if Self::enclosing(ctx, terminator) == Some(self)
+                    && Continue::matches(ctx, terminator) =>
+            {
+                Ok(RegionSuccessors::new([RegionSuccessor::Region(
+                    self.body(ctx),
+                )]))
+            }
+            RegionBranchPoint::Terminator(terminator)
+                if Self::enclosing(ctx, terminator) == Some(self)
+                    && Break::matches(ctx, terminator) =>
+            {
+                Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+            }
+            RegionBranchPoint::Terminator(terminator) => {
+                Err(ControlFlowInterfaceError::not_applicable(format!(
+                    "{terminator} is not a continue or break for this scf.loop"
+                )))
             }
         }
-        RegionSuccessor::Region(_) => Err(interface_error("scf.break cannot enter a region")),
+    }
+
+    fn entry_successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        self.validate_region_shape(ctx)?;
+        match successor {
+            RegionSuccessor::Region(region) if region == self.body(ctx) => {
+                Ok(ForwardedValues::new(self.init(ctx).iter().copied()))
+            }
+            _ => Err(ControlFlowInterfaceError::new(
+                "successor is not the scf.loop body",
+            )),
+        }
+    }
+}
+
+impl Switch {
+    fn successor_regions(
+        self,
+        ctx: &IrContext,
+    ) -> Result<Vec<crate::refs::RegionRef>, ControlFlowInterfaceError> {
+        let op = self.op_ref();
+        if ctx.op_operands(op).len() != 1 || ctx.op(op).regions.len() != 1 {
+            return Err(ControlFlowInterfaceError::new(
+                "scf.switch requires one discriminant and exactly one body region",
+            ));
+        }
+        let body = ctx.region(self.body(ctx));
+        let [block] = body.blocks.as_slice() else {
+            return Err(ControlFlowInterfaceError::new(format!(
+                "scf.switch body must contain one block, found {}",
+                body.blocks.len()
+            )));
+        };
+        let mut regions = Vec::new();
+        let mut default_count = 0usize;
+        for &child in &ctx.block(*block).ops {
+            if let Ok(case) = Case::from_op(ctx, child) {
+                regions.push(case.body(ctx));
+            } else if let Ok(default) = Default::from_op(ctx, child) {
+                default_count += 1;
+                regions.push(default.body(ctx));
+            } else {
+                return Err(ControlFlowInterfaceError::new(format!(
+                    "scf.switch body contains unsupported operation {child}"
+                )));
+            }
+        }
+        if default_count > 1 {
+            return Err(ControlFlowInterfaceError::new(
+                "scf.switch contains multiple default regions",
+            ));
+        }
+        Ok(regions)
+    }
+
+    fn has_default(ctx: &IrContext, regions: &[crate::refs::RegionRef]) -> bool {
+        regions.iter().any(|region| {
+            ctx.region(*region)
+                .parent_op
+                .is_some_and(|parent| Default::matches(ctx, parent))
+        })
+    }
+}
+
+impl RegionBranchModel for Switch {
+    fn successors(
+        self,
+        ctx: &IrContext,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+        let regions = self.successor_regions(ctx)?;
+        match point {
+            RegionBranchPoint::Parent => {
+                let mut successors: Vec<_> = regions
+                    .iter()
+                    .copied()
+                    .map(RegionSuccessor::Region)
+                    .collect();
+                if !Self::has_default(ctx, &regions) {
+                    successors.push(RegionSuccessor::Parent);
+                }
+                Ok(RegionSuccessors::new(successors))
+            }
+            RegionBranchPoint::Terminator(terminator)
+                if Yield::matches(ctx, terminator)
+                    && op_parent_region(ctx, terminator)
+                        .is_some_and(|region| regions.contains(&region)) =>
+            {
+                Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+            }
+            RegionBranchPoint::Terminator(terminator) => {
+                Err(ControlFlowInterfaceError::not_applicable(format!(
+                    "{terminator} is not a yield from this scf.switch"
+                )))
+            }
+        }
+    }
+
+    fn entry_successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        let regions = self.successor_regions(ctx)?;
+        match successor {
+            RegionSuccessor::Region(region) if regions.contains(&region) => {
+                Ok(ForwardedValues::default())
+            }
+            RegionSuccessor::Parent if !Self::has_default(ctx, &regions) => {
+                Ok(ForwardedValues::default())
+            }
+            _ => Err(ControlFlowInterfaceError::new(
+                "successor is not an scf.switch entry target",
+            )),
+        }
+    }
+}
+
+trait SwitchArmModel: DialectOp {
+    fn body_region(self, ctx: &IrContext) -> crate::refs::RegionRef;
+
+    fn checked_body(
+        self,
+        ctx: &IrContext,
+    ) -> Result<crate::refs::RegionRef, ControlFlowInterfaceError> {
+        if ctx.op(self.op_ref()).regions.len() != 1 {
+            return Err(ControlFlowInterfaceError::new(
+                "scf.case/default requires exactly one body region",
+            ));
+        }
+        Ok(self.body_region(ctx))
+    }
+
+    fn arm_successors(
+        self,
+        ctx: &IrContext,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+        let body = self.checked_body(ctx)?;
+        match point {
+            RegionBranchPoint::Parent => Ok(RegionSuccessors::new([RegionSuccessor::Region(body)])),
+            RegionBranchPoint::Terminator(terminator)
+                if Yield::matches(ctx, terminator)
+                    && immediate_region_owner(ctx, terminator) == Some(self.op_ref()) =>
+            {
+                Ok(RegionSuccessors::new([RegionSuccessor::Parent]))
+            }
+            RegionBranchPoint::Terminator(terminator) => {
+                Err(ControlFlowInterfaceError::not_applicable(format!(
+                    "{terminator} is not a yield from this switch arm"
+                )))
+            }
+        }
+    }
+
+    fn arm_entry_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        let body = self.checked_body(ctx)?;
+        match successor {
+            RegionSuccessor::Region(region) if region == body => Ok(ForwardedValues::default()),
+            _ => Err(ControlFlowInterfaceError::new(
+                "successor is not this switch arm's body",
+            )),
+        }
+    }
+}
+
+impl SwitchArmModel for Case {
+    fn body_region(self, ctx: &IrContext) -> crate::refs::RegionRef {
+        self.body(ctx)
+    }
+}
+
+impl SwitchArmModel for Default {
+    fn body_region(self, ctx: &IrContext) -> crate::refs::RegionRef {
+        self.body(ctx)
+    }
+}
+
+impl RegionBranchModel for Case {
+    fn successors(
+        self,
+        ctx: &IrContext,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+        self.arm_successors(ctx, point)
+    }
+
+    fn entry_successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        self.arm_entry_operands(ctx, successor)
+    }
+}
+
+impl RegionBranchModel for Default {
+    fn successors(
+        self,
+        ctx: &IrContext,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+        self.arm_successors(ctx, point)
+    }
+
+    fn entry_successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        self.arm_entry_operands(ctx, successor)
+    }
+}
+
+impl RegionBranchTerminatorModel for Yield {
+    fn successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        match successor {
+            RegionSuccessor::Parent => Ok(ForwardedValues::new(self.values(ctx).iter().copied())),
+            RegionSuccessor::Region(_) => Err(ControlFlowInterfaceError::new(
+                "scf.yield can only return to a parent",
+            )),
+        }
+    }
+}
+
+impl RegionBranchTerminatorModel for Continue {
+    fn successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        match successor {
+            RegionSuccessor::Region(region) => {
+                let owner = Loop::enclosing(ctx, self.op_ref()).ok_or_else(|| {
+                    ControlFlowInterfaceError::new("scf.continue has no enclosing scf.loop")
+                })?;
+                if region != owner.body(ctx) {
+                    return Err(ControlFlowInterfaceError::new(
+                        "successor is not the enclosing scf.loop body",
+                    ));
+                }
+                Ok(ForwardedValues::new(self.values(ctx).iter().copied()))
+            }
+            RegionSuccessor::Parent => Err(ControlFlowInterfaceError::new(
+                "scf.continue cannot exit its loop",
+            )),
+        }
+    }
+}
+
+impl RegionBranchTerminatorModel for Break {
+    fn successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        let op = self.op_ref();
+        if ctx.op_operands(op).len() != 1 {
+            return Err(ControlFlowInterfaceError::new(
+                "scf.break requires exactly one value",
+            ));
+        }
+        match successor {
+            RegionSuccessor::Parent => {
+                let owner = Loop::enclosing(ctx, op).ok_or_else(|| {
+                    ControlFlowInterfaceError::new("scf.break has no enclosing scf.loop")
+                })?;
+                if ctx.op_results(owner.op_ref()).is_empty() {
+                    Ok(ForwardedValues::default())
+                } else {
+                    Ok(ForwardedValues::new([self.value(ctx)]))
+                }
+            }
+            RegionSuccessor::Region(_) => Err(ControlFlowInterfaceError::new(
+                "scf.break cannot enter a region",
+            )),
+        }
     }
 }
 
 inventory::submit! {
-    RegionBranchOps::register("scf", "if", if_successors, if_entry_operands)
+    RegionBranchOps::register::<If>()
 }
 inventory::submit! {
-    RegionBranchOps::register("scf", "switch", switch_successors, switch_entry_operands)
+    RegionBranchOps::register::<Switch>()
 }
 inventory::submit! {
-    RegionBranchOps::register("scf", "case", wrapper_successors, wrapper_entry_operands)
+    RegionBranchOps::register::<Case>()
 }
 inventory::submit! {
-    RegionBranchOps::register("scf", "default", wrapper_successors, wrapper_entry_operands)
+    RegionBranchOps::register::<Default>()
 }
 inventory::submit! {
-    RegionBranchOps::register("scf", "loop", loop_successors, loop_entry_operands)
+    RegionBranchOps::register::<Loop>()
 }
 inventory::submit! {
-    RegionBranchTerminatorOps::register("scf", "yield", yield_operands)
+    RegionBranchTerminatorOps::register::<Yield>()
 }
 inventory::submit! {
-    RegionBranchTerminatorOps::register("scf", "continue", continue_operands)
+    RegionBranchTerminatorOps::register::<Continue>()
 }
 inventory::submit! {
-    RegionBranchTerminatorOps::register("scf", "break", break_operands)
+    RegionBranchTerminatorOps::register::<Break>()
 }
 
 // =========================================================================

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -10,6 +10,7 @@ use std::sync::LazyLock;
 use smallvec::SmallVec;
 
 use crate::Symbol;
+use crate::ops::DialectOp;
 use crate::{BlockRef, IrContext, OpRef, RegionRef, TypeRef, ValueRef};
 
 /// Marker trait for pure operations (no side effects, safe to remove if unused).
@@ -297,10 +298,6 @@ impl ForwardedValues {
         &self.values
     }
 
-    pub fn len(&self) -> usize {
-        self.values.len()
-    }
-
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
@@ -411,6 +408,25 @@ pub trait Branch: Sync {
     ) -> Result<BranchSuccessors, ControlFlowInterfaceError>;
 }
 
+/// Typed block-branch semantics supplied by a generated dialect operation wrapper.
+pub trait BranchModel: DialectOp {
+    fn successors(self, ctx: &IrContext) -> Result<BranchSuccessors, ControlFlowInterfaceError>;
+}
+
+fn branch_model_successors<T: BranchModel>(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+    let model = T::from_op(ctx, op).map_err(|error| {
+        ControlFlowInterfaceError::new(format!(
+            "malformed {}.{}: {error:?}",
+            T::DIALECT_NAME,
+            T::OP_NAME
+        ))
+    })?;
+    model.successors(ctx)
+}
+
 pub type BranchSuccessorsFn =
     fn(&IrContext, OpRef) -> Result<BranchSuccessors, ControlFlowInterfaceError>;
 
@@ -456,15 +472,11 @@ pub struct BranchOps;
 
 impl BranchOps {
     #[doc(hidden)]
-    pub const fn register(
-        dialect: &'static str,
-        op_name: &'static str,
-        successors: BranchSuccessorsFn,
-    ) -> BranchRegistration {
+    pub const fn register<T: BranchModel>() -> BranchRegistration {
         BranchRegistration {
-            dialect,
-            op_name,
-            successors,
+            dialect: T::DIALECT_NAME,
+            op_name: T::OP_NAME,
+            successors: branch_model_successors::<T>,
         }
     }
 
@@ -491,6 +503,51 @@ pub trait RegionBranch: Sync {
         op: OpRef,
         successor: RegionSuccessor,
     ) -> Result<ForwardedValues, ControlFlowInterfaceError>;
+}
+
+/// Typed structured-region semantics supplied by a generated dialect operation wrapper.
+pub trait RegionBranchModel: DialectOp {
+    fn successors(
+        self,
+        ctx: &IrContext,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError>;
+
+    fn entry_successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError>;
+}
+
+fn region_branch_model_successors<T: RegionBranchModel>(
+    ctx: &IrContext,
+    op: OpRef,
+    point: RegionBranchPoint,
+) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+    let model = T::from_op(ctx, op).map_err(|error| {
+        ControlFlowInterfaceError::new(format!(
+            "malformed {}.{}: {error:?}",
+            T::DIALECT_NAME,
+            T::OP_NAME
+        ))
+    })?;
+    model.successors(ctx, point)
+}
+
+fn region_branch_model_entry_operands<T: RegionBranchModel>(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    let model = T::from_op(ctx, op).map_err(|error| {
+        ControlFlowInterfaceError::new(format!(
+            "malformed {}.{}: {error:?}",
+            T::DIALECT_NAME,
+            T::OP_NAME
+        ))
+    })?;
+    model.entry_successor_operands(ctx, successor)
 }
 
 pub type RegionSuccessorsFn =
@@ -552,17 +609,12 @@ pub struct RegionBranchOps;
 
 impl RegionBranchOps {
     #[doc(hidden)]
-    pub const fn register(
-        dialect: &'static str,
-        op_name: &'static str,
-        successors: RegionSuccessorsFn,
-        entry_successor_operands: EntrySuccessorOperandsFn,
-    ) -> RegionBranchRegistration {
+    pub const fn register<T: RegionBranchModel>() -> RegionBranchRegistration {
         RegionBranchRegistration {
-            dialect,
-            op_name,
-            successors,
-            entry_successor_operands,
+            dialect: T::DIALECT_NAME,
+            op_name: T::OP_NAME,
+            successors: region_branch_model_successors::<T>,
+            entry_successor_operands: region_branch_model_entry_operands::<T>,
         }
     }
 
@@ -624,6 +676,30 @@ pub trait RegionBranchTerminator: Sync {
     ) -> Result<ForwardedValues, ControlFlowInterfaceError>;
 }
 
+/// Typed region-exit forwarding supplied by a generated dialect operation wrapper.
+pub trait RegionBranchTerminatorModel: DialectOp {
+    fn successor_operands(
+        self,
+        ctx: &IrContext,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError>;
+}
+
+fn region_terminator_model_operands<T: RegionBranchTerminatorModel>(
+    ctx: &IrContext,
+    op: OpRef,
+    successor: RegionSuccessor,
+) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+    let model = T::from_op(ctx, op).map_err(|error| {
+        ControlFlowInterfaceError::new(format!(
+            "malformed {}.{}: {error:?}",
+            T::DIALECT_NAME,
+            T::OP_NAME
+        ))
+    })?;
+    model.successor_operands(ctx, successor)
+}
+
 pub type RegionSuccessorOperandsFn =
     fn(&IrContext, OpRef, RegionSuccessor) -> Result<ForwardedValues, ControlFlowInterfaceError>;
 
@@ -671,15 +747,11 @@ pub struct RegionBranchTerminatorOps;
 
 impl RegionBranchTerminatorOps {
     #[doc(hidden)]
-    pub const fn register(
-        dialect: &'static str,
-        op_name: &'static str,
-        successor_operands: RegionSuccessorOperandsFn,
-    ) -> RegionBranchTerminatorRegistration {
+    pub const fn register<T: RegionBranchTerminatorModel>() -> RegionBranchTerminatorRegistration {
         RegionBranchTerminatorRegistration {
-            dialect,
-            op_name,
-            successor_operands,
+            dialect: T::DIALECT_NAME,
+            op_name: T::OP_NAME,
+            successor_operands: region_terminator_model_operands::<T>,
         }
     }
 
@@ -799,16 +871,5 @@ mod tests {
     fn test_unregistered_ops_are_not_isolated() {
         // This test would need a database and operation, so we just verify the struct exists
         let _ = IsolatedFromAboveOps;
-    }
-
-    #[test]
-    fn control_flow_interfaces_are_object_safe() {
-        fn accepts_branch(_: &dyn Branch) {}
-        fn accepts_region_branch(_: &dyn RegionBranch) {}
-        fn accepts_region_terminator(_: &dyn RegionBranchTerminator) {}
-
-        let _ = accepts_branch;
-        let _ = accepts_region_branch;
-        let _ = accepts_region_terminator;
     }
 }

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -7,8 +7,10 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::LazyLock;
 
+use smallvec::SmallVec;
+
 use crate::Symbol;
-use crate::{IrContext, OpRef, TypeRef};
+use crate::{BlockRef, IrContext, OpRef, RegionRef, TypeRef, ValueRef};
 
 /// Marker trait for pure operations (no side effects, safe to remove if unused).
 ///
@@ -234,6 +236,462 @@ macro_rules! register_isolated_op {
 }
 
 // =============================================================================
+// Control-flow interfaces
+// =============================================================================
+
+/// Failure to provide a complete control-flow interface answer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ControlFlowInterfaceError {
+    kind: ControlFlowInterfaceErrorKind,
+    detail: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ControlFlowInterfaceErrorKind {
+    Incomplete,
+    NotApplicable,
+}
+
+impl ControlFlowInterfaceError {
+    pub fn new(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ControlFlowInterfaceErrorKind::Incomplete,
+            detail: detail.into(),
+        }
+    }
+
+    pub fn not_applicable(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ControlFlowInterfaceErrorKind::NotApplicable,
+            detail: detail.into(),
+        }
+    }
+
+    pub fn is_not_applicable(&self) -> bool {
+        self.kind == ControlFlowInterfaceErrorKind::NotApplicable
+    }
+}
+
+impl fmt::Display for ControlFlowInterfaceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for ControlFlowInterfaceError {}
+
+/// Values forwarded along one control-flow edge.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ForwardedValues {
+    values: SmallVec<[ValueRef; 4]>,
+}
+
+impl ForwardedValues {
+    pub fn new(values: impl IntoIterator<Item = ValueRef>) -> Self {
+        Self {
+            values: values.into_iter().collect(),
+        }
+    }
+
+    pub fn as_slice(&self) -> &[ValueRef] {
+        &self.values
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+/// One raw block successor and the values forwarded to its block arguments.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BranchSuccessor {
+    pub block: BlockRef,
+    pub forwarded: ForwardedValues,
+}
+
+impl BranchSuccessor {
+    pub fn new(block: BlockRef, forwarded: impl IntoIterator<Item = ValueRef>) -> Self {
+        Self {
+            block,
+            forwarded: ForwardedValues::new(forwarded),
+        }
+    }
+}
+
+/// Complete block-successor answer for one branch operation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BranchSuccessors {
+    edges: SmallVec<[BranchSuccessor; 2]>,
+}
+
+impl BranchSuccessors {
+    pub fn new(edges: impl IntoIterator<Item = BranchSuccessor>) -> Self {
+        Self {
+            edges: edges.into_iter().collect(),
+        }
+    }
+
+    pub fn as_slice(&self) -> &[BranchSuccessor] {
+        &self.edges
+    }
+}
+
+/// Source of a transfer through a region-holding operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RegionBranchPoint {
+    /// First entry into the operation from its parent block.
+    Parent,
+    /// A terminator in one of the operation's semantic nested regions.
+    Terminator(OpRef),
+}
+
+/// Target of a transfer through a region-holding operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RegionSuccessor {
+    /// Enter a nested region.
+    Region(RegionRef),
+    /// Leave the operation and make its results available.
+    Parent,
+}
+
+/// Complete successor answer for one region branch point.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RegionSuccessors {
+    successors: SmallVec<[RegionSuccessor; 4]>,
+}
+
+impl RegionSuccessors {
+    pub fn new(successors: impl IntoIterator<Item = RegionSuccessor>) -> Self {
+        Self {
+            successors: successors.into_iter().collect(),
+        }
+    }
+
+    pub fn as_slice(&self) -> &[RegionSuccessor] {
+        &self.successors
+    }
+}
+
+/// Values receiving the forwarded operands of a region transfer.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SuccessorInputs {
+    values: SmallVec<[ValueRef; 4]>,
+}
+
+impl SuccessorInputs {
+    fn new(values: impl IntoIterator<Item = ValueRef>) -> Self {
+        Self {
+            values: values.into_iter().collect(),
+        }
+    }
+
+    pub fn as_slice(&self) -> &[ValueRef] {
+        &self.values
+    }
+}
+
+/// Named operand-to-input transfer for one region edge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegionValueTransfer {
+    pub successor: RegionSuccessor,
+    pub forwarded: ForwardedValues,
+    pub inputs: SuccessorInputs,
+}
+
+/// Object-safe block branch semantics.
+pub trait Branch: Sync {
+    fn successors(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+    ) -> Result<BranchSuccessors, ControlFlowInterfaceError>;
+}
+
+pub type BranchSuccessorsFn =
+    fn(&IrContext, OpRef) -> Result<BranchSuccessors, ControlFlowInterfaceError>;
+
+/// Registry entry for [`Branch`].
+pub struct BranchRegistration {
+    pub dialect: &'static str,
+    pub op_name: &'static str,
+    pub successors: BranchSuccessorsFn,
+}
+
+impl Branch for BranchRegistration {
+    fn successors(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+    ) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+        (self.successors)(ctx, op)
+    }
+}
+
+inventory::collect!(BranchRegistration);
+
+static BRANCH_REGISTRY: LazyLock<HashMap<(Symbol, Symbol), &'static BranchRegistration>> =
+    LazyLock::new(|| {
+        let mut registry = HashMap::new();
+        for registration in inventory::iter::<BranchRegistration> {
+            let key = (
+                Symbol::from_dynamic(registration.dialect),
+                Symbol::from_dynamic(registration.op_name),
+            );
+            assert!(
+                registry.insert(key, registration).is_none(),
+                "duplicate Branch registration for '{}.{}'",
+                registration.dialect,
+                registration.op_name,
+            );
+        }
+        registry
+    });
+
+/// Dyn query and registration entry point for [`Branch`].
+pub struct BranchOps;
+
+impl BranchOps {
+    #[doc(hidden)]
+    pub const fn register(
+        dialect: &'static str,
+        op_name: &'static str,
+        successors: BranchSuccessorsFn,
+    ) -> BranchRegistration {
+        BranchRegistration {
+            dialect,
+            op_name,
+            successors,
+        }
+    }
+
+    pub fn get(ctx: &IrContext, op: OpRef) -> Option<&'static dyn Branch> {
+        let data = ctx.op(op);
+        BRANCH_REGISTRY
+            .get(&(data.dialect, data.name))
+            .map(|registration| *registration as &dyn Branch)
+    }
+}
+
+/// Object-safe control-flow semantics between an operation and nested regions.
+pub trait RegionBranch: Sync {
+    fn successors(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError>;
+
+    fn entry_successor_operands(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError>;
+}
+
+pub type RegionSuccessorsFn =
+    fn(&IrContext, OpRef, RegionBranchPoint) -> Result<RegionSuccessors, ControlFlowInterfaceError>;
+pub type EntrySuccessorOperandsFn =
+    fn(&IrContext, OpRef, RegionSuccessor) -> Result<ForwardedValues, ControlFlowInterfaceError>;
+
+/// Registry entry for [`RegionBranch`].
+pub struct RegionBranchRegistration {
+    pub dialect: &'static str,
+    pub op_name: &'static str,
+    pub successors: RegionSuccessorsFn,
+    pub entry_successor_operands: EntrySuccessorOperandsFn,
+}
+
+impl RegionBranch for RegionBranchRegistration {
+    fn successors(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        point: RegionBranchPoint,
+    ) -> Result<RegionSuccessors, ControlFlowInterfaceError> {
+        (self.successors)(ctx, op, point)
+    }
+
+    fn entry_successor_operands(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        (self.entry_successor_operands)(ctx, op, successor)
+    }
+}
+
+inventory::collect!(RegionBranchRegistration);
+
+static REGION_BRANCH_REGISTRY: LazyLock<
+    HashMap<(Symbol, Symbol), &'static RegionBranchRegistration>,
+> = LazyLock::new(|| {
+    let mut registry = HashMap::new();
+    for registration in inventory::iter::<RegionBranchRegistration> {
+        let key = (
+            Symbol::from_dynamic(registration.dialect),
+            Symbol::from_dynamic(registration.op_name),
+        );
+        assert!(
+            registry.insert(key, registration).is_none(),
+            "duplicate RegionBranch registration for '{}.{}'",
+            registration.dialect,
+            registration.op_name,
+        );
+    }
+    registry
+});
+
+/// Dyn query and transfer helpers for [`RegionBranch`].
+pub struct RegionBranchOps;
+
+impl RegionBranchOps {
+    #[doc(hidden)]
+    pub const fn register(
+        dialect: &'static str,
+        op_name: &'static str,
+        successors: RegionSuccessorsFn,
+        entry_successor_operands: EntrySuccessorOperandsFn,
+    ) -> RegionBranchRegistration {
+        RegionBranchRegistration {
+            dialect,
+            op_name,
+            successors,
+            entry_successor_operands,
+        }
+    }
+
+    pub fn get(ctx: &IrContext, op: OpRef) -> Option<&'static dyn RegionBranch> {
+        let data = ctx.op(op);
+        REGION_BRANCH_REGISTRY
+            .get(&(data.dialect, data.name))
+            .map(|registration| *registration as &dyn RegionBranch)
+    }
+
+    /// Build the named value transfer for one already-reported successor.
+    pub fn value_transfer(
+        ctx: &IrContext,
+        op: OpRef,
+        point: RegionBranchPoint,
+        successor: RegionSuccessor,
+    ) -> Result<RegionValueTransfer, ControlFlowInterfaceError> {
+        let interface = Self::get(ctx, op).ok_or_else(|| {
+            ControlFlowInterfaceError::new("operation has no RegionBranch registration")
+        })?;
+        let forwarded = match point {
+            RegionBranchPoint::Parent => interface.entry_successor_operands(ctx, op, successor)?,
+            RegionBranchPoint::Terminator(terminator) => {
+                let terminator_interface = RegionBranchTerminatorOps::get(ctx, terminator)
+                    .ok_or_else(|| {
+                        ControlFlowInterfaceError::new(format!(
+                            "terminator {terminator} has no RegionBranchTerminator registration"
+                        ))
+                    })?;
+                terminator_interface.successor_operands(ctx, terminator, successor)?
+            }
+        };
+        let inputs = match successor {
+            RegionSuccessor::Parent => SuccessorInputs::new(ctx.op_results(op).iter().copied()),
+            RegionSuccessor::Region(region) => {
+                let entry = ctx.region(region).blocks.first().copied().ok_or_else(|| {
+                    ControlFlowInterfaceError::new(format!(
+                        "successor region {region} has no entry block"
+                    ))
+                })?;
+                SuccessorInputs::new(ctx.block_args(entry).iter().copied())
+            }
+        };
+        Ok(RegionValueTransfer {
+            successor,
+            forwarded,
+            inputs,
+        })
+    }
+}
+
+/// Object-safe SSA forwarding semantics for a nested-region terminator.
+pub trait RegionBranchTerminator: Sync {
+    fn successor_operands(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError>;
+}
+
+pub type RegionSuccessorOperandsFn =
+    fn(&IrContext, OpRef, RegionSuccessor) -> Result<ForwardedValues, ControlFlowInterfaceError>;
+
+/// Registry entry for [`RegionBranchTerminator`].
+pub struct RegionBranchTerminatorRegistration {
+    pub dialect: &'static str,
+    pub op_name: &'static str,
+    pub successor_operands: RegionSuccessorOperandsFn,
+}
+
+impl RegionBranchTerminator for RegionBranchTerminatorRegistration {
+    fn successor_operands(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        successor: RegionSuccessor,
+    ) -> Result<ForwardedValues, ControlFlowInterfaceError> {
+        (self.successor_operands)(ctx, op, successor)
+    }
+}
+
+inventory::collect!(RegionBranchTerminatorRegistration);
+
+static REGION_BRANCH_TERMINATOR_REGISTRY: LazyLock<
+    HashMap<(Symbol, Symbol), &'static RegionBranchTerminatorRegistration>,
+> = LazyLock::new(|| {
+    let mut registry = HashMap::new();
+    for registration in inventory::iter::<RegionBranchTerminatorRegistration> {
+        let key = (
+            Symbol::from_dynamic(registration.dialect),
+            Symbol::from_dynamic(registration.op_name),
+        );
+        assert!(
+            registry.insert(key, registration).is_none(),
+            "duplicate RegionBranchTerminator registration for '{}.{}'",
+            registration.dialect,
+            registration.op_name,
+        );
+    }
+    registry
+});
+
+/// Dyn query and registration entry point for [`RegionBranchTerminator`].
+pub struct RegionBranchTerminatorOps;
+
+impl RegionBranchTerminatorOps {
+    #[doc(hidden)]
+    pub const fn register(
+        dialect: &'static str,
+        op_name: &'static str,
+        successor_operands: RegionSuccessorOperandsFn,
+    ) -> RegionBranchTerminatorRegistration {
+        RegionBranchTerminatorRegistration {
+            dialect,
+            op_name,
+            successor_operands,
+        }
+    }
+
+    pub fn get(ctx: &IrContext, op: OpRef) -> Option<&'static dyn RegionBranchTerminator> {
+        let data = ctx.op(op);
+        REGION_BRANCH_TERMINATOR_REGISTRY
+            .get(&(data.dialect, data.name))
+            .map(|registration| *registration as &dyn RegionBranchTerminator)
+    }
+}
+
+// =============================================================================
 // TypeAliasHint — dialect-provided alias name suggestions for printer
 // =============================================================================
 
@@ -341,5 +799,16 @@ mod tests {
     fn test_unregistered_ops_are_not_isolated() {
         // This test would need a database and operation, so we just verify the struct exists
         let _ = IsolatedFromAboveOps;
+    }
+
+    #[test]
+    fn control_flow_interfaces_are_object_safe() {
+        fn accepts_branch(_: &dyn Branch) {}
+        fn accepts_region_branch(_: &dyn RegionBranch) {}
+        fn accepts_region_terminator(_: &dyn RegionBranchTerminator) {}
+
+        let _ = accepts_branch;
+        let _ = accepts_region_branch;
+        let _ = accepts_region_terminator;
     }
 }

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -20,6 +20,10 @@ use std::fmt;
 use derive_more::{Display, Error};
 
 use super::context::IrContext;
+use super::op_interface::{
+    BranchOps, RegionBranchOps, RegionBranchPoint, RegionBranchTerminatorOps, RegionSuccessor,
+    RegionValueTransfer,
+};
 use super::refs::{BlockRef, OpRef, RegionRef, ValueDef, ValueRef};
 use super::rewrite::Module;
 use super::walk;
@@ -323,11 +327,17 @@ pub fn validate_operation_verifiers(ctx: &IrContext, module: Module) -> Validati
     };
 
     walk::walk_region::<std::convert::Infallible>(ctx, body, &mut |op| {
+        let error_count = errors.len();
         validate_arith_cmpf_predicate(ctx, op, &mut errors);
         validate_scf_if_structure(ctx, op, &mut errors);
         validate_scf_loop_result_arity(ctx, op, &mut errors);
         validate_scf_switch_result_arity(ctx, op, &mut errors);
         validate_func_tail_call_indirect(ctx, op, &mut errors);
+        if errors.len() == error_count {
+            validate_branch_interface(ctx, op, &mut errors);
+            validate_region_branch_interface(ctx, op, &mut errors);
+            validate_region_branch_terminator_interface(ctx, op, &mut errors);
+        }
         std::ops::ControlFlow::Continue(walk::WalkAction::Advance)
     });
 
@@ -468,6 +478,342 @@ fn operation_verifier_error(
     }
 }
 
+fn validate_forwarding_types(
+    ctx: &IrContext,
+    op: OpRef,
+    forwarded: &[ValueRef],
+    inputs: &[ValueRef],
+    edge_name: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    if forwarded.len() != inputs.len() {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            format!(
+                "{edge_name} forwards {} value(s), but its successor expects {} input(s)",
+                forwarded.len(),
+                inputs.len(),
+            ),
+        ));
+        return;
+    }
+    for (index, (&value, &input)) in forwarded.iter().zip(inputs).enumerate() {
+        if ctx.value_ty(value) != ctx.value_ty(input) {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("{edge_name} value #{index} type does not match successor input type"),
+            ));
+        }
+    }
+}
+
+fn forwarding_comes_from_operands(source: &[ValueRef], forwarded: &[ValueRef]) -> bool {
+    let mut available = HashMap::<ValueRef, usize>::new();
+    for &value in source {
+        *available.entry(value).or_default() += 1;
+    }
+    for &value in forwarded {
+        let Some(count) = available.get_mut(&value) else {
+            return false;
+        };
+        if *count == 0 {
+            return false;
+        }
+        *count -= 1;
+    }
+    true
+}
+
+fn validate_branch_interface(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
+    let Some(interface) = BranchOps::get(ctx, op) else {
+        return;
+    };
+    if !ctx.op_results(op).is_empty() {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "Branch operation must be resultless",
+        ));
+    }
+    let parent_block = ctx.op(op).parent_block;
+    if parent_block.is_none_or(|block| ctx.block(block).ops.last().copied() != Some(op)) {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "Branch operation must be the final operation in its block",
+        ));
+    }
+    let successors = match interface.successors(ctx, op) {
+        Ok(successors) => successors,
+        Err(error) => {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("Branch interface is incomplete: {error}"),
+            ));
+            return;
+        }
+    };
+    let raw_successors = &ctx.op(op).successors;
+    if successors.as_slice().len() != raw_successors.len() {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            format!(
+                "Branch interface reports {} successor(s), but the operation stores {}",
+                successors.as_slice().len(),
+                raw_successors.len(),
+            ),
+        ));
+        return;
+    }
+    let source_region = ctx
+        .op(op)
+        .parent_block
+        .and_then(|block| ctx.block(block).parent_region);
+    for (index, (edge, &raw_successor)) in
+        successors.as_slice().iter().zip(raw_successors).enumerate()
+    {
+        if edge.block != raw_successor {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("Branch interface successor #{index} does not match the stored successor"),
+            ));
+            continue;
+        }
+        if source_region.is_none() || ctx.block(edge.block).parent_region != source_region {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("Branch successor #{index} leaves the source region"),
+            ));
+        }
+        if !forwarding_comes_from_operands(ctx.op_operands(op), edge.forwarded.as_slice()) {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("Branch successor #{index} reports a value that is not a branch operand"),
+            ));
+        }
+        validate_forwarding_types(
+            ctx,
+            op,
+            edge.forwarded.as_slice(),
+            ctx.block_args(edge.block),
+            &format!("Branch successor #{index}"),
+            errors,
+        );
+    }
+}
+
+fn region_is_nested_under_op(ctx: &IrContext, region: RegionRef, owner: OpRef) -> bool {
+    let mut current = Some(region);
+    while let Some(region) = current {
+        let Some(parent_op) = ctx.region(region).parent_op else {
+            return false;
+        };
+        if parent_op == owner {
+            return true;
+        }
+        current = ctx
+            .op(parent_op)
+            .parent_block
+            .and_then(|block| ctx.block(block).parent_region);
+    }
+    false
+}
+
+fn validate_region_transfer(
+    ctx: &IrContext,
+    owner: OpRef,
+    point: RegionBranchPoint,
+    successor: RegionSuccessor,
+    errors: &mut Vec<ValidationError>,
+) {
+    if let RegionSuccessor::Region(region) = successor
+        && !region_is_nested_under_op(ctx, region, owner)
+    {
+        errors.push(operation_verifier_error(
+            ctx,
+            owner,
+            format!("RegionBranch successor {region} is outside the operation's region tree"),
+        ));
+        return;
+    }
+    let transfer = match RegionBranchOps::value_transfer(ctx, owner, point, successor) {
+        Ok(transfer) => transfer,
+        Err(error) => {
+            errors.push(operation_verifier_error(
+                ctx,
+                owner,
+                format!("RegionBranch value mapping is incomplete: {error}"),
+            ));
+            return;
+        }
+    };
+    let RegionValueTransfer {
+        successor,
+        forwarded,
+        inputs,
+    } = transfer;
+    let source_operands = match point {
+        RegionBranchPoint::Parent => ctx.op_operands(owner),
+        RegionBranchPoint::Terminator(terminator) => ctx.op_operands(terminator),
+    };
+    if !forwarding_comes_from_operands(source_operands, forwarded.as_slice()) {
+        errors.push(operation_verifier_error(
+            ctx,
+            owner,
+            format!(
+                "RegionBranch edge to {successor:?} reports a value that is not a source operand"
+            ),
+        ));
+    }
+    validate_forwarding_types(
+        ctx,
+        owner,
+        forwarded.as_slice(),
+        inputs.as_slice(),
+        &format!("RegionBranch edge to {successor:?}"),
+        errors,
+    );
+}
+
+fn validate_region_branch_interface(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
+    let Some(interface) = RegionBranchOps::get(ctx, op) else {
+        return;
+    };
+    let successors = match interface.successors(ctx, op, RegionBranchPoint::Parent) {
+        Ok(successors) => successors,
+        Err(error) => {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("RegionBranch entry mapping is incomplete: {error}"),
+            ));
+            return;
+        }
+    };
+    let mut unique = HashSet::new();
+    for &successor in successors.as_slice() {
+        if !unique.insert(successor) {
+            errors.push(operation_verifier_error(
+                ctx,
+                op,
+                format!("RegionBranch entry reports duplicate successor {successor:?}"),
+            ));
+            continue;
+        }
+        validate_region_transfer(ctx, op, RegionBranchPoint::Parent, successor, errors);
+        let RegionSuccessor::Region(region) = successor else {
+            continue;
+        };
+        for &block in &ctx.region(region).blocks {
+            let Some(_) = ctx.block(block).ops.last() else {
+                errors.push(operation_verifier_error(
+                    ctx,
+                    op,
+                    format!("RegionBranch successor region {region} contains an empty block"),
+                ));
+                continue;
+            };
+            // RegionBranch describes the semantic edges exposed by the owning
+            // operation; it does not impose a terminator kind on every
+            // successor region. Some existing resultless structured regions
+            // use implicit fallthrough, while explicit terminators are checked
+            // independently through RegionBranchTerminatorOps below.
+        }
+    }
+}
+
+fn validate_region_branch_terminator_interface(
+    ctx: &IrContext,
+    op: OpRef,
+    errors: &mut Vec<ValidationError>,
+) {
+    if RegionBranchTerminatorOps::get(ctx, op).is_none() {
+        return;
+    }
+    if !ctx.op_results(op).is_empty() {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "RegionBranchTerminator must be resultless",
+        ));
+    }
+    if !ctx.op(op).successors.is_empty() {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "RegionBranchTerminator must not store raw block successors",
+        ));
+    }
+    let Some(parent_block) = ctx.op(op).parent_block else {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "RegionBranchTerminator is detached from a block",
+        ));
+        return;
+    };
+    if ctx.block(parent_block).ops.last().copied() != Some(op) {
+        errors.push(operation_verifier_error(
+            ctx,
+            op,
+            "RegionBranchTerminator must be the final operation in its block",
+        ));
+    }
+
+    let point = RegionBranchPoint::Terminator(op);
+    let mut region = ctx.block(parent_block).parent_region;
+    while let Some(current_region) = region {
+        let Some(owner) = ctx.region(current_region).parent_op else {
+            break;
+        };
+        if let Some(interface) = RegionBranchOps::get(ctx, owner) {
+            match interface.successors(ctx, owner, point) {
+                Ok(successors) => {
+                    if successors.as_slice().is_empty() {
+                        errors.push(operation_verifier_error(
+                            ctx,
+                            op,
+                            "owning RegionBranch reports no successor for this terminator",
+                        ));
+                        return;
+                    }
+                    let mut unique = HashSet::new();
+                    for &successor in successors.as_slice() {
+                        if !unique.insert(successor) {
+                            errors.push(operation_verifier_error(
+                                ctx,
+                                op,
+                                format!("terminator reports duplicate successor {successor:?}"),
+                            ));
+                            continue;
+                        }
+                        validate_region_transfer(ctx, owner, point, successor, errors);
+                    }
+                    return;
+                }
+                Err(error) if error.is_not_applicable() => {}
+                Err(_) => return,
+            }
+        }
+        region = ctx
+            .op(owner)
+            .parent_block
+            .and_then(|block| ctx.block(block).parent_region);
+    }
+    errors.push(operation_verifier_error(
+        ctx,
+        op,
+        "has no complete owning RegionBranch mapping",
+    ));
+}
+
 const SUPPORTED_CMPF_PREDICATES: [&str; 6] = ["oeq", "une", "olt", "ole", "ogt", "oge"];
 
 fn supported_cmpf_predicates_text() -> String {
@@ -530,7 +876,6 @@ fn validate_scf_if_structure(ctx: &IrContext, op: OpRef, errors: &mut Vec<Valida
         return;
     }
 
-    let result_arity = ctx.op_results(op).len();
     for (region_name, &region) in [
         ("then_region", &data.regions[0]),
         ("else_region", &data.regions[1]),
@@ -572,17 +917,6 @@ fn validate_scf_if_structure(ctx: &IrContext, op: OpRef, errors: &mut Vec<Valida
                 format!("{region_name} must terminate with scf.yield"),
             ));
             continue;
-        }
-
-        let yield_arity = ctx.op_operands(yield_op).len();
-        if yield_arity != result_arity {
-            errors.push(operation_verifier_error(
-                ctx,
-                op,
-                format!(
-                    "{region_name} yields {yield_arity} value(s), but scf.if has {result_arity} result(s)"
-                ),
-            ));
         }
     }
 }
@@ -867,6 +1201,21 @@ mod tests {
                 Some(message.as_str())
             })
             .collect()
+    }
+
+    fn operations_named(ctx: &IrContext, module: Module, dialect: &str, name: &str) -> Vec<OpRef> {
+        let mut operations = Vec::new();
+        let dialect = Symbol::from_dynamic(dialect);
+        let name = Symbol::from_dynamic(name);
+        let body = module.body(ctx).expect("test module must have a body");
+        walk::walk_region::<std::convert::Infallible>(ctx, body, &mut |op| {
+            let data = ctx.op(op);
+            if data.dialect == dialect && data.name == name {
+                operations.push(op);
+            }
+            std::ops::ControlFlow::Continue(walk::WalkAction::Advance)
+        });
+        operations
     }
 
     fn single_block_yield_region(
@@ -1929,8 +2278,296 @@ mod tests {
         let operation_errors = operation_error_messages(&result);
         assert_eq!(operation_errors.len(), 1);
         assert!(operation_errors[0].contains("operation verifier failed for scf.if"));
-        assert!(operation_errors[0].contains("then_region yields 0 value(s)"));
-        assert!(operation_errors[0].contains("scf.if has 1 result(s)"));
+        assert!(operation_errors[0].contains("forwards 0 value(s)"));
+        assert!(operation_errors[0].contains("successor expects 1 input(s)"));
+    }
+
+    #[test]
+    fn cf_branch_interface_reports_textual_value_forwarding() {
+        let input = r#"core.module @test {
+  func.func @main(%x: core.i32) -> core.i32 {
+    ^entry:
+      cf.br %x [^exit]
+    ^exit(%forwarded: core.i32):
+      func.return %forwarded
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
+        let branches = operations_named(&ctx, module, "cf", "br");
+        let [branch] = branches.as_slice() else {
+            panic!("expected one cf.br");
+        };
+        let interface = BranchOps::get(&ctx, *branch).expect("cf.br must implement Branch");
+        let successors = interface.successors(&ctx, *branch).unwrap();
+        let [edge] = successors.as_slice() else {
+            panic!("cf.br must report one edge");
+        };
+        assert_eq!(edge.forwarded.as_slice(), ctx.op_operands(*branch));
+        assert_eq!(ctx.block_args(edge.block).len(), 1);
+    }
+
+    #[test]
+    fn cf_cond_branch_interface_reports_both_textual_successors() {
+        let input = r#"core.module @test {
+  func.func @main(%condition: core.i1, %value: core.i32) -> core.i32 {
+    ^entry:
+      cf.cond_br %condition [^left, ^right]
+    ^left:
+      cf.br %value [^exit]
+    ^right:
+      cf.br %value [^exit]
+    ^exit(%forwarded: core.i32):
+      func.return %forwarded
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
+        let branches = operations_named(&ctx, module, "cf", "cond_br");
+        let [branch] = branches.as_slice() else {
+            panic!("expected one cf.cond_br");
+        };
+        let successors = BranchOps::get(&ctx, *branch)
+            .unwrap()
+            .successors(&ctx, *branch)
+            .unwrap();
+        assert_eq!(successors.as_slice().len(), 2);
+        assert!(
+            successors
+                .as_slice()
+                .iter()
+                .all(|edge| edge.forwarded.is_empty())
+        );
+    }
+
+    #[test]
+    fn cf_branch_interface_rejects_textual_cardinality_and_type_mismatches() {
+        let input = r#"core.module @test {
+  func.func @missing(%x: core.i32) -> core.i32 {
+    ^entry:
+      cf.br [^exit]
+    ^exit(%forwarded: core.i32):
+      func.return %forwarded
+  }
+  func.func @wrong_type(%flag: core.i1) -> core.i32 {
+    ^entry:
+      cf.br %flag [^exit]
+    ^exit(%forwarded: core.i32):
+      func.return %forwarded
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        let messages = operation_error_messages(&result);
+        assert_eq!(messages.len(), 2, "{result}");
+        assert!(messages.iter().any(|message| {
+            message.contains("forwards 0 value(s)")
+                && message.contains("successor expects 1 input(s)")
+        }));
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("type does not match successor input type"))
+        );
+    }
+
+    #[test]
+    fn region_branch_interfaces_cover_nested_if_forwarding() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1, %x: core.i32) -> core.i32 {
+    %outer = scf.if %cond : core.i32 {
+      %inner = scf.if %cond : core.i32 {
+        scf.yield %x
+      } {
+        scf.yield %x
+      }
+      scf.yield %inner
+    } {
+      scf.yield %x
+    }
+    func.return %outer
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
+        let ifs = operations_named(&ctx, module, "scf", "if");
+        assert_eq!(ifs.len(), 2);
+        for if_op in ifs {
+            let interface = RegionBranchOps::get(&ctx, if_op).unwrap();
+            let successors = interface
+                .successors(&ctx, if_op, RegionBranchPoint::Parent)
+                .unwrap();
+            assert_eq!(successors.as_slice().len(), 2);
+            assert!(
+                successors
+                    .as_slice()
+                    .iter()
+                    .all(|successor| matches!(successor, RegionSuccessor::Region(_)))
+            );
+        }
+    }
+
+    #[test]
+    fn region_branch_interfaces_cover_loop_entry_backedge_and_exit() {
+        let input = r#"core.module @test {
+  func.func @main(%init: core.i32) -> core.i32 {
+    %result = scf.loop %init : core.i32 {
+      ^header(%iter: core.i32):
+        scf.continue %iter
+      ^exit_path(%value: core.i32):
+        scf.break %value
+    }
+    func.return %result
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
+        let loops = operations_named(&ctx, module, "scf", "loop");
+        let [loop_op] = loops.as_slice() else {
+            panic!("expected one scf.loop");
+        };
+        let interface = RegionBranchOps::get(&ctx, *loop_op).unwrap();
+        let entry = interface
+            .successors(&ctx, *loop_op, RegionBranchPoint::Parent)
+            .unwrap();
+        let [RegionSuccessor::Region(body)] = entry.as_slice() else {
+            panic!("loop entry must target its body");
+        };
+        let continues = operations_named(&ctx, module, "scf", "continue");
+        let [continue_op] = continues.as_slice() else {
+            panic!("expected one scf.continue");
+        };
+        let backedge = RegionBranchOps::value_transfer(
+            &ctx,
+            *loop_op,
+            RegionBranchPoint::Terminator(*continue_op),
+            RegionSuccessor::Region(*body),
+        )
+        .unwrap();
+        assert_eq!(backedge.forwarded.as_slice().len(), 1);
+        assert_eq!(backedge.inputs.as_slice().len(), 1);
+
+        let breaks = operations_named(&ctx, module, "scf", "break");
+        let [break_op] = breaks.as_slice() else {
+            panic!("expected one scf.break");
+        };
+        let exit = RegionBranchOps::value_transfer(
+            &ctx,
+            *loop_op,
+            RegionBranchPoint::Terminator(*break_op),
+            RegionSuccessor::Parent,
+        )
+        .unwrap();
+        assert_eq!(exit.forwarded.as_slice().len(), 1);
+        assert_eq!(exit.inputs.as_slice().len(), 1);
+    }
+
+    #[test]
+    fn region_branch_interfaces_cover_switch_case_and_default() {
+        let input = r#"core.module @test {
+  func.func @main(%discriminant: core.i32) -> core.nil {
+    scf.switch %discriminant {
+      scf.case {value = 0} {
+        scf.yield
+      }
+      scf.default {
+        scf.yield
+      }
+    }
+    %unit = arith.const {value = 0} : core.nil
+    func.return %unit
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        assert!(result.is_ok(), "{result}");
+        let switches = operations_named(&ctx, module, "scf", "switch");
+        let [switch] = switches.as_slice() else {
+            panic!("expected one scf.switch");
+        };
+        let interface = RegionBranchOps::get(&ctx, *switch).unwrap();
+        let successors = interface
+            .successors(&ctx, *switch, RegionBranchPoint::Parent)
+            .unwrap();
+        assert_eq!(successors.as_slice().len(), 2);
+        assert!(
+            successors
+                .as_slice()
+                .iter()
+                .all(|successor| matches!(successor, RegionSuccessor::Region(_)))
+        );
+        for wrapper in operations_named(&ctx, module, "scf", "case")
+            .into_iter()
+            .chain(operations_named(&ctx, module, "scf", "default"))
+        {
+            assert!(RegionBranchOps::get(&ctx, wrapper).is_some());
+        }
+    }
+
+    #[test]
+    fn region_branch_interfaces_reject_incomplete_loop_mappings() {
+        let input = r#"core.module @test {
+  func.func @main(%init: core.i32) -> core.i32 {
+    %result = scf.loop %init : core.i32 {
+      ^header(%iter: core.i32, %extra: core.i32):
+        scf.continue
+      ^exit_path(%value: core.i32):
+        scf.break %value
+    }
+    func.return %result
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        let messages = operation_error_messages(&result);
+        assert_eq!(messages.len(), 2, "{result}");
+        assert!(messages.iter().any(|message| {
+            message.contains("forwards 1 value(s)")
+                && message.contains("successor expects 2 input(s)")
+        }));
+        assert!(messages.iter().any(|message| {
+            message.contains("forwards 0 value(s)")
+                && message.contains("successor expects 2 input(s)")
+        }));
+    }
+
+    #[test]
+    fn region_branch_interface_rejects_textual_forwarding_type_mismatch() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1, %x: core.i32) -> core.i32 {
+    %result = scf.if %cond : core.i32 {
+      scf.yield %cond
+    } {
+      scf.yield %x
+    }
+    func.return %result
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let result = validate_operation_verifiers(&ctx, module);
+        let messages = operation_error_messages(&result);
+        assert_eq!(messages.len(), 1, "{result}");
+        assert!(messages[0].contains("type does not match successor input type"));
     }
 
     #[test]

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -2298,15 +2298,13 @@ mod tests {
         let result = validate_operation_verifiers(&ctx, module);
         assert!(result.is_ok(), "{result}");
         let branches = operations_named(&ctx, module, "cf", "br");
-        let [branch] = branches.as_slice() else {
-            panic!("expected one cf.br");
-        };
-        let interface = BranchOps::get(&ctx, *branch).expect("cf.br must implement Branch");
-        let successors = interface.successors(&ctx, *branch).unwrap();
-        let [edge] = successors.as_slice() else {
-            panic!("cf.br must report one edge");
-        };
-        assert_eq!(edge.forwarded.as_slice(), ctx.op_operands(*branch));
+        assert_eq!(branches.len(), 1);
+        let branch = branches[0];
+        let interface = BranchOps::get(&ctx, branch).expect("cf.br must implement Branch");
+        let successors = interface.successors(&ctx, branch).unwrap();
+        assert_eq!(successors.as_slice().len(), 1);
+        let edge = &successors.as_slice()[0];
+        assert_eq!(edge.forwarded.as_slice(), ctx.op_operands(branch));
         assert_eq!(ctx.block_args(edge.block).len(), 1);
     }
 
@@ -2330,12 +2328,11 @@ mod tests {
         let result = validate_operation_verifiers(&ctx, module);
         assert!(result.is_ok(), "{result}");
         let branches = operations_named(&ctx, module, "cf", "cond_br");
-        let [branch] = branches.as_slice() else {
-            panic!("expected one cf.cond_br");
-        };
-        let successors = BranchOps::get(&ctx, *branch)
+        assert_eq!(branches.len(), 1);
+        let branch = branches[0];
+        let successors = BranchOps::get(&ctx, branch)
             .unwrap()
-            .successors(&ctx, *branch)
+            .successors(&ctx, branch)
             .unwrap();
         assert_eq!(successors.as_slice().len(), 2);
         assert!(
@@ -2437,38 +2434,36 @@ mod tests {
         let result = validate_operation_verifiers(&ctx, module);
         assert!(result.is_ok(), "{result}");
         let loops = operations_named(&ctx, module, "scf", "loop");
-        let [loop_op] = loops.as_slice() else {
-            panic!("expected one scf.loop");
-        };
-        let interface = RegionBranchOps::get(&ctx, *loop_op).unwrap();
+        assert_eq!(loops.len(), 1);
+        let loop_op = loops[0];
+        let interface = RegionBranchOps::get(&ctx, loop_op).unwrap();
         let entry = interface
-            .successors(&ctx, *loop_op, RegionBranchPoint::Parent)
+            .successors(&ctx, loop_op, RegionBranchPoint::Parent)
             .unwrap();
-        let [RegionSuccessor::Region(body)] = entry.as_slice() else {
-            panic!("loop entry must target its body");
+        assert_eq!(entry.as_slice().len(), 1);
+        let RegionSuccessor::Region(body) = entry.as_slice()[0] else {
+            unreachable!()
         };
         let continues = operations_named(&ctx, module, "scf", "continue");
-        let [continue_op] = continues.as_slice() else {
-            panic!("expected one scf.continue");
-        };
+        assert_eq!(continues.len(), 1);
+        let continue_op = continues[0];
         let backedge = RegionBranchOps::value_transfer(
             &ctx,
-            *loop_op,
-            RegionBranchPoint::Terminator(*continue_op),
-            RegionSuccessor::Region(*body),
+            loop_op,
+            RegionBranchPoint::Terminator(continue_op),
+            RegionSuccessor::Region(body),
         )
         .unwrap();
         assert_eq!(backedge.forwarded.as_slice().len(), 1);
         assert_eq!(backedge.inputs.as_slice().len(), 1);
 
         let breaks = operations_named(&ctx, module, "scf", "break");
-        let [break_op] = breaks.as_slice() else {
-            panic!("expected one scf.break");
-        };
+        assert_eq!(breaks.len(), 1);
+        let break_op = breaks[0];
         let exit = RegionBranchOps::value_transfer(
             &ctx,
-            *loop_op,
-            RegionBranchPoint::Terminator(*break_op),
+            loop_op,
+            RegionBranchPoint::Terminator(break_op),
             RegionSuccessor::Parent,
         )
         .unwrap();
@@ -2498,12 +2493,11 @@ mod tests {
         let result = validate_operation_verifiers(&ctx, module);
         assert!(result.is_ok(), "{result}");
         let switches = operations_named(&ctx, module, "scf", "switch");
-        let [switch] = switches.as_slice() else {
-            panic!("expected one scf.switch");
-        };
-        let interface = RegionBranchOps::get(&ctx, *switch).unwrap();
+        assert_eq!(switches.len(), 1);
+        let switch = switches[0];
+        let interface = RegionBranchOps::get(&ctx, switch).unwrap();
         let successors = interface
-            .successors(&ctx, *switch, RegionBranchPoint::Parent)
+            .successors(&ctx, switch, RegionBranchPoint::Parent)
             .unwrap();
         assert_eq!(successors.as_slice().len(), 2);
         assert!(
@@ -2518,6 +2512,393 @@ mod tests {
         {
             assert!(RegionBranchOps::get(&ctx, wrapper).is_some());
         }
+    }
+
+    #[test]
+    fn typed_region_models_fail_closed_for_invalid_semantic_queries() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1, %discriminant: core.i32, %value: core.i32) -> core.i32 {
+    %selected = scf.if %cond : core.i32 {
+      scf.yield %value
+    } {
+      scf.yield %value
+    }
+    scf.switch %discriminant {
+      scf.case {value = 0} {
+        scf.yield
+      }
+      scf.default {
+        scf.yield
+      }
+    }
+    %looped = scf.loop %value : core.i32 {
+      ^continue_path(%continue_value: core.i32):
+        scf.continue %continue_value
+      ^break_path(%break_value: core.i32):
+        scf.break %break_value
+    }
+    scf.loop %value {
+      ^resultless_break_path(%resultless_value: core.i32):
+        scf.break %resultless_value
+    }
+    %zero = arith.const {value = 0} : core.i32
+    func.return %selected
+  }
+  func.func @stray(%value: core.i32) {
+    scf.break %value
+  }
+  func.func @stray_continue(%other_value: core.i32) {
+    scf.continue %other_value
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let direct_owner = |op: OpRef| {
+            ctx.op(op)
+                .parent_block
+                .and_then(|block| ctx.block(block).parent_region)
+                .and_then(|region| ctx.region(region).parent_op)
+        };
+
+        let if_op = operations_named(&ctx, module, "scf", "if")[0];
+        let switch = operations_named(&ctx, module, "scf", "switch")[0];
+        let case = operations_named(&ctx, module, "scf", "case")[0];
+        let default = operations_named(&ctx, module, "scf", "default")[0];
+        let yields = operations_named(&ctx, module, "scf", "yield");
+        let if_yield = *yields
+            .iter()
+            .find(|&&op| direct_owner(op) == Some(if_op))
+            .unwrap();
+        let case_yield = *yields
+            .iter()
+            .find(|&&op| direct_owner(op) == Some(case))
+            .unwrap();
+
+        let if_interface = RegionBranchOps::get(&ctx, if_op).unwrap();
+        let error = if_interface
+            .successors(&ctx, if_op, RegionBranchPoint::Terminator(case_yield))
+            .unwrap_err();
+        assert!(error.is_not_applicable());
+        assert!(error.to_string().contains("not an scf.if region yield"));
+        assert!(
+            if_interface
+                .entry_successor_operands(&ctx, if_op, RegionSuccessor::Parent)
+                .is_err()
+        );
+
+        let switch_interface = RegionBranchOps::get(&ctx, switch).unwrap();
+        assert_eq!(
+            switch_interface
+                .successors(&ctx, switch, RegionBranchPoint::Terminator(case_yield),)
+                .unwrap()
+                .as_slice(),
+            &[RegionSuccessor::Parent]
+        );
+        assert!(
+            switch_interface
+                .successors(&ctx, switch, RegionBranchPoint::Terminator(if_yield),)
+                .unwrap_err()
+                .is_not_applicable()
+        );
+        assert!(
+            switch_interface
+                .entry_successor_operands(&ctx, switch, RegionSuccessor::Parent)
+                .is_err()
+        );
+
+        for wrapper in [case, default] {
+            let interface = RegionBranchOps::get(&ctx, wrapper).unwrap();
+            assert!(
+                interface
+                    .successors(&ctx, wrapper, RegionBranchPoint::Terminator(if_yield),)
+                    .unwrap_err()
+                    .is_not_applicable()
+            );
+            assert!(
+                interface
+                    .entry_successor_operands(&ctx, wrapper, RegionSuccessor::Parent)
+                    .is_err()
+            );
+        }
+
+        let loops = operations_named(&ctx, module, "scf", "loop");
+        let result_loop = *loops
+            .iter()
+            .find(|&&op| !ctx.op_results(op).is_empty())
+            .unwrap();
+        let result_loop_interface = RegionBranchOps::get(&ctx, result_loop).unwrap();
+        assert!(
+            result_loop_interface
+                .successors(&ctx, result_loop, RegionBranchPoint::Terminator(if_yield),)
+                .unwrap_err()
+                .is_not_applicable()
+        );
+        assert!(
+            result_loop_interface
+                .entry_successor_operands(&ctx, result_loop, RegionSuccessor::Parent)
+                .is_err()
+        );
+        let loop_entry = result_loop_interface
+            .successors(&ctx, result_loop, RegionBranchPoint::Parent)
+            .unwrap();
+        assert_eq!(loop_entry.as_slice().len(), 1);
+        let RegionSuccessor::Region(loop_body) = loop_entry.as_slice()[0] else {
+            unreachable!()
+        };
+
+        let continues = operations_named(&ctx, module, "scf", "continue");
+        let continue_op = *continues
+            .iter()
+            .find(|&&op| direct_owner(op) == Some(result_loop))
+            .unwrap();
+        let stray_continue = *continues
+            .iter()
+            .find(|&&op| {
+                direct_owner(op).is_some_and(|owner| ctx.op(owner).dialect == Symbol::new("func"))
+            })
+            .unwrap();
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, continue_op)
+                .unwrap()
+                .successor_operands(&ctx, continue_op, RegionSuccessor::Parent)
+                .is_err()
+        );
+        let unrelated_region = ctx.op(case).regions[0];
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, continue_op)
+                .unwrap()
+                .successor_operands(&ctx, continue_op, RegionSuccessor::Region(unrelated_region),)
+                .is_err()
+        );
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, stray_continue)
+                .unwrap()
+                .successor_operands(&ctx, stray_continue, RegionSuccessor::Region(loop_body),)
+                .unwrap_err()
+                .to_string()
+                .contains("no enclosing scf.loop")
+        );
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, case_yield)
+                .unwrap()
+                .successor_operands(&ctx, case_yield, RegionSuccessor::Region(loop_body))
+                .is_err()
+        );
+
+        let breaks = operations_named(&ctx, module, "scf", "break");
+        let result_break = *breaks
+            .iter()
+            .find(|&&op| direct_owner(op) == Some(result_loop))
+            .unwrap();
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, result_break)
+                .unwrap()
+                .successor_operands(&ctx, result_break, RegionSuccessor::Region(loop_body))
+                .is_err()
+        );
+        let resultless_break = *breaks
+            .iter()
+            .find(|&&op| {
+                direct_owner(op).is_some_and(|owner| {
+                    ctx.op(owner).dialect == Symbol::new("scf")
+                        && ctx.op(owner).name == Symbol::new("loop")
+                        && ctx.op_results(owner).is_empty()
+                })
+            })
+            .unwrap();
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, resultless_break)
+                .unwrap()
+                .successor_operands(&ctx, resultless_break, RegionSuccessor::Parent)
+                .unwrap()
+                .is_empty()
+        );
+        let stray_break = *breaks
+            .iter()
+            .find(|&&op| {
+                direct_owner(op).is_some_and(|owner| ctx.op(owner).dialect == Symbol::new("func"))
+            })
+            .unwrap();
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, stray_break)
+                .unwrap()
+                .successor_operands(&ctx, stray_break, RegionSuccessor::Parent)
+                .unwrap_err()
+                .to_string()
+                .contains("no enclosing scf.loop")
+        );
+
+        let constant = operations_named(&ctx, module, "arith", "const")[0];
+        assert!(
+            RegionBranchOps::value_transfer(
+                &ctx,
+                constant,
+                RegionBranchPoint::Parent,
+                RegionSuccessor::Parent,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("no RegionBranch registration")
+        );
+        assert!(
+            RegionBranchOps::value_transfer(
+                &ctx,
+                if_op,
+                RegionBranchPoint::Terminator(constant),
+                RegionSuccessor::Parent,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("no RegionBranchTerminator registration")
+        );
+    }
+
+    #[test]
+    fn typed_models_reject_malformed_wrappers_shapes_and_region_structure() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1, %discriminant: core.i32, %value: core.i32) -> core.i32 {
+    ^entry:
+      cf.cond_br %cond [^left, ^right]
+    ^left:
+      cf.br %value [^merge]
+      %after_branch = arith.const {value = 0} : core.i32
+    ^right:
+      cf.br %value [^merge]
+    ^merge(%forwarded: core.i32):
+      %selected = scf.if %cond : core.i32 {
+        scf.yield %forwarded
+      } {
+        scf.yield %forwarded
+      }
+      scf.switch %discriminant {
+        scf.case {value = 0} { scf.yield }
+      }
+      scf.switch %discriminant {
+        scf.case {value = 1} {
+          ^empty_case:
+        }
+      }
+      scf.switch %discriminant {
+        %unsupported = arith.const {value = 2} : core.i32
+      }
+      scf.switch %discriminant {
+        scf.default { scf.yield }
+        scf.default { scf.yield }
+      }
+      %looped = scf.loop %forwarded : core.i32 {
+        ^loop_exit(%loop_value: core.i32):
+          scf.break %loop_value
+      }
+      func.return %selected
+  }
+  func.func @stray(%stray_value: core.i32) {
+    scf.break %stray_value
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+
+        let validation = validate_operation_verifiers(&ctx, module);
+        let messages = operation_error_messages(&validation).join("\n");
+        for expected in [
+            "Branch operation must be the final operation in its block",
+            "contains an empty block",
+            "body contains unsupported operation",
+            "contains multiple default regions",
+            "has no complete owning RegionBranch mapping",
+        ] {
+            assert!(
+                messages.contains(expected),
+                "missing {expected}: {validation}"
+            );
+        }
+
+        let branch = operations_named(&ctx, module, "cf", "br")[0];
+        let cond_branch = operations_named(&ctx, module, "cf", "cond_br")[0];
+        let if_op = operations_named(&ctx, module, "scf", "if")[0];
+        let switches = operations_named(&ctx, module, "scf", "switch");
+        let loop_op = operations_named(&ctx, module, "scf", "loop")[0];
+        let case = operations_named(&ctx, module, "scf", "case")[0];
+        let yield_op = operations_named(&ctx, module, "scf", "yield")[0];
+        let break_op = operations_named(&ctx, module, "scf", "break")[0];
+        let wrong_op = operations_named(&ctx, module, "func", "return")[0];
+
+        assert!(
+            BranchOps::get(&ctx, branch)
+                .unwrap()
+                .successors(&ctx, wrong_op)
+                .unwrap_err()
+                .to_string()
+                .contains("malformed cf.br")
+        );
+        let region_interface = RegionBranchOps::get(&ctx, if_op).unwrap();
+        assert!(
+            region_interface
+                .successors(&ctx, wrong_op, RegionBranchPoint::Parent)
+                .is_err()
+        );
+        assert!(
+            region_interface
+                .entry_successor_operands(&ctx, wrong_op, RegionSuccessor::Parent)
+                .is_err()
+        );
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, yield_op)
+                .unwrap()
+                .successor_operands(&ctx, wrong_op, RegionSuccessor::Parent)
+                .is_err()
+        );
+
+        ctx.op_mut(branch).successors.clear();
+        assert!(
+            BranchOps::get(&ctx, branch)
+                .unwrap()
+                .successors(&ctx, branch)
+                .is_err()
+        );
+        ctx.op_mut(cond_branch).successors.pop();
+        assert!(
+            BranchOps::get(&ctx, cond_branch)
+                .unwrap()
+                .successors(&ctx, cond_branch)
+                .is_err()
+        );
+        ctx.op_mut(loop_op).regions.clear();
+        assert!(
+            RegionBranchOps::get(&ctx, loop_op)
+                .unwrap()
+                .successors(&ctx, loop_op, RegionBranchPoint::Parent)
+                .is_err()
+        );
+        ctx.remove_op_operand(switches[0], 0);
+        assert!(
+            RegionBranchOps::get(&ctx, switches[0])
+                .unwrap()
+                .successors(&ctx, switches[0], RegionBranchPoint::Parent)
+                .is_err()
+        );
+        let second_switch_body = ctx.op(switches[1]).regions[0];
+        ctx.region_mut(second_switch_body).blocks.clear();
+        assert!(
+            RegionBranchOps::get(&ctx, switches[1])
+                .unwrap()
+                .successors(&ctx, switches[1], RegionBranchPoint::Parent)
+                .is_err()
+        );
+        ctx.op_mut(case).regions.clear();
+        assert!(
+            RegionBranchOps::get(&ctx, case)
+                .unwrap()
+                .successors(&ctx, case, RegionBranchPoint::Parent)
+                .is_err()
+        );
+        ctx.remove_op_operand(break_op, 0);
+        assert!(
+            RegionBranchTerminatorOps::get(&ctx, break_op)
+                .unwrap()
+                .successor_operands(&ctx, break_op, RegionSuccessor::Parent)
+                .is_err()
+        );
     }
 
     #[test]

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -104,6 +104,43 @@ verifiers should remain responsible for graph-wide invariants that require
 walking use-def chains, symbol tables, or nested region relationships. Operation
 interfaces describe behavior, not validation phases.
 
+Control-flow and SSA forwarding queries use three target-independent operation
+interfaces. `Branch` describes raw block successors and the operands forwarded
+to each successor block's arguments. `RegionBranch` describes possible transfers
+from an operation entry or one of its nested-region terminators to a nested
+region or back to the parent operation. `RegionBranchTerminator` describes the
+values a terminator forwards along such a region transfer. Region branch points
+and successors are explicit values: a point is either `Parent` or a concrete
+nested-region terminator, and a successor is either a concrete region or
+`Parent`.
+
+These interfaces are queried through TrunkIR's operation registry and remain
+object-safe. Their dyn-facing methods return named concrete small collections;
+they do not use RPITIT, GATs, caller-visible tuples, or dialect-specific
+downcasts. The collections describe transfers from the existing operand,
+result, block, region, and successor lists rather than storing a second copy of
+those IR facts.
+
+Shared interface verification is fail-closed for every registered mapping. A
+block edge must report every raw successor exactly once, remain in the source
+region, and forward exactly one type-compatible value per successor block
+argument. A region edge must remain within the owning operation's nested region
+tree, use a valid nested terminator branch point, and forward exactly one
+type-compatible value per successor region entry argument or parent operation
+result. A registered region terminator without a complete owning
+`RegionBranch` mapping is invalid. Consumers that require a complete control-flow
+view must likewise reject operations for which the applicable interface is not
+registered; interfaces describe possible transfers and do not materialize a
+flat CFG.
+
+`scf.switch` keeps its existing textual container region of `scf.case` and
+`scf.default` wrapper operations. That container is declarative rather than an
+executable successor. The switch's `RegionBranch` successors are the case and
+default body regions derived from those direct wrappers (or `Parent` for the
+implicit unmatched path when no default exists). The wrappers also expose
+their own parent/body boundary, so generic nested-region walkers never need to
+decode the switch's container shape themselves.
+
 ## Core Invariants
 
 - A `core.module` owns the top-level region for a compilation unit.


### PR DESCRIPTION
## Summary

- Add object-safe Branch, RegionBranch, and RegionBranchTerminator interfaces through the existing TrunkIR registry, with explicit branch points, successors, and named value-transfer collections.
- Enforce fail-closed validation for block successors, structured region entry and exit, and forwarded value arity, identity, and types.
- Implement the interfaces for cf.br, cf.cond_br, scf.if, scf.switch, scf.case, scf.default, scf.loop, scf.yield, scf.continue, and scf.break.
- Migrate the tribute_control resume-token mutual-exclusivity query to RegionBranch while preserving its existing behavior.

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo nextest run -p trunk-ir -p tribute-ir: 471 passed
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --workspace: 1,983 passed, 1 skipped

Closes #904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generalized control-flow interfaces for branches, structured regions, and region terminators.
  * Added successor and value-forwarding support for conditionals, switches, loops, and related operations.

* **Bug Fixes**
  * Improved validation of successor mappings, region ownership, forwarded values, and type or arity mismatches.
  * Improved resume-token validation across compatible control-flow regions.
  * Added clearer errors for malformed or incomplete control-flow operations.

* **Documentation**
  * Documented the target-independent control-flow and SSA interface design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->