### PR TITLE
Add dependent analyses and cascading invalidation

### DIFF
--- a/crates/trunk-ir/src/analysis.rs
+++ b/crates/trunk-ir/src/analysis.rs
@@ -370,11 +370,17 @@ impl AnalysisCache {
     }
 
     /// Invalidate the cached analysis `A` for `target`, if present.
+    ///
+    /// Every analysis that transitively depends on it is also invalidated,
+    /// including analyses of other types and other targets. Prerequisites of
+    /// the invalidated analyses are kept.
     pub fn invalidate<A: Analysis>(&mut self, target: OpRef) {
         self.invalidate_keys([AnalysisKey::of::<A>(target)]);
     }
 
-    /// Invalidate every cached analysis for `target`.
+    /// Invalidate every cached analysis for `target`, and every analysis that
+    /// transitively depends on them. Dependents attached to other targets are
+    /// invalidated too; prerequisites are kept.
     pub fn invalidate_all(&mut self, target: OpRef) {
         let keys = self
             .cache
@@ -503,6 +509,12 @@ mod tests {
     static MIDDLE_COMPUTES: AtomicUsize = AtomicUsize::new(0);
     static ROOT_COMPUTES: AtomicUsize = AtomicUsize::new(0);
     static COUNTER_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_counters() -> std::sync::MutexGuard<'static, ()> {
+        COUNTER_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 
     #[derive(Debug)]
     struct CountedAnalysis;
@@ -663,6 +675,7 @@ mod tests {
 
     #[test]
     fn get_returns_same_arc_on_cache_hit() {
+        let _counters = lock_counters();
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
         COUNTED_COMPUTES.store(0, Ordering::SeqCst);
@@ -829,7 +842,7 @@ mod tests {
 
     #[test]
     fn dependent_chain_and_diamond_compute_each_key_once() {
-        let _counters = COUNTER_LOCK.lock().unwrap();
+        let _counters = lock_counters();
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
         LEAF_COMPUTES.store(0, Ordering::SeqCst);
@@ -847,6 +860,7 @@ mod tests {
 
     #[test]
     fn cached_prerequisite_lookup_records_direct_dependency() {
+        let _counters = lock_counters();
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
 
@@ -897,7 +911,7 @@ mod tests {
 
     #[test]
     fn prerequisite_invalidation_cascades_but_dependent_invalidation_preserves_prerequisites() {
-        let _counters = COUNTER_LOCK.lock().unwrap();
+        let _counters = lock_counters();
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
         LEAF_COMPUTES.store(0, Ordering::SeqCst);
@@ -957,7 +971,7 @@ mod tests {
 
     #[test]
     fn failed_dependent_leaves_no_cache_entry_or_dependency_edge() {
-        let _counters = COUNTER_LOCK.lock().unwrap();
+        let _counters = lock_counters();
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
 
@@ -1010,7 +1024,7 @@ mod tests {
 
     #[test]
     fn clear_removes_dependency_metadata() {
-        let _counters = COUNTER_LOCK.lock().unwrap();
+        let _counters = lock_counters();
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
         let _ = analyses.get::<RootAnalysis>(&ctx, op).unwrap();

--- a/crates/trunk-ir/src/analysis.rs
+++ b/crates/trunk-ir/src/analysis.rs
@@ -846,6 +846,19 @@ mod tests {
     }
 
     #[test]
+    fn cached_prerequisite_lookup_records_direct_dependency() {
+        let (ctx, op) = test_ctx();
+        let mut analyses = AnalysisCache::new();
+
+        let _ = analyses.get::<LeafAnalysis>(&ctx, op).unwrap();
+        let _ = analyses.get::<MiddleAnalysis>(&ctx, op).unwrap();
+
+        analyses.invalidate::<LeafAnalysis>(op);
+        assert!(analyses.get_cached::<LeafAnalysis>(op).is_none());
+        assert!(analyses.get_cached::<MiddleAnalysis>(op).is_none());
+    }
+
+    #[test]
     fn direct_and_indirect_cycles_are_structured_and_publish_nothing() {
         let (ctx, op) = test_ctx();
         let mut analyses = AnalysisCache::new();
@@ -959,32 +972,38 @@ mod tests {
     }
 
     #[test]
-    fn cross_target_dependencies_cascade_and_invalidate_all_cleans_metadata() {
+    fn cross_target_invalidate_all_cascades_but_preserves_unrelated_entries() {
         let mut ctx = IrContext::new();
         let outer = crate::parser::parse_test_module(
             &mut ctx,
-            "core.module @outer { core.module @inner {} }",
+            "core.module @outer { core.module @inner {} core.module @unrelated {} }",
         )
         .op();
         let body = ctx.op(outer).regions[0];
         let block = ctx.region(body).blocks[0];
         let inner = ctx.block(block).ops[0];
+        let unrelated = ctx.block(block).ops[1];
         let mut analyses = AnalysisCache::new();
 
+        let _ = analyses
+            .get::<CrossTargetPrerequisite>(&ctx, inner)
+            .unwrap();
         let _ = analyses.get::<CrossTargetDependent>(&ctx, outer).unwrap();
+        let _ = analyses.get::<OtherAnalysis>(&ctx, inner).unwrap();
+        let _ = analyses.get::<DummyAnalysis>(&ctx, outer).unwrap();
+        let _ = analyses.get::<DummyAnalysis>(&ctx, unrelated).unwrap();
+        analyses.invalidate_all(inner);
+
         assert!(
             analyses
                 .get_cached::<CrossTargetPrerequisite>(inner)
-                .is_some()
+                .is_none()
         );
-        analyses.invalidate::<CrossTargetPrerequisite>(inner);
-        assert!(analyses.is_empty());
-        assert!(analyses.dependencies.is_empty());
-        assert!(analyses.dependents.is_empty());
-
-        let _ = analyses.get::<CrossTargetDependent>(&ctx, outer).unwrap();
-        analyses.invalidate_all(inner);
-        assert!(analyses.is_empty());
+        assert!(analyses.get_cached::<CrossTargetDependent>(outer).is_none());
+        assert!(analyses.get_cached::<OtherAnalysis>(inner).is_none());
+        assert!(analyses.get_cached::<DummyAnalysis>(outer).is_some());
+        assert!(analyses.get_cached::<DummyAnalysis>(unrelated).is_some());
+        assert_eq!(analyses.len(), 2);
         assert!(analyses.dependencies.is_empty());
         assert!(analyses.dependents.is_empty());
     }

--- a/crates/trunk-ir/src/analysis.rs
+++ b/crates/trunk-ir/src/analysis.rs
@@ -64,7 +64,7 @@
 //! itself is single-threaded.
 
 use std::any::{Any, TypeId, type_name};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
@@ -81,6 +81,7 @@ pub struct AnalysisError {
     analysis_type: &'static str,
     target: OpRef,
     source: Box<dyn Error + Send + Sync>,
+    cycle: Option<AnalysisCycle>,
 }
 
 impl AnalysisError {
@@ -94,6 +95,17 @@ impl AnalysisError {
             analysis_type: type_name::<A>(),
             target,
             source: Box::new(source),
+            cycle: None,
+        }
+    }
+
+    fn construction_cycle<A: Analysis>(target: OpRef, queries: Vec<AnalysisQuery>) -> Self {
+        let cycle = AnalysisCycle { queries };
+        Self {
+            analysis_type: type_name::<A>(),
+            target,
+            source: Box::new(cycle.clone()),
+            cycle: Some(cycle),
         }
     }
 
@@ -105,6 +117,11 @@ impl AnalysisError {
     /// Operation for which the failed analysis was requested.
     pub fn target(&self) -> OpRef {
         self.target
+    }
+
+    /// Return the construction cycle, if this failure was caused by one.
+    pub fn cycle(&self) -> Option<&AnalysisCycle> {
+        self.cycle.as_ref()
     }
 }
 
@@ -124,6 +141,53 @@ impl Error for AnalysisError {
     }
 }
 
+/// One analysis query participating in a construction cycle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnalysisQuery {
+    analysis_type: &'static str,
+    target: OpRef,
+}
+
+impl AnalysisQuery {
+    /// Concrete Rust type of the requested analysis.
+    pub fn analysis_type(&self) -> &'static str {
+        self.analysis_type
+    }
+
+    /// Operation requested by this query.
+    pub fn target(&self) -> OpRef {
+        self.target
+    }
+}
+
+/// Structured description of an analysis-construction cycle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnalysisCycle {
+    queries: Vec<AnalysisQuery>,
+}
+
+impl AnalysisCycle {
+    /// The closed query path. The first and last entries are the same query.
+    pub fn queries(&self) -> &[AnalysisQuery] {
+        &self.queries
+    }
+}
+
+impl fmt::Display for AnalysisCycle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "analysis construction cycle: ")?;
+        for (index, query) in self.queries.iter().enumerate() {
+            if index != 0 {
+                write!(f, " -> ")?;
+            }
+            write!(f, "{} for {}", query.analysis_type, query.target)?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for AnalysisCycle {}
+
 /// An analysis computable from an IR context plus a target operation
 /// (typically a `core.module` op).
 ///
@@ -132,7 +196,7 @@ impl Error for AnalysisError {
 /// typed static factory: the analysis type is both the query key and the
 /// complete concrete result stored by [`AnalysisCache`].
 pub trait Analysis: Any + Send + Sync {
-    /// Compute this analysis for `target` in `ctx`.
+    /// Compute this analysis for `target` through `ctx`.
     ///
     /// Return an error for invalid input IR or an unsupported analysis
     /// boundary. Construct failures with [`AnalysisError::new`] using this
@@ -140,9 +204,55 @@ pub trait Analysis: Any + Send + Sync {
     /// analysis and target context. Violated caller contracts and impossible
     /// implementation invariants must panic rather than be represented as
     /// analysis failures.
-    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError>
+    fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError>
     where
         Self: Sized;
+}
+
+/// Read-only IR access and dependent-analysis lookup for one computation.
+///
+/// A context is created only while one [`Analysis::compute`] call is active.
+/// Dependent lookups use its owning cache and are recorded atomically if the
+/// enclosing computation succeeds.
+pub struct AnalysisContext<'a> {
+    ir: &'a IrContext,
+    cache: &'a mut AnalysisCache,
+    dependencies: HashSet<AnalysisKey>,
+}
+
+impl<'a> AnalysisContext<'a> {
+    /// The IR context being analysed. It cannot be mutated through this API.
+    pub fn ir(&self) -> &IrContext {
+        self.ir
+    }
+
+    /// Get a typed prerequisite through the same cache.
+    pub fn get<A: Analysis>(&mut self, target: OpRef) -> Result<Arc<A>, AnalysisError> {
+        let analysis = self.cache.get::<A>(self.ir, target)?;
+        self.dependencies.insert(AnalysisKey::of::<A>(target));
+        Ok(analysis)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct AnalysisKey {
+    analysis_type: TypeId,
+    target: OpRef,
+}
+
+impl AnalysisKey {
+    fn of<A: Analysis>(target: OpRef) -> Self {
+        Self {
+            analysis_type: TypeId::of::<A>(),
+            target,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct InProgressAnalysis {
+    key: AnalysisKey,
+    analysis_type: &'static str,
 }
 
 /// Lazy, typed cache of analyses keyed by `(TypeId, OpRef)`.
@@ -151,7 +261,12 @@ pub trait Analysis: Any + Send + Sync {
 /// model and the single-context invariant.
 #[derive(Default)]
 pub struct AnalysisCache {
-    cache: HashMap<(TypeId, OpRef), Arc<dyn Any + Send + Sync>>,
+    cache: HashMap<AnalysisKey, Arc<dyn Any + Send + Sync>>,
+    /// Computed analysis -> its direct prerequisites.
+    dependencies: HashMap<AnalysisKey, HashSet<AnalysisKey>>,
+    /// Prerequisite -> analyses that directly depend on it.
+    dependents: HashMap<AnalysisKey, HashSet<AnalysisKey>>,
+    in_progress: Vec<InProgressAnalysis>,
 }
 
 impl AnalysisCache {
@@ -194,24 +309,59 @@ impl AnalysisCache {
         ctx: &IrContext,
         target: OpRef,
     ) -> Result<Arc<A>, AnalysisError> {
-        let key = (TypeId::of::<A>(), target);
+        let key = AnalysisKey::of::<A>(target);
         if let Some(entry) = self.cache.get(&key) {
             return Ok(Arc::clone(entry)
                 .downcast::<A>()
                 .expect("analysis cache type mismatch"));
         }
 
-        // Compute before inserting so a failure cannot publish a partial or
-        // failed type-erased entry. The next lookup is therefore a retry.
-        let analysis = Arc::new(A::compute(ctx, target)?);
+        if let Some(cycle_start) = self.in_progress.iter().position(|entry| entry.key == key) {
+            let mut queries = self.in_progress[cycle_start..]
+                .iter()
+                .map(|entry| AnalysisQuery {
+                    analysis_type: entry.analysis_type,
+                    target: entry.key.target,
+                })
+                .collect::<Vec<_>>();
+            queries.push(AnalysisQuery {
+                analysis_type: type_name::<A>(),
+                target,
+            });
+            return Err(AnalysisError::construction_cycle::<A>(target, queries));
+        }
+
+        self.in_progress.push(InProgressAnalysis {
+            key,
+            analysis_type: type_name::<A>(),
+        });
+        let (result, dependencies) = {
+            let mut computation = AnalysisContext {
+                ir: ctx,
+                cache: self,
+                dependencies: HashSet::new(),
+            };
+            let result = A::compute(&mut computation, target);
+            (result, computation.dependencies)
+        };
+        let completed = self
+            .in_progress
+            .pop()
+            .expect("analysis construction stack unexpectedly empty");
+        assert_eq!(completed.key, key, "analysis construction stack corrupted");
+
+        // Publish only a complete result and its complete dependency set. A
+        // failure leaves neither a cache entry nor dependency metadata behind.
+        let analysis = Arc::new(result?);
         let entry: Arc<dyn Any + Send + Sync> = analysis.clone();
+        self.replace_dependencies(key, dependencies);
         self.cache.insert(key, entry);
         Ok(analysis)
     }
 
     /// Return the cached analysis `A` for `target` without computing it.
     pub fn get_cached<A: Analysis>(&self, target: OpRef) -> Option<Arc<A>> {
-        let key = (TypeId::of::<A>(), target);
+        let key = AnalysisKey::of::<A>(target);
         self.cache.get(&key).map(|v| {
             Arc::clone(v)
                 .downcast::<A>()
@@ -221,17 +371,26 @@ impl AnalysisCache {
 
     /// Invalidate the cached analysis `A` for `target`, if present.
     pub fn invalidate<A: Analysis>(&mut self, target: OpRef) {
-        self.cache.remove(&(TypeId::of::<A>(), target));
+        self.invalidate_keys([AnalysisKey::of::<A>(target)]);
     }
 
     /// Invalidate every cached analysis for `target`.
     pub fn invalidate_all(&mut self, target: OpRef) {
-        self.cache.retain(|(_, t), _| *t != target);
+        let keys = self
+            .cache
+            .keys()
+            .filter(|key| key.target == target)
+            .copied()
+            .collect::<Vec<_>>();
+        self.invalidate_keys(keys);
     }
 
     /// Drop every cached analysis.
     pub fn clear(&mut self) {
         self.cache.clear();
+        self.dependencies.clear();
+        self.dependents.clear();
+        self.in_progress.clear();
     }
 
     /// Number of cached analyses (useful for diagnostics/tests).
@@ -243,6 +402,59 @@ impl AnalysisCache {
     pub fn is_empty(&self) -> bool {
         self.cache.is_empty()
     }
+
+    fn replace_dependencies(&mut self, key: AnalysisKey, dependencies: HashSet<AnalysisKey>) {
+        self.remove_dependencies(key);
+        if dependencies.is_empty() {
+            return;
+        }
+        for prerequisite in &dependencies {
+            self.dependents
+                .entry(*prerequisite)
+                .or_default()
+                .insert(key);
+        }
+        self.dependencies.insert(key, dependencies);
+    }
+
+    fn remove_dependencies(&mut self, key: AnalysisKey) {
+        let Some(prerequisites) = self.dependencies.remove(&key) else {
+            return;
+        };
+        for prerequisite in prerequisites {
+            let remove_entry = self
+                .dependents
+                .get_mut(&prerequisite)
+                .is_some_and(|dependents| {
+                    dependents.remove(&key);
+                    dependents.is_empty()
+                });
+            if remove_entry {
+                self.dependents.remove(&prerequisite);
+            }
+        }
+    }
+
+    fn invalidate_keys(&mut self, roots: impl IntoIterator<Item = AnalysisKey>) {
+        let mut invalidated = HashSet::new();
+        let mut pending = roots.into_iter().collect::<Vec<_>>();
+        while let Some(key) = pending.pop() {
+            if !invalidated.insert(key) {
+                continue;
+            }
+            if let Some(dependents) = self.dependents.get(&key) {
+                pending.extend(dependents.iter().copied());
+            }
+        }
+
+        for key in &invalidated {
+            self.cache.remove(key);
+            self.remove_dependencies(*key);
+        }
+        for key in invalidated {
+            self.dependents.remove(&key);
+        }
+    }
 }
 
 // =========================================================================
@@ -253,6 +465,7 @@ impl AnalysisCache {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     fn test_ctx() -> (IrContext, OpRef) {
         let mut ctx = IrContext::new();
@@ -267,7 +480,7 @@ mod tests {
     }
 
     impl Analysis for DummyAnalysis {
-        fn compute(_ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError> {
+        fn compute(_ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
             Ok(Self { target })
         }
     }
@@ -276,7 +489,7 @@ mod tests {
     struct OtherAnalysis;
 
     impl Analysis for OtherAnalysis {
-        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, AnalysisError> {
+        fn compute(_ctx: &mut AnalysisContext<'_>, _target: OpRef) -> Result<Self, AnalysisError> {
             Ok(Self)
         }
     }
@@ -286,14 +499,150 @@ mod tests {
     struct TestAnalysisError;
 
     static COUNTED_COMPUTES: AtomicUsize = AtomicUsize::new(0);
+    static LEAF_COMPUTES: AtomicUsize = AtomicUsize::new(0);
+    static MIDDLE_COMPUTES: AtomicUsize = AtomicUsize::new(0);
+    static ROOT_COMPUTES: AtomicUsize = AtomicUsize::new(0);
+    static COUNTER_LOCK: Mutex<()> = Mutex::new(());
 
     #[derive(Debug)]
     struct CountedAnalysis;
 
     impl Analysis for CountedAnalysis {
-        fn compute(_ctx: &IrContext, _target: OpRef) -> Result<Self, AnalysisError> {
+        fn compute(_ctx: &mut AnalysisContext<'_>, _target: OpRef) -> Result<Self, AnalysisError> {
             COUNTED_COMPUTES.fetch_add(1, Ordering::SeqCst);
             Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct LeafAnalysis;
+
+    impl Analysis for LeafAnalysis {
+        fn compute(_ctx: &mut AnalysisContext<'_>, _target: OpRef) -> Result<Self, AnalysisError> {
+            LEAF_COMPUTES.fetch_add(1, Ordering::SeqCst);
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct MiddleAnalysis;
+
+    impl Analysis for MiddleAnalysis {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            MIDDLE_COMPUTES.fetch_add(1, Ordering::SeqCst);
+            let _ = ctx.get::<LeafAnalysis>(target)?;
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct RootAnalysis;
+
+    impl Analysis for RootAnalysis {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            ROOT_COMPUTES.fetch_add(1, Ordering::SeqCst);
+            let _ = ctx.get::<MiddleAnalysis>(target)?;
+            let _ = ctx.get::<LeafAnalysis>(target)?;
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct DirectCycleAnalysis;
+
+    impl Analysis for DirectCycleAnalysis {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            let _ = ctx.get::<Self>(target)?;
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct IndirectCycleFirst;
+
+    #[derive(Debug)]
+    struct IndirectCycleSecond;
+
+    impl Analysis for IndirectCycleFirst {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            let _ = ctx.get::<IndirectCycleSecond>(target)?;
+            Ok(Self)
+        }
+    }
+
+    impl Analysis for IndirectCycleSecond {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            let _ = ctx.get::<IndirectCycleFirst>(target)?;
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct CrossTargetPrerequisite;
+
+    impl Analysis for CrossTargetPrerequisite {
+        fn compute(_ctx: &mut AnalysisContext<'_>, _target: OpRef) -> Result<Self, AnalysisError> {
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct CrossTargetDependent;
+
+    impl Analysis for CrossTargetDependent {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            let body = ctx.ir().op(target).regions[0];
+            let block = ctx.ir().region(body).blocks[0];
+            let prerequisite_target = ctx.ir().block(block).ops[0];
+            let _ = ctx.get::<CrossTargetPrerequisite>(prerequisite_target)?;
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct ChoicePrerequisiteFirst;
+
+    impl Analysis for ChoicePrerequisiteFirst {
+        fn compute(_ctx: &mut AnalysisContext<'_>, _target: OpRef) -> Result<Self, AnalysisError> {
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct ChoicePrerequisiteSecond;
+
+    impl Analysis for ChoicePrerequisiteSecond {
+        fn compute(_ctx: &mut AnalysisContext<'_>, _target: OpRef) -> Result<Self, AnalysisError> {
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct ChoiceDependent;
+
+    impl Analysis for ChoiceDependent {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            let body = ctx.ir().op(target).regions[0];
+            let block = ctx.ir().region(body).blocks[0];
+            let first_child = ctx.ir().block(block).ops[0];
+            if ctx.ir().op(first_child).attributes.get_symbol("sym_name")
+                == Some(crate::symbol::Symbol::new("first"))
+            {
+                let _ = ctx.get::<ChoicePrerequisiteFirst>(first_child)?;
+            } else {
+                let _ = ctx.get::<ChoicePrerequisiteSecond>(first_child)?;
+            }
+            Ok(Self)
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingDependent;
+
+    impl Analysis for FailingDependent {
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            let _ = ctx.get::<LeafAnalysis>(target)?;
+            Err(AnalysisError::new::<Self>(target, TestAnalysisError))
         }
     }
 
@@ -301,12 +650,12 @@ mod tests {
     struct NonEmptyModuleAnalysis;
 
     impl Analysis for NonEmptyModuleAnalysis {
-        fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError> {
-            let module = crate::rewrite::Module::new(ctx, target)
+        fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+            let module = crate::rewrite::Module::new(ctx.ir(), target)
                 .expect("test only requests this analysis for core.module targets");
             module
-                .body(ctx)
-                .filter(|&body| !ctx.region(body).blocks.is_empty())
+                .body(ctx.ir())
+                .filter(|&body| !ctx.ir().region(body).blocks.is_empty())
                 .map(|_| Self)
                 .ok_or_else(|| AnalysisError::new::<Self>(target, TestAnalysisError))
         }
@@ -476,5 +825,183 @@ mod tests {
                 .unwrap()
         ));
         assert_eq!(analyses.len(), 2);
+    }
+
+    #[test]
+    fn dependent_chain_and_diamond_compute_each_key_once() {
+        let _counters = COUNTER_LOCK.lock().unwrap();
+        let (ctx, op) = test_ctx();
+        let mut analyses = AnalysisCache::new();
+        LEAF_COMPUTES.store(0, Ordering::SeqCst);
+        MIDDLE_COMPUTES.store(0, Ordering::SeqCst);
+        ROOT_COMPUTES.store(0, Ordering::SeqCst);
+
+        let _ = analyses.get::<RootAnalysis>(&ctx, op).unwrap();
+        let _ = analyses.get::<RootAnalysis>(&ctx, op).unwrap();
+
+        assert_eq!(LEAF_COMPUTES.load(Ordering::SeqCst), 1);
+        assert_eq!(MIDDLE_COMPUTES.load(Ordering::SeqCst), 1);
+        assert_eq!(ROOT_COMPUTES.load(Ordering::SeqCst), 1);
+        assert_eq!(analyses.len(), 3);
+    }
+
+    #[test]
+    fn direct_and_indirect_cycles_are_structured_and_publish_nothing() {
+        let (ctx, op) = test_ctx();
+        let mut analyses = AnalysisCache::new();
+
+        let direct = analyses.get::<DirectCycleAnalysis>(&ctx, op).unwrap_err();
+        let direct_queries = direct.cycle().unwrap().queries();
+        assert_eq!(direct_queries.len(), 2);
+        assert_eq!(
+            direct_queries[0].analysis_type(),
+            type_name::<DirectCycleAnalysis>()
+        );
+        assert_eq!(direct_queries[0].target(), op);
+        assert_eq!(direct_queries[1], direct_queries[0]);
+        assert!(analyses.is_empty());
+        assert!(analyses.dependencies.is_empty());
+        assert!(analyses.dependents.is_empty());
+
+        let indirect = analyses.get::<IndirectCycleFirst>(&ctx, op).unwrap_err();
+        let indirect_queries = indirect.cycle().unwrap().queries();
+        assert_eq!(indirect_queries.len(), 3);
+        assert_eq!(
+            indirect_queries
+                .iter()
+                .map(AnalysisQuery::analysis_type)
+                .collect::<Vec<_>>(),
+            vec![
+                type_name::<IndirectCycleFirst>(),
+                type_name::<IndirectCycleSecond>(),
+                type_name::<IndirectCycleFirst>(),
+            ]
+        );
+        assert!(analyses.is_empty());
+        assert!(analyses.dependencies.is_empty());
+        assert!(analyses.dependents.is_empty());
+    }
+
+    #[test]
+    fn prerequisite_invalidation_cascades_but_dependent_invalidation_preserves_prerequisites() {
+        let _counters = COUNTER_LOCK.lock().unwrap();
+        let (ctx, op) = test_ctx();
+        let mut analyses = AnalysisCache::new();
+        LEAF_COMPUTES.store(0, Ordering::SeqCst);
+        MIDDLE_COMPUTES.store(0, Ordering::SeqCst);
+        ROOT_COMPUTES.store(0, Ordering::SeqCst);
+        let _ = analyses.get::<RootAnalysis>(&ctx, op).unwrap();
+
+        analyses.invalidate::<RootAnalysis>(op);
+        assert!(analyses.get_cached::<RootAnalysis>(op).is_none());
+        assert!(analyses.get_cached::<MiddleAnalysis>(op).is_some());
+        assert!(analyses.get_cached::<LeafAnalysis>(op).is_some());
+        let _ = analyses.get::<RootAnalysis>(&ctx, op).unwrap();
+        assert_eq!(ROOT_COMPUTES.load(Ordering::SeqCst), 2);
+        assert_eq!(MIDDLE_COMPUTES.load(Ordering::SeqCst), 1);
+        assert_eq!(LEAF_COMPUTES.load(Ordering::SeqCst), 1);
+
+        analyses.invalidate::<LeafAnalysis>(op);
+        assert!(analyses.is_empty());
+        assert!(analyses.dependencies.is_empty());
+        assert!(analyses.dependents.is_empty());
+    }
+
+    #[test]
+    fn recomputation_replaces_obsolete_dependency_edges() {
+        let mut ctx = IrContext::new();
+        let outer = crate::parser::parse_test_module(
+            &mut ctx,
+            "core.module @outer { core.module @first {} core.module @second {} }",
+        )
+        .op();
+        let body = ctx.op(outer).regions[0];
+        let block = ctx.region(body).blocks[0];
+        let first = ctx.block(block).ops[0];
+        let second = ctx.block(block).ops[1];
+        let mut analyses = AnalysisCache::new();
+
+        let _ = analyses.get::<ChoiceDependent>(&ctx, outer).unwrap();
+        assert!(
+            analyses
+                .get_cached::<ChoicePrerequisiteFirst>(first)
+                .is_some()
+        );
+        ctx.block_mut(block).ops.swap(0, 1);
+        analyses.invalidate::<ChoiceDependent>(outer);
+        let _ = analyses.get::<ChoiceDependent>(&ctx, outer).unwrap();
+
+        assert!(
+            analyses
+                .get_cached::<ChoicePrerequisiteSecond>(second)
+                .is_some()
+        );
+        analyses.invalidate::<ChoicePrerequisiteFirst>(first);
+        assert!(analyses.get_cached::<ChoiceDependent>(outer).is_some());
+        analyses.invalidate::<ChoicePrerequisiteSecond>(second);
+        assert!(analyses.get_cached::<ChoiceDependent>(outer).is_none());
+    }
+
+    #[test]
+    fn failed_dependent_leaves_no_cache_entry_or_dependency_edge() {
+        let _counters = COUNTER_LOCK.lock().unwrap();
+        let (ctx, op) = test_ctx();
+        let mut analyses = AnalysisCache::new();
+
+        assert!(analyses.get::<FailingDependent>(&ctx, op).is_err());
+        assert!(analyses.get_cached::<FailingDependent>(op).is_none());
+        assert!(analyses.get_cached::<LeafAnalysis>(op).is_some());
+        assert!(analyses.dependencies.is_empty());
+        assert!(analyses.dependents.is_empty());
+
+        analyses.invalidate::<LeafAnalysis>(op);
+        assert!(analyses.is_empty());
+    }
+
+    #[test]
+    fn cross_target_dependencies_cascade_and_invalidate_all_cleans_metadata() {
+        let mut ctx = IrContext::new();
+        let outer = crate::parser::parse_test_module(
+            &mut ctx,
+            "core.module @outer { core.module @inner {} }",
+        )
+        .op();
+        let body = ctx.op(outer).regions[0];
+        let block = ctx.region(body).blocks[0];
+        let inner = ctx.block(block).ops[0];
+        let mut analyses = AnalysisCache::new();
+
+        let _ = analyses.get::<CrossTargetDependent>(&ctx, outer).unwrap();
+        assert!(
+            analyses
+                .get_cached::<CrossTargetPrerequisite>(inner)
+                .is_some()
+        );
+        analyses.invalidate::<CrossTargetPrerequisite>(inner);
+        assert!(analyses.is_empty());
+        assert!(analyses.dependencies.is_empty());
+        assert!(analyses.dependents.is_empty());
+
+        let _ = analyses.get::<CrossTargetDependent>(&ctx, outer).unwrap();
+        analyses.invalidate_all(inner);
+        assert!(analyses.is_empty());
+        assert!(analyses.dependencies.is_empty());
+        assert!(analyses.dependents.is_empty());
+    }
+
+    #[test]
+    fn clear_removes_dependency_metadata() {
+        let _counters = COUNTER_LOCK.lock().unwrap();
+        let (ctx, op) = test_ctx();
+        let mut analyses = AnalysisCache::new();
+        let _ = analyses.get::<RootAnalysis>(&ctx, op).unwrap();
+        assert!(!analyses.dependencies.is_empty());
+        assert!(!analyses.dependents.is_empty());
+
+        analyses.clear();
+        assert!(analyses.is_empty());
+        assert!(analyses.dependencies.is_empty());
+        assert!(analyses.dependents.is_empty());
+        assert!(analyses.in_progress.is_empty());
     }
 }

--- a/crates/trunk-ir/src/transforms/call_graph.rs
+++ b/crates/trunk-ir/src/transforms/call_graph.rs
@@ -12,7 +12,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 
-use crate::analysis::{Analysis, AnalysisError};
+use crate::analysis::{Analysis, AnalysisContext, AnalysisError};
 use crate::context::IrContext;
 use crate::refs::{OpRef, RegionRef};
 use crate::rewrite::Module;
@@ -53,10 +53,10 @@ pub fn build_call_graph(ctx: &IrContext, module: Module) -> CallGraph {
 /// `CallGraph` as an [`Analysis`]: expects `target` to be a `core.module` op
 /// and delegates to [`build_call_graph`].
 impl Analysis for CallGraph {
-    fn compute(ctx: &IrContext, target: OpRef) -> Result<Self, AnalysisError> {
-        let module =
-            Module::new(ctx, target).expect("CallGraph analysis target must be a `core.module` op");
-        Ok(build_call_graph(ctx, module))
+    fn compute(ctx: &mut AnalysisContext<'_>, target: OpRef) -> Result<Self, AnalysisError> {
+        let module = Module::new(ctx.ir(), target)
+            .expect("CallGraph analysis target must be a `core.module` op");
+        Ok(build_call_graph(ctx.ir(), module))
     }
 }
 

--- a/new-plans/lowering.md
+++ b/new-plans/lowering.md
@@ -196,6 +196,23 @@ Module or function analyses should be pure computations over IR. Passes may use
 analysis results, but should not accumulate hidden mutable state that affects
 rewrite behavior.
 
+Analyses query prerequisites through the computation-scoped analysis context,
+which provides read-only IR access and typed lookups through the same
+pipeline-scoped cache. Cache identity is the pair `(TypeId, OpRef)`, so an
+analysis may depend on a different analysis and/or a different operation
+target, including a target in another module or region. The context records
+each direct prerequisite whether it is already cached or newly computed.
+
+The cache detects direct and indirect construction cycles and reports a
+structured analysis failure. A computation publishes its result and its entire
+new direct-dependency set only after it succeeds; failed computations publish
+neither a cache result nor dependency metadata. Replacing a cached result
+replaces its dependency set, removing obsolete reverse edges. Invalidating a
+key invalidates every transitive dependent, while invalidating only a dependent
+does not invalidate its prerequisites. Invalidating all analyses rooted at one
+operation also follows reverse dependencies to other targets. Clearing a cache
+removes results, dependency metadata, and construction state.
+
 Planner-style data, such as data segments, WASI imports, memory layout, or
 native layout metadata, should be represented as immutable plans that can be
 computed before the pass that consumes them.


### PR DESCRIPTION
## Summary

- add typed dependent-analysis queries through `AnalysisContext`
- identify analysis computations by analysis type and target operation
- detect direct and indirect dependency cycles with deterministic structured errors
- cascade invalidation through transitive dependents while preserving prerequisites and unrelated cached results
- atomically replace dependency edges after successful recomputation and publish no result or stale edge metadata after failure
- support dependencies across target operations and adapt `CallGraph` to the new computation context

## Design contract

Dependency metadata is committed only after successful analysis computation. Failed or cyclic computations remain uncached, invalidating a dependent does not invalidate its prerequisites, and invalidation removes all and only the transitive dependents of the selected analysis key.

## Validation

- focused analysis tests: 18 passed
- `cargo nextest run -p trunk-ir`: 407 passed
- `cargo nextest run --workspace`: 2,004 passed, 1 skipped
- `cargo clippy --workspace`
- `cargo fmt --all --check`
- `git diff --check`

Closes #930


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analyses can request prerequisite analyses recursively through a shared computation context.
  * The system detects direct and indirect analysis cycles and reports structured cycle details.
  * Analysis results are invalidated transitively when dependencies change, while failed computations remain isolated.
  * Dependency tracking stays up to date when cached analyses are recomputed or replaced.

* **Documentation**
  * Updated lowering architecture documentation to describe analysis contexts, caching, dependency tracking, cycle detection, and invalidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->