### PR TITLE
#825: Convert anyref through the native TypeConverter

### DIFF
--- a/crates/tribute-passes/src/native/rc_materialization.rs
+++ b/crates/tribute-passes/src/native/rc_materialization.rs
@@ -9,10 +9,10 @@ use std::collections::HashMap;
 use tribute_ir::dialect::tribute_rt::{self, RC_HEADER_SIZE};
 use trunk_ir::adt_layout::{compute_enum_layout, compute_struct_layout, get_struct_fields};
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{adt, clif, core};
+use trunk_ir::dialect::adt;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::rewrite::{Module, TypeConverter};
-use trunk_ir::{BlockRef, OpRef, RegionRef, Symbol, TypeRef, ValueRef};
+use trunk_ir::{BlockRef, OpRef, Symbol, TypeRef, ValueRef};
 
 use super::ownership_plan::{ActionAnchor, ActionKind, NativeOwnershipPlan, OwnershipPlanError};
 
@@ -87,130 +87,6 @@ pub fn materialize(
         insert_after(ctx, block, op, operations);
     }
     Ok(())
-}
-
-/// Erase the remaining `anyref` spelling after explicit plan actions have
-/// already fixed RC meaning. This is representation conversion only; it does
-/// not inspect values to discover further ownership operations.
-pub fn lower_anyref_to_ptr(ctx: &mut IrContext, module: Module) {
-    let ptr_ty = core::ptr(ctx).as_type_ref();
-    let anyref_ty = ctx.types.intern(
-        trunk_ir::TypeDataBuilder::new(Symbol::new("tribute_rt"), Symbol::new("anyref")).build(),
-    );
-    let Some(first_block) = module.first_block(ctx) else {
-        return;
-    };
-    let module_ops = ctx
-        .block(first_block)
-        .ops
-        .iter()
-        .copied()
-        .collect::<Vec<_>>();
-    for op in module_ops {
-        if let Ok(function) = clif::Func::from_op(ctx, op) {
-            let ty = function.r#type(ctx);
-            let rewritten = rewrite_type_anyref(ctx, ty, anyref_ty, ptr_ty);
-            if rewritten != ty {
-                ctx.op_mut(op)
-                    .attributes
-                    .insert(Symbol::new("type"), trunk_ir::Attribute::Type(rewritten));
-            }
-            lower_anyref_in_region(ctx, function.body(ctx), ptr_ty);
-        }
-    }
-}
-
-fn lower_anyref_in_region(ctx: &mut IrContext, region: RegionRef, ptr_ty: TypeRef) {
-    let anyref_ty = ctx.types.intern(
-        trunk_ir::TypeDataBuilder::new(Symbol::new("tribute_rt"), Symbol::new("anyref")).build(),
-    );
-    let blocks = ctx
-        .region(region)
-        .blocks
-        .iter()
-        .copied()
-        .collect::<Vec<_>>();
-    for block in blocks {
-        for index in 0..ctx.block_args(block).len() {
-            let value = ctx.block_args(block)[index];
-            if ctx.value_ty(value) == anyref_ty {
-                ctx.set_block_arg_type(block, index as u32, ptr_ty);
-            }
-        }
-        let operations = ctx.block(block).ops.iter().copied().collect::<Vec<_>>();
-        for op in operations {
-            for index in 0..ctx.op_results(op).len() {
-                if ctx.value_ty(ctx.op_result(op, index as u32)) == anyref_ty {
-                    ctx.set_op_result_type(op, index as u32, ptr_ty);
-                }
-            }
-            rewrite_op_type_attrs(ctx, op, anyref_ty, ptr_ty);
-            let nested_regions = ctx.op(op).regions.iter().copied().collect::<Vec<_>>();
-            for nested in nested_regions {
-                lower_anyref_in_region(ctx, nested, ptr_ty);
-            }
-        }
-    }
-}
-
-fn rewrite_op_type_attrs(ctx: &mut IrContext, op: OpRef, anyref_ty: TypeRef, ptr_ty: TypeRef) {
-    let attrs = ctx
-        .op(op)
-        .attributes
-        .iter()
-        .map(|(key, value)| (*key, value.clone()))
-        .collect::<Vec<_>>();
-    for (key, attr) in attrs {
-        if let trunk_ir::Attribute::Type(ty) = attr {
-            let rewritten = rewrite_type_anyref(ctx, ty, anyref_ty, ptr_ty);
-            if rewritten != ty {
-                ctx.op_mut(op)
-                    .attributes
-                    .insert(key, trunk_ir::Attribute::Type(rewritten));
-            }
-        }
-    }
-}
-
-fn rewrite_type_anyref(
-    ctx: &mut IrContext,
-    ty: TypeRef,
-    anyref_ty: TypeRef,
-    ptr_ty: TypeRef,
-) -> TypeRef {
-    if ty == anyref_ty {
-        return ptr_ty;
-    }
-    let (dialect, name, params, attrs) = {
-        let data = ctx.types.get(ty);
-        (
-            data.dialect,
-            data.name,
-            data.params.to_vec(),
-            data.attrs
-                .iter()
-                .map(|(key, value)| (*key, value.clone()))
-                .collect::<Vec<_>>(),
-        )
-    };
-    if dialect != Symbol::new("core") || name != Symbol::new("func") {
-        return ty;
-    }
-    let rewritten = params
-        .iter()
-        .map(|&param| rewrite_type_anyref(ctx, param, anyref_ty, ptr_ty))
-        .collect::<Vec<_>>();
-    if rewritten == params {
-        return ty;
-    }
-    let mut builder = trunk_ir::TypeDataBuilder::new(dialect, name);
-    for param in rewritten {
-        builder = builder.param(param);
-    }
-    for (key, attr) in attrs {
-        builder = builder.attr(key, attr);
-    }
-    ctx.types.intern(builder.build())
 }
 
 fn build_schedule(

--- a/crates/tribute-passes/src/native/type_converter.rs
+++ b/crates/tribute-passes/src/native/type_converter.rs
@@ -120,6 +120,9 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
 
     // === Primitive type conversions ===
     tc.add_conversion(move |ctx, ty| {
+        if ty == r.tribute_rt_anyref {
+            return Some(r.core_ptr);
+        }
         if ty == r.tribute_rt_int || ty == r.tribute_rt_nat || ty == r.tribute_rt_bool {
             return Some(r.core_i32);
         }
@@ -506,4 +509,78 @@ struct NativeTypeRefsCopy {
     core_i8: TypeRef,
     evidence_ty: TypeRef,
     marker_ty: TypeRef,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::dialect::clif;
+    use trunk_ir::ops::DialectOp;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    #[test]
+    fn native_type_converter_maps_anyref_to_ptr() {
+        let mut ctx = IrContext::new();
+        let (type_converter, refs) = native_type_converter(&mut ctx);
+
+        assert_eq!(
+            type_converter.convert_type(&ctx, refs.tribute_rt_anyref),
+            Some(refs.core_ptr)
+        );
+    }
+
+    #[test]
+    fn native_func_lowering_converts_bodyless_and_bodied_anyref_functions() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @declaration(%value: tribute_rt.anyref) -> tribute_rt.anyref
+  func.func @definition(%value: tribute_rt.anyref) -> tribute_rt.anyref {
+    func.return %value
+  }
+}"#,
+        );
+        let (type_converter, refs) = native_type_converter(&mut ctx);
+
+        trunk_ir_cranelift_backend::passes::func_to_clif::lower(&mut ctx, module, type_converter)
+            .expect("func-to-clif lowering");
+
+        let functions = module
+            .ops(&ctx)
+            .into_iter()
+            .map(|op| clif::Func::from_op(&ctx, op).expect("clif.func"))
+            .collect::<Vec<_>>();
+        let declaration = functions
+            .iter()
+            .find(|function| function.sym_name(&ctx) == Symbol::new("declaration"))
+            .expect("bodyless declaration");
+        let definition = functions
+            .iter()
+            .find(|function| function.sym_name(&ctx) == Symbol::new("definition"))
+            .expect("bodied definition");
+
+        assert_eq!(ctx.op(declaration.op_ref()).regions.len(), 0);
+        assert_eq!(
+            ctx.types.get(declaration.r#type(&ctx)).params.as_slice(),
+            [refs.core_ptr, refs.core_ptr]
+        );
+        assert_eq!(
+            ctx.types.get(definition.r#type(&ctx)).params.as_slice(),
+            [refs.core_ptr, refs.core_ptr]
+        );
+
+        let body = definition.body(&ctx);
+        let entry = ctx
+            .region(body)
+            .blocks
+            .first()
+            .copied()
+            .expect("definition entry");
+        assert_eq!(ctx.value_ty(ctx.block_args(entry)[0]), refs.core_ptr);
+
+        let printed = print_module(&ctx, module.op());
+        assert!(!printed.contains("tribute_rt.anyref"), "{printed}");
+    }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -244,6 +244,9 @@ impl RewritePattern for FuncCallPattern {
             Symbol::new("clif"),
             Symbol::new("call"),
         );
+        for (index, result_ty) in rewriter.result_types(ctx, op).into_iter().enumerate() {
+            ctx.set_op_result_type(new_op, index as u32, result_ty);
+        }
         ctx.op_mut(new_op)
             .attributes
             .insert(Symbol::new("callee"), Attribute::Symbol(callee));
@@ -519,10 +522,13 @@ impl RewritePattern for ClosureStructAdaptPattern {
 
 #[cfg(test)]
 mod tests {
+    use trunk_ir::Symbol;
     use trunk_ir::context::IrContext;
+    use trunk_ir::dialect::core;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
     use trunk_ir::rewrite::TypeConverter;
+    use trunk_ir::types::TypeDataBuilder;
 
     const TAIL_TRANSFERS: &str = r#"core.module @test {
   func.func @direct_target(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
@@ -554,6 +560,37 @@ mod tests {
 }"#,
         );
         insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn direct_call_result_uses_the_converted_type() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @callee() -> tribute_rt.anyref
+  func.func @caller() -> tribute_rt.anyref {
+    %result = func.call {callee = @callee} : tribute_rt.anyref
+    func.return %result
+  }
+}"#,
+        );
+        let anyref_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("tribute_rt"), Symbol::new("anyref")).build());
+        let ptr_ty = core::ptr(&mut ctx).as_type_ref();
+        let mut type_converter = TypeConverter::new();
+        type_converter.add_conversion(move |_, ty| (ty == anyref_ty).then_some(ptr_ty));
+
+        super::lower(&mut ctx, module, type_converter).expect("func-to-clif lowering");
+
+        let printed = print_module(&ctx, module.op());
+        let call = printed
+            .lines()
+            .find(|line| line.contains("clif.call"))
+            .expect("lowered direct call");
+        assert!(call.contains(": core.ptr"), "{printed}");
+        assert!(!call.contains("tribute_rt.anyref"), "{printed}");
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1229,7 +1229,6 @@ fn prepare_module_to_native(
             tribute_passes::native::type_converter::native_type_converter(ctx);
         tribute_passes::native::tribute_rt_to_clif::lower(ctx, module, type_converter)
             .map_err(native_conversion_failure)?;
-        tribute_passes::native::rc_materialization::lower_anyref_to_ptr(ctx, module);
     }
 
     if stop_after == Some(NativePipelineStage::AfterRcInsertion) {


### PR DESCRIPTION
## Summary

- add the exact native `tribute_rt.anyref` to `core.ptr` TypeConverter rule
- remove the misplaced Cranelift-dependent sweep from RC materialization and the pipeline
- cover bodyless and bodied functions through the real `func` to `clif` lowering boundary

This is a prerequisite consumed by #825; it does not close #825.

## Validation

- `tribute-passes`: 243 passed
- native E2E: 67 passed
- ability-handler tests: 42 passed
- backend-ready tests: 9 passed
- normal hooks: 1,988 passed, 1 skipped
- warnings-denied Clippy, formatting, diff checks, and focused LCOV passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native compilation now converts `anyref` values to native pointer types across function signatures, parameters, return values, and direct call results.
  * Functions using `anyref` parameters or return values can now be lowered consistently, including declarations without bodies and fully defined functions.

* **Bug Fixes**
  * Improved native module generation so converted functions no longer retain unsupported `anyref` types in signatures, entry blocks, or call results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->