### PR TITLE
Register read-line intrinsic provenance

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/mod.rs
@@ -93,6 +93,7 @@ static SUPPORTED_COMPILER_INTRINSICS: LazyLock<HashSet<Symbol>> = LazyLock::new(
         "Float::<=",
         "Float::>",
         "Float::>=",
+        "std::io::__tribute_io_read_line",
     ]
     .into_iter()
     .map(Symbol::new)
@@ -247,6 +248,9 @@ mod tests {
     #[test]
     fn compiler_intrinsic_registry_is_explicit() {
         assert!(is_supported_compiler_intrinsic(Symbol::new("Float::==")));
+        assert!(is_supported_compiler_intrinsic(Symbol::new(
+            "std::io::__tribute_io_read_line"
+        )));
         assert!(!is_supported_compiler_intrinsic(Symbol::new(
             "user_intrinsic"
         )));

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -4979,16 +4979,16 @@ mod tests {
     }
 
     #[test]
-    fn managed_bodyless_external_and_raw_pointer_cast_chain_fail_closed() {
+    fn managed_bodyless_external_read_line_shape_and_raw_pointer_cast_chain_fail_closed() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !S = adt.struct() {name = @S, fields = []}
-  !R = adt.typeref() {name = @S}
-  tribute_control.func @private_helper(%value: !R) -> !R convention(direct)
-    attributes {abi = "C"}
-  tribute_control.func @masquerade(%raw: core.ptr) -> !R convention(direct) {
+  !ReadLineResult = adt.enum() {name = @ReadLineResult, variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
+  !ReadLineResultRef = adt.typeref() {name = @ReadLineResult}
+  tribute_control.func @user_read_line() -> !ReadLineResultRef convention(direct)
+    attributes {abi = "intrinsic"}
+  tribute_control.func @masquerade(%raw: core.ptr) -> !ReadLineResultRef convention(direct) {
     %middle = arith.cast %raw : core.i64
-    %managed = core.unrealized_conversion_cast %middle : !R
+    %managed = core.unrealized_conversion_cast %middle : !ReadLineResultRef
     tribute_control.return %managed
   }
 }"#,
@@ -4996,7 +4996,12 @@ mod tests {
 
         let result = validate(&ctx, module, &[], &[]);
         let diagnostics = messages(&result);
-        assert!(diagnostics.contains("bodyless external"), "{result}");
+        assert!(
+            diagnostics.contains(
+                "unclassified bodyless external declaration cannot use managed adt.typeref"
+            ),
+            "{result}"
+        );
         assert!(diagnostics.contains("core.ptr cast chain"), "{result}");
     }
 


### PR DESCRIPTION
## Summary

- Register the canonical `std::io::__tribute_io_read_line` declaration in the explicit compiler-intrinsic registry so exact pre-CPS identity, complete-signature, and Direct-convention validation can accept its managed result.
- Keep the verifier fail-closed with a same-shaped user-authored `extern "intrinsic"` regression.
- Leave pipeline composition, CPS/target ABI, lowering, and ownership unchanged.

Prerequisite for #825.

## Validation

- `cargo nextest run -p tribute-front` (623 passed)
- `cargo nextest run -p tribute-ir` (83 passed)
- `cargo nextest run -p tribute-passes tribute_control_to_cps` (33 passed)
- `cargo nextest run -p tribute frontend_registers_only_compiler_owned_intrinsic_origins` (1 passed)
- `cargo run -- compile lang-examples/native_calculator.trb --target none`
- `cargo llvm-cov nextest -p tribute-front --lcov --output-path /tmp/tribute-read-line-provenance.lcov compiler_intrinsic_registry_is_explicit` (new registry line hit)
- `cargo nextest run --workspace` (1,976 passed, 1 leaky-process annotation, 1 skipped)
- `cargo clippy -p tribute-front -p tribute-ir -p tribute-passes -p tribute --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
- normal pre-commit hook (Clippy, formatting, 1,976 passed, 1 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the standard input line-reading intrinsic.

* **Bug Fixes**
  * Improved validation for line-reading result types and managed type references.
  * Preserved safeguards preventing unsafe pointer-cast chains and invalid external declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->