### PR TITLE
Guard paired RC elimination across potential owner releases

### DIFF
--- a/crates/tribute-passes/src/native/rc_optimization.rs
+++ b/crates/tribute-passes/src/native/rc_optimization.rs
@@ -56,6 +56,11 @@ fn eliminate_one_pair(ctx: &mut IrContext, block: BlockRef) -> bool {
                     erase_op(ctx, retain_ref);
                     return true;
                 }
+
+                // A release of another pointer may recursively release `ptr`
+                // through an owning field. Without alias information, do not
+                // move this retain/release pair across it.
+                break;
             }
 
             if is_barrier_for(ctx, op, ptr, retained) {
@@ -217,6 +222,24 @@ mod tests {
         );
         assert!(output.contains("tribute_rt.retain"));
         assert!(output.contains("tribute_rt.release"));
+    }
+
+    #[test]
+    fn release_of_potential_owner_is_an_alias_barrier() {
+        let output = printed_after_pass(
+            r#"core.module @test {
+  clif.func @f(%0: core.ptr) -> core.i32 {
+    %1 = clif.load %0 {offset = 0} : core.ptr
+    %2 = tribute_rt.retain %1 : core.ptr
+    tribute_rt.release %0 {alloc_size = 16}
+    %3 = clif.load %2 {offset = 0} : core.i32
+    tribute_rt.release %2 {alloc_size = 12}
+    clif.return %3
+  }
+}"#,
+        );
+        assert_eq!(output.matches("tribute_rt.retain").count(), 1, "{output}");
+        assert_eq!(output.matches("tribute_rt.release").count(), 2, "{output}");
     }
 
     #[test]

--- a/tests/e2e_int_text.rs
+++ b/tests/e2e_int_text.rs
@@ -2,7 +2,8 @@
 
 mod common;
 
-use common::compile_and_run_native_asan;
+use common::{compile_and_run_native_asan, compile_and_run_native_with_paired_rc_elimination};
+use tribute::pipeline::PairedRcEliminationPolicy;
 
 #[test]
 fn public_int_to_string_formats_zero() {
@@ -47,6 +48,34 @@ fn main() ->{Io} Nil {
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(String::from_utf8_lossy(&output.stdout), "0\n");
+}
+
+#[test]
+fn paired_rc_elimination_preserves_nested_parsed_integers() {
+    let output = compile_and_run_native_with_paired_rc_elimination(
+        "nested_parsed_integers.trb",
+        r##"
+use std::io::{Io, print_line}
+
+fn main() ->{Io} Nil {
+    case Int::parse("2") {
+        Ok(left) -> case Int::parse("3") {
+            Ok(right) -> print_line(Int::to_string(left + right))
+            Error(_) -> print_line("error")
+        }
+        Error(_) -> print_line("error")
+    }
+}
+"##,
+        PairedRcEliminationPolicy::Enabled,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "5\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Treat an intervening nonmatching `tribute_rt.release` as a conservative alias barrier during paired RC elimination.
- Adds structural and native execution regressions; this is a prerequisite discovered while validating #842.

## Tests
- `cargo nextest run -p tribute-passes rc_optimization`
- `cargo nextest run -p tribute --test e2e_int_text`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reference-count optimization to preserve required retain/release operations when potential ownership or aliasing could affect object lifetime.
  * Ensured nested parsed integer values remain valid when paired reference-count elimination is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->