### PR TITLE
fix(frontend): register read line intrinsic provenance

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/mod.rs
@@ -93,6 +93,7 @@ static SUPPORTED_COMPILER_INTRINSICS: LazyLock<HashSet<Symbol>> = LazyLock::new(
         "Float::<=",
         "Float::>",
         "Float::>=",
+        "std::io::__tribute_io_read_line",
     ]
     .into_iter()
     .map(Symbol::new)
@@ -247,6 +248,9 @@ mod tests {
     #[test]
     fn compiler_intrinsic_registry_is_explicit() {
         assert!(is_supported_compiler_intrinsic(Symbol::new("Float::==")));
+        assert!(is_supported_compiler_intrinsic(Symbol::new(
+            "std::io::__tribute_io_read_line"
+        )));
         assert!(!is_supported_compiler_intrinsic(Symbol::new(
             "user_intrinsic"
         )));

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -4979,16 +4979,16 @@ mod tests {
     }
 
     #[test]
-    fn managed_bodyless_external_and_raw_pointer_cast_chain_fail_closed() {
+    fn managed_bodyless_external_read_line_shape_and_raw_pointer_cast_chain_fail_closed() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !S = adt.struct() {name = @S, fields = []}
-  !R = adt.typeref() {name = @S}
-  tribute_control.func @private_helper(%value: !R) -> !R convention(direct)
-    attributes {abi = "C"}
-  tribute_control.func @masquerade(%raw: core.ptr) -> !R convention(direct) {
+  !ReadLineResult = adt.enum() {name = @ReadLineResult, variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
+  !ReadLineResultRef = adt.typeref() {name = @ReadLineResult}
+  tribute_control.func @user_read_line() -> !ReadLineResultRef convention(direct)
+    attributes {abi = "intrinsic"}
+  tribute_control.func @masquerade(%raw: core.ptr) -> !ReadLineResultRef convention(direct) {
     %middle = arith.cast %raw : core.i64
-    %managed = core.unrealized_conversion_cast %middle : !R
+    %managed = core.unrealized_conversion_cast %middle : !ReadLineResultRef
     tribute_control.return %managed
   }
 }"#,


### PR DESCRIPTION
Summary:
- Register only the canonical compiler-owned std::io::__tribute_io_read_line identity through the existing provenance registry.
- Preserve the existing Direct convention and complete-signature validation path.
- Keep a same-shaped user intrinsic external fail-closed.

This is a prerequisite for #825 and completes the applicable exact-provenance contract from #898.

Validation:
- cargo nextest run -p tribute-front
- cargo nextest run -p tribute-ir
- cargo clippy -p tribute-front -p tribute-ir --all-targets -- -D warnings
- cargo fmt --all
- git diff --check
- normal pre-commit hook: 1,976 passed, 1 skipped