### PR TITLE
#835: Preserve resume lambda effect metadata

### DIFF
--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -342,6 +342,7 @@ impl<'db> TypeChecker<'db> {
 
                 // Use a new scope for lambda parameters so they don't leak out
                 ctx.push_scope();
+                ctx.enter_lambda();
 
                 // Bind lambda parameters in the new scope
                 for (param, ty) in params.iter().zip(param_types.iter()) {
@@ -357,28 +358,21 @@ impl<'db> TypeChecker<'db> {
                 let inferred_effect = ctx.current_effect();
 
                 ctx.pop_scope();
+                let resume_effect = ctx.exit_lambda();
 
                 // Restore the outer context's effect
                 ctx.set_current_effect(outer_effect);
 
-                // Use the expected effect if provided, otherwise use the inferred effect.
-                // When expected effect is given, it means the lambda is being checked against
-                // a known function type. We must constrain the inferred effect to match the
-                // expected effect so that any UniVars created during body checking get resolved.
-                let lambda_effect = if let Some(expected) = expected_effect {
-                    // Constrain the inferred effect (fresh_effect after body checking)
-                    // to match the expected effect. This ensures UniVars in the body's
-                    // types that reference fresh_effect get properly resolved.
+                let lambda_effect = resume_effect.unwrap_or(inferred_effect);
+                if let Some(expected) = expected_effect {
+                    // This resolves generic ability arguments selected by the body.
                     ctx.constrain_row_eq_at(
-                        inferred_effect,
+                        lambda_effect,
                         expected,
                         expr.id,
                         ConstraintOriginKind::Lambda,
                     );
-                    expected
-                } else {
-                    inferred_effect
-                };
+                }
 
                 let result_ty = ctx.fresh_type_var();
                 ctx.constrain_eq(result_ty, body_ty);
@@ -518,10 +512,11 @@ impl<'db> TypeChecker<'db> {
                     && let TypeKind::Continuation {
                         arg: cont_arg,
                         result: cont_result,
-                        ..
+                        effect,
                     } = cont_ty.kind(self.db())
                 {
                     ctx.constrain_eq(arg_ty, *cont_arg);
+                    ctx.record_lambda_resume_effect(*effect);
                     *cont_result
                 } else {
                     ctx.fresh_type_var()
@@ -761,6 +756,7 @@ impl<'db> TypeChecker<'db> {
                 ctx.set_current_effect(fresh_effect);
 
                 ctx.push_scope();
+                ctx.enter_lambda();
                 for (param, ty) in params.iter().zip(param_types.iter()) {
                     if let Some(local_id) = param.local_id {
                         ctx.bind_local(local_id, *ty);
@@ -772,11 +768,33 @@ impl<'db> TypeChecker<'db> {
                 let inferred_effect = ctx.current_effect();
 
                 ctx.pop_scope();
+                let resume_effect = ctx.exit_lambda();
                 ctx.set_current_effect(outer_effect);
 
-                let lambda_type = ctx.func_type(param_types, body_ty, inferred_effect);
+                let lambda_type = ctx.func_type(
+                    param_types,
+                    body_ty,
+                    resume_effect.unwrap_or(inferred_effect),
+                );
                 ctx.record_inferred_lambda_type(expr.id, lambda_type);
                 lambda_type
+            }
+            ExprKind::Resume { arg, local_id } => {
+                let arg_ty = self.infer_expr_type_with_ctx(ctx, arg);
+                if let Some(local_id) = local_id
+                    && let Some(cont_ty) = ctx.lookup_local(*local_id)
+                    && let TypeKind::Continuation {
+                        arg: cont_arg,
+                        result: cont_result,
+                        effect,
+                    } = cont_ty.kind(self.db())
+                {
+                    ctx.constrain_eq(arg_ty, *cont_arg);
+                    ctx.record_lambda_resume_effect(*effect);
+                    *cont_result
+                } else {
+                    ctx.fresh_type_var()
+                }
             }
             ExprKind::Tuple(elems) => {
                 let elem_tys = elems

--- a/crates/tribute-front/src/typeck/checker/expr.rs
+++ b/crates/tribute-front/src/typeck/checker/expr.rs
@@ -363,7 +363,20 @@ impl<'db> TypeChecker<'db> {
                 // Restore the outer context's effect
                 ctx.set_current_effect(outer_effect);
 
-                let lambda_effect = resume_effect.unwrap_or(inferred_effect);
+                // A `resume` selects the effect row of the captured continuation,
+                // but ordinary calls in this lambda have already accumulated in
+                // `inferred_effect`. Keep that latent row as the lambda's
+                // signature and constrain it to the continuation row so solving
+                // retains both the continuation identity and local effects.
+                if let Some(resume_effect) = resume_effect {
+                    ctx.constrain_row_eq_at(
+                        inferred_effect,
+                        resume_effect,
+                        expr.id,
+                        ConstraintOriginKind::Lambda,
+                    );
+                }
+                let lambda_effect = inferred_effect;
                 if let Some(expected) = expected_effect {
                     // This resolves generic ability arguments selected by the body.
                     ctx.constrain_row_eq_at(
@@ -771,11 +784,15 @@ impl<'db> TypeChecker<'db> {
                 let resume_effect = ctx.exit_lambda();
                 ctx.set_current_effect(outer_effect);
 
-                let lambda_type = ctx.func_type(
-                    param_types,
-                    body_ty,
-                    resume_effect.unwrap_or(inferred_effect),
-                );
+                if let Some(resume_effect) = resume_effect {
+                    ctx.constrain_row_eq_at(
+                        inferred_effect,
+                        resume_effect,
+                        expr.id,
+                        ConstraintOriginKind::Lambda,
+                    );
+                }
+                let lambda_type = ctx.func_type(param_types, body_ty, inferred_effect);
                 ctx.record_inferred_lambda_type(expr.id, lambda_type);
                 lambda_type
             }

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -655,6 +655,7 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             .expect("lambda resume effect stack must be balanced")
     }
 
+    /// Record the continuation row selected by a resume in the active lambda.
     pub(crate) fn record_lambda_resume_effect(&mut self, effect: EffectRow<'db>) {
         if let Some(slot) = self.lambda_resume_effects.last_mut() {
             *slot = Some(effect);

--- a/crates/tribute-front/src/typeck/func_context.rs
+++ b/crates/tribute-front/src/typeck/func_context.rs
@@ -117,6 +117,9 @@ pub struct FunctionInferenceContext<'a, 'db> {
     /// Current accumulated effects.
     current_effect: EffectRow<'db>,
 
+    /// Continuation effect rows captured while checking active lambdas.
+    lambda_resume_effects: Vec<Option<EffectRow<'db>>>,
+
     /// Stack of handle expression contexts.
     ///
     /// Pushed during the infer phase of a handle expression and
@@ -183,6 +186,7 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
             // used in collect.rs for function signature effect rows
             next_row_var: 1,
             current_effect: EffectRow::pure(db),
+            lambda_resume_effects: Vec::new(),
             handle_ctx_stack: Vec::new(),
             resolved_methods: HashMap::new(),
             deferred_methods: Vec::new(),
@@ -639,6 +643,22 @@ impl<'a, 'db> FunctionInferenceContext<'a, 'db> {
     /// Set the current effect row.
     pub fn set_current_effect(&mut self, effect: EffectRow<'db>) {
         self.current_effect = effect;
+    }
+
+    pub(crate) fn enter_lambda(&mut self) {
+        self.lambda_resume_effects.push(None);
+    }
+
+    pub(crate) fn exit_lambda(&mut self) -> Option<EffectRow<'db>> {
+        self.lambda_resume_effects
+            .pop()
+            .expect("lambda resume effect stack must be balanced")
+    }
+
+    pub(crate) fn record_lambda_resume_effect(&mut self, effect: EffectRow<'db>) {
+        if let Some(slot) = self.lambda_resume_effects.last_mut() {
+            *slot = Some(effect);
+        }
     }
 
     /// Push a handle context onto the stack.

--- a/crates/tribute-front/tests/let_generalization.rs
+++ b/crates/tribute-front/tests/let_generalization.rs
@@ -437,14 +437,23 @@ ability Writer(w) {
     op tell(value: w) -> Nil
 }
 
+ability Audit {
+    fn mark() -> Nil
+}
+
 fn run_writer(comp: fn() ->{e, Writer(w)} a) ->{e} a {
     handle comp() {
         do result { result }
-        op Writer::tell(v) { run_writer(fn() { resume Nil }) }
+        op Writer::tell(v) { run_writer(fn() {
+            Audit::mark()
+            resume Nil
+        }) }
     }
 }
 "#,
     );
+    let errors = type_errors(db, source);
+    assert!(errors.is_empty(), "unexpected type errors: {errors:#?}");
 
     let output = tribute_front::query::type_check_output(db, source)
         .expect("type checking should produce output");
@@ -477,9 +486,26 @@ fn run_writer(comp: fn() ->{e, Writer(w)} a) ->{e} a {
     else {
         panic!("resume lambda metadata must be callable");
     };
+    let continuation_writer = computation_effect
+        .effects(db)
+        .iter()
+        .find(|effect| effect.ability_id == AbilityId::source(db, Symbol::new("Writer")))
+        .expect("the enclosing computation must retain Writer(w)");
+    let lambda_writer = lambda_effect
+        .effects(db)
+        .iter()
+        .find(|effect| effect.ability_id == AbilityId::source(db, Symbol::new("Writer")))
+        .expect("the resume lambda must retain Writer(w)");
     assert_eq!(
-        lambda_effect, computation_effect,
-        "the resume lambda must preserve the enclosing handler computation effect"
+        lambda_writer.args, continuation_writer.args,
+        "the resume lambda must preserve the enclosing Writer ability argument"
+    );
+    assert!(
+        lambda_effect
+            .effects(db)
+            .iter()
+            .any(|effect| effect.ability_id == AbilityId::source(db, Symbol::new("Audit"))),
+        "the resume lambda must retain its independently performed Audit effect"
     );
 }
 

--- a/crates/tribute-front/tests/let_generalization.rs
+++ b/crates/tribute-front/tests/let_generalization.rs
@@ -428,6 +428,62 @@ fn pair() -> Nil {
 }
 
 #[salsa_test]
+fn resume_lambda_metadata_uses_the_enclosing_handler_effect(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "resume_lambda_effect.trb",
+        r#"
+ability Writer(w) {
+    op tell(value: w) -> Nil
+}
+
+fn run_writer(comp: fn() ->{e, Writer(w)} a) ->{e} a {
+    handle comp() {
+        do result { result }
+        op Writer::tell(v) { run_writer(fn() { resume Nil }) }
+    }
+}
+"#,
+    );
+
+    let output = tribute_front::query::type_check_output(db, source)
+        .expect("type checking should produce output");
+    let run_writer = output
+        .function_types(db)
+        .iter()
+        .find_map(|(name, scheme)| (*name == Symbol::new("run_writer")).then_some(*scheme))
+        .expect("run_writer scheme should be present");
+    let TypeKind::Func { params, .. } = run_writer.body(db).kind(db) else {
+        panic!("run_writer scheme must be callable");
+    };
+    let TypeKind::Func {
+        effect: computation_effect,
+        ..
+    } = params[0].kind(db)
+    else {
+        panic!("run_writer computation parameter must be callable");
+    };
+
+    let signatures: Vec<_> = output
+        .lambda_signatures(db)
+        .iter()
+        .map(|(_, signature)| signature.clone())
+        .collect();
+    assert_eq!(signatures.len(), 1, "fixture has one resume lambda");
+    let TypeKind::Func {
+        effect: lambda_effect,
+        ..
+    } = signatures[0].function_type.kind(db)
+    else {
+        panic!("resume lambda metadata must be callable");
+    };
+    assert_eq!(
+        lambda_effect, computation_effect,
+        "the resume lambda must preserve the enclosing handler computation effect"
+    );
+}
+
+#[salsa_test]
 fn variant_destructuring_preserves_polymorphism(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
         db,


### PR DESCRIPTION
## Summary

- preserve the continuation effect selected by `resume` while checking lambda bodies
- constrain that continuation row against the independently inferred lambda row instead of replacing it
- retain both generic continuation identity and local lambda effects in solved metadata

## Validation

- `cargo nextest run -p tribute-front --no-fail-fast`
- `cargo nextest run -p tribute --test e2e_ability_nested test_three_abilities_nested_handlers_slow --no-fail-fast`
- `cargo clippy -p tribute-front --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #835.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking for lambdas that use `resume` continuations.
  * Preserved enclosing handler effects when inferring resume lambda metadata.
  * Ensured lambdas retain their independently declared effects alongside captured continuation effects.

* **Tests**
  * Added coverage for nested handler and resume scenarios involving multiple effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->