### PR TITLE
#825: Fix target-lowering prerequisites

### DIFF
--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -667,14 +667,37 @@ fn tagged_closure_transfers_are_legal(ctx: &mut IrContext, func_op: func::Func) 
 /// Lower closures using arena IR.
 ///
 /// This compatibility entry point prepares module-level function signatures,
-/// then lowers each function body independently.
+/// then lowers every function body in the module tree.
 pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) {
     prepare_closure_lowering(ctx, module);
 
-    for op in module.ops(ctx) {
-        let Ok(func_op) = func::Func::from_op(ctx, op) else {
-            continue;
+    lower_prepared_closures(ctx, module);
+}
+
+/// Lower every already-prepared function body in a module to closure storage.
+///
+/// The worklist is refreshed after each function so functions introduced by an
+/// earlier transformation are lowered once as well. Processing each function
+/// operation at most once keeps this traversal bounded without relying on
+/// function names or target-specific pipeline ordering.
+pub fn lower_prepared_closures(ctx: &mut IrContext, module: Module) {
+    let mut lowered = HashSet::new();
+    let mut worklist = Vec::new();
+
+    loop {
+        let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+            if let Ok(func_op) = func::Func::from_op(ctx, op)
+                && lowered.insert(op)
+            {
+                worklist.push(func_op);
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+
+        let Some(func_op) = worklist.pop() else {
+            break;
         };
+
         lower_closures_in_func(ctx, func_op);
     }
 }
@@ -891,6 +914,23 @@ impl Pass for LowerClosures {
     }
 }
 
+/// PassManager-friendly closure lowering for a module prepared earlier in the
+/// pipeline.
+pub struct LowerPreparedClosures;
+
+impl Pass for LowerPreparedClosures {
+    type Target = core::Module;
+
+    fn name(&self) -> &'static str {
+        "lower-prepared-closures"
+    }
+
+    fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
+        lower_prepared_closures(ctx, target.into());
+        Ok(())
+    }
+}
+
 /// PassManager-friendly module preparation for closure lowering.
 pub struct PrepareClosureLowering;
 
@@ -1032,6 +1072,20 @@ mod tests {
         )
     }
 
+    fn assert_module_is_structurally_valid(ctx: &IrContext, module: Module) {
+        let use_chains = trunk_ir::validation::validate_use_chains(ctx, module);
+        assert!(
+            use_chains.is_ok(),
+            "invalid use chains after lowering:\n{use_chains}"
+        );
+
+        let operation_verifiers = trunk_ir::validation::validate_operation_verifiers(ctx, module);
+        assert!(
+            operation_verifiers.is_ok(),
+            "invalid operations after lowering:\n{operation_verifiers}"
+        );
+    }
+
     #[test]
     fn prepare_pass_adapter_updates_function_signatures() {
         let mut ctx = IrContext::new();
@@ -1122,6 +1176,45 @@ mod tests {
                 "{name} should pass the enclosing function's evidence argument immediately after table index"
             );
         }
+    }
+
+    #[test]
+    fn module_entrypoint_lowers_nested_function_closures() {
+        let mut ctx = IrContext::new();
+        let module = nested_closure_test_module(&mut ctx);
+
+        lower_closures(&mut ctx, module);
+        assert_module_is_structurally_valid(&ctx, module);
+
+        let inner = func_by_name_recursive(&ctx, module, "inner");
+        let inner_ir = print_module(&ctx, inner.op_ref());
+        assert!(
+            !inner_ir.contains("closure.new"),
+            "module lowering must revisit nested functions:\n{inner_ir}"
+        );
+        assert!(
+            !inner_ir.contains("closure.func") && !inner_ir.contains("closure.env"),
+            "nested closure accessors must be fully lowered:\n{inner_ir}"
+        );
+    }
+
+    #[test]
+    fn prepared_module_worklist_lowers_nested_function_closures() {
+        let mut ctx = IrContext::new();
+        let module = nested_closure_test_module(&mut ctx);
+
+        prepare_closure_lowering(&mut ctx, module);
+        let core_module = core::Module::from_op(&ctx, module.op()).unwrap();
+        let mut pass = LowerPreparedClosures;
+        pass.run(&mut ctx, core_module).unwrap();
+        assert_module_is_structurally_valid(&ctx, module);
+
+        let inner = func_by_name_recursive(&ctx, module, "inner");
+        let inner_ir = print_module(&ctx, inner.op_ref());
+        assert!(
+            !inner_ir.contains("closure.new"),
+            "prepared module worklist must lower nested functions:\n{inner_ir}"
+        );
     }
 
     #[test]

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -35,7 +35,7 @@ use crate::context::{BlockArgData, BlockData, IrContext};
 use crate::dialect::{arith, cf, func, scf};
 use crate::ops::DialectOp;
 use crate::pass::{Pass, pass_fn};
-use crate::refs::{BlockRef, OpRef, RegionRef};
+use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
 use crate::rewrite::Module;
 use crate::rewrite::helpers::{inline_region_blocks, split_block};
 use crate::symbol::Symbol;
@@ -129,12 +129,80 @@ fn is_scf_control_flow(ctx: &IrContext, op: OpRef) -> bool {
     n == Symbol::new("if") || n == Symbol::new("loop") || n == Symbol::new("switch")
 }
 
+/// Whether this is a terminal `scf.if : core.never` whose branches each
+/// already transfer control. Such an if has no continuation to merge into.
+fn is_terminal_never_if(
+    ctx: &IrContext,
+    block: BlockRef,
+    scf_op: OpRef,
+    then_region: RegionRef,
+    else_region: RegionRef,
+) -> bool {
+    let [result] = ctx.op_results(scf_op) else {
+        return false;
+    };
+    let result_ty = ctx.types.get(ctx.value_ty(*result));
+    if result_ty.dialect != Symbol::new("core")
+        || result_ty.name != Symbol::new("never")
+        || ctx.has_uses(*result)
+        || ctx.block(block).ops.last() != Some(&scf_op)
+    {
+        return false;
+    }
+
+    [then_region, else_region].into_iter().all(|region| {
+        let [branch] = ctx.region(region).blocks.as_slice() else {
+            return false;
+        };
+        let Some(&terminator) = ctx.block(*branch).ops.last() else {
+            return false;
+        };
+        !is_scf_control_flow(ctx, terminator)
+            && crate::validation::is_proper_tail_terminator(ctx, terminator)
+    })
+}
+
+/// Lower a terminal `scf.if : core.never` without creating a merge block.
+fn lower_terminal_never_if(
+    ctx: &mut IrContext,
+    block: BlockRef,
+    scf_op: OpRef,
+    loc: Location,
+    cond: ValueRef,
+    then_region: RegionRef,
+    else_region: RegionRef,
+) {
+    let parent_region = ctx.block(block).parent_region.unwrap();
+    let blocks = ctx.region(parent_region).blocks.to_vec();
+    let insert_before = blocks
+        .iter()
+        .position(|&candidate| candidate == block)
+        .and_then(|index| blocks.get(index + 1).copied());
+
+    ctx.detach_op(scf_op);
+    let then_blocks = inline_region_blocks(ctx, then_region, parent_region, insert_before);
+    let else_blocks = inline_region_blocks(ctx, else_region, parent_region, insert_before);
+    ctx.remove_op(scf_op);
+
+    let cond_br = cf::cond_br(ctx, loc, cond, then_blocks[0], else_blocks[0]);
+    ctx.push_op(block, cond_br.op_ref());
+
+    for &branch in then_blocks.iter().chain(&else_blocks) {
+        transform_block(ctx, branch);
+    }
+}
+
 /// Lower `scf.if` to cf.cond_br + then/else/merge blocks.
 fn lower_scf_if(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Location) {
     let if_op = scf::If::from_op(ctx, scf_op).unwrap();
     let cond = if_op.cond(ctx);
     let then_region = if_op.then_region(ctx);
     let else_region = if_op.else_region(ctx);
+
+    if is_terminal_never_if(ctx, block, scf_op, then_region, else_region) {
+        lower_terminal_never_if(ctx, block, scf_op, loc, cond, then_region, else_region);
+        return;
+    }
 
     // Only results with users need a CFG merge value. This intentionally
     // applies to every result type: an unused result does not need a block
@@ -926,7 +994,7 @@ mod tests {
         let input = r#"core.module @test {
   func.func @main(%cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     %discarded = scf.if %cond : core.never {
-      func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+      func.unreachable
     } {
       func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
     }
@@ -948,9 +1016,14 @@ mod tests {
                 .iter()
                 .filter(|name| name.as_str() == "func.tail_call_indirect")
                 .count(),
-            2
+            1
         );
+        assert!(names.iter().any(|name| name == "func.unreachable"));
         assert!(crate::validation::validate_use_chains(&ctx, module).is_ok());
+        assert!(
+            crate::validation::validate_operation_verifiers(&ctx, module).is_ok(),
+            "terminal lowering must keep the CFG well-formed"
+        );
 
         let has_non_entry_never_arg = ctx
             .region(body)
@@ -965,6 +1038,11 @@ mod tests {
         assert!(
             !has_non_entry_never_arg,
             "unused scf.if result must not create a core.never CFG block argument"
+        );
+        assert_eq!(
+            count_blocks(&ctx, body),
+            3,
+            "a terminal core.never scf.if must not leave an empty merge block"
         );
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -950,7 +950,7 @@ enum TargetClosureStorageBoundary {
 }
 
 /// Enter the sole target-side closure storage boundary. Exact ABI validation
-/// observes semantic closure types first; `LowerClosuresInFunc` then consumes
+/// observes semantic closure types first; `LowerPreparedClosures` then consumes
 /// any remaining closure operations before whole-module storage finalization.
 fn enter_target_closure_storage_boundary(
     ctx: &mut IrContext,
@@ -964,8 +964,7 @@ fn enter_target_closure_storage_boundary(
     let core_module = core_dialect::Module::from_op(ctx, m.op())
         .expect("target closure lowering requires a core.module");
     let mut pm = PassManager::new();
-    pm.nest::<func_dialect::Func>()
-        .add_pass(tribute_passes::closure_lower::LowerClosuresInFunc);
+    pm.add_pass(tribute_passes::closure_lower::LowerPreparedClosures);
     install_debug_use_chain_verifier(&mut pm);
     pm.run(ctx, core_module)?;
     Ok(TargetClosureStorageBoundary::SourceLogicalCps)


### PR DESCRIPTION
## Summary

- lower terminal resultless `scf.if` without creating an empty merge block
- lower already-prepared nested closures to convergence at the target boundary
- preserve the target-boundary debug use-chain verifier

These are independent prerequisites consumed by #825; this PR does not close it.

## Validation

- focused `trunk-ir`, `tribute-passes`, target-boundary, and Wasm regressions
- normal hook: 1,986 passed, 1 skipped
- changed executable-line coverage: 110/115 (95.7%)

## Commits

- `01cfc52b` Fix terminal SCF lowering without empty merge
- `e9e664d3` Lower nested closures to convergence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved processing of nested functions and newly introduced closures.
  * Added support for lowering closures in modules that were prepared in an earlier stage.

* **Bug Fixes**
  * Improved control-flow lowering for terminal conditional branches.
  * Eliminated unnecessary merge blocks and preserved correct tail-transfer behavior.
  * Added validation to ensure generated control flow remains well-formed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->