### PR TITLE
Limit native layout planning to reachable types

### DIFF
--- a/crates/tribute-passes/src/native/ownership_plan.rs
+++ b/crates/tribute-passes/src/native/ownership_plan.rs
@@ -493,22 +493,53 @@ fn collect_and_validate_managed_layouts(
     let mut nominal_layouts: HashMap<Symbol, Vec<TypeRef>> = HashMap::new();
     let mut typerefs = HashSet::new();
     for &(_, ty) in ctx.type_aliases() {
-        collect_type_contract(ctx, ty, &mut typerefs, &mut nominal_layouts);
+        index_nominal_layout(ctx, ty, &mut nominal_layouts);
     }
+    let mut visited_types = HashSet::new();
     walk_module(ctx, module, |op| {
         for &ty in ctx.op_result_types(op) {
-            collect_type_contract(ctx, ty, &mut typerefs, &mut nominal_layouts);
+            collect_reachable_type_contract(
+                ctx,
+                ty,
+                &mut typerefs,
+                &mut nominal_layouts,
+                &mut layouts,
+                &mut visited_types,
+            );
         }
         for &operand in ctx.op_operands(op) {
-            collect_type_contract(
+            collect_reachable_type_contract(
                 ctx,
                 ctx.value_ty(operand),
                 &mut typerefs,
                 &mut nominal_layouts,
+                &mut layouts,
+                &mut visited_types,
             );
         }
         for attribute in ctx.op(op).attributes.values() {
-            collect_attribute_type_contract(ctx, attribute, &mut typerefs, &mut nominal_layouts);
+            collect_reachable_attribute_type_contract(
+                ctx,
+                attribute,
+                &mut typerefs,
+                &mut nominal_layouts,
+                &mut layouts,
+                &mut visited_types,
+            );
+        }
+        for region in ctx.op(op).regions.iter().copied() {
+            for block in ctx.region(region).blocks.iter().copied() {
+                for &argument in ctx.block_args(block) {
+                    collect_reachable_type_contract(
+                        ctx,
+                        ctx.value_ty(argument),
+                        &mut typerefs,
+                        &mut nominal_layouts,
+                        &mut layouts,
+                        &mut visited_types,
+                    );
+                }
+            }
         }
         if let Ok(new) = adt::StructNew::from_op(ctx, op) {
             let layout = new.r#type(ctx);
@@ -523,7 +554,12 @@ fn collect_and_validate_managed_layouts(
         }
     });
 
-    for typeref in typerefs {
+    let mut visited_typerefs = HashSet::new();
+    while let Some(typeref) = typerefs
+        .iter()
+        .copied()
+        .find(|typeref| visited_typerefs.insert(*typeref))
+    {
         let Some(name) = ctx.types.get(typeref).attrs.get_symbol("name") else {
             return Err(OwnershipPlanError::new(
                 "adt.typeref lacks nominal identity",
@@ -542,25 +578,27 @@ fn collect_and_validate_managed_layouts(
                 "adt.typeref @{name} has no unique native layout"
             )));
         }
-    }
-    for nominal in nominal_layouts.values() {
-        for &layout in nominal {
-            layouts.insert(layout);
-        }
+        let layout = nominal_layouts[&name][0];
+        layouts.insert(layout);
+        collect_reachable_type_contract(
+            ctx,
+            layout,
+            &mut typerefs,
+            &mut nominal_layouts,
+            &mut layouts,
+            &mut visited_types,
+        );
     }
     Ok(layouts)
 }
 
-fn collect_type_contract(
+fn index_nominal_layout(
     ctx: &IrContext,
     ty: TypeRef,
-    typerefs: &mut HashSet<TypeRef>,
     nominal_layouts: &mut HashMap<Symbol, Vec<TypeRef>>,
 ) {
     let data = ctx.types.get(ty);
-    if data.dialect == Symbol::new("adt") && data.name == Symbol::new("typeref") {
-        typerefs.insert(ty);
-    } else if data.dialect == Symbol::new("adt")
+    if data.dialect == Symbol::new("adt")
         && (data.name == Symbol::new("struct") || data.name == Symbol::new("enum"))
         && let Some(name) = data.attrs.get_symbol("name")
     {
@@ -569,27 +607,80 @@ fn collect_type_contract(
             layouts.push(ty);
         }
     }
+}
+
+fn collect_reachable_type_contract(
+    ctx: &IrContext,
+    ty: TypeRef,
+    typerefs: &mut HashSet<TypeRef>,
+    nominal_layouts: &mut HashMap<Symbol, Vec<TypeRef>>,
+    layouts: &mut HashSet<TypeRef>,
+    visited_types: &mut HashSet<TypeRef>,
+) {
+    if !visited_types.insert(ty) {
+        return;
+    }
+    let data = ctx.types.get(ty);
+    index_nominal_layout(ctx, ty, nominal_layouts);
+    if (data.dialect == Symbol::new("adt"))
+        && (data.name == Symbol::new("struct") || data.name == Symbol::new("enum"))
+    {
+        layouts.insert(ty);
+    }
+    if data.dialect == Symbol::new("adt") && data.name == Symbol::new("typeref") {
+        typerefs.insert(ty);
+    }
     for &parameter in &data.params {
-        collect_type_contract(ctx, parameter, typerefs, nominal_layouts);
+        collect_reachable_type_contract(
+            ctx,
+            parameter,
+            typerefs,
+            nominal_layouts,
+            layouts,
+            visited_types,
+        );
     }
     for attribute in data.attrs.values() {
-        collect_attribute_type_contract(ctx, attribute, typerefs, nominal_layouts);
+        collect_reachable_attribute_type_contract(
+            ctx,
+            attribute,
+            typerefs,
+            nominal_layouts,
+            layouts,
+            visited_types,
+        );
     }
 }
 
-fn collect_attribute_type_contract(
+fn collect_reachable_attribute_type_contract(
     ctx: &IrContext,
     attribute: &trunk_ir::Attribute,
     typerefs: &mut HashSet<TypeRef>,
     nominal_layouts: &mut HashMap<Symbol, Vec<TypeRef>>,
+    layouts: &mut HashSet<TypeRef>,
+    visited_types: &mut HashSet<TypeRef>,
 ) {
     match attribute {
         trunk_ir::Attribute::Type(ty) => {
-            collect_type_contract(ctx, *ty, typerefs, nominal_layouts);
+            collect_reachable_type_contract(
+                ctx,
+                *ty,
+                typerefs,
+                nominal_layouts,
+                layouts,
+                visited_types,
+            );
         }
         trunk_ir::Attribute::List(values) => {
             for value in values {
-                collect_attribute_type_contract(ctx, value, typerefs, nominal_layouts);
+                collect_reachable_attribute_type_contract(
+                    ctx,
+                    value,
+                    typerefs,
+                    nominal_layouts,
+                    layouts,
+                    visited_types,
+                );
             }
         }
         _ => {}

--- a/crates/tribute-passes/src/native/ownership_plan.rs
+++ b/crates/tribute-passes/src/native/ownership_plan.rs
@@ -492,6 +492,7 @@ fn collect_and_validate_managed_layouts(
     let mut layouts = HashSet::new();
     let mut nominal_layouts: HashMap<Symbol, Vec<TypeRef>> = HashMap::new();
     let mut typerefs = HashSet::new();
+    let mut pending_typerefs = Vec::new();
     for &(_, ty) in ctx.type_aliases() {
         index_nominal_layout(ctx, ty, &mut nominal_layouts);
     }
@@ -502,6 +503,7 @@ fn collect_and_validate_managed_layouts(
                 ctx,
                 ty,
                 &mut typerefs,
+                &mut pending_typerefs,
                 &mut nominal_layouts,
                 &mut layouts,
                 &mut visited_types,
@@ -512,6 +514,7 @@ fn collect_and_validate_managed_layouts(
                 ctx,
                 ctx.value_ty(operand),
                 &mut typerefs,
+                &mut pending_typerefs,
                 &mut nominal_layouts,
                 &mut layouts,
                 &mut visited_types,
@@ -522,6 +525,7 @@ fn collect_and_validate_managed_layouts(
                 ctx,
                 attribute,
                 &mut typerefs,
+                &mut pending_typerefs,
                 &mut nominal_layouts,
                 &mut layouts,
                 &mut visited_types,
@@ -534,6 +538,7 @@ fn collect_and_validate_managed_layouts(
                         ctx,
                         ctx.value_ty(argument),
                         &mut typerefs,
+                        &mut pending_typerefs,
                         &mut nominal_layouts,
                         &mut layouts,
                         &mut visited_types,
@@ -554,12 +559,7 @@ fn collect_and_validate_managed_layouts(
         }
     });
 
-    let mut visited_typerefs = HashSet::new();
-    while let Some(typeref) = typerefs
-        .iter()
-        .copied()
-        .find(|typeref| visited_typerefs.insert(*typeref))
-    {
+    while let Some(typeref) = pending_typerefs.pop() {
         let Some(name) = ctx.types.get(typeref).attrs.get_symbol("name") else {
             return Err(OwnershipPlanError::new(
                 "adt.typeref lacks nominal identity",
@@ -584,6 +584,7 @@ fn collect_and_validate_managed_layouts(
             ctx,
             layout,
             &mut typerefs,
+            &mut pending_typerefs,
             &mut nominal_layouts,
             &mut layouts,
             &mut visited_types,
@@ -613,6 +614,7 @@ fn collect_reachable_type_contract(
     ctx: &IrContext,
     ty: TypeRef,
     typerefs: &mut HashSet<TypeRef>,
+    pending_typerefs: &mut Vec<TypeRef>,
     nominal_layouts: &mut HashMap<Symbol, Vec<TypeRef>>,
     layouts: &mut HashSet<TypeRef>,
     visited_types: &mut HashSet<TypeRef>,
@@ -627,14 +629,18 @@ fn collect_reachable_type_contract(
     {
         layouts.insert(ty);
     }
-    if data.dialect == Symbol::new("adt") && data.name == Symbol::new("typeref") {
-        typerefs.insert(ty);
+    if data.dialect == Symbol::new("adt")
+        && data.name == Symbol::new("typeref")
+        && typerefs.insert(ty)
+    {
+        pending_typerefs.push(ty);
     }
     for &parameter in &data.params {
         collect_reachable_type_contract(
             ctx,
             parameter,
             typerefs,
+            pending_typerefs,
             nominal_layouts,
             layouts,
             visited_types,
@@ -645,6 +651,7 @@ fn collect_reachable_type_contract(
             ctx,
             attribute,
             typerefs,
+            pending_typerefs,
             nominal_layouts,
             layouts,
             visited_types,
@@ -656,6 +663,7 @@ fn collect_reachable_attribute_type_contract(
     ctx: &IrContext,
     attribute: &trunk_ir::Attribute,
     typerefs: &mut HashSet<TypeRef>,
+    pending_typerefs: &mut Vec<TypeRef>,
     nominal_layouts: &mut HashMap<Symbol, Vec<TypeRef>>,
     layouts: &mut HashSet<TypeRef>,
     visited_types: &mut HashSet<TypeRef>,
@@ -666,6 +674,7 @@ fn collect_reachable_attribute_type_contract(
                 ctx,
                 *ty,
                 typerefs,
+                pending_typerefs,
                 nominal_layouts,
                 layouts,
                 visited_types,
@@ -677,6 +686,7 @@ fn collect_reachable_attribute_type_contract(
                     ctx,
                     value,
                     typerefs,
+                    pending_typerefs,
                     nominal_layouts,
                     layouts,
                     visited_types,

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -1319,6 +1319,83 @@ fn stale_identity_unsupported_regions_and_malformed_calls_fail_unchanged() {
 }
 
 #[test]
+fn unused_frame_alias_with_missing_nominal_result_is_not_a_live_ownership_root() {
+    let mut ctx = IrContext::new();
+    let module = parse_test_module(
+        &mut ctx,
+        r#"core.module @test {
+  !Missing = adt.typeref() {name = @Missing}
+  !DeadFrame = adt.struct() {name = @ContinuationFrame, fields = [[@result, !Missing]]}
+  func.func @live() -> core.nil { func.return }
+}"#,
+    );
+
+    let plan = build_native_ownership_plan(&ctx, module)
+        .expect("unused continuation-frame aliases must not affect ownership planning");
+    let dead_frame = ctx
+        .type_alias_by_name(Symbol::new("DeadFrame"))
+        .expect("parsed dead frame alias");
+    assert!(!plan.is_managed_type(&ctx, dead_frame));
+    assert!(plan.rtti_types().is_empty());
+}
+
+#[test]
+fn reachable_missing_nominal_typeref_still_fails_before_planning() {
+    assert_plan_error_unchanged(
+        r#"core.module @test {
+  !Missing = adt.typeref() {name = @Missing}
+  !DeadFrame = adt.struct() {name = @ContinuationFrame, fields = [[@result, !Missing]]}
+  func.func @live() -> core.nil {
+    ^entry:
+      func.return
+    ^unreachable(%value: !Missing):
+      func.unreachable
+  }
+}"#,
+        "adt.typeref @Missing has no unique native layout",
+    );
+}
+
+#[test]
+fn reachable_recursive_nominal_layout_is_validated_once() {
+    let (_ctx, _module, plan) = build(
+        r#"core.module @test {
+  !CursorRef = adt.typeref() {name = @Cursor}
+  !Cursor = adt.struct() {name = @Cursor, fields = [[@next, !CursorRef]]}
+  func.func @make(%next: !CursorRef) -> !CursorRef {
+    %cursor = adt.struct_new %next {type = !Cursor} : !CursorRef
+    func.return %cursor
+  }
+}"#,
+    );
+
+    assert_eq!(plan.rtti_types().len(), 1);
+    assert!(matches!(
+        &plan.rtti_types()[0].fields,
+        ManagedFieldBitmap::Struct(fields) if fields == &[true]
+    ));
+}
+
+#[test]
+fn direct_layout_in_live_null_metadata_is_managed() {
+    let (ctx, _module, plan) = build(
+        r#"core.module @test {
+  !Node = adt.struct() {name = @__native_node, fields = [[@value, core.i32]]}
+  func.func @empty() -> tribute_rt.anyref {
+    %null = adt.ref_null {type = !Node} : tribute_rt.anyref
+    func.return %null
+  }
+}"#,
+    );
+
+    let node = ctx
+        .type_alias_by_name(Symbol::new("Node"))
+        .expect("parsed native node alias");
+    assert!(plan.is_managed_type(&ctx, node));
+    assert!(plan.rtti_types().is_empty());
+}
+
+#[test]
 fn nominal_layout_lookup_ignores_unreachable_interner_entries() {
     let mut ctx = IrContext::new();
     let module = parse_test_module(


### PR DESCRIPTION
## Summary

- index nominal layout declarations without treating every registered type alias as a live ownership root
- validate managed layouts recursively from types reachable through live operations
- preserve fail-closed checks for reachable missing or ambiguous layouts and direct live layout metadata

## Validation

- cargo nextest run -p tribute-passes
- cargo nextest run --workspace
- cargo clippy -p tribute-passes --tests -- -D warnings
- cargo fmt --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ownership metadata planning to account for only layouts reachable from active module types.
  - Prevented unused type aliases from incorrectly affecting ownership management or generating runtime type information.
  - Improved validation of reachable type references, including recursive layouts, while preserving errors for missing required types.
  - Correctly handles direct layouts used in live null metadata without generating unnecessary runtime entries.

- **Tests**
  - Added coverage for unreachable aliases, missing reachable types, recursive layouts, and live null metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->