### PR TITLE
Decouple native ownership planning from concrete CF operations

### DIFF
--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -562,7 +562,7 @@ impl ActionPlanner<'_> {
                     });
                 }
             }
-        } else if let Some(transfers) = self.cfg.branch_transfers(self.ir, op) {
+        } else if let Some(transfers) = self.cfg.branch_transfers(op) {
             let mut counts = HashMap::<ValueRef, u32>::new();
             for (index, transfer) in transfers.enumerate() {
                 if is_managed_value(self.ir, transfer.destination, self.managed_layouts) {

--- a/crates/tribute-passes/src/native/ownership_plan/cfg.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/cfg.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{cf, func};
+use trunk_ir::dialect::func;
+use trunk_ir::op_interface::BranchOps;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::{BlockRef, OpRef, RegionRef, ValueRef};
 
@@ -9,16 +10,17 @@ use super::OwnershipPlanError;
 
 /// The flat control-flow facts accepted by typed ownership planning.
 ///
-/// Construction validates the concrete `cf` representation once. Consumers
-/// can then use stable block order, successors, and branch argument transfers
+/// Construction validates registered `Branch` semantics once. Consumers can
+/// then use stable block order, successors, and branch argument transfers
 /// without decoding operation layouts independently.
 pub(super) struct ValidatedFlatCfg {
     blocks: Vec<BlockRef>,
     terminators: HashMap<BlockRef, OpRef>,
     successors: HashMap<BlockRef, Vec<BlockRef>>,
-    branches: HashMap<OpRef, BlockRef>,
+    branches: HashMap<OpRef, Vec<ValueTransfer>>,
 }
 
+#[derive(Clone, Copy)]
 pub(super) struct ValueTransfer {
     pub(super) source: ValueRef,
     pub(super) destination: ValueRef,
@@ -60,35 +62,52 @@ impl ValidatedFlatCfg {
             }
 
             let block_successors = ctx.op(terminator).successors.to_vec();
-            if block_successors
-                .iter()
-                .any(|successor| !block_set.contains(successor))
-            {
-                return Err(OwnershipPlanError::new(
-                    "CFG successor leaves function body",
-                ));
-            }
-
-            if cf::Br::matches(ctx, terminator) {
-                let [destination] = block_successors.as_slice() else {
+            if let Some(interface) = BranchOps::get(ctx, terminator) {
+                let edges = interface.successors(ctx, terminator).map_err(|error| {
+                    OwnershipPlanError::new(format!("Branch interface is incomplete: {error}"))
+                })?;
+                if edges.as_slice().len() != block_successors.len() {
                     return Err(OwnershipPlanError::new(
-                        "branch argument contract is malformed",
-                    ));
-                };
-                let operands = ctx.op_operands(terminator);
-                let arguments = ctx.block_args(*destination);
-                if operands.len() != arguments.len() {
-                    return Err(OwnershipPlanError::new(
-                        "branch argument contract is malformed",
+                        "Branch successors leave the function or are incomplete",
                     ));
                 }
-                branches.insert(terminator, *destination);
-            } else if cf::CondBr::matches(ctx, terminator) {
-                if ctx.op_operands(terminator).len() != 1 || block_successors.len() != 2 {
-                    return Err(OwnershipPlanError::new(
-                        "conditional branch contract is malformed",
-                    ));
+                let mut transfers = Vec::new();
+                for (edge, &successor) in edges.as_slice().iter().zip(&block_successors) {
+                    if edge.block != successor || !block_set.contains(&successor) {
+                        return Err(OwnershipPlanError::new(
+                            "Branch successors leave the function or are incomplete",
+                        ));
+                    }
+                    let inputs = ctx.block_args(edge.block);
+                    if edge.forwarded.as_slice().len() != inputs.len()
+                        || edge.forwarded.as_slice().iter().zip(inputs).any(
+                            |(&source, &destination)| {
+                                ctx.value_ty(source) != ctx.value_ty(destination)
+                            },
+                        )
+                    {
+                        return Err(OwnershipPlanError::new(
+                            "branch argument contract is malformed",
+                        ));
+                    }
+                    if edges.as_slice().len() != 1 && !edge.forwarded.is_empty() {
+                        return Err(OwnershipPlanError::new(
+                            "multi-successor Branch forwarding is unsupported",
+                        ));
+                    }
+                    transfers.extend(
+                        edge.forwarded
+                            .as_slice()
+                            .iter()
+                            .copied()
+                            .zip(inputs.iter().copied())
+                            .map(|(source, destination)| ValueTransfer {
+                                source,
+                                destination,
+                            }),
+                    );
                 }
+                branches.insert(terminator, transfers);
             } else if !is_native_terminator(ctx, terminator) {
                 return Err(OwnershipPlanError::new("unsupported native CFG terminator"));
             }
@@ -127,28 +146,18 @@ impl ValidatedFlatCfg {
         &self.successors[&block]
     }
 
-    pub(super) fn branch_transfers<'a>(
-        &'a self,
-        ctx: &'a IrContext,
+    pub(super) fn branch_transfers(
+        &self,
         op: OpRef,
-    ) -> Option<impl Iterator<Item = ValueTransfer> + 'a> {
-        let destination = *self.branches.get(&op)?;
-        Some(
-            ctx.op_operands(op)
-                .iter()
-                .copied()
-                .zip(ctx.block_args(destination).iter().copied())
-                .map(|(source, destination)| ValueTransfer {
-                    source,
-                    destination,
-                }),
-        )
+    ) -> Option<impl Iterator<Item = ValueTransfer> + '_> {
+        self.branches
+            .get(&op)
+            .map(|transfers| transfers.iter().copied())
     }
 }
 
 fn is_native_terminator(ctx: &IrContext, op: OpRef) -> bool {
-    cf::Br::matches(ctx, op)
-        || cf::CondBr::matches(ctx, op)
+    BranchOps::get(ctx, op).is_some()
         || func::Return::matches(ctx, op)
         || func::TailCall::matches(ctx, op)
         || func::TailCallIndirect::matches(ctx, op)

--- a/crates/tribute-passes/src/native/ownership_plan/cfg.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/cfg.rs
@@ -79,33 +79,27 @@ impl ValidatedFlatCfg {
                         ));
                     }
                     let inputs = ctx.block_args(edge.block);
-                    if edge.forwarded.as_slice().len() != inputs.len()
-                        || edge.forwarded.as_slice().iter().zip(inputs).any(
-                            |(&source, &destination)| {
-                                ctx.value_ty(source) != ctx.value_ty(destination)
-                            },
-                        )
+                    let forwarded = edge.forwarded.as_slice();
+                    if forwarded.len() != inputs.len()
+                        || forwarded.iter().zip(inputs).any(|(&source, &destination)| {
+                            ctx.value_ty(source) != ctx.value_ty(destination)
+                        })
                     {
                         return Err(OwnershipPlanError::new(
                             "branch argument contract is malformed",
                         ));
                     }
-                    if edges.as_slice().len() != 1 && !edge.forwarded.is_empty() {
+                    if edges.as_slice().len() != 1 && !forwarded.is_empty() {
                         return Err(OwnershipPlanError::new(
                             "multi-successor Branch forwarding is unsupported",
                         ));
                     }
-                    transfers.extend(
-                        edge.forwarded
-                            .as_slice()
-                            .iter()
-                            .copied()
-                            .zip(inputs.iter().copied())
-                            .map(|(source, destination)| ValueTransfer {
-                                source,
-                                destination,
-                            }),
-                    );
+                    transfers.extend(forwarded.iter().copied().zip(inputs.iter().copied()).map(
+                        |(source, destination)| ValueTransfer {
+                            source,
+                            destination,
+                        },
+                    ));
                 }
                 branches.insert(terminator, transfers);
             } else if !is_native_terminator(ctx, terminator) {

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -796,7 +796,7 @@ fn cross_block_borrowed_load_keeps_owner_alive_without_releasing_the_load() {
 
 #[test]
 fn cfg_copy_and_tail_dying_value_actions_are_complete() {
-    let (ctx, module, plan) = build(
+    let (mut ctx, module, plan) = build(
         r#"core.module @test {
   !R = adt.typeref() {name = @R}
   !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
@@ -842,6 +842,38 @@ fn cfg_copy_and_tail_dying_value_actions_are_complete() {
     let mut after_tail = plan.clone();
     after_tail.functions[tail_index].actions[action_index].anchor = ActionAnchor::After(tail_op);
     assert!(after_tail.validate_against(&ctx, module).is_err());
+
+    materialize(&mut ctx, module, &plan).expect("branch ownership plan materializes");
+    let materialized = print_module(&ctx, module.op());
+    assert_eq!(materialized.matches("tribute_rt.retain").count(), 1);
+    assert_eq!(materialized.matches("tribute_rt.release").count(), 4);
+}
+
+#[test]
+fn cfg_accepts_conditional_branch_with_duplicate_successors() {
+    let (mut ctx, module, plan) = build(
+        r#"core.module @test {
+  !R = adt.typeref() {name = @R}
+  !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
+  func.func @duplicate_successor(%condition: core.i1, %value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
+    ^entry:
+      cf.cond_br %condition [^exit, ^exit]
+    ^exit:
+      func.unreachable
+  }
+}"#,
+    );
+    let function = plan.function(Symbol::new("duplicate_successor")).unwrap();
+    assert_eq!(count(function, ActionKind::EntryAcquire), 0);
+    assert_eq!(count(function, ActionKind::FinalRelease), 1);
+
+    materialize(&mut ctx, module, &plan).expect("duplicate-successor plan materializes");
+    assert_eq!(
+        print_module(&ctx, module.op())
+            .matches("cf.cond_br")
+            .count(),
+        1
+    );
 }
 
 #[test]

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -2,10 +2,85 @@ use super::*;
 use crate::native::evidence::lower_evidence_to_native;
 use crate::native::rc_materialization::materialize;
 use crate::native::type_converter::native_type_converter;
+use trunk_ir::OpRef;
+use trunk_ir::op_interface::{
+    BranchRegistration, BranchSuccessor, BranchSuccessors, ControlFlowInterfaceError,
+};
 use trunk_ir::parser::parse_test_module;
 use trunk_ir::printer::print_module;
 use trunk_ir::types::TypeDataBuilder;
 use trunk_ir_cranelift_backend::passes::func_to_clif;
+
+fn incomplete_test_branch(
+    _ctx: &IrContext,
+    _op: OpRef,
+) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+    Err(ControlFlowInterfaceError::new(
+        "test branch interface is incomplete",
+    ))
+}
+
+fn missing_edge_test_branch(
+    _ctx: &IrContext,
+    _op: OpRef,
+) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+    Ok(BranchSuccessors::default())
+}
+
+fn reversed_test_branch(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+    let successors = &ctx.op(op).successors;
+    Ok(BranchSuccessors::new([
+        BranchSuccessor::new(successors[1], []),
+        BranchSuccessor::new(successors[0], []),
+    ]))
+}
+
+fn multi_forwarding_test_branch(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<BranchSuccessors, ControlFlowInterfaceError> {
+    let successors = &ctx.op(op).successors;
+    let forwarded = ctx.op_operands(op)[0];
+    Ok(BranchSuccessors::new([
+        BranchSuccessor::new(successors[0], [forwarded]),
+        BranchSuccessor::new(successors[1], [forwarded]),
+    ]))
+}
+
+trunk_ir::inventory::submit! {
+    BranchRegistration {
+        dialect: "test",
+        op_name: "incomplete_branch",
+        successors: incomplete_test_branch,
+    }
+}
+
+trunk_ir::inventory::submit! {
+    BranchRegistration {
+        dialect: "test",
+        op_name: "missing_edge_branch",
+        successors: missing_edge_test_branch,
+    }
+}
+
+trunk_ir::inventory::submit! {
+    BranchRegistration {
+        dialect: "test",
+        op_name: "reversed_branch",
+        successors: reversed_test_branch,
+    }
+}
+
+trunk_ir::inventory::submit! {
+    BranchRegistration {
+        dialect: "test",
+        op_name: "multi_forwarding_branch",
+        successors: multi_forwarding_test_branch,
+    }
+}
 
 fn build(ir: &str) -> (IrContext, Module, NativeOwnershipPlan) {
     let mut ctx = IrContext::new();
@@ -723,6 +798,75 @@ fn early_native_terminators_and_successors_fail_before_mutation() {
             ir,
             "control-flow operation precedes the final block operation",
         );
+    }
+}
+
+#[test]
+fn branch_interfaces_fail_closed_before_mutation() {
+    for (ir, expected) in [
+        (
+            r#"core.module @test {
+  func.func @f() -> core.nil {
+    ^entry:
+      test.incomplete_branch [^exit]
+    ^exit:
+      func.return
+  }
+}"#,
+            "Branch interface is incomplete",
+        ),
+        (
+            r#"core.module @test {
+  func.func @f() -> core.nil {
+    ^entry:
+      test.unregistered_branch [^exit]
+    ^exit:
+      func.return
+  }
+}"#,
+            "unsupported native CFG terminator",
+        ),
+        (
+            r#"core.module @test {
+  func.func @f() -> core.nil {
+    ^entry:
+      test.missing_edge_branch [^exit]
+    ^exit:
+      func.return
+  }
+}"#,
+            "Branch successors leave the function or are incomplete",
+        ),
+        (
+            r#"core.module @test {
+  func.func @f() -> core.nil {
+    ^entry:
+      test.reversed_branch [^left, ^right]
+    ^left:
+      func.return
+    ^right:
+      func.return
+  }
+}"#,
+            "Branch successors leave the function or are incomplete",
+        ),
+        (
+            r#"core.module @test {
+  !R = adt.typeref() {name = @R}
+  !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
+  func.func @f(%value: !R) -> core.nil {
+    ^entry:
+      test.multi_forwarding_branch %value [^left, ^right]
+    ^left(%left: !R):
+      func.return
+    ^right(%right: !R):
+      func.return
+  }
+}"#,
+            "multi-successor Branch forwarding is unsupported",
+        ),
+    ] {
+        assert_plan_error_unchanged(ir, expected);
     }
 }
 


### PR DESCRIPTION
## Summary

- Validate Branch successor and forwarding contracts through `BranchOps`, preserving positional duplicate successors.
- Keep native ownership planning and materialization after `scf_to_cf`; no structured ownership analysis is introduced.
- Structured ownership remains explicitly deferred to #909. #904 is background and follow-up context.

## Checks

- Normal pre-commit: workspace clippy, formatting, and nextest (1,950 passed; 1 skipped)
- Focused ownership-plan nextest (35 passed)
- Focused TrunkIR Branch interface tests (2 passed)
- Canonical calculator CLI and ASan variants (3 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved control-flow handling across supported branch operations.
  * Added validation for successor edges, block arguments, and argument types.
  * Correctly handles conditional branches with duplicate successors.

* **Tests**
  * Expanded coverage for ownership actions, including retain and release operations.
  * Added verification that conditional branches are preserved during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->