### PR TITLE
fix(frontend): materialize constructor layout fields

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/lower/expr.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/expr.rs
@@ -33,7 +33,7 @@ use crate::ast::CallingConvention;
 /// Coerce constructor arguments to the representation recorded in the enum
 /// layout. Generic enum fields are erased to `anyref`, so primitive payloads
 /// must cross an explicit conversion boundary before `adt.variant_new`.
-fn cast_variant_args<'db>(
+pub(super) fn cast_variant_args<'db>(
     builder: &mut IrBuilder<'_, 'db>,
     location: Location,
     args: Vec<ValueRef>,

--- a/crates/tribute-front/src/ast_to_ir/lower/logical.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/logical.rs
@@ -1238,6 +1238,7 @@ fn lower_constructor<'db>(
         &ctor.resolved,
         ctor.ty,
     );
+    let values = super::expr::cast_variant_args(builder, location, values, type_attr, variant);
     let variant = adt::variant_new(builder.ir, location, values, result_ty, type_attr, variant);
     builder.ir.push_op(builder.block, variant.op_ref());
     Some(variant.result(builder.ir))

--- a/crates/tribute-front/tests/int_text.rs
+++ b/crates/tribute-front/tests/int_text.rs
@@ -58,15 +58,95 @@ fn format_box(value: Int) -> String {
         .split("tribute_control.func @format_box")
         .nth(1)
         .expect("format_box function must be lowered");
+    let layout_cast = format_box
+        .find("core.unrealized_conversion_cast")
+        .expect("generic constructor field must be converted to its erased layout type");
     let construct = format_box
         .find("adt.variant_new")
         .expect("generic constructor must construct Box");
-    let cast = format_box
-        .find("core.unrealized_conversion_cast")
-        .expect("erased generic field must be recovered for Int::to_string");
+    let int_to_string = format_box
+        .find("callee = @\"Int::to_string\"")
+        .expect("Box payload must be passed to Int::to_string");
+    let payload_recovery = format_box[..int_to_string]
+        .rfind("core.unrealized_conversion_cast")
+        .expect("erased Box payload must be recovered before Int::to_string");
     assert!(
-        construct < cast,
-        "logical generic construction must not use a cast as a control carrier before Box is built:\n{format_box}"
+        format_box[layout_cast..construct].contains(": tribute_rt.anyref"),
+        "generic Box field must be converted to its erased layout type before construction:\n{format_box}"
+    );
+    assert!(
+        format_box[payload_recovery..int_to_string].contains(": core.i32"),
+        "pattern use must recover the erased Box payload as Int before Int::to_string:\n{format_box}"
+    );
+    assert!(
+        layout_cast < construct && construct < payload_recovery && payload_recovery < int_to_string,
+        "generic Box construction and pattern use must cross distinct layout and recovery boundaries:\n{format_box}"
+    );
+}
+
+#[salsa_test]
+fn generic_result_constructor_boxes_int_for_its_specialized_layout(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "generic_result_constructor_int.trb",
+        r#"
+enum Result(a, e) {
+    Ok(a),
+    Error(e),
+}
+
+fn ok_int(value: Int) -> Result(Int, String) {
+    Ok(value)
+}
+"#,
+    );
+
+    let ir = run_ast_pipeline_with_ir(db, source);
+    let ok_int = ir
+        .split("tribute_control.func @ok_int")
+        .nth(1)
+        .expect("ok_int function must be lowered");
+    let construct = ok_int
+        .find("adt.variant_new")
+        .expect("generic Result constructor must construct Ok");
+    let cast = ok_int
+        .find("core.unrealized_conversion_cast")
+        .expect("generic Result field must be explicitly converted to its erased layout type");
+    assert!(
+        ok_int[cast..construct].contains(": tribute_rt.anyref"),
+        "generic Result field must be converted to the resolved erased layout type:\n{ok_int}"
+    );
+    assert!(
+        cast < construct,
+        "logical generic construction must convert its Int field before adt.variant_new:\n{ok_int}"
+    );
+}
+
+#[salsa_test]
+fn concrete_constructor_does_not_insert_a_redundant_cast(db: &salsa::DatabaseImpl) {
+    let source = SourceCst::from_source_str(
+        db,
+        "concrete_constructor_int.trb",
+        r#"
+enum IntBox {
+    IntBox(Int),
+}
+
+fn box_int(value: Int) -> IntBox {
+    IntBox(value)
+}
+"#,
+    );
+
+    let ir = run_ast_pipeline_with_ir(db, source);
+    let box_int = ir
+        .split("tribute_control.func @box_int")
+        .nth(1)
+        .expect("box_int function must be lowered");
+    assert!(box_int.contains("adt.variant_new"), "{box_int}");
+    assert!(
+        !box_int.contains("core.unrealized_conversion_cast"),
+        "already-matching concrete constructor fields must not be converted:\n{box_int}"
     );
 }
 


### PR DESCRIPTION
## Summary

Independent prerequisite for #825. Source-logical constructor lowering now materializes operands to the resolved enum-layout field types before adt.variant_new. It reuses the fail-closed variant/arity validation and conversion helper, preserving source argument order.

## Regression coverage

- Generic Boxed(Int): verifies i32-to-anyref materialization before construction and anyref-to-i32 recovery before Int::to_string.
- Generic Result(Int, String)::Ok: verifies i32-to-anyref materialization before adt.variant_new.
- Concrete IntBox(Int): verifies matching fields introduce no redundant conversion.

## Validation

- Three focused tribute-front regressions
- cargo nextest run -p tribute-front (626 passed)
- cargo nextest run --workspace (2037 passed; 1 leaky, 1 skipped)
- cargo clippy -p tribute-front --all-targets -- -D warnings
- cargo fmt --all --check
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved construction of generic data variants by correctly converting values to their specialized field types.
  - Fixed generic boxed integer and result constructors to preserve values through construction and pattern matching.
  - Prevented unnecessary type conversions in concrete constructors, improving generated operations and consistency.

- **Tests**
  - Added coverage for generic boxed values, generic result constructors, and concrete constructors without redundant conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->