### PR TITLE
#774: Make the CPS root bridge frame-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-tribute",
+ "tribute-core",
  "tribute-front",
  "tribute-ir",
  "tribute-passes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ insta.workspace = true
 itertools.workspace = true
 salsa-test-macros = { path = "crates/salsa-test-macros" }
 serde.workspace = true
+tribute-core.workspace = true
 
 [profile.dev]
 debug = "line-tables-only"

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -715,10 +715,15 @@ fn validate_root_dispatch_type(
     };
     if callable.r#return(ctx) != physical_result
         || *actual_evidence != evidence
-        || !is_core_i32(ctx, *prompt)
-        || !is_core_i32(ctx, *ability)
-        || !is_core_i32(ctx, *operation)
-        || !is_tribute_anyref(ctx, *payload)
+        || !is_parameterless_dialect_type(ctx, *prompt, Symbol::new("core"), Symbol::new("i32"))
+        || !is_parameterless_dialect_type(ctx, *ability, Symbol::new("core"), Symbol::new("i32"))
+        || !is_parameterless_dialect_type(ctx, *operation, Symbol::new("core"), Symbol::new("i32"))
+        || !is_parameterless_dialect_type(
+            ctx,
+            *payload,
+            Symbol::new("tribute_rt"),
+            Symbol::new("anyref"),
+        )
     {
         return Err(TargetAbiError::new(
             "target root bridge: frame Dispatch operands differ from the exact terminal ABI",
@@ -741,7 +746,12 @@ fn validate_root_dispatch_type(
         || resume.params(ctx).len() != 3
         || resume.params(ctx)[0] != evidence
         || resume.params(ctx)[1] != frame
-        || !is_tribute_anyref(ctx, resume.params(ctx)[2])
+        || !is_parameterless_dialect_type(
+            ctx,
+            resume.params(ctx)[2],
+            Symbol::new("tribute_rt"),
+            Symbol::new("anyref"),
+        )
     {
         return Err(TargetAbiError::new(
             "target root bridge: frame Dispatch resume differs from the exact frame ABI",
@@ -773,16 +783,13 @@ fn dispatch_entry_function_type(
     Ok(core::func(ctx, callable.r#return(ctx), params).as_type_ref())
 }
 
-fn is_core_i32(ctx: &IrContext, ty: TypeRef) -> bool {
-    let data = ctx.types.get(ty);
-    data.dialect == Symbol::new("core") && data.name == Symbol::new("i32") && data.params.is_empty()
-}
-
-fn is_tribute_anyref(ctx: &IrContext, ty: TypeRef) -> bool {
-    let data = ctx.types.get(ty);
-    data.dialect == Symbol::new("tribute_rt")
-        && data.name == Symbol::new("anyref")
-        && data.params.is_empty()
+fn is_parameterless_dialect_type(
+    ctx: &IrContext,
+    ty: TypeRef,
+    dialect: Symbol,
+    name: Symbol,
+) -> bool {
+    ctx.types.is_dialect(ty, dialect, name) && ctx.types.get(ty).params.is_empty()
 }
 
 fn root_export_convention(

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -1703,6 +1703,71 @@ mod tests {
     }
 
     #[test]
+    fn parameterized_dispatch_tag_fails_before_bridge_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main(%evidence: core.i32, %frame: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+        );
+        let main = function(&ctx, module, "main");
+        let nil = core::nil(&mut ctx).as_type_ref();
+        let never = core::never(&mut ctx).as_type_ref();
+        let evidence = ability::evidence_adt_type_ref(&mut ctx);
+        let frame_name = Symbol::new("__tribute_parameterized_dispatch_tag");
+        let frame = tribute_core::calling_convention::cps_continuation_frame_ref_type(
+            &mut ctx, frame_name, nil,
+        );
+        let done = tribute_core::calling_convention::cps_done_type(&mut ctx, nil);
+        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let parameterized_i32 = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32"))
+                .param(nil)
+                .build(),
+        );
+        let dispatch = tribute_core::calling_convention::cps_dispatch_type(
+            &mut ctx,
+            evidence,
+            frame,
+            anyref,
+            parameterized_i32,
+        );
+        let layout = tribute_core::calling_convention::cps_continuation_frame_layout_type(
+            &mut ctx, frame_name, nil, done, dispatch,
+        );
+        ctx.register_type_alias(frame_name, layout);
+        let worker = core::func(&mut ctx, never, [evidence, frame]).as_type_ref();
+        ctx.op_mut(main.op_ref())
+            .attributes
+            .insert(Symbol::new("type"), Attribute::Type(worker));
+        let entry = ctx.region(main.body(&ctx)).blocks[0];
+        ctx.set_block_arg_type(entry, 0, evidence);
+        ctx.set_block_arg_type(entry, 1, frame);
+        ctx.op_mut(main.op_ref()).attributes.insert(
+            Symbol::new(ROOT_EXPORT_CONVENTION_ATTR),
+            Attribute::Int(CallingConvention::Direct as i128),
+        );
+        ctx.op_mut(main.op_ref())
+            .attributes
+            .insert(Symbol::new(ROOT_SOURCE_RESULT_ATTR), Attribute::Type(nil));
+
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        let before = print_module(&ctx, module.op());
+        let error = compose_root_entry_bridge(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("frame Dispatch operands differ from the exact terminal ABI"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
     fn malformed_transfers_and_ambiguous_nested_never_leave_ir_unchanged() {
         for (input, expected) in [
             (

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -10,12 +10,15 @@ use std::error::Error;
 use std::fmt;
 use std::ops::ControlFlow;
 
-use tribute_core::calling_convention::CLOSURE_ENVIRONMENT_INDEX_ATTR;
+use tribute_core::calling_convention::{
+    CLOSURE_ENVIRONMENT_INDEX_ATTR, cps_closure_function_type, cps_continuation_frame_result_type,
+    get_physical_closure_environment_index,
+};
 use tribute_core::{
     CALLING_CONVENTION_ATTR, CallingConvention, INDIRECT_CALL_SIGNATURE_ATTR,
     get_calling_convention, get_indirect_call_signature, get_physical_closure_convention,
 };
-use tribute_ir::dialect::{ability, closure, tribute_rt};
+use tribute_ir::dialect::{ability, tribute_rt};
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, arith, core, func};
@@ -30,6 +33,7 @@ const ROOT_EXPORT_CONVENTION_ATTR: &str = "tribute.root_export_convention";
 const ROOT_SOURCE_RESULT_ATTR: &str = "tribute.root_source_result";
 const CPS_MAIN_SYMBOL: &str = "__tribute_cps_main";
 const ROOT_DONE_K_SYMBOL: &str = "__tribute_root_done_k";
+const ROOT_DISPATCH_SYMBOL: &str = "__tribute_root_dispatch";
 const ROOT_COMPLETION_CELL_NAME: &str = "__tribute_root_completion_cell";
 const ROOT_COMPLETION_CELL_VALUE_FIELD: &str = "value";
 const ROOT_CPS_CALL_ATTR: &str = "tribute.root_cps_call";
@@ -56,6 +60,14 @@ struct FunctionIdentity {
     signature: TypeRef,
     convention: CallingConvention,
     environment_index: Option<usize>,
+}
+
+#[derive(Clone, Copy)]
+struct RootFrameContract {
+    reference: TypeRef,
+    layout: TypeRef,
+    done: TypeRef,
+    dispatch: TypeRef,
 }
 
 /// Physicalize exact CPS callables without selecting target instructions.
@@ -247,10 +259,10 @@ pub fn has_root_entry_contract(ctx: &IrContext, module: Module) -> bool {
 /// Construct the target-independent export delimiter for a root worker that
 /// was promoted from Direct or EvidenceDirect to Cps.
 ///
-/// This runs after physical signature lowering: the worker and `done_k` use
-/// the target's empty `core.nil` result, while the wrapper keeps the exact
-/// source ABI and performs one ordinary call. Legacy modules carry no root
-/// metadata, so they are left unchanged.
+/// This runs after physical signature lowering: the worker and the exact
+/// `ContinuationFrame<R>` members use the target's empty `core.nil` result,
+/// while the wrapper keeps the exact source ABI and performs one ordinary
+/// call. Legacy modules carry no root metadata, so they are left unchanged.
 pub fn compose_root_entry_bridge(
     ctx: &mut IrContext,
     module: Module,
@@ -315,11 +327,16 @@ pub fn compose_root_entry_bridge(
         || worker_params[0] != evidence_ty
     {
         return Err(TargetAbiError::new(
-            "target root bridge: Cps root must have exact physical evidence and done_k ABI",
+            "target root bridge: Cps root must have exact physical evidence and ContinuationFrame ABI",
         ));
     }
-    let done_k_ty = worker_params[1];
-    validate_root_done_k_type(ctx, done_k_ty, source_result, nil_ty)?;
+    let frame = validate_root_continuation_frame(
+        ctx,
+        worker_params[1],
+        source_result,
+        evidence_ty,
+        nil_ty,
+    )?;
     if ctx.op(worker_op).regions.is_empty() {
         return Err(TargetAbiError::new(
             "target root bridge: root worker must be a definition",
@@ -328,11 +345,13 @@ pub fn compose_root_entry_bridge(
 
     let cps_main = Symbol::new(CPS_MAIN_SYMBOL);
     let root_done_k = Symbol::new(ROOT_DONE_K_SYMBOL);
+    let root_dispatch = Symbol::new(ROOT_DISPATCH_SYMBOL);
     for &op in &top_level_ops {
         let Ok(function) = func::Func::from_op(ctx, op) else {
             continue;
         };
-        if matches!(function.sym_name(ctx), name if name == cps_main || name == root_done_k) {
+        if matches!(function.sym_name(ctx), name if name == cps_main || name == root_done_k || name == root_dispatch)
+        {
             return Err(TargetAbiError::new(
                 "target root bridge: reserved root symbol collision",
             ));
@@ -388,6 +407,43 @@ pub fn compose_root_entry_bridge(
         Attribute::Int(0),
     );
 
+    let dispatch_function_ty = dispatch_entry_function_type(ctx, frame.dispatch, anyref_ty)?;
+    let dispatch_entry = ctx.create_block(BlockData {
+        location,
+        args: core::Func::from_type_ref(ctx, dispatch_function_ty)
+            .expect("validated dispatch entry contract")
+            .params(ctx)
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(index, ty)| BlockArgData {
+                ty,
+                attrs: bind_name(if index == 1 { "__env" } else { "__arg" }),
+            })
+            .collect(),
+        ops: smallvec![],
+        parent_region: None,
+    });
+    let dispatch_unreachable = func::unreachable(ctx, location);
+    ctx.push_op(dispatch_entry, dispatch_unreachable.op_ref());
+    let dispatch_region = ctx.create_region(RegionData {
+        location,
+        blocks: smallvec![dispatch_entry],
+        parent_op: None,
+    });
+    let dispatch_function = func::func(
+        ctx,
+        location,
+        root_dispatch,
+        dispatch_function_ty,
+        dispatch_region,
+    );
+    set_root_convention(ctx, dispatch_function.op_ref(), CallingConvention::Cps);
+    ctx.op_mut(dispatch_function.op_ref()).attributes.insert(
+        Symbol::new(CLOSURE_ENVIRONMENT_INDEX_ATTR),
+        Attribute::Int(1),
+    );
+
     let wrapper_params = if export_convention == CallingConvention::EvidenceDirect {
         vec![evidence_ty]
     } else {
@@ -425,8 +481,35 @@ pub fn compose_root_entry_bridge(
     );
     ctx.push_op(wrapper_entry, done_closure.op_ref());
     let typed_done =
-        core::unrealized_conversion_cast(ctx, location, done_closure.result(ctx), done_k_ty);
+        core::unrealized_conversion_cast(ctx, location, done_closure.result(ctx), frame.done);
     ctx.push_op(wrapper_entry, typed_done.op_ref());
+
+    let dispatch_callable_ty = dispatch_callable_function_type(ctx, frame.dispatch)?;
+    let dispatch_constant = func::constant(ctx, location, dispatch_callable_ty, root_dispatch);
+    ctx.push_op(wrapper_entry, dispatch_constant.op_ref());
+    let dispatch_closure = adt::struct_new(
+        ctx,
+        location,
+        [dispatch_constant.result(ctx), erased_cell.result(ctx)],
+        closure_struct_ty,
+        closure_struct_ty,
+    );
+    ctx.push_op(wrapper_entry, dispatch_closure.op_ref());
+    let typed_dispatch = core::unrealized_conversion_cast(
+        ctx,
+        location,
+        dispatch_closure.result(ctx),
+        frame.dispatch,
+    );
+    ctx.push_op(wrapper_entry, typed_dispatch.op_ref());
+    let frame_value = adt::struct_new(
+        ctx,
+        location,
+        [typed_done.result(ctx), typed_dispatch.result(ctx)],
+        frame.reference,
+        frame.layout,
+    );
+    ctx.push_op(wrapper_entry, frame_value.op_ref());
 
     let evidence = if export_convention == CallingConvention::EvidenceDirect {
         ctx.block_args(wrapper_entry)[0]
@@ -443,7 +526,7 @@ pub fn compose_root_entry_bridge(
     let worker_call = func::call(
         ctx,
         location,
-        [evidence, typed_done.result(ctx)],
+        [evidence, frame_value.result(ctx)],
         nil_ty,
         cps_main,
     );
@@ -479,6 +562,7 @@ pub fn compose_root_entry_bridge(
     set_root_convention(ctx, wrapper.op_ref(), export_convention);
 
     ctx.push_op(module_block, done_function.op_ref());
+    ctx.push_op(module_block, dispatch_function.op_ref());
     ctx.push_op(module_block, wrapper.op_ref());
     Ok(())
 }
@@ -506,27 +590,199 @@ fn root_completion_cell_type(ctx: &mut IrContext, value_ty: TypeRef) -> TypeRef 
     })
 }
 
-fn validate_root_done_k_type(
+fn validate_root_continuation_frame(
     ctx: &IrContext,
-    done_k_ty: TypeRef,
+    frame: TypeRef,
+    source_result: TypeRef,
+    evidence: TypeRef,
+    physical_result: TypeRef,
+) -> Result<RootFrameContract, TargetAbiError> {
+    let reference_data = ctx.types.get(frame);
+    if reference_data.dialect != Symbol::new("adt") || reference_data.name != Symbol::new("typeref")
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame must be an exact nominal adt.typeref",
+        ));
+    }
+    if cps_continuation_frame_result_type(ctx, frame) != Some(source_result) {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame result provenance differs from root source result",
+        ));
+    }
+    let name = reference_data.attrs.get_symbol("name").ok_or_else(|| {
+        TargetAbiError::new("target root bridge: worker frame lacks nominal layout identity")
+    })?;
+    let layout = ctx.type_alias_by_name(name).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: worker frame must have an exact nominal layout")
+    })?;
+    let layout_data = ctx.types.get(layout);
+    if layout_data.dialect != Symbol::new("adt")
+        || layout_data.name != Symbol::new("struct")
+        || layout_data.attrs.get_symbol("name") != Some(name)
+        || cps_continuation_frame_result_type(ctx, layout) != Some(source_result)
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame layout provenance is malformed",
+        ));
+    }
+    let fields = layout_data.attrs.get("fields").ok_or_else(|| {
+        TargetAbiError::new("target root bridge: worker frame layout lacks fields")
+    })?;
+    let Attribute::List(fields) = fields else {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame layout fields are malformed",
+        ));
+    };
+    let [Attribute::List(done_field), Attribute::List(dispatch_field)] = fields.as_slice() else {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame layout must contain done then dispatch",
+        ));
+    };
+    let [Attribute::Symbol(done_name), Attribute::Type(done)] = done_field.as_slice() else {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame done field is malformed",
+        ));
+    };
+    let [Attribute::Symbol(dispatch_name), Attribute::Type(dispatch)] = dispatch_field.as_slice()
+    else {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame dispatch field is malformed",
+        ));
+    };
+    if *done_name != Symbol::new("done") || *dispatch_name != Symbol::new("dispatch") {
+        return Err(TargetAbiError::new(
+            "target root bridge: worker frame field roles must be exact Done then Dispatch",
+        ));
+    }
+    validate_root_done_type(ctx, *done, source_result, physical_result)?;
+    validate_root_dispatch_type(ctx, *dispatch, frame, evidence, physical_result)?;
+    Ok(RootFrameContract {
+        reference: frame,
+        layout,
+        done: *done,
+        dispatch: *dispatch,
+    })
+}
+
+fn validate_root_done_type(
+    ctx: &IrContext,
+    done: TypeRef,
     source_result: TypeRef,
     physical_result: TypeRef,
 ) -> Result<(), TargetAbiError> {
-    if get_physical_closure_convention(ctx, done_k_ty) != Some(CallingConvention::Cps) {
+    if get_physical_closure_convention(ctx, done) != Some(CallingConvention::Cps)
+        || get_physical_closure_environment_index(ctx, done) != Some(0)
+    {
         return Err(TargetAbiError::new(
-            "target root bridge: done_k must carry exact Cps closure provenance",
+            "target root bridge: frame Done must carry exact Cps closure provenance",
         ));
     }
-    let done = closure::Closure::from_type_ref(ctx, done_k_ty)
-        .ok_or_else(|| TargetAbiError::new("target root bridge: done_k is not a closure"))?;
-    let callable = core::Func::from_type_ref(ctx, done.func_type(ctx))
-        .ok_or_else(|| TargetAbiError::new("target root bridge: done_k is not core.func"))?;
+    let callable = cps_closure_function_type(ctx, done).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Done is not an exact Cps closure")
+    })?;
+    let callable = core::Func::from_type_ref(ctx, callable).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Done callable is not core.func")
+    })?;
     if callable.r#return(ctx) != physical_result || callable.params(ctx) != [source_result] {
         return Err(TargetAbiError::new(
-            "target root bridge: done_k must accept the exact source result and return empty",
+            "target root bridge: frame Done must accept the exact source result and return empty",
         ));
     }
     Ok(())
+}
+
+fn validate_root_dispatch_type(
+    ctx: &IrContext,
+    dispatch: TypeRef,
+    frame: TypeRef,
+    evidence: TypeRef,
+    physical_result: TypeRef,
+) -> Result<(), TargetAbiError> {
+    if get_physical_closure_convention(ctx, dispatch) != Some(CallingConvention::Cps)
+        || get_physical_closure_environment_index(ctx, dispatch) != Some(1)
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: frame Dispatch must carry exact Cps closure provenance",
+        ));
+    }
+    let callable = dispatch_callable_function_type(ctx, dispatch)?;
+    let callable = core::Func::from_type_ref(ctx, callable).expect("validated dispatch callable");
+    let params = callable.params(ctx);
+    let [actual_evidence, resume, prompt, ability, operation, payload] = params else {
+        return Err(TargetAbiError::new(
+            "target root bridge: frame Dispatch must have the exact terminal dispatch ABI",
+        ));
+    };
+    if callable.r#return(ctx) != physical_result
+        || *actual_evidence != evidence
+        || !is_core_i32(ctx, *prompt)
+        || !is_core_i32(ctx, *ability)
+        || !is_core_i32(ctx, *operation)
+        || !is_tribute_anyref(ctx, *payload)
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: frame Dispatch operands differ from the exact terminal ABI",
+        ));
+    }
+    if get_physical_closure_convention(ctx, *resume) != Some(CallingConvention::Cps)
+        || get_physical_closure_environment_index(ctx, *resume) != Some(0)
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: frame Dispatch resume must carry exact Cps closure provenance",
+        ));
+    }
+    let resume = cps_closure_function_type(ctx, *resume).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Dispatch resume is not an exact Cps closure")
+    })?;
+    let resume = core::Func::from_type_ref(ctx, resume).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Dispatch resume callable is not core.func")
+    })?;
+    if resume.r#return(ctx) != physical_result
+        || resume.params(ctx).len() != 3
+        || resume.params(ctx)[0] != evidence
+        || resume.params(ctx)[1] != frame
+        || !is_tribute_anyref(ctx, resume.params(ctx)[2])
+    {
+        return Err(TargetAbiError::new(
+            "target root bridge: frame Dispatch resume differs from the exact frame ABI",
+        ));
+    }
+    Ok(())
+}
+
+fn dispatch_callable_function_type(
+    ctx: &IrContext,
+    dispatch: TypeRef,
+) -> Result<TypeRef, TargetAbiError> {
+    cps_closure_function_type(ctx, dispatch).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Dispatch is not an exact Cps closure")
+    })
+}
+
+fn dispatch_entry_function_type(
+    ctx: &mut IrContext,
+    dispatch: TypeRef,
+    anyref: TypeRef,
+) -> Result<TypeRef, TargetAbiError> {
+    let callable = dispatch_callable_function_type(ctx, dispatch)?;
+    let callable = core::Func::from_type_ref(ctx, callable).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Dispatch callable is not core.func")
+    })?;
+    let mut params = callable.params(ctx).to_vec();
+    params.insert(1, anyref);
+    Ok(core::func(ctx, callable.r#return(ctx), params).as_type_ref())
+}
+
+fn is_core_i32(ctx: &IrContext, ty: TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::new("core") && data.name == Symbol::new("i32") && data.params.is_empty()
+}
+
+fn is_tribute_anyref(ctx: &IrContext, ty: TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::new("tribute_rt")
+        && data.name == Symbol::new("anyref")
+        && data.params.is_empty()
 }
 
 fn root_export_convention(
@@ -1150,7 +1406,7 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @main(%evidence: core.i32, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%evidence: core.i32, %frame: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     func.unreachable
   }
 }"#,
@@ -1166,13 +1422,28 @@ mod tests {
             CallingConvention::Cps,
             0,
         );
-        let worker = core::func(&mut ctx, never, [evidence, done]).as_type_ref();
+        let frame_name = Symbol::new("__tribute_continuation_frame_root_nil");
+        let frame = tribute_core::calling_convention::cps_continuation_frame_ref_type(
+            &mut ctx, frame_name, nil,
+        );
+        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let dispatch = tribute_core::calling_convention::cps_dispatch_type(
+            &mut ctx, evidence, frame, anyref, i32_ty,
+        );
+        let layout = tribute_core::calling_convention::cps_continuation_frame_layout_type(
+            &mut ctx, frame_name, nil, done, dispatch,
+        );
+        ctx.register_type_alias(frame_name, layout);
+        let worker = core::func(&mut ctx, never, [evidence, frame]).as_type_ref();
         ctx.op_mut(main.op_ref())
             .attributes
             .insert(Symbol::new("type"), Attribute::Type(worker));
         let entry = ctx.region(main.body(&ctx)).blocks[0];
         ctx.set_block_arg_type(entry, 0, evidence);
-        ctx.set_block_arg_type(entry, 1, done);
+        ctx.set_block_arg_type(entry, 1, frame);
         ctx.op_mut(main.op_ref()).attributes.insert(
             Symbol::new(ROOT_EXPORT_CONVENTION_ATTR),
             Attribute::Int(export as i128),
@@ -1193,12 +1464,13 @@ mod tests {
         let wrapper = function(&ctx, module, "main");
         let worker = function(&ctx, module, CPS_MAIN_SYMBOL);
         let done_k = function(&ctx, module, ROOT_DONE_K_SYMBOL);
+        let dispatch = function(&ctx, module, ROOT_DISPATCH_SYMBOL);
 
         assert_eq!(
             get_calling_convention(&ctx, wrapper.op_ref()),
             Some(CallingConvention::Direct)
         );
-        for function in [worker, done_k] {
+        for function in [worker, done_k, dispatch] {
             assert_eq!(
                 get_calling_convention(&ctx, function.op_ref()),
                 Some(CallingConvention::Cps)
@@ -1215,6 +1487,12 @@ mod tests {
                 .attributes
                 .get_u32(CLOSURE_ENVIRONMENT_INDEX_ATTR),
             Ok(Some(0))
+        );
+        assert_eq!(
+            ctx.op(dispatch.op_ref())
+                .attributes
+                .get_u32(CLOSURE_ENVIRONMENT_INDEX_ATTR),
+            Ok(Some(1))
         );
         assert!(
             !ctx.op(worker.op_ref())
@@ -1237,6 +1515,55 @@ mod tests {
             ctx.op(call).attributes.get_symbol("callee"),
             Some(Symbol::new(CPS_MAIN_SYMBOL))
         );
+        let worker_callable = core::Func::from_type_ref(&ctx, worker.r#type(&ctx)).unwrap();
+        let [worker_evidence, worker_frame] = worker_callable.params(&ctx) else {
+            panic!("root worker must have Evidence and ContinuationFrame parameters");
+        };
+        assert_eq!(ctx.value_ty(ctx.op_operands(call)[0]), *worker_evidence);
+        assert_eq!(ctx.value_ty(ctx.op_operands(call)[1]), *worker_frame);
+        assert_eq!(ctx.types.get(*worker_frame).dialect, Symbol::new("adt"));
+        assert_eq!(ctx.types.get(*worker_frame).name, Symbol::new("typeref"));
+        let frame_name = ctx
+            .types
+            .get(*worker_frame)
+            .attrs
+            .get_symbol("name")
+            .unwrap();
+        let frame_layout = ctx
+            .type_alias_by_name(frame_name)
+            .expect("worker frame must retain its exact nominal layout");
+        let fields = ctx.types.get(frame_layout).attrs.get("fields");
+        let Attribute::List(fields) = fields.expect("frame fields") else {
+            panic!("frame fields must be a list");
+        };
+        let [Attribute::List(done_field), Attribute::List(dispatch_field)] = fields.as_slice()
+        else {
+            panic!("frame must have distinct Done and Dispatch fields");
+        };
+        let [Attribute::Symbol(done_name), Attribute::Type(done_ty)] = done_field.as_slice() else {
+            panic!("Done field must retain its exact type");
+        };
+        let [
+            Attribute::Symbol(dispatch_name),
+            Attribute::Type(dispatch_ty),
+        ] = dispatch_field.as_slice()
+        else {
+            panic!("Dispatch field must retain its exact type");
+        };
+        assert_eq!(*done_name, Symbol::new("done"));
+        assert_eq!(*dispatch_name, Symbol::new("dispatch"));
+        assert_ne!(*worker_frame, *done_ty);
+        assert_ne!(*done_ty, *dispatch_ty);
+        assert!(wrapper_ops.iter().any(|op| {
+            adt::StructNew::from_op(&ctx, *op).is_ok()
+                && ctx.op_result_types(*op) == [*worker_frame]
+                && ctx
+                    .op_operands(*op)
+                    .iter()
+                    .map(|value| ctx.value_ty(*value))
+                    .collect::<Vec<_>>()
+                    == vec![*done_ty, *dispatch_ty]
+        }));
         assert!(
             wrapper_ops
                 .iter()
@@ -1267,6 +1594,7 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(!printed.contains("__tribute_cps_control"), "{printed}");
         assert!(!printed.contains("Step"), "{printed}");
+        assert!(!printed.contains("trampoline"), "{printed}");
     }
 
     #[test]
@@ -1299,6 +1627,72 @@ mod tests {
 
         assert!(!printed.contains("closure.lambda"), "{printed}");
         assert!(printed.contains("adt.struct_new"), "{printed}");
+    }
+
+    #[test]
+    fn malformed_root_frame_contract_fails_before_bridge_mutation() {
+        for (frame_result, malformed_layout, expected) in [
+            (
+                false,
+                false,
+                "result provenance differs from root source result",
+            ),
+            (true, false, "must have an exact nominal layout"),
+            (true, true, "layout provenance is malformed"),
+        ] {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                r#"core.module @test {
+  func.func @main(%evidence: core.i32, %frame: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.unreachable
+  }
+}"#,
+            );
+            let main = function(&ctx, module, "main");
+            let nil = core::nil(&mut ctx).as_type_ref();
+            let never = core::never(&mut ctx).as_type_ref();
+            let evidence = ability::evidence_adt_type_ref(&mut ctx);
+            let frame_name = Symbol::new("__tribute_malformed_root_frame");
+            let i32_ty = ctx
+                .types
+                .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+            let frame = tribute_core::calling_convention::cps_continuation_frame_ref_type(
+                &mut ctx,
+                frame_name,
+                if frame_result { nil } else { i32_ty },
+            );
+            if malformed_layout {
+                let wrong = ctx.types.intern(
+                    TypeDataBuilder::new(Symbol::new("adt"), Symbol::new("struct"))
+                        .attr("name", Attribute::Symbol(frame_name))
+                        .attr("fields", Attribute::List(vec![]))
+                        .build(),
+                );
+                ctx.register_type_alias(frame_name, wrong);
+            }
+            let worker = core::func(&mut ctx, never, [evidence, frame]).as_type_ref();
+            ctx.op_mut(main.op_ref())
+                .attributes
+                .insert(Symbol::new("type"), Attribute::Type(worker));
+            let entry = ctx.region(main.body(&ctx)).blocks[0];
+            ctx.set_block_arg_type(entry, 0, evidence);
+            ctx.set_block_arg_type(entry, 1, frame);
+            ctx.op_mut(main.op_ref()).attributes.insert(
+                Symbol::new(ROOT_EXPORT_CONVENTION_ATTR),
+                Attribute::Int(CallingConvention::Direct as i128),
+            );
+            ctx.op_mut(main.op_ref())
+                .attributes
+                .insert(Symbol::new(ROOT_SOURCE_RESULT_ATTR), Attribute::Type(nil));
+
+            lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+            let before = print_module(&ctx, module.op());
+            let error = compose_root_entry_bridge(&mut ctx, module).unwrap_err();
+
+            assert!(error.to_string().contains(expected), "{error}");
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
     }
 
     #[test]

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -330,16 +330,20 @@ Root `main`은 하나뿐인 target-independent CPS delimiter다. Source residual
 거부한다. Nested module의 `main`은 일반 worker다.
 
 Target-independent 경계는 Direct/EvidenceDirect export wrapper가 source result
-type의 completion cell과 이를 capture한 root `done_k`를 소유한다는 추상 조합
-계약만 정한다. Shared IR에서 CPS entry와 `done_k`의 result는 `core.never`이며,
+type의 completion cell과 이를 capture한 terminal `Done<R>` 및 terminal
+`Dispatch<R>`를 담은 정확한 `ContinuationFrame<R>`를 소유한다는 추상 조합
+계약만 정한다. Worker ABI의 두 번째 operand는 이 nominal frame이며 bare
+`done_k`로 대체하거나 closure storage/arity에서 복원하지 않는다. Shared IR에서
+CPS entry와 `done_k`의 result는 `core.never`이며,
 `func.tail_call`과 `func.tail_call_indirect` verifier도 caller/callee의
 `core.never` 일치를 검사한다.
 
 Target signature lowering은 이 CPS signature를 native/Wasm empty-result
 signature로 바꾼 뒤 실제 wrapper와 ordinary call을 합성한다. Wasm은 nil/void
 machinery처럼 target이 지원하는 표현을 사용한다. Root `done_k`는 source result를
-cell에 정확히 한 번 쓰고 target empty result로 반환하며, wrapper는
-proper-tail-call chain이 끝난 뒤 cell을 읽어 source result로 반환한다. Shared
+cell에 정확히 한 번 쓰고 terminal dispatch는 root 밖 general operation transfer를
+끝내며, wrapper는 이 둘을 immutable `ContinuationFrame<R>`로 materialize해 worker에
+전달한 뒤 proper-tail-call chain이 끝나면 cell을 읽어 source result로 반환한다. Shared
 `core.func<Return, ...>`와 `func.call`의 단일 logical result 계약을 유지하고 새
 zero-result call 형상을 요구하지 않으며 두 번째 control carrier도 도입하지
 않는다. 이 adapter는 answer-type polymorphism, trampoline, in-band sentinel 또는

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -433,9 +433,13 @@ entrypoint 전에 거부한다. Frontend는 root body도 direct-style control로
 shared conversion은 typed completion cell과 `core.never` root `done_k`의 추상
 계약을 만든다. Target signature lowering이 CPS entry를 empty result로 바꾼 뒤에만
 Direct/EvidenceDirect export wrapper의 ordinary call을 합성한다. Wrapper는
-completion cell을 소유하고 root `done_k`가 이를 쓴 뒤 target call이 돌아오면
-cell을 읽는다. Shared `func.call`에 zero-result 형상을 추가하지 않으며
-nested-module `main`은 특별하지 않다.
+completion cell을 소유하고 이를 capture한 terminal `Done<R>`와 terminal
+`Dispatch<R>`를 exact nominal `ContinuationFrame<R>`에 materialize해 worker에
+전달한다. `done_k`가 cell을 쓴 뒤 target call이 돌아오면 wrapper가 cell을 읽는다.
+worker frame 계약은 명시적 frame result/layout provenance로 검사하며 closure 이름,
+arity, raw storage, `anyref`에서 추론하지 않는다.
+Shared `func.call`에 zero-result 형상을 추가하지 않으며 nested-module `main`은
+특별하지 않다.
 
 기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
 Frontend shared lowering은 private runtime bridge stub을 `tribute_io.write`와

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1731,7 +1731,7 @@ mod tests {
         let module = trunk_ir::parser::parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @main(%evidence: core.i32, %done: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%evidence: core.i32, %frame: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     func.unreachable
   }
 }"#,
@@ -1744,6 +1744,19 @@ mod tests {
         let nil = core_dialect::nil(&mut ctx).as_type_ref();
         let never = core_dialect::never(&mut ctx).as_type_ref();
         let evidence = tribute_ir::dialect::ability::evidence_adt_type_ref(&mut ctx);
+        let frame_name = trunk_ir::Symbol::new("__tribute_continuation_frame_root_nil");
+        let frame = ctx.types.intern(
+            trunk_ir::TypeDataBuilder::new(
+                trunk_ir::Symbol::new("adt"),
+                trunk_ir::Symbol::new("typeref"),
+            )
+            .attr("name", trunk_ir::Attribute::Symbol(frame_name))
+            .attr(
+                "tribute.cps_continuation_frame_result",
+                trunk_ir::Attribute::Type(nil),
+            )
+            .build(),
+        );
         let done_callable = core_dialect::func(&mut ctx, never, [nil]).as_type_ref();
         let done = ctx.types.intern(
             trunk_ir::TypeDataBuilder::new(
@@ -1758,14 +1771,82 @@ mod tests {
             )
             .build(),
         );
-        let worker = core_dialect::func(&mut ctx, never, [evidence, done]).as_type_ref();
+        let anyref = tribute_ir::dialect::tribute_rt::anyref(&mut ctx).as_type_ref();
+        let i32_ty = ctx.types.intern(
+            trunk_ir::TypeDataBuilder::new(
+                trunk_ir::Symbol::new("core"),
+                trunk_ir::Symbol::new("i32"),
+            )
+            .build(),
+        );
+        let resume_callable =
+            core_dialect::func(&mut ctx, never, [evidence, frame, anyref]).as_type_ref();
+        let resume = ctx.types.intern(
+            trunk_ir::TypeDataBuilder::new(
+                trunk_ir::Symbol::new("closure"),
+                trunk_ir::Symbol::new("closure"),
+            )
+            .param(resume_callable)
+            .attr("tribute.calling_convention", trunk_ir::Attribute::Int(2))
+            .attr(
+                "tribute.closure_environment_index",
+                trunk_ir::Attribute::Int(0),
+            )
+            .build(),
+        );
+        let dispatch_callable = core_dialect::func(
+            &mut ctx,
+            never,
+            [evidence, resume, i32_ty, i32_ty, i32_ty, anyref],
+        )
+        .as_type_ref();
+        let dispatch = ctx.types.intern(
+            trunk_ir::TypeDataBuilder::new(
+                trunk_ir::Symbol::new("closure"),
+                trunk_ir::Symbol::new("closure"),
+            )
+            .param(dispatch_callable)
+            .attr("tribute.calling_convention", trunk_ir::Attribute::Int(2))
+            .attr(
+                "tribute.closure_environment_index",
+                trunk_ir::Attribute::Int(1),
+            )
+            .build(),
+        );
+        let layout = ctx.types.intern(
+            trunk_ir::TypeDataBuilder::new(
+                trunk_ir::Symbol::new("adt"),
+                trunk_ir::Symbol::new("struct"),
+            )
+            .attr("name", trunk_ir::Attribute::Symbol(frame_name))
+            .attr(
+                "tribute.cps_continuation_frame_result",
+                trunk_ir::Attribute::Type(nil),
+            )
+            .attr(
+                "fields",
+                trunk_ir::Attribute::List(vec![
+                    trunk_ir::Attribute::List(vec![
+                        trunk_ir::Attribute::Symbol(trunk_ir::Symbol::new("done")),
+                        trunk_ir::Attribute::Type(done),
+                    ]),
+                    trunk_ir::Attribute::List(vec![
+                        trunk_ir::Attribute::Symbol(trunk_ir::Symbol::new("dispatch")),
+                        trunk_ir::Attribute::Type(dispatch),
+                    ]),
+                ]),
+            )
+            .build(),
+        );
+        ctx.register_type_alias(frame_name, layout);
+        let worker = core_dialect::func(&mut ctx, never, [evidence, frame]).as_type_ref();
         ctx.op_mut(main.op_ref()).attributes.insert(
             trunk_ir::Symbol::new("type"),
             trunk_ir::Attribute::Type(worker),
         );
         let entry = ctx.region(main.body(&ctx)).blocks[0];
         ctx.set_block_arg_type(entry, 0, evidence);
-        ctx.set_block_arg_type(entry, 1, done);
+        ctx.set_block_arg_type(entry, 1, frame);
         ctx.op_mut(main.op_ref()).attributes.insert(
             trunk_ir::Symbol::new("tribute.root_export_convention"),
             trunk_ir::Attribute::Int(0),

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1725,6 +1725,10 @@ pub fn link_native_binary(object_bytes: &[u8], output: &Path) -> Result<(), Link
 mod tests {
     use super::*;
     use salsa_test_macros::salsa_test;
+    use tribute_core::calling_convention::{
+        cps_continuation_frame_layout_type, cps_continuation_frame_ref_type, cps_dispatch_type,
+        cps_done_type,
+    };
 
     fn source_logical_cps_root_module() -> (IrContext, Module) {
         let mut ctx = IrContext::new();
@@ -1745,32 +1749,8 @@ mod tests {
         let never = core_dialect::never(&mut ctx).as_type_ref();
         let evidence = tribute_ir::dialect::ability::evidence_adt_type_ref(&mut ctx);
         let frame_name = trunk_ir::Symbol::new("__tribute_continuation_frame_root_nil");
-        let frame = ctx.types.intern(
-            trunk_ir::TypeDataBuilder::new(
-                trunk_ir::Symbol::new("adt"),
-                trunk_ir::Symbol::new("typeref"),
-            )
-            .attr("name", trunk_ir::Attribute::Symbol(frame_name))
-            .attr(
-                "tribute.cps_continuation_frame_result",
-                trunk_ir::Attribute::Type(nil),
-            )
-            .build(),
-        );
-        let done_callable = core_dialect::func(&mut ctx, never, [nil]).as_type_ref();
-        let done = ctx.types.intern(
-            trunk_ir::TypeDataBuilder::new(
-                trunk_ir::Symbol::new("closure"),
-                trunk_ir::Symbol::new("closure"),
-            )
-            .param(done_callable)
-            .attr("tribute.calling_convention", trunk_ir::Attribute::Int(2))
-            .attr(
-                "tribute.closure_environment_index",
-                trunk_ir::Attribute::Int(0),
-            )
-            .build(),
-        );
+        let frame = cps_continuation_frame_ref_type(&mut ctx, frame_name, nil);
+        let done = cps_done_type(&mut ctx, nil);
         let anyref = tribute_ir::dialect::tribute_rt::anyref(&mut ctx).as_type_ref();
         let i32_ty = ctx.types.intern(
             trunk_ir::TypeDataBuilder::new(
@@ -1779,65 +1759,8 @@ mod tests {
             )
             .build(),
         );
-        let resume_callable =
-            core_dialect::func(&mut ctx, never, [evidence, frame, anyref]).as_type_ref();
-        let resume = ctx.types.intern(
-            trunk_ir::TypeDataBuilder::new(
-                trunk_ir::Symbol::new("closure"),
-                trunk_ir::Symbol::new("closure"),
-            )
-            .param(resume_callable)
-            .attr("tribute.calling_convention", trunk_ir::Attribute::Int(2))
-            .attr(
-                "tribute.closure_environment_index",
-                trunk_ir::Attribute::Int(0),
-            )
-            .build(),
-        );
-        let dispatch_callable = core_dialect::func(
-            &mut ctx,
-            never,
-            [evidence, resume, i32_ty, i32_ty, i32_ty, anyref],
-        )
-        .as_type_ref();
-        let dispatch = ctx.types.intern(
-            trunk_ir::TypeDataBuilder::new(
-                trunk_ir::Symbol::new("closure"),
-                trunk_ir::Symbol::new("closure"),
-            )
-            .param(dispatch_callable)
-            .attr("tribute.calling_convention", trunk_ir::Attribute::Int(2))
-            .attr(
-                "tribute.closure_environment_index",
-                trunk_ir::Attribute::Int(1),
-            )
-            .build(),
-        );
-        let layout = ctx.types.intern(
-            trunk_ir::TypeDataBuilder::new(
-                trunk_ir::Symbol::new("adt"),
-                trunk_ir::Symbol::new("struct"),
-            )
-            .attr("name", trunk_ir::Attribute::Symbol(frame_name))
-            .attr(
-                "tribute.cps_continuation_frame_result",
-                trunk_ir::Attribute::Type(nil),
-            )
-            .attr(
-                "fields",
-                trunk_ir::Attribute::List(vec![
-                    trunk_ir::Attribute::List(vec![
-                        trunk_ir::Attribute::Symbol(trunk_ir::Symbol::new("done")),
-                        trunk_ir::Attribute::Type(done),
-                    ]),
-                    trunk_ir::Attribute::List(vec![
-                        trunk_ir::Attribute::Symbol(trunk_ir::Symbol::new("dispatch")),
-                        trunk_ir::Attribute::Type(dispatch),
-                    ]),
-                ]),
-            )
-            .build(),
-        );
+        let dispatch = cps_dispatch_type(&mut ctx, evidence, frame, anyref, i32_ty);
+        let layout = cps_continuation_frame_layout_type(&mut ctx, frame_name, nil, done, dispatch);
         ctx.register_type_alias(frame_name, layout);
         let worker = core_dialect::func(&mut ctx, never, [evidence, frame]).as_type_ref();
         ctx.op_mut(main.op_ref()).attributes.insert(


### PR DESCRIPTION
## Summary

- validate the root worker against the exact `ContinuationFrame<R>` result and nominal layout provenance
- construct distinct terminal `Done<R>` and `Dispatch<R>` closures and materialize the immutable frame
- pass the frame through the ordinary Direct/EvidenceDirect root wrapper call
- reject malformed frame contracts before mutating the module

This is a target-ABI prerequisite for #825 and part of #774. It does not change production pipeline ordering, backend tail lowering, ownership, or legacy paths.

## Validation

- normal commit hook: 1,983 passed, 1 skipped
- `tribute-passes` tests: 238 passed
- focused target ABI, closure, native root, Wasm root, and handler tests
- warnings-denied Clippy, formatting, and diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved CPS root execution handling with explicit continuation frames containing completion and dispatch information.
  - Added validation for continuation-frame structure and terminal dispatch behavior, providing clearer failures for invalid configurations.
  - Root workers now receive fully constructed continuation frames for more reliable result completion and operation transfer.

- **Documentation**
  - Updated CPS effects and implementation guidance to describe the continuation-frame root entry contract and result-handling flow.

- **Tests**
  - Expanded coverage for frame construction, dispatch behavior, worker arguments, and malformed contract rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->