### PR TITLE
feat(ir): declare indirect callable signatures

### DIFF
--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -3,6 +3,8 @@
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
+use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -204,8 +206,21 @@ pub fn cps_dispatch_type(
 /// Callers must reject absent or malformed outer closure provenance rather than infer a
 /// callable contract from a structurally similar type.
 pub fn cps_closure_function_type(ctx: &IrContext, closure: TypeRef) -> Option<TypeRef> {
+    physical_closure_function_type(ctx, closure, CallingConvention::Cps)
+}
+
+/// Return the exact `core.func` contract only for a provenance-bearing physical closure
+/// with the requested convention.
+///
+/// The result comes from the closure type's explicit callable contract, never from
+/// an erased closure operand or its runtime storage shape.
+pub fn physical_closure_function_type(
+    ctx: &IrContext,
+    closure: TypeRef,
+    convention: CallingConvention,
+) -> Option<TypeRef> {
     let environment_index = get_physical_closure_environment_index(ctx, closure)?;
-    if get_physical_closure_convention(ctx, closure) != Some(CallingConvention::Cps) {
+    if get_physical_closure_convention(ctx, closure) != Some(convention) {
         return None;
     }
     let [function] = ctx.types.get(closure).params.as_slice() else {
@@ -224,6 +239,10 @@ fn generated_cps_closure_type(ctx: &mut IrContext, function: TypeRef) -> TypeRef
 }
 
 /// Attach the exact callable signature to an indirect transfer.
+///
+/// On `func.*` this is the dialect-declared `signature` attribute. Target
+/// lowering carries the same canonical attribute onto its own indirect
+/// transfer operations until their backend-specific signature index is ready.
 pub fn set_indirect_call_signature(ctx: &mut IrContext, op: OpRef, signature: TypeRef) {
     ctx.op_mut(op).attributes.insert(
         Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
@@ -233,7 +252,14 @@ pub fn set_indirect_call_signature(ctx: &mut IrContext, op: OpRef, signature: Ty
 
 /// Read the exact callable signature retained on an indirect transfer.
 pub fn get_indirect_call_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
-    ctx.op(op).attributes.get_type(INDIRECT_CALL_SIGNATURE_ATTR)
+    func::CallIndirect::from_op(ctx, op)
+        .ok()
+        .and_then(|call| call.signature(ctx))
+        .or_else(|| {
+            func::TailCallIndirect::from_op(ctx, op)
+                .ok()
+                .and_then(|tail| tail.signature(ctx))
+        })
 }
 
 /// Retain a typed closure contract on its canonical runtime pair.

--- a/crates/tribute-front/src/ast_to_ir/lower/control.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/control.rs
@@ -103,7 +103,14 @@ pub(super) fn invoke_continuation<D: ControlDomain>(
     let closure_ty = builder.ctx.closure_type(builder.ir, closure_func_ty);
     let continuation = builder.cast_if_needed(location, continuation.0, closure_ty);
     let value = builder.cast_if_needed(location, value, anyref_ty);
-    let call = func::call_indirect(builder.ir, location, continuation, vec![value], anyref_ty);
+    let call = func::call_indirect(
+        builder.ir,
+        location,
+        continuation,
+        vec![value],
+        anyref_ty,
+        None,
+    );
     builder.ir.push_op(builder.block, call.op_ref());
     control_from_abi(call.result(builder.ir))
 }

--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -404,6 +404,7 @@ fn lower_value_impl<'db>(
                                     callee_closure,
                                     vec![resume_anyref],
                                     anyref_ty,
+                                    None,
                                 );
                                 set_calling_convention(
                                     builder.ir,
@@ -477,6 +478,7 @@ fn lower_value_impl<'db>(
                                 callee,
                                 hidden_args,
                                 call_result_ty,
+                                None,
                             );
                             set_calling_convention(builder.ir, op.op_ref(), convention);
                             builder.ir.push_op(builder.block, op.op_ref());
@@ -576,6 +578,7 @@ fn lower_value_impl<'db>(
                         callee,
                         hidden_args,
                         call_result_ty,
+                        None,
                     );
                     set_calling_convention(builder.ir, op.op_ref(), convention);
                     builder.ir.push_op(builder.block, op.op_ref());
@@ -1382,8 +1385,9 @@ fn lower_cps_call_expr<'db, D: ControlDomain>(
                 let mut cps_args = vec![evidence, continuation];
                 cps_args.append(&mut arg_values);
 
-                let call_op =
-                    func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty);
+                let call_op = func::call_indirect(
+                    builder.ir, location, callee_cps, cps_args, anyref_ty, None,
+                );
                 set_calling_convention(builder.ir, call_op.op_ref(), CallingConvention::Cps);
                 builder.ir.push_op(builder.block, call_op.op_ref());
                 Some(control_from_abi(call_op.result(builder.ir)))
@@ -1405,7 +1409,7 @@ fn lower_cps_call_expr<'db, D: ControlDomain>(
             let mut cps_args = vec![evidence, continuation];
             cps_args.append(&mut arg_values);
             let call_op =
-                func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty);
+                func::call_indirect(builder.ir, location, callee_cps, cps_args, anyref_ty, None);
             set_calling_convention(builder.ir, call_op.op_ref(), CallingConvention::Cps);
             builder.ir.push_op(builder.block, call_op.op_ref());
             Some(control_from_abi(call_op.result(builder.ir)))

--- a/crates/tribute-front/src/ast_to_ir/lower/handle.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/handle.rs
@@ -327,6 +327,7 @@ fn build_cps_body<'db>(
         body_closure,
         vec![super::control::continuation_abi(done_k)],
         result_ty,
+        None,
     );
     builder.ir.push_op(builder.block, call_op.op_ref());
     Some(call_op.result(builder.ir))

--- a/crates/tribute-front/src/ast_to_ir/lower/mod.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/mod.rs
@@ -658,6 +658,7 @@ pub(super) fn emit_done_k_call(
         done_k_closure,
         vec![result_anyref],
         anyref_ty,
+        None,
     );
     builder.ir.push_op(builder.block, call.op_ref());
 

--- a/crates/tribute-passes/src/backend_ready.rs
+++ b/crates/tribute-passes/src/backend_ready.rs
@@ -302,7 +302,7 @@ impl<'ctx> RecursiveLegalityWalker<'ctx> {
         }
         key == Symbol::new(match self.backend {
             TributeBackend::Native => "sig",
-            TributeBackend::Wasm => "func.indirect_call_signature",
+            TributeBackend::Wasm => "signature",
         })
     }
 

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -27,7 +27,7 @@ use tribute_core::calling_convention::{
 };
 use tribute_core::{
     CallableAbi, CallingConvention, get_calling_convention, get_closure_callable_type,
-    get_physical_closure_convention, set_closure_callable_type, set_indirect_call_signature,
+    get_physical_closure_convention, set_closure_callable_type,
 };
 use tribute_ir::dialect::closure;
 use tribute_ir::dialect::tribute_rt;
@@ -321,18 +321,31 @@ impl RewritePattern for LowerClosureCallArena {
             legacy.extend_from_slice(&args);
             legacy
         };
-        let new_call = func::call_indirect(ctx, loc, table_idx, new_args, callee_return_ty);
-        if let Some(contract) = exact_contract {
+        let signature = exact_contract
+            .as_ref()
+            .map(|contract| contract.signature)
+            .unwrap_or_else(|| {
+                core::func(
+                    ctx,
+                    callee_return_ty,
+                    new_args
+                        .iter()
+                        .map(|&value| ctx.value_ty(value))
+                        .collect::<Vec<_>>(),
+                )
+                .as_type_ref()
+            });
+        let new_call = func::call_indirect(
+            ctx,
+            loc,
+            table_idx,
+            new_args,
+            callee_return_ty,
+            Some(signature),
+        );
+        if exact_contract.is_some() {
             let attributes = ctx.op(op).attributes.clone();
             ctx.op_mut(new_call.op_ref()).attributes.extend(attributes);
-            set_indirect_call_signature(ctx, new_call.op_ref(), contract.signature);
-        } else {
-            let parameter_types = ctx.op_operands(new_call.op_ref())[1..]
-                .iter()
-                .map(|&value| ctx.value_ty(value))
-                .collect::<Vec<_>>();
-            let signature = core::func(ctx, callee_return_ty, parameter_types).as_type_ref();
-            set_indirect_call_signature(ctx, new_call.op_ref(), signature);
         }
 
         rewriter.insert_op(table_idx_op.op_ref());
@@ -403,10 +416,15 @@ impl RewritePattern for LowerClosureTailCallArena {
             args[index] = cast.result(ctx);
         }
         args.insert(contract.environment_index, environment.result(ctx));
-        let tail = func::tail_call_indirect(ctx, location, func_ref.result(ctx), args);
+        let tail = func::tail_call_indirect(
+            ctx,
+            location,
+            func_ref.result(ctx),
+            args,
+            Some(contract.signature),
+        );
         let attributes = ctx.op(op).attributes.clone();
         ctx.op_mut(tail.op_ref()).attributes.extend(attributes);
-        set_indirect_call_signature(ctx, tail.op_ref(), contract.signature);
 
         rewriter.insert_op(func_ref.op_ref());
         rewriter.insert_op(environment.op_ref());
@@ -1080,7 +1098,7 @@ mod tests {
             "module entrypoint should lower closure accessors:\n{ir}"
         );
         assert_eq!(
-            ir.matches("func.indirect_call_signature").count(),
+            ir.matches("signature").count(),
             2,
             "each lowered indirect call must retain an exact signature:\n{ir}"
         );

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -344,8 +344,7 @@ impl RewritePattern for LowerClosureCallArena {
             Some(signature),
         );
         if exact_contract.is_some() {
-            let attributes = ctx.op(op).attributes.clone();
-            ctx.op_mut(new_call.op_ref()).attributes.extend(attributes);
+            copy_indirect_call_attributes(ctx, op, new_call.op_ref());
         }
 
         rewriter.insert_op(table_idx_op.op_ref());
@@ -423,8 +422,7 @@ impl RewritePattern for LowerClosureTailCallArena {
             args,
             Some(contract.signature),
         );
-        let attributes = ctx.op(op).attributes.clone();
-        ctx.op_mut(tail.op_ref()).attributes.extend(attributes);
+        copy_indirect_call_attributes(ctx, op, tail.op_ref());
 
         rewriter.insert_op(func_ref.op_ref());
         rewriter.insert_op(environment.op_ref());
@@ -435,6 +433,13 @@ impl RewritePattern for LowerClosureTailCallArena {
     fn name(&self) -> &'static str {
         "LowerClosureTailCallArena"
     }
+}
+
+/// Copy source metadata without replacing the physical indirect-call contract.
+fn copy_indirect_call_attributes(ctx: &mut IrContext, source: OpRef, destination: OpRef) {
+    let mut attributes = ctx.op(source).attributes.clone();
+    attributes.remove(func::INDIRECT_CALL_SIGNATURE_ATTR);
+    ctx.op_mut(destination).attributes.extend(attributes);
 }
 
 fn physical_closure_type_for_callee(ctx: &IrContext, callee: ValueRef) -> Option<TypeRef> {
@@ -1218,7 +1223,7 @@ mod tests {
                 r#"core.module @test {{
   !cps = closure.closure(core.func(core.never, {ev}, core.i32, core.i32, core.i32)) {{tribute.calling_convention = 2, tribute.closure_environment_index = 1}}
   func.func @run(%callee: !cps, %evidence: {ev}, %done: core.i32, %dispatch: core.i32, %value: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
-    func.tail_call_indirect %callee, %evidence, %done, %dispatch, %value {{tribute.calling_convention = 2}}
+    func.tail_call_indirect %callee, %evidence, %done, %dispatch, %value {{tribute.calling_convention = 2, signature = core.func(core.never, {ev}, core.i32, core.i32, core.i32)}}
   }}
 }}"#
             ),
@@ -1241,7 +1246,6 @@ mod tests {
             .unwrap();
         let signature = tribute_core::get_indirect_call_signature(&ctx, tail).unwrap();
         let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
-        assert_eq!(callable.params(&ctx).len(), 5);
         assert_eq!(ctx.op_operands(tail).len(), 6);
         assert_eq!(ctx.op_operands(tail)[1], evidence);
         assert_eq!(
@@ -1251,6 +1255,14 @@ mod tests {
         assert_eq!(ctx.op_operands(tail)[3], done);
         assert_eq!(ctx.op_operands(tail)[4], dispatch);
         assert_eq!(ctx.op_operands(tail)[5], value);
+        assert_eq!(
+            callable.params(&ctx),
+            ctx.op_operands(tail)[1..]
+                .iter()
+                .map(|&operand| ctx.value_ty(operand))
+                .collect::<Vec<_>>(),
+            "the physical signature must include the inserted environment operand"
+        );
     }
 
     #[test]

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -373,6 +373,7 @@ impl RewritePattern for LowerLegacyEffectDispatchCpsToNative {
                 dispatch_op.payload(ctx),
             ],
             *result_ty,
+            None,
         );
         attach_exact_indirect_signature(ctx, call.op_ref());
         let result = call.result(ctx);
@@ -578,6 +579,7 @@ impl RewritePattern for LowerEffectDispatchTailToNative {
                 dispatch_op.payload(ctx),
             ],
             result_ty,
+            None,
         );
         attach_exact_indirect_signature(ctx, call.op_ref());
         let new_result = call.result(ctx);
@@ -658,6 +660,7 @@ impl RewritePattern for LowerEffectDispatchCpsToNative {
                 op_idx_val,
                 dispatch_op.payload(ctx),
             ],
+            None,
         );
         attach_exact_indirect_signature(ctx, tail.op_ref());
         set_calling_convention(ctx, tail.op_ref(), tribute_core::CallingConvention::Cps);
@@ -1247,7 +1250,7 @@ mod tests {
             "the native tail must not cast the explicit dispatch operand: {output}"
         );
         assert!(output.contains("func.tail_call_indirect"), "{output}");
-        assert!(output.contains("func.indirect_call_signature"), "{output}");
+        assert!(output.contains("signature"), "{output}");
         assert!(
             output.contains("tribute.calling_convention = 2"),
             "{output}"

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -1188,7 +1188,7 @@ fn direct_indirect_return_and_tail_contracts_are_typed() {
   func.func @caller(%value: !R, %callee: core.func(!R, !R)) -> !R {
     %seen = func.call %value {callee = @observe} : core.i32
     %direct = func.call %value {callee = @ordinary} : !R
-    %indirect = func.call_indirect %callee, %direct {func.indirect_call_signature = core.func(!R, !R)} : !R
+    %indirect = func.call_indirect %callee, %direct {signature = core.func(!R, !R)} : !R
     func.return %indirect
   }
   func.func @tail(%value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
@@ -1232,7 +1232,7 @@ fn stale_identity_unsupported_regions_and_malformed_calls_fail_unchanged() {
   !R = adt.typeref() {name = @R}
   !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
   func.func @f(%value: !R, %callee: core.func(!R, !R)) -> !R {
-    %x = func.call_indirect %callee {func.indirect_call_signature = core.func(!R, !R)} : !R
+    %x = func.call_indirect %callee {signature = core.func(!R, !R)} : !R
     func.return %x
   }
 }"#,

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -914,6 +914,7 @@ fn transform_shifts_in_block(
                                     .chain(operands[2..].iter().copied())
                                     .collect::<Vec<_>>(),
                                 ctx.op_result_types(candidate)[0],
+                                None,
                             );
                             attach_exact_indirect_signature(ctx, new_call.op_ref());
                             let old_result = ctx.op_result(candidate, 0);
@@ -1000,7 +1001,8 @@ fn transform_shifts_in_block(
                     let mut new_args = vec![ev_value];
                     new_args.extend(current_operands[2..].iter().copied());
 
-                    let new_call = func::call_indirect(ctx, loc, table_idx, new_args, result_ty);
+                    let new_call =
+                        func::call_indirect(ctx, loc, table_idx, new_args, result_ty, None);
                     attach_exact_indirect_signature(ctx, new_call.op_ref());
 
                     if !ctx.op_results(op).is_empty() {

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -1111,7 +1111,7 @@ mod tests {
   func.func @evidence() -> core.never attributes {tribute.calling_convention = 1} { func.unreachable }
   func.func @cps() -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
   func.func @run(%callee: core.i32, %evidence: core.i32, %env: tribute_rt.anyref, %done: core.i32, %dispatch: core.i32, %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %evidence, %env, %done, %dispatch, %value {func.indirect_call_signature = core.func(core.never, core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %evidence, %env, %done, %dispatch, %value {signature = core.func(core.never, core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32), tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -1136,7 +1136,7 @@ mod tests {
         }
         let printed = print_module(&ctx, module.op());
         assert!(
-            printed.contains("func.indirect_call_signature = core.func(core.nil"),
+            printed.contains("signature = core.func(core.nil"),
             "{printed}"
         );
         assert!(
@@ -1311,6 +1311,14 @@ mod tests {
   }
 }"#,
                 "lacks exact callable signature",
+            ),
+            (
+                r#"core.module @test {
+  func.func @run(%callee: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee {signature = core.i32, tribute.calling_convention = 2}
+  }
+}"#,
+                "indirect callable signature is not core.func",
             ),
             (
                 r#"core.module @test {

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -11,11 +11,11 @@ use std::fmt;
 use tribute_core::calling_convention::{
     cps_closure_function_type, cps_completion_type, cps_continuation_frame_layout_type,
     cps_continuation_frame_ref_type, cps_done_type, cps_resume_exact_type,
-    physical_closure_type_with_environment_index,
+    physical_closure_function_type, physical_closure_type_with_environment_index,
 };
 use tribute_core::{
     CALLING_CONVENTION_ATTR, CallableAbi, CallingConvention, physical_closure_type,
-    set_calling_convention, set_indirect_call_signature,
+    set_calling_convention,
 };
 use tribute_ir::dialect::{ability, closure, effect, tribute_control, tribute_rt};
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
@@ -872,9 +872,8 @@ impl<'a> Converter<'a> {
                 "CPS indirect tail operands differ from the exact closure contract",
             ));
         }
-        let tail = func::tail_call_indirect(self.ctx, location, callee, args);
+        let tail = func::tail_call_indirect(self.ctx, location, callee, args, Some(signature));
         set_calling_convention(self.ctx, tail.op_ref(), CallingConvention::Cps);
-        set_indirect_call_signature(self.ctx, tail.op_ref(), signature);
         self.ctx.push_op(block, tail.op_ref());
         Ok(tail.op_ref())
     }
@@ -3074,12 +3073,26 @@ impl<'a> Converter<'a> {
             if general {
                 self.emit_cps_tail_call_indirect(case_block, location, arm.value, call_args)?;
             } else {
+                let signature = physical_closure_function_type(
+                    self.ctx,
+                    self.ctx.value_ty(arm.value),
+                    CallingConvention::EvidenceDirect,
+                )
+                .ok_or_else(|| {
+                    TributeControlToCpsError::one(
+                        POST_CPS_BOUNDARY,
+                        Some(arm.op),
+                        Some(location),
+                        "fn handler indirect callee has no exact provenance-bearing closure contract",
+                    )
+                })?;
                 let call = func::call_indirect(
                     self.ctx,
                     location,
                     arm.value,
                     call_args,
                     arm.operation_result,
+                    Some(signature),
                 );
                 set_calling_convention(self.ctx, call.op_ref(), CallingConvention::EvidenceDirect);
                 self.ctx.push_op(case_block, call.op_ref());
@@ -3499,7 +3512,8 @@ impl<'a> Converter<'a> {
                             .map(|arg| mapping.get(arg).copied().unwrap_or(*arg)),
                     );
                     let result_type = self.convert_type(self.ctx.op_result_types(source)[0]);
-                    let call = func::call_indirect(self.ctx, location, callee, args, result_type);
+                    let call =
+                        func::call_indirect(self.ctx, location, callee, args, result_type, None);
                     set_calling_convention(self.ctx, call.op_ref(), convention);
                     self.ctx.push_op(block, call.op_ref());
                     mapping.insert(self.ctx.op_result(source, 0), call.result(self.ctx));
@@ -5164,10 +5178,7 @@ mod tests {
         crate::closure_lower::lower_closures(&mut ctx, module);
         let lowered = print_module(&ctx, module.op());
         assert!(!lowered.contains("closure.new"), "{lowered}");
-        assert!(
-            lowered.contains("func.indirect_call_signature"),
-            "{lowered}"
-        );
+        assert!(lowered.contains("signature"), "{lowered}");
     }
 
     #[test]
@@ -5586,6 +5597,35 @@ mod tests {
         assert!(!printed.contains("@consumed"));
         assert!(!printed.contains("adt.struct_set"));
         assert!(printed.contains("tribute.calling_convention = 1"));
+        let mut indirect_calls = Vec::new();
+        fn collect_indirect_calls(ctx: &IrContext, op: OpRef, calls: &mut Vec<OpRef>) {
+            if func::CallIndirect::matches(ctx, op) {
+                calls.push(op);
+            }
+            for region in ctx.op(op).regions.iter().copied() {
+                for block in ctx.region(region).blocks.iter().copied() {
+                    for child in ctx.block(block).ops.iter().copied() {
+                        collect_indirect_calls(ctx, child, calls);
+                    }
+                }
+            }
+        }
+        collect_indirect_calls(&ctx, module.op(), &mut indirect_calls);
+        let call = indirect_calls
+            .into_iter()
+            .find(|op| {
+                tribute_core::get_calling_convention(&ctx, *op)
+                    == Some(CallingConvention::EvidenceDirect)
+            })
+            .expect("fn handler dispatcher call");
+        let call = func::CallIndirect::from_op(&ctx, call).unwrap();
+        let expected = physical_closure_function_type(
+            &ctx,
+            ctx.value_ty(call.callee(&ctx)),
+            CallingConvention::EvidenceDirect,
+        )
+        .expect("fn arm retains an exact closure contract");
+        assert_eq!(call.signature(&ctx), Some(expected));
     }
 
     #[test]

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -1473,7 +1473,8 @@ mod tests {
             output.contains("tribute.calling_convention = 2"),
             "{output}"
         );
-        assert!(output.contains("signature"), "{output}");
+        assert!(output.contains("signature ="), "{output}");
+        assert!(!output.contains("func.indirect_call_signature"), "{output}");
     }
 
     #[test]

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -1473,7 +1473,7 @@ mod tests {
             output.contains("tribute.calling_convention = 2"),
             "{output}"
         );
-        assert!(output.contains("func.indirect_call_signature"), "{output}");
+        assert!(output.contains("signature"), "{output}");
     }
 
     #[test]

--- a/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
+++ b/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
@@ -191,7 +191,8 @@ impl RewritePattern for NormalizeCallIndirectPattern {
             .expect("NormalizeCallIndirectPattern: func.call_indirect matched but has no operands");
         let args: Vec<_> = operands[1..].to_vec();
 
-        let new_op = func::call_indirect(ctx, loc, callee, args, new_result_ty);
+        let signature = tribute_core::get_indirect_call_signature(ctx, op);
+        let new_op = func::call_indirect(ctx, loc, callee, args, new_result_ty, signature);
         rewriter.replace_op(new_op.op_ref());
         true
     }

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -532,7 +532,7 @@ mod tests {
     func.tail_call %value {callee = @direct_target, tribute.calling_convention = 2}
   }
   func.func @indirect_caller(%callee: core.ptr, %value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.nil, core.i32), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32), tribute.calling_convention = 2}
   }
 }"#;
 
@@ -613,7 +613,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.i32, core.i32), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %value {signature = core.func(core.i32, core.i32), tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -632,7 +632,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.nil, core.i32)}
+    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32)}
   }
 }"#,
         );
@@ -653,7 +653,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {func.indirect_call_signature = core.func(core.nil, core.i32), tribute.calling_convention = 0}
+    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32), tribute.calling_convention = 0}
   }
 }"#,
         );

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -1235,7 +1235,7 @@ mod tests {
     wasm.return
   }
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
   }
   wasm.export_func {name = "caller", func = @caller}
 }"#,
@@ -1285,7 +1285,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
   }
 }"#,
         );
@@ -1327,7 +1327,7 @@ mod tests {
             r#"core.module @test {
   wasm.func @tail_indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
     wasm.block {
-      wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+      wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
     }
   }
   wasm.func @tail_direct(%value: core.i32) -> core.nil {

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -117,9 +117,7 @@ pub(crate) fn exact_return_call_indirect_signature(
         .attributes
         .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
         .ok_or_else(|| {
-            CompilationError::invalid_module(
-                "wasm.return_call_indirect lacks func.indirect_call_signature",
-            )
+            CompilationError::invalid_module("wasm.return_call_indirect lacks signature")
         })?;
     let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
         CompilationError::invalid_module("wasm.return_call_indirect signature must be core.func")

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -325,7 +325,7 @@ impl RewritePattern for FuncTailCallPattern {
 /// Pattern for `func.tail_call_indirect` -> `wasm.return_call_indirect`.
 ///
 /// The shared physical-ABI boundary retains the precise callee signature in
-/// `func.indirect_call_signature` after closure lowering has replaced the
+/// `signature` after closure lowering has replaced the
 /// typed closure with a table index.  This backend must carry that metadata
 /// through instead of rebuilding a signature from the runtime operands.
 struct FuncTailCallIndirectPattern;
@@ -563,7 +563,7 @@ mod tests {
     func.tail_call %value {callee = @target}
   }
   func.func @indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32)}
+    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32)}
   }
   func.func @ordinary(%table_index: core.i32, %value: core.i32) -> core.i32 {
     %result = func.call_indirect %table_index, %value : core.i32
@@ -585,7 +585,7 @@ mod tests {
         );
         assert!(output.contains(" = wasm.call_indirect "), "{output}");
         assert!(
-            output.contains("func.indirect_call_signature = core.func(core.nil, core.i32)"),
+            output.contains("signature = core.func(core.nil, core.i32)"),
             "{output}"
         );
     }
@@ -601,7 +601,7 @@ mod tests {
   }
   func.func @caller(%value: core.i32) -> core.nil {
     %table_index = func.constant {func_ref = @target} : core.i32
-    func.tail_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32)}
+    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32)}
   }
 }"#,
         );
@@ -629,7 +629,7 @@ mod tests {
     func.tail_call_indirect %table_index, %value
   }
   func.func @malformed(%table_index: core.i32, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.i32, core.i32)}
+    func.tail_call_indirect %table_index, %value {signature = core.func(core.i32, core.i32)}
   }
 }"#,
         );

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -128,13 +128,13 @@ mod tests {
     wasm.return_call_indirect %table_index, %value {table = 0, type_idx = 0}
   }
 }"#,
-            "lacks func.indirect_call_signature",
+            "lacks signature",
         );
 
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.i32, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = core.i32, table = 0, type_idx = 0}
   }
 }"#,
             "signature must be core.func",
@@ -143,7 +143,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.i32, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.i32, core.i32), table = 0, type_idx = 0}
   }
 }"#,
             "must have an empty result",
@@ -152,7 +152,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller() -> core.nil {
-    wasm.return_call_indirect {func.indirect_call_signature = core.func(core.nil), table = 0, type_idx = 0}
+    wasm.return_call_indirect {signature = core.func(core.nil), table = 0, type_idx = 0}
   }
 }"#,
             "requires a table index operand",
@@ -161,7 +161,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i64, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
   }
 }"#,
             "first operand must be an i32 table index",
@@ -170,7 +170,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i64) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {func.indirect_call_signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
   }
 }"#,
             "operands do not match its exact signature",

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -1,8 +1,8 @@
 //! Arena-based func dialect.
 
-/// Exact callable signature retained after a typed indirect callee becomes a
-/// runtime function or table index.
-pub const INDIRECT_CALL_SIGNATURE_ATTR: &str = "func.indirect_call_signature";
+/// The optional exact callable signature retained after a typed indirect callee
+/// becomes a runtime function or table index.
+pub const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
 
 // === Operation registrations ===
 crate::register_pure_op!(func.constant);
@@ -19,11 +19,13 @@ mod func {
     #[attr(callee: Symbol)]
     fn call(#[rest] args: ()) -> result {}
 
+    #[attr(signature?: Type)]
     fn call_indirect(callee: (), #[rest] args: ()) -> result {}
 
     #[attr(callee: Symbol)]
     fn tail_call(#[rest] args: ()) {}
 
+    #[attr(signature?: Type)]
     fn tail_call_indirect(callee: (), #[rest] args: ()) {}
 
     fn r#return(#[rest] values: ()) {}
@@ -246,5 +248,35 @@ inventory::submit! {
         op_name: "func",
         print_fn: print_func,
         parse_fn: parse_func,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::DialectOp;
+    use crate::parser::parse_test_module;
+    use crate::printer::print_module;
+
+    #[test]
+    fn indirect_signature_is_declared_and_round_trips() {
+        let input = r#"core.module @test {
+  func.func @run(%callee: core.func(core.i32, core.i32), %value: core.i32) -> core.i32 {
+    %result = func.call_indirect %callee, %value {signature = core.func(core.i32, core.i32)} : core.i32
+    func.return %result
+  }
+}"#;
+        let mut ctx = crate::IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let function = Func::from_op(&ctx, ctx.block(module.first_block(&ctx).unwrap()).ops[0])
+            .expect("function");
+        let body = function.body_if_present(&ctx).expect("function body");
+        let call = CallIndirect::from_op(&ctx, ctx.block(ctx.region(body).blocks[0]).ops[0])
+            .expect("indirect call");
+        assert!(call.signature(&ctx).is_some(), "declared signature");
+
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("signature = core.func(core.i32, core.i32)"));
+        assert!(!printed.contains("func.indirect_call_signature"));
     }
 }

--- a/crates/trunk-ir/src/dialect/mod.rs
+++ b/crates/trunk-ir/src/dialect/mod.rs
@@ -344,6 +344,7 @@ mod tests {
             v1,     // callee
             [v2],   // args
             i32_ty, // result type
+            None,   // exact signature
         );
 
         assert_eq!(call.callee(&ctx), v1);

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -900,7 +900,7 @@ mod tests {
         assert_eq!(nil_merge_args, expected_nil_merge_args);
 
         let printed = crate::printer::print_module(&ctx, module.op());
-        assert!(printed.contains("func.indirect_call_signature = core.func(core.never, core.nil)"));
+        assert!(printed.contains("signature = core.func(core.never, core.nil)"));
         assert!(printed.contains("tribute.calling_convention = 2"));
     }
 
@@ -914,7 +914,7 @@ mod tests {
     } {
       scf.yield %unit
     }
-    func.tail_call_indirect %callee, %selected {func.indirect_call_signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %selected {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
   }
 }"#,
             1,
@@ -926,9 +926,9 @@ mod tests {
         let input = r#"core.module @test {
   func.func @main(%cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     %discarded = scf.if %cond : core.never {
-      func.tail_call_indirect %callee, %unit {func.indirect_call_signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+      func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
     } {
-      func.tail_call_indirect %callee, %unit {func.indirect_call_signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+      func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
     }
   }
 }"#;
@@ -983,7 +983,7 @@ mod tests {
     } {
       scf.yield %inner
     }
-    func.tail_call_indirect %callee, %outer {func.indirect_call_signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %outer {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
   }
 }"#,
             2,

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -690,6 +690,12 @@ make these attributes round-trip explicitly.
 
 `func.*` represents function definitions, direct calls, indirect calls, function
 references, returns, tail calls, and unreachable control flow.
+`func.call_indirect`와 `func.tail_call_indirect`는 선택적 `signature: TypeRef`
+attribute로 erased callee/table index 이전의 exact `core.func` contract를 보존할 수
+있다. 일반 pre-contract indirect call은 이 attribute 없이 존재할 수 있지만,
+`tribute.calling_convention`이 붙은 indirect transfer는 exact `signature`를 반드시
+가지며 verifier가 operand/result 및 convention과 대조한다. Physical operand type,
+symbol, ABI string 또는 storage shape로 signature를 재구성하지 않는다.
 `func.tail_call_indirect`는 callable operand와 argument를 받고 result가 없는
 terminator다. Shared verifier는 callee `core.func`와 enclosing caller의 result가
 모두 `core.never`인지 검사한다. Native/Wasm signature lowering은 이를 empty result

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -68,7 +68,7 @@ core.module @direct_fn_native {
       %21 = tribute_rt.into_raw %18 : core.ptr
       %22 = tribute_rt.into_raw %15 : core.ptr
       %23 = func.call %0, %20, %19, %21, %22 {callee = @__tribute_evidence_extend} : core.ptr
-      %24 = func.call_indirect %11, %23, %12, %9 {func.indirect_call_signature = core.func(tribute_rt.anyref, !t2, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
+      %24 = func.call_indirect %11, %23, %12, %9 {signature = core.func(tribute_rt.anyref, !t2, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
       %25 = adt.variant_is %24 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %26 = scf.if %25 : tribute_rt.anyref {
           %27 = adt.variant_cast %24 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -77,7 +77,7 @@ core.module @direct_fn_native {
           %30 = func.call {callee = @__tribute_evidence_empty} : core.ptr
           %31 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
           %32 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %33 = func.call_indirect %31, %23, %32, %28 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %33 = func.call_indirect %31, %23, %32, %28 {signature = !t0} : tribute_rt.anyref
           scf.yield %33
       } {
           %34 = adt.variant_cast %24 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -88,7 +88,7 @@ core.module @direct_fn_native {
               %39 = func.call {callee = @__tribute_evidence_empty} : core.ptr
               %40 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
               %41 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %42 = func.call_indirect %40, %39, %41, %36 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+              %42 = func.call_indirect %40, %39, %41, %36 {signature = !t0} : tribute_rt.anyref
               scf.yield %42
           } {
               scf.yield %24
@@ -108,19 +108,19 @@ core.module @direct_fn_native {
       %7 = arith.const {value = 664197438} : core.i32
       %8 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
       %9 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-      %10 = func.call_indirect %8, %0, %9, %7, %4 {func.indirect_call_signature = !t3} : tribute_rt.anyref
+      %10 = func.call_indirect %8, %0, %9, %7, %4 {signature = !t3} : tribute_rt.anyref
       %11 = tribute_rt.unbox_int %10 : core.i32
       %12 = arith.const {value = 1361557906} : core.i32
       %13 = func.call %0, %12 {callee = @__tribute_evidence_lookup_tr} : core.ptr
       %14 = arith.const {value = 2110389019} : core.i32
       %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
       %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %17 = func.call_indirect %15, %0, %16, %14, %10 {func.indirect_call_signature = !t3} : tribute_rt.anyref
+      %17 = func.call_indirect %15, %0, %16, %14, %10 {signature = !t3} : tribute_rt.anyref
       %18 = core.unrealized_conversion_cast %17 : core.nil
       %19 = core.unrealized_conversion_cast %2 : closure.closure(!t1)
       %20 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
       %21 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-      %22 = func.call_indirect %20, %0, %21, %10 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+      %22 = func.call_indirect %20, %0, %21, %10 {signature = !t0} : tribute_rt.anyref
       func.return %22
   }
 
@@ -135,7 +135,7 @@ core.module @direct_fn_native {
           %13 = tribute_rt.box_int %12 : tribute_rt.anyref
           %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
           %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %13 {signature = !t0} : tribute_rt.anyref
           scf.yield %16
       } {
           %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -145,7 +145,7 @@ core.module @direct_fn_native {
           %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
           %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
           %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-          %24 = func.call_indirect %22, %0, %23, %21 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %24 = func.call_indirect %22, %0, %23, %21 {signature = !t0} : tribute_rt.anyref
           scf.yield %24
       }
       func.return %8
@@ -162,7 +162,7 @@ core.module @direct_fn_native {
           %11 = tribute_rt.box_int %10 : tribute_rt.anyref
           %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
           %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %14 = func.call_indirect %12, %0, %13, %11 {signature = !t0} : tribute_rt.anyref
           scf.yield %14
       } {
           %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -172,7 +172,7 @@ core.module @direct_fn_native {
           %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
           %20 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
           %21 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
-          %22 = func.call_indirect %20, %0, %21, %19 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %22 = func.call_indirect %20, %0, %21, %19 {signature = !t0} : tribute_rt.anyref
           scf.yield %22
       }
       func.return %6

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -76,7 +76,7 @@ core.module @mixed_nested_native {
       %21 = tribute_rt.into_raw %18 : core.ptr
       %22 = tribute_rt.into_raw %15 : core.ptr
       %23 = func.call %0, %20, %19, %21, %22 {callee = @__tribute_evidence_extend} : core.ptr
-      %24 = func.call_indirect %11, %23, %12, %9 {func.indirect_call_signature = !t4} : tribute_rt.anyref
+      %24 = func.call_indirect %11, %23, %12, %9 {signature = !t4} : tribute_rt.anyref
       %25 = adt.variant_is %24 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %26 = scf.if %25 : tribute_rt.anyref {
           %27 = adt.variant_cast %24 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -85,7 +85,7 @@ core.module @mixed_nested_native {
           %30 = func.call {callee = @__tribute_evidence_empty} : core.ptr
           %31 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
           %32 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %33 = func.call_indirect %31, %23, %32, %28 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %33 = func.call_indirect %31, %23, %32, %28 {signature = !t0} : tribute_rt.anyref
           scf.yield %33
       } {
           %34 = adt.variant_cast %24 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -96,7 +96,7 @@ core.module @mixed_nested_native {
               %39 = func.call {callee = @__tribute_evidence_empty} : core.ptr
               %40 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
               %41 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %42 = func.call_indirect %40, %39, %41, %36 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+              %42 = func.call_indirect %40, %39, %41, %36 {signature = !t0} : tribute_rt.anyref
               scf.yield %42
           } {
               scf.yield %24
@@ -124,7 +124,7 @@ core.module @mixed_nested_native {
       %15 = arith.const {value = 1348736788} : core.i32
       %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
       %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %18 = func.call_indirect %16, %0, %17, %10, %14, %15, %11 {func.indirect_call_signature = !t5} : tribute_rt.anyref
+      %18 = func.call_indirect %16, %0, %17, %10, %14, %15, %11 {signature = !t5} : tribute_rt.anyref
       func.return %18
   }
 
@@ -135,7 +135,7 @@ core.module @mixed_nested_native {
       %6 = arith.const {value = 664197438} : core.i32
       %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
       %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %6, %3 {func.indirect_call_signature = !t6} : tribute_rt.anyref
+      %9 = func.call_indirect %7, %0, %8, %6, %3 {signature = !t6} : tribute_rt.anyref
       %10 = tribute_rt.unbox_int %9 : core.i32
       %11 = adt.struct_new %10, %2 {type = !"step::__clam_0::env"} : !"step::__clam_0::env"
       %12 = func.constant {func_ref = @"step::__clam_0"} : !t1
@@ -147,7 +147,7 @@ core.module @mixed_nested_native {
       %18 = arith.const {value = 1972422014} : core.i32
       %19 = adt.struct_get %16 {field = 0, type = !_closure} : core.i32
       %20 = adt.struct_get %16 {field = 1, type = !_closure} : tribute_rt.anyref
-      %21 = func.call_indirect %19, %0, %20, %13, %17, %18, %14 {func.indirect_call_signature = !t5} : tribute_rt.anyref
+      %21 = func.call_indirect %19, %0, %20, %13, %17, %18, %14 {signature = !t5} : tribute_rt.anyref
       func.return %21
   }
 
@@ -163,7 +163,7 @@ core.module @mixed_nested_native {
           %14 = tribute_rt.box_int %12 : tribute_rt.anyref
           %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
           %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %17 = func.call_indirect %15, %0, %16, %14 {signature = !t0} : tribute_rt.anyref
           %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
           %19 = scf.if %18 : tribute_rt.anyref {
               %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -171,7 +171,7 @@ core.module @mixed_nested_native {
               %22 = tribute_rt.unbox_int %21 : core.i32
               %23 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
               %24 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %25 = func.call_indirect %23, %0, %24, %21 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+              %25 = func.call_indirect %23, %0, %24, %21 {signature = !t0} : tribute_rt.anyref
               %26 = adt.variant_cast %25 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
               %27 = adt.variant_get %26 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
               %28 = adt.variant_get %26 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -196,7 +196,7 @@ core.module @mixed_nested_native {
           %37 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
           %38 = adt.struct_get %36 {field = 0, type = !_closure} : core.i32
           %39 = adt.struct_get %36 {field = 1, type = !_closure} : tribute_rt.anyref
-          %40 = func.call_indirect %38, %0, %39, %37 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %40 = func.call_indirect %38, %0, %39, %37 {signature = !t0} : tribute_rt.anyref
           %41 = adt.variant_is %40 {tag = @Normal, type = !__tribute_cps_control} : core.i1
           %42 = scf.if %41 : tribute_rt.anyref {
               %43 = adt.variant_cast %40 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -204,7 +204,7 @@ core.module @mixed_nested_native {
               %45 = tribute_rt.unbox_int %44 : core.i32
               %46 = adt.struct_get %34 {field = 0, type = !_closure} : core.i32
               %47 = adt.struct_get %34 {field = 1, type = !_closure} : tribute_rt.anyref
-              %48 = func.call_indirect %46, %0, %47, %44 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+              %48 = func.call_indirect %46, %0, %47, %44 {signature = !t0} : tribute_rt.anyref
               %49 = adt.variant_cast %48 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
               %50 = adt.variant_get %49 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
               %51 = adt.variant_get %49 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -246,7 +246,7 @@ core.module @mixed_nested_native {
       %21 = core.unrealized_conversion_cast %18 : core.ptr
       %22 = tribute_rt.into_raw %17 : core.ptr
       %23 = func.call %0, %20, %19, %21, %22 {callee = @__tribute_evidence_extend} : core.ptr
-      %24 = func.call_indirect %13, %23, %14, %12 {func.indirect_call_signature = !t4} : tribute_rt.anyref
+      %24 = func.call_indirect %13, %23, %14, %12 {signature = !t4} : tribute_rt.anyref
       %25 = adt.variant_is %24 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %26 = scf.if %25 : tribute_rt.anyref {
           %27 = adt.variant_cast %24 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -254,7 +254,7 @@ core.module @mixed_nested_native {
           %29 = tribute_rt.unbox_int %28 : core.i32
           %30 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
           %31 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-          %32 = func.call_indirect %30, %23, %31, %28 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %32 = func.call_indirect %30, %23, %31, %28 {signature = !t0} : tribute_rt.anyref
           scf.yield %32
       } {
           %33 = adt.variant_cast %24 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -264,7 +264,7 @@ core.module @mixed_nested_native {
           %37 = scf.if %36 : tribute_rt.anyref {
               %38 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
               %39 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
-              %40 = func.call_indirect %38, %0, %39, %35 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+              %40 = func.call_indirect %38, %0, %39, %35 {signature = !t0} : tribute_rt.anyref
               scf.yield %40
           } {
               scf.yield %24
@@ -275,7 +275,7 @@ core.module @mixed_nested_native {
       %42 = core.unrealized_conversion_cast %2 : !t3
       %43 = adt.struct_get %42 {field = 0, type = !_closure} : core.i32
       %44 = adt.struct_get %42 {field = 1, type = !_closure} : tribute_rt.anyref
-      %45 = func.call_indirect %43, %0, %44, %26 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+      %45 = func.call_indirect %43, %0, %44, %26 {signature = !t0} : tribute_rt.anyref
       func.return %45
   }
 
@@ -290,7 +290,7 @@ core.module @mixed_nested_native {
           %13 = tribute_rt.box_int %12 : tribute_rt.anyref
           %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
           %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %13 {signature = !t0} : tribute_rt.anyref
           scf.yield %16
       } {
           %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -300,7 +300,7 @@ core.module @mixed_nested_native {
           %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
           %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
           %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-          %24 = func.call_indirect %22, %0, %23, %21 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %24 = func.call_indirect %22, %0, %23, %21 {signature = !t0} : tribute_rt.anyref
           scf.yield %24
       }
       func.return %8
@@ -317,7 +317,7 @@ core.module @mixed_nested_native {
           %11 = tribute_rt.box_int %10 : tribute_rt.anyref
           %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
           %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %14 = func.call_indirect %12, %0, %13, %11 {signature = !t0} : tribute_rt.anyref
           scf.yield %14
       } {
           %15 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -327,7 +327,7 @@ core.module @mixed_nested_native {
           %19 = core.unrealized_conversion_cast %18 : tribute_rt.anyref
           %20 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
           %21 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
-          %22 = func.call_indirect %20, %0, %21, %19 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+          %22 = func.call_indirect %20, %0, %21, %19 {signature = !t0} : tribute_rt.anyref
           scf.yield %22
       }
       func.return %6
@@ -345,14 +345,14 @@ core.module @mixed_nested_native {
       %11 = arith.const {value = 2110389019} : core.i32
       %12 = adt.struct_get %10 {field = 0, type = !_closure} : core.i32
       %13 = adt.struct_get %10 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = func.call_indirect %12, %0, %13, %11, %8 {func.indirect_call_signature = !t6} : tribute_rt.anyref
+      %14 = func.call_indirect %12, %0, %13, %11, %8 {signature = !t6} : tribute_rt.anyref
       %15 = core.unrealized_conversion_cast %14 : core.nil
       %16 = arith.addi %5, %4 : core.i32
       %17 = core.unrealized_conversion_cast %6 : !t3
       %18 = tribute_rt.box_int %16 : tribute_rt.anyref
       %19 = adt.struct_get %17 {field = 0, type = !_closure} : core.i32
       %20 = adt.struct_get %17 {field = 1, type = !_closure} : tribute_rt.anyref
-      %21 = func.call_indirect %19, %0, %20, %18 {func.indirect_call_signature = !t0} : tribute_rt.anyref
+      %21 = func.call_indirect %19, %0, %20, %18 {signature = !t0} : tribute_rt.anyref
       func.return %21
   }
 

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -71,7 +71,7 @@ core.module @resumptive_op_native {
       %19 = core.unrealized_conversion_cast %16 : core.ptr
       %20 = tribute_rt.into_raw %15 : core.ptr
       %21 = func.call %0, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
-      %22 = func.call_indirect %11, %21, %12, %9 {func.indirect_call_signature = core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
+      %22 = func.call_indirect %11, %21, %12, %9 {signature = core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
       %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %24 = scf.if %23 : tribute_rt.anyref {
           %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -80,7 +80,7 @@ core.module @resumptive_op_native {
           %28 = func.call {callee = @__tribute_evidence_empty} : core.ptr
           %29 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
           %30 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %31 = func.call_indirect %29, %21, %30, %26 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %31 = func.call_indirect %29, %21, %30, %26 {signature = !t1} : tribute_rt.anyref
           scf.yield %31
       } {
           %32 = adt.variant_cast %22 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -91,7 +91,7 @@ core.module @resumptive_op_native {
               %37 = func.call {callee = @__tribute_evidence_empty} : core.ptr
               %38 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
               %39 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %40 = func.call_indirect %38, %37, %39, %34 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %40 = func.call_indirect %38, %37, %39, %34 {signature = !t1} : tribute_rt.anyref
               scf.yield %40
           } {
               scf.yield %22
@@ -119,7 +119,7 @@ core.module @resumptive_op_native {
       %15 = arith.const {value = 1348736788} : core.i32
       %16 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
       %17 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-      %18 = func.call_indirect %16, %0, %17, %10, %14, %15, %11 {func.indirect_call_signature = !t4} : tribute_rt.anyref
+      %18 = func.call_indirect %16, %0, %17, %10, %14, %15, %11 {signature = !t4} : tribute_rt.anyref
       func.return %18
   }
 
@@ -135,7 +135,7 @@ core.module @resumptive_op_native {
       %11 = arith.const {value = 1972422014} : core.i32
       %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
       %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-      %14 = func.call_indirect %12, %0, %13, %6, %10, %11, %7 {func.indirect_call_signature = !t4} : tribute_rt.anyref
+      %14 = func.call_indirect %12, %0, %13, %6, %10, %11, %7 {signature = !t4} : tribute_rt.anyref
       func.return %14
   }
 
@@ -151,7 +151,7 @@ core.module @resumptive_op_native {
           %14 = tribute_rt.box_int %12 : tribute_rt.anyref
           %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
           %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %17 = func.call_indirect %15, %0, %16, %14 {signature = !t1} : tribute_rt.anyref
           %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
           %19 = scf.if %18 : tribute_rt.anyref {
               %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -159,7 +159,7 @@ core.module @resumptive_op_native {
               %22 = tribute_rt.unbox_int %21 : core.i32
               %23 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
               %24 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %25 = func.call_indirect %23, %0, %24, %21 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %25 = func.call_indirect %23, %0, %24, %21 {signature = !t1} : tribute_rt.anyref
               %26 = adt.variant_cast %25 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
               %27 = adt.variant_get %26 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
               %28 = adt.variant_get %26 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -184,7 +184,7 @@ core.module @resumptive_op_native {
           %37 = core.unrealized_conversion_cast %35 : tribute_rt.anyref
           %38 = adt.struct_get %36 {field = 0, type = !_closure} : core.i32
           %39 = adt.struct_get %36 {field = 1, type = !_closure} : tribute_rt.anyref
-          %40 = func.call_indirect %38, %0, %39, %37 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %40 = func.call_indirect %38, %0, %39, %37 {signature = !t1} : tribute_rt.anyref
           %41 = adt.variant_is %40 {tag = @Normal, type = !__tribute_cps_control} : core.i1
           %42 = scf.if %41 : tribute_rt.anyref {
               %43 = adt.variant_cast %40 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -192,7 +192,7 @@ core.module @resumptive_op_native {
               %45 = tribute_rt.unbox_int %44 : core.i32
               %46 = adt.struct_get %34 {field = 0, type = !_closure} : core.i32
               %47 = adt.struct_get %34 {field = 1, type = !_closure} : tribute_rt.anyref
-              %48 = func.call_indirect %46, %0, %47, %44 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %48 = func.call_indirect %46, %0, %47, %44 {signature = !t1} : tribute_rt.anyref
               %49 = adt.variant_cast %48 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
               %50 = adt.variant_get %49 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
               %51 = adt.variant_get %49 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -221,7 +221,7 @@ core.module @resumptive_op_native {
       %8 = tribute_rt.box_int %4 : tribute_rt.anyref
       %9 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
       %10 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = func.call_indirect %9, %0, %10, %8 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+      %11 = func.call_indirect %9, %0, %10, %8 {signature = !t1} : tribute_rt.anyref
       func.return %11
   }
 

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -81,7 +81,7 @@ core.module @direct_fn {
       %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
       %20 = func.call {callee = @__tribute_next_tag} : core.i32
       %21 = effect.extend %1, %20, %19, %16 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %22 = func.call_indirect %12, %21, %13, %10 {func.indirect_call_signature = core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
+      %22 = func.call_indirect %12, %21, %13, %10 {signature = core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
       %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %24 = scf.if %23 : tribute_rt.anyref {
           %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -91,7 +91,7 @@ core.module @direct_fn {
           %29 = adt.ref_null {type = !t0} : !t0
           %30 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
           %31 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-          %32 = func.call_indirect %30, %21, %31, %28 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %32 = func.call_indirect %30, %21, %31, %28 {signature = !t1} : tribute_rt.anyref
           scf.yield %32
       } {
           %33 = adt.variant_cast %22 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -102,7 +102,7 @@ core.module @direct_fn {
               %38 = adt.ref_null {type = !t0} : !t0
               %39 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
               %40 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-              %41 = func.call_indirect %39, %38, %40, %35 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %41 = func.call_indirect %39, %38, %40, %35 {signature = !t1} : tribute_rt.anyref
               scf.yield %41
           } {
               scf.yield %22
@@ -126,7 +126,7 @@ core.module @direct_fn {
       %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
       %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
       %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %6 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+      %9 = func.call_indirect %7, %0, %8, %6 {signature = !t1} : tribute_rt.anyref
       func.return %9
   }
 
@@ -141,7 +141,7 @@ core.module @direct_fn {
           %13 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
           %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
           %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %13 {signature = !t1} : tribute_rt.anyref
           scf.yield %16
       } {
           %17 = arith.const {value = 1} : core.i1
@@ -153,7 +153,7 @@ core.module @direct_fn {
               %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
               %24 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
               %25 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %26 = func.call_indirect %24, %0, %25, %23 {signature = !t1} : tribute_rt.anyref
               scf.yield %26
           } {
               func.unreachable
@@ -174,7 +174,7 @@ core.module @direct_fn {
           %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
           %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
           %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %14 = func.call_indirect %12, %0, %13, %11 {signature = !t1} : tribute_rt.anyref
           scf.yield %14
       } {
           %15 = arith.const {value = 1} : core.i1
@@ -186,7 +186,7 @@ core.module @direct_fn {
               %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
               %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
               %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-              %24 = func.call_indirect %22, %0, %23, %21 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %24 = func.call_indirect %22, %0, %23, %21 {signature = !t1} : tribute_rt.anyref
               scf.yield %24
           } {
               func.unreachable

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -85,7 +85,7 @@ core.module @mixed_nested {
       %15 = arith.const {value = 0} : tribute_rt.anyref
       %16 = func.call {callee = @__tribute_next_tag} : core.i32
       %17 = effect.extend %0, %16, %15, %14 {ability_ref = core.ability_ref() {name = @State}} : !t0
-      %18 = func.call_indirect %10, %17, %11, %9 {func.indirect_call_signature = !t7} : tribute_rt.anyref
+      %18 = func.call_indirect %10, %17, %11, %9 {signature = !t7} : tribute_rt.anyref
       %19 = adt.variant_is %18 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %20 = scf.if %19 : tribute_rt.anyref {
           %21 = adt.variant_cast %18 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -94,7 +94,7 @@ core.module @mixed_nested {
           %24 = core.unrealized_conversion_cast %23 : tribute_rt.anyref
           %25 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
           %26 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-          %27 = func.call_indirect %25, %17, %26, %24 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %27 = func.call_indirect %25, %17, %26, %24 {signature = !t1} : tribute_rt.anyref
           scf.yield %27
       } {
           %28 = adt.variant_cast %18 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -104,7 +104,7 @@ core.module @mixed_nested {
           %32 = scf.if %31 : tribute_rt.anyref {
               %33 = adt.struct_get %3 {field = 0, type = !_closure} : core.i32
               %34 = adt.struct_get %3 {field = 1, type = !_closure} : tribute_rt.anyref
-              %35 = func.call_indirect %33, %0, %34, %30 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %35 = func.call_indirect %33, %0, %34, %30 {signature = !t1} : tribute_rt.anyref
               scf.yield %35
           } {
               scf.yield %18
@@ -138,7 +138,7 @@ core.module @mixed_nested {
       %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
       %20 = func.call {callee = @__tribute_next_tag} : core.i32
       %21 = effect.extend %1, %20, %19, %16 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %22 = func.call_indirect %12, %21, %13, %10 {func.indirect_call_signature = !t7} : tribute_rt.anyref
+      %22 = func.call_indirect %12, %21, %13, %10 {signature = !t7} : tribute_rt.anyref
       %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %24 = scf.if %23 : tribute_rt.anyref {
           %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -148,7 +148,7 @@ core.module @mixed_nested {
           %29 = adt.ref_null {type = !t0} : !t0
           %30 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
           %31 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-          %32 = func.call_indirect %30, %21, %31, %28 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %32 = func.call_indirect %30, %21, %31, %28 {signature = !t1} : tribute_rt.anyref
           scf.yield %32
       } {
           %33 = adt.variant_cast %22 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -159,7 +159,7 @@ core.module @mixed_nested {
               %38 = adt.ref_null {type = !t0} : !t0
               %39 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
               %40 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-              %41 = func.call_indirect %39, %38, %40, %35 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %41 = func.call_indirect %39, %38, %40, %35 {signature = !t1} : tribute_rt.anyref
               scf.yield %41
           } {
               scf.yield %22
@@ -208,7 +208,7 @@ core.module @mixed_nested {
           %14 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
           %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
           %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %17 = func.call_indirect %15, %0, %16, %14 {signature = !t1} : tribute_rt.anyref
           %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
           %19 = scf.if %18 : tribute_rt.anyref {
               %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -217,7 +217,7 @@ core.module @mixed_nested {
               %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
               %24 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
               %25 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %26 = func.call_indirect %24, %0, %25, %23 {signature = !t1} : tribute_rt.anyref
               %27 = adt.variant_cast %26 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
               %28 = adt.variant_get %27 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
               %29 = adt.variant_get %27 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -244,7 +244,7 @@ core.module @mixed_nested {
               %40 = core.unrealized_conversion_cast %38 : tribute_rt.anyref
               %41 = adt.struct_get %39 {field = 0, type = !_closure} : core.i32
               %42 = adt.struct_get %39 {field = 1, type = !_closure} : tribute_rt.anyref
-              %43 = func.call_indirect %41, %0, %42, %40 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %43 = func.call_indirect %41, %0, %42, %40 {signature = !t1} : tribute_rt.anyref
               %44 = adt.variant_is %43 {tag = @Normal, type = !__tribute_cps_control} : core.i1
               %45 = scf.if %44 : tribute_rt.anyref {
                   %46 = adt.variant_cast %43 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -253,7 +253,7 @@ core.module @mixed_nested {
                   %49 = core.unrealized_conversion_cast %48 : tribute_rt.anyref
                   %50 = adt.struct_get %37 {field = 0, type = !_closure} : core.i32
                   %51 = adt.struct_get %37 {field = 1, type = !_closure} : tribute_rt.anyref
-                  %52 = func.call_indirect %50, %0, %51, %49 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+                  %52 = func.call_indirect %50, %0, %51, %49 {signature = !t1} : tribute_rt.anyref
                   %53 = adt.variant_cast %52 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
                   %54 = adt.variant_get %53 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
                   %55 = adt.variant_get %53 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -284,7 +284,7 @@ core.module @mixed_nested {
       %6 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
       %7 = adt.struct_get %5 {field = 0, type = !_closure} : core.i32
       %8 = adt.struct_get %5 {field = 1, type = !_closure} : tribute_rt.anyref
-      %9 = func.call_indirect %7, %0, %8, %6 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+      %9 = func.call_indirect %7, %0, %8, %6 {signature = !t1} : tribute_rt.anyref
       func.return %9
   }
 
@@ -299,7 +299,7 @@ core.module @mixed_nested {
           %13 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
           %14 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
           %15 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-          %16 = func.call_indirect %14, %0, %15, %13 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %16 = func.call_indirect %14, %0, %15, %13 {signature = !t1} : tribute_rt.anyref
           scf.yield %16
       } {
           %17 = arith.const {value = 1} : core.i1
@@ -311,7 +311,7 @@ core.module @mixed_nested {
               %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
               %24 = adt.struct_get %21 {field = 0, type = !_closure} : core.i32
               %25 = adt.struct_get %21 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %26 = func.call_indirect %24, %0, %25, %23 {signature = !t1} : tribute_rt.anyref
               scf.yield %26
           } {
               func.unreachable
@@ -332,7 +332,7 @@ core.module @mixed_nested {
           %11 = core.unrealized_conversion_cast %10 : tribute_rt.anyref
           %12 = adt.struct_get %9 {field = 0, type = !_closure} : core.i32
           %13 = adt.struct_get %9 {field = 1, type = !_closure} : tribute_rt.anyref
-          %14 = func.call_indirect %12, %0, %13, %11 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %14 = func.call_indirect %12, %0, %13, %11 {signature = !t1} : tribute_rt.anyref
           scf.yield %14
       } {
           %15 = arith.const {value = 1} : core.i1
@@ -344,7 +344,7 @@ core.module @mixed_nested {
               %21 = core.unrealized_conversion_cast %20 : tribute_rt.anyref
               %22 = adt.struct_get %19 {field = 0, type = !_closure} : core.i32
               %23 = adt.struct_get %19 {field = 1, type = !_closure} : tribute_rt.anyref
-              %24 = func.call_indirect %22, %0, %23, %21 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %24 = func.call_indirect %22, %0, %23, %21 {signature = !t1} : tribute_rt.anyref
               scf.yield %24
           } {
               func.unreachable
@@ -368,7 +368,7 @@ core.module @mixed_nested {
       %13 = core.unrealized_conversion_cast %11 : tribute_rt.anyref
       %14 = adt.struct_get %12 {field = 0, type = !_closure} : core.i32
       %15 = adt.struct_get %12 {field = 1, type = !_closure} : tribute_rt.anyref
-      %16 = func.call_indirect %14, %0, %15, %13 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+      %16 = func.call_indirect %14, %0, %15, %13 {signature = !t1} : tribute_rt.anyref
       func.return %16
   }
 

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -83,7 +83,7 @@ core.module @resumptive_op {
       %17 = arith.const {value = 0} : tribute_rt.anyref
       %18 = func.call {callee = @__tribute_next_tag} : core.i32
       %19 = effect.extend %1, %18, %17, %16 {ability_ref = core.ability_ref() {name = @State}} : !t0
-      %20 = func.call_indirect %12, %19, %13, %10 {func.indirect_call_signature = core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
+      %20 = func.call_indirect %12, %19, %13, %10 {signature = core.func(tribute_rt.anyref, !t0, tribute_rt.anyref, !_closure)} : tribute_rt.anyref
       %21 = adt.variant_is %20 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %22 = scf.if %21 : tribute_rt.anyref {
           %23 = adt.variant_cast %20 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -93,7 +93,7 @@ core.module @resumptive_op {
           %27 = adt.ref_null {type = !t0} : !t0
           %28 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
           %29 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-          %30 = func.call_indirect %28, %19, %29, %26 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %30 = func.call_indirect %28, %19, %29, %26 {signature = !t1} : tribute_rt.anyref
           scf.yield %30
       } {
           %31 = adt.variant_cast %20 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -104,7 +104,7 @@ core.module @resumptive_op {
               %36 = adt.ref_null {type = !t0} : !t0
               %37 = adt.struct_get %4 {field = 0, type = !_closure} : core.i32
               %38 = adt.struct_get %4 {field = 1, type = !_closure} : tribute_rt.anyref
-              %39 = func.call_indirect %37, %36, %38, %33 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %39 = func.call_indirect %37, %36, %38, %33 {signature = !t1} : tribute_rt.anyref
               scf.yield %39
           } {
               scf.yield %20
@@ -154,7 +154,7 @@ core.module @resumptive_op {
           %14 = core.unrealized_conversion_cast %12 : tribute_rt.anyref
           %15 = adt.struct_get %13 {field = 0, type = !_closure} : core.i32
           %16 = adt.struct_get %13 {field = 1, type = !_closure} : tribute_rt.anyref
-          %17 = func.call_indirect %15, %0, %16, %14 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+          %17 = func.call_indirect %15, %0, %16, %14 {signature = !t1} : tribute_rt.anyref
           %18 = adt.variant_is %17 {tag = @Normal, type = !__tribute_cps_control} : core.i1
           %19 = scf.if %18 : tribute_rt.anyref {
               %20 = adt.variant_cast %17 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -163,7 +163,7 @@ core.module @resumptive_op {
               %23 = core.unrealized_conversion_cast %22 : tribute_rt.anyref
               %24 = adt.struct_get %11 {field = 0, type = !_closure} : core.i32
               %25 = adt.struct_get %11 {field = 1, type = !_closure} : tribute_rt.anyref
-              %26 = func.call_indirect %24, %0, %25, %23 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %26 = func.call_indirect %24, %0, %25, %23 {signature = !t1} : tribute_rt.anyref
               %27 = adt.variant_cast %26 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
               %28 = adt.variant_get %27 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
               %29 = adt.variant_get %27 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -190,7 +190,7 @@ core.module @resumptive_op {
               %40 = core.unrealized_conversion_cast %38 : tribute_rt.anyref
               %41 = adt.struct_get %39 {field = 0, type = !_closure} : core.i32
               %42 = adt.struct_get %39 {field = 1, type = !_closure} : tribute_rt.anyref
-              %43 = func.call_indirect %41, %0, %42, %40 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+              %43 = func.call_indirect %41, %0, %42, %40 {signature = !t1} : tribute_rt.anyref
               %44 = adt.variant_is %43 {tag = @Normal, type = !__tribute_cps_control} : core.i1
               %45 = scf.if %44 : tribute_rt.anyref {
                   %46 = adt.variant_cast %43 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -199,7 +199,7 @@ core.module @resumptive_op {
                   %49 = core.unrealized_conversion_cast %48 : tribute_rt.anyref
                   %50 = adt.struct_get %37 {field = 0, type = !_closure} : core.i32
                   %51 = adt.struct_get %37 {field = 1, type = !_closure} : tribute_rt.anyref
-                  %52 = func.call_indirect %50, %0, %51, %49 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+                  %52 = func.call_indirect %50, %0, %51, %49 {signature = !t1} : tribute_rt.anyref
                   %53 = adt.variant_cast %52 {tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
                   %54 = adt.variant_get %53 {field = 0, tag = @Escape, type = !__tribute_cps_control} : core.i32
                   %55 = adt.variant_get %53 {field = 1, tag = @Escape, type = !__tribute_cps_control} : tribute_rt.anyref
@@ -232,7 +232,7 @@ core.module @resumptive_op {
       %8 = core.unrealized_conversion_cast %4 : tribute_rt.anyref
       %9 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
       %10 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
-      %11 = func.call_indirect %9, %0, %10, %8 {func.indirect_call_signature = !t1} : tribute_rt.anyref
+      %11 = func.call_indirect %9, %0, %10, %8 {signature = !t1} : tribute_rt.anyref
       func.return %11
   }
 


### PR DESCRIPTION
## Summary

- declare optional `signature: TypeRef` on `func.call_indirect` and `func.tail_call_indirect`
- require exact signatures fail-closed for convention-tagged indirect transfers
- derive `fn` handler-arm calls from their exact provenance-bearing closure contract

This is a prerequisite for #825.

Snapshot updates only rename the canonical attribute key from `func.indirect_call_signature` to `signature`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indirect calls and tail calls now preserve exact callable signatures, improving closure and continuation execution.
  * Calling conventions are validated consistently through compilation and WebAssembly output.

* **Bug Fixes**
  * Reduced indirect-call signature mismatches during lowering and backend validation.
  * Improved diagnostics for invalid or missing callable signatures.

* **Documentation**
  * Updated IR guidance for signature preservation and validation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->