### PR TITLE
Validate Wasm indirect-tail arguments by physical type

### DIFF
--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -252,7 +252,7 @@ struct FunctionEmitContext {
     func_return_type: Option<TypeRef>,
 }
 
-pub fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationResult<Vec<u8>> {
+pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationResult<Vec<u8>> {
     debug!("emit_wasm: collecting module info...");
     let module_info = match collect_module_info(ctx, module) {
         Ok(info) => {
@@ -1242,6 +1242,25 @@ mod tests {
         )
     }
 
+    fn typeref_return_call_indirect_module(ctx: &mut IrContext) -> IrModule {
+        parse_test_module(
+            ctx,
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.elem {table = 0, offset = 0} {
+    wasm.ref_func {func_name = @target} : wasm.funcref
+  }
+  wasm.func @target(%value: wasm.structref) -> core.nil {
+    wasm.return
+  }
+  wasm.func @caller(%table_index: core.i32, %value: adt.typeref) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.structref), table = 0, type_idx = 0}
+  }
+  wasm.export_func {name = "caller", func = @caller}
+}"#,
+        )
+    }
+
     #[test]
     fn encodes_and_validates_return_call_indirect_with_exact_signature() {
         let mut ctx = IrContext::new();
@@ -1276,6 +1295,20 @@ mod tests {
             )),
             "missing return_call_indirect in {instructions:?}"
         );
+    }
+
+    #[test]
+    fn encodes_typeref_tail_argument_as_structref() {
+        let mut ctx = IrContext::new();
+        let module = typeref_return_call_indirect_module(&mut ctx);
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("typeref tail argument must be emission-ready")
+            .bytes;
+        let mut validator =
+            Validator::new_with_features(WasmFeatures::default() | WasmFeatures::TAIL_CALL);
+        validator
+            .validate_all(&bytes)
+            .expect("encoded typeref tail transfer must validate");
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -105,6 +105,47 @@ pub(crate) fn func_type_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef
     Some((params, *ret))
 }
 
+/// Whether an argument can satisfy an indirect-tail parameter after the Wasm
+/// backend's physical type mapping.
+fn is_wasm_physical_argument_assignable(
+    ctx: &IrContext,
+    argument: TypeRef,
+    parameter: TypeRef,
+) -> bool {
+    if argument == parameter {
+        return true;
+    }
+
+    let argument_is_typeref = is_type(ctx, argument, "adt", "typeref");
+    let argument_is_structref = is_type(ctx, argument, "wasm", "structref");
+    let parameter_is_structref = is_type(ctx, parameter, "wasm", "structref");
+    let parameter_is_anyref = is_type(ctx, parameter, "wasm", "anyref");
+
+    // `adt.typeref` is emitted as the abstract Wasm `structref` type.
+    if argument_is_typeref && parameter_is_structref {
+        return true;
+    }
+
+    let argument_is_generic_adt_struct = is_type(ctx, argument, "adt", "struct")
+        || ctx.types.get(argument).attrs.get_bool("is_variant") == Some(true);
+    if argument_is_generic_adt_struct && parameter_is_anyref {
+        return true;
+    }
+
+    let argument_is_core_array = is_type(ctx, argument, "core", "array");
+    let parameter_is_arrayref = is_type(ctx, parameter, "wasm", "arrayref");
+    if argument_is_core_array && parameter_is_arrayref {
+        return true;
+    }
+
+    // WasmGC abstract-reference upcasts. The reverse directions are checked
+    // downcasts and therefore intentionally remain false here.
+    let argument_is_wasm_gc_ref = is_type(ctx, argument, "wasm", "i31ref")
+        || argument_is_structref
+        || is_type(ctx, argument, "wasm", "arrayref");
+    argument_is_wasm_gc_ref && parameter_is_anyref
+}
+
 /// Read and validate the exact physical function type required by an indirect
 /// proper tail transfer. This backend deliberately does not infer the type
 /// from the runtime table index and operands.
@@ -139,10 +180,9 @@ pub(crate) fn exact_return_call_indirect_signature(
         ));
     }
     if params.len() != args.len()
-        || params
-            .iter()
-            .zip(args)
-            .any(|(param, arg)| *param != value_type(ctx, *arg))
+        || params.iter().zip(args).any(|(param, arg)| {
+            !is_wasm_physical_argument_assignable(ctx, value_type(ctx, *arg), *param)
+        })
     {
         return Err(CompilationError::invalid_module(
             "wasm.return_call_indirect operands do not match its exact signature",
@@ -233,6 +273,14 @@ pub(crate) fn type_to_valtype(
         Ok(ValType::Ref(RefType {
             nullable: true,
             heap_type: HeapType::Concrete(CLOSURE_STRUCT_IDX),
+        }))
+    } else if is_type(ctx, ty, "adt", "typeref") {
+        Ok(ValType::Ref(RefType {
+            nullable: true,
+            heap_type: HeapType::Abstract {
+                shared: false,
+                ty: AbstractHeapType::Struct,
+            },
         }))
     } else if ctx.types.get(ty).dialect == Symbol::new("adt") {
         Ok(ValType::Ref(RefType::ANYREF))

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -122,7 +122,7 @@ fn is_wasm_physical_argument_assignable(
     let parameter_is_anyref = is_type(ctx, parameter, "wasm", "anyref");
 
     // `adt.typeref` is emitted as the abstract Wasm `structref` type.
-    if argument_is_typeref && parameter_is_structref {
+    if argument_is_typeref && (parameter_is_structref || parameter_is_anyref) {
         return true;
     }
 

--- a/crates/trunk-ir-wasm-backend/src/lib.rs
+++ b/crates/trunk-ir-wasm-backend/src/lib.rs
@@ -27,7 +27,6 @@ mod translate;
 mod validation;
 
 pub use data_registry::{DataEntry, DataRegistry};
-pub use emit::emit_wasm;
 pub use errors::{CompilationError, CompilationErrorKind, CompilationResult};
 pub use plan::{MainExports, MemoryPlan};
 pub use translate::{WasmBinary, emit_module_to_wasm};

--- a/crates/trunk-ir-wasm-backend/src/translate.rs
+++ b/crates/trunk-ir-wasm-backend/src/translate.rs
@@ -9,7 +9,8 @@ use trunk_ir::Symbol;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 
-use crate::{CompilationResult, emit_wasm, validate_wasm_ir};
+use crate::emit::emit_wasm;
+use crate::{CompilationResult, validate_wasm_ir};
 
 /// A compiled WebAssembly module with metadata.
 pub struct WasmBinary {

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -197,6 +197,9 @@ mod tests {
             r#"core.module @test {
   !Array = core.array(core.i32)
   !Struct = adt.struct() {fields = [[@value, core.i32]], name = @Struct}
+  wasm.func @typeref(%table_index: core.i32, %value: adt.typeref) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.anyref), table = 0, type_idx = 0}
+  }
   wasm.func @struct(%table_index: core.i32, %value: !Struct) -> core.nil {
     wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.anyref), table = 0, type_idx = 0}
   }

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -113,6 +113,18 @@ mod tests {
     use super::*;
     use trunk_ir::parser::parse_test_module;
 
+    fn assert_rejects_tail_signature(source: &str) {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, source);
+        let error = validate_wasm_ir(&ctx, module).expect_err("invalid physical relation");
+        assert!(
+            error
+                .to_string()
+                .contains("operands do not match its exact signature"),
+            "{error}"
+        );
+    }
+
     #[test]
     fn rejects_invalid_return_call_indirect_exact_contracts() {
         let rejects = |source: &str, diagnostic: &str| {
@@ -174,6 +186,58 @@ mod tests {
   }
 }"#,
             "operands do not match its exact signature",
+        );
+    }
+
+    #[test]
+    fn accepts_physical_equivalence_and_gc_upcasts_in_return_call_indirect() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !Array = core.array(core.i32)
+  !Struct = adt.struct() {fields = [[@value, core.i32]], name = @Struct}
+  wasm.func @struct(%table_index: core.i32, %value: !Struct) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.anyref), table = 0, type_idx = 0}
+  }
+  wasm.func @array(%table_index: core.i32, %value: !Array) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.arrayref), table = 0, type_idx = 0}
+  }
+  wasm.func @i31(%table_index: core.i32, %value: wasm.i31ref) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.anyref), table = 0, type_idx = 0}
+  }
+}"#,
+        );
+
+        validate_wasm_ir(&ctx, module).expect("physical-compatible tail arguments must validate");
+    }
+
+    #[test]
+    fn rejects_downcasts_and_unrelated_reference_families_in_return_call_indirect() {
+        for (value_ty, parameter_ty) in [
+            ("wasm.anyref", "wasm.structref"),
+            ("wasm.arrayref", "wasm.structref"),
+            ("wasm.funcref", "wasm.anyref"),
+        ] {
+            assert_rejects_tail_signature(&format!(
+                r#"core.module @test {{
+  wasm.func @caller(%table_index: core.i32, %value: {value_ty}) -> core.nil {{
+    wasm.return_call_indirect %table_index, %value {{signature = core.func(core.nil, {parameter_ty}), table = 0, type_idx = 0}}
+  }}
+}}"#
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_unregistered_adt_struct_as_structref_tail_argument() {
+        assert_rejects_tail_signature(
+            r#"core.module @test {
+  !Struct = adt.struct() {fields = [[@value, core.i32]], name = @Struct}
+  wasm.func @caller(%table_index: core.i32, %value: !Struct) -> core.nil {
+    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.structref), table = 0, type_idx = 0}
+  }
+}"#,
         );
     }
 }


### PR DESCRIPTION
## Summary
- Keep the recorded exact core.func signature authoritative while validating indirect-tail operands with conservative Wasm physical assignability.
- Map adt.typeref to abstract structref and preserve only the source reference representations needed by signature conversion.
- Make raw Wasm emission crate-private so public emission always validates first.

## Checks
- cargo fmt --all --check
- cargo nextest run -p trunk-ir-wasm-backend
- cargo clippy -p trunk-ir-wasm-backend --all-targets -- -D warnings
- Normal pre-commit hook: workspace clippy, format, and nextest (2,011 passed, 1 skipped)
- git diff --check origin/main

Related to #774.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebAssembly compilation for indirect tail calls involving type references and structured reference types.
  - Added support for compatible reference-type conversions, including structured, array, and general reference types.
  - Strengthened validation to accept valid reference upcasts while rejecting incompatible or unsupported signatures.

- **Tests**
  - Expanded coverage for indirect tail-call signatures and type-reference argument encoding.
  - Added validation checks for both accepted and rejected reference-type combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->