### PR TITLE
fix(frontend): materialize resume token input

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/lower/logical.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/logical.rs
@@ -1201,15 +1201,13 @@ fn lower_expr<'db>(
         }
         ExprKind::Resume { arg, local_id } => {
             let token = builder.ctx.lookup_resume(local_id?)?;
+            let (input_ty, answer_ty) =
+                tribute_control::resume_token_parts(builder.ir, builder.ir.value_ty(token))
+                    .expect("typechecked resume local must lower to a resume token");
             let value = lower_expr(builder, arg, declarations)?;
-            let result_ty = builder
-                .ctx
-                .get_node_type(expr.id)
-                .copied()
-                .map(|ty| builder.ctx.convert_logical_type(builder.ir, ty))
-                .unwrap_or_else(|| panic!("missing typechecked result for resume"));
+            let value = builder.cast_if_needed(location, value, input_ty);
             let resume = op(builder.ir, builder.block, location, "resume", |builder| {
-                builder.operand(token).operand(value).result(result_ty)
+                builder.operand(token).operand(value).result(answer_ty)
             });
             Some(result(builder.ir, resume))
         }

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -147,6 +147,63 @@ fn main() { }
     assert_resume_shape(checked_logical_function(&ir_text, "run"));
 }
 
+/// Resume materializes an erased literal to the token input and returns the
+/// token answer, rather than using the literal or source-expression type.
+#[salsa_test]
+fn resume_uses_exact_token_input_and_answer_types(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "test.trb",
+        r#"
+enum String {
+    Leaf(Bytes),
+    Branch(String, String, Nat),
+}
+
+ability Read {
+    op read() -> String
+}
+
+fn run() -> Int {
+    handle Read::read() {
+        do result { 0 }
+        op Read::read() {
+            let answer = resume "resumed"
+            answer + 1
+        }
+    }
+}
+
+fn main() { }
+"#,
+    );
+
+    let ir = run_ast_pipeline_with_ir(db, source);
+    let run = checked_logical_function(&ir, "run");
+    assert!(
+        run.contains("resume_token(!String, core.i32)"),
+        "handler token must retain its exact input and answer types:\n{run}"
+    );
+    assert_in_order(
+        run,
+        &[
+            "adt.string_const",
+            "core.unrealized_conversion_cast",
+            "tribute_control.resume",
+        ],
+    );
+    let cast = run
+        .lines()
+        .find(|line| line.contains("core.unrealized_conversion_cast"))
+        .expect("resume input materialization");
+    assert!(cast.contains(": !String"), "{run}");
+    let resume = run
+        .lines()
+        .find(|line| line.contains("= tribute_control.resume "))
+        .expect("source-logical resume");
+    assert!(resume.contains(": core.i32"), "{run}");
+}
+
 #[salsa_test]
 fn handler_kind_mismatch_is_a_type_diagnostic_not_a_lowering_panic(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -184,7 +184,8 @@ pub fn callable_convention(ctx: &IrContext, ty: TypeRef) -> Option<CallingConven
         .and_then(|code| CallingConvention::try_from(code).ok())
 }
 
-fn resume_token_parts(ctx: &IrContext, ty: TypeRef) -> Option<(TypeRef, TypeRef)> {
+/// Read the exact input and answer types carried by a resume token.
+pub fn resume_token_parts(ctx: &IrContext, ty: TypeRef) -> Option<(TypeRef, TypeRef)> {
     if !ResumeToken::matches(ctx, ty) {
         return None;
     }


### PR DESCRIPTION
## Summary

- derive the exact input and answer types from each `tribute_control.resume_token`
- materialize the resume operand to the token input type
- preserve the token answer type as the resume result
- add a focused source-logical regression with distinct input and answer types

This is a prerequisite for #825.

## Validation

- normal pre-commit suite: 1,981 passed, 1 skipped
- focused frontend and IR resume tests
- foreign-escape end-to-end regression
- warnings-denied Clippy, formatting, and diff checks