### PR TITLE
Convert exact indirect call signatures during target lowering

### DIFF
--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -3,8 +3,6 @@
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::core;
-use trunk_ir::dialect::func::{self, IndirectCallLike};
-use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 
@@ -248,18 +246,6 @@ pub fn set_indirect_call_signature(ctx: &mut IrContext, op: OpRef, signature: Ty
         Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
         Attribute::Type(signature),
     );
-}
-
-/// Read the exact callable signature retained on an indirect transfer.
-pub fn get_indirect_call_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
-    func::CallIndirect::from_op(ctx, op)
-        .ok()
-        .and_then(|call| IndirectCallLike::exact_signature(&call, ctx))
-        .or_else(|| {
-            func::TailCallIndirect::from_op(ctx, op)
-                .ok()
-                .and_then(|tail| IndirectCallLike::exact_signature(&tail, ctx))
-        })
 }
 
 /// Retain a typed closure contract on its canonical runtime pair.

--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -9,8 +9,6 @@ use trunk_ir::types::{Attribute, TypeDataBuilder};
 pub const CALLING_CONVENTION_ATTR: &str = "tribute.calling_convention";
 /// Result type carried by a private immutable CPS continuation frame.
 pub const CPS_CONTINUATION_FRAME_RESULT_ATTR: &str = "tribute.cps_continuation_frame_result";
-pub const INDIRECT_CALL_SIGNATURE_ATTR: &str =
-    trunk_ir::dialect::func::INDIRECT_CALL_SIGNATURE_ATTR;
 pub const CLOSURE_CALLABLE_TYPE_ATTR: &str = "tribute.closure_callable_type";
 pub const CLOSURE_ENVIRONMENT_INDEX_ATTR: &str = "tribute.closure_environment_index";
 
@@ -234,18 +232,6 @@ pub fn physical_closure_function_type(
 
 fn generated_cps_closure_type(ctx: &mut IrContext, function: TypeRef) -> TypeRef {
     physical_closure_type_with_environment_index(ctx, function, CallingConvention::Cps, 0)
-}
-
-/// Attach the exact callable signature to an indirect transfer.
-///
-/// On `func.*` this is the dialect-declared `signature` attribute. Target
-/// lowering carries the same canonical attribute onto its own indirect
-/// transfer operations until their backend-specific signature index is ready.
-pub fn set_indirect_call_signature(ctx: &mut IrContext, op: OpRef, signature: TypeRef) {
-    ctx.op_mut(op).attributes.insert(
-        Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
-        Attribute::Type(signature),
-    );
 }
 
 /// Retain a typed closure contract on its canonical runtime pair.

--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -3,7 +3,7 @@
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::core;
-use trunk_ir::dialect::func;
+use trunk_ir::dialect::func::{self, IndirectCallLike};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
@@ -254,11 +254,11 @@ pub fn set_indirect_call_signature(ctx: &mut IrContext, op: OpRef, signature: Ty
 pub fn get_indirect_call_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
     func::CallIndirect::from_op(ctx, op)
         .ok()
-        .and_then(|call| call.signature(ctx))
+        .and_then(|call| IndirectCallLike::exact_signature(&call, ctx))
         .or_else(|| {
             func::TailCallIndirect::from_op(ctx, op)
                 .ok()
-                .and_then(|tail| tail.signature(ctx))
+                .and_then(|tail| IndirectCallLike::exact_signature(&tail, ctx))
         })
 }
 

--- a/crates/tribute-core/src/lib.rs
+++ b/crates/tribute-core/src/lib.rs
@@ -7,10 +7,9 @@ pub mod target;
 
 pub use callable_abi::CallableAbi;
 pub use calling_convention::{
-    CALLING_CONVENTION_ATTR, CLOSURE_CALLABLE_TYPE_ATTR, CallingConvention,
-    INDIRECT_CALL_SIGNATURE_ATTR, get_calling_convention, get_closure_callable_type,
-    get_physical_closure_convention, physical_closure_type, set_calling_convention,
-    set_closure_callable_type, set_indirect_call_signature,
+    CALLING_CONVENTION_ATTR, CLOSURE_CALLABLE_TYPE_ATTR, CallingConvention, get_calling_convention,
+    get_closure_callable_type, get_physical_closure_convention, physical_closure_type,
+    set_calling_convention, set_closure_callable_type,
 };
 pub use diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 pub use target::*;

--- a/crates/tribute-core/src/lib.rs
+++ b/crates/tribute-core/src/lib.rs
@@ -9,8 +9,8 @@ pub use callable_abi::CallableAbi;
 pub use calling_convention::{
     CALLING_CONVENTION_ATTR, CLOSURE_CALLABLE_TYPE_ATTR, CallingConvention,
     INDIRECT_CALL_SIGNATURE_ATTR, get_calling_convention, get_closure_callable_type,
-    get_indirect_call_signature, get_physical_closure_convention, physical_closure_type,
-    set_calling_convention, set_closure_callable_type, set_indirect_call_signature,
+    get_physical_closure_convention, physical_closure_type, set_calling_convention,
+    set_closure_callable_type, set_indirect_call_signature,
 };
 pub use diagnostic::{CompilationPhase, Diagnostic, DiagnosticSeverity};
 pub use target::*;

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -438,7 +438,7 @@ impl RewritePattern for LowerClosureTailCallArena {
 /// Copy source metadata without replacing the physical indirect-call contract.
 fn copy_indirect_call_attributes(ctx: &mut IrContext, source: OpRef, destination: OpRef) {
     let mut attributes = ctx.op(source).attributes.clone();
-    attributes.remove(func::INDIRECT_CALL_SIGNATURE_ATTR);
+    func::remove_indirect_call_signature(&mut attributes);
     ctx.op_mut(destination).attributes.extend(attributes);
 }
 
@@ -1337,7 +1337,8 @@ mod tests {
             .copied()
             .find(|op| func::TailCallIndirect::from_op(&ctx, *op).is_ok())
             .unwrap();
-        let signature = func::indirect_call_signature(&ctx, tail).unwrap();
+        let signature =
+            trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, tail).unwrap();
         let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
         assert_eq!(ctx.op_operands(tail).len(), 6);
         assert_eq!(ctx.op_operands(tail)[1], evidence);

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -1337,7 +1337,7 @@ mod tests {
             .copied()
             .find(|op| func::TailCallIndirect::from_op(&ctx, *op).is_ok())
             .unwrap();
-        let signature = tribute_core::get_indirect_call_signature(&ctx, tail).unwrap();
+        let signature = func::indirect_call_signature(&ctx, tail).unwrap();
         let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
         assert_eq!(ctx.op_operands(tail).len(), 6);
         assert_eq!(ctx.op_operands(tail)[1], evidence);

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -926,7 +926,6 @@ fn rewrite_evidence_ops_in_block(ctx: &mut IrContext, block: BlockRef) -> PassRu
 mod tests {
     use super::*;
     use std::ops::ControlFlow;
-    use tribute_core::get_indirect_call_signature;
     use trunk_ir::Span;
     use trunk_ir::context::{BlockArgData, BlockData, RegionData};
     use trunk_ir::parser::parse_test_module;
@@ -1197,7 +1196,7 @@ mod tests {
             .find(|&op| func::CallIndirect::matches(&ctx, op))
             .expect("lowered indirect dispatch");
         assert!(
-            get_indirect_call_signature(&ctx, inner_call).is_some(),
+            func::indirect_call_signature(&ctx, inner_call).is_some(),
             "native-generated indirect calls must carry an exact signature"
         );
     }

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -24,9 +24,7 @@
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 
-use tribute_core::{
-    get_physical_closure_convention, set_calling_convention, set_indirect_call_signature,
-};
+use tribute_core::{get_physical_closure_convention, set_calling_convention};
 use tribute_ir::dialect::ability::{
     self, MarkerField, compute_op_idx, evidence_abi, evidence_runtime_symbols,
 };
@@ -57,7 +55,7 @@ fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
         .map(|&value| ctx.value_ty(value))
         .collect::<Vec<_>>();
     let signature = core::func(ctx, result, parameters).as_type_ref();
-    set_indirect_call_signature(ctx, call, signature);
+    let _ = func::set_indirect_call_signature(ctx, call, signature);
 }
 
 /// Lower evidence operations for the native backend.
@@ -1196,7 +1194,8 @@ mod tests {
             .find(|&op| func::CallIndirect::matches(&ctx, op))
             .expect("lowered indirect dispatch");
         assert!(
-            func::indirect_call_signature(&ctx, inner_call).is_some(),
+            trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, inner_call)
+                .is_some(),
             "native-generated indirect calls must carry an exact signature"
         );
     }

--- a/crates/tribute-passes/src/native/ownership_plan.rs
+++ b/crates/tribute-passes/src/native/ownership_plan.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::ops::ControlFlow;
 
-use tribute_core::{CallingConvention, get_calling_convention, get_indirect_call_signature};
+use tribute_core::{CallingConvention, get_calling_convention};
 use tribute_ir::dialect::closure;
 use trunk_ir::adt_layout::{get_enum_variants, get_struct_fields};
 use trunk_ir::context::IrContext;

--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -768,7 +768,12 @@ impl ActionPlanner<'_> {
         let tail =
             func::TailCall::matches(self.ir, op) || func::TailCallIndirect::matches(self.ir, op);
         let operands = self.ir.op_operands(op);
-        let args = operands.get(usize::from(indirect)..).unwrap_or_default();
+        let args = if indirect {
+            trunk_ir::op_interface::IndirectCallLikeOps::arguments(self.ir, op)
+                .ok_or_else(|| OwnershipPlanError::new("indirect call has malformed operands"))?
+        } else {
+            operands
+        };
         let entries = if indirect {
             let signature = trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(self.ir, op)
                 .and_then(|ty| core::Func::from_type_ref(self.ir, ty))

--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -770,7 +770,7 @@ impl ActionPlanner<'_> {
         let operands = self.ir.op_operands(op);
         let args = operands.get(usize::from(indirect)..).unwrap_or_default();
         let entries = if indirect {
-            let signature = get_indirect_call_signature(self.ir, op)
+            let signature = func::indirect_call_signature(self.ir, op)
                 .and_then(|ty| core::Func::from_type_ref(self.ir, ty))
                 .ok_or_else(|| {
                     OwnershipPlanError::new(format!(

--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -770,7 +770,7 @@ impl ActionPlanner<'_> {
         let operands = self.ir.op_operands(op);
         let args = operands.get(usize::from(indirect)..).unwrap_or_default();
         let entries = if indirect {
-            let signature = func::indirect_call_signature(self.ir, op)
+            let signature = trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(self.ir, op)
                 .and_then(|ty| core::Func::from_type_ref(self.ir, ty))
                 .ok_or_else(|| {
                     OwnershipPlanError::new(format!(

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -13,7 +13,6 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 
-use tribute_core::set_indirect_call_signature;
 use tribute_ir::dialect::ability::{self, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
@@ -48,7 +47,7 @@ fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
         .map(|&value| ctx.value_ty(value))
         .collect::<Vec<_>>();
     let signature = core::func(ctx, result, parameters).as_type_ref();
-    set_indirect_call_signature(ctx, call, signature);
+    let _ = func::set_indirect_call_signature(ctx, call, signature);
 }
 
 #[derive(Debug)]

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -15,13 +15,14 @@ use tribute_core::calling_convention::{
     get_physical_closure_environment_index,
 };
 use tribute_core::{
-    CALLING_CONVENTION_ATTR, CallingConvention, INDIRECT_CALL_SIGNATURE_ATTR,
-    get_calling_convention, get_physical_closure_convention,
+    CALLING_CONVENTION_ATTR, CallingConvention, get_calling_convention,
+    get_physical_closure_convention,
 };
 use tribute_ir::dialect::{ability, tribute_rt};
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, arith, core, func};
+use trunk_ir::op_interface::IndirectCallLikeOps;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::Module;
@@ -162,6 +163,7 @@ pub fn lower_cps_signatures_to_physical(
             }
         }
 
+        let indirect_signature = IndirectCallLikeOps::exact_signature(converter.ctx, op);
         let op_attributes: Vec<_> = converter
             .ctx
             .op(op)
@@ -173,11 +175,10 @@ pub fn lower_cps_signatures_to_physical(
             if func::Func::matches(converter.ctx, op) && name == Symbol::new("type") {
                 continue;
             }
-            let converted = if name == Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR) {
+            let converted = if matches!(&value, Attribute::Type(signature) if Some(*signature) == indirect_signature)
+            {
                 let Attribute::Type(signature) = value else {
-                    return Err(TargetAbiError::new(
-                        "target ABI: indirect callable signature must be a type attribute",
-                    ));
+                    unreachable!("matched indirect signature must be a type attribute");
                 };
                 let convention = exact_convention(converter.ctx, op)?.ok_or_else(|| {
                     TargetAbiError::new(
@@ -978,7 +979,7 @@ fn validate_transfers(
         if !func::CallIndirect::matches(ctx, op) && !func::TailCallIndirect::matches(ctx, op) {
             continue;
         }
-        let signature = func::indirect_call_signature(ctx, op);
+        let signature = IndirectCallLikeOps::exact_signature(ctx, op);
         let convention = exact_convention(ctx, op)?;
         if signature.is_none() && convention.is_none() {
             continue;

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -993,7 +993,9 @@ fn validate_transfers(
         let callable = core::Func::from_type_ref(ctx, signature).ok_or_else(|| {
             TargetAbiError::new("target ABI: indirect callable signature is not core.func")
         })?;
-        let args = ctx.op_operands(op).get(1..).unwrap_or_default();
+        let args = IndirectCallLikeOps::arguments(ctx, op).ok_or_else(|| {
+            TargetAbiError::new("target ABI: indirect transfer has malformed operands")
+        })?;
         if !operands_match(ctx, args, callable.params(ctx)) {
             return Err(TargetAbiError::new(
                 "target ABI: indirect transfer operands differ from exact callable signature",

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -92,6 +92,7 @@ pub fn lower_cps_signatures_to_physical(
     let mut function_types = Vec::new();
     let mut result_types = Vec::new();
     let mut attributes = Vec::new();
+    let mut indirect_signatures = Vec::new();
     let mut block_args = Vec::new();
 
     for (name, ty) in aliases {
@@ -173,16 +174,15 @@ pub fn lower_cps_signatures_to_physical(
                 )
             })?;
             let signature = converter.convert_callable(signature, convention)?;
-            if !IndirectCallLikeOps::set_exact_signature(
-                converter.ctx,
-                op,
-                &mut converted_attributes,
-                signature,
-            ) {
+            if !func::CallIndirect::matches(converter.ctx, op)
+                && !func::TailCallIndirect::matches(converter.ctx, op)
+            {
                 return Err(TargetAbiError::new(
                     "target ABI: indirect callable signature cannot be set",
                 ));
             }
+            func::remove_indirect_call_signature(&mut converted_attributes);
+            indirect_signatures.push((op, signature));
         }
         let op_attributes: Vec<_> = converted_attributes
             .iter()
@@ -237,6 +237,9 @@ pub fn lower_cps_signatures_to_physical(
     }
     for (op, name, value) in attributes {
         ctx.op_mut(op).attributes.insert(name, value);
+    }
+    for (op, signature) in indirect_signatures {
+        assert!(IndirectCallLikeOps::set_exact_signature(ctx, op, signature));
     }
     for (block, index, ty) in block_args {
         ctx.set_block_arg_type(block, index, ty);

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -16,7 +16,7 @@ use tribute_core::calling_convention::{
 };
 use tribute_core::{
     CALLING_CONVENTION_ATTR, CallingConvention, INDIRECT_CALL_SIGNATURE_ATTR,
-    get_calling_convention, get_indirect_call_signature, get_physical_closure_convention,
+    get_calling_convention, get_physical_closure_convention,
 };
 use tribute_ir::dialect::{ability, tribute_rt};
 use trunk_ir::Symbol;
@@ -978,7 +978,7 @@ fn validate_transfers(
         if !func::CallIndirect::matches(ctx, op) && !func::TailCallIndirect::matches(ctx, op) {
             continue;
         }
-        let signature = get_indirect_call_signature(ctx, op);
+        let signature = func::indirect_call_signature(ctx, op);
         let convention = exact_convention(ctx, op)?;
         if signature.is_none() && convention.is_none() {
             continue;

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -163,11 +163,11 @@ pub fn lower_cps_signatures_to_physical(
             }
         }
 
-        let indirect_signature = IndirectCallLikeOps::exact_signature(converter.ctx, op);
-        let op_attributes: Vec<_> = converter
-            .ctx
-            .op(op)
-            .attributes
+        let original_attributes = converter.ctx.op(op).attributes.clone();
+        let mut converted_attributes = original_attributes.clone();
+        let indirect_signature =
+            IndirectCallLikeOps::take_exact_signature(converter.ctx, op, &mut converted_attributes);
+        let op_attributes: Vec<_> = converted_attributes
             .iter()
             .map(|(name, value)| (*name, value.clone()))
             .collect();
@@ -175,26 +175,21 @@ pub fn lower_cps_signatures_to_physical(
             if func::Func::matches(converter.ctx, op) && name == Symbol::new("type") {
                 continue;
             }
-            let converted = if IndirectCallLikeOps::is_exact_signature_attribute(
-                converter.ctx,
-                op,
-                name,
-            ) && matches!(&value, Attribute::Type(signature) if Some(*signature) == indirect_signature)
-            {
-                let Attribute::Type(signature) = value else {
-                    unreachable!("matched indirect signature must be a type attribute");
-                };
-                let convention = exact_convention(converter.ctx, op)?.ok_or_else(|| {
-                    TargetAbiError::new(
-                        "target ABI: indirect callable signature has no convention metadata",
-                    )
-                })?;
-                Attribute::Type(converter.convert_callable(signature, convention)?)
-            } else {
-                converter.convert_attribute(value.clone())?
-            };
-            if converted != value {
-                attributes.push((op, name, converted));
+            let converted = converter.convert_attribute(value)?;
+            converted_attributes.insert(name, converted);
+        }
+        if let Some(signature_slot) = indirect_signature {
+            let convention = exact_convention(converter.ctx, op)?.ok_or_else(|| {
+                TargetAbiError::new(
+                    "target ABI: indirect callable signature has no convention metadata",
+                )
+            })?;
+            let signature = converter.convert_callable(signature_slot.signature(), convention)?;
+            signature_slot.restore(&mut converted_attributes, signature);
+        }
+        for (name, value) in converted_attributes {
+            if original_attributes.get(name) != Some(&value) {
+                attributes.push((op, name, value));
             }
         }
 

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -165,8 +165,25 @@ pub fn lower_cps_signatures_to_physical(
 
         let original_attributes = converter.ctx.op(op).attributes.clone();
         let mut converted_attributes = original_attributes.clone();
-        let indirect_signature =
-            IndirectCallLikeOps::take_exact_signature(converter.ctx, op, &mut converted_attributes);
+        let indirect_signature = IndirectCallLikeOps::exact_signature(converter.ctx, op);
+        if let Some(signature) = indirect_signature {
+            let convention = exact_convention(converter.ctx, op)?.ok_or_else(|| {
+                TargetAbiError::new(
+                    "target ABI: indirect callable signature has no convention metadata",
+                )
+            })?;
+            let signature = converter.convert_callable(signature, convention)?;
+            if !IndirectCallLikeOps::set_exact_signature(
+                converter.ctx,
+                op,
+                &mut converted_attributes,
+                signature,
+            ) {
+                return Err(TargetAbiError::new(
+                    "target ABI: indirect callable signature cannot be set",
+                ));
+            }
+        }
         let op_attributes: Vec<_> = converted_attributes
             .iter()
             .map(|(name, value)| (*name, value.clone()))
@@ -177,15 +194,6 @@ pub fn lower_cps_signatures_to_physical(
             }
             let converted = converter.convert_attribute(value)?;
             converted_attributes.insert(name, converted);
-        }
-        if let Some(signature_slot) = indirect_signature {
-            let convention = exact_convention(converter.ctx, op)?.ok_or_else(|| {
-                TargetAbiError::new(
-                    "target ABI: indirect callable signature has no convention metadata",
-                )
-            })?;
-            let signature = converter.convert_callable(signature_slot.signature(), convention)?;
-            signature_slot.restore(&mut converted_attributes, signature);
         }
         for (name, value) in converted_attributes {
             if original_attributes.get(name) != Some(&value) {

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -175,7 +175,11 @@ pub fn lower_cps_signatures_to_physical(
             if func::Func::matches(converter.ctx, op) && name == Symbol::new("type") {
                 continue;
             }
-            let converted = if matches!(&value, Attribute::Type(signature) if Some(*signature) == indirect_signature)
+            let converted = if IndirectCallLikeOps::is_exact_signature_attribute(
+                converter.ctx,
+                op,
+                name,
+            ) && matches!(&value, Attribute::Type(signature) if Some(*signature) == indirect_signature)
             {
                 let Attribute::Type(signature) = value else {
                     unreachable!("matched indirect signature must be a type attribute");
@@ -1409,6 +1413,38 @@ mod tests {
             printed.contains("closure.closure(core.func(core.nil"),
             "{printed}"
         );
+    }
+
+    #[test]
+    fn unrelated_type_metadata_never_becomes_an_indirect_signature() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @run(%callee: core.i32, %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %value {signature = core.func(core.never, core.i32), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let run = function(&ctx, module, "run");
+        let body = run.body_if_present(&ctx).unwrap();
+        let indirect = ctx.block(ctx.region(body).blocks[0]).ops[0];
+        let signature = IndirectCallLikeOps::exact_signature(&ctx, indirect).unwrap();
+        ctx.op_mut(indirect).attributes.insert(
+            Symbol::new("unrelated_callable_metadata"),
+            Attribute::Type(signature),
+        );
+        let before = print_module(&ctx, module.op());
+
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("untagged nested core.func<core.never, ...>"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     fn compose_promoted_root(export: CallingConvention) -> (IrContext, Module) {

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -4979,8 +4979,9 @@ mod tests {
             "the dispatch adapter and separate handler paths must tail-transfer: {printed}"
         );
         for tail in tails {
-            let signature = func::indirect_call_signature(&ctx, tail)
-                .expect("every emitted CPS indirect tail has its exact closure contract");
+            let signature =
+                trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, tail)
+                    .expect("every emitted CPS indirect tail has its exact closure contract");
             let callable = core::Func::from_type_ref(&ctx, signature)
                 .expect("the indirect tail signature is a core.func");
             assert_eq!(callable.r#return(&ctx), core::never(&mut ctx).as_type_ref());
@@ -5129,8 +5130,9 @@ mod tests {
             "the dispatch adapter and independent CPS exits must both tail-transfer: {printed}"
         );
         for tail in tails {
-            let signature = func::indirect_call_signature(&ctx, tail)
-                .expect("every emitted CPS indirect tail has its exact closure contract");
+            let signature =
+                trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, tail)
+                    .expect("every emitted CPS indirect tail has its exact closure contract");
             let callable = core::Func::from_type_ref(&ctx, signature)
                 .expect("the indirect tail signature is a core.func");
             assert_eq!(callable.r#return(&ctx), core::never(&mut ctx).as_type_ref());

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -4979,7 +4979,7 @@ mod tests {
             "the dispatch adapter and separate handler paths must tail-transfer: {printed}"
         );
         for tail in tails {
-            let signature = tribute_core::get_indirect_call_signature(&ctx, tail)
+            let signature = func::indirect_call_signature(&ctx, tail)
                 .expect("every emitted CPS indirect tail has its exact closure contract");
             let callable = core::Func::from_type_ref(&ctx, signature)
                 .expect("the indirect tail signature is a core.func");
@@ -5129,7 +5129,7 @@ mod tests {
             "the dispatch adapter and independent CPS exits must both tail-transfer: {printed}"
         );
         for tail in tails {
-            let signature = tribute_core::get_indirect_call_signature(&ctx, tail)
+            let signature = func::indirect_call_signature(&ctx, tail)
                 .expect("every emitted CPS indirect tail has its exact closure contract");
             let callable = core::Func::from_type_ref(&ctx, signature)
                 .expect("the indirect tail signature is a core.func");

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -20,7 +20,7 @@
 //! binary search (O(log n)) since the evidence array is maintained in sorted order
 //! by ability_id.
 
-use tribute_core::{CallingConvention, set_calling_convention, set_indirect_call_signature};
+use tribute_core::{CallingConvention, set_calling_convention};
 use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
@@ -204,6 +204,7 @@ impl RewritePattern for LegacyEffectDispatchCpsPattern {
             [*result_ty],
             0,
             0,
+            None,
         );
         let result = call.results(ctx)[0];
         rewriter.insert_op(call.op_ref());
@@ -418,6 +419,7 @@ impl RewritePattern for EffectDispatchTailPattern {
             [result_ty],
             0,
             0,
+            None,
         );
         let call_result = call.results(ctx)[0];
         rewriter.insert_op(call.op_ref());
@@ -492,6 +494,7 @@ impl RewritePattern for EffectDispatchCpsPattern {
             ],
             0,
             0,
+            None,
         );
         attach_exact_indirect_signature(ctx, tail.op_ref());
         set_calling_convention(ctx, tail.op_ref(), CallingConvention::Cps);
@@ -511,7 +514,7 @@ fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
         .collect::<Vec<_>>();
     let result = core::nil(ctx).as_type_ref();
     let signature = core::func(ctx, result, parameters).as_type_ref();
-    set_indirect_call_signature(ctx, call, signature);
+    let _ = wasm_dialect::set_indirect_call_signature(ctx, call, signature);
 }
 
 /// Pattern that matches `ability.evidence_extend` and replaces it with

--- a/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
+++ b/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
@@ -186,11 +186,15 @@ impl RewritePattern for NormalizeCallIndirectPattern {
         debug!("normalize_primitive_types: func.call_indirect result type normalized");
 
         let loc = ctx.op(op).location;
-        let operands = ctx.op_operands(op).to_vec();
-        let callee = *operands
-            .first()
-            .expect("NormalizeCallIndirectPattern: func.call_indirect matched but has no operands");
-        let args: Vec<_> = operands[1..].to_vec();
+        let Some(callee) = IndirectCallLikeOps::callee(ctx, op) else {
+            return false;
+        };
+        let Some(args) = IndirectCallLikeOps::arguments(ctx, op) else {
+            return false;
+        };
+        // Constructing the replacement mutates the context, so release the
+        // interface's borrowed view before creating the new operation.
+        let args = args.to_vec();
 
         let signature = IndirectCallLikeOps::exact_signature(ctx, op);
         let new_op = func::call_indirect(ctx, loc, callee, args, new_result_ty, signature);

--- a/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
+++ b/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
@@ -29,6 +29,7 @@ use tracing::debug;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::func;
+use trunk_ir::op_interface::IndirectCallLikeOps;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -191,7 +192,7 @@ impl RewritePattern for NormalizeCallIndirectPattern {
             .expect("NormalizeCallIndirectPattern: func.call_indirect matched but has no operands");
         let args: Vec<_> = operands[1..].to_vec();
 
-        let signature = func::indirect_call_signature(ctx, op);
+        let signature = IndirectCallLikeOps::exact_signature(ctx, op);
         let new_op = func::call_indirect(ctx, loc, callee, args, new_result_ty, signature);
         rewriter.replace_op(new_op.op_ref());
         true

--- a/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
+++ b/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
@@ -191,7 +191,7 @@ impl RewritePattern for NormalizeCallIndirectPattern {
             .expect("NormalizeCallIndirectPattern: func.call_indirect matched but has no operands");
         let args: Vec<_> = operands[1..].to_vec();
 
-        let signature = tribute_core::get_indirect_call_signature(ctx, op);
+        let signature = func::indirect_call_signature(ctx, op);
         let new_op = func::call_indirect(ctx, loc, callee, args, new_result_ty, signature);
         rewriter.replace_op(new_op.op_ref());
         true

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -280,13 +280,19 @@ impl RewritePattern for FuncCallIndirectPattern {
             let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
                 return false;
             };
+            let callable_result = callable.r#return(ctx);
+            let results_match = if crate::function::is_nil_type(ctx, callable_result) {
+                result_types.is_empty()
+            } else {
+                result_types == [callable_result]
+            };
             if callable.params(ctx).len() != CallLike::call_args(&call, ctx).len()
                 || callable
                     .params(ctx)
                     .iter()
                     .zip(CallLike::call_args(&call, ctx))
                     .any(|(&param, &arg)| param != ctx.value_ty(arg))
-                || result_types != [callable.r#return(ctx)]
+                || !results_match
             {
                 return false;
             }
@@ -636,6 +642,24 @@ mod tests {
 }"#,
         );
         insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn exact_unit_call_indirect_has_no_ssa_result() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @test_fn(%callee: core.ptr) -> core.nil {
+    func.call_indirect %callee {signature = core.func(core.nil)}
+    func.return
+  }
+}"#,
+        );
+
+        assert!(
+            result.contains("clif.call_indirect %0 {sig = core.func(core.nil)}"),
+            "{result}"
+        );
+        assert!(!result.contains("func.call_indirect"), "{result}");
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -270,7 +270,7 @@ impl RewritePattern for FuncCallIndirectPattern {
         };
 
         let result_types = rewriter.result_types(ctx, op);
-        let sig_ty = if let Some(signature) = IndirectCallLike::exact_signature(&call, ctx) {
+        let sig_ty = if let Some(signature) = call.exact_signature(ctx) {
             let Some(signature) =
                 trunk_ir::rewrite::convert_function_type(ctx, signature, rewriter.type_converter())
             else {
@@ -398,7 +398,7 @@ impl RewritePattern for FuncTailCallIndirectPattern {
             return false;
         }
 
-        let Some(signature) = IndirectCallLike::exact_signature(&tail, ctx) else {
+        let Some(signature) = tail.exact_signature(ctx) else {
             return false;
         };
         let Some(signature) =

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -393,6 +393,27 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         if callable.r#return(ctx) != core::nil(ctx).as_type_ref() {
             return false;
         }
+        let type_converter = rewriter.type_converter();
+        let result = type_converter.convert_type_or_identity(ctx, callable.r#return(ctx));
+        let params = callable
+            .params(ctx)
+            .iter()
+            .map(|&ty| type_converter.convert_type_or_identity(ctx, ty))
+            .collect::<Vec<_>>();
+        let operands = ctx.op_operands(op);
+        let Some((_callee, args)) = operands.split_first() else {
+            return false;
+        };
+        if !ctx.op_result_types(op).is_empty()
+            || params.len() != args.len()
+            || params
+                .iter()
+                .zip(args)
+                .any(|(&param, &arg)| param != ctx.value_ty(arg))
+        {
+            return false;
+        }
+        let signature = core::func(ctx, result, params).as_type_ref();
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,
@@ -612,6 +633,61 @@ mod tests {
     fn test_tail_transfers_to_clif() {
         let result = run_pass(TAIL_TRANSFERS);
         insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn tail_call_indirect_signature_converts_array_to_ptr() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !evidence = core.array(core.i32)
+  func.func @caller(%callee: core.ptr, %evidence: !evidence) -> core.nil attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %evidence {signature = core.func(core.nil, !evidence), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+        let caller = module.ops(&ctx)[0];
+        let entry = ctx.region(ctx.op(caller).regions[0]).blocks[0];
+        let evidence_ty = ctx.value_ty(ctx.block_args(entry)[1]);
+        let ptr_ty = core::ptr(&mut ctx).as_type_ref();
+        let mut type_converter = TypeConverter::new();
+        type_converter.add_conversion(move |_, ty| (ty == evidence_ty).then_some(ptr_ty));
+
+        super::lower(&mut ctx, module, type_converter).expect("func-to-clif lowering");
+
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            printed.contains("clif.return_call_indirect")
+                && printed.contains("sig = core.func(core.nil, core.ptr)"),
+            "{printed}"
+        );
+        assert!(
+            !printed.contains("sig = core.func(core.nil, !evidence)"),
+            "{printed}"
+        );
+    }
+
+    #[test]
+    fn tail_call_indirect_with_mismatched_signature_params_is_rejected_before_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i64), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+
+        let error = super::lower(&mut ctx, module, TypeConverter::new()).unwrap_err();
+        assert!(
+            error.to_string().contains("func.tail_call_indirect"),
+            "{error}"
+        );
+        let after = print_module(&ctx, module.op());
+        assert!(after.contains("func.tail_call_indirect"), "{after}");
+        assert!(!after.contains("clif.return_call_indirect"), "{after}");
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -17,7 +17,7 @@ use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::clif;
 use trunk_ir::dialect::core;
-use trunk_ir::dialect::func;
+use trunk_ir::dialect::func::{self, CallLike, IndirectCallLike, TailCallLike};
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -265,26 +265,42 @@ impl RewritePattern for FuncCallIndirectPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if func::CallIndirect::from_op(ctx, op).is_err() {
+        let Ok(call) = func::CallIndirect::from_op(ctx, op) else {
             return false;
-        }
+        };
 
-        let operands = ctx.op_operands(op).to_vec();
-        if operands.is_empty() {
-            return false;
-        }
-
-        // Collect arg types (skip operand 0 = callee).
-        // Operand types are already converted by the applicator's cast insertion.
-        let param_types: Vec<TypeRef> = operands[1..].iter().map(|&v| ctx.value_ty(v)).collect();
-
-        // Result type with conversion applied
-        let result_ty = rewriter.result_type(ctx, op, 0);
-
-        // Build sig type matching translate_signature layout:
-        // params[0] = return type, params[1..] = parameter types
-        let ret_ty = result_ty.unwrap_or_else(|| core::nil(ctx).as_type_ref());
-        let sig_ty = core::func(ctx, ret_ty, param_types.iter().copied()).as_type_ref();
+        let result_types = rewriter.result_types(ctx, op);
+        let sig_ty = if let Some(signature) = IndirectCallLike::exact_signature(&call, ctx) {
+            let Some(signature) =
+                trunk_ir::rewrite::convert_function_type(ctx, signature, rewriter.type_converter())
+            else {
+                return false;
+            };
+            let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
+                return false;
+            };
+            if callable.params(ctx).len() != CallLike::call_args(&call, ctx).len()
+                || callable
+                    .params(ctx)
+                    .iter()
+                    .zip(CallLike::call_args(&call, ctx))
+                    .any(|(&param, &arg)| param != ctx.value_ty(arg))
+                || result_types != [callable.r#return(ctx)]
+            {
+                return false;
+            }
+            signature
+        } else {
+            let param_types: Vec<TypeRef> = CallLike::call_args(&call, ctx)
+                .iter()
+                .map(|&value| ctx.value_ty(value))
+                .collect();
+            let result = result_types
+                .first()
+                .copied()
+                .unwrap_or_else(|| core::nil(ctx).as_type_ref());
+            core::func(ctx, result, param_types).as_type_ref()
+        };
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,
@@ -292,9 +308,12 @@ impl RewritePattern for FuncCallIndirectPattern {
             Symbol::new("clif"),
             Symbol::new("call_indirect"),
         );
-        ctx.op_mut(new_op)
-            .attributes
-            .insert(Symbol::new("sig"), Attribute::Type(sig_ty));
+        let attributes = &mut ctx.op_mut(new_op).attributes;
+        attributes.remove(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR));
+        attributes.insert(Symbol::new("sig"), Attribute::Type(sig_ty));
+        for (index, result_ty) in result_types.into_iter().enumerate() {
+            ctx.set_op_result_type(new_op, index as u32, result_ty);
+        }
         rewriter.replace_op(new_op);
         true
     }
@@ -367,9 +386,9 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if func::TailCallIndirect::from_op(ctx, op).is_err() {
+        let Ok(tail) = func::TailCallIndirect::from_op(ctx, op) else {
             return false;
-        }
+        };
         if ctx
             .op(op)
             .attributes
@@ -379,41 +398,28 @@ impl RewritePattern for FuncTailCallIndirectPattern {
             return false;
         }
 
-        let signature = match ctx
-            .op(op)
-            .attributes
-            .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
-        {
-            Some(signature) => signature,
-            None => return false,
+        let Some(signature) = IndirectCallLike::exact_signature(&tail, ctx) else {
+            return false;
+        };
+        let Some(signature) =
+            trunk_ir::rewrite::convert_function_type(ctx, signature, rewriter.type_converter())
+        else {
+            return false;
         };
         let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
             return false;
         };
-        if callable.r#return(ctx) != core::nil(ctx).as_type_ref() {
-            return false;
-        }
-        let type_converter = rewriter.type_converter();
-        let result = type_converter.convert_type_or_identity(ctx, callable.r#return(ctx));
-        let params = callable
-            .params(ctx)
-            .iter()
-            .map(|&ty| type_converter.convert_type_or_identity(ctx, ty))
-            .collect::<Vec<_>>();
-        let operands = ctx.op_operands(op);
-        let Some((_callee, args)) = operands.split_first() else {
-            return false;
-        };
-        if !ctx.op_result_types(op).is_empty()
-            || params.len() != args.len()
-            || params
+        if callable.r#return(ctx) != core::nil(ctx).as_type_ref()
+            || !TailCallLike::is_resultless(&tail, ctx)
+            || callable.params(ctx).len() != CallLike::call_args(&tail, ctx).len()
+            || callable
+                .params(ctx)
                 .iter()
-                .zip(args)
+                .zip(CallLike::call_args(&tail, ctx))
                 .any(|(&param, &arg)| param != ctx.value_ty(arg))
         {
             return false;
         }
-        let signature = core::func(ctx, result, params).as_type_ref();
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,
@@ -665,6 +671,48 @@ mod tests {
         assert!(
             !printed.contains("sig = core.func(core.nil, !evidence)"),
             "{printed}"
+        );
+    }
+
+    #[test]
+    fn indirect_call_signature_converts_before_physical_validation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !evidence = core.array(core.i32)
+  func.func @physical(%callee: core.ptr, %evidence: core.ptr) -> core.i32 {
+    %result = func.call_indirect %callee, %evidence {signature = core.func(core.i32, !evidence)} : core.i32
+    func.return %result
+  }
+  func.func @mismatch(%callee: core.ptr, %value: core.i32) -> core.i32 {
+    %result = func.call_indirect %callee, %value {signature = core.func(core.i32, !evidence)} : core.i32
+    func.return %result
+  }
+}"#,
+        );
+        let ptr_ty = core::ptr(&mut ctx).as_type_ref();
+        let mut type_converter = TypeConverter::new();
+        type_converter.add_conversion(move |ctx, ty| {
+            ctx.types
+                .is_dialect(ty, Symbol::new("core"), Symbol::new("array"))
+                .then_some(ptr_ty)
+        });
+
+        let error = super::lower(&mut ctx, module, type_converter).unwrap_err();
+        assert!(error.to_string().contains("func.call_indirect"), "{error}");
+
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            printed.contains("clif.call_indirect")
+                && printed.contains("sig = core.func(core.i32, core.ptr)"),
+            "{printed}"
+        );
+        assert!(
+            printed.contains(
+                "func.call_indirect %0, %1 {signature = core.func(core.i32, !evidence)} : core.i32"
+            ),
+            "the mismatched call must remain unchanged: {printed}"
         );
     }
 

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -17,7 +17,8 @@ use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
 use trunk_ir::dialect::clif;
 use trunk_ir::dialect::core;
-use trunk_ir::dialect::func::{self, CallLike, IndirectCallLike, TailCallLike};
+use trunk_ir::dialect::func::{self, CallLike, TailCallLike};
+use trunk_ir::op_interface::IndirectCallLikeModel;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
@@ -308,9 +309,10 @@ impl RewritePattern for FuncCallIndirectPattern {
             Symbol::new("clif"),
             Symbol::new("call_indirect"),
         );
-        let attributes = &mut ctx.op_mut(new_op).attributes;
-        attributes.remove(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR));
-        attributes.insert(Symbol::new("sig"), Attribute::Type(sig_ty));
+        func::remove_indirect_call_signature(&mut ctx.op_mut(new_op).attributes);
+        if !clif::set_indirect_call_signature(ctx, new_op, sig_ty) {
+            return false;
+        }
         for (index, result_ty) in result_types.into_iter().enumerate() {
             ctx.set_op_result_type(new_op, index as u32, result_ty);
         }
@@ -427,9 +429,10 @@ impl RewritePattern for FuncTailCallIndirectPattern {
             Symbol::new("clif"),
             Symbol::new("return_call_indirect"),
         );
-        let attributes = &mut ctx.op_mut(new_op).attributes;
-        attributes.remove(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR));
-        attributes.insert(Symbol::new("sig"), Attribute::Type(signature));
+        func::remove_indirect_call_signature(&mut ctx.op_mut(new_op).attributes);
+        if !clif::set_indirect_call_signature(ctx, new_op, signature) {
+            return false;
+        }
         rewriter.replace_op(new_op);
         true
     }

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -1353,6 +1353,38 @@ mod tests {
     }
 
     #[test]
+    fn collects_ordinary_call_indirect_exact_signature() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.func @caller(%table_index: core.i32, %value: wasm.structref) -> core.i32 {
+    %result = wasm.call_indirect %table_index, %value {signature = core.func(core.i32, wasm.anyref), table = 0, type_idx = 0} : core.i32
+    wasm.return %result
+  }
+}"#,
+        );
+
+        let info = collect_module_info(&mut ctx, module).expect("collect module info");
+        let [(_, signature)] = info.call_indirect_types.as_slice() else {
+            panic!("expected one collected exact signature")
+        };
+        let Some((params, result)) = helpers::func_type_parts(&ctx, *signature) else {
+            panic!("expected core.func signature")
+        };
+        assert_eq!(ctx.types.get(params[0]).name, Symbol::new("anyref"));
+        assert_eq!(ctx.types.get(result).name, Symbol::new("i32"));
+
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("exact ordinary indirect call must emit")
+            .bytes;
+        Validator::new()
+            .validate_all(&bytes)
+            .expect("encoded ordinary indirect call must validate");
+    }
+
+    #[test]
     fn region_contains_call_indirect_recognizes_return_call_indirect() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -165,16 +165,13 @@ pub(crate) fn collect_call_indirect_types(
                         continue;
                     }
 
-                    // Build function type from operands and results
-                    let operands: Vec<_> = ctx.op_operands(op).to_vec();
-
-                    if operands.is_empty() {
-                        continue; // Skip invalid call_indirect
-                    }
-
+                    // Build function type from the interface's callee and
+                    // argument accessors when no exact contract was retained.
+                    let Some(first_operand) = IndirectCallLikeOps::callee(ctx, op) else {
+                        continue;
+                    };
                     // The callee (i32 table index) is the FIRST operand, followed by args.
                     // All indirect calls use table-based call_indirect.
-                    let first_operand = operands[0];
                     let first_operand_ty = helpers::value_type(ctx, first_operand);
                     let callee_is_first = {
                         // First operand should be i32 table index or closure struct
@@ -187,6 +184,9 @@ pub(crate) fn collect_call_indirect_types(
                     // Types that are already anyref (after normalize_primitive_types pass)
                     // should remain anyref in the signature.
                     let anyref_ty = intern_simple_wasm_type(ctx, "anyref");
+                    let Some(args) = IndirectCallLikeOps::arguments(ctx, op) else {
+                        continue; // Skip invalid call_indirect
+                    };
 
                     // Callee (i32 table index) is FIRST operand, params are operands[1..]
                     assert!(
@@ -194,9 +194,8 @@ pub(crate) fn collect_call_indirect_types(
                         "call_indirect first operand must be i32 table index or closure struct, got {:?}",
                         fmt_type(ctx, first_operand_ty)
                     );
-                    let param_types: Vec<TypeRef> = operands
+                    let param_types: Vec<TypeRef> = args
                         .iter()
-                        .skip(1)
                         .map(|v| {
                             let ty = helpers::value_type(ctx, *v);
                             // After normalize_primitive_types pass:

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -148,6 +148,24 @@ pub(crate) fn collect_call_indirect_types(
 
                 // Check if this is a result-producing call_indirect.
                 if wasm_dialect::CallIndirect::matches(ctx, op) {
+                    // When source lowering retained an exact contract, use it
+                    // as the sole type-section key. It must not be recreated
+                    // from the erased table index and operands.
+                    if ctx.op(op).attributes.contains_key(trunk_ir::Symbol::new(
+                        trunk_ir::dialect::func::INDIRECT_CALL_SIGNATURE_ATTR,
+                    )) {
+                        let func_type = helpers::exact_call_indirect_signature(ctx, op)?;
+                        if let std::collections::hash_map::Entry::Vacant(entry) =
+                            type_idx_by_type.entry(func_type)
+                        {
+                            let index = *next_type_idx;
+                            *next_type_idx += 1;
+                            entry.insert(index);
+                            new_types.push((index, func_type));
+                        }
+                        continue;
+                    }
+
                     // Build function type from operands and results
                     let operands: Vec<_> = ctx.op_operands(op).to_vec();
 

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -11,6 +11,7 @@ use trunk_ir::Module;
 use trunk_ir::Symbol;
 use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::op_interface::IndirectCallLikeOps;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{RegionRef, TypeRef};
 use trunk_ir::smallvec::SmallVec;
@@ -151,9 +152,7 @@ pub(crate) fn collect_call_indirect_types(
                     // When source lowering retained an exact contract, use it
                     // as the sole type-section key. It must not be recreated
                     // from the erased table index and operands.
-                    if ctx.op(op).attributes.contains_key(trunk_ir::Symbol::new(
-                        trunk_ir::dialect::func::INDIRECT_CALL_SIGNATURE_ATTR,
-                    )) {
+                    if IndirectCallLikeOps::exact_signature(ctx, op).is_some() {
                         let func_type = helpers::exact_call_indirect_signature(ctx, op)?;
                         if let std::collections::hash_map::Entry::Vacant(entry) =
                             type_idx_by_type.entry(func_type)

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -8,7 +8,8 @@
 use tracing::debug;
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::{func, wasm as wasm_dialect};
+use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::op_interface::IndirectCallLikeOps;
 use trunk_ir::refs::{OpRef, TypeRef, ValueDef};
 use wasm_encoder::{Function, Instruction};
 
@@ -76,11 +77,7 @@ pub(crate) fn handle_call_indirect(
         )));
     }
 
-    if ctx
-        .op(op)
-        .attributes
-        .contains_key(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR))
-    {
+    if IndirectCallLikeOps::exact_signature(ctx, op).is_some() {
         let signature = helpers::exact_call_indirect_signature(ctx, op)?;
         let type_index = module_info
             .type_idx_by_type

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -51,21 +51,18 @@ pub(crate) fn handle_call_indirect(
     module_info: &ModuleInfo,
     function: &mut Function,
 ) -> CompilationResult<()> {
-    let operands = ctx.op_operands(op);
-
     // wasm.call_indirect: indirect function call via i32 table index
     // All indirect calls use table-based call_indirect (no call_ref).
     // Operands: [table_idx, arg1, arg2, ..., argN]
     // WebAssembly expects: [arg1, arg2, ..., argN, table_idx]
 
-    if operands.is_empty() {
-        return Err(CompilationError::invalid_module(
-            "wasm.call_indirect requires at least a table index operand",
-        ));
-    }
-
     // The callee (i32 table index) is the FIRST operand, followed by args.
-    let first_operand = operands[0];
+    let first_operand = IndirectCallLikeOps::callee(ctx, op).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.call_indirect requires a table index operand")
+    })?;
+    let args = IndirectCallLikeOps::arguments(ctx, op).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.call_indirect has malformed operands")
+    })?;
     let first_operand_ty = helpers::value_type(ctx, first_operand);
 
     // All call_indirect operations must use i32 table index
@@ -95,10 +92,10 @@ pub(crate) fn handle_call_indirect(
             .transpose()?
             .unwrap_or(0);
 
-        for &arg in operands.iter().skip(1) {
+        for &arg in args {
             emit_value(ctx, arg, emit_ctx, function)?;
         }
-        emit_value(ctx, operands[0], emit_ctx, function)?;
+        emit_value(ctx, first_operand, emit_ctx, function)?;
         function.instruction(&Instruction::CallIndirect {
             type_index,
             table_index,
@@ -157,9 +154,8 @@ pub(crate) fn handle_call_indirect(
             ty
         }
     };
-    let param_types: Vec<TypeRef> = operands
+    let param_types: Vec<TypeRef> = args
         .iter()
-        .skip(1)
         .map(|v| {
             let ty = helpers::value_type(ctx, *v);
             normalize_param_type(ty)
@@ -258,13 +254,12 @@ pub(crate) fn handle_call_indirect(
         None => 0,
     };
 
-    // Emit arguments first (operands[1..])
-    for &operand in operands.iter().skip(1) {
+    // Emit arguments before the runtime table index.
+    for &operand in args {
         emit_value(ctx, operand, emit_ctx, function)?;
     }
 
-    // Emit the table index (operands[0])
-    emit_value(ctx, operands[0], emit_ctx, function)?;
+    emit_value(ctx, first_operand, emit_ctx, function)?;
 
     function.instruction(&Instruction::CallIndirect {
         type_index: type_idx,
@@ -319,13 +314,18 @@ pub(crate) fn handle_return_call_indirect(
         .map(|_| attr_u32(&ctx.op(op).attributes, Symbol::new("table")))
         .transpose()?
         .unwrap_or(0);
-    let operands = ctx.op_operands(op);
+    let table_index_value = IndirectCallLikeOps::callee(ctx, op).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.return_call_indirect requires a table index operand")
+    })?;
+    let args = IndirectCallLikeOps::arguments(ctx, op).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.return_call_indirect has malformed operands")
+    })?;
 
     // WebAssembly evaluates arguments before the table index.
-    for &arg in operands.iter().skip(1) {
+    for &arg in args {
         emit_value(ctx, arg, emit_ctx, function)?;
     }
-    emit_value(ctx, operands[0], emit_ctx, function)?;
+    emit_value(ctx, table_index_value, emit_ctx, function)?;
     function.instruction(&Instruction::ReturnCallIndirect {
         type_index,
         table_index,

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -8,7 +8,7 @@
 use tracing::debug;
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::dialect::{func, wasm as wasm_dialect};
 use trunk_ir::refs::{OpRef, TypeRef, ValueDef};
 use wasm_encoder::{Function, Instruction};
 
@@ -74,6 +74,40 @@ pub(crate) fn handle_call_indirect(
             "call_indirect first operand must be i32 table index, got {}.{}",
             data.dialect, data.name
         )));
+    }
+
+    if ctx
+        .op(op)
+        .attributes
+        .contains_key(Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR))
+    {
+        let signature = helpers::exact_call_indirect_signature(ctx, op)?;
+        let type_index = module_info
+            .type_idx_by_type
+            .get(&signature)
+            .copied()
+            .ok_or_else(|| {
+                CompilationError::invalid_module(
+                    "wasm.call_indirect function type not registered in type section",
+                )
+            })?;
+        let attrs = &ctx.op(op).attributes;
+        let table_index = attrs
+            .get("table")
+            .map(|_| attr_u32(attrs, Symbol::new("table")))
+            .transpose()?
+            .unwrap_or(0);
+
+        for &arg in operands.iter().skip(1) {
+            emit_value(ctx, arg, emit_ctx, function)?;
+        }
+        emit_value(ctx, operands[0], emit_ctx, function)?;
+        function.instruction(&Instruction::CallIndirect {
+            type_index,
+            table_index,
+        });
+        set_result_local(ctx, op, emit_ctx, function)?;
+        return Ok(());
     }
 
     debug!(

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -168,10 +168,14 @@ pub(crate) fn exact_call_indirect_signature_with(
     let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
         CompilationError::invalid_module("wasm.call_indirect signature must be core.func")
     })?;
-    let operands = ctx.op_operands(op);
-    let Some((_table_index, args)) = operands.split_first() else {
+    let Some(_table_index) = IndirectCallLikeOps::callee(ctx, op) else {
         return Err(CompilationError::invalid_module(
             "wasm.call_indirect requires a table index operand",
+        ));
+    };
+    let Some(args) = IndirectCallLikeOps::arguments(ctx, op) else {
+        return Err(CompilationError::invalid_module(
+            "wasm.call_indirect has malformed operands",
         ));
     };
     if params.len() != args.len()
@@ -215,10 +219,14 @@ pub(crate) fn exact_return_call_indirect_signature_with(
             "wasm.return_call_indirect signature must have an empty result",
         ));
     }
-    let operands = ctx.op_operands(op);
-    let Some((&table_index, args)) = operands.split_first() else {
+    let Some(table_index) = IndirectCallLikeOps::callee(ctx, op) else {
         return Err(CompilationError::invalid_module(
             "wasm.return_call_indirect requires a table index operand",
+        ));
+    };
+    let Some(args) = IndirectCallLikeOps::arguments(ctx, op) else {
+        return Err(CompilationError::invalid_module(
+            "wasm.return_call_indirect has malformed operands",
         ));
     };
     if !is_type(ctx, value_type(ctx, table_index), "core", "i32") {

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -178,11 +178,17 @@ pub(crate) fn exact_call_indirect_signature_with(
             "wasm.call_indirect has malformed operands",
         ));
     };
+    let results = ctx.op_result_types(op);
+    let results_match = if is_nil_type(ctx, result) {
+        results.is_empty()
+    } else {
+        results == [result]
+    };
     if params.len() != args.len()
         || params.iter().zip(args).any(|(param, arg)| {
             !is_wasm_physical_argument_assignable(ctx, value_type(ctx, *arg), *param)
         })
-        || ctx.op_result_types(op) != [result]
+        || !results_match
     {
         return Err(CompilationError::invalid_module(
             "wasm.call_indirect operands or result do not match its exact signature",

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -146,6 +146,50 @@ fn is_wasm_physical_argument_assignable(
     argument_is_wasm_gc_ref && parameter_is_anyref
 }
 
+/// Read and validate an optional exact function type retained by an ordinary
+/// indirect call. When present, the attribute remains authoritative rather
+/// than being reconstructed from erased operands.
+pub(crate) fn exact_call_indirect_signature(
+    ctx: &IrContext,
+    op: OpRef,
+) -> CompilationResult<TypeRef> {
+    let signature = ctx
+        .op(op)
+        .attributes
+        .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
+        .ok_or_else(|| CompilationError::invalid_module("wasm.call_indirect lacks signature"))?;
+    exact_call_indirect_signature_with(ctx, op, signature)
+}
+
+/// Validate an exact ordinary indirect-call signature without mutating the
+/// operation that carries it.
+pub(crate) fn exact_call_indirect_signature_with(
+    ctx: &IrContext,
+    op: OpRef,
+    signature: TypeRef,
+) -> CompilationResult<TypeRef> {
+    let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.call_indirect signature must be core.func")
+    })?;
+    let operands = ctx.op_operands(op);
+    let Some((_table_index, args)) = operands.split_first() else {
+        return Err(CompilationError::invalid_module(
+            "wasm.call_indirect requires a table index operand",
+        ));
+    };
+    if params.len() != args.len()
+        || params.iter().zip(args).any(|(param, arg)| {
+            !is_wasm_physical_argument_assignable(ctx, value_type(ctx, *arg), *param)
+        })
+        || ctx.op_result_types(op) != [result]
+    {
+        return Err(CompilationError::invalid_module(
+            "wasm.call_indirect operands or result do not match its exact signature",
+        ));
+    }
+    Ok(signature)
+}
+
 /// Read and validate the exact physical function type required by an indirect
 /// proper tail transfer. This backend deliberately does not infer the type
 /// from the runtime table index and operands.

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -160,6 +160,16 @@ pub(crate) fn exact_return_call_indirect_signature(
         .ok_or_else(|| {
             CompilationError::invalid_module("wasm.return_call_indirect lacks signature")
         })?;
+    exact_return_call_indirect_signature_with(ctx, op, signature)
+}
+
+/// Validate an exact callable signature against an indirect proper tail
+/// transfer without reading or mutating its attribute map.
+pub(crate) fn exact_return_call_indirect_signature_with(
+    ctx: &IrContext,
+    op: OpRef,
+    signature: TypeRef,
+) -> CompilationResult<TypeRef> {
     let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
         CompilationError::invalid_module("wasm.return_call_indirect signature must be core.func")
     })?;

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::func;
+use trunk_ir::op_interface::IndirectCallLikeOps;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, AttributeMap};
 use wasm_encoder::{AbstractHeapType, HeapType, RefType, ValType};
@@ -153,10 +153,7 @@ pub(crate) fn exact_call_indirect_signature(
     ctx: &IrContext,
     op: OpRef,
 ) -> CompilationResult<TypeRef> {
-    let signature = ctx
-        .op(op)
-        .attributes
-        .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
+    let signature = IndirectCallLikeOps::exact_signature(ctx, op)
         .ok_or_else(|| CompilationError::invalid_module("wasm.call_indirect lacks signature"))?;
     exact_call_indirect_signature_with(ctx, op, signature)
 }
@@ -197,13 +194,9 @@ pub(crate) fn exact_return_call_indirect_signature(
     ctx: &IrContext,
     op: OpRef,
 ) -> CompilationResult<TypeRef> {
-    let signature = ctx
-        .op(op)
-        .attributes
-        .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
-        .ok_or_else(|| {
-            CompilationError::invalid_module("wasm.return_call_indirect lacks signature")
-        })?;
+    let signature = IndirectCallLikeOps::exact_signature(ctx, op).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.return_call_indirect lacks signature")
+    })?;
     exact_return_call_indirect_signature_with(ctx, op, signature)
 }
 

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -25,6 +25,7 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, clone_attrs_except,
+    convert_function_type,
 };
 use trunk_ir::types::Attribute;
 use trunk_ir::types::TypeDataBuilder;
@@ -341,11 +342,35 @@ impl RewritePattern for FuncTailCallIndirectPattern {
             return false;
         }
 
+        // The exact callable metadata is source-authoritative, but the
+        // arguments have already reached their Wasm representations. Convert
+        // the attribute with the shared signature converter before validating
+        // it; never derive a replacement signature from the operands.
+        let Some(signature) = ctx
+            .op(op)
+            .attributes
+            .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
+        else {
+            return false;
+        };
+        let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())
+        else {
+            return false;
+        };
+
+        let mut converted_attrs = ctx.op(op).attributes.clone();
+        converted_attrs.insert(
+            Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR),
+            Attribute::Type(signature),
+        );
+
         // This is intentionally checked before creating any replacement.
         // Missing or malformed metadata remains a residual `func.*` op and is
         // rejected by the Wasm readiness boundary rather than guessed from
         // table-index and argument values.
-        if crate::emit::helpers::exact_return_call_indirect_signature(ctx, op).is_err() {
+        if crate::emit::helpers::exact_return_call_indirect_signature_with(ctx, op, signature)
+            .is_err()
+        {
             return false;
         }
 
@@ -355,9 +380,10 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         }
 
         let loc = ctx.op(op).location;
-        let attrs = ctx.op(op).attributes.clone();
         let new_op = wasm_dialect::return_call_indirect(ctx, loc, operands, 0, 0);
-        ctx.op_mut(new_op.op_ref()).attributes.extend(attrs);
+        ctx.op_mut(new_op.op_ref())
+            .attributes
+            .extend(converted_attrs);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -617,6 +643,61 @@ mod tests {
         );
         assert!(output.contains("wasm.i32_const {value = 0}"), "{output}");
         assert!(output.contains("wasm.return_call_indirect"), "{output}");
+    }
+
+    #[test]
+    fn converts_exact_tail_signature_before_validating_physical_operands() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @physical(%table_index: core.i32, %value: wasm.anyref) -> core.nil {
+    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+  }
+  func.func @mismatch(%table_index: core.i32, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, tribute_rt.float), tribute.calling_convention = 2}
+  }
+}"#,
+        );
+
+        let anyref_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("anyref")).build());
+        let f64_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("f64")).build());
+        let mut type_converter = TypeConverter::new();
+        type_converter.add_conversion(move |ctx, ty| {
+            (ctx.types
+                .is_dialect(ty, Symbol::new("tribute_rt"), Symbol::new("anyref")))
+            .then_some(anyref_ty)
+        });
+        type_converter.add_conversion(move |ctx, ty| {
+            (ctx.types
+                .is_dialect(ty, Symbol::new("tribute_rt"), Symbol::new("float")))
+            .then_some(f64_ty)
+        });
+        lower(&mut ctx, module, type_converter);
+
+        let output = print_module(&ctx, module.op());
+        assert!(
+            output.contains(
+                "wasm.return_call_indirect %0, %1 {signature = core.func(core.nil, wasm.anyref)"
+            ),
+            "{output}"
+        );
+        assert!(
+            output.contains("wasm.return_call_indirect %0, %1 {signature = core.func(core.nil, wasm.anyref), table = 0, tribute.calling_convention = 2, type_idx = 0}"),
+            "the converted transfer must retain its calling convention: {output}"
+        );
+        assert!(
+            !output.contains("signature = core.func(core.nil, tribute_rt.anyref)"),
+            "{output}"
+        );
+        assert!(
+            output.contains("func.tail_call_indirect %0, %1 {signature = core.func(core.nil, tribute_rt.float), tribute.calling_convention = 2}"),
+            "the mismatched transfer must remain unchanged: {output}"
+        );
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -270,7 +270,7 @@ impl RewritePattern for FuncCallIndirectPattern {
             .collect::<Vec<_>>();
         let result_types = CallLike::call_result_types(&call, ctx).to_vec();
 
-        let signature = if let Some(signature) = IndirectCallLike::exact_signature(&call, ctx) {
+        let signature = if let Some(signature) = call.exact_signature(ctx) {
             let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())
             else {
                 return false;
@@ -368,7 +368,7 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         // arguments have already reached their Wasm representations. Convert
         // the attribute with the shared signature converter before validating
         // it; never derive a replacement signature from the operands.
-        let Some(signature) = IndirectCallLike::exact_signature(&tail, ctx) else {
+        let Some(signature) = tail.exact_signature(ctx) else {
             return false;
         };
         let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -269,9 +269,8 @@ impl RewritePattern for FuncCallIndirectPattern {
             .chain(CallLike::call_args(&call, ctx).iter().copied())
             .collect::<Vec<_>>();
         let result_types = CallLike::call_result_types(&call, ctx).to_vec();
-        let mut attrs = ctx.op(op).attributes.clone();
 
-        if let Some(signature) = IndirectCallLike::exact_signature(&call, ctx) {
+        let signature = if let Some(signature) = IndirectCallLike::exact_signature(&call, ctx) {
             let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())
             else {
                 return false;
@@ -280,16 +279,20 @@ impl RewritePattern for FuncCallIndirectPattern {
             {
                 return false;
             }
-            attrs.insert(
-                Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR),
-                Attribute::Type(signature),
-            );
-        }
+            Some(signature)
+        } else {
+            None
+        };
 
         // The emit phase resolves the type index and table attributes. An
         // optional exact signature stays attached for authoritative indexing.
         let new_op = wasm_dialect::call_indirect(ctx, loc, all_operands, result_types, 0, 0);
-        ctx.op_mut(new_op.op_ref()).attributes.extend(attrs);
+        if let Some(signature) = signature {
+            ctx.op_mut(new_op.op_ref()).attributes.insert(
+                Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR),
+                Attribute::Type(signature),
+            );
+        }
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -724,7 +727,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @physical(%table_index: core.i32, %value: wasm.anyref) -> core.i32 {
-    %result = func.call_indirect %table_index, %value {signature = core.func(core.i32, tribute_rt.anyref)} : core.i32
+    %result = func.call_indirect %table_index, %value {signature = core.func(core.i32, tribute_rt.anyref), table = 7, type_idx = 9} : core.i32
     func.return %result
   }
   func.func @mismatch(%table_index: core.i32, %value: core.i32) -> core.i32 {
@@ -759,6 +762,10 @@ mod tests {
                 "wasm.call_indirect %0, %1 {signature = core.func(core.i32, wasm.anyref), table = 0, type_idx = 0}"
             ),
             "{output}"
+        );
+        assert!(
+            !output.contains("table = 7") && !output.contains("type_idx = 9"),
+            "stale source table metadata must not reach Wasm: {output}"
         );
         assert!(
             !output.contains("signature = core.func(core.i32, tribute_rt.anyref)"),

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -631,6 +631,31 @@ mod tests {
     }
 
     #[test]
+    fn lowers_exact_unit_call_indirect_without_an_ssa_result() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%table_index: core.i32) -> core.nil {
+    func.call_indirect %table_index {signature = core.func(core.nil)}
+    func.return
+  }
+}"#,
+        );
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let output = print_module(&ctx, module.op());
+        assert!(
+            output.contains(
+                "wasm.call_indirect %0 {signature = core.func(core.nil), table = 0, type_idx = 0}"
+            ),
+            "{output}"
+        );
+        assert!(!output.contains("func.call_indirect"), "{output}");
+    }
+
+    #[test]
     fn lowers_indirect_tail_transfer_with_a_function_table_entry() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::{IrContext, OperationDataBuilder};
-use trunk_ir::dialect::func;
+use trunk_ir::dialect::func::{self, CallLike, IndirectCallLike, TailCallLike};
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
@@ -260,17 +260,36 @@ impl RewritePattern for FuncCallIndirectPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        let Ok(_call_indirect) = func::CallIndirect::from_op(ctx, op) else {
+        let Ok(call) = func::CallIndirect::from_op(ctx, op) else {
             return false;
         };
 
         let loc = ctx.op(op).location;
-        let all_operands: Vec<_> = ctx.op_operands(op).to_vec();
-        let result_types: Vec<TypeRef> = ctx.op_result_types(op).to_vec();
+        let all_operands = std::iter::once(IndirectCallLike::callee(&call, ctx))
+            .chain(CallLike::call_args(&call, ctx).iter().copied())
+            .collect::<Vec<_>>();
+        let result_types = CallLike::call_result_types(&call, ctx).to_vec();
+        let mut attrs = ctx.op(op).attributes.clone();
 
-        // Build wasm.call_indirect with same operands
-        // The emit phase will resolve the type_idx and table attributes
+        if let Some(signature) = IndirectCallLike::exact_signature(&call, ctx) {
+            let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())
+            else {
+                return false;
+            };
+            if crate::emit::helpers::exact_call_indirect_signature_with(ctx, op, signature).is_err()
+            {
+                return false;
+            }
+            attrs.insert(
+                Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR),
+                Attribute::Type(signature),
+            );
+        }
+
+        // The emit phase resolves the type index and table attributes. An
+        // optional exact signature stays attached for authoritative indexing.
         let new_op = wasm_dialect::call_indirect(ctx, loc, all_operands, result_types, 0, 0);
+        ctx.op_mut(new_op.op_ref()).attributes.extend(attrs);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -338,19 +357,15 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         op: OpRef,
         rewriter: &mut PatternRewriter<'_>,
     ) -> bool {
-        if func::TailCallIndirect::from_op(ctx, op).is_err() {
+        let Ok(tail) = func::TailCallIndirect::from_op(ctx, op) else {
             return false;
-        }
+        };
 
         // The exact callable metadata is source-authoritative, but the
         // arguments have already reached their Wasm representations. Convert
         // the attribute with the shared signature converter before validating
         // it; never derive a replacement signature from the operands.
-        let Some(signature) = ctx
-            .op(op)
-            .attributes
-            .get_type(func::INDIRECT_CALL_SIGNATURE_ATTR)
-        else {
+        let Some(signature) = IndirectCallLike::exact_signature(&tail, ctx) else {
             return false;
         };
         let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())
@@ -374,8 +389,10 @@ impl RewritePattern for FuncTailCallIndirectPattern {
             return false;
         }
 
-        let operands: Vec<_> = ctx.op_operands(op).to_vec();
-        if operands.is_empty() || !ctx.op_result_types(op).is_empty() {
+        let operands = std::iter::once(IndirectCallLike::callee(&tail, ctx))
+            .chain(CallLike::call_args(&tail, ctx).iter().copied())
+            .collect::<Vec<_>>();
+        if !TailCallLike::is_resultless(&tail, ctx) {
             return false;
         }
 
@@ -697,6 +714,61 @@ mod tests {
         assert!(
             output.contains("func.tail_call_indirect %0, %1 {signature = core.func(core.nil, tribute_rt.float), tribute.calling_convention = 2}"),
             "the mismatched transfer must remain unchanged: {output}"
+        );
+    }
+
+    #[test]
+    fn converts_exact_indirect_signature_before_validating_physical_operands() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @physical(%table_index: core.i32, %value: wasm.anyref) -> core.i32 {
+    %result = func.call_indirect %table_index, %value {signature = core.func(core.i32, tribute_rt.anyref)} : core.i32
+    func.return %result
+  }
+  func.func @mismatch(%table_index: core.i32, %value: core.i32) -> core.i32 {
+    %result = func.call_indirect %table_index, %value {signature = core.func(core.i32, tribute_rt.float)} : core.i32
+    func.return %result
+  }
+}"#,
+        );
+
+        let anyref_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("anyref")).build());
+        let f64_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("f64")).build());
+        let mut type_converter = TypeConverter::new();
+        type_converter.add_conversion(move |ctx, ty| {
+            (ctx.types
+                .is_dialect(ty, Symbol::new("tribute_rt"), Symbol::new("anyref")))
+            .then_some(anyref_ty)
+        });
+        type_converter.add_conversion(move |ctx, ty| {
+            (ctx.types
+                .is_dialect(ty, Symbol::new("tribute_rt"), Symbol::new("float")))
+            .then_some(f64_ty)
+        });
+        lower(&mut ctx, module, type_converter);
+
+        let output = print_module(&ctx, module.op());
+        assert!(
+            output.contains(
+                "wasm.call_indirect %0, %1 {signature = core.func(core.i32, wasm.anyref), table = 0, type_idx = 0}"
+            ),
+            "{output}"
+        );
+        assert!(
+            !output.contains("signature = core.func(core.i32, tribute_rt.anyref)"),
+            "{output}"
+        );
+        assert!(
+            output.contains(
+                "func.call_indirect %0, %1 {signature = core.func(core.i32, tribute_rt.float)} : core.i32"
+            ),
+            "the mismatched call must remain unchanged: {output}"
         );
     }
 

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -19,16 +19,16 @@ use std::collections::HashMap;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::{IrContext, OperationDataBuilder};
-use trunk_ir::dialect::func::{self, CallLike, IndirectCallLike, TailCallLike};
+use trunk_ir::dialect::func::{self, CallLike, TailCallLike};
 use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::op_interface::IndirectCallLikeModel;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, clone_attrs_except,
     convert_function_type,
 };
-use trunk_ir::types::Attribute;
-use trunk_ir::types::TypeDataBuilder;
+use trunk_ir::types::{Attribute, TypeDataBuilder};
 use trunk_ir::{BlockData, RegionData};
 
 use trunk_ir::smallvec::smallvec;
@@ -265,7 +265,7 @@ impl RewritePattern for FuncCallIndirectPattern {
         };
 
         let loc = ctx.op(op).location;
-        let all_operands = std::iter::once(IndirectCallLike::callee(&call, ctx))
+        let all_operands = std::iter::once(call.callee(ctx))
             .chain(CallLike::call_args(&call, ctx).iter().copied())
             .collect::<Vec<_>>();
         let result_types = CallLike::call_result_types(&call, ctx).to_vec();
@@ -286,13 +286,8 @@ impl RewritePattern for FuncCallIndirectPattern {
 
         // The emit phase resolves the type index and table attributes. An
         // optional exact signature stays attached for authoritative indexing.
-        let new_op = wasm_dialect::call_indirect(ctx, loc, all_operands, result_types, 0, 0);
-        if let Some(signature) = signature {
-            ctx.op_mut(new_op.op_ref()).attributes.insert(
-                Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR),
-                Attribute::Type(signature),
-            );
-        }
+        let new_op =
+            wasm_dialect::call_indirect(ctx, loc, all_operands, result_types, 0, 0, signature);
         rewriter.replace_op(new_op.op_ref());
         true
     }
@@ -377,10 +372,9 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         };
 
         let mut converted_attrs = ctx.op(op).attributes.clone();
-        converted_attrs.insert(
-            Symbol::new(func::INDIRECT_CALL_SIGNATURE_ATTR),
-            Attribute::Type(signature),
-        );
+        func::remove_indirect_call_signature(&mut converted_attrs);
+        converted_attrs.remove("table");
+        converted_attrs.remove("type_idx");
 
         // This is intentionally checked before creating any replacement.
         // Missing or malformed metadata remains a residual `func.*` op and is
@@ -392,7 +386,7 @@ impl RewritePattern for FuncTailCallIndirectPattern {
             return false;
         }
 
-        let operands = std::iter::once(IndirectCallLike::callee(&tail, ctx))
+        let operands = std::iter::once(tail.callee(ctx))
             .chain(CallLike::call_args(&tail, ctx).iter().copied())
             .collect::<Vec<_>>();
         if !TailCallLike::is_resultless(&tail, ctx) {
@@ -400,7 +394,7 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         }
 
         let loc = ctx.op(op).location;
-        let new_op = wasm_dialect::return_call_indirect(ctx, loc, operands, 0, 0);
+        let new_op = wasm_dialect::return_call_indirect(ctx, loc, operands, 0, 0, Some(signature));
         ctx.op_mut(new_op.op_ref())
             .attributes
             .extend(converted_attrs);
@@ -672,7 +666,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @physical(%table_index: core.i32, %value: wasm.anyref) -> core.nil {
-    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, tribute_rt.anyref), tribute.calling_convention = 2}
+    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, tribute_rt.anyref), table = 7, tribute.calling_convention = 2, type_idx = 9}
   }
   func.func @mismatch(%table_index: core.i32, %value: core.i32) -> core.nil {
     func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, tribute_rt.float), tribute.calling_convention = 2}
@@ -713,6 +707,10 @@ mod tests {
         assert!(
             !output.contains("signature = core.func(core.nil, tribute_rt.anyref)"),
             "{output}"
+        );
+        assert!(
+            !output.contains("table = 7") && !output.contains("type_idx = 9"),
+            "stale source table metadata must not reach Wasm: {output}"
         );
         assert!(
             output.contains("func.tail_call_indirect %0, %1 {signature = core.func(core.nil, tribute_rt.float), tribute.calling_convention = 2}"),

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -120,22 +120,18 @@ mod clif {
 const INDIRECT_CALL_SIGNATURE_ATTR: &str = "sig";
 
 impl IndirectCallLikeModel for CallIndirect {
+    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
+
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         Some(self.sig(ctx))
-    }
-
-    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
-        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 
 impl IndirectCallLikeModel for ReturnCallIndirect {
+    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
+
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         Some(self.sig(ctx))
-    }
-
-    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
-        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -124,8 +124,8 @@ impl IndirectCallLikeModel for CallIndirect {
         Some(self.sig(ctx))
     }
 
-    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
-        set_indirect_call_signature_attribute(attributes, signature);
+    fn set_exact_signature(self, ctx: &mut crate::IrContext, signature: crate::TypeRef) -> bool {
+        set_indirect_call_signature(ctx, self.op_ref(), signature)
     }
 }
 
@@ -134,8 +134,8 @@ impl IndirectCallLikeModel for ReturnCallIndirect {
         Some(self.sig(ctx))
     }
 
-    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
-        set_indirect_call_signature_attribute(attributes, signature);
+    fn set_exact_signature(self, ctx: &mut crate::IrContext, signature: crate::TypeRef) -> bool {
+        set_indirect_call_signature(ctx, self.op_ref(), signature)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -120,18 +120,22 @@ mod clif {
 const INDIRECT_CALL_SIGNATURE_ATTR: &str = "sig";
 
 impl IndirectCallLikeModel for CallIndirect {
-    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
-
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         Some(self.sig(ctx))
+    }
+
+    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
+        set_indirect_call_signature_attribute(attributes, signature);
     }
 }
 
 impl IndirectCallLikeModel for ReturnCallIndirect {
-    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
-
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         Some(self.sig(ctx))
+    }
+
+    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
+        set_indirect_call_signature_attribute(attributes, signature);
     }
 }
 
@@ -158,11 +162,18 @@ pub fn set_indirect_call_signature(
     {
         return false;
     }
-    ctx.op_mut(op).attributes.insert(
+    set_indirect_call_signature_attribute(&mut ctx.op_mut(op).attributes, signature);
+    true
+}
+
+fn set_indirect_call_signature_attribute(
+    attributes: &mut crate::AttributeMap,
+    signature: crate::TypeRef,
+) {
+    attributes.insert(
         crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
         crate::Attribute::Type(signature),
     );
-    true
 }
 
 #[cfg(test)]

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -1,5 +1,8 @@
 //! Arena-based clif dialect.
 
+use crate::op_interface::{IndirectCallLikeModel, IndirectCallLikeOps};
+use crate::ops::{DialectOp, DialectType};
+
 #[trunk_ir::dialect]
 mod clif {
     // Module
@@ -112,4 +115,88 @@ mod clif {
     fn fcvt_from_sint(operand: ()) -> result {}
     fn fcvt_to_uint(operand: ()) -> result {}
     fn fcvt_from_uint(operand: ()) -> result {}
+}
+
+const INDIRECT_CALL_SIGNATURE_ATTR: &str = "sig";
+
+impl IndirectCallLikeModel for CallIndirect {
+    fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        Some(self.sig(ctx))
+    }
+}
+
+impl IndirectCallLikeModel for ReturnCallIndirect {
+    fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        Some(self.sig(ctx))
+    }
+}
+
+inventory::submit! {
+    IndirectCallLikeOps::register::<CallIndirect>()
+}
+
+inventory::submit! {
+    IndirectCallLikeOps::register::<ReturnCallIndirect>()
+}
+
+/// Attach the required exact callable contract to a `clif` indirect transfer.
+///
+/// Returns `false` without mutation when the operation is not a `clif`
+/// indirect call or the supplied type is not a `core.func` contract.
+pub fn set_indirect_call_signature(
+    ctx: &mut crate::IrContext,
+    op: crate::OpRef,
+    signature: crate::TypeRef,
+) -> bool {
+    if crate::dialect::core::Func::from_type_ref(ctx, signature).is_none()
+        || (CallIndirect::from_op(ctx, op).is_err()
+            && ReturnCallIndirect::from_op(ctx, op).is_err())
+    {
+        return false;
+    }
+    ctx.op_mut(op).attributes.insert(
+        crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
+        crate::Attribute::Type(signature),
+    );
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::op_interface::IndirectCallLikeOps;
+    use crate::parser::parse_test_module;
+    use crate::printer::print_module;
+
+    #[test]
+    fn indirect_call_interface_uses_clif_owned_sig() {
+        let mut ctx = crate::IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @ordinary(%callee: core.ptr, %value: core.i32) -> core.i32 {
+    %result = clif.call_indirect %callee, %value {sig = core.func(core.i32, core.i32)} : core.i32
+    clif.return %result
+  }
+  clif.func @tail(%callee: core.ptr, %value: core.i32) -> core.nil {
+    clif.return_call_indirect %callee, %value {sig = core.func(core.nil, core.i32)}
+  }
+  clif.func @direct() -> core.nil {
+    clif.return
+  }
+}"#,
+        );
+        let functions = module.ops(&ctx);
+        let body_op = |index| {
+            let body = ctx.op(functions[index]).regions[0];
+            ctx.block(ctx.region(body).blocks[0]).ops[0]
+        };
+
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, body_op(0)).is_some());
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, body_op(1)).is_some());
+        assert!(IndirectCallLikeOps::get(&ctx, body_op(2)).is_none());
+
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("clif.call_indirect"));
+        assert!(printed.contains("sig = core.func(core.i32, core.i32)"));
+    }
 }

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -123,11 +123,19 @@ impl IndirectCallLikeModel for CallIndirect {
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         Some(self.sig(ctx))
     }
+
+    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
+        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
+    }
 }
 
 impl IndirectCallLikeModel for ReturnCallIndirect {
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         Some(self.sig(ctx))
+    }
+
+    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
+        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -191,9 +191,22 @@ mod tests {
             ctx.block(ctx.region(body).blocks[0]).ops[0]
         };
 
-        assert!(IndirectCallLikeOps::exact_signature(&ctx, body_op(0)).is_some());
-        assert!(IndirectCallLikeOps::exact_signature(&ctx, body_op(1)).is_some());
-        assert!(IndirectCallLikeOps::get(&ctx, body_op(2)).is_none());
+        let ordinary = body_op(0);
+        let tail = body_op(1);
+        let direct = body_op(2);
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, ordinary).is_some());
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, tail).is_some());
+        for op in [ordinary, tail] {
+            let operands = ctx.op_operands(op);
+            assert_eq!(IndirectCallLikeOps::callee(&ctx, op), Some(operands[0]));
+            assert_eq!(
+                IndirectCallLikeOps::arguments(&ctx, op),
+                Some(&operands[1..])
+            );
+        }
+        assert!(IndirectCallLikeOps::get(&ctx, direct).is_none());
+        assert_eq!(IndirectCallLikeOps::callee(&ctx, direct), None);
+        assert_eq!(IndirectCallLikeOps::arguments(&ctx, direct), None);
 
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("clif.call_indirect"));

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -1,5 +1,7 @@
 //! Arena-based func dialect.
 
+use crate::ops::DialectOp;
+
 /// The optional exact callable signature retained after a typed indirect callee
 /// becomes a runtime function or table index.
 pub const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
@@ -36,6 +38,21 @@ pub trait TailCallLike: CallLike {
     fn is_resultless(&self, ctx: &crate::IrContext) -> bool {
         self.call_result_types(ctx).is_empty()
     }
+}
+
+/// Read the exact callable signature from a typed indirect-call operation.
+///
+/// This deliberately recognizes only the two `func` indirect-call forms;
+/// arbitrary operations do not implement [`IndirectCallLike`].
+pub fn indirect_call_signature(ctx: &crate::IrContext, op: crate::OpRef) -> Option<crate::TypeRef> {
+    CallIndirect::from_op(ctx, op)
+        .ok()
+        .and_then(|call| call.exact_signature(ctx))
+        .or_else(|| {
+            TailCallIndirect::from_op(ctx, op)
+                .ok()
+                .and_then(|tail| tail.exact_signature(ctx))
+        })
 }
 
 // === Operation registrations ===
@@ -360,5 +377,43 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("signature = core.func(core.i32, core.i32)"));
         assert!(!printed.contains("func.indirect_call_signature"));
+    }
+
+    #[test]
+    fn indirect_call_signature_recognizes_only_indirect_calls() {
+        let mut ctx = crate::IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @ordinary(%callee: core.func(core.i32, core.i32), %value: core.i32) -> core.i32 {
+    %result = func.call_indirect %callee, %value {signature = core.func(core.i32, core.i32)} : core.i32
+    func.return %result
+  }
+  func.func @tail(%callee: core.func(core.nil, core.i32), %value: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32)}
+  }
+  func.func @direct() -> core.nil {
+    func.return
+  }
+}"#,
+        );
+
+        let functions = module.ops(&ctx);
+        let ordinary = Func::from_op(&ctx, functions[0]).expect("ordinary function");
+        let tail = Func::from_op(&ctx, functions[1]).expect("tail function");
+        let direct = Func::from_op(&ctx, functions[2]).expect("direct function");
+        let ordinary_op = ctx
+            .block(ctx.region(ordinary.body_if_present(&ctx).unwrap()).blocks[0])
+            .ops[0];
+        let tail_op = ctx
+            .block(ctx.region(tail.body_if_present(&ctx).unwrap()).blocks[0])
+            .ops[0];
+        let direct_op = ctx
+            .block(ctx.region(direct.body_if_present(&ctx).unwrap()).blocks[0])
+            .ops[0];
+
+        assert!(indirect_call_signature(&ctx, ordinary_op).is_some());
+        assert!(indirect_call_signature(&ctx, tail_op).is_some());
+        assert_eq!(indirect_call_signature(&ctx, direct_op), None);
     }
 }

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -81,8 +81,8 @@ impl IndirectCallLikeModel for CallIndirect {
         CallIndirect::signature(&self, ctx)
     }
 
-    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
-        set_indirect_call_signature_attribute(attributes, signature);
+    fn set_exact_signature(self, ctx: &mut crate::IrContext, signature: crate::TypeRef) -> bool {
+        set_indirect_call_signature(ctx, self.op_ref(), signature)
     }
 }
 
@@ -105,8 +105,8 @@ impl IndirectCallLikeModel for TailCallIndirect {
         TailCallIndirect::signature(&self, ctx)
     }
 
-    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
-        set_indirect_call_signature_attribute(attributes, signature);
+    fn set_exact_signature(self, ctx: &mut crate::IrContext, signature: crate::TypeRef) -> bool {
+        set_indirect_call_signature(ctx, self.op_ref(), signature)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -420,6 +420,16 @@ mod tests {
         assert!(IndirectCallLikeOps::get(&ctx, tail_op).is_some());
         assert!(IndirectCallLikeOps::exact_signature(&ctx, ordinary_op).is_some());
         assert!(IndirectCallLikeOps::exact_signature(&ctx, tail_op).is_some());
+        for op in [ordinary_op, tail_op] {
+            let operands = ctx.op_operands(op);
+            assert_eq!(IndirectCallLikeOps::callee(&ctx, op), Some(operands[0]));
+            assert_eq!(
+                IndirectCallLikeOps::arguments(&ctx, op),
+                Some(&operands[1..])
+            );
+        }
         assert!(IndirectCallLikeOps::get(&ctx, direct_op).is_none());
+        assert_eq!(IndirectCallLikeOps::callee(&ctx, direct_op), None);
+        assert_eq!(IndirectCallLikeOps::arguments(&ctx, direct_op), None);
     }
 }

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -77,12 +77,10 @@ impl CallLike for CallIndirect {
 }
 
 impl IndirectCallLikeModel for CallIndirect {
+    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
+
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         CallIndirect::signature(&self, ctx)
-    }
-
-    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
-        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 
@@ -101,12 +99,10 @@ impl CallLike for TailCallIndirect {
 }
 
 impl IndirectCallLikeModel for TailCallIndirect {
+    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
+
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         TailCallIndirect::signature(&self, ctx)
-    }
-
-    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
-        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -1,10 +1,11 @@
 //! Arena-based func dialect.
 
-use crate::ops::DialectOp;
+use crate::op_interface::{IndirectCallLikeModel, IndirectCallLikeOps};
+use crate::ops::{DialectOp, DialectType};
 
 /// The optional exact callable signature retained after a typed indirect callee
 /// becomes a runtime function or table index.
-pub const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
+const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
 
 /// Shared accessors for function calls with ordinary results or arguments.
 ///
@@ -20,39 +21,15 @@ pub trait CallLike: crate::ops::DialectOp {
     }
 }
 
-/// Shared accessors for indirect calls with an erased runtime callee.
-pub trait IndirectCallLike: CallLike {
-    /// Runtime function or table-index operand.
-    fn callee(&self, ctx: &crate::IrContext) -> crate::ValueRef;
-
-    /// Optional exact callable contract retained through callee erasure.
-    fn exact_signature(&self, ctx: &crate::IrContext) -> Option<crate::TypeRef>;
-}
-
 /// Marker and resultless query for proper-tail transfers.
 ///
-/// Exact callable signatures belong only to [`IndirectCallLike`], keeping
+/// Exact callable signatures belong only to `IndirectCallLike`, keeping
 /// CPS/tail legality independent from indirect-call metadata.
 pub trait TailCallLike: CallLike {
     /// Proper tail transfers cannot produce SSA results.
     fn is_resultless(&self, ctx: &crate::IrContext) -> bool {
         self.call_result_types(ctx).is_empty()
     }
-}
-
-/// Read the exact callable signature from a typed indirect-call operation.
-///
-/// This deliberately recognizes only the two `func` indirect-call forms;
-/// arbitrary operations do not implement [`IndirectCallLike`].
-pub fn indirect_call_signature(ctx: &crate::IrContext, op: crate::OpRef) -> Option<crate::TypeRef> {
-    CallIndirect::from_op(ctx, op)
-        .ok()
-        .and_then(|call| call.exact_signature(ctx))
-        .or_else(|| {
-            TailCallIndirect::from_op(ctx, op)
-                .ok()
-                .and_then(|tail| tail.exact_signature(ctx))
-        })
 }
 
 // === Operation registrations ===
@@ -99,13 +76,9 @@ impl CallLike for CallIndirect {
     }
 }
 
-impl IndirectCallLike for CallIndirect {
-    fn callee(&self, ctx: &crate::IrContext) -> crate::ValueRef {
-        CallIndirect::callee(self, ctx)
-    }
-
-    fn exact_signature(&self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
-        CallIndirect::signature(self, ctx)
+impl IndirectCallLikeModel for CallIndirect {
+    fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        CallIndirect::signature(&self, ctx)
     }
 }
 
@@ -123,17 +96,47 @@ impl CallLike for TailCallIndirect {
     }
 }
 
-impl IndirectCallLike for TailCallIndirect {
-    fn callee(&self, ctx: &crate::IrContext) -> crate::ValueRef {
-        TailCallIndirect::callee(self, ctx)
-    }
-
-    fn exact_signature(&self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
-        TailCallIndirect::signature(self, ctx)
+impl IndirectCallLikeModel for TailCallIndirect {
+    fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        TailCallIndirect::signature(&self, ctx)
     }
 }
 
 impl TailCallLike for TailCallIndirect {}
+
+inventory::submit! {
+    IndirectCallLikeOps::register::<CallIndirect>()
+}
+
+inventory::submit! {
+    IndirectCallLikeOps::register::<TailCallIndirect>()
+}
+
+/// Attach an exact callable contract to a `func` indirect transfer.
+///
+/// Returns `false` without mutation when the operation is not a `func`
+/// indirect call or the supplied type is not a `core.func` contract.
+pub fn set_indirect_call_signature(
+    ctx: &mut crate::IrContext,
+    op: crate::OpRef,
+    signature: crate::TypeRef,
+) -> bool {
+    if crate::dialect::core::Func::from_type_ref(ctx, signature).is_none()
+        || (CallIndirect::from_op(ctx, op).is_err() && TailCallIndirect::from_op(ctx, op).is_err())
+    {
+        return false;
+    }
+    ctx.op_mut(op).attributes.insert(
+        crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
+        crate::Attribute::Type(signature),
+    );
+    true
+}
+
+/// Remove the `func`-owned exact-signature attribute from copied metadata.
+pub fn remove_indirect_call_signature(attributes: &mut crate::AttributeMap) {
+    attributes.remove(INDIRECT_CALL_SIGNATURE_ATTR);
+}
 
 impl Func {
     /// Return the function body when this declaration has one.
@@ -353,6 +356,7 @@ inventory::submit! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::op_interface::IndirectCallLikeOps;
     use crate::ops::DialectOp;
     use crate::parser::parse_test_module;
     use crate::printer::print_module;
@@ -412,8 +416,10 @@ mod tests {
             .block(ctx.region(direct.body_if_present(&ctx).unwrap()).blocks[0])
             .ops[0];
 
-        assert!(indirect_call_signature(&ctx, ordinary_op).is_some());
-        assert!(indirect_call_signature(&ctx, tail_op).is_some());
-        assert_eq!(indirect_call_signature(&ctx, direct_op), None);
+        assert!(IndirectCallLikeOps::get(&ctx, ordinary_op).is_some());
+        assert!(IndirectCallLikeOps::get(&ctx, tail_op).is_some());
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, ordinary_op).is_some());
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, tail_op).is_some());
+        assert!(IndirectCallLikeOps::get(&ctx, direct_op).is_none());
     }
 }

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -4,6 +4,40 @@
 /// becomes a runtime function or table index.
 pub const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
 
+/// Shared accessors for function calls with ordinary results or arguments.
+///
+/// This is a static Rust interface over the four `func.*call*` operations;
+/// it does not participate in dynamic operation dispatch.
+pub trait CallLike: crate::ops::DialectOp {
+    /// Arguments supplied to the callable, excluding an indirect callee.
+    fn call_args<'a>(&self, ctx: &'a crate::IrContext) -> &'a [crate::ValueRef];
+
+    /// Result types produced by this call.
+    fn call_result_types<'a>(&self, ctx: &'a crate::IrContext) -> &'a [crate::TypeRef] {
+        ctx.op_result_types(self.op_ref())
+    }
+}
+
+/// Shared accessors for indirect calls with an erased runtime callee.
+pub trait IndirectCallLike: CallLike {
+    /// Runtime function or table-index operand.
+    fn callee(&self, ctx: &crate::IrContext) -> crate::ValueRef;
+
+    /// Optional exact callable contract retained through callee erasure.
+    fn exact_signature(&self, ctx: &crate::IrContext) -> Option<crate::TypeRef>;
+}
+
+/// Marker and resultless query for proper-tail transfers.
+///
+/// Exact callable signatures belong only to [`IndirectCallLike`], keeping
+/// CPS/tail legality independent from indirect-call metadata.
+pub trait TailCallLike: CallLike {
+    /// Proper tail transfers cannot produce SSA results.
+    fn is_resultless(&self, ctx: &crate::IrContext) -> bool {
+        self.call_result_types(ctx).is_empty()
+    }
+}
+
 // === Operation registrations ===
 crate::register_pure_op!(func.constant);
 crate::register_isolated_op!(func.func);
@@ -35,6 +69,54 @@ mod func {
 
     fn unreachable() {}
 }
+
+impl CallLike for Call {
+    fn call_args<'a>(&self, ctx: &'a crate::IrContext) -> &'a [crate::ValueRef] {
+        self.args(ctx)
+    }
+}
+
+impl CallLike for CallIndirect {
+    fn call_args<'a>(&self, ctx: &'a crate::IrContext) -> &'a [crate::ValueRef] {
+        self.args(ctx)
+    }
+}
+
+impl IndirectCallLike for CallIndirect {
+    fn callee(&self, ctx: &crate::IrContext) -> crate::ValueRef {
+        CallIndirect::callee(self, ctx)
+    }
+
+    fn exact_signature(&self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        CallIndirect::signature(self, ctx)
+    }
+}
+
+impl CallLike for TailCall {
+    fn call_args<'a>(&self, ctx: &'a crate::IrContext) -> &'a [crate::ValueRef] {
+        self.args(ctx)
+    }
+}
+
+impl TailCallLike for TailCall {}
+
+impl CallLike for TailCallIndirect {
+    fn call_args<'a>(&self, ctx: &'a crate::IrContext) -> &'a [crate::ValueRef] {
+        self.args(ctx)
+    }
+}
+
+impl IndirectCallLike for TailCallIndirect {
+    fn callee(&self, ctx: &crate::IrContext) -> crate::ValueRef {
+        TailCallIndirect::callee(self, ctx)
+    }
+
+    fn exact_signature(&self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        TailCallIndirect::signature(self, ctx)
+    }
+}
+
+impl TailCallLike for TailCallIndirect {}
 
 impl Func {
     /// Return the function body when this declaration has one.

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -77,10 +77,12 @@ impl CallLike for CallIndirect {
 }
 
 impl IndirectCallLikeModel for CallIndirect {
-    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
-
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         CallIndirect::signature(&self, ctx)
+    }
+
+    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
+        set_indirect_call_signature_attribute(attributes, signature);
     }
 }
 
@@ -99,10 +101,12 @@ impl CallLike for TailCallIndirect {
 }
 
 impl IndirectCallLikeModel for TailCallIndirect {
-    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
-
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         TailCallIndirect::signature(&self, ctx)
+    }
+
+    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
+        set_indirect_call_signature_attribute(attributes, signature);
     }
 }
 
@@ -130,11 +134,18 @@ pub fn set_indirect_call_signature(
     {
         return false;
     }
-    ctx.op_mut(op).attributes.insert(
+    set_indirect_call_signature_attribute(&mut ctx.op_mut(op).attributes, signature);
+    true
+}
+
+fn set_indirect_call_signature_attribute(
+    attributes: &mut crate::AttributeMap,
+    signature: crate::TypeRef,
+) {
+    attributes.insert(
         crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
         crate::Attribute::Type(signature),
     );
-    true
 }
 
 /// Remove the `func`-owned exact-signature attribute from copied metadata.

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -80,6 +80,10 @@ impl IndirectCallLikeModel for CallIndirect {
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         CallIndirect::signature(&self, ctx)
     }
+
+    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
+        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
+    }
 }
 
 impl CallLike for TailCall {
@@ -99,6 +103,10 @@ impl CallLike for TailCallIndirect {
 impl IndirectCallLikeModel for TailCallIndirect {
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         TailCallIndirect::signature(&self, ctx)
+    }
+
+    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
+        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -386,18 +386,22 @@ mod wasm {
 const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
 
 impl IndirectCallLikeModel for CallIndirect {
-    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
-
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         self.signature(ctx)
+    }
+
+    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
+        set_indirect_call_signature_attribute(attributes, signature);
     }
 }
 
 impl IndirectCallLikeModel for ReturnCallIndirect {
-    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
-
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         self.signature(ctx)
+    }
+
+    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
+        set_indirect_call_signature_attribute(attributes, signature);
     }
 }
 
@@ -424,11 +428,18 @@ pub fn set_indirect_call_signature(
     {
         return false;
     }
-    ctx.op_mut(op).attributes.insert(
+    set_indirect_call_signature_attribute(&mut ctx.op_mut(op).attributes, signature);
+    true
+}
+
+fn set_indirect_call_signature_attribute(
+    attributes: &mut crate::AttributeMap,
+    signature: crate::TypeRef,
+) {
+    attributes.insert(
         crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
         crate::Attribute::Type(signature),
     );
-    true
 }
 
 #[cfg(test)]

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -1,5 +1,8 @@
 //! Arena-based wasm dialect.
 
+use crate::op_interface::{IndirectCallLikeModel, IndirectCallLikeOps};
+use crate::ops::{DialectOp, DialectType};
+
 crate::register_isolated_op!(wasm.func);
 
 #[trunk_ir::dialect]
@@ -46,14 +49,14 @@ mod wasm {
     #[rest_results]
     fn call(#[rest] args: ()) -> results {}
 
-    #[attr(type_idx: u32, table: u32)]
+    #[attr(type_idx: u32, table: u32, signature?: Type)]
     #[rest_results]
     fn call_indirect(#[rest] args: ()) -> results {}
 
     #[attr(callee: Symbol)]
     fn return_call(#[rest] args: ()) {}
 
-    #[attr(type_idx: u32, table: u32)]
+    #[attr(type_idx: u32, table: u32, signature?: Type)]
     fn return_call_indirect(#[rest] args: ()) {}
 
     fn unreachable() {}
@@ -378,4 +381,98 @@ mod wasm {
 
     #[attr(offset: u32, align: u32, memory: u32)]
     fn i64_store32(addr: (), value: ()) {}
+}
+
+const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
+
+impl IndirectCallLikeModel for CallIndirect {
+    fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        self.signature(ctx)
+    }
+}
+
+impl IndirectCallLikeModel for ReturnCallIndirect {
+    fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        self.signature(ctx)
+    }
+}
+
+inventory::submit! {
+    IndirectCallLikeOps::register::<CallIndirect>()
+}
+
+inventory::submit! {
+    IndirectCallLikeOps::register::<ReturnCallIndirect>()
+}
+
+/// Attach an exact callable contract to a `wasm` indirect transfer.
+///
+/// Returns `false` without mutation when the operation is not a `wasm`
+/// indirect call or the supplied type is not a `core.func` contract.
+pub fn set_indirect_call_signature(
+    ctx: &mut crate::IrContext,
+    op: crate::OpRef,
+    signature: crate::TypeRef,
+) -> bool {
+    if crate::dialect::core::Func::from_type_ref(ctx, signature).is_none()
+        || (CallIndirect::from_op(ctx, op).is_err()
+            && ReturnCallIndirect::from_op(ctx, op).is_err())
+    {
+        return false;
+    }
+    ctx.op_mut(op).attributes.insert(
+        crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR),
+        crate::Attribute::Type(signature),
+    );
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::op_interface::IndirectCallLikeOps;
+    use crate::parser::parse_test_module;
+    use crate::printer::print_module;
+
+    #[test]
+    fn indirect_call_interface_uses_wasm_owned_signature() {
+        let mut ctx = crate::IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @ordinary(%table: core.i32, %value: core.i32) -> core.i32 {
+    %result = wasm.call_indirect %table, %value {signature = core.func(core.i32, core.i32), table = 0, type_idx = 0} : core.i32
+    wasm.return %result
+  }
+  wasm.func @plain(%table: core.i32, %value: core.i32) -> core.i32 {
+    %result = wasm.call_indirect %table, %value {table = 0, type_idx = 0} : core.i32
+    wasm.return %result
+  }
+  wasm.func @tail(%table: core.i32, %value: core.i32) -> core.nil {
+    wasm.return_call_indirect %table, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+  }
+  wasm.func @direct() -> core.nil {
+    wasm.return
+  }
+}"#,
+        );
+        let functions = module.ops(&ctx);
+        let body_op = |index| {
+            let body = ctx.op(functions[index]).regions[0];
+            ctx.block(ctx.region(body).blocks[0]).ops[0]
+        };
+        let ordinary = body_op(0);
+        let plain = body_op(1);
+        let tail = body_op(2);
+        let direct = body_op(3);
+
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, ordinary).is_some());
+        assert!(IndirectCallLikeOps::get(&ctx, plain).is_some());
+        assert_eq!(IndirectCallLikeOps::exact_signature(&ctx, plain), None);
+        assert!(IndirectCallLikeOps::exact_signature(&ctx, tail).is_some());
+        assert!(IndirectCallLikeOps::get(&ctx, direct).is_none());
+
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("wasm.call_indirect"));
+        assert!(printed.contains("signature = core.func(core.i32, core.i32)"));
+    }
 }

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -389,11 +389,19 @@ impl IndirectCallLikeModel for CallIndirect {
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         self.signature(ctx)
     }
+
+    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
+        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
+    }
 }
 
 impl IndirectCallLikeModel for ReturnCallIndirect {
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         self.signature(ctx)
+    }
+
+    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
+        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -386,22 +386,18 @@ mod wasm {
 const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
 
 impl IndirectCallLikeModel for CallIndirect {
+    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
+
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         self.signature(ctx)
-    }
-
-    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
-        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 
 impl IndirectCallLikeModel for ReturnCallIndirect {
+    const EXACT_SIGNATURE_ATTRIBUTE: &'static str = INDIRECT_CALL_SIGNATURE_ATTR;
+
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         self.signature(ctx)
-    }
-
-    fn is_exact_signature_attribute(self, attribute: crate::Symbol) -> bool {
-        attribute == crate::Symbol::new(INDIRECT_CALL_SIGNATURE_ATTR)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -390,8 +390,8 @@ impl IndirectCallLikeModel for CallIndirect {
         self.signature(ctx)
     }
 
-    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
-        set_indirect_call_signature_attribute(attributes, signature);
+    fn set_exact_signature(self, ctx: &mut crate::IrContext, signature: crate::TypeRef) -> bool {
+        set_indirect_call_signature(ctx, self.op_ref(), signature)
     }
 }
 
@@ -400,8 +400,8 @@ impl IndirectCallLikeModel for ReturnCallIndirect {
         self.signature(ctx)
     }
 
-    fn set_exact_signature(self, attributes: &mut crate::AttributeMap, signature: crate::TypeRef) {
-        set_indirect_call_signature_attribute(attributes, signature);
+    fn set_exact_signature(self, ctx: &mut crate::IrContext, signature: crate::TypeRef) -> bool {
+        set_indirect_call_signature(ctx, self.op_ref(), signature)
     }
 }
 

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -469,7 +469,19 @@ mod tests {
         assert!(IndirectCallLikeOps::get(&ctx, plain).is_some());
         assert_eq!(IndirectCallLikeOps::exact_signature(&ctx, plain), None);
         assert!(IndirectCallLikeOps::exact_signature(&ctx, tail).is_some());
+        for op in [ordinary, tail] {
+            let operands = ctx.op_operands(op);
+            assert_eq!(IndirectCallLikeOps::callee(&ctx, op), Some(operands[0]));
+            assert_eq!(
+                IndirectCallLikeOps::arguments(&ctx, op),
+                Some(&operands[1..])
+            );
+        }
+        assert!(IndirectCallLikeOps::callee(&ctx, plain).is_some());
+        assert!(IndirectCallLikeOps::arguments(&ctx, plain).is_some());
         assert!(IndirectCallLikeOps::get(&ctx, direct).is_none());
+        assert_eq!(IndirectCallLikeOps::callee(&ctx, direct), None);
+        assert_eq!(IndirectCallLikeOps::arguments(&ctx, direct), None);
 
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("wasm.call_indirect"));

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -399,19 +399,48 @@ pub struct RegionValueTransfer {
     pub inputs: SuccessorInputs,
 }
 
-/// Object-safe exact-signature semantics for indirect calls.
+/// Object-safe semantic accessors for indirect calls.
 ///
-/// The interface deliberately returns no signature for an ordinary indirect
-/// transfer. Consumers must not reconstruct a contract from erased operands or
-/// operation result types.
+/// An exact signature is optional on otherwise valid ordinary indirect
+/// transfers. When it is absent, consumers must not reconstruct a contract
+/// from erased operands or operation result types.
 pub trait IndirectCallLike: Sync {
+    fn callee(&self, ctx: &IrContext, op: OpRef) -> Option<ValueRef>;
+
+    fn arguments<'a>(&self, ctx: &'a IrContext, op: OpRef) -> Option<&'a [ValueRef]>;
+
     fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef>;
 }
 
-/// Typed exact-signature semantics supplied by an indirect-call operation
-/// wrapper.
+/// Typed indirect-call semantics supplied by a generated operation wrapper.
 pub trait IndirectCallLikeModel: DialectOp {
+    fn indirect_callee(self, ctx: &IrContext) -> Option<ValueRef> {
+        ctx.op_operands(self.op_ref()).first().copied()
+    }
+
+    fn indirect_arguments(self, ctx: &IrContext) -> Option<&[ValueRef]> {
+        ctx.op_operands(self.op_ref()).get(1..)
+    }
+
     fn exact_signature(self, ctx: &IrContext) -> Option<TypeRef>;
+}
+
+fn indirect_call_like_model_callee<T: IndirectCallLikeModel>(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Option<ValueRef> {
+    T::from_op(ctx, op)
+        .ok()
+        .and_then(|model| model.indirect_callee(ctx))
+}
+
+fn indirect_call_like_model_arguments<T: IndirectCallLikeModel>(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Option<&[ValueRef]> {
+    T::from_op(ctx, op)
+        .ok()
+        .and_then(|model| model.indirect_arguments(ctx))
 }
 
 fn indirect_call_like_model_signature<T: IndirectCallLikeModel>(
@@ -427,10 +456,20 @@ fn indirect_call_like_model_signature<T: IndirectCallLikeModel>(
 pub struct IndirectCallLikeRegistration {
     pub dialect: &'static str,
     pub op_name: &'static str,
+    pub callee: fn(&IrContext, OpRef) -> Option<ValueRef>,
+    pub arguments: fn(&IrContext, OpRef) -> Option<&[ValueRef]>,
     pub exact_signature: fn(&IrContext, OpRef) -> Option<TypeRef>,
 }
 
 impl IndirectCallLike for IndirectCallLikeRegistration {
+    fn callee(&self, ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
+        (self.callee)(ctx, op)
+    }
+
+    fn arguments<'a>(&self, ctx: &'a IrContext, op: OpRef) -> Option<&'a [ValueRef]> {
+        (self.arguments)(ctx, op)
+    }
+
     fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
         (self.exact_signature)(ctx, op)
     }
@@ -466,6 +505,8 @@ impl IndirectCallLikeOps {
         IndirectCallLikeRegistration {
             dialect: T::DIALECT_NAME,
             op_name: T::OP_NAME,
+            callee: indirect_call_like_model_callee::<T>,
+            arguments: indirect_call_like_model_arguments::<T>,
             exact_signature: indirect_call_like_model_signature::<T>,
         }
     }
@@ -480,6 +521,16 @@ impl IndirectCallLikeOps {
     /// Read an indirect transfer's exact callable signature, if it has one.
     pub fn exact_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
         Self::get(ctx, op).and_then(|interface| interface.exact_signature(ctx, op))
+    }
+
+    /// Read an indirect transfer's erased runtime callee or table-index value.
+    pub fn callee(ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
+        Self::get(ctx, op).and_then(|interface| interface.callee(ctx, op))
+    }
+
+    /// Read arguments supplied to an indirect transfer, excluding its callee.
+    pub fn arguments(ctx: &IrContext, op: OpRef) -> Option<&[ValueRef]> {
+        Self::get(ctx, op).and_then(|interface| interface.arguments(ctx, op))
     }
 }
 

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -412,28 +412,13 @@ pub trait IndirectCallLike: Sync {
 
     fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef>;
 
-    fn take_exact_signature(
+    fn set_exact_signature(
         &self,
         ctx: &IrContext,
         op: OpRef,
         attributes: &mut AttributeMap,
-    ) -> Option<ExactSignatureSlot>;
-}
-
-/// Dialect-owned storage for an exact indirect-call signature.
-pub struct ExactSignatureSlot {
-    name: Symbol,
-    signature: TypeRef,
-}
-
-impl ExactSignatureSlot {
-    pub fn signature(&self) -> TypeRef {
-        self.signature
-    }
-
-    pub fn restore(self, attributes: &mut AttributeMap, signature: TypeRef) {
-        attributes.insert(self.name, Attribute::Type(signature));
-    }
+        signature: TypeRef,
+    ) -> bool;
 }
 
 /// Typed indirect-call semantics supplied by a generated operation wrapper.
@@ -450,16 +435,11 @@ pub trait IndirectCallLikeModel: DialectOp {
 
     fn exact_signature(self, ctx: &IrContext) -> Option<TypeRef>;
 
-    fn take_exact_signature(self, attributes: &mut AttributeMap) -> Option<ExactSignatureSlot> {
-        let name = Symbol::new(Self::EXACT_SIGNATURE_ATTRIBUTE);
-        match attributes.remove(name) {
-            Some(Attribute::Type(signature)) => Some(ExactSignatureSlot { name, signature }),
-            Some(attribute) => {
-                attributes.insert(name, attribute);
-                None
-            }
-            None => None,
-        }
+    fn set_exact_signature(self, attributes: &mut AttributeMap, signature: TypeRef) {
+        attributes.insert(
+            Symbol::new(Self::EXACT_SIGNATURE_ATTRIBUTE),
+            Attribute::Type(signature),
+        );
     }
 }
 
@@ -490,15 +470,17 @@ fn indirect_call_like_model_signature<T: IndirectCallLikeModel>(
         .and_then(|model| model.exact_signature(ctx))
 }
 
-fn indirect_call_like_model_take_signature<T: IndirectCallLikeModel>(
+fn indirect_call_like_model_set_signature<T: IndirectCallLikeModel>(
     ctx: &IrContext,
     op: OpRef,
     attributes: &mut AttributeMap,
-) -> Option<ExactSignatureSlot> {
+    signature: TypeRef,
+) -> bool {
     let Ok(model) = T::from_op(ctx, op) else {
-        return None;
+        return false;
     };
-    model.take_exact_signature(attributes)
+    model.set_exact_signature(attributes, signature);
+    true
 }
 
 /// Registry entry for [`IndirectCallLike`].
@@ -508,8 +490,7 @@ pub struct IndirectCallLikeRegistration {
     pub callee: fn(&IrContext, OpRef) -> Option<ValueRef>,
     pub arguments: fn(&IrContext, OpRef) -> Option<&[ValueRef]>,
     pub exact_signature: fn(&IrContext, OpRef) -> Option<TypeRef>,
-    pub take_exact_signature:
-        fn(&IrContext, OpRef, &mut AttributeMap) -> Option<ExactSignatureSlot>,
+    pub set_exact_signature: fn(&IrContext, OpRef, &mut AttributeMap, TypeRef) -> bool,
 }
 
 impl IndirectCallLike for IndirectCallLikeRegistration {
@@ -525,13 +506,14 @@ impl IndirectCallLike for IndirectCallLikeRegistration {
         (self.exact_signature)(ctx, op)
     }
 
-    fn take_exact_signature(
+    fn set_exact_signature(
         &self,
         ctx: &IrContext,
         op: OpRef,
         attributes: &mut AttributeMap,
-    ) -> Option<ExactSignatureSlot> {
-        (self.take_exact_signature)(ctx, op, attributes)
+        signature: TypeRef,
+    ) -> bool {
+        (self.set_exact_signature)(ctx, op, attributes, signature)
     }
 }
 
@@ -568,7 +550,7 @@ impl IndirectCallLikeOps {
             callee: indirect_call_like_model_callee::<T>,
             arguments: indirect_call_like_model_arguments::<T>,
             exact_signature: indirect_call_like_model_signature::<T>,
-            take_exact_signature: indirect_call_like_model_take_signature::<T>,
+            set_exact_signature: indirect_call_like_model_set_signature::<T>,
         }
     }
 
@@ -584,13 +566,15 @@ impl IndirectCallLikeOps {
         Self::get(ctx, op).and_then(|interface| interface.exact_signature(ctx, op))
     }
 
-    /// Remove and return an exact signature from a copied attribute map.
-    pub fn take_exact_signature(
+    /// Set an exact signature in a copied attribute map.
+    pub fn set_exact_signature(
         ctx: &IrContext,
         op: OpRef,
         attributes: &mut AttributeMap,
-    ) -> Option<ExactSignatureSlot> {
-        Self::get(ctx, op).and_then(|interface| interface.take_exact_signature(ctx, op, attributes))
+        signature: TypeRef,
+    ) -> bool {
+        Self::get(ctx, op)
+            .is_some_and(|interface| interface.set_exact_signature(ctx, op, attributes, signature))
     }
 
     /// Read an indirect transfer's erased runtime callee or table-index value.

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -399,6 +399,90 @@ pub struct RegionValueTransfer {
     pub inputs: SuccessorInputs,
 }
 
+/// Object-safe exact-signature semantics for indirect calls.
+///
+/// The interface deliberately returns no signature for an ordinary indirect
+/// transfer. Consumers must not reconstruct a contract from erased operands or
+/// operation result types.
+pub trait IndirectCallLike: Sync {
+    fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef>;
+}
+
+/// Typed exact-signature semantics supplied by an indirect-call operation
+/// wrapper.
+pub trait IndirectCallLikeModel: DialectOp {
+    fn exact_signature(self, ctx: &IrContext) -> Option<TypeRef>;
+}
+
+fn indirect_call_like_model_signature<T: IndirectCallLikeModel>(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Option<TypeRef> {
+    T::from_op(ctx, op)
+        .ok()
+        .and_then(|model| model.exact_signature(ctx))
+}
+
+/// Registry entry for [`IndirectCallLike`].
+pub struct IndirectCallLikeRegistration {
+    pub dialect: &'static str,
+    pub op_name: &'static str,
+    pub exact_signature: fn(&IrContext, OpRef) -> Option<TypeRef>,
+}
+
+impl IndirectCallLike for IndirectCallLikeRegistration {
+    fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
+        (self.exact_signature)(ctx, op)
+    }
+}
+
+inventory::collect!(IndirectCallLikeRegistration);
+
+static INDIRECT_CALL_LIKE_REGISTRY: LazyLock<
+    HashMap<(Symbol, Symbol), &'static IndirectCallLikeRegistration>,
+> = LazyLock::new(|| {
+    let mut registry = HashMap::new();
+    for registration in inventory::iter::<IndirectCallLikeRegistration> {
+        let key = (
+            Symbol::from_dynamic(registration.dialect),
+            Symbol::from_dynamic(registration.op_name),
+        );
+        assert!(
+            registry.insert(key, registration).is_none(),
+            "duplicate IndirectCallLike registration for '{}.{}'",
+            registration.dialect,
+            registration.op_name,
+        );
+    }
+    registry
+});
+
+/// Dynamic query and registration entry point for [`IndirectCallLike`].
+pub struct IndirectCallLikeOps;
+
+impl IndirectCallLikeOps {
+    #[doc(hidden)]
+    pub const fn register<T: IndirectCallLikeModel>() -> IndirectCallLikeRegistration {
+        IndirectCallLikeRegistration {
+            dialect: T::DIALECT_NAME,
+            op_name: T::OP_NAME,
+            exact_signature: indirect_call_like_model_signature::<T>,
+        }
+    }
+
+    pub fn get(ctx: &IrContext, op: OpRef) -> Option<&'static dyn IndirectCallLike> {
+        let data = ctx.op(op);
+        INDIRECT_CALL_LIKE_REGISTRY
+            .get(&(data.dialect, data.name))
+            .map(|registration| *registration as &dyn IndirectCallLike)
+    }
+
+    /// Read an indirect transfer's exact callable signature, if it has one.
+    pub fn exact_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
+        Self::get(ctx, op).and_then(|interface| interface.exact_signature(ctx, op))
+    }
+}
+
 /// Object-safe block branch semantics.
 pub trait Branch: Sync {
     fn successors(

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -11,7 +11,6 @@ use smallvec::SmallVec;
 
 use crate::Symbol;
 use crate::ops::DialectOp;
-use crate::types::AttributeMap;
 use crate::{BlockRef, IrContext, OpRef, RegionRef, TypeRef, ValueRef};
 
 /// Marker trait for pure operations (no side effects, safe to remove if unused).
@@ -412,13 +411,7 @@ pub trait IndirectCallLike: Sync {
 
     fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef>;
 
-    fn set_exact_signature(
-        &self,
-        ctx: &IrContext,
-        op: OpRef,
-        attributes: &mut AttributeMap,
-        signature: TypeRef,
-    ) -> bool;
+    fn set_exact_signature(&self, ctx: &mut IrContext, op: OpRef, signature: TypeRef) -> bool;
 }
 
 /// Typed indirect-call semantics supplied by a generated operation wrapper.
@@ -433,7 +426,7 @@ pub trait IndirectCallLikeModel: DialectOp {
 
     fn exact_signature(self, ctx: &IrContext) -> Option<TypeRef>;
 
-    fn set_exact_signature(self, attributes: &mut AttributeMap, signature: TypeRef);
+    fn set_exact_signature(self, ctx: &mut IrContext, signature: TypeRef) -> bool;
 }
 
 fn indirect_call_like_model_callee<T: IndirectCallLikeModel>(
@@ -464,16 +457,14 @@ fn indirect_call_like_model_signature<T: IndirectCallLikeModel>(
 }
 
 fn indirect_call_like_model_set_signature<T: IndirectCallLikeModel>(
-    ctx: &IrContext,
+    ctx: &mut IrContext,
     op: OpRef,
-    attributes: &mut AttributeMap,
     signature: TypeRef,
 ) -> bool {
     let Ok(model) = T::from_op(ctx, op) else {
         return false;
     };
-    model.set_exact_signature(attributes, signature);
-    true
+    model.set_exact_signature(ctx, signature)
 }
 
 /// Registry entry for [`IndirectCallLike`].
@@ -483,7 +474,7 @@ pub struct IndirectCallLikeRegistration {
     pub callee: fn(&IrContext, OpRef) -> Option<ValueRef>,
     pub arguments: fn(&IrContext, OpRef) -> Option<&[ValueRef]>,
     pub exact_signature: fn(&IrContext, OpRef) -> Option<TypeRef>,
-    pub set_exact_signature: fn(&IrContext, OpRef, &mut AttributeMap, TypeRef) -> bool,
+    pub set_exact_signature: fn(&mut IrContext, OpRef, TypeRef) -> bool,
 }
 
 impl IndirectCallLike for IndirectCallLikeRegistration {
@@ -499,14 +490,8 @@ impl IndirectCallLike for IndirectCallLikeRegistration {
         (self.exact_signature)(ctx, op)
     }
 
-    fn set_exact_signature(
-        &self,
-        ctx: &IrContext,
-        op: OpRef,
-        attributes: &mut AttributeMap,
-        signature: TypeRef,
-    ) -> bool {
-        (self.set_exact_signature)(ctx, op, attributes, signature)
+    fn set_exact_signature(&self, ctx: &mut IrContext, op: OpRef, signature: TypeRef) -> bool {
+        (self.set_exact_signature)(ctx, op, signature)
     }
 }
 
@@ -559,15 +544,10 @@ impl IndirectCallLikeOps {
         Self::get(ctx, op).and_then(|interface| interface.exact_signature(ctx, op))
     }
 
-    /// Set an exact signature in a copied attribute map.
-    pub fn set_exact_signature(
-        ctx: &IrContext,
-        op: OpRef,
-        attributes: &mut AttributeMap,
-        signature: TypeRef,
-    ) -> bool {
+    /// Set an indirect transfer's exact callable signature.
+    pub fn set_exact_signature(ctx: &mut IrContext, op: OpRef, signature: TypeRef) -> bool {
         Self::get(ctx, op)
-            .is_some_and(|interface| interface.set_exact_signature(ctx, op, attributes, signature))
+            .is_some_and(|interface| interface.set_exact_signature(ctx, op, signature))
     }
 
     /// Read an indirect transfer's erased runtime callee or table-index value.

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -11,7 +11,7 @@ use smallvec::SmallVec;
 
 use crate::Symbol;
 use crate::ops::DialectOp;
-use crate::types::{Attribute, AttributeMap};
+use crate::types::AttributeMap;
 use crate::{BlockRef, IrContext, OpRef, RegionRef, TypeRef, ValueRef};
 
 /// Marker trait for pure operations (no side effects, safe to remove if unused).
@@ -423,8 +423,6 @@ pub trait IndirectCallLike: Sync {
 
 /// Typed indirect-call semantics supplied by a generated operation wrapper.
 pub trait IndirectCallLikeModel: DialectOp {
-    const EXACT_SIGNATURE_ATTRIBUTE: &'static str;
-
     fn indirect_callee(self, ctx: &IrContext) -> Option<ValueRef> {
         ctx.op_operands(self.op_ref()).first().copied()
     }
@@ -435,12 +433,7 @@ pub trait IndirectCallLikeModel: DialectOp {
 
     fn exact_signature(self, ctx: &IrContext) -> Option<TypeRef>;
 
-    fn set_exact_signature(self, attributes: &mut AttributeMap, signature: TypeRef) {
-        attributes.insert(
-            Symbol::new(Self::EXACT_SIGNATURE_ATTRIBUTE),
-            Attribute::Type(signature),
-        );
-    }
+    fn set_exact_signature(self, attributes: &mut AttributeMap, signature: TypeRef);
 }
 
 fn indirect_call_like_model_callee<T: IndirectCallLikeModel>(

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -410,6 +410,8 @@ pub trait IndirectCallLike: Sync {
     fn arguments<'a>(&self, ctx: &'a IrContext, op: OpRef) -> Option<&'a [ValueRef]>;
 
     fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef>;
+
+    fn is_exact_signature_attribute(&self, ctx: &IrContext, op: OpRef, attribute: Symbol) -> bool;
 }
 
 /// Typed indirect-call semantics supplied by a generated operation wrapper.
@@ -423,6 +425,8 @@ pub trait IndirectCallLikeModel: DialectOp {
     }
 
     fn exact_signature(self, ctx: &IrContext) -> Option<TypeRef>;
+
+    fn is_exact_signature_attribute(self, attribute: Symbol) -> bool;
 }
 
 fn indirect_call_like_model_callee<T: IndirectCallLikeModel>(
@@ -452,6 +456,16 @@ fn indirect_call_like_model_signature<T: IndirectCallLikeModel>(
         .and_then(|model| model.exact_signature(ctx))
 }
 
+fn indirect_call_like_model_is_signature_attribute<T: IndirectCallLikeModel>(
+    ctx: &IrContext,
+    op: OpRef,
+    attribute: Symbol,
+) -> bool {
+    T::from_op(ctx, op)
+        .map(|model| model.is_exact_signature_attribute(attribute))
+        .unwrap_or(false)
+}
+
 /// Registry entry for [`IndirectCallLike`].
 pub struct IndirectCallLikeRegistration {
     pub dialect: &'static str,
@@ -459,6 +473,7 @@ pub struct IndirectCallLikeRegistration {
     pub callee: fn(&IrContext, OpRef) -> Option<ValueRef>,
     pub arguments: fn(&IrContext, OpRef) -> Option<&[ValueRef]>,
     pub exact_signature: fn(&IrContext, OpRef) -> Option<TypeRef>,
+    pub is_exact_signature_attribute: fn(&IrContext, OpRef, Symbol) -> bool,
 }
 
 impl IndirectCallLike for IndirectCallLikeRegistration {
@@ -472,6 +487,10 @@ impl IndirectCallLike for IndirectCallLikeRegistration {
 
     fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
         (self.exact_signature)(ctx, op)
+    }
+
+    fn is_exact_signature_attribute(&self, ctx: &IrContext, op: OpRef, attribute: Symbol) -> bool {
+        (self.is_exact_signature_attribute)(ctx, op, attribute)
     }
 }
 
@@ -508,6 +527,7 @@ impl IndirectCallLikeOps {
             callee: indirect_call_like_model_callee::<T>,
             arguments: indirect_call_like_model_arguments::<T>,
             exact_signature: indirect_call_like_model_signature::<T>,
+            is_exact_signature_attribute: indirect_call_like_model_is_signature_attribute::<T>,
         }
     }
 
@@ -521,6 +541,12 @@ impl IndirectCallLikeOps {
     /// Read an indirect transfer's exact callable signature, if it has one.
     pub fn exact_signature(ctx: &IrContext, op: OpRef) -> Option<TypeRef> {
         Self::get(ctx, op).and_then(|interface| interface.exact_signature(ctx, op))
+    }
+
+    /// Whether an attribute belongs to this operation's exact callable contract.
+    pub fn is_exact_signature_attribute(ctx: &IrContext, op: OpRef, attribute: Symbol) -> bool {
+        Self::get(ctx, op)
+            .is_some_and(|interface| interface.is_exact_signature_attribute(ctx, op, attribute))
     }
 
     /// Read an indirect transfer's erased runtime callee or table-index value.

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -11,6 +11,7 @@ use smallvec::SmallVec;
 
 use crate::Symbol;
 use crate::ops::DialectOp;
+use crate::types::{Attribute, AttributeMap};
 use crate::{BlockRef, IrContext, OpRef, RegionRef, TypeRef, ValueRef};
 
 /// Marker trait for pure operations (no side effects, safe to remove if unused).
@@ -411,11 +412,34 @@ pub trait IndirectCallLike: Sync {
 
     fn exact_signature(&self, ctx: &IrContext, op: OpRef) -> Option<TypeRef>;
 
-    fn is_exact_signature_attribute(&self, ctx: &IrContext, op: OpRef, attribute: Symbol) -> bool;
+    fn take_exact_signature(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        attributes: &mut AttributeMap,
+    ) -> Option<ExactSignatureSlot>;
+}
+
+/// Dialect-owned storage for an exact indirect-call signature.
+pub struct ExactSignatureSlot {
+    name: Symbol,
+    signature: TypeRef,
+}
+
+impl ExactSignatureSlot {
+    pub fn signature(&self) -> TypeRef {
+        self.signature
+    }
+
+    pub fn restore(self, attributes: &mut AttributeMap, signature: TypeRef) {
+        attributes.insert(self.name, Attribute::Type(signature));
+    }
 }
 
 /// Typed indirect-call semantics supplied by a generated operation wrapper.
 pub trait IndirectCallLikeModel: DialectOp {
+    const EXACT_SIGNATURE_ATTRIBUTE: &'static str;
+
     fn indirect_callee(self, ctx: &IrContext) -> Option<ValueRef> {
         ctx.op_operands(self.op_ref()).first().copied()
     }
@@ -426,7 +450,17 @@ pub trait IndirectCallLikeModel: DialectOp {
 
     fn exact_signature(self, ctx: &IrContext) -> Option<TypeRef>;
 
-    fn is_exact_signature_attribute(self, attribute: Symbol) -> bool;
+    fn take_exact_signature(self, attributes: &mut AttributeMap) -> Option<ExactSignatureSlot> {
+        let name = Symbol::new(Self::EXACT_SIGNATURE_ATTRIBUTE);
+        match attributes.remove(name) {
+            Some(Attribute::Type(signature)) => Some(ExactSignatureSlot { name, signature }),
+            Some(attribute) => {
+                attributes.insert(name, attribute);
+                None
+            }
+            None => None,
+        }
+    }
 }
 
 fn indirect_call_like_model_callee<T: IndirectCallLikeModel>(
@@ -456,14 +490,15 @@ fn indirect_call_like_model_signature<T: IndirectCallLikeModel>(
         .and_then(|model| model.exact_signature(ctx))
 }
 
-fn indirect_call_like_model_is_signature_attribute<T: IndirectCallLikeModel>(
+fn indirect_call_like_model_take_signature<T: IndirectCallLikeModel>(
     ctx: &IrContext,
     op: OpRef,
-    attribute: Symbol,
-) -> bool {
-    T::from_op(ctx, op)
-        .map(|model| model.is_exact_signature_attribute(attribute))
-        .unwrap_or(false)
+    attributes: &mut AttributeMap,
+) -> Option<ExactSignatureSlot> {
+    let Ok(model) = T::from_op(ctx, op) else {
+        return None;
+    };
+    model.take_exact_signature(attributes)
 }
 
 /// Registry entry for [`IndirectCallLike`].
@@ -473,7 +508,8 @@ pub struct IndirectCallLikeRegistration {
     pub callee: fn(&IrContext, OpRef) -> Option<ValueRef>,
     pub arguments: fn(&IrContext, OpRef) -> Option<&[ValueRef]>,
     pub exact_signature: fn(&IrContext, OpRef) -> Option<TypeRef>,
-    pub is_exact_signature_attribute: fn(&IrContext, OpRef, Symbol) -> bool,
+    pub take_exact_signature:
+        fn(&IrContext, OpRef, &mut AttributeMap) -> Option<ExactSignatureSlot>,
 }
 
 impl IndirectCallLike for IndirectCallLikeRegistration {
@@ -489,8 +525,13 @@ impl IndirectCallLike for IndirectCallLikeRegistration {
         (self.exact_signature)(ctx, op)
     }
 
-    fn is_exact_signature_attribute(&self, ctx: &IrContext, op: OpRef, attribute: Symbol) -> bool {
-        (self.is_exact_signature_attribute)(ctx, op, attribute)
+    fn take_exact_signature(
+        &self,
+        ctx: &IrContext,
+        op: OpRef,
+        attributes: &mut AttributeMap,
+    ) -> Option<ExactSignatureSlot> {
+        (self.take_exact_signature)(ctx, op, attributes)
     }
 }
 
@@ -527,7 +568,7 @@ impl IndirectCallLikeOps {
             callee: indirect_call_like_model_callee::<T>,
             arguments: indirect_call_like_model_arguments::<T>,
             exact_signature: indirect_call_like_model_signature::<T>,
-            is_exact_signature_attribute: indirect_call_like_model_is_signature_attribute::<T>,
+            take_exact_signature: indirect_call_like_model_take_signature::<T>,
         }
     }
 
@@ -543,10 +584,13 @@ impl IndirectCallLikeOps {
         Self::get(ctx, op).and_then(|interface| interface.exact_signature(ctx, op))
     }
 
-    /// Whether an attribute belongs to this operation's exact callable contract.
-    pub fn is_exact_signature_attribute(ctx: &IrContext, op: OpRef, attribute: Symbol) -> bool {
-        Self::get(ctx, op)
-            .is_some_and(|interface| interface.is_exact_signature_attribute(ctx, op, attribute))
+    /// Remove and return an exact signature from a copied attribute map.
+    pub fn take_exact_signature(
+        ctx: &IrContext,
+        op: OpRef,
+        attributes: &mut AttributeMap,
+    ) -> Option<ExactSignatureSlot> {
+        Self::get(ctx, op).and_then(|interface| interface.take_exact_signature(ctx, op, attributes))
     }
 
     /// Read an indirect transfer's erased runtime callee or table-index value.

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -19,7 +19,7 @@ pub use helpers::{clone_attrs_except, erase_op, inline_region_blocks, split_bloc
 pub use pattern::RewritePattern;
 pub use rewriter::PatternRewriter;
 pub use signature_conversion::{
-    FuncSignatureConversionPattern, WasmFuncSignatureConversionPattern,
+    FuncSignatureConversionPattern, WasmFuncSignatureConversionPattern, convert_function_type,
 };
 pub use type_converter::TypeConverter;
 

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -21,13 +21,14 @@ struct ConvertedSignature {
     new_params: Vec<TypeRef>,
     new_result: TypeRef,
     params_changed: bool,
+    changed: bool,
 }
 
 /// Analyze a `core.func` TypeRef and convert params/result via the type converter.
 ///
 /// `core.func` type layout: `params[0]` = return type, `params[1..]` = param types.
 ///
-/// Returns `None` if no types changed.
+/// Returns `None` when `func_type` is not a well-formed `core.func` type.
 fn convert_func_signature(
     ctx: &IrContext,
     func_type: TypeRef,
@@ -55,20 +56,31 @@ fn convert_func_signature(
         .any(|(new, old)| new != old);
     let result_changed = new_result != old_result;
 
-    if !params_changed && !result_changed {
-        return None;
-    }
-
     Some(ConvertedSignature {
         new_params,
         new_result,
         params_changed,
+        changed: params_changed || result_changed,
     })
 }
 
 /// Build a new `core.func` TypeRef from converted params/result.
 fn rebuild_func_type(ctx: &mut IrContext, sig: &ConvertedSignature) -> TypeRef {
     crate::dialect::core::func(ctx, sig.new_result, sig.new_params.iter().copied()).as_type_ref()
+}
+
+/// Convert the parameter and result types of a `core.func` type.
+///
+/// This is the type-only counterpart to the function-signature rewrite
+/// patterns. It is for exact callable attributes whose source operation does
+/// not own a function body or block arguments to rewrite.
+pub fn convert_function_type(
+    ctx: &mut IrContext,
+    func_type: TypeRef,
+    converter: &TypeConverter,
+) -> Option<TypeRef> {
+    let signature = convert_func_signature(ctx, func_type, converter)?;
+    Some(rebuild_func_type(ctx, &signature))
 }
 
 /// Update entry block argument types in-place to match converted params.
@@ -134,6 +146,9 @@ fn rewrite_function_signature(
     let Some(sig) = convert_func_signature(ctx, func_type, converter) else {
         return false;
     };
+    if !sig.changed {
+        return false;
+    }
 
     // Update entry block args in-place
     if sig.params_changed && !update_entry_block_args(ctx, op, &sig.new_params) {

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -696,6 +696,12 @@ attribute로 erased callee/table index 이전의 exact `core.func` contract를 �
 `tribute.calling_convention`이 붙은 indirect transfer는 exact `signature`를 반드시
 가지며 verifier가 operand/result 및 convention과 대조한다. Physical operand type,
 symbol, ABI string 또는 storage shape로 signature를 재구성하지 않는다.
+Backend indirect-call operation도 runtime-queried `IndirectCallLike` operation
+interface를 통해 같은 contract를 보존한다. 각 dialect는 attribute spelling과
+accessor를 소유한다 (`func`와 `wasm`은 선택적 `signature`, `clif`는 필수 `sig`).
+Generic consumer는 다른 dialect의 attribute key 대신 interface를 query한다.
+Interface를 구현하지 않는 operation에는 exact signature가 없으며, erased callee나
+result operand로 이를 추론해서는 안 된다.
 `func.tail_call_indirect`는 callable operand와 argument를 받고 result가 없는
 terminator다. Shared verifier는 callee `core.func`와 enclosing caller의 result가
 모두 `core.never`인지 검사한다. Native/Wasm signature lowering은 이를 empty result


### PR DESCRIPTION
## Summary

- convert authoritative exact signatures for ordinary and tail indirect calls in the Cranelift and Wasm lowerings
- expose a runtime-queryable IndirectCallLike interface across func, wasm, and clif while each dialect owns its signature storage
- keep CallLike and TailCallLike as typed interfaces and prevent stale Wasm table/type-index metadata from propagating

## Why

Typed indirect-call signatures became stale after operands were converted to physical target types, blocking the #825 production route. A shared operation interface now preserves the semantic contract without leaking dialect-specific attribute keys.

## Testing

- focused TrunkIR, tribute-passes, Cranelift, and Wasm backend suites
- native and Wasm integration witnesses
- normal workspace pre-commit hook (2,028 passed, 1 skipped)

Part of #774.
Prerequisite for #825.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indirect calls and tail calls now preserve exact callable signatures across supported compilation targets.
  * Improved handling of indirect-call arguments, parameters, and return types.

* **Bug Fixes**
  * Unit-returning indirect calls now lower successfully without invalid results.
  * Signature conversions are applied before indirect-call operand validation.

* **Tests**
  * Added coverage for indirect-call signatures, WebAssembly emission, tail calls, and unit-returning calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->