### PR TITLE
Preserve nested borrowed owners in native ownership planning

### DIFF
--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -272,6 +272,24 @@ fn root_value(aliases: &HashMap<ValueRef, ValueRef>, value: ValueRef) -> ValueRe
     aliases.get(&value).copied().unwrap_or(value)
 }
 
+fn borrowed_owner(
+    borrowed: &HashMap<ValueRef, ValueRef>,
+    aliases: &HashMap<ValueRef, ValueRef>,
+    value: ValueRef,
+) -> Option<ValueRef> {
+    let mut owner = root_value(aliases, value);
+    let mut found = false;
+    while let Some(next) = borrowed.get(&owner) {
+        let next = root_value(aliases, *next);
+        if next == owner {
+            break;
+        }
+        owner = next;
+        found = true;
+    }
+    found.then_some(owner)
+}
+
 fn collect_borrowed_loads(
     ctx: &IrContext,
     blocks: &[BlockRef],
@@ -378,10 +396,7 @@ fn compute_liveness(
                 if managed.contains(&root) && !block_defs.contains(&root) {
                     block_uses.insert(root);
                 }
-                if let Some(owner) = borrowed
-                    .get(&operand)
-                    .copied()
-                    .map(|v| root_value(aliases, v))
+                if let Some(owner) = borrowed_owner(borrowed, aliases, root)
                     && managed.contains(&owner)
                     && !block_defs.contains(&owner)
                 {
@@ -967,11 +982,7 @@ impl ActionPlanner<'_> {
                 if self.owned.contains(&root) {
                     last_use.insert(root, index);
                 }
-                if let Some(owner) = self
-                    .borrowed
-                    .get(&operand)
-                    .copied()
-                    .map(|v| root_value(&self.aliases, v))
+                if let Some(owner) = borrowed_owner(&self.borrowed, &self.aliases, root)
                     && self.owned.contains(&owner)
                 {
                     last_use.insert(owner, index);

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -445,6 +445,54 @@ fn into_raw_fixture(transfers: &str) -> String {
 }
 
 #[test]
+fn nested_field_borrow_keeps_the_outer_owner_alive_through_the_last_use() {
+    let (ctx, _module, plan) = build(
+        r#"core.module @test {
+  !Child = adt.struct() {name = @Child, fields = [[@value, core.i32]]}
+  !ChildRef = adt.typeref() {name = @Child}
+  !Inner = adt.struct() {name = @Inner, fields = [[@child, !ChildRef]]}
+  !InnerRef = adt.typeref() {name = @Inner}
+  !Box = adt.struct() {name = @Box, fields = [[@inner, !InnerRef]]}
+  func.func @observe(%child: !ChildRef) -> core.i32 {
+    %value = adt.struct_get %child {field = 0, type = !Child} : core.i32
+    func.return %value
+  }
+  func.func @load(%child: !ChildRef) -> core.nil {
+    %inner = adt.struct_new %child {type = !Inner} : !InnerRef
+    %owner = adt.struct_new %inner {type = !Box} : !Box
+    %loaded = adt.struct_get %owner {field = 0, type = !Box} : !InnerRef
+    %erased = adt.ref_cast %loaded {type = tribute_rt.anyref} : tribute_rt.anyref
+    %restored = adt.ref_cast %erased {type = !InnerRef} : !InnerRef
+    %nested = adt.struct_get %restored {field = 0, type = !Inner} : !ChildRef
+    %value = func.call %nested {callee = @observe} : core.i32
+    func.return
+  }
+}"#,
+    );
+    let function = plan.function(Symbol::new("load")).unwrap();
+    let body = ctx.op(function.operation()).regions[0];
+    let block = ctx.region(body).blocks[0];
+    let box_layout = ctx.type_alias_by_name(Symbol::new("Box")).unwrap();
+    let mut owner = None;
+    let mut call = None;
+    for &op in &ctx.block(block).ops {
+        if adt::StructNew::from_op(&ctx, op).is_ok_and(|new| new.r#type(&ctx) == box_layout) {
+            owner = Some(ctx.op_result(op, 0));
+        }
+        if func::Call::matches(&ctx, op) {
+            call = Some(op);
+        }
+    }
+    let owner = owner.expect("outer owner");
+    let call = call.expect("nested borrowed field use");
+    assert!(function.actions().iter().any(|action| {
+        action.kind == ActionKind::FinalRelease
+            && action.value == owner
+            && action.anchor == ActionAnchor::After(call)
+    }));
+}
+
+#[test]
 fn into_raw_grouped_transfers_acquire_exact_extra_units_before_the_first_transfer() {
     for (count, transfers) in [
         (


### PR DESCRIPTION
## Summary

- trace managed projection borrows transitively through compatible casts
- keep the outer owned root live through the final nested projection use
- add a structural regression for the nested owner release anchor

## Validation

- `cargo nextest run -p tribute-passes native::ownership_plan --no-fail-fast`
- `cargo fmt --all -- --check`

Related to #912.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ownership tracking for values borrowed through nested fields and aliases.
  * Ensured outer owners remain available through the final use of nested borrowed values.
  * Corrected final-release planning for complex borrowed-value chains.

* **Tests**
  * Added coverage for nested field borrows involving casting and subsequent field access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->