### PR TITLE
Validate case exhaustiveness after type solving

### DIFF
--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -1354,11 +1354,6 @@ impl<'db> TypeChecker<'db> {
                     })
                     .collect();
 
-                // Check exhaustiveness
-                if self.check_exhaustiveness(scrutinee_ty, &converted_arms, scrutinee_expr.id) {
-                    ctx.record_exhaustive_case(expr_id);
-                }
-
                 ExprKind::Case {
                     scrutinee: scrutinee_expr,
                     arms: converted_arms,
@@ -2563,7 +2558,7 @@ impl<'db> TypeChecker<'db> {
     /// - If the last arm has a wildcard or bind pattern, it's exhaustive
     /// - If matching an enum, all variants must be covered
     /// - Otherwise, emit a warning for patterns we can't fully analyze
-    fn check_exhaustiveness(
+    pub(super) fn check_exhaustiveness(
         &self,
         scrutinee_ty: Type<'db>,
         arms: &[Arm<TypedRef<'db>>],

--- a/crates/tribute-front/src/typeck/checker/func_check.rs
+++ b/crates/tribute-front/src/typeck/checker/func_check.rs
@@ -133,7 +133,6 @@ impl<'db> TypeChecker<'db> {
         let func_perform_operations = ctx.take_perform_operations();
         let func_lambda_signatures = ctx.take_lambda_signatures();
         let local_generalizations = ctx.take_local_generalizations();
-        let func_exhaustive_cases = ctx.take_exhaustive_cases();
         // Save the accumulated effect row from the body before dropping ctx
         let body_effect_row = ctx.current_effect();
         // Take deferred methods for post-solve resolution
@@ -364,7 +363,14 @@ impl<'db> TypeChecker<'db> {
         // Update the function's type scheme with the generalized version
         self.env.register_function(func_id, new_scheme);
 
-        // 6. Apply substitution and generalization to all TypedRef types in the body
+        // 6. Materialize the solved node types before rebuilding the body.
+        // Post-solve case coverage consults these entries during body substitution.
+        for (node_id, ty) in func_node_types {
+            let substituted = self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index);
+            self.node_types.insert(node_id, substituted);
+        }
+
+        // 7. Apply substitution and generalization to all TypedRef types in the body.
         let body = self.apply_subst_to_body(
             body,
             type_subst,
@@ -373,13 +379,6 @@ impl<'db> TypeChecker<'db> {
             &deferred_resolutions,
         );
 
-        // 7. Collect node types from this function's context and apply substitution.
-        // These entries describe concrete expression storage for lowering; the
-        // source-logical operation metadata is carried separately on TypedRef.
-        for (node_id, ty) in func_node_types {
-            let substituted = self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index);
-            self.node_types.insert(node_id, substituted);
-        }
         for (callee_id, ty) in func_call_callee_types {
             let substituted = self.apply_subst_to_type(ty, type_subst, row_subst, &var_to_index);
             self.call_callee_types.insert(callee_id, substituted);
@@ -468,8 +467,6 @@ impl<'db> TypeChecker<'db> {
                 },
             );
         }
-        self.exhaustive_cases.extend(func_exhaustive_cases);
-
         FuncDecl {
             id: func.id,
             is_pub: func.is_pub,
@@ -652,7 +649,7 @@ impl<'db> TypeChecker<'db> {
     /// 1. Their resolved concrete type (from substitution), or
     /// 2. The corresponding BoundVar (from generalization mapping)
     fn apply_subst_to_body(
-        &self,
+        &mut self,
         body: Expr<TypedRef<'db>>,
         type_subst: &TypeSubst<'db>,
         row_subst: &RowSubst<'db>,
@@ -672,7 +669,7 @@ impl<'db> TypeChecker<'db> {
 
     /// Apply substitution to an expression kind.
     fn apply_subst_to_expr_kind(
-        &self,
+        &mut self,
         node_id: crate::ast::NodeId,
         kind: ExprKind<TypedRef<'db>>,
         type_subst: &TypeSubst<'db>,
@@ -856,15 +853,15 @@ impl<'db> TypeChecker<'db> {
                     deferred_resolutions,
                 ),
             },
-            ExprKind::Case { scrutinee, arms } => ExprKind::Case {
-                scrutinee: self.apply_subst_to_body(
+            ExprKind::Case { scrutinee, arms } => {
+                let scrutinee = self.apply_subst_to_body(
                     scrutinee,
                     type_subst,
                     row_subst,
                     var_to_index,
                     deferred_resolutions,
-                ),
-                arms: arms
+                );
+                let arms = arms
                     .into_iter()
                     .map(|arm| {
                         self.apply_subst_to_arm(
@@ -875,8 +872,17 @@ impl<'db> TypeChecker<'db> {
                             deferred_resolutions,
                         )
                     })
-                    .collect(),
-            },
+                    .collect::<Vec<_>>();
+
+                if let Some(scrutinee_ty) = self.node_types.get(&scrutinee.id).copied()
+                    && self.check_exhaustiveness(scrutinee_ty, &arms, scrutinee.id)
+                    && !self.exhaustive_cases.contains(&node_id)
+                {
+                    self.exhaustive_cases.push(node_id);
+                }
+
+                ExprKind::Case { scrutinee, arms }
+            }
             ExprKind::Lambda { params, body } => ExprKind::Lambda {
                 params,
                 body: self.apply_subst_to_body(
@@ -986,7 +992,7 @@ impl<'db> TypeChecker<'db> {
 
     /// Apply substitution to a statement.
     fn apply_subst_to_stmt(
-        &self,
+        &mut self,
         stmt: Stmt<TypedRef<'db>>,
         type_subst: &TypeSubst<'db>,
         row_subst: &RowSubst<'db>,
@@ -1026,7 +1032,7 @@ impl<'db> TypeChecker<'db> {
 
     /// Apply substitution to a case arm.
     fn apply_subst_to_arm(
-        &self,
+        &mut self,
         arm: Arm<TypedRef<'db>>,
         type_subst: &TypeSubst<'db>,
         row_subst: &RowSubst<'db>,
@@ -1057,7 +1063,7 @@ impl<'db> TypeChecker<'db> {
 
     /// Apply substitution to a handler arm.
     fn apply_subst_to_handler_arm(
-        &self,
+        &mut self,
         arm: HandlerArm<TypedRef<'db>>,
         type_subst: &TypeSubst<'db>,
         row_subst: &RowSubst<'db>,

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -105,9 +105,6 @@ pub struct FunctionInferenceContext<'a, 'db> {
     /// Source-logical callable signatures for lambda nodes.
     lambda_signatures: HashMap<NodeId, LambdaSignature<'db>>,
 
-    /// Case expressions whose typechecking coverage analysis proved exhaustive.
-    exhaustive_cases: Vec<NodeId>,
-
     /// Generated constraints for this function.
     constraints: ConstraintSet<'db>,
 
@@ -180,7 +177,6 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             ability_op_callee_types: HashMap::new(),
             inferred_lambda_types: HashMap::new(),
             lambda_signatures: HashMap::new(),
-            exhaustive_cases: Vec::new(),
             constraints: ConstraintSet::new(),
             next_type_var: 0,
             // Start from 1 to avoid collision with EffectVar { id: 0 } placeholder
@@ -491,16 +487,6 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
 
     pub fn take_lambda_signatures(&mut self) -> HashMap<NodeId, LambdaSignature<'db>> {
         std::mem::take(&mut self.lambda_signatures)
-    }
-
-    pub fn record_exhaustive_case(&mut self, case: NodeId) {
-        if !self.exhaustive_cases.contains(&case) {
-            self.exhaustive_cases.push(case);
-        }
-    }
-
-    pub fn take_exhaustive_cases(&mut self) -> Vec<NodeId> {
-        std::mem::take(&mut self.exhaustive_cases)
     }
 
     // =========================================================================

--- a/crates/tribute-front/tests/case_type.rs
+++ b/crates/tribute-front/tests/case_type.rs
@@ -8,7 +8,10 @@ mod common;
 use self::common::{ast_pipeline_error_messages, run_ast_pipeline_with_ir};
 use insta::assert_snapshot;
 use salsa_test_macros::salsa_test;
-use tribute_front::SourceCst;
+use tribute_front::{
+    SourceCst,
+    ast::{Decl, ExprKind},
+};
 
 // ========================================================================
 // Basic Case Expression Tests
@@ -200,4 +203,127 @@ fn nested(x: Nat, y: Bool) -> Nat {
 
     let ir_text = run_ast_pipeline_with_ir(db, source);
     assert_snapshot!(ir_text);
+}
+
+fn nested_case_ids(
+    module: &tribute_front::ast::Module<tribute_front::ast::TypedRef<'_>>,
+) -> (tribute_front::ast::NodeId, tribute_front::ast::NodeId) {
+    let function_body = module
+        .decls
+        .iter()
+        .find_map(|decl| match decl {
+            Decl::Function(function) if function.name == trunk_ir::Symbol::new("nested") => {
+                Some(&function.body)
+            }
+            _ => None,
+        })
+        .expect("nested function should be typechecked");
+    let ExprKind::Block { value: outer, .. } = &*function_body.kind else {
+        panic!("nested function should begin with a block");
+    };
+    let ExprKind::Case { arms, .. } = &*outer.kind else {
+        panic!("nested function block should end with a case");
+    };
+    let ExprKind::Case { .. } = &*arms[0].body.kind else {
+        panic!("first outer arm should contain the nested case");
+    };
+    (outer.id, arms[0].body.id)
+}
+
+/// Pattern constraints resolve the inner scrutinee only after the body has
+/// been checked. Both the already-concrete outer case and the solved inner
+/// case must be recorded exactly once.
+#[salsa_test]
+fn nested_bool_case_is_recorded_after_solving(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn nested(flag: Bool) -> Nat {
+    let identity = fn(value) value
+    case flag {
+        True -> case identity(True) {
+            True -> 1
+            False -> 0
+        }
+        False -> 0
+    }
+}
+"#,
+    );
+
+    let checked = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    let (outer, inner) = nested_case_ids(checked.module(db));
+    let exhaustive = checked.exhaustive_cases(db);
+    assert_eq!(exhaustive.iter().filter(|&&case| case == outer).count(), 1);
+    assert_eq!(exhaustive.iter().filter(|&&case| case == inner).count(), 1);
+
+    let ir_text = run_ast_pipeline_with_ir(db, source);
+    assert!(
+        !ir_text.contains("core.nil"),
+        "an exhaustive inner Bool case must not lower an empty nil-cast tail:\n{ir_text}"
+    );
+    assert!(
+        ir_text.contains("scf.yield"),
+        "valued case branches must retain their structured yields:\n{ir_text}"
+    );
+}
+
+#[salsa_test]
+fn nested_result_case_is_recorded_after_solving(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+enum Result(a, e) {
+    Ok(a),
+    Err(e),
+}
+
+fn nested(flag: Bool) -> Nat {
+    let identity = fn(value) value
+    case flag {
+        True -> case identity(Ok(1)) {
+            Ok(value) -> value
+            Err(_) -> 0
+        }
+        False -> 0
+    }
+}
+"#,
+    );
+
+    let checked = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    let (outer, inner) = nested_case_ids(checked.module(db));
+    let exhaustive = checked.exhaustive_cases(db);
+    assert_eq!(exhaustive.iter().filter(|&&case| case == outer).count(), 1);
+    assert_eq!(exhaustive.iter().filter(|&&case| case == inner).count(), 1);
+}
+
+#[salsa_test]
+fn solved_partial_bool_case_reports_one_non_exhaustive_error(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+fn partial() -> Nat {
+    let identity = fn(value) value
+    case identity(True) {
+        True -> 1
+    }
+}
+"#,
+    );
+
+    let errors = ast_pipeline_error_messages(db, source);
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|error| error.contains("non-exhaustive case expression"))
+            .count(),
+        1,
+        "partial Bool case should report exactly one error: {errors:?}"
+    );
 }


### PR DESCRIPTION
## Summary
- Collect case coverage after solved node types are materialized, preventing unresolved scrutinees from being missed.
- Removes fake empty case tails in logical lowering; this is a prerequisite found while validating #842.

## Tests
- cargo nextest run -p tribute-front
- cargo clippy -p tribute-front -- -D warnings
- cargo fmt --check
- git diff --check
- normal pre-commit hook (1,958 passed, 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-expression exhaustiveness checking after type information is resolved.
  * Prevented duplicate or premature exhaustiveness diagnostics.
  * Ensured partial Boolean cases produce the expected non-exhaustiveness warning.

* **Tests**
  * Added coverage for nested case expressions, solved scrutinee types, exhaustive-case tracking, and generated intermediate representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->