### PR TITLE
fix(pipeline): finalize closure storage after target ABI

### DIFF
--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -19,9 +19,12 @@
 //!
 //! Uses `RewritePattern` + `PatternApplicator` for declarative transformation.
 
+use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 
-use tribute_core::calling_convention::get_physical_closure_environment_index;
+use tribute_core::calling_convention::{
+    CLOSURE_CALLABLE_TYPE_ATTR, get_physical_closure_environment_index,
+};
 use tribute_core::{
     CallableAbi, CallingConvention, get_calling_convention, get_closure_callable_type,
     get_physical_closure_convention, set_closure_callable_type, set_indirect_call_signature,
@@ -40,7 +43,7 @@ use trunk_ir::rewrite::{
     ConversionTarget, Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
-use trunk_ir::walk::{WalkAction, walk_region};
+use trunk_ir::walk::{WalkAction, walk_op, walk_region};
 
 /// Create the unified closure struct type in arena: `{ table_idx: i32, env: anyref }`.
 pub fn closure_struct_type_ref(ctx: &mut IrContext) -> TypeRef {
@@ -690,6 +693,165 @@ pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
     applicator.apply_partial(ctx, func_op);
 }
 
+/// Select the canonical `_closure` storage type after all semantic consumers
+/// have validated the exact convention-proven callable type.
+///
+/// The plan covers aliases, nested type parameters, type-bearing operation
+/// attributes, results, and block arguments before applying any update. The
+/// pack provenance is consumed by exact closure lowering, then removed: it is
+/// not a type-equivalence rule or final physical-IR contract.
+pub fn finalize_closure_storage_layout(ctx: &mut IrContext, module: Module) {
+    let closure_struct = closure_struct_type_ref(ctx);
+    let ops = collect_ops(ctx, module.op());
+    let aliases = ctx.type_aliases().to_vec();
+    let mut physicalizer = ClosureTypePhysicalizer::new(ctx, closure_struct);
+    let mut alias_updates = Vec::new();
+    let mut attribute_removals = Vec::new();
+    let mut attribute_updates = Vec::new();
+    let mut result_updates = Vec::new();
+    let mut block_arg_updates = Vec::new();
+
+    for (name, ty) in aliases {
+        let converted = physicalizer.convert_type(ty);
+        if converted != ty {
+            alias_updates.push((name, converted));
+        }
+    }
+    for op in ops {
+        for (name, value) in physicalizer.ctx.op(op).attributes.clone() {
+            if name == Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR) {
+                attribute_removals.push(op);
+                continue;
+            }
+            let converted = physicalizer.convert_attribute(value.clone());
+            if converted != value {
+                attribute_updates.push((op, name, converted));
+            }
+        }
+        for (index, ty) in physicalizer
+            .ctx
+            .op_result_types(op)
+            .to_vec()
+            .into_iter()
+            .enumerate()
+        {
+            let converted = physicalizer.convert_type(ty);
+            if converted != ty {
+                result_updates.push((op, index as u32, converted));
+            }
+        }
+        for region in physicalizer.ctx.op(op).regions.clone() {
+            for block in physicalizer.ctx.region(region).blocks.clone() {
+                let args = physicalizer
+                    .ctx
+                    .block(block)
+                    .args
+                    .iter()
+                    .map(|argument| argument.ty)
+                    .collect::<Vec<_>>();
+                for (index, ty) in args.into_iter().enumerate() {
+                    let converted = physicalizer.convert_type(ty);
+                    if converted != ty {
+                        block_arg_updates.push((block, index as u32, converted));
+                    }
+                }
+            }
+        }
+    }
+
+    drop(physicalizer);
+    for (name, ty) in alias_updates {
+        ctx.register_type_alias(name, ty);
+    }
+    for op in attribute_removals {
+        ctx.op_mut(op)
+            .attributes
+            .remove(Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR));
+    }
+    for (op, name, value) in attribute_updates {
+        ctx.op_mut(op).attributes.insert(name, value);
+    }
+    for (op, index, ty) in result_updates {
+        ctx.set_op_result_type(op, index, ty);
+    }
+    for (block, index, ty) in block_arg_updates {
+        ctx.set_block_arg_type(block, index, ty);
+    }
+}
+
+struct ClosureTypePhysicalizer<'a> {
+    ctx: &'a mut IrContext,
+    closure_struct: TypeRef,
+    cache: HashMap<TypeRef, TypeRef>,
+    visiting: HashSet<TypeRef>,
+}
+
+impl<'a> ClosureTypePhysicalizer<'a> {
+    fn new(ctx: &'a mut IrContext, closure_struct: TypeRef) -> Self {
+        Self {
+            ctx,
+            closure_struct,
+            cache: HashMap::new(),
+            visiting: HashSet::new(),
+        }
+    }
+
+    fn convert_type(&mut self, ty: TypeRef) -> TypeRef {
+        if closure::Closure::matches(self.ctx, ty) {
+            return self.closure_struct;
+        }
+        if let Some(&converted) = self.cache.get(&ty) {
+            return converted;
+        }
+        if !self.visiting.insert(ty) {
+            return ty;
+        }
+
+        let data = self.ctx.types.get(ty).clone();
+        let mut converted = data.clone();
+        for parameter in &mut converted.params {
+            *parameter = self.convert_type(*parameter);
+        }
+        let attributes: Vec<_> = data
+            .attrs
+            .iter()
+            .map(|(name, value)| (*name, self.convert_attribute(value.clone())))
+            .collect();
+        converted.attrs.clear();
+        converted.attrs.extend(attributes);
+        let converted = if converted == data {
+            ty
+        } else {
+            self.ctx.types.intern(converted)
+        };
+        self.visiting.remove(&ty);
+        self.cache.insert(ty, converted);
+        converted
+    }
+
+    fn convert_attribute(&mut self, attribute: Attribute) -> Attribute {
+        match attribute {
+            Attribute::Type(ty) => Attribute::Type(self.convert_type(ty)),
+            Attribute::List(values) => Attribute::List(
+                values
+                    .into_iter()
+                    .map(|value| self.convert_attribute(value))
+                    .collect(),
+            ),
+            value => value,
+        }
+    }
+}
+
+fn collect_ops(ctx: &IrContext, root: OpRef) -> Vec<OpRef> {
+    let mut ops = Vec::new();
+    let _ = walk_op::<()>(ctx, root, &mut |op| {
+        ops.push(op);
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    ops
+}
+
 /// PassManager-friendly wrapper for [`lower_closures`].
 pub struct LowerClosures;
 
@@ -937,6 +1099,69 @@ mod tests {
                 "{name} should pass the enclosing function's evidence argument immediately after table index"
             );
         }
+    }
+
+    #[test]
+    fn storage_finalization_rewrites_every_type_surface_but_not_pack_provenance() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !closure = closure.closure(core.func(core.i32, core.i32)) {tribute.calling_convention = 0}
+  !nested = core.tuple(!closure)
+  func.func @run(%callback: !closure) -> !nested {
+    %environment = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
+    %created = closure.new %environment {func_ref = @callback} : !closure
+    %packed = core.tuple_pack %created : !nested
+    func.return %packed
+  }
+}"#,
+        );
+
+        let run = func_by_name(&ctx, module, "run");
+        let logical = ctx
+            .type_aliases()
+            .iter()
+            .find_map(|(name, ty)| (*name == Symbol::new("closure")).then_some(*ty))
+            .expect("test module must define the logical closure alias");
+        let pack = ctx
+            .block(ctx.region(run.body(&ctx)).blocks[0])
+            .ops
+            .iter()
+            .copied()
+            .find(|op| closure::New::from_op(&ctx, *op).is_ok())
+            .expect("test module must create a closure");
+        ctx.op_mut(pack).attributes.insert(
+            Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR),
+            Attribute::Type(logical),
+        );
+
+        finalize_closure_storage_layout(&mut ctx, module);
+
+        let physical = closure_struct_type_ref(&mut ctx);
+        let signature = core::Func::from_type_ref(&ctx, run.r#type(&ctx)).unwrap();
+        assert_eq!(signature.params(&ctx), [physical]);
+        assert_eq!(
+            ctx.value_ty(ctx.block_args(ctx.region(run.body(&ctx)).blocks[0])[0]),
+            physical
+        );
+        assert_eq!(ctx.op_result_types(pack), [physical]);
+        assert!(
+            !ctx.op(pack)
+                .attributes
+                .contains_key(CLOSURE_CALLABLE_TYPE_ATTR),
+            "final physical IR must not retain logical closure provenance"
+        );
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            !printed.contains(CLOSURE_CALLABLE_TYPE_ATTR),
+            "final physical IR must not retain logical closure provenance:\n{printed}"
+        );
+        assert!(printed.contains("!closure = adt.struct"), "{printed}");
+        assert!(
+            printed.contains("!nested = core.tuple(!closure)"),
+            "{printed}"
+        );
     }
 
     #[test]

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -1293,6 +1293,15 @@ mod tests {
     }
 
     #[test]
+    fn root_bridge_creates_no_lambda_for_target_phase() {
+        let (ctx, module) = compose_promoted_root(CallingConvention::Direct);
+        let printed = print_module(&ctx, module.op());
+
+        assert!(!printed.contains("closure.lambda"), "{printed}");
+        assert!(printed.contains("adt.struct_new"), "{printed}");
+    }
+
+    #[test]
     fn malformed_transfers_and_ambiguous_nested_never_leave_ir_unchanged() {
         for (input, expected) in [
             (
@@ -1328,6 +1337,31 @@ mod tests {
             assert!(error.to_string().contains(expected), "{error}");
             assert_eq!(print_module(&ctx, module.op()), before);
         }
+    }
+
+    #[test]
+    fn raw_closure_storage_never_satisfies_a_semantic_direct_transfer() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !semantic = closure.closure(core.func(core.i32)) {tribute.calling_convention = 0}
+  !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
+  func.func @factory(%callback: !semantic) -> core.i32 attributes {tribute.calling_convention = 0} {
+    func.unreachable
+  }
+  func.func @run(%raw: !_closure) -> core.i32 attributes {tribute.calling_convention = 0} {
+    %result = func.call %raw {callee = @factory, tribute.calling_convention = 0} : core.i32
+    func.return %result
+  }
+}"#,
+        );
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+        assert!(error.to_string().contains("operands differ"), "{error}");
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -204,10 +204,12 @@ named pre-CPS boundary가 아니다.
 `tribute_control` operation 또는 `callable`/`resume_token` type은 source
 location에서 conversion failure가 된다. 이 경계에는 일관된 physical
 `func.*`/`closure.*`/`core.func` graph와 logical `ability.*` dispatch 표면만
-남는다. 이후 기존 `lower_closure_lambda`, `prepare_closure_lowering`,
-`lower_closures_in_func`가 closure 표면을 소비하고, `lower_ability_perform`,
-`resolve_evidence`, `lower_handle_dispatch`가 `ability.*`를 `effect.*`까지
-낮춘다. Native와 Wasm의 evidence pass가 `effect.*`를 backend ABI로 제거한다.
+남는다. `lower_closure_lambda`와 `prepare_closure_lowering`은 이 shared graph를
+준비하지만 `closure.new`, `closure.func`, `closure.env`와 convention-proven closure
+type은 target ABI validation까지 유지한다. `lower_ability_perform`,
+`resolve_evidence`, `lower_handle_dispatch`가 `ability.*`를 `effect.*`까지 낮춘 뒤,
+target pipeline의 closure storage finalization과 Native/Wasm evidence pass가
+backend ABI로 제거한다.
 Backend-ready Tribute boundary는 남은 `tribute_control.*`, `ability.*`,
 `effect.*`를 각각 독립적으로 거부한다.
 
@@ -436,25 +438,34 @@ __tribute_evidence_lookup_handler(ev: ptr, ability_id: i32) -> ptr
 
 Callable/control과 effect 관련 pass의 순서는 다음과 같다:
 
+이 순서는 exact root contract가 있는 source-logical CPS route의 contract다.
+Compatibility route는 그 metadata 없이 기존 closure-lowering 순서를 유지하며,
+이를 이 target ABI boundary에 진입시키지 않는다.
+
 ```text
 ast_to_ir (tribute_control callable/control + ordinary value IR)
 → tribute_control_to_cps
 → lower_closure_lambda
 → prepare_closure_lowering
-→ lower_closures_in_func
 → lower_ability_perform
 → resolve_evidence
 → lower_handle_dispatch
 → effect ABI verification
-→ backend-specific effect/signature/tail-call lowering
+→ target ABI validation and CPS signature physicalization
+→ lower_closures_in_func
+→ native evidence lowering → finalize_closure_storage_layout → native tail-call lowering
+  or finalize_closure_storage_layout → integrated Wasm evidence/tail-call lowering
 → backend-ready verification
 ```
 
 `tribute_control_to_cps`의 출력은 physical `func.*`/`closure.*` callable 표면과
-logical `ability.*` dispatch 표면이다. Closure pass가 전자를 소비하고,
-ability/evidence pass가 후자를 `effect.*`까지 낮춘 뒤 backend가 evidence runtime
-call, closure decomposition과 proper tail transfer로 제거한다. 다른 일반
-최적화는 이 경계 사이에 놓일 수 있지만 각 named legality를 바꾸지 않는다.
+logical `ability.*` dispatch 표면이다. Shared ability/evidence pass와 strict target
+ABI validation은 convention-proven `closure.closure` callable type을 그대로
+소비한다. 그 뒤 target pipeline이 closure operation과 모든 type-bearing storage
+surface를 canonical `_closure` layout으로 함께 바꾸고 backend evidence/runtime와
+proper tail transfer lowering이 이를 소비한다. `tribute.closure_callable_type`은
+exact closure lowering에서만 잠시 쓰고 storage finalization에서 제거한다. 이는
+semantic type equivalence를 만들지 않는다.
 
 ## Effect ABI Boundary
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -800,22 +800,29 @@ tail ABI의 구분과 순서는 [cps-effects.md](cps-effects.md#dispatch-layers)
 
 **파이프라인 분기:**
 
+아래 target-side closure storage 순서는 exact root contract가 있는 source-logical
+CPS route에 적용한다. Compatibility route는 그 contract를 만들지 않는 동안 기존
+closure-lowering 순서를 유지한다.
+
 ```text
 공통: parse → resolve → typecheck → tdnr → ast_to_ir
       → tribute_control_to_cps
-      → lower_closure_lambda → prepare_closure_lowering → lower_closures_in_func
+      → lower_closure_lambda → prepare_closure_lowering
       → lower_ability_perform → resolve_evidence → lower_handle_dispatch
-      → effect ABI verification → dce → resolve_casts
+      → effect ABI verification → target ABI validation
 
-WASM:   → lower_to_wasm [includes evidence_to_wasm and empty-result mapping]
+WASM:   → lower_closures_in_func → finalize_closure_storage_layout
+        → lower_to_wasm [includes evidence_to_wasm]
         → backend-ready verification → emit_wasm
-Native: → evidence_to_native → lower_to_clif [includes empty-result mapping]
+Native: → lower_closures_in_func → evidence_to_native
+        → finalize_closure_storage_layout → lower_to_clif
         → backend-ready verification → emit_native
 ```
 
 `tribute_control_to_cps`의 출력은 physical callable/closure 표면과 logical
-`ability.*` 표면이며, closure, ability/evidence, backend effect ABI pass가
-순서대로 소비한다.
+`ability.*` 표면이다. `closure.closure`의 exact callable signature는 shared
+ability/evidence pass와 target ABI validation이 먼저 소비한다. `_closure` storage
+layout과 closure projection은 그 validation 뒤 target pipeline에서만 선택한다.
 
 ---
 
@@ -965,7 +972,8 @@ flowchart TB
 | | `tribute_control_to_cps` | logical callable/control + typechecked metadata | physical func/closure/tail-call + logical `ability.*`; `effect.*` 없음 | shared |
 | **Closure (공유 후속)** | `lower_closure_lambda` | closure.lambda | func.func + closure.new | module-wide |
 | | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
-| | `lower_closures_in_func` | closure.new | func.call_indirect + evidence arg | function-anchored |
+| **Closure (target storage)** | `lower_closures_in_func` | closure.new/func/env after target ABI validation | indirect transfer + `_closure` storage ops | function-anchored |
+| | `finalize_closure_storage_layout` | remaining closure type surfaces | canonical `_closure` layout in aliases, signatures, values, and type attributes | module-wide |
 | **Ability/evidence (공유 후속)** | `lower_ability_perform` | ability.perform/call | effect.dispatch_* + evidence lookup | function-anchored |
 | | `resolve_evidence` | handler evidence setup | effect.extend | module-wide setup before function-local lowering |
 | | `lower_handle_dispatch` | ability.handle_dispatch | final handler result | function-anchored |

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -627,9 +627,14 @@ continuation, and handler closures. It must not expose Marker field indices,
 handler-table storage layout, closure field positions, or backend function
 pointer representation.
 
-`closure.*` represents closure allocation and projection. Closures lower
-differently per backend: Wasm uses function references plus GC structures, while
-native uses function pointers plus heap environments.
+`closure.*` represents closure allocation and projection. Convention-proven
+`closure.closure` keeps its exact callable type through shared effect lowering
+and target-ABI validation. Only after that validation may target lowering choose
+the canonical closure storage layout, rewriting every type-bearing surface
+coherently and removing transient storage-pack provenance; that provenance is
+not semantic type equivalence. Closures lower differently per backend: Wasm uses function
+references plus GC structures, while native uses function pointers plus heap
+environments.
 
 `adt.*` represents target-independent product, sum, array, reference, and
 literal operations.

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -632,9 +632,9 @@ pointer representation.
 and target-ABI validation. Only after that validation may target lowering choose
 the canonical closure storage layout, rewriting every type-bearing surface
 coherently and removing transient storage-pack provenance; that provenance is
-not semantic type equivalence. Closures lower differently per backend: Wasm uses function
-references plus GC structures, while native uses function pointers plus heap
-environments.
+not semantic type equivalence. Closures lower differently per backend: Wasm
+uses function references plus GC structures, while native uses function
+pointers plus heap environments.
 
 `adt.*` represents target-independent product, sum, array, reference, and
 literal operations.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1726,6 +1726,81 @@ mod tests {
     use super::*;
     use salsa_test_macros::salsa_test;
 
+    fn source_logical_cps_root_module() -> (IrContext, Module) {
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main(%evidence: core.i32, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+        );
+        let main = module
+            .ops(&ctx)
+            .into_iter()
+            .find_map(|op| func_dialect::Func::from_op(&ctx, op).ok())
+            .expect("test module must define main");
+        let nil = core_dialect::nil(&mut ctx).as_type_ref();
+        let never = core_dialect::never(&mut ctx).as_type_ref();
+        let evidence = tribute_ir::dialect::ability::evidence_adt_type_ref(&mut ctx);
+        let done_callable = core_dialect::func(&mut ctx, never, [nil]).as_type_ref();
+        let done = ctx.types.intern(
+            trunk_ir::TypeDataBuilder::new(
+                trunk_ir::Symbol::new("closure"),
+                trunk_ir::Symbol::new("closure"),
+            )
+            .param(done_callable)
+            .attr("tribute.calling_convention", trunk_ir::Attribute::Int(2))
+            .attr(
+                "tribute.closure_environment_index",
+                trunk_ir::Attribute::Int(0),
+            )
+            .build(),
+        );
+        let worker = core_dialect::func(&mut ctx, never, [evidence, done]).as_type_ref();
+        ctx.op_mut(main.op_ref()).attributes.insert(
+            trunk_ir::Symbol::new("type"),
+            trunk_ir::Attribute::Type(worker),
+        );
+        let entry = ctx.region(main.body(&ctx)).blocks[0];
+        ctx.set_block_arg_type(entry, 0, evidence);
+        ctx.set_block_arg_type(entry, 1, done);
+        ctx.op_mut(main.op_ref()).attributes.insert(
+            trunk_ir::Symbol::new("tribute.root_export_convention"),
+            trunk_ir::Attribute::Int(0),
+        );
+        ctx.op_mut(main.op_ref()).attributes.insert(
+            trunk_ir::Symbol::new("tribute.root_source_result"),
+            trunk_ir::Attribute::Type(nil),
+        );
+        (ctx, module)
+    }
+
+    #[test]
+    fn source_logical_root_defers_closure_storage_until_target_finalization() {
+        let (mut ctx, module) = source_logical_cps_root_module();
+        let core_module = core_dialect::Module::from_op(&ctx, module.op())
+            .expect("test module must be a core.module");
+        let before = trunk_ir::printer::print_module(&ctx, module.op());
+
+        lower_legacy_closures_before_target_boundary(&mut ctx, module, core_module).unwrap();
+
+        assert_eq!(trunk_ir::printer::print_module(&ctx, module.op()), before);
+        let boundary = enter_target_closure_storage_boundary(&mut ctx, module).unwrap();
+        assert!(matches!(
+            boundary,
+            TargetClosureStorageBoundary::SourceLogicalCps
+        ));
+        let after_abi = trunk_ir::printer::print_module(&ctx, module.op());
+        assert!(after_abi.contains("closure.closure"), "{after_abi}");
+
+        finalize_target_closure_storage(&mut ctx, module, boundary);
+
+        let physical = trunk_ir::printer::print_module(&ctx, module.op());
+        assert!(!physical.contains("closure.closure"), "{physical}");
+    }
+
     #[test]
     fn native_ownership_plan_options_follow_stage_policy_table() {
         let parameter_elision_only = NativeOptimizationOptions {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -36,8 +36,8 @@
 //!     ▼ evidence_params (Phase 1)
 //! Module (evidence params added to signatures)
 //!     │
-//!     ▼ prepare_closure_lowering + lower_closures_in_func
-//! Module (closure.* lowered, evidence passed through closure calls)
+//!     ▼ prepare_closure_lowering
+//! Module (semantic closure contracts prepared)
 //!     │
 //!     ▼ lower_ability_perform (CPS tail-call)
 //! Module (ability.perform/call lowered to effect.dispatch_*)
@@ -48,8 +48,8 @@
 //!     ▼ lower_handle_dispatch
 //! Module (ability.handle_dispatch lowered)
 //!     │
-//!     ▼ dce ─► resolve_casts
-//! Module (ready for codegen)
+//!     ▼ target ABI validation ─► lower_closures_in_func
+//! Module (target closure storage selected)
 //!     │
 //!     ├─► [wasm]   compile_to_wasm (includes evidence_to_wasm)
 //!     └─► [native] compile_to_native (includes evidence_to_native)
@@ -696,11 +696,10 @@ fn run_shared_pipeline_with_options(
         .add_pass(tribute_passes::io_lowering::LowerIoIntrinsics)
         // Evidence params are now inserted directly during ast_to_ir lowering.
         .add_pass(tribute_passes::closure_lower::PrepareClosureLowering);
-    structural_pm
-        .nest::<func_dialect::Func>()
-        .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
     install_debug_use_chain_verifier(&mut structural_pm);
     structural_pm.run(&mut ctx, core_module)?;
+
+    lower_legacy_closures_before_target_boundary(&mut ctx, m, core_module)?;
 
     // CPS effect handling, function-local phase: lower_ability_perform produces
     // ability.evidence_lookup ops that resolve_evidence needs to process.
@@ -881,10 +880,8 @@ fn run_wasm_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), DumpIr
         trunk_ir::transforms::inline::inline_functions(ctx, m, analyses);
     });
 
-    if tribute_passes::target_abi::has_root_entry_contract(ctx, m) {
-        tribute_passes::target_abi::lower_cps_signatures_to_physical(ctx, m)?;
-        tribute_passes::target_abi::compose_root_entry_bridge(ctx, m)?;
-    }
+    let closure_boundary = enter_target_closure_storage_boundary(ctx, m)?;
+    finalize_target_closure_storage(ctx, m, closure_boundary);
 
     run_cleanup_passes(ctx, m);
     Ok(())
@@ -902,10 +899,7 @@ fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Dump
         trunk_ir::transforms::inline::inline_functions(ctx, m, analyses);
     });
 
-    if tribute_passes::target_abi::has_root_entry_contract(ctx, m) {
-        tribute_passes::target_abi::lower_cps_signatures_to_physical(ctx, m)?;
-        tribute_passes::target_abi::compose_root_entry_bridge(ctx, m)?;
-    }
+    let closure_boundary = enter_target_closure_storage_boundary(ctx, m)?;
 
     if let Ok(core_module) = core_dialect::Module::from_op(ctx, m.op()) {
         tribute_passes::native::evidence::prepare_native_evidence_runtime(ctx, m);
@@ -917,6 +911,7 @@ fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Dump
     } else {
         tribute_passes::native::evidence::lower_evidence_to_native(ctx, m);
     }
+    finalize_target_closure_storage(ctx, m, closure_boundary);
     if cfg!(debug_assertions) {
         let result = trunk_ir::validation::validate_value_integrity(ctx, m);
         if !result.is_ok() {
@@ -929,6 +924,61 @@ fn run_native_target_pipeline(ctx: &mut IrContext, m: Module) -> Result<(), Dump
 
     run_cleanup_passes(ctx, m);
     Ok(())
+}
+
+/// Keep legacy closure lowering on its established shared path. Source-logical
+/// CPS modules cross the explicit target boundary below instead.
+fn lower_legacy_closures_before_target_boundary(
+    ctx: &mut IrContext,
+    m: Module,
+    core_module: core_dialect::Module,
+) -> PassResult {
+    if tribute_passes::target_abi::has_root_entry_contract(ctx, m) {
+        return Ok(());
+    }
+    let mut pm = PassManager::new();
+    pm.nest::<func_dialect::Func>()
+        .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
+    install_debug_use_chain_verifier(&mut pm);
+    pm.run(ctx, core_module)
+}
+
+#[derive(Clone, Copy)]
+enum TargetClosureStorageBoundary {
+    Legacy,
+    SourceLogicalCps,
+}
+
+/// Enter the sole target-side closure storage boundary. Exact ABI validation
+/// observes semantic closure types first; `LowerClosuresInFunc` then consumes
+/// any remaining closure operations before whole-module storage finalization.
+fn enter_target_closure_storage_boundary(
+    ctx: &mut IrContext,
+    m: Module,
+) -> Result<TargetClosureStorageBoundary, DumpIrError> {
+    if !tribute_passes::target_abi::has_root_entry_contract(ctx, m) {
+        return Ok(TargetClosureStorageBoundary::Legacy);
+    }
+    tribute_passes::target_abi::lower_cps_signatures_to_physical(ctx, m)?;
+    tribute_passes::target_abi::compose_root_entry_bridge(ctx, m)?;
+    let core_module = core_dialect::Module::from_op(ctx, m.op())
+        .expect("target closure lowering requires a core.module");
+    let mut pm = PassManager::new();
+    pm.nest::<func_dialect::Func>()
+        .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
+    install_debug_use_chain_verifier(&mut pm);
+    pm.run(ctx, core_module)?;
+    Ok(TargetClosureStorageBoundary::SourceLogicalCps)
+}
+
+fn finalize_target_closure_storage(
+    ctx: &mut IrContext,
+    m: Module,
+    boundary: TargetClosureStorageBoundary,
+) {
+    if matches!(boundary, TargetClosureStorageBoundary::SourceLogicalCps) {
+        tribute_passes::closure_lower::finalize_closure_storage_layout(ctx, m);
+    }
 }
 
 /// Dump IR text after running the pipeline up to the target-specific passes.


### PR DESCRIPTION
## Summary
- preserve semantic closure types through exact target ABI validation, then lower active closure storage and finalize every type-bearing surface
- remove transient tribute.closure_callable_type metadata from final physical IR without weakening exact target ABI equality
- keep legacy closure lowering on its existing shared route behind one explicit compatibility boundary; target lowering no longer reruns LowerClosureLambda

Prerequisite for #825. Related to #774.

## Validation
- normal pre-commit hook: cargo clippy --workspace, cargo fmt -- --check, cargo nextest run --workspace (1979 passed; 1 existing leaky classification)
- focused closure storage, target ABI, pipeline, Wasm, and native-pipeline regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved closure compilation across native and WebAssembly targets.
  - Ensured closure types and storage layouts remain consistent throughout compilation.
  - Preserved distinctions between callable closures and raw closure storage.
  - Improved handling of legacy and CPS-based compilation paths.

- **Bug Fixes**
  - Prevented invalid direct transfers involving raw closure storage.
  - Avoided unnecessary lambda generation in supported target scenarios.

- **Documentation**
  - Updated compiler pipeline and intermediate representation documentation to reflect revised closure-lowering stages and target-specific storage finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->