### PR TITLE
Lower resultless scf.switch to structured Wasm control

### DIFF
--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -91,6 +91,8 @@ pub fn wasm_emission_ready_target() -> ConversionTarget {
 
 /// Run the full WASM lowering pipeline on arena IR.
 pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowerError> {
+    trunk_ir_wasm_backend::passes::scf_to_wasm::validate_lowerable_switches(ctx, module)?;
+
     let const_analysis = super::const_to_wasm::analyze_consts(ctx, module);
     let io_analysis = IoAnalysis::analyze(ctx, module, const_analysis.total_size());
     {
@@ -107,7 +109,7 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowe
     {
         let _span = tracing::info_span!("scf_to_wasm").entered();
         let tc = wasm_type_converter(ctx);
-        trunk_ir_wasm_backend::passes::scf_to_wasm::lower(ctx, module, tc);
+        trunk_ir_wasm_backend::passes::scf_to_wasm::lower(ctx, module, tc)?;
     }
 
     // Normalize tribute_rt primitive types (int, nat, bool, float) to core types
@@ -1225,6 +1227,39 @@ mod tests {
                 .contains("adt.string_const must produce wasm.anyref"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn lower_to_wasm_rejects_nonlowerable_switch_before_io_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main(%bytes: core.bytes, %newline: core.i1, %choice: core.i64) -> core.nil {
+    %write = tribute_io.write %bytes, %newline : core.nil
+    scf.switch %choice {
+      scf.case {value = 0} { scf.yield }
+      scf.default { scf.yield }
+    }
+    func.return
+  }
+}"#,
+        );
+        let before = print_module(&ctx, module.op());
+        assert!(before.contains("tribute_io.write"), "{before}");
+
+        let error = lower_to_wasm(&mut ctx, module)
+            .expect_err("nonlowerable switch must fail the wasm lowering boundary");
+
+        assert!(matches!(error, WasmLowerError::Conversion(_)), "{error}");
+        assert!(error.to_string().contains("scf-to-wasm"), "{error}");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported discriminant type `core.i64`; expected `core.i32`"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
@@ -12,24 +12,240 @@ use trunk_ir::dialect::core;
 use trunk_ir::dialect::scf;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
-use trunk_ir::refs::OpRef;
+use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::smallvec::smallvec;
+use trunk_ir::types::Attribute;
 
 /// Lower scf dialect to wasm dialect using arena IR.
 ///
 /// The `type_converter` parameter allows language-specific backends to provide
 /// their own type conversion rules.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+    if has_malformed_switch(ctx, module.op()) {
+        return;
+    }
     let applicator = PatternApplicator::new(type_converter)
         .add_pattern(ScfIfPattern)
+        .add_pattern(ScfSwitchPattern)
         .add_pattern(ScfLoopPattern)
         .add_pattern(ScfYieldPattern)
         .add_pattern(ScfContinuePattern)
         .add_pattern(ScfBreakPattern);
     applicator.apply_partial(ctx, module);
+}
+
+/// Validated data for a resultless `scf.switch` that this target can lower.
+///
+/// Wasm branch conditions and the available concrete comparison operations are
+/// `i32`, so other source switch shapes remain for an earlier or richer
+/// lowering rather than being partially rewritten here.
+struct ScfSwitchArms {
+    discriminant: ValueRef,
+    cases: Vec<(i32, RegionRef)>,
+    default: Option<RegionRef>,
+}
+
+struct ScfSwitchShape {
+    discriminant: ValueRef,
+    cases: Vec<(Attribute, RegionRef)>,
+    default: Option<RegionRef>,
+}
+
+fn is_i32(ctx: &IrContext, value: ValueRef) -> bool {
+    let ty = ctx.types.get(ctx.value_ty(value));
+    ty.dialect == core::DIALECT_NAME() && ty.name == "i32"
+}
+
+/// Validate the complete declarative switch container before rewriting any
+/// nested region. This keeps malformed arms from being partly lowered by the
+/// recursive pattern walk.
+fn switch_shape(ctx: &IrContext, op: OpRef) -> Option<ScfSwitchShape> {
+    if !ctx.op_results(op).is_empty() {
+        return None;
+    }
+    let [discriminant] = ctx.op_operands(op) else {
+        return None;
+    };
+    let [switch_body] = ctx.op(op).regions.as_slice() else {
+        return None;
+    };
+    let [body_block] = ctx.region(*switch_body).blocks.as_slice() else {
+        return None;
+    };
+    if !ctx.block_args(*body_block).is_empty() {
+        return None;
+    }
+
+    let mut cases = Vec::new();
+    let mut default = None;
+    for &arm in &ctx.block(*body_block).ops {
+        if !ctx.op_results(arm).is_empty() || !ctx.op_operands(arm).is_empty() {
+            return None;
+        }
+        let [body] = ctx.op(arm).regions.as_slice() else {
+            return None;
+        };
+        let [entry] = ctx.region(*body).blocks.as_slice() else {
+            return None;
+        };
+        if !ctx.block_args(*entry).is_empty() {
+            return None;
+        }
+        if scf::Case::matches(ctx, arm) {
+            cases.push((ctx.op(arm).attributes.get("value")?.clone(), *body));
+        } else if scf::Default::matches(ctx, arm) {
+            if default.replace(*body).is_some() {
+                return None;
+            }
+        } else {
+            return None;
+        }
+    }
+
+    if cases.is_empty() && default.is_none() {
+        return None;
+    }
+
+    Some(ScfSwitchShape {
+        discriminant: *discriminant,
+        cases,
+        default,
+    })
+}
+
+fn switch_arms(ctx: &IrContext, op: OpRef) -> Option<ScfSwitchArms> {
+    let shape = switch_shape(ctx, op)?;
+    if !is_i32(ctx, shape.discriminant) {
+        return None;
+    }
+    let mut cases = Vec::with_capacity(shape.cases.len());
+    for (value, body) in shape.cases {
+        let Attribute::Int(value) = value else {
+            return None;
+        };
+        cases.push((i32::try_from(value).ok()?, body));
+    }
+    Some(ScfSwitchArms {
+        discriminant: shape.discriminant,
+        cases,
+        default: shape.default,
+    })
+}
+
+fn has_malformed_switch(ctx: &IrContext, op: OpRef) -> bool {
+    if scf::Switch::matches(ctx, op) && switch_shape(ctx, op).is_none() {
+        return true;
+    }
+    ctx.op(op)
+        .regions
+        .iter()
+        .copied()
+        .flat_map(|region| ctx.region(region).blocks.iter().copied())
+        .flat_map(|block| ctx.block(block).ops.iter().copied())
+        .any(|nested| has_malformed_switch(ctx, nested))
+}
+
+fn region_with_ops(
+    ctx: &mut IrContext,
+    loc: trunk_ir::types::Location,
+    ops: Vec<OpRef>,
+) -> RegionRef {
+    let block = ctx.create_block(BlockData {
+        location: loc,
+        args: vec![],
+        ops: smallvec![],
+        parent_region: None,
+    });
+    for op in ops {
+        ctx.push_op(block, op);
+    }
+    ctx.create_region(RegionData {
+        location: loc,
+        blocks: smallvec![block],
+        parent_op: None,
+    })
+}
+
+fn take_region_ops(ctx: &mut IrContext, region: RegionRef) -> Vec<OpRef> {
+    let [block] = ctx.region(region).blocks.as_slice() else {
+        unreachable!("switch regions are preflighted as single-block");
+    };
+    let ops = ctx.block(*block).ops.to_vec();
+    for &op in &ops {
+        ctx.detach_op(op);
+    }
+    ops
+}
+
+/// Pattern for a resultless `scf.switch` -> nested `wasm.if` comparisons.
+struct ScfSwitchPattern;
+
+impl RewritePattern for ScfSwitchPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(_switch) = scf::Switch::from_op(ctx, op) else {
+            return false;
+        };
+        let Some(arms) = switch_arms(ctx, op) else {
+            return false;
+        };
+        let loc = ctx.op(op).location;
+        let nil_ty = core::nil(ctx).as_type_ref();
+
+        for &(_, body) in &arms.cases {
+            ctx.detach_region(body);
+        }
+        if let Some(body) = arms.default {
+            ctx.detach_region(body);
+        }
+
+        if arms.cases.is_empty() {
+            if let Some(default) = arms.default {
+                for child in take_region_ops(ctx, default) {
+                    rewriter.insert_op(child);
+                }
+            }
+            rewriter.erase_op(vec![]);
+            return true;
+        }
+
+        let discriminant = arms.discriminant;
+        let case_count = arms.cases.len();
+        let mut next = arms
+            .default
+            .unwrap_or_else(|| region_with_ops(ctx, loc, vec![]));
+        let mut outer_ops = None;
+        for (index, (value, body)) in arms.cases.into_iter().rev().enumerate() {
+            let case = wasm_dialect::i32_const(ctx, loc, ctx.value_ty(discriminant), value);
+            let matches = wasm_dialect::i32_eq(
+                ctx,
+                loc,
+                discriminant,
+                case.result(ctx),
+                ctx.value_ty(discriminant),
+            );
+            let branch = wasm_dialect::r#if(ctx, loc, matches.result(ctx), nil_ty, body, next);
+            let ops = vec![case.op_ref(), matches.op_ref(), branch.op_ref()];
+            if index + 1 == case_count {
+                outer_ops = Some(ops);
+            } else {
+                next = region_with_ops(ctx, loc, ops);
+            }
+        }
+
+        for inserted in outer_ops.expect("nonempty switch cases build an outer dispatch") {
+            rewriter.insert_op(inserted);
+        }
+        rewriter.erase_op(vec![]);
+        true
+    }
 }
 
 /// Pattern for `scf.if` -> `wasm.if`
@@ -267,3 +483,194 @@ impl RewritePattern for ScfBreakPattern {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::parser::parse_test_module;
+    use trunk_ir::printer::print_module;
+
+    fn lower_text(ir: &str) -> String {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ir);
+        lower(&mut ctx, module, TypeConverter::new());
+        let use_chains = trunk_ir::validation::validate_use_chains(&ctx, module);
+        assert!(use_chains.is_ok(), "{use_chains}");
+        let verifiers = trunk_ir::validation::validate_operation_verifiers(&ctx, module);
+        assert!(verifiers.is_ok(), "{verifiers}");
+        print_module(&ctx, module.op())
+    }
+
+    fn assert_no_scf_switch_wrappers(output: &str) {
+        for name in ["scf.switch", "scf.case", "scf.default", "scf.yield"] {
+            assert!(!output.contains(name), "residual {name}:\n{output}");
+        }
+    }
+
+    #[test]
+    fn lowers_resultless_switch_with_explicit_default() {
+        let output = lower_text(
+            r#"core.module @test {
+  func.func @main(%choice: core.i32, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+      }
+      scf.default {
+        func.unreachable
+      }
+    }
+  }
+}"#,
+        );
+
+        assert_no_scf_switch_wrappers(&output);
+        assert!(output.contains("wasm.i32_eq"), "{output}");
+        assert!(output.contains("wasm.if"), "{output}");
+        assert!(output.contains("func.tail_call_indirect"), "{output}");
+        assert!(output.contains("func.unreachable"), "{output}");
+    }
+
+    #[test]
+    fn lowers_resultless_switch_without_default_to_fallthrough() {
+        let output = lower_text(
+            r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        scf.yield
+      }
+    }
+    func.return
+  }
+}"#,
+        );
+
+        assert_no_scf_switch_wrappers(&output);
+        assert!(output.contains("wasm.i32_eq"), "{output}");
+        assert!(output.contains("wasm.if"), "{output}");
+        assert!(output.contains("func.return"), "{output}");
+    }
+
+    #[test]
+    fn lowers_multiple_i32_switch_cases_in_source_order() {
+        let output = lower_text(
+            r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 1} {
+        scf.yield
+      }
+      scf.case {value = 2} {
+        scf.yield
+      }
+      scf.default {
+        scf.yield
+      }
+    }
+    func.return
+  }
+}"#,
+        );
+
+        assert_no_scf_switch_wrappers(&output);
+        assert_eq!(output.matches("wasm.i32_eq").count(), 2, "{output}");
+        assert!(
+            output.find("wasm.i32_const {value = 1}") < output.find("wasm.i32_const {value = 2}"),
+            "case dispatch order changed: {output}"
+        );
+    }
+
+    #[test]
+    fn lowers_nested_proper_tail_switch_arms() {
+        let output = lower_text(
+            r#"core.module @test {
+  func.func @main(%choice: core.i32, %cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        %never = scf.if %cond : core.never {
+          func.unreachable
+        } {
+          func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+        }
+      }
+      scf.default {
+        func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+      }
+    }
+  }
+}"#,
+        );
+
+        assert_no_scf_switch_wrappers(&output);
+        assert!(output.contains("wasm.i32_eq"), "{output}");
+        assert_eq!(output.matches("wasm.if").count(), 2, "{output}");
+        assert_eq!(
+            output.matches("func.tail_call_indirect").count(),
+            2,
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn leaves_malformed_switch_unchanged() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.default { scf.yield }
+      scf.default { scf.yield }
+    }
+    func.return
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+        lower(&mut ctx, module, TypeConverter::new());
+
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn leaves_malformed_switch_arm_operands_and_entry_args_unchanged() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case %choice {value = 0} {
+        ^case_entry(%unexpected: core.i32):
+          scf.yield
+      }
+      scf.default %choice {
+        scf.yield
+      }
+    }
+    func.return
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn lowers_default_only_switch() {
+        let output = lower_text(
+            r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.default { scf.yield }
+    }
+    func.return
+  }
+}"#,
+        );
+
+        assert_no_scf_switch_wrappers(&output);
+        assert!(!output.contains("wasm.i32_eq"), "{output}");
+        assert!(output.contains("func.return"), "{output}");
+    }
+}

--- a/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
@@ -14,27 +14,60 @@ use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, ValueRef};
 use trunk_ir::rewrite::{
-    Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter,
+    ConversionError, ConversionTarget, IllegalOp, LegalityCheck, Module, PatternApplicator,
+    PatternRewriter, RewritePattern, TypeConverter,
 };
 use trunk_ir::smallvec::smallvec;
 use trunk_ir::types::Attribute;
+
+const SCF_TO_WASM_BOUNDARY: &str = "scf-to-wasm";
+
+/// Require successful conversion to remove every SCF operation.
+pub fn scf_to_wasm_target() -> ConversionTarget {
+    ConversionTarget::new().illegal_dialect("scf")
+}
 
 /// Lower scf dialect to wasm dialect using arena IR.
 ///
 /// The `type_converter` parameter allows language-specific backends to provide
 /// their own type conversion rules.
-pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
-    if has_malformed_switch(ctx, module.op()) {
-        return;
-    }
-    let applicator = PatternApplicator::new(type_converter)
+pub fn lower(
+    ctx: &mut IrContext,
+    module: Module,
+    type_converter: TypeConverter,
+) -> Result<(), ConversionError> {
+    validate_lowerable_switches(ctx, module)?;
+    PatternApplicator::new(type_converter)
         .add_pattern(ScfIfPattern)
         .add_pattern(ScfSwitchPattern)
         .add_pattern(ScfLoopPattern)
         .add_pattern(ScfYieldPattern)
         .add_pattern(ScfContinuePattern)
-        .add_pattern(ScfBreakPattern);
-    applicator.apply_partial(ctx, module);
+        .add_pattern(ScfBreakPattern)
+        .with_target(scf_to_wasm_target())
+        .apply_partial_conversion(ctx, module, SCF_TO_WASM_BOUNDARY)?;
+    Ok(())
+}
+
+/// Reject switches this target cannot lower without mutating the module.
+pub fn validate_lowerable_switches(ctx: &IrContext, module: Module) -> Result<(), ConversionError> {
+    if let Some((op, reason)) = find_nonlowerable_switch(ctx, module.op()) {
+        let data = ctx.op(op);
+        return Err(ConversionError::new(
+            SCF_TO_WASM_BOUNDARY,
+            vec![
+                IllegalOp {
+                    op,
+                    dialect: data.dialect,
+                    name: data.name,
+                    legality: LegalityCheck::Illegal,
+                    reason: None,
+                }
+                .with_reason(reason.to_string()),
+            ],
+        ));
+    }
+    Ok(())
 }
 
 /// Validated data for a resultless `scf.switch` that this target can lower.
@@ -52,6 +85,34 @@ struct ScfSwitchShape {
     discriminant: ValueRef,
     cases: Vec<(Attribute, RegionRef)>,
     default: Option<RegionRef>,
+}
+
+#[derive(Debug)]
+enum SwitchLoweringReason {
+    MalformedShape,
+    UnsupportedDiscriminantType(String),
+    NonIntegerCaseAttribute,
+    CaseValueOutsideI32Range,
+}
+
+impl std::fmt::Display for SwitchLoweringReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MalformedShape => write!(f, "malformed resultless switch shape"),
+            Self::UnsupportedDiscriminantType(ty) => {
+                write!(
+                    f,
+                    "unsupported discriminant type `{ty}`; expected `core.i32`"
+                )
+            }
+            Self::NonIntegerCaseAttribute => {
+                write!(f, "case attribute `value` must be an integer")
+            }
+            Self::CaseValueOutsideI32Range => {
+                write!(f, "case integer value is outside the i32 range")
+            }
+        }
+    }
 }
 
 fn is_i32(ctx: &IrContext, value: ValueRef) -> bool {
@@ -116,36 +177,48 @@ fn switch_shape(ctx: &IrContext, op: OpRef) -> Option<ScfSwitchShape> {
     })
 }
 
-fn switch_arms(ctx: &IrContext, op: OpRef) -> Option<ScfSwitchArms> {
-    let shape = switch_shape(ctx, op)?;
+fn switch_arms(ctx: &IrContext, op: OpRef) -> Result<ScfSwitchArms, SwitchLoweringReason> {
+    let shape = switch_shape(ctx, op).ok_or(SwitchLoweringReason::MalformedShape)?;
     if !is_i32(ctx, shape.discriminant) {
-        return None;
+        let ty = ctx.types.get(ctx.value_ty(shape.discriminant));
+        return Err(SwitchLoweringReason::UnsupportedDiscriminantType(format!(
+            "{}.{}",
+            ty.dialect, ty.name
+        )));
     }
     let mut cases = Vec::with_capacity(shape.cases.len());
     for (value, body) in shape.cases {
         let Attribute::Int(value) = value else {
-            return None;
+            return Err(SwitchLoweringReason::NonIntegerCaseAttribute);
         };
-        cases.push((i32::try_from(value).ok()?, body));
+        let value =
+            i32::try_from(value).map_err(|_| SwitchLoweringReason::CaseValueOutsideI32Range)?;
+        cases.push((value, body));
     }
-    Some(ScfSwitchArms {
+    Ok(ScfSwitchArms {
         discriminant: shape.discriminant,
         cases,
         default: shape.default,
     })
 }
 
-fn has_malformed_switch(ctx: &IrContext, op: OpRef) -> bool {
-    if scf::Switch::matches(ctx, op) && switch_shape(ctx, op).is_none() {
-        return true;
+/// Find the first switch rejected by the same acceptance contract as lowering.
+fn find_nonlowerable_switch(ctx: &IrContext, op: OpRef) -> Option<(OpRef, SwitchLoweringReason)> {
+    if scf::Switch::matches(ctx, op)
+        && let Err(reason) = switch_arms(ctx, op)
+    {
+        return Some((op, reason));
     }
-    ctx.op(op)
-        .regions
-        .iter()
-        .copied()
-        .flat_map(|region| ctx.region(region).blocks.iter().copied())
-        .flat_map(|block| ctx.block(block).ops.iter().copied())
-        .any(|nested| has_malformed_switch(ctx, nested))
+    for region in ctx.op(op).regions.iter().copied() {
+        for block in ctx.region(region).blocks.iter().copied() {
+            for nested in ctx.block(block).ops.iter().copied() {
+                if let Some(rejected) = find_nonlowerable_switch(ctx, nested) {
+                    return Some(rejected);
+                }
+            }
+        }
+    }
+    None
 }
 
 fn region_with_ops(
@@ -193,7 +266,7 @@ impl RewritePattern for ScfSwitchPattern {
         let Ok(_switch) = scf::Switch::from_op(ctx, op) else {
             return false;
         };
-        let Some(arms) = switch_arms(ctx, op) else {
+        let Ok(arms) = switch_arms(ctx, op) else {
             return false;
         };
         let loc = ctx.op(op).location;
@@ -493,12 +566,34 @@ mod tests {
     fn lower_text(ir: &str) -> String {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
-        lower(&mut ctx, module, TypeConverter::new());
+        lower(&mut ctx, module, TypeConverter::new()).expect("test module should lower to wasm");
         let use_chains = trunk_ir::validation::validate_use_chains(&ctx, module);
         assert!(use_chains.is_ok(), "{use_chains}");
         let verifiers = trunk_ir::validation::validate_operation_verifiers(&ctx, module);
         assert!(verifiers.is_ok(), "{verifiers}");
-        print_module(&ctx, module.op())
+        let output = print_module(&ctx, module.op());
+        assert!(
+            !output.contains("scf."),
+            "residual scf operation:\n{output}"
+        );
+        output
+    }
+
+    fn assert_switch_rejected_unchanged(input: &str, reason: &str) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        let before = print_module(&ctx, module.op());
+
+        let error = lower(&mut ctx, module, TypeConverter::new())
+            .expect_err("nonlowerable switch should reject the entire conversion");
+
+        assert_eq!(error.boundary(), SCF_TO_WASM_BOUNDARY);
+        assert_eq!(error.operations().len(), 1);
+        assert_eq!(error.operations()[0].legality, LegalityCheck::Illegal);
+        assert_eq!(error.operations()[0].reason.as_deref(), Some(reason));
+        assert!(error.to_string().contains("scf.switch"), "{error}");
+        assert!(error.to_string().contains(reason), "{error}");
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     fn assert_no_scf_switch_wrappers(output: &str) {
@@ -623,12 +718,7 @@ mod tests {
     func.return
   }
 }"#;
-        let mut ctx = IrContext::new();
-        let module = parse_test_module(&mut ctx, input);
-        let before = print_module(&ctx, module.op());
-        lower(&mut ctx, module, TypeConverter::new());
-
-        assert_eq!(print_module(&ctx, module.op()), before);
+        assert_switch_rejected_unchanged(input, "malformed resultless switch shape");
     }
 
     #[test]
@@ -647,13 +737,59 @@ mod tests {
     func.return
   }
 }"#;
-        let mut ctx = IrContext::new();
-        let module = parse_test_module(&mut ctx, input);
-        let before = print_module(&ctx, module.op());
+        assert_switch_rejected_unchanged(input, "malformed resultless switch shape");
+    }
 
-        lower(&mut ctx, module, TypeConverter::new());
+    #[test]
+    fn rejects_shape_valid_non_i32_switch_without_mutating() {
+        let input = r#"core.module @test {
+  func.func @main(%cond: core.i1, %choice: core.i64) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        scf.if %cond : core.nil {
+          scf.yield
+        } {
+          scf.yield
+        }
+        scf.yield
+      }
+      scf.default { scf.yield }
+    }
+    func.return
+  }
+}"#;
+        assert_switch_rejected_unchanged(
+            input,
+            "unsupported discriminant type `core.i64`; expected `core.i32`",
+        );
+    }
 
-        assert_eq!(print_module(&ctx, module.op()), before);
+    #[test]
+    fn rejects_shape_valid_out_of_range_case_without_mutating() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 2147483648} { scf.yield }
+      scf.default { scf.yield }
+    }
+    func.return
+  }
+}"#;
+        assert_switch_rejected_unchanged(input, "case integer value is outside the i32 range");
+    }
+
+    #[test]
+    fn rejects_non_integer_case_attribute_without_mutating() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = @not_an_integer} { scf.yield }
+      scf.default { scf.yield }
+    }
+    func.return
+  }
+}"#;
+        assert_switch_rejected_unchanged(input, "case attribute `value` must be an integer");
     }
 
     #[test]

--- a/crates/trunk-ir/src/rewrite/conversion_target.rs
+++ b/crates/trunk-ir/src/rewrite/conversion_target.rs
@@ -455,6 +455,7 @@ impl ConversionTarget {
                     dialect: data.dialect,
                     name: data.name,
                     legality,
+                    reason: None,
                 });
             }
             let action = if self.is_recursively_legal(ctx, op) {
@@ -482,6 +483,16 @@ pub struct IllegalOp {
     pub dialect: Symbol,
     pub name: Symbol,
     pub legality: LegalityCheck,
+    /// Optional conversion-specific explanation for this otherwise illegal operation.
+    pub reason: Option<String>,
+}
+
+impl IllegalOp {
+    /// Attach a conversion-specific explanation to this failed operation.
+    pub fn with_reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason = Some(reason.into());
+        self
+    }
 }
 
 impl std::fmt::Display for IllegalOp {
@@ -490,7 +501,11 @@ impl std::fmt::Display for IllegalOp {
             f,
             "{}.{} ({}, {:?})",
             self.dialect, self.name, self.op, self.legality
-        )
+        )?;
+        if let Some(reason) = &self.reason {
+            write!(f, ": {reason}")?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

- lower resultless `scf.switch` directly to nested structured Wasm control
- preserve case order and default behavior, including proper-tail nested branches
- validate the complete switch shape before rewriting so malformed input remains unchanged

Stacked on #942 and required by #825.

## Validation

- trunk-ir-wasm-backend tests
- focused CPS Wasm regression
- workspace pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for lowering resultless switch statements to WebAssembly conditional branches, including defaults, fallthrough behavior, multiple cases, nested tail-call arms, and default-only switches.
  * Added clearer conversion diagnostics explaining why a switch cannot be lowered.

* **Bug Fixes**
  * Invalid or unsupported switches now fail conversion cleanly without partially modifying the module.

* **Tests**
  * Expanded coverage for successful lowering, unsupported discriminants, invalid case values, and malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->