### PR TITLE
Classify long-running ability regressions as slow tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,7 @@
 [profile.default]
 slow-timeout = { period = "30s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter = "package(tribute) & test(/_slow$/)"
+slow-timeout = { period = "60s", terminate-after = 1 }
+threads-required = "num-test-threads"

--- a/tests/e2e_ability_effect_row.rs
+++ b/tests/e2e_ability_effect_row.rs
@@ -19,7 +19,7 @@ use common::assert_native_output;
 /// a `State` handler, `e` is instantiated to `{State(Nat)}`, so the callback
 /// can perform State operations.
 #[test]
-fn test_effect_row_poly_higher_order_function() {
+fn test_effect_row_poly_higher_order_function_slow() {
     let code = r#"ability State(s) {
     op get() -> s
     op set(value: s) -> Nil
@@ -126,7 +126,7 @@ fn main() {
 /// `apply` is called twice: once where `e = {State(Nat)}` and once where
 /// `e = {Reader(Nat)}`. Each call site independently instantiates the row variable.
 #[test]
-fn test_effect_row_poly_unification_across_call_sites() {
+fn test_effect_row_poly_unification_across_call_sites_slow() {
     let code = r#"ability State(s) {
     op get() -> s
     op set(value: s) -> Nil

--- a/tests/e2e_ability_handler.rs
+++ b/tests/e2e_ability_handler.rs
@@ -87,7 +87,7 @@ fn main() {
 }
 
 #[test]
-fn test_cps_control_carrier_preserves_read_outcome_and_nested_zero_resume() {
+fn test_cps_control_carrier_preserves_read_outcome_and_nested_zero_resume_slow() {
     let source = cps_control_read_outcome_program();
     let profiles = [
         (
@@ -178,7 +178,7 @@ fn main() {
 /// A non-resumptive outer handler must cross an inner, non-matching handler
 /// boundary without invoking either `do` arm.
 #[test]
-fn test_cps_control_outer_nonresumptive_bypasses_nested_do_arms() {
+fn test_cps_control_outer_nonresumptive_bypasses_nested_do_arms_slow() {
     let source = cps_control_outer_nonresumptive_crosses_inner_handle_program();
     let profiles = [
         (

--- a/tests/e2e_ability_nested.rs
+++ b/tests/e2e_ability_nested.rs
@@ -144,7 +144,7 @@ fn main() {
 /// Handlers: Reader provides 5, Writer is no-op, State starts at 0.
 /// Expected: 5.
 #[test]
-fn test_three_abilities_nested_handlers() {
+fn test_three_abilities_nested_handlers_slow() {
     let code = r#"ability State(s) {
     op get() -> s
     op set(value: s) -> Nil


### PR DESCRIPTION
## Summary

- give the five long-running ability regressions a `_slow` suffix
- select them through nextest configuration
- allow 60 seconds and reserve the test runner for each selected test

## Validation

- `cargo nextest list -p tribute -E 'test(/_slow$/)'`
- `cargo nextest run -p tribute -E 'test(/_slow$/)' --no-fail-fast`
- `cargo fmt --all -- --check`

Related to #842.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test execution for slower end-to-end scenarios with a dedicated 60-second timeout and appropriate parallelism.
  - Clearly labeled several longer-running ability and handler tests as slow.
  - No test behavior, assertions, or expected results changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->