### PR TITLE
Fix recursive generic handler inference

### DIFF
--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -2184,14 +2184,14 @@ impl<'db> TypeChecker<'db> {
         arm: HandlerArm<ResolvedRef<'db>>,
         handle_ctx: &super::super::func_context::HandleContext<'db>,
     ) -> HandlerArm<TypedRef<'db>> {
-        let kind = match arm.kind {
+        let (kind, body_mode) = match arm.kind {
             HandlerKind::Do { binding } => {
                 let pattern_ty = self.infer_pattern_type_with_ctx(ctx, &binding);
                 ctx.constrain_eq(pattern_ty, handle_ctx.body_ty);
                 self.bind_pattern_vars_with_ctx(ctx, &binding, handle_ctx.body_ty);
                 let binding =
                     self.convert_pattern_with_expected_ctx(ctx, binding, handle_ctx.body_ty);
-                HandlerKind::Do { binding }
+                (HandlerKind::Do { binding }, Mode::Infer)
             }
             HandlerKind::Fn {
                 ability,
@@ -2209,15 +2209,21 @@ impl<'db> TypeChecker<'db> {
                         handle_ctx,
                     },
                 );
-                ctx.record_handler_operation(arm.id, operation);
-                HandlerKind::Fn {
-                    ability: self.convert_ref_with_ctx(ctx, None, ability),
-                    op,
-                    params: params
-                        .into_iter()
-                        .map(|p| self.convert_pattern_with_ctx(ctx, p))
-                        .collect(),
-                }
+                ctx.record_handler_operation(arm.id, operation.clone());
+                (
+                    HandlerKind::Fn {
+                        ability: self.convert_ref_with_ctx(ctx, None, ability),
+                        op,
+                        params: params
+                            .into_iter()
+                            .map(|p| self.convert_pattern_with_ctx(ctx, p))
+                            .collect(),
+                    },
+                    // A tail-resumptive arm returns the operation's resume
+                    // value; the continuation carries that value to the
+                    // enclosing handler result.
+                    Mode::Check(operation.result),
+                )
             }
             HandlerKind::Op {
                 ability,
@@ -2262,21 +2268,26 @@ impl<'db> TypeChecker<'db> {
                     }
                 }
 
-                HandlerKind::Op {
-                    ability: self.convert_ref_with_ctx(ctx, None, ability),
-                    op,
-                    params: params
-                        .into_iter()
-                        .map(|p| self.convert_pattern_with_ctx(ctx, p))
-                        .collect(),
-                    resume_local_id,
-                }
+                (
+                    HandlerKind::Op {
+                        ability: self.convert_ref_with_ctx(ctx, None, ability),
+                        op,
+                        params: params
+                            .into_iter()
+                            .map(|p| self.convert_pattern_with_ctx(ctx, p))
+                            .collect(),
+                        resume_local_id,
+                    },
+                    // An explicit operation arm either resumes (whose result
+                    // is the handler answer) or aborts with that same answer.
+                    Mode::Check(handle_ctx.answer_ty),
+                )
             }
         };
         HandlerArm {
             id: arm.id,
             kind,
-            body: self.check_expr_with_ctx(ctx, arm.body, Mode::Infer),
+            body: self.check_expr_with_ctx(ctx, arm.body, body_mode),
         }
     }
 

--- a/crates/tribute-front/tests/lambda_effect_type.rs
+++ b/crates/tribute-front/tests/lambda_effect_type.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use self::common::run_ast_pipeline_with_ir;
+use self::common::{ast_pipeline_error_messages, run_ast_pipeline_with_ir};
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
 use tribute_front::SourceCst;
@@ -169,6 +169,37 @@ fn main() -> Int {
 // ========================================================================
 // Handler Arm Lambda Tests - Core Ability Pattern
 // ========================================================================
+
+/// An `op` arm that drops its continuation supplies the enclosing handler's
+/// answer, not the operation result. Keep that equality in inference so an
+/// aborting arm cannot silently choose an unrelated type.
+#[salsa_test]
+fn op_handler_abort_must_return_handler_answer(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "op_handler_answer.trb",
+        r#"
+ability State(s) {
+    op get() -> s
+}
+
+fn result() {
+    handle State::get() {
+        do value { Nil }
+        op State::get() { 0 }
+    }
+}
+"#,
+    );
+
+    let errors = ast_pipeline_error_messages(db, source);
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.contains("expected `Nat`, found `Nil`")),
+        "an aborting op arm must be checked against the handler answer"
+    );
+}
 
 /// Test handler arm lambdas that call continuations.
 ///

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2269,6 +2269,11 @@ fn main() {
 "#,
             );
             let typed = parse_and_lower_ast(db, source).expect("frontend output");
+            let diagnostics = parse_and_lower_ast::accumulated::<Diagnostic>(db, source);
+            assert!(
+                diagnostics.is_empty(),
+                "recursive handler fixture must type-check without diagnostics: {diagnostics:#?}"
+            );
             let (_, monomorphized) =
                 merge_and_lower_to_ir_with(db, &typed, source, |typed, _, _, _| typed);
             let specialized = trunk_ir::Symbol::new("run_state$Nat$Nat");

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2242,6 +2242,65 @@ fn main() {
         });
     }
 
+    #[test]
+    fn recursive_generic_handler_collects_a_concrete_specialization() {
+        salsa::Database::attach(&salsa::DatabaseImpl::default(), |db| {
+            let source = source_from_str(
+                "recursive_generic_handler.trb",
+                r#"
+ability State(s) {
+    op get() -> s
+    op set(value: s) -> Nil
+}
+
+fn run_state(comp: fn() ->{e, State(s)} a, init: s) ->{e} a {
+    handle comp() {
+        do result { result }
+        op State::get() { run_state(fn() { resume init }, init) }
+        op State::set(value) { run_state(fn() { resume Nil }, value) }
+    }
+}
+
+fn consume(value: Nat) { Nil }
+
+fn main() {
+    consume(run_state(fn() { State::get() }, 0))
+}
+"#,
+            );
+            let typed = parse_and_lower_ast(db, source).expect("frontend output");
+            let (_, monomorphized) =
+                merge_and_lower_to_ir_with(db, &typed, source, |typed, _, _, _| typed);
+            let specialized = trunk_ir::Symbol::new("run_state$Nat$Nat");
+            let scheme = monomorphized
+                .function_types
+                .get(&specialized)
+                .expect("recursive handler call must collect a concrete run_state specialization");
+
+            assert!(
+                scheme.type_params(db).is_empty(),
+                "specialized run_state must not retain generic binders: {scheme:?}"
+            );
+            let specialized_body = monomorphized
+                .ast
+                .decls
+                .iter()
+                .find_map(|decl| match decl {
+                    tribute_front::ast::Decl::Function(function)
+                        if function.name == specialized =>
+                    {
+                        Some(function)
+                    }
+                    _ => None,
+                })
+                .expect("monomorphization must materialize the concrete run_state body");
+            assert!(
+                !format!("{specialized_body:#?}").contains("BoundVar"),
+                "specialized handler body must not retain BoundVar metadata"
+            );
+        });
+    }
+
     #[salsa_test]
     fn frontend_registers_only_compiler_owned_intrinsic_origins(db: &salsa::DatabaseImpl) {
         let source = source_from_str(

--- a/tests/e2e_ability_core.rs
+++ b/tests/e2e_ability_core.rs
@@ -155,8 +155,8 @@ fn get_state() ->{State(Int)} Int {
 fn run() -> Int {
     handle get_state() {
         do result { result }
-        op State::get() { 42 }
-        op State::set(v) { 0 }
+        op State::get() { +42 }
+        op State::set(v) { +0 }
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix a pre-existing generic handler inference bug on main that the legacy uniform ABI masked; #842 exposed it.
- Enforce the documented contracts: fn arm -> operation result; op arm -> enclosing handler answer.
- Add a concrete run_state Nat specialization regression and a focused handler-answer mismatch regression.

## Tests

- cargo test -p tribute-front
- cargo test -p tribute
- cargo clippy --workspace --all-targets -- -D warnings
- .ci/lint.sh
- Pre-commit hook: cargo nextest run --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking for handler arms, including aborting operation handlers and their expected return types.
  * Fixed recursive generic handler specialization so generated calls use concrete types correctly.
  * Aligned handler return-value syntax for state operations with supported literal expressions.
* **Tests**
  * Added regression coverage for handler return-type validation and recursive generic specialization.
  * Expanded validation to confirm affected programs type-check successfully without diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->