### PR TITLE
Make TrunkIR analysis computation fallible

### DIFF
--- a/crates/trunk-ir/src/analysis.rs
+++ b/crates/trunk-ir/src/analysis.rs
@@ -72,26 +72,6 @@ use std::sync::Arc;
 use crate::context::IrContext;
 use crate::refs::OpRef;
 
-/// An analysis computable from an IR context plus a target operation
-/// (typically a `core.module` op).
-///
-/// Analyses should be pure functions of the IR state: computing twice on
-/// an unchanged context must produce equivalent results.
-pub trait Analysis: Any + Send + Sync {
-    /// Internal IR-analysis failure returned when computation cannot produce
-    /// a valid result for the requested target.
-    type Error: Error + Send + Sync + 'static;
-
-    /// Compute this analysis for `target` in `ctx`.
-    ///
-    /// Return an error for invalid input IR or an unsupported analysis
-    /// boundary. Violated caller contracts and impossible implementation
-    /// invariants must panic rather than be represented as analysis failures.
-    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error>
-    where
-        Self: Sized;
-}
-
 /// Internal IR-analysis failure returned by [`AnalysisCache::get`].
 ///
 /// The wrapper records the concrete analysis type and requested target in
@@ -104,7 +84,12 @@ pub struct AnalysisError {
 }
 
 impl AnalysisError {
-    fn new<A: Analysis>(target: OpRef, source: A::Error) -> Self {
+    /// Attach an analysis-specific source error to its exact analysis type
+    /// and target operation.
+    pub fn new<A>(target: OpRef, source: impl Error + Send + Sync + 'static) -> Self
+    where
+        A: Analysis,
+    {
         Self {
             analysis_type: type_name::<A>(),
             target,
@@ -121,6 +106,27 @@ impl AnalysisError {
     pub fn target(&self) -> OpRef {
         self.target
     }
+}
+
+/// An analysis computable from an IR context plus a target operation
+/// (typically a `core.module` op).
+///
+/// Analyses should be pure functions of the IR state: computing twice on
+/// an unchanged context must produce equivalent results. `compute` is a
+/// typed static factory: the analysis type is both the query key and the
+/// complete concrete result stored by [`AnalysisCache`].
+pub trait Analysis: Any + Send + Sync {
+    /// Compute this analysis for `target` in `ctx`.
+    ///
+    /// Return an error for invalid input IR or an unsupported analysis
+    /// boundary. Construct failures with [`AnalysisError::new`] using this
+    /// analysis type so dependent queries can preserve their original
+    /// analysis and target context. Violated caller contracts and impossible
+    /// implementation invariants must panic rather than be represented as
+    /// analysis failures.
+    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError>
+    where
+        Self: Sized;
 }
 
 impl fmt::Display for AnalysisError {
@@ -197,9 +203,7 @@ impl AnalysisCache {
 
         // Compute before inserting so a failure cannot publish a partial or
         // failed type-erased entry. The next lookup is therefore a retry.
-        let analysis = Arc::new(
-            A::compute(ctx, target).map_err(|error| AnalysisError::new::<A>(target, error))?,
-        );
+        let analysis = Arc::new(A::compute(ctx, target)?);
         let entry: Arc<dyn Any + Send + Sync> = analysis.clone();
         self.cache.insert(key, entry);
         Ok(analysis)
@@ -263,9 +267,7 @@ mod tests {
     }
 
     impl Analysis for DummyAnalysis {
-        type Error = TestAnalysisError;
-
-        fn compute(_ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error> {
+        fn compute(_ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError> {
             Ok(Self { target })
         }
     }
@@ -274,9 +276,7 @@ mod tests {
     struct OtherAnalysis;
 
     impl Analysis for OtherAnalysis {
-        type Error = TestAnalysisError;
-
-        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, Self::Error> {
+        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, AnalysisError> {
             Ok(Self)
         }
     }
@@ -291,9 +291,7 @@ mod tests {
     struct CountedAnalysis;
 
     impl Analysis for CountedAnalysis {
-        type Error = TestAnalysisError;
-
-        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, Self::Error> {
+        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, AnalysisError> {
             COUNTED_COMPUTES.fetch_add(1, Ordering::SeqCst);
             Ok(Self)
         }
@@ -303,16 +301,14 @@ mod tests {
     struct NonEmptyModuleAnalysis;
 
     impl Analysis for NonEmptyModuleAnalysis {
-        type Error = TestAnalysisError;
-
-        fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error> {
+        fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError> {
             let module = crate::rewrite::Module::new(ctx, target)
                 .expect("test only requests this analysis for core.module targets");
             module
                 .body(ctx)
                 .filter(|&body| !ctx.region(body).blocks.is_empty())
                 .map(|_| Self)
-                .ok_or(TestAnalysisError)
+                .ok_or_else(|| AnalysisError::new::<Self>(target, TestAnalysisError))
         }
     }
 

--- a/crates/trunk-ir/src/analysis.rs
+++ b/crates/trunk-ir/src/analysis.rs
@@ -108,6 +108,22 @@ impl AnalysisError {
     }
 }
 
+impl fmt::Display for AnalysisError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "analysis {} failed for {}: {}",
+            self.analysis_type, self.target, self.source
+        )
+    }
+}
+
+impl Error for AnalysisError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
 /// An analysis computable from an IR context plus a target operation
 /// (typically a `core.module` op).
 ///
@@ -127,22 +143,6 @@ pub trait Analysis: Any + Send + Sync {
     fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError>
     where
         Self: Sized;
-}
-
-impl fmt::Display for AnalysisError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "analysis {} failed for {}: {}",
-            self.analysis_type, self.target, self.source
-        )
-    }
-}
-
-impl Error for AnalysisError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(self.source.as_ref())
-    }
 }
 
 /// Lazy, typed cache of analyses keyed by `(TypeId, OpRef)`.

--- a/crates/trunk-ir/src/analysis.rs
+++ b/crates/trunk-ir/src/analysis.rs
@@ -6,6 +6,16 @@
 //! mutate the IR are expected to call [`AnalysisCache::invalidate`] to
 //! keep downstream consumers correct.
 //!
+//! A lookup either returns a complete cached result or an [`AnalysisError`].
+//! Analysis errors describe invalid input IR or an unsupported analysis
+//! boundary, not ordinary source-language diagnostics. A failed computation
+//! is never inserted: a later lookup retries from scratch after the IR is
+//! repaired or changed, while cached results for other analysis types and
+//! targets remain available. This also means the type-erased cache can never
+//! expose a partially constructed result. Unchanged invalid IR is expected to
+//! fail again; cache type mismatches and caller-contract violations remain
+//! programming errors and panic.
+//!
 //! Design inspired by MLIR's `AnalysisManager`. See issue #679 for
 //! context and the follow-up roadmap (#680 hybrid inliner, #676
 //! canonicalize).
@@ -41,7 +51,7 @@
 //! use trunk_ir::transforms::CallGraph;
 //!
 //! let mut analyses = AnalysisCache::new();
-//! let graph = analyses.get::<CallGraph>(ctx, module.op());
+//! let graph = analyses.get::<CallGraph>(ctx, module.op())?;
 //! // `graph: Arc<CallGraph>` — safe to hold while `ctx` is mutated.
 //! do_some_mutation(ctx);
 //! analyses.invalidate::<CallGraph>(module.op());
@@ -53,8 +63,10 @@
 //! `Arc<dyn Any + Send + Sync>` for future flexibility, but the cache
 //! itself is single-threaded.
 
-use std::any::{Any, TypeId};
+use std::any::{Any, TypeId, type_name};
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
 use std::sync::Arc;
 
 use crate::context::IrContext;
@@ -66,10 +78,65 @@ use crate::refs::OpRef;
 /// Analyses should be pure functions of the IR state: computing twice on
 /// an unchanged context must produce equivalent results.
 pub trait Analysis: Any + Send + Sync {
+    /// Internal IR-analysis failure returned when computation cannot produce
+    /// a valid result for the requested target.
+    type Error: Error + Send + Sync + 'static;
+
     /// Compute this analysis for `target` in `ctx`.
-    fn compute(ctx: &IrContext, target: OpRef) -> Self
+    ///
+    /// Return an error for invalid input IR or an unsupported analysis
+    /// boundary. Violated caller contracts and impossible implementation
+    /// invariants must panic rather than be represented as analysis failures.
+    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error>
     where
         Self: Sized;
+}
+
+/// Internal IR-analysis failure returned by [`AnalysisCache::get`].
+///
+/// The wrapper records the concrete analysis type and requested target in
+/// addition to preserving the analysis-specific error as its source.
+#[derive(Debug)]
+pub struct AnalysisError {
+    analysis_type: &'static str,
+    target: OpRef,
+    source: Box<dyn Error + Send + Sync>,
+}
+
+impl AnalysisError {
+    fn new<A: Analysis>(target: OpRef, source: A::Error) -> Self {
+        Self {
+            analysis_type: type_name::<A>(),
+            target,
+            source: Box::new(source),
+        }
+    }
+
+    /// Concrete Rust type of the analysis whose computation failed.
+    pub fn analysis_type(&self) -> &'static str {
+        self.analysis_type
+    }
+
+    /// Operation for which the failed analysis was requested.
+    pub fn target(&self) -> OpRef {
+        self.target
+    }
+}
+
+impl fmt::Display for AnalysisError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "analysis {} failed for {}: {}",
+            self.analysis_type, self.target, self.source
+        )
+    }
+}
+
+impl Error for AnalysisError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.source.as_ref())
+    }
 }
 
 /// Lazy, typed cache of analyses keyed by `(TypeId, OpRef)`.
@@ -113,16 +180,29 @@ impl AnalysisCache {
     /// Compute (or return cached) analysis `A` for `target`.
     ///
     /// Returns an `Arc` so callers may hold the result across IR
-    /// mutations without keeping the cache borrowed.
-    pub fn get<A: Analysis>(&mut self, ctx: &IrContext, target: OpRef) -> Arc<A> {
+    /// mutations without keeping the cache borrowed. On an internal
+    /// IR-analysis failure, returns [`AnalysisError`] without publishing a
+    /// cache entry; retry after repairing or changing the IR recomputes it.
+    pub fn get<A: Analysis>(
+        &mut self,
+        ctx: &IrContext,
+        target: OpRef,
+    ) -> Result<Arc<A>, AnalysisError> {
         let key = (TypeId::of::<A>(), target);
-        let entry = self
-            .cache
-            .entry(key)
-            .or_insert_with(|| Arc::new(A::compute(ctx, target)) as Arc<dyn Any + Send + Sync>);
-        Arc::clone(entry)
-            .downcast::<A>()
-            .expect("analysis cache type mismatch")
+        if let Some(entry) = self.cache.get(&key) {
+            return Ok(Arc::clone(entry)
+                .downcast::<A>()
+                .expect("analysis cache type mismatch"));
+        }
+
+        // Compute before inserting so a failure cannot publish a partial or
+        // failed type-erased entry. The next lookup is therefore a retry.
+        let analysis = Arc::new(
+            A::compute(ctx, target).map_err(|error| AnalysisError::new::<A>(target, error))?,
+        );
+        let entry: Arc<dyn Any + Send + Sync> = analysis.clone();
+        self.cache.insert(key, entry);
+        Ok(analysis)
     }
 
     /// Return the cached analysis `A` for `target` without computing it.
@@ -168,6 +248,7 @@ impl AnalysisCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn test_ctx() -> (IrContext, OpRef) {
         let mut ctx = IrContext::new();
@@ -182,8 +263,10 @@ mod tests {
     }
 
     impl Analysis for DummyAnalysis {
-        fn compute(_ctx: &IrContext, target: OpRef) -> Self {
-            Self { target }
+        type Error = TestAnalysisError;
+
+        fn compute(_ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error> {
+            Ok(Self { target })
         }
     }
 
@@ -191,8 +274,45 @@ mod tests {
     struct OtherAnalysis;
 
     impl Analysis for OtherAnalysis {
-        fn compute(_ctx: &IrContext, _target: OpRef) -> Self {
-            Self
+        type Error = TestAnalysisError;
+
+        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug, derive_more::Display, derive_more::Error)]
+    #[display("test analysis failed")]
+    struct TestAnalysisError;
+
+    static COUNTED_COMPUTES: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug)]
+    struct CountedAnalysis;
+
+    impl Analysis for CountedAnalysis {
+        type Error = TestAnalysisError;
+
+        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, Self::Error> {
+            COUNTED_COMPUTES.fetch_add(1, Ordering::SeqCst);
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct NonEmptyModuleAnalysis;
+
+    impl Analysis for NonEmptyModuleAnalysis {
+        type Error = TestAnalysisError;
+
+        fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error> {
+            let module = crate::rewrite::Module::new(ctx, target)
+                .expect("test only requests this analysis for core.module targets");
+            module
+                .body(ctx)
+                .filter(|&body| !ctx.region(body).blocks.is_empty())
+                .map(|_| Self)
+                .ok_or(TestAnalysisError)
         }
     }
 
@@ -200,14 +320,15 @@ mod tests {
     fn get_returns_same_arc_on_cache_hit() {
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
+        COUNTED_COMPUTES.store(0, Ordering::SeqCst);
 
-        let a1 = analyses.get::<DummyAnalysis>(&ctx, op);
-        let a2 = analyses.get::<DummyAnalysis>(&ctx, op);
+        let a1 = analyses.get::<CountedAnalysis>(&ctx, op).unwrap();
+        let a2 = analyses.get::<CountedAnalysis>(&ctx, op).unwrap();
 
-        // Cache hit: both calls return the very same `Arc`, proving
-        // `compute` was not re-invoked on the second `get`.
+        // Cache hit: both calls return the very same `Arc` and compute runs
+        // exactly once.
         assert!(Arc::ptr_eq(&a1, &a2));
-        assert_eq!(a1.target, a2.target);
+        assert_eq!(COUNTED_COMPUTES.load(Ordering::SeqCst), 1);
         assert_eq!(analyses.len(), 1);
     }
 
@@ -216,9 +337,9 @@ mod tests {
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
 
-        let a1 = analyses.get::<DummyAnalysis>(&ctx, op);
+        let a1 = analyses.get::<DummyAnalysis>(&ctx, op).unwrap();
         analyses.invalidate::<DummyAnalysis>(op);
-        let a2 = analyses.get::<DummyAnalysis>(&ctx, op);
+        let a2 = analyses.get::<DummyAnalysis>(&ctx, op).unwrap();
 
         // After invalidation the cached entry is dropped, so the next
         // `get` rebuilds the analysis — a distinct `Arc` results.
@@ -237,7 +358,7 @@ mod tests {
     fn get_cached_returns_some_after_compute() {
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
-        let _ = analyses.get::<DummyAnalysis>(&ctx, op);
+        let _ = analyses.get::<DummyAnalysis>(&ctx, op).unwrap();
         assert!(analyses.get_cached::<DummyAnalysis>(op).is_some());
     }
 
@@ -245,8 +366,8 @@ mod tests {
     fn invalidate_all_clears_all_analyses_for_target() {
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
-        let _ = analyses.get::<DummyAnalysis>(&ctx, op);
-        let _ = analyses.get::<OtherAnalysis>(&ctx, op);
+        let _ = analyses.get::<DummyAnalysis>(&ctx, op).unwrap();
+        let _ = analyses.get::<OtherAnalysis>(&ctx, op).unwrap();
         assert_eq!(analyses.len(), 2);
 
         analyses.invalidate_all(op);
@@ -257,8 +378,8 @@ mod tests {
     fn different_analyses_cached_independently() {
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
-        let _ = analyses.get::<DummyAnalysis>(&ctx, op);
-        let _ = analyses.get::<OtherAnalysis>(&ctx, op);
+        let _ = analyses.get::<DummyAnalysis>(&ctx, op).unwrap();
+        let _ = analyses.get::<OtherAnalysis>(&ctx, op).unwrap();
         assert_eq!(analyses.len(), 2);
 
         analyses.invalidate::<DummyAnalysis>(op);
@@ -270,8 +391,8 @@ mod tests {
     fn clear_drops_every_entry() {
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
-        let _ = analyses.get::<DummyAnalysis>(&ctx, op);
-        let _ = analyses.get::<OtherAnalysis>(&ctx, op);
+        let _ = analyses.get::<DummyAnalysis>(&ctx, op).unwrap();
+        let _ = analyses.get::<OtherAnalysis>(&ctx, op).unwrap();
         analyses.clear();
         assert!(analyses.is_empty());
     }
@@ -280,9 +401,84 @@ mod tests {
     fn scope_provides_ctx_and_cache_together() {
         let (mut ctx, op) = test_ctx();
         let len = AnalysisCache::scope(&mut ctx, |_ctx, analyses| {
-            let _ = analyses.get::<DummyAnalysis>(_ctx, op);
+            let _ = analyses.get::<DummyAnalysis>(_ctx, op).unwrap();
             analyses.len()
         });
         assert_eq!(len, 1);
+    }
+
+    #[test]
+    fn failed_computation_is_not_cached_and_can_retry() {
+        let mut ctx = IrContext::new();
+        let op = crate::parser::parse_test_module(&mut ctx, "core.module @empty {}").op();
+        let mut analyses = AnalysisCache::new();
+
+        let error = analyses
+            .get::<NonEmptyModuleAnalysis>(&ctx, op)
+            .unwrap_err();
+        assert_eq!(error.analysis_type(), type_name::<NonEmptyModuleAnalysis>());
+        assert_eq!(error.target(), op);
+        assert_eq!(error.source().unwrap().to_string(), "test analysis failed");
+        assert!(analyses.get_cached::<NonEmptyModuleAnalysis>(op).is_none());
+        assert!(analyses.is_empty());
+
+        // Repair the analysis input before retrying. An unchanged malformed
+        // module would fail again rather than becoming valid by retry alone.
+        let location = ctx.op(op).location;
+        let block = ctx.create_block(crate::context::BlockData {
+            location,
+            args: vec![],
+            ops: smallvec::SmallVec::new(),
+            parent_region: None,
+        });
+        let body = ctx.create_region(crate::context::RegionData {
+            location,
+            blocks: smallvec::smallvec![block],
+            parent_op: Some(op),
+        });
+        ctx.op_mut(op).regions.push(body);
+
+        let first_success = analyses.get::<NonEmptyModuleAnalysis>(&ctx, op).unwrap();
+        let second_success = analyses.get::<NonEmptyModuleAnalysis>(&ctx, op).unwrap();
+        assert!(Arc::ptr_eq(&first_success, &second_success));
+        assert_eq!(analyses.len(), 1);
+    }
+
+    #[test]
+    fn failure_isolated_from_other_targets_and_analysis_types() {
+        let input = r#"core.module @outer {
+  core.module @empty {
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input).op();
+        let body = ctx.op(module).regions[0];
+        let block = ctx.region(body).blocks[0];
+        let empty_module = ctx.block(block).ops[0];
+        let mut analyses = AnalysisCache::new();
+
+        let _ = analyses.get::<DummyAnalysis>(&ctx, module).unwrap();
+        let module_analysis = analyses
+            .get::<NonEmptyModuleAnalysis>(&ctx, module)
+            .unwrap();
+        assert!(
+            analyses
+                .get::<NonEmptyModuleAnalysis>(&ctx, empty_module)
+                .is_err()
+        );
+
+        assert!(
+            analyses
+                .get_cached::<NonEmptyModuleAnalysis>(empty_module)
+                .is_none()
+        );
+        assert!(analyses.get_cached::<DummyAnalysis>(module).is_some());
+        assert!(Arc::ptr_eq(
+            &module_analysis,
+            &analyses
+                .get_cached::<NonEmptyModuleAnalysis>(module)
+                .unwrap()
+        ));
+        assert_eq!(analyses.len(), 2);
     }
 }

--- a/crates/trunk-ir/src/transforms/call_graph.rs
+++ b/crates/trunk-ir/src/transforms/call_graph.rs
@@ -10,6 +10,7 @@
 //! with their module path (e.g. `nested::helper`).
 
 use std::collections::{HashMap, HashSet};
+use std::convert::Infallible;
 use std::ops::ControlFlow;
 
 use crate::analysis::Analysis;
@@ -53,10 +54,12 @@ pub fn build_call_graph(ctx: &IrContext, module: Module) -> CallGraph {
 /// `CallGraph` as an [`Analysis`]: expects `target` to be a `core.module` op
 /// and delegates to [`build_call_graph`].
 impl Analysis for CallGraph {
-    fn compute(ctx: &IrContext, target: OpRef) -> Self {
+    type Error = Infallible;
+
+    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error> {
         let module =
             Module::new(ctx, target).expect("CallGraph analysis target must be a `core.module` op");
-        build_call_graph(ctx, module)
+        Ok(build_call_graph(ctx, module))
     }
 }
 
@@ -578,7 +581,7 @@ mod tests {
         let direct = build_call_graph(&ctx, module);
 
         let mut am = AnalysisCache::new();
-        let cached = am.get::<CallGraph>(&ctx, module.op());
+        let cached = am.get::<CallGraph>(&ctx, module.op()).unwrap();
 
         assert_eq!(direct.func_ops.len(), cached.func_ops.len());
         assert_eq!(direct.edges.len(), cached.edges.len());
@@ -589,7 +592,7 @@ mod tests {
         assert!(cached.edges.contains_key(&Symbol::new("main")));
 
         // Second call should hit the cache.
-        let cached2 = am.get::<CallGraph>(&ctx, module.op());
+        let cached2 = am.get::<CallGraph>(&ctx, module.op()).unwrap();
         assert!(std::sync::Arc::ptr_eq(&cached, &cached2));
     }
 

--- a/crates/trunk-ir/src/transforms/call_graph.rs
+++ b/crates/trunk-ir/src/transforms/call_graph.rs
@@ -10,10 +10,9 @@
 //! with their module path (e.g. `nested::helper`).
 
 use std::collections::{HashMap, HashSet};
-use std::convert::Infallible;
 use std::ops::ControlFlow;
 
-use crate::analysis::Analysis;
+use crate::analysis::{Analysis, AnalysisError};
 use crate::context::IrContext;
 use crate::refs::{OpRef, RegionRef};
 use crate::rewrite::Module;
@@ -54,9 +53,7 @@ pub fn build_call_graph(ctx: &IrContext, module: Module) -> CallGraph {
 /// `CallGraph` as an [`Analysis`]: expects `target` to be a `core.module` op
 /// and delegates to [`build_call_graph`].
 impl Analysis for CallGraph {
-    type Error = Infallible;
-
-    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, Self::Error> {
+    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError> {
         let module =
             Module::new(ctx, target).expect("CallGraph analysis target must be a `core.module` op");
         Ok(build_call_graph(ctx, module))

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -338,7 +338,9 @@ pub fn inline_functions_with_config(
     let mut inlined_count = 0usize;
 
     loop {
-        let graph = am.get::<CallGraph>(ctx, module.op());
+        let graph = am
+            .get::<CallGraph>(ctx, module.op())
+            .expect("CallGraph analysis computes infallibly for a core.module target");
         let recursive = recursive_functions(&graph);
 
         let pattern = InlineCallSite::new(Arc::clone(&graph), recursive, config.clone());
@@ -1128,7 +1130,7 @@ mod pass {
 
         let mut am = AnalysisCache::new();
         // Seed the cache by pulling the graph once.
-        let pre = am.get::<CallGraph>(&ctx, module.op());
+        let pre = am.get::<CallGraph>(&ctx, module.op()).unwrap();
         assert_eq!(pre.call_site_count.get(&Symbol::new("helper")), Some(&1));
 
         let result = inline_functions(&mut ctx, module, &mut am);
@@ -1144,7 +1146,7 @@ mod pass {
         assert_eq!(post.call_site_count.get(&Symbol::new("helper")), None);
         // And a subsequent explicit `get` must coincide with the cached
         // Arc (no recomputation).
-        let fetched = am.get::<CallGraph>(&ctx, module.op());
+        let fetched = am.get::<CallGraph>(&ctx, module.op()).unwrap();
         assert!(std::sync::Arc::ptr_eq(&post, &fetched));
     }
 
@@ -1165,7 +1167,7 @@ mod pass {
         let module = crate::parser::parse_test_module(&mut ctx, input);
 
         let mut am = AnalysisCache::new();
-        let before = am.get::<CallGraph>(&ctx, module.op());
+        let before = am.get::<CallGraph>(&ctx, module.op()).unwrap();
 
         let result = inline_functions(&mut ctx, module, &mut am);
         assert_eq!(result.inlined_count, 0);
@@ -1225,7 +1227,7 @@ mod pass {
 
         // After the pass, `a` and `b` must still contain exactly one
         // `func.call` (to `@large`) — not a copy of `large`'s body.
-        let post = am.get::<CallGraph>(&ctx, module.op());
+        let post = am.get::<CallGraph>(&ctx, module.op()).unwrap();
         for name in ["a", "b"] {
             let f = post
                 .func_ops
@@ -1284,7 +1286,7 @@ mod pass {
         assert_eq!(result.inlined_count, 2);
 
         // Fresh graph must contain no call edges at all.
-        let post = am.get::<CallGraph>(&ctx, module.op());
+        let post = am.get::<CallGraph>(&ctx, module.op()).unwrap();
         assert!(post.call_site_count.is_empty());
     }
 
@@ -1320,7 +1322,7 @@ mod pass {
         let module = crate::parser::parse_test_module(&mut ctx, input);
 
         let mut am = AnalysisCache::new();
-        let graph = am.get::<CallGraph>(&ctx, module.op());
+        let graph = am.get::<CallGraph>(&ctx, module.op()).unwrap();
         let recursive = recursive_functions(&graph);
 
         let inline_pattern =


### PR DESCRIPTION
## Summary

- make `Analysis::compute` and `AnalysisCache::get` return structured internal IR-analysis failures
- publish only complete successful results, leaving failed computations uncached for retry after IR repair or change
- retain analysis type, target operation, and source error context in `AnalysisError`
- preserve panic/assert behavior for caller-contract and impossible cache invariants
- adapt `CallGraph` as infallible while preserving existing call-graph and inliner behavior

## Design contract

Analysis failures represent fail-closed invalid intermediate IR or unsupported analysis boundaries, not ordinary source-language diagnostics. `CallGraph` still asserts that its target is a `core.module`; type-erasure mismatches remain programming errors.

## Validation

- focused analysis tests: 12 passed
- `cargo nextest run -p trunk-ir`: 394 passed
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo nextest run --workspace`: 1,991 passed, 1 skipped
- normal pre-commit hooks passed

Closes #929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Analysis computations now return a consistent framework-level error type.
  * Retrieving cached analyses may return an error, so callers must handle failures explicitly.
  * Error details identify the affected analysis and target.
* **Bug Fixes**
  * Analysis failures are now reported instead of being silently treated as successful results.
  * Failed analyses are no longer cached, allowing subsequent attempts to succeed after the underlying issue is fixed.
  * Analysis failures remain isolated by target and analysis type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->