### PR TITLE
refactor(ir): move shared function signature to func.func_sig

### DIFF
--- a/crates/tribute-core/src/calling_convention.rs
+++ b/crates/tribute-core/src/calling_convention.rs
@@ -2,7 +2,7 @@
 
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::core;
+use trunk_ir::dialect::{core, func};
 use trunk_ir::ops::DialectType;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::types::{Attribute, TypeDataBuilder};
@@ -89,7 +89,7 @@ pub fn get_calling_convention(ctx: &IrContext, op: OpRef) -> Option<CallingConve
 /// Result-indexed CPS completion target `Done<R>`.
 pub fn cps_done_type(ctx: &mut IrContext, result: TypeRef) -> TypeRef {
     let never = core::never(ctx).as_type_ref();
-    let function = core::func(ctx, [result], [never]).as_type_ref();
+    let function = func::func_sig(ctx, [result], [never]).as_type_ref();
     generated_cps_closure_type(ctx, function)
 }
 
@@ -155,7 +155,7 @@ pub fn cps_completion_type(
     frame: TypeRef,
 ) -> TypeRef {
     let never = core::never(ctx).as_type_ref();
-    let function = core::func(ctx, [evidence, frame, value], [never]).as_type_ref();
+    let function = func::func_sig(ctx, [evidence, frame, value], [never]).as_type_ref();
     generated_cps_closure_type(ctx, function)
 }
 
@@ -189,7 +189,7 @@ pub fn cps_dispatch_type(
 ) -> TypeRef {
     let never = core::never(ctx).as_type_ref();
     let resume = cps_resume_type(ctx, evidence, frame, anyref);
-    let function = core::func(
+    let function = func::func_sig(
         ctx,
         [evidence, resume, i32_type, i32_type, i32_type, anyref],
         [never],
@@ -198,7 +198,7 @@ pub fn cps_dispatch_type(
     physical_closure_type(ctx, function, CallingConvention::Cps)
 }
 
-/// Return the underlying exact `core.func` only for a provenance-bearing CPS closure.
+/// Return the underlying exact `func.func_sig` only for a provenance-bearing CPS closure.
 ///
 /// Callers must reject absent or malformed outer closure provenance rather than infer a
 /// callable contract from a structurally similar type.
@@ -206,7 +206,7 @@ pub fn cps_closure_function_type(ctx: &IrContext, closure: TypeRef) -> Option<Ty
     physical_closure_function_type(ctx, closure, CallingConvention::Cps)
 }
 
-/// Return the exact `core.func` contract only for a provenance-bearing physical closure
+/// Return the exact `func.func_sig` contract only for a provenance-bearing physical closure
 /// with the requested convention.
 ///
 /// The result comes from the closure type's explicit callable contract, never from
@@ -223,7 +223,7 @@ pub fn physical_closure_function_type(
     let [function] = ctx.types.get(closure).params.as_slice() else {
         return None;
     };
-    let callable = core::Func::from_type_ref(ctx, *function)?;
+    let callable = func::FuncSig::from_type_ref(ctx, *function)?;
     let argument_count = callable.inputs(ctx).len();
     (environment_index <= argument_count).then_some(*function)
 }
@@ -330,7 +330,7 @@ mod tests {
     fn physical_closure_convention_is_exact_type_identity() {
         let mut ctx = IrContext::new();
         let never = trunk_ir::dialect::core::never(&mut ctx).as_type_ref();
-        let function = trunk_ir::dialect::core::func(&mut ctx, [], [never]).as_type_ref();
+        let function = trunk_ir::dialect::func::func_sig(&mut ctx, [], [never]).as_type_ref();
         let direct = physical_closure_type(&mut ctx, function, CallingConvention::Direct);
         let cps = physical_closure_type(&mut ctx, function, CallingConvention::Cps);
 
@@ -434,7 +434,7 @@ mod tests {
     fn continuation_frame_and_cps_closure_readers_fail_closed_on_malformed_metadata() {
         let mut ctx = IrContext::new();
         let never = core::never(&mut ctx).as_type_ref();
-        let function = core::func(&mut ctx, [], [never]).as_type_ref();
+        let function = func::func_sig(&mut ctx, [], [never]).as_type_ref();
         let missing_environment = ctx.types.intern(
             TypeDataBuilder::new(Symbol::new("closure"), Symbol::new("closure"))
                 .param(function)

--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -11,7 +11,7 @@ use tribute_ir::dialect::tribute_rt;
 use trunk_ir::Symbol;
 use trunk_ir::SymbolVec;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::core;
+use trunk_ir::dialect::{core, func};
 use trunk_ir::ops::DialectType as _;
 use trunk_ir::refs::{BlockRef, PathRef, TypeRef, ValueRef};
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
@@ -906,11 +906,11 @@ impl<'db> IrLoweringCtx<'db> {
         tribute_rt::anyref(ir).as_type_ref()
     }
 
-    /// Create a `core.func` type with params and result.
+    /// Create a `func.func_sig` type with params and result.
     ///
-    /// Construct an input-first, one-result `core.func`.
+    /// Construct an input-first, one-result `func.func_sig`.
     pub fn func_type(&self, ir: &mut IrContext, params: &[TypeRef], result: TypeRef) -> TypeRef {
-        core::func(ir, params.iter().copied(), [result]).as_type_ref()
+        func::func_sig(ir, params.iter().copied(), [result]).as_type_ref()
     }
 
     /// Create a `core.ability_ref` type.
@@ -1089,14 +1089,14 @@ impl<'db> IrLoweringCtx<'db> {
         )
     }
 
-    /// Check if a type is a `core.func` type.
+    /// Check if a type is a `func.func_sig` type.
     pub fn is_func_type(&self, ir: &IrContext, ty: TypeRef) -> bool {
-        core::Func::from_type_ref(ir, ty).is_some()
+        func::FuncSig::from_type_ref(ir, ty).is_some()
     }
 
-    /// Get the input count from a validated `core.func` type.
+    /// Get the input count from a validated `func.func_sig` type.
     pub fn func_type_param_count(&self, ir: &IrContext, ty: TypeRef) -> usize {
-        core::Func::from_type_ref(ir, ty)
+        func::FuncSig::from_type_ref(ir, ty)
             .map(|function| function.inputs(ir).len())
             .unwrap_or(0)
     }
@@ -1189,7 +1189,7 @@ mod tests {
             HashMap::new(),
         );
         let i32_ty = ctx.i32_type(&mut ir);
-        let resultless = core::func(&mut ir, [i32_ty, i32_ty], []).as_type_ref();
+        let resultless = func::func_sig(&mut ir, [i32_ty, i32_ty], []).as_type_ref();
 
         assert!(ctx.is_func_type(&ir, resultless));
         assert_eq!(ctx.func_type_param_count(&ir, resultless), 2);
@@ -1300,7 +1300,7 @@ mod tests {
 
     /// The logical frontend boundary has its own recursive conversion: source
     /// callables, bottom values, resumptions, tuple layouts, and forward
-    /// nominals must never fall back to the physical `core.func` carrier.
+    /// nominals must never fall back to the physical `func.func_sig` carrier.
     #[test]
     fn test_convert_logical_types_preserves_recursive_control_shapes() {
         let db = test_db();
@@ -1591,7 +1591,7 @@ mod tests {
         );
         let ir_ty = ctx.convert_type(&mut ir, ty);
 
-        // BoundVar params/result → tribute_rt.any, wrapped in core.func
+        // BoundVar params/result → tribute_rt.any, wrapped in func.func_sig
         let any_ty = ctx.anyref_type(&mut ir);
         let expected = ctx.func_type(&mut ir, &[any_ty], any_ty);
         assert_eq!(ir_ty, expected);

--- a/crates/tribute-front/src/ast_to_ir/lower/case.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/case.rs
@@ -559,7 +559,7 @@ pub(super) fn emit_pattern_check<'db>(
 ///
 /// This intentionally does not call the physical tuple/list helpers above:
 /// their layouts use `convert_type`, which represents callable values as
-/// `core.func`.  Keep legacy lowering on those helpers and make the logical
+/// `func.func_sig`.  Keep legacy lowering on those helpers and make the logical
 /// boundary select its own recursively converted aggregate layouts.
 pub(super) fn emit_logical_pattern_check<'db>(
     builder: &mut IrBuilder<'_, 'db>,
@@ -1495,7 +1495,7 @@ pub(super) fn bind_pattern_fields<'db>(
 
 /// Logical counterpart to [`bind_pattern_fields`].  Tuple and list extraction
 /// must preserve recursively logical element types; using the legacy helper
-/// would create `core.func` fields before the shared CPS boundary.
+/// would create `func.func_sig` fields before the shared CPS boundary.
 pub(super) fn bind_logical_pattern_fields<'db>(
     ctx: &mut IrLoweringCtx<'db>,
     ir: &mut IrContext,

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -29,7 +29,7 @@ fn assert_logical_boundary(ir: &str) {
         "ability.handle",
         "effect.",
         "__tribute_cps_control",
-        "core.func",
+        "func.func_sig",
     ] {
         assert!(
             !ir.contains(forbidden),
@@ -470,7 +470,7 @@ pub mod Nested {
     );
     assert!(
         ir_text.contains("tribute_control.callable(core.i32, core.i32)")
-            && !ir_text.contains("core.func"),
+            && !ir_text.contains("func.func_sig"),
         "nested callable fields must remain source-logical:\n{ir_text}"
     );
 }
@@ -1528,7 +1528,7 @@ fn run() ->{Trace} Pair {
 }
 
 /// Logical aggregate construction and matching must preserve callable fields
-/// recursively; no physical `core.func` carrier may enter tuple/list layouts.
+/// recursively; no physical `func.func_sig` carrier may enter tuple/list layouts.
 #[salsa_test]
 fn logical_callable_tuple_and_list_layouts_remain_distinct(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -1600,14 +1600,14 @@ fn from_list(callback: fn(Int) -> Int) -> Int {
         "length-delimited logical keys must not alias delimiter-sensitive tuple shapes:\n{ir}"
     );
     assert!(
-        !ir.contains("core.func"),
-        "callable aggregate layouts must not use physical core.func:\n{ir}"
+        !ir.contains("func.func_sig"),
+        "callable aggregate layouts must not use physical func.func_sig:\n{ir}"
     );
 }
 
 /// Nominal logical layouts must share the same recursive callable conversion:
 /// generated field accessors, enum construction, and enum pattern extraction
-/// cannot reintroduce a physical `core.func` field.
+/// cannot reintroduce a physical `func.func_sig` field.
 #[salsa_test]
 fn logical_nominal_callable_fields_use_control_callables(db: &salsa::DatabaseImpl) {
     let source = SourceCst::from_source_str(
@@ -1641,7 +1641,7 @@ fn inspect(choice: Choice, fallback: fn(Int) -> Int) -> fn(Int) -> Int {
         "nested callable variant patterns must stay in the logical aggregate dialect:\n{inspect}"
     );
     assert!(inspect.contains("-> !t"));
-    assert!(!ir.contains("core.func"));
+    assert!(!ir.contains("func.func_sig"));
 }
 
 /// Callable list patterns use the source-logical list layout through exact,
@@ -1671,7 +1671,7 @@ fn first_or(values: List(fn(Int) -> Int), fallback: fn(Int) -> Int) -> fn(Int) -
             && ir.contains("tribute_control.callable(core.i32, core.i32)"),
         "callable list pattern extraction must retain its logical element type:\n{first_or}"
     );
-    assert!(!first_or.contains("core.func"));
+    assert!(!first_or.contains("func.func_sig"));
 }
 
 /// Nonempty list and tuple pattern checks both extract callable values through
@@ -1714,7 +1714,7 @@ fn choose_pair(pair: #(fn(Int) -> Int, Bool), fallback: fn(Int) -> Int) -> fn(In
             && tuple_case.contains("scf.if"),
         "callable tuple pattern check must stay in logical aggregate IR:\n{tuple_case}"
     );
-    assert!(!ir.contains("core.func"));
+    assert!(!ir.contains("func.func_sig"));
 }
 
 /// Multi-field variants and exact list literals retain each nested pattern

--- a/crates/tribute-ir/src/dialect/closure.rs
+++ b/crates/tribute-ir/src/dialect/closure.rs
@@ -76,13 +76,13 @@ fn print_closure_lambda(
     write!(h, ")")?;
 
     // "-> return_type"
-    // Decompose: result type = closure.closure<core.func<(inputs...) -> result>>
+    // Decompose: result type = closure.closure<func.func_sig<(inputs...) -> result>>
     let return_ty = {
         let result_ty = h.ctx().op_result_types(op)[0];
         let closure_ty_data = h.ctx().types.get(result_ty);
         if !closure_ty_data.params.is_empty() {
             let func_ty = closure_ty_data.params[0];
-            trunk_ir::dialect::core::Func::from_type_ref(h.ctx(), func_ty)
+            trunk_ir::dialect::func::FuncSig::from_type_ref(h.ctx(), func_ty)
                 .and_then(|function| function.single_result(h.ctx()))
         } else {
             None
@@ -214,7 +214,7 @@ fn parse_closure_lambda<'a>(
         regions.push(region);
     }
 
-    // Reconstruct closure.closure<core.func<(param_types...) -> return_ty>> type.
+    // Reconstruct closure.closure<func.func_sig<(param_types...) -> return_ty>> type.
     let param_raw_types: Vec<RawType<'a>> = params.iter().map(|(_, ty)| ty.clone()).collect();
 
     let func_raw_ty = RawType::Function {
@@ -223,7 +223,7 @@ fn parse_closure_lambda<'a>(
         attrs: vec![],
     };
 
-    // closure.closure<core.func<...>>
+    // closure.closure<func.func_sig<...>>
     let closure_raw_ty = RawType::Concrete {
         dialect: "closure",
         name: "closure",
@@ -260,7 +260,7 @@ impl trunk_ir::op_interface::CallableOwnerModel for Lambda {
     fn callable_signature(
         self,
         ctx: &trunk_ir::IrContext,
-    ) -> Option<trunk_ir::dialect::core::Func> {
+    ) -> Option<trunk_ir::dialect::func::FuncSig> {
         use trunk_ir::ops::DialectType;
         let [result] = ctx.op_result_types(self.op_ref()) else {
             return None;
@@ -269,7 +269,7 @@ impl trunk_ir::op_interface::CallableOwnerModel for Lambda {
         let [function] = ctx.types.get(closure.as_type_ref()).params.as_slice() else {
             return None;
         };
-        trunk_ir::dialect::core::Func::from_type_ref(ctx, *function)
+        trunk_ir::dialect::func::FuncSig::from_type_ref(ctx, *function)
     }
 }
 inventory::submit! { trunk_ir::op_interface::CallableOwnerOps::register::<Lambda>() }
@@ -639,7 +639,7 @@ mod malformed_owner_tests {
             let mut ctx = trunk_ir::IrContext::new();
             let input = "core.module @m {
           func.func @host() -> core.never {
-            %lambda = closure.lambda(%k: core.func<() -> core.never>) -> core.never [] {
+            %lambda = closure.lambda(%k: func.func_sig<() -> core.never>) -> core.never [] {
               func.tail_call_indirect %k
             }
             func.unreachable
@@ -678,7 +678,7 @@ mod callable_owner_regressions {
                 "core.module @m {{
               func.func @host() {{
                 %outer = closure.lambda() -> core.i32 [] {{
-                  %inner = closure.lambda(%k: core.func<() -> {callee_result}>) -> core.never [] {{
+                  %inner = closure.lambda(%k: func.func_sig<() -> {callee_result}>) -> core.never [] {{
                     func.tail_call_indirect %k
                   }}
                   %v = arith.const {{value = 0}} : core.i32

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -793,7 +793,7 @@ fn contains_forbidden_logical_component(
         return true;
     }
     let data = ctx.types.get(ty);
-    let forbidden = (data.dialect == Symbol::new("core") && data.name == Symbol::new("func"))
+    let forbidden = (data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig"))
         || (data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure"))
         || ResumeToken::matches(ctx, ty)
         || is_unresolved_type(ctx, ty)
@@ -4651,7 +4651,7 @@ mod tests {
     fn resume_token_components_are_checked_recursively() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !physical = core.func(core.i32)
+  !physical = func.func_sig<() -> core.i32>
   !wrapper = core.tuple(!physical)
   !token = tribute_control.resume_token(!wrapper, core.i32)
 }"#,

--- a/crates/tribute-passes/src/backend_ready.rs
+++ b/crates/tribute-passes/src/backend_ready.rs
@@ -12,7 +12,7 @@ use std::ops::ControlFlow;
 use tribute_core::{CallingConvention, get_calling_convention};
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::ops::DialectType;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::Module;
@@ -193,13 +193,14 @@ impl<'ctx> RecursiveLegalityWalker<'ctx> {
                 data.dialect, data.name
             )));
         }
-        let is_function = data.dialect == Symbol::new("core") && data.name == Symbol::new("func");
+        let is_function =
+            data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig");
         if is_function {
-            let Some(function) = core::Func::from_type_ref(self.ctx, ty) else {
-                return Err(self.error(format!("malformed `core.func` type in {where_}")));
+            let Some(function) = func::FuncSig::from_type_ref(self.ctx, ty) else {
+                return Err(self.error(format!("malformed `func.func_sig` type in {where_}")));
             };
             let Some(result) = function.single_result(self.ctx) else {
-                return Err(self.error(format!("`core.func` has no result type in {where_}")));
+                return Err(self.error(format!("`func.func_sig` has no result type in {where_}")));
             };
             self.verify_type(result, TypeSurface::Result, "function result")?;
             for &parameter in function.inputs(self.ctx) {
@@ -271,7 +272,7 @@ impl<'ctx> RecursiveLegalityWalker<'ctx> {
                 .attributes
                 .get_type("type")
                 .ok_or_else(|| self.error("Cps function has no signature"))?;
-            let signature = core::Func::from_type_ref(self.ctx, signature);
+            let signature = func::FuncSig::from_type_ref(self.ctx, signature);
             if signature
                 .and_then(|function| function.single_result(self.ctx))
                 .is_none_or(|result| !is_core_type(self.ctx, result, "nil"))
@@ -320,7 +321,7 @@ fn type_is_legal(
 ) -> bool {
     match surface {
         TypeSurface::Signature => {
-            data.dialect == Symbol::new("core") && data.name == Symbol::new("func")
+            data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig")
         }
         TypeSurface::Value => target_value_type(backend, data),
         TypeSurface::Result => {
@@ -343,9 +344,10 @@ fn target_value_type(backend: TributeBackend, data: &trunk_ir::types::TypeData) 
                 data.dialect,
                 data.name,
                 &[
-                    "nil", "i1", "i32", "i64", "f32", "f64", "bytes", "ptr", "array", "func",
+                    "nil", "i1", "i32", "i64", "f32", "f64", "bytes", "ptr", "array",
                 ],
-            ) || adt_type_is(data)
+            ) || func_sig_type_is(data)
+                || adt_type_is(data)
                 || wasm_reference_type(data.dialect, data.name)
         }
     }
@@ -356,11 +358,15 @@ fn target_metadata_type(backend: TributeBackend, data: &trunk_ir::types::TypeDat
         data.dialect,
         data.name,
         &[
-            "func", "nil", "i1", "i8", "i16", "i32", "i64", "f32", "f64", "ptr", "bytes", "ref",
-            "array",
+            "nil", "i1", "i8", "i16", "i32", "i64", "f32", "f64", "ptr", "bytes", "ref", "array",
         ],
-    ) || adt_type_is(data)
+    ) || func_sig_type_is(data)
+        || adt_type_is(data)
         || (backend == TributeBackend::Wasm && wasm_reference_type(data.dialect, data.name))
+}
+
+fn func_sig_type_is(data: &trunk_ir::types::TypeData) -> bool {
+    data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig")
 }
 
 fn core_type_is(dialect: Symbol, name: Symbol, names: &[&str]) -> bool {
@@ -403,6 +409,7 @@ fn is_core_type(ctx: &IrContext, ty: TypeRef, expected: &str) -> bool {
 mod tests {
     use super::*;
     use trunk_ir::parser::parse_test_module;
+    use trunk_ir::types::TypeDataBuilder;
 
     fn verify(ir: &str, backend: TributeBackend) -> Result<(), String> {
         let mut ctx = IrContext::new();
@@ -428,7 +435,7 @@ mod tests {
             let op = module.ops(&ctx)[0];
             let ty = ctx.op(op).attributes.get_type("type").unwrap();
             let mut malformed = ctx.types.get(ty).clone();
-            malformed.attrs.remove(core::NUM_RESULTS_ATTR);
+            malformed.attrs.remove(func::NUM_RESULTS_ATTR);
             let malformed = ctx.types.intern(malformed);
             ctx.op_mut(op)
                 .attributes
@@ -440,11 +447,68 @@ mod tests {
             }
             .unwrap_err();
             assert!(
-                error.to_string().contains("malformed `core.func`"),
+                error.to_string().contains("malformed `func.func_sig`"),
                 "{error}"
             );
             assert_eq!(trunk_ir::printer::print_module(&ctx, module.op()), before);
         }
+    }
+
+    #[test]
+    fn shared_func_sig_replaces_core_func_on_value_and_metadata_surfaces() {
+        let mut ctx = IrContext::new();
+        let shared = func::func_sig(&mut ctx, [], []).as_type_ref();
+        let retired = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func")).build());
+
+        assert!(type_is_legal(
+            TributeBackend::Wasm,
+            TypeSurface::Value,
+            ctx.types.get(shared)
+        ));
+        assert!(!type_is_legal(
+            TributeBackend::Wasm,
+            TypeSurface::Value,
+            ctx.types.get(retired)
+        ));
+        for backend in [TributeBackend::Native, TributeBackend::Wasm] {
+            assert!(type_is_legal(
+                backend,
+                TypeSurface::Metadata,
+                ctx.types.get(shared)
+            ));
+            assert!(!type_is_legal(
+                backend,
+                TypeSurface::Metadata,
+                ctx.types.get(retired)
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_retired_core_func_nested_in_reachable_metadata() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            "core.module @m { wasm.func @main() -> core.nil { wasm.return } }",
+        );
+        let retired = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func")).build());
+        let nested = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("array"))
+                .params([retired])
+                .build(),
+        );
+        ctx.op_mut(module.op())
+            .attributes
+            .insert(Symbol::new("metadata"), Attribute::Type(nested));
+
+        let error = verify_wasm_backend_ready(&ctx, module)
+            .expect_err("retired core.func must not cross the backend boundary")
+            .to_string();
+        assert!(error.contains("core.func"), "{error}");
     }
 
     #[test]
@@ -517,8 +581,8 @@ mod tests {
     #[test]
     fn rejects_illegal_types_nested_in_callable_signatures() {
         for signature in [
-            "core.func(core.ref(core.ptr))",
-            "core.func(core.nil, core.ref(core.ptr))",
+            "func.func_sig<() -> core.ref(core.ptr)>",
+            "func.func_sig<(core.ref(core.ptr)) -> core.nil>",
         ] {
             let ir = format!(
                 r#"core.module @test {{
@@ -613,7 +677,7 @@ mod tests {
         ] {
             let ir = format!(
                 r#"core.module @test {{
-  clif.func {{sym_name = @main, tribute.calling_convention = {convention}, type = core.func(core.i32)}} {{
+  clif.func {{sym_name = @main, tribute.calling_convention = {convention}, type = func.func_sig<() -> core.i32>}} {{
     ^entry:
     %zero = clif.iconst {{value = 0}} : core.i32
     clif.return %zero

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -84,7 +84,7 @@ pub(crate) fn is_closure_struct_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
 // Rewrite Patterns
 // ============================================================================
 
-/// Update function signatures to convert `core.func` params to `closure.closure`.
+/// Update function signatures to convert `func.func_sig` params to `closure.closure`.
 struct UpdateFuncSignatureArena;
 
 impl RewritePattern for UpdateFuncSignatureArena {
@@ -99,7 +99,7 @@ impl RewritePattern for UpdateFuncSignatureArena {
         };
 
         let func_ty = func_op.r#type(ctx);
-        let Some(signature) = core::Func::from_type_ref(ctx, func_ty) else {
+        let Some(signature) = func::FuncSig::from_type_ref(ctx, func_ty) else {
             return false;
         };
         let Some(return_ty) = signature.single_result(ctx) else {
@@ -111,8 +111,8 @@ impl RewritePattern for UpdateFuncSignatureArena {
         let mut new_params = Vec::with_capacity(params.len());
 
         for &param_ty in &params {
-            if core::Func::matches(ctx, param_ty) {
-                // Convert core.func to closure.closure wrapping the func type
+            if func::FuncSig::matches(ctx, param_ty) {
+                // Convert func.func_sig to closure.closure wrapping the func type
                 let closure_ty = closure::closure(ctx, param_ty).as_type_ref();
                 new_params.push(closure_ty);
                 needs_update = true;
@@ -127,10 +127,10 @@ impl RewritePattern for UpdateFuncSignatureArena {
 
         // Build new func type
         let mut type_attrs = ctx.types.get(func_ty).attrs.clone();
-        type_attrs.remove(core::NUM_INPUTS_ATTR);
-        type_attrs.remove(core::NUM_RESULTS_ATTR);
+        type_attrs.remove(func::NUM_INPUTS_ATTR);
+        type_attrs.remove(func::NUM_RESULTS_ATTR);
         let new_func_ty =
-            core::func_with_attrs(ctx, new_params.iter().copied(), [return_ty], type_attrs)
+            func::func_sig_with_attrs(ctx, new_params.iter().copied(), [return_ty], type_attrs)
                 .as_type_ref();
 
         // Rebuild the function with new type
@@ -228,7 +228,7 @@ impl RewritePattern for LowerClosureCallArena {
         } else if is_closure_struct_type_ref(ctx, callee_ty) {
             // Already lowered closure struct
             true
-        } else if core::Func::matches(ctx, callee_ty) {
+        } else if func::FuncSig::matches(ctx, callee_ty) {
             !matches!(
                 ctx.value_def(callee),
                 trunk_ir::refs::ValueDef::OpResult(defining_op, _)
@@ -323,7 +323,7 @@ impl RewritePattern for LowerClosureCallArena {
             .as_ref()
             .map(|contract| contract.signature)
             .unwrap_or_else(|| {
-                core::func(
+                func::func_sig(
                     ctx,
                     new_args
                         .iter()
@@ -496,7 +496,7 @@ fn exact_physical_call_contract(
     let closure_ty = physical_closure_type_for_callee(ctx, callee)?;
     (get_physical_closure_convention(ctx, closure_ty) == Some(convention)).then_some(())?;
     let function = closure::Closure::from_type_ref(ctx, closure_ty)?.func_type(ctx);
-    let callable = core::Func::from_type_ref(ctx, function)?;
+    let callable = func::FuncSig::from_type_ref(ctx, function)?;
     if callable.results(ctx) != [result] || callable.inputs(ctx).len() != args.len() {
         return None;
     }
@@ -524,11 +524,11 @@ fn exact_physical_call_contract(
     let mut params = callable.inputs(ctx).to_vec();
     params.insert(environment_index, environment);
     let mut type_attrs = ctx.types.get(function).attrs.clone();
-    type_attrs.remove(core::NUM_INPUTS_ATTR);
-    type_attrs.remove(core::NUM_RESULTS_ATTR);
+    type_attrs.remove(func::NUM_INPUTS_ATTR);
+    type_attrs.remove(func::NUM_RESULTS_ATTR);
     Some(PhysicalCallContract {
         environment_index,
-        signature: core::func_with_attrs(ctx, params, [result], type_attrs).as_type_ref(),
+        signature: func::func_sig_with_attrs(ctx, params, [result], type_attrs).as_type_ref(),
         argument_casts: casts,
     })
 }
@@ -593,15 +593,15 @@ impl RewritePattern for LowerClosureEnvArena {
     }
 }
 
-/// Extract the single result type from a callee type (closure.closure or core.func).
+/// Extract the single result type from a callee type (closure.closure or func.func_sig).
 fn extract_return_type_from_callee(ctx: &IrContext, callee_ty: TypeRef) -> Option<TypeRef> {
     let data = ctx.types.get(callee_ty);
-    // closure.closure<core.func<(Inputs...) -> Result>>
+    // closure.closure<func.func_sig<(Inputs...) -> Result>>
     if data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure") {
         let func_ty = *data.params.first()?;
-        return core::Func::from_type_ref(ctx, func_ty)?.single_result(ctx);
+        return func::FuncSig::from_type_ref(ctx, func_ty)?.single_result(ctx);
     }
-    core::Func::from_type_ref(ctx, callee_ty)?.single_result(ctx)
+    func::FuncSig::from_type_ref(ctx, callee_ty)?.single_result(ctx)
 }
 
 fn evidence_param_for_func(ctx: &IrContext, func_op: func::Func) -> Option<ValueRef> {
@@ -698,7 +698,7 @@ pub fn lower_prepared_closures(ctx: &mut IrContext, module: Module) {
 
 /// Prepare module-level closure lowering state.
 ///
-/// This updates function signatures (`core.func` params → `closure.closure`) and
+/// This updates function signatures (`func.func_sig` params → `closure.closure`) and
 /// remains module-scoped because function signatures are interprocedural
 /// contracts.
 pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
@@ -974,7 +974,7 @@ mod tests {
             ctx,
             &format!(
                 r#"core.module @test {{
-  !closure = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !closure = closure.closure(func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>)
 
   func.func @callee(%ev: {ev_ty}, %env: tribute_rt.anyref, %arg: tribute_rt.anyref) -> tribute_rt.anyref {{
       func.return %arg
@@ -1046,7 +1046,7 @@ mod tests {
             ctx,
             &format!(
                 r#"core.module @test {{
-  !closure = closure.closure(core.func(tribute_rt.anyref, tribute_rt.anyref))
+  !closure = closure.closure(func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>)
 
   func.func @callee(%ev: {ev_ty}, %env: tribute_rt.anyref, %arg: tribute_rt.anyref) -> tribute_rt.anyref {{
       func.return %arg
@@ -1086,7 +1086,7 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @apply(%f: core.func(tribute_rt.anyref, tribute_rt.anyref), %arg: tribute_rt.anyref) -> tribute_rt.anyref {
+  func.func @apply(%f: func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>, %arg: tribute_rt.anyref) -> tribute_rt.anyref {
       %result = func.call_indirect %f, %arg : tribute_rt.anyref
       func.return %result
   }
@@ -1099,7 +1099,7 @@ mod tests {
 
         let ir = print_module(&ctx, module.op());
         assert!(
-            ir.contains("closure.closure(core.func<(tribute_rt.anyref) -> tribute_rt.anyref>)"),
+            ir.contains("closure.closure(func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>)"),
             "function-typed params should be prepared as closure params:\n{ir}"
         );
     }
@@ -1217,7 +1217,7 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  !closure = closure.closure(core.func(core.i32, core.i32)) {tribute.calling_convention = 0}
+  !closure = closure.closure(func.func_sig<(core.i32) -> core.i32>) {tribute.calling_convention = 0}
   !nested = core.tuple(!closure)
   func.func @run(%callback: !closure) -> !nested {
     %environment = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
@@ -1249,7 +1249,7 @@ mod tests {
         finalize_closure_storage_layout(&mut ctx, module);
 
         let physical = closure_struct_type_ref(&mut ctx);
-        let signature = core::Func::from_type_ref(&ctx, run.r#type(&ctx)).unwrap();
+        let signature = func::FuncSig::from_type_ref(&ctx, run.r#type(&ctx)).unwrap();
         assert_eq!(signature.inputs(&ctx), [physical]);
         assert_eq!(
             ctx.value_ty(ctx.block_args(ctx.region(run.body(&ctx)).blocks[0])[0]),
@@ -1308,9 +1308,9 @@ mod tests {
             &mut ctx,
             &format!(
                 r#"core.module @test {{
-  !cps = closure.closure(core.func(core.never, {ev}, core.i32, core.i32, core.i32)) {{tribute.calling_convention = 2, tribute.closure_environment_index = 1}}
+  !cps = closure.closure(func.func_sig<({ev}, core.i32, core.i32, core.i32) -> core.never>) {{tribute.calling_convention = 2, tribute.closure_environment_index = 1}}
   func.func @run(%callee: !cps, %evidence: {ev}, %done: core.i32, %dispatch: core.i32, %value: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
-    func.tail_call_indirect %callee, %evidence, %done, %dispatch, %value {{tribute.calling_convention = 2, signature = core.func(core.never, {ev}, core.i32, core.i32, core.i32)}}
+    func.tail_call_indirect %callee, %evidence, %done, %dispatch, %value {{tribute.calling_convention = 2, signature = func.func_sig<({ev}, core.i32, core.i32, core.i32) -> core.never>}}
   }}
 }}"#
             ),
@@ -1333,7 +1333,7 @@ mod tests {
             .unwrap();
         let signature =
             trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, tail).unwrap();
-        let callable = core::Func::from_type_ref(&ctx, signature).unwrap();
+        let callable = func::FuncSig::from_type_ref(&ctx, signature).unwrap();
         assert_eq!(ctx.op_operands(tail).len(), 6);
         assert_eq!(ctx.op_operands(tail)[1], evidence);
         assert_eq!(
@@ -1361,7 +1361,7 @@ mod tests {
             &mut ctx,
             &format!(
                 r#"core.module @test {{
-  !cps = closure.closure(core.func(core.never, {evidence}, core.i32)) {{tribute.calling_convention = 2}}
+  !cps = closure.closure(func.func_sig<({evidence}, core.i32) -> core.never>) {{tribute.calling_convention = 2}}
   func.func @callee(%evidence: {evidence}, %env: tribute_rt.anyref, %done: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
     func.unreachable
   }}
@@ -1406,7 +1406,7 @@ mod tests {
             r#"core.module @test {
   func.func @external(%value: core.i32) -> core.i32
   func.func @caller(%value: core.i32) -> core.i32 {
-    %callee = func.constant {func_ref = @external} : core.func(core.i32, core.i32)
+    %callee = func.constant {func_ref = @external} : func.func_sig<(core.i32) -> core.i32>
     %result = func.call_indirect %callee, %value : core.i32
     func.return %result
   }
@@ -1429,15 +1429,15 @@ mod tests {
             &format!(
                 r#"core.module @test {{
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {{name = @_closure}}
-  !expected = closure.closure(core.func(core.never, {evidence}, core.i32, core.i32)) {{tribute.calling_convention = 2}}
-  !actual = closure.closure(core.func(core.never, {evidence}, core.i32, core.bool)) {{tribute.calling_convention = 2}}
-  !outer = closure.closure(core.func(core.never, {evidence}, core.i32, !expected)) {{tribute.calling_convention = 2}}
+  !expected = closure.closure(func.func_sig<({evidence}, core.i32, core.i32) -> core.never>) {{tribute.calling_convention = 2}}
+  !actual = closure.closure(func.func_sig<({evidence}, core.i32, core.bool) -> core.never>) {{tribute.calling_convention = 2}}
+  !outer = closure.closure(func.func_sig<({evidence}, core.i32, !expected) -> core.never>) {{tribute.calling_convention = 2}}
 
   func.func @actual_fn(%evidence: {evidence}, %done: core.i32, %value: core.bool) -> core.never attributes {{tribute.calling_convention = 2}} {{
     func.unreachable
   }}
   func.func @run(%callee: !outer, %evidence: {evidence}, %done: core.i32) -> core.never attributes {{tribute.calling_convention = 2}} {{
-    %function = func.constant {{func_ref = @actual_fn}} : core.func(core.never, {evidence}, core.i32, core.bool)
+    %function = func.constant {{func_ref = @actual_fn}} : func.func_sig<({evidence}, core.i32, core.bool) -> core.never>
     %environment = adt.ref_null {{type = tribute_rt.anyref}} : tribute_rt.anyref
     %argument = adt.struct_new %function, %environment {{type = !_closure, tribute.closure_callable_type = !actual}} : !_closure
     func.tail_call_indirect %callee, %evidence, %done, %argument {{tribute.calling_convention = 2}}

--- a/crates/tribute-passes/src/evidence.rs
+++ b/crates/tribute-passes/src/evidence.rs
@@ -4,13 +4,13 @@
 
 use tribute_ir::dialect::ability;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{core, func};
+use trunk_ir::dialect::func;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
 
-/// Check if a `core.func` type has evidence as its first parameter.
+/// Check if a `func.func_sig` type has evidence as its first parameter.
 pub fn has_evidence_first_param(ctx: &IrContext, func_ty: TypeRef) -> bool {
-    let Some(function) = core::Func::from_type_ref(ctx, func_ty) else {
+    let Some(function) = func::FuncSig::from_type_ref(ctx, func_ty) else {
         return false;
     };
     function
@@ -19,14 +19,14 @@ pub fn has_evidence_first_param(ctx: &IrContext, func_ty: TypeRef) -> bool {
         .is_some_and(|&input| ability::is_evidence_type_ref(ctx, input))
 }
 
-/// Build a new `core.func` TypeRef with evidence prepended to params.
+/// Build a new `func.func_sig` TypeRef with evidence prepended to params.
 pub fn build_func_type_with_evidence(
     ctx: &mut IrContext,
     old_func_ty: TypeRef,
     ev_ty: TypeRef,
 ) -> TypeRef {
-    let function = core::Func::from_type_ref(ctx, old_func_ty)
-        .expect("build_func_type_with_evidence requires a valid core.func type");
+    let function = func::FuncSig::from_type_ref(ctx, old_func_ty)
+        .expect("build_func_type_with_evidence requires a valid func.func_sig type");
     let results = function.results(ctx).to_vec();
     let old_params = function.inputs(ctx);
     let type_attrs = function
@@ -38,7 +38,7 @@ pub fn build_func_type_with_evidence(
     new_params.push(ev_ty);
     new_params.extend_from_slice(old_params);
 
-    core::func_with_attrs(ctx, new_params, results, type_attrs).as_type_ref()
+    func::func_sig_with_attrs(ctx, new_params, results, type_attrs).as_type_ref()
 }
 
 /// Find the evidence value from the enclosing `func.func`'s entry block.
@@ -67,6 +67,7 @@ pub fn find_enclosing_evidence(ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trunk_ir::dialect::core;
     use trunk_ir::{Attribute, AttributeMap, Symbol};
 
     #[test]
@@ -81,10 +82,10 @@ mod tests {
             let attrs =
                 AttributeMap::from_iter([(Symbol::new("metadata"), Attribute::Type(i32_ty))]);
             let source =
-                core::func_with_attrs(&mut ctx, [i32_ty], results.clone(), attrs).as_type_ref();
+                func::func_sig_with_attrs(&mut ctx, [i32_ty], results.clone(), attrs).as_type_ref();
             assert!(!has_evidence_first_param(&ctx, source));
             let converted = build_func_type_with_evidence(&mut ctx, source, evidence);
-            let function = core::Func::from_type_ref(&ctx, converted).unwrap();
+            let function = func::FuncSig::from_type_ref(&ctx, converted).unwrap();
             assert_eq!(function.inputs(&ctx), [evidence, i32_ty]);
             assert_eq!(function.results(&ctx), results);
             assert_eq!(

--- a/crates/tribute-passes/src/intrinsic_to_arith.rs
+++ b/crates/tribute-passes/src/intrinsic_to_arith.rs
@@ -289,8 +289,8 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
 
         // All mapped intrinsics are binary (lhs, rhs) -> result.
         // This will panic if a non-binary intrinsic is ever added to the map.
-        let function = core::Func::from_type_ref(ctx, func_ty)
-            .expect("mapped intrinsic declaration must have a valid core.func type");
+        let function = func::FuncSig::from_type_ref(ctx, func_ty)
+            .expect("mapped intrinsic declaration must have a valid func.func_sig type");
         let Some(return_ty) = function.single_result(ctx) else {
             return false;
         };
@@ -345,7 +345,7 @@ impl RewritePattern for ArithIntrinsicFuncDeclPattern {
 }
 
 fn exact_signature(ctx: &IrContext, ty: TypeRef, symbol: Symbol, mapping: &ArithMapping) -> bool {
-    let Some(function) = core::Func::from_type_ref(ctx, ty) else {
+    let Some(function) = func::FuncSig::from_type_ref(ctx, ty) else {
         return false;
     };
     let [left, right] = function.inputs(ctx) else {

--- a/crates/tribute-passes/src/list_intrinsics.rs
+++ b/crates/tribute-passes/src/list_intrinsics.rs
@@ -58,19 +58,21 @@ impl Pass for LowerListIntrinsics {
                 && ctx.op(op).attributes.get_symbol(COMPILER_INTRINSIC_ATTR)
                     == Some(Symbol::new(PREPEND_INTRINSIC))
                 && {
-                    core::Func::from_type_ref(ctx, function.r#type(ctx)).is_some_and(|signature| {
-                        let [element, tail] = signature.inputs(ctx) else {
-                            return false;
-                        };
-                        let Some(result) = signature.single_result(ctx) else {
-                            return false;
-                        };
-                        [result, *element, *tail].into_iter().all(|ty| {
-                            let data = ctx.types.get(ty);
-                            data.dialect == Symbol::new("tribute_rt")
-                                && data.name == Symbol::new("anyref")
-                        })
-                    })
+                    func::FuncSig::from_type_ref(ctx, function.r#type(ctx)).is_some_and(
+                        |signature| {
+                            let [element, tail] = signature.inputs(ctx) else {
+                                return false;
+                            };
+                            let Some(result) = signature.single_result(ctx) else {
+                                return false;
+                            };
+                            [result, *element, *tail].into_iter().all(|ty| {
+                                let data = ctx.types.get(ty);
+                                data.dialect == Symbol::new("tribute_rt")
+                                    && data.name == Symbol::new("anyref")
+                            })
+                        },
+                    )
                 }
             {
                 intrinsic_declarations.eligible.insert(name);

--- a/crates/tribute-passes/src/lower_closure_lambda.rs
+++ b/crates/tribute-passes/src/lower_closure_lambda.rs
@@ -177,7 +177,7 @@ fn lower_single_lambda(
     else {
         return false;
     };
-    let Some(callable) = core::Func::from_type_ref(ctx, function_ty) else {
+    let Some(callable) = func::FuncSig::from_type_ref(ctx, function_ty) else {
         return false;
     };
     let Some(func_result_ty) = callable.single_result(ctx) else {
@@ -233,9 +233,9 @@ fn lower_single_lambda(
         all_param_tys.insert(0, ability::evidence_adt_type_ref(ctx));
     }
     let mut type_attrs = ctx.types.get(function_ty).attrs.clone();
-    type_attrs.remove(core::NUM_INPUTS_ATTR);
-    type_attrs.remove(core::NUM_RESULTS_ATTR);
-    let func_ty = core::func_with_attrs(
+    type_attrs.remove(func::NUM_INPUTS_ATTR);
+    type_attrs.remove(func::NUM_RESULTS_ATTR);
+    let func_ty = func::func_sig_with_attrs(
         ctx,
         all_param_tys.iter().copied(),
         [func_result_ty],
@@ -618,8 +618,8 @@ mod tests {
             parent_op: None,
         });
 
-        // closure type: closure.closure<core.func<i32, i32>>
-        let func_ty = core::func(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
+        // closure type: closure.closure<func.func_sig<i32, i32>>
+        let func_ty = func::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
         let closure_ty =
             tribute_core::physical_closure_type(&mut ctx, func_ty, CallingConvention::Direct);
 
@@ -648,7 +648,7 @@ mod tests {
             parent_op: None,
         });
         let outer_func_ty =
-            core::func(&mut ctx, std::iter::empty::<TypeRef>(), [anyref_ty]).as_type_ref();
+            func::func_sig(&mut ctx, std::iter::empty::<TypeRef>(), [anyref_ty]).as_type_ref();
         let outer_func = func::func(
             &mut ctx,
             loc,
@@ -688,7 +688,7 @@ mod tests {
 
         // Direct lifted function has only the physical environment and source arg.
         let lifted_ty = lifted.r#type(&ctx);
-        let lifted_type = core::Func::from_type_ref(&ctx, lifted_ty).unwrap();
+        let lifted_type = func::FuncSig::from_type_ref(&ctx, lifted_ty).unwrap();
         assert_eq!(lifted_type.inputs(&ctx).len(), 2); // environment + x
         assert!(lifted_type.single_result(&ctx).is_some());
     }
@@ -730,7 +730,7 @@ mod tests {
             parent_op: None,
         });
 
-        let lambda_func_ty = core::func(&mut ctx, std::iter::empty::<TypeRef>(), [anyref_ty]);
+        let lambda_func_ty = func::func_sig(&mut ctx, std::iter::empty::<TypeRef>(), [anyref_ty]);
         let lambda_ty = ctx.types.intern(
             TypeDataBuilder::new(Symbol::new("closure"), Symbol::new("closure"))
                 .param(lambda_func_ty.as_type_ref())
@@ -755,7 +755,7 @@ mod tests {
             blocks: trunk_ir::smallvec::smallvec![outer_entry],
             parent_op: None,
         });
-        let outer_ty = core::func(&mut ctx, [evidence_ty], [anyref_ty]).as_type_ref();
+        let outer_ty = func::func_sig(&mut ctx, [evidence_ty], [anyref_ty]).as_type_ref();
         let outer = func::func(&mut ctx, loc, Symbol::new("test_fn"), outer_ty, outer_body);
         ctx.push_op(module_block, outer.op_ref());
 
@@ -817,7 +817,7 @@ mod tests {
             parent_op: None,
         });
 
-        let func_ty = core::func(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
         let closure_ty =
             tribute_core::physical_closure_type(&mut ctx, func_ty, CallingConvention::Direct);
 
@@ -831,7 +831,7 @@ mod tests {
             blocks: trunk_ir::smallvec::smallvec![outer_entry],
             parent_op: None,
         });
-        let outer_func_ty = core::func(&mut ctx, [i32_ty], [anyref_ty]).as_type_ref();
+        let outer_func_ty = func::func_sig(&mut ctx, [i32_ty], [anyref_ty]).as_type_ref();
         let outer_func = func::func(
             &mut ctx,
             loc,

--- a/crates/tribute-passes/src/native/adt_rc_header.rs
+++ b/crates/tribute-passes/src/native/adt_rc_header.rs
@@ -370,7 +370,7 @@ mod tests {
     ) -> String {
         // Keep the test at the typed pre-erasure boundary consumed by the
         // ownership plan. The ADT lowering later selects `core.ptr`.
-        let func_ty = core::func(ctx, field_types.iter().copied(), [struct_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, field_types.iter().copied(), [struct_ty]).as_type_ref();
 
         // Create entry block with field arguments
         let args: Vec<BlockArgData> = field_types
@@ -444,7 +444,8 @@ mod tests {
         // planning in the production pipeline, keeping the historical ADT
         // lowering snapshot focused on this pass.
         let ptr_ty = intern_ty(ctx, "core", "ptr");
-        let erased_func_ty = core::func(ctx, field_types.iter().copied(), [ptr_ty]).as_type_ref();
+        let erased_func_ty =
+            func::func_sig(ctx, field_types.iter().copied(), [ptr_ty]).as_type_ref();
         ctx.op_mut(func_op.op_ref())
             .attributes
             .insert(Symbol::new("type"), Attribute::Type(erased_func_ty));

--- a/crates/tribute-passes/src/native/entrypoint.rs
+++ b/crates/tribute-passes/src/native/entrypoint.rs
@@ -56,7 +56,7 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
                 found_main = true;
                 // Extract return type from func type
                 let func_ty = func_op.r#type(ctx);
-                if let Some(function) = core::Func::from_type_ref(ctx, func_ty) {
+                if let Some(function) = func::FuncSig::from_type_ref(ctx, func_ty) {
                     main_return_ty = function.single_result(ctx);
                     main_param_types = function.inputs(ctx).to_vec();
                 }
@@ -93,7 +93,7 @@ pub fn generate_native_entrypoint(ctx: &mut IrContext, module: Module, sanitize:
     let tribute_main_return_ty = main_return_ty.unwrap_or_else(|| {
         panic!(
             "entrypoint: `func.func @main` has no return type in its signature; \
-             expected a valid `core.func` type with at least a return type parameter"
+             expected a valid `func.func_sig` type with at least a return type parameter"
         )
     });
 
@@ -218,7 +218,7 @@ fn build_entrypoint(
     let nil_ty = core::nil(ctx).as_type_ref();
 
     // Build func type: () -> i32
-    let func_ty = core::func(ctx, [], [i32_ty]).as_type_ref();
+    let func_ty = func::func_sig(ctx, [], [i32_ty]).as_type_ref();
 
     // Create entry block
     let entry_block = ctx.create_block(BlockData {
@@ -334,7 +334,7 @@ mod tests {
     /// Build an arena module with a single main function returning i32.
     fn make_main_module(ctx: &mut IrContext, loc: Location) -> Module {
         let i32_ty = i32_type(ctx);
-        let func_ty = core::func(ctx, [], [i32_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, [], [i32_ty]).as_type_ref();
 
         // Build main function: const 42, return
         let entry = ctx.create_block(BlockData {
@@ -386,7 +386,7 @@ mod tests {
     fn make_evidence_main_module(ctx: &mut IrContext, loc: Location) -> Module {
         let nil_ty = nil_type(ctx);
         let evidence_ty = tribute_ir::dialect::ability::evidence_adt_type_ref(ctx);
-        let func_ty = core::func(ctx, [evidence_ty], [nil_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, [evidence_ty], [nil_ty]).as_type_ref();
         let entry = ctx.create_block(BlockData {
             location: loc,
             args: vec![BlockArgData {
@@ -472,7 +472,7 @@ mod tests {
     fn entrypoint_no_main() {
         let (mut ctx, loc) = test_ctx();
         let i32_ty = i32_type(&mut ctx);
-        let func_ty = core::func(&mut ctx, [], [i32_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [], [i32_ty]).as_type_ref();
 
         // Build helper function (not main)
         let entry = ctx.create_block(BlockData {
@@ -535,7 +535,7 @@ mod tests {
 
         // Build module with main returning nil
         let nil_ty = nil_type(&mut ctx);
-        let func_ty = core::func(&mut ctx, [], [nil_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [], [nil_ty]).as_type_ref();
 
         let entry = ctx.create_block(BlockData {
             location: loc,
@@ -588,7 +588,7 @@ mod tests {
                 && f.sym_name(&ctx) == Symbol::new("main")
             {
                 let func_ty_ref = f.r#type(&ctx);
-                let function = core::Func::from_type_ref(&ctx, func_ty_ref).unwrap();
+                let function = func::FuncSig::from_type_ref(&ctx, func_ty_ref).unwrap();
                 assert_eq!(function.single_result(&ctx), Some(i32_ty));
                 return;
             }

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -54,7 +54,7 @@ fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
         .iter()
         .map(|&value| ctx.value_ty(value))
         .collect::<Vec<_>>();
-    let signature = core::func(ctx, parameters, [result]).as_type_ref();
+    let signature = func::func_sig(ctx, parameters, [result]).as_type_ref();
     let _ = func::set_indirect_call_signature(ctx, call, signature);
 }
 
@@ -1079,7 +1079,8 @@ mod tests {
         let (mut ctx, loc) = test_ctx();
         let evidence_ty = ability::evidence_adt_type_ref(&mut ctx);
         let marker_ty = ability::marker_adt_type_ref(&mut ctx);
-        let func_ty = core::func(&mut ctx, [evidence_ty, marker_ty], [evidence_ty]).as_type_ref();
+        let func_ty =
+            func::func_sig(&mut ctx, [evidence_ty, marker_ty], [evidence_ty]).as_type_ref();
 
         let entry = ctx.create_block(BlockData {
             location: loc,

--- a/crates/tribute-passes/src/native/mod.rs
+++ b/crates/tribute-passes/src/native/mod.rs
@@ -29,7 +29,6 @@ pub mod type_converter;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
-use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::smallvec::smallvec;
@@ -46,7 +45,7 @@ pub(crate) fn build_extern_func(
     params: &[TypeRef],
     result: TypeRef,
 ) -> OpRef {
-    let func_ty = core::func(ctx, params.iter().copied(), [result]).as_type_ref();
+    let func_ty = func::func_sig(ctx, params.iter().copied(), [result]).as_type_ref();
 
     let args: Vec<BlockArgData> = params
         .iter()

--- a/crates/tribute-passes/src/native/ownership_plan.rs
+++ b/crates/tribute-passes/src/native/ownership_plan.rs
@@ -887,7 +887,7 @@ fn is_defined_physical_cps_function(ctx: &IrContext, op: OpRef) -> bool {
     let Some(signature) = ctx.op(op).attributes.get_type("type") else {
         return false;
     };
-    core::Func::from_type_ref(ctx, signature).is_some_and(|callable| {
+    func::FuncSig::from_type_ref(ctx, signature).is_some_and(|callable| {
         let Some(result) = callable.single_result(ctx) else {
             return false;
         };
@@ -950,7 +950,7 @@ fn validate_bodyless_signature(
         .op(op)
         .attributes
         .get_type("type")
-        .and_then(|ty| core::Func::from_type_ref(ctx, ty))
+        .and_then(|ty| func::FuncSig::from_type_ref(ctx, ty))
         .ok_or_else(|| OwnershipPlanError::new("bodyless function lacks exact signature"))?;
     if signature
         .inputs(ctx)
@@ -975,7 +975,7 @@ fn validate_function_contract(
         .op(function_op)
         .attributes
         .get_type("type")
-        .and_then(|ty| core::Func::from_type_ref(ctx, ty))
+        .and_then(|ty| func::FuncSig::from_type_ref(ctx, ty))
         .ok_or_else(|| OwnershipPlanError::new("defined function lacks exact signature"))?;
     let entry_args = ctx.block_args(cfg.entry());
     if entry_args.len() != signature.inputs(ctx).len()

--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -215,7 +215,7 @@ fn build_aliases(
             // unit live through the callable use. This is a typed pre-erasure
             // handoff, not a `core.ptr` provenance rule.
             let callable_handoff = core::UnrealizedConversionCast::matches(ctx, op)
-                && core::Func::from_type_ref(ctx, ctx.value_ty(*output)).is_some();
+                && func::FuncSig::from_type_ref(ctx, ctx.value_ty(*output)).is_some();
             if input_managed
                 && is_internal_closure_layout(ctx, ctx.value_ty(*input), managed_layouts)
                 && is_core_ptr_type(ctx, ctx.value_ty(*output))
@@ -776,7 +776,7 @@ impl ActionPlanner<'_> {
         };
         let entries = if indirect {
             let signature = trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(self.ir, op)
-                .and_then(|ty| core::Func::from_type_ref(self.ir, ty))
+                .and_then(|ty| func::FuncSig::from_type_ref(self.ir, ty))
                 .ok_or_else(|| {
                     OwnershipPlanError::new(format!(
                         "indirect call {op:?} lacks exact signature; attrs = {:?}, operand types = {:?}",
@@ -831,7 +831,7 @@ impl ActionPlanner<'_> {
                 .op(callee_op)
                 .attributes
                 .get_type("type")
-                .and_then(|ty| core::Func::from_type_ref(self.ir, ty))
+                .and_then(|ty| func::FuncSig::from_type_ref(self.ir, ty))
                 .ok_or_else(|| OwnershipPlanError::new("direct callee lacks exact signature"))?;
             validate_call_contract(self.ir, op, signature, args, self.managed_layouts)?;
             self.entry_contracts
@@ -911,7 +911,7 @@ fn validate_allocation_result(
 fn validate_call_contract(
     ctx: &IrContext,
     op: OpRef,
-    signature: core::Func,
+    signature: func::FuncSig,
     args: &[ValueRef],
     managed_layouts: &HashSet<TypeRef>,
 ) -> Result<(), OwnershipPlanError> {

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -194,8 +194,8 @@ fn continuation_frame_capture_has_entry_store_and_deep_release_plan() {
         r#"core.module @test {
   !Frame = adt.struct() {name = @ContinuationFrame, fields = [[@value, core.i32]]}
   !FrameRef = adt.typeref() {name = @ContinuationFrame}
-  !Env = adt.struct() {name = @continuation_env, fields = [[@frame, !FrameRef], [@code, core.func(core.nil)]]}
-  func.func @capture(%frame: !FrameRef, %code: core.func(core.nil)) -> core.nil {
+  !Env = adt.struct() {name = @continuation_env, fields = [[@frame, !FrameRef], [@code, func.func_sig<() -> core.nil>]]}
+  func.func @capture(%frame: !FrameRef, %code: func.func_sig<() -> core.nil>) -> core.nil {
     %env = adt.struct_new %frame, %code {type = !Env} : !Env
     func.return
   }
@@ -220,8 +220,8 @@ fn continuation_frame_capture_materializes_the_typed_entry_and_store_actions() {
     let ir = r#"core.module @test {
   !Frame = adt.struct() {name = @ContinuationFrame, fields = [[@value, core.i32]]}
   !FrameRef = adt.typeref() {name = @ContinuationFrame}
-  !Env = adt.struct() {name = @continuation_env, fields = [[@frame, !FrameRef], [@code, core.func(core.nil)]]}
-  func.func @capture(%frame: !FrameRef, %code: core.func(core.nil)) -> core.nil {
+  !Env = adt.struct() {name = @continuation_env, fields = [[@frame, !FrameRef], [@code, func.func_sig<() -> core.nil>]]}
+  func.func @capture(%frame: !FrameRef, %code: func.func_sig<() -> core.nil>) -> core.nil {
     %env = adt.struct_new %frame, %code {type = !Env} : !Env
     func.return
   }
@@ -1101,7 +1101,7 @@ fn unmanaged_physical_and_buffer_types_never_receive_actions() {
         r#"core.module @test {
   !Marker = adt.struct() {name = @EvidenceMarker, fields = [[@code, core.ptr]]}
   !Evidence = core.array(!Marker)
-  func.func @raw(%raw: core.ptr, %bytes: core.bytes, %array: core.array(core.i32), %evidence: !Evidence, %code: core.func(core.nil)) -> core.ptr {
+  func.func @raw(%raw: core.ptr, %bytes: core.bytes, %array: core.array(core.i32), %evidence: !Evidence, %code: func.func_sig<() -> core.nil>) -> core.ptr {
     func.return %raw
   }
 }"#,
@@ -1113,7 +1113,7 @@ fn unmanaged_physical_and_buffer_types_never_receive_actions() {
         .op(function.operation())
         .attributes
         .get_type("type")
-        .and_then(|ty| core::Func::from_type_ref(&ctx, ty))
+        .and_then(|ty| func::FuncSig::from_type_ref(&ctx, ty))
         .unwrap()
         .inputs(&ctx)
     {
@@ -1125,7 +1125,7 @@ fn unmanaged_physical_and_buffer_types_never_receive_actions() {
 fn semantic_closure_values_are_managed_by_the_typed_contract() {
     let (ctx, _module, plan) = build(
         r#"core.module @test {
-  !Closure = closure.closure(core.func(core.i32, core.i32))
+  !Closure = closure.closure(func.func_sig<(core.i32) -> core.i32>)
   func.func @identity(%closure: !Closure) -> !Closure {
     func.return %closure
   }
@@ -1146,7 +1146,7 @@ fn semantic_closure_release_uses_its_compiler_generated_allocation_layout() {
     let module = parse_test_module(
         &mut ctx,
         r#"core.module @test {
-  !Closure = closure.closure(core.func(core.nil, tribute_rt.anyref))
+  !Closure = closure.closure(func.func_sig<(tribute_rt.anyref) -> core.nil>)
   func.func @target(%environment: tribute_rt.anyref) -> core.nil {
     func.return
   }
@@ -1185,10 +1185,10 @@ fn direct_indirect_return_and_tail_contracts_are_typed() {
     %seen = adt.struct_get %value {field = 0, type = !Layout} : core.i32
     func.return %seen
   }
-  func.func @caller(%value: !R, %callee: core.func(!R, !R)) -> !R {
+  func.func @caller(%value: !R, %callee: func.func_sig<(!R) -> !R>) -> !R {
     %seen = func.call %value {callee = @observe} : core.i32
     %direct = func.call %value {callee = @ordinary} : !R
-    %indirect = func.call_indirect %callee, %direct {signature = core.func(!R, !R)} : !R
+    %indirect = func.call_indirect %callee, %direct {signature = func.func_sig<(!R) -> !R>} : !R
     func.return %indirect
   }
   func.func @tail(%value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
@@ -1231,8 +1231,8 @@ fn stale_identity_unsupported_regions_and_malformed_calls_fail_unchanged() {
         r#"core.module @test {
   !R = adt.typeref() {name = @R}
   !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
-  func.func @f(%value: !R, %callee: core.func(!R, !R)) -> !R {
-    %x = func.call_indirect %callee {signature = core.func(!R, !R)} : !R
+  func.func @f(%value: !R, %callee: func.func_sig<(!R) -> !R>) -> !R {
+    %x = func.call_indirect %callee {signature = func.func_sig<(!R) -> !R>} : !R
     func.return %x
   }
 }"#,
@@ -1287,7 +1287,7 @@ fn stale_identity_unsupported_regions_and_malformed_calls_fail_unchanged() {
         r#"core.module @test {
   !R = adt.typeref() {name = @R}
   !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
-  func.func @f(%value: !R, %callee: core.func(!R, !R)) -> !R {
+  func.func @f(%value: !R, %callee: func.func_sig<(!R) -> !R>) -> !R {
     %result = func.call_indirect %callee, %value : !R
     func.return %result
   }

--- a/crates/tribute-passes/src/native/rtti.rs
+++ b/crates/tribute-passes/src/native/rtti.rs
@@ -34,7 +34,7 @@ use trunk_ir::adt_layout::{
 };
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::clif;
-use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::location::Span;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::rewrite::{Module, TypeConverter};
@@ -234,7 +234,7 @@ fn generate_fixed_release_function(
     loc: Location,
 ) -> OpRef {
     let tys = ClifTypes::intern(ctx);
-    let func_ty = core::func(ctx, [tys.ptr], [tys.nil]).as_type_ref();
+    let func_ty = func::func_sig(ctx, [tys.ptr], [tys.nil]).as_type_ref();
     let entry_block = ctx.create_block(BlockData {
         location: loc,
         args: vec![BlockArgData {
@@ -293,7 +293,7 @@ fn generate_release_function_for_struct(
     let func_name = format!("{}{}", RELEASE_FN_PREFIX, rtti_idx);
 
     // Function type: (core.ptr) -> core.nil
-    let func_ty = core::func(ctx, [ptr_ty], [nil_ty]).as_type_ref();
+    let func_ty = func::func_sig(ctx, [ptr_ty], [nil_ty]).as_type_ref();
 
     assert_eq!(fields.len(), managed_fields.len());
     let managed_field_offsets: Vec<i32> = fields
@@ -516,7 +516,7 @@ fn generate_release_function_for_enum(
     let i8_ty = tys.i8;
 
     let func_name = format!("{}{}", RELEASE_FN_PREFIX, rtti_idx);
-    let func_ty = core::func(ctx, [ptr_ty], [nil_ty]).as_type_ref();
+    let func_ty = func::func_sig(ctx, [ptr_ty], [nil_ty]).as_type_ref();
 
     let entry_block = ctx.create_block(BlockData {
         location: loc,
@@ -787,7 +787,7 @@ mod tests {
         field_types: &[TypeRef],
     ) -> Module {
         // Build function type: (field_types...) -> struct_ty
-        let func_ty = core::func(ctx, field_types.iter().copied(), [struct_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, field_types.iter().copied(), [struct_ty]).as_type_ref();
 
         // Create entry block with field arguments
         let args: Vec<BlockArgData> = field_types
@@ -964,7 +964,7 @@ mod tests {
         let node_ty = make_struct_type(&mut ctx, &[("value", i32_ty), ("next", ptr_ty)]);
 
         // Build module with two struct_new ops
-        let func_ty = core::func(&mut ctx, [i32_ty, i32_ty, ptr_ty], [node_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [i32_ty, i32_ty, ptr_ty], [node_ty]).as_type_ref();
 
         let entry = ctx.create_block(BlockData {
             location: loc,

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_empty.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_empty.snap
@@ -17,7 +17,7 @@ core.module @test {
       %7 = clif.iadd %5, %6 : core.ptr
       func.return %7
   }
-  clif.func {sym_name = @__tribute_release_32, type = core.func<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 8} : core.i64
       %2 = clif.isub %0, %1 : core.ptr

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_to_clif.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_to_clif.snap
@@ -18,7 +18,7 @@ core.module @test {
       %9 = clif.iadd %7, %8 : core.ptr
       func.return %9
   }
-  clif.func {sym_name = @__tribute_release_32, type = core.func<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 8} : core.i64
       %2 = clif.isub %0, %1 : core.ptr

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_release.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_release.snap
@@ -3,7 +3,7 @@ source: crates/tribute-passes/src/native/rc_lowering.rs
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @f, type = core.func<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @f, type = func.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 0} : core.ptr
       %2 = clif.icmp %0, %1 {cond = @eq} : core.i8

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain.snap
@@ -3,7 +3,7 @@ source: crates/tribute-passes/src/native/rc_lowering.rs
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @f, type = core.func<(core.ptr) -> core.ptr>} {
+  clif.func {sym_name = @f, type = func.func_sig<(core.ptr) -> core.ptr>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 0} : core.ptr
       %2 = clif.icmp %0, %1 {cond = @eq} : core.i8

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain_and_release.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain_and_release.snap
@@ -3,7 +3,7 @@ source: crates/tribute-passes/src/native/rc_lowering.rs
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @f, type = core.func<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @f, type = func.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 0} : core.ptr
       %2 = clif.icmp %0, %1 {cond = @eq} : core.i8

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_no_ptr_fields.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_no_ptr_fields.snap
@@ -9,7 +9,7 @@ core.module @test {
       %2 = adt.struct_new %0, %1 {type = !t0} : !t0
       func.return %2
   }
-  clif.func {sym_name = @__tribute_release_32, type = core.func<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 8} : core.i64
       %2 = clif.isub %0, %1 : core.ptr

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_with_ptr_fields.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_with_ptr_fields.snap
@@ -9,7 +9,7 @@ core.module @test {
       %2 = adt.struct_new %0, %1 {type = !t0} : !t0
       func.return %2
   }
-  clif.func {sym_name = @__tribute_release_32, type = core.func<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.load %0 {offset = 8} : core.ptr
       %2 = clif.iconst {value = 0} : core.ptr

--- a/crates/tribute-passes/src/native/type_converter.rs
+++ b/crates/tribute-passes/src/native/type_converter.rs
@@ -151,7 +151,7 @@ pub fn native_type_converter(ctx: &mut IrContext) -> (TypeConverter, NativeTypeR
         if is_closure_type(ctx, ty) {
             return Some(r.core_ptr);
         }
-        // core.func → ptr
+        // func.func_sig → ptr
         if is_func_type(ctx, ty) {
             return Some(r.core_ptr);
         }
@@ -421,8 +421,8 @@ pub fn is_ptr_like(ctx: &IrContext, ty: TypeRef, evidence_ty: TypeRef, ptr_ty: T
         return true;
     }
 
-    // core.func (function pointers)
-    if data.dialect == Symbol::new("core") && data.name == Symbol::new("func") {
+    // func.func_sig (function pointers)
+    if data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig") {
         return true;
     }
 
@@ -448,10 +448,10 @@ fn is_closure_type(ctx: &IrContext, ty: TypeRef) -> bool {
     data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure")
 }
 
-/// Helper: Check if a type is core.func.
+/// Helper: Check if a type is func.func_sig.
 fn is_func_type(ctx: &IrContext, ty: TypeRef) -> bool {
     let data = ctx.types.get(ty);
-    data.dialect == Symbol::new("core") && data.name == Symbol::new("func")
+    data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig")
 }
 
 /// Helper: Check if a type is core.array.
@@ -514,7 +514,7 @@ struct NativeTypeRefsCopy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use trunk_ir::dialect::clif;
+    use trunk_ir::dialect::{clif, func};
     use trunk_ir::ops::{DialectOp, DialectType};
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
@@ -562,10 +562,11 @@ mod tests {
             .expect("bodied definition");
 
         assert_eq!(ctx.op(declaration.op_ref()).regions.len(), 0);
-        let declaration_type = core::Func::from_type_ref(&ctx, declaration.r#type(&ctx)).unwrap();
+        let declaration_type =
+            func::FuncSig::from_type_ref(&ctx, declaration.r#type(&ctx)).unwrap();
         assert_eq!(declaration_type.inputs(&ctx), [refs.core_ptr]);
         assert_eq!(declaration_type.single_result(&ctx), Some(refs.core_ptr));
-        let definition_type = core::Func::from_type_ref(&ctx, definition.r#type(&ctx)).unwrap();
+        let definition_type = func::FuncSig::from_type_ref(&ctx, definition.r#type(&ctx)).unwrap();
         assert_eq!(definition_type.inputs(&ctx), [refs.core_ptr]);
         assert_eq!(definition_type.single_result(&ctx), Some(refs.core_ptr));
 

--- a/crates/tribute-passes/src/resolve_evidence.rs
+++ b/crates/tribute-passes/src/resolve_evidence.rs
@@ -46,7 +46,7 @@ fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
         .iter()
         .map(|&value| ctx.value_ty(value))
         .collect::<Vec<_>>();
-    let signature = core::func(ctx, parameters, [result]).as_type_ref();
+    let signature = func::func_sig(ctx, parameters, [result]).as_type_ref();
     let _ = func::set_indirect_call_signature(ctx, call, signature);
 }
 
@@ -254,7 +254,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
         let marker_ty = ability::marker_adt_type_ref(ctx);
 
         // fn __tribute_evidence_lookup(ev: Evidence, ability_id: i32) -> Marker
-        let func_ty = core::func(ctx, [evidence_ty, i32_ty], [marker_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, [evidence_ty, i32_ty], [marker_ty]).as_type_ref();
 
         // Body with unreachable
         let body_block = ctx.create_block(trunk_ir::context::BlockData {
@@ -292,7 +292,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
         let marker_ty = ability::marker_adt_type_ref(ctx);
 
         // fn __tribute_evidence_extend(ev: Evidence, marker: Marker) -> Evidence
-        let func_ty = core::func(ctx, [evidence_ty, marker_ty], [evidence_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, [evidence_ty, marker_ty], [evidence_ty]).as_type_ref();
 
         let body_block = ctx.create_block(trunk_ir::context::BlockData {
             location: loc,
@@ -330,7 +330,7 @@ fn ensure_runtime_functions(ctx: &mut IrContext, module: Module) {
         let i32_ty = i32_type_ref(ctx);
 
         // fn __tribute_next_tag() -> i32
-        let func_ty = core::func(ctx, std::iter::empty(), [i32_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, std::iter::empty(), [i32_ty]).as_type_ref();
 
         let body_block = ctx.create_block(trunk_ir::context::BlockData {
             location: loc,
@@ -373,9 +373,9 @@ fn collect_functions_with_evidence(ctx: &IrContext, module: Module) -> HashSet<S
     fns_with_evidence
 }
 
-/// Check if a `core.func` type has evidence as its first parameter.
+/// Check if a `func.func_sig` type has evidence as its first parameter.
 fn has_evidence_first_param(ctx: &IrContext, func_ty: TypeRef) -> bool {
-    let Some(func) = core::Func::from_type_ref(ctx, func_ty) else {
+    let Some(func) = func::FuncSig::from_type_ref(ctx, func_ty) else {
         return false;
     };
     let params = func.inputs(ctx);

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -329,8 +329,8 @@ pub fn compose_root_entry_bridge(
     }
     let worker = func::Func::from_op(ctx, worker_op)
         .map_err(|_| TargetAbiError::new("target root bridge: main is not func.func"))?;
-    let worker_callable = core::Func::from_type_ref(ctx, worker.r#type(ctx))
-        .ok_or_else(|| TargetAbiError::new("target root bridge: main is not core.func"))?;
+    let worker_callable = func::FuncSig::from_type_ref(ctx, worker.r#type(ctx))
+        .ok_or_else(|| TargetAbiError::new("target root bridge: main is not func.func_sig"))?;
     let evidence_ty = ability::evidence_adt_type_ref(ctx);
     let worker_params = worker_callable.inputs(ctx);
     if worker_callable.single_result(ctx) != Some(nil_ty)
@@ -380,8 +380,8 @@ pub fn compose_root_entry_bridge(
 
     let cell_ty = root_completion_cell_type(ctx, source_result);
     let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
-    let done_callable_ty = core::func(ctx, [source_result], [nil_ty]).as_type_ref();
-    let done_function_ty = core::func(ctx, [anyref_ty, source_result], [nil_ty]).as_type_ref();
+    let done_callable_ty = func::func_sig(ctx, [source_result], [nil_ty]).as_type_ref();
+    let done_function_ty = func::func_sig(ctx, [anyref_ty, source_result], [nil_ty]).as_type_ref();
     let done_entry = ctx.create_block(BlockData {
         location,
         args: vec![
@@ -421,7 +421,7 @@ pub fn compose_root_entry_bridge(
     let dispatch_function_ty = dispatch_entry_function_type(ctx, frame.dispatch, anyref_ty)?;
     let dispatch_entry = ctx.create_block(BlockData {
         location,
-        args: core::Func::from_type_ref(ctx, dispatch_function_ty)
+        args: func::FuncSig::from_type_ref(ctx, dispatch_function_ty)
             .expect("validated dispatch entry contract")
             .inputs(ctx)
             .iter()
@@ -562,7 +562,8 @@ pub fn compose_root_entry_bridge(
         blocks: smallvec![wrapper_entry],
         parent_op: None,
     });
-    let wrapper_ty = core::func(ctx, wrapper_params.iter().copied(), [source_result]).as_type_ref();
+    let wrapper_ty =
+        func::func_sig(ctx, wrapper_params.iter().copied(), [source_result]).as_type_ref();
     let wrapper = func::func(
         ctx,
         location,
@@ -691,8 +692,8 @@ fn validate_root_done_type(
     let callable = cps_closure_function_type(ctx, done).ok_or_else(|| {
         TargetAbiError::new("target root bridge: frame Done is not an exact Cps closure")
     })?;
-    let callable = core::Func::from_type_ref(ctx, callable).ok_or_else(|| {
-        TargetAbiError::new("target root bridge: frame Done callable is not core.func")
+    let callable = func::FuncSig::from_type_ref(ctx, callable).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Done callable is not func.func_sig")
     })?;
     if callable.single_result(ctx) != Some(physical_result)
         || callable.inputs(ctx) != [source_result]
@@ -719,7 +720,8 @@ fn validate_root_dispatch_type(
         ));
     }
     let callable = dispatch_callable_function_type(ctx, dispatch)?;
-    let callable = core::Func::from_type_ref(ctx, callable).expect("validated dispatch callable");
+    let callable =
+        func::FuncSig::from_type_ref(ctx, callable).expect("validated dispatch callable");
     let params = callable.inputs(ctx);
     let [actual_evidence, resume, prompt, ability, operation, payload] = params else {
         return Err(TargetAbiError::new(
@@ -752,8 +754,10 @@ fn validate_root_dispatch_type(
     let resume = cps_closure_function_type(ctx, *resume).ok_or_else(|| {
         TargetAbiError::new("target root bridge: frame Dispatch resume is not an exact Cps closure")
     })?;
-    let resume = core::Func::from_type_ref(ctx, resume).ok_or_else(|| {
-        TargetAbiError::new("target root bridge: frame Dispatch resume callable is not core.func")
+    let resume = func::FuncSig::from_type_ref(ctx, resume).ok_or_else(|| {
+        TargetAbiError::new(
+            "target root bridge: frame Dispatch resume callable is not func.func_sig",
+        )
     })?;
     if resume.single_result(ctx) != Some(physical_result)
         || resume.inputs(ctx).len() != 3
@@ -788,8 +792,8 @@ fn dispatch_entry_function_type(
     anyref: TypeRef,
 ) -> Result<TypeRef, TargetAbiError> {
     let callable_ty = dispatch_callable_function_type(ctx, dispatch)?;
-    let callable = core::Func::from_type_ref(ctx, callable_ty).ok_or_else(|| {
-        TargetAbiError::new("target root bridge: frame Dispatch callable is not core.func")
+    let callable = func::FuncSig::from_type_ref(ctx, callable_ty).ok_or_else(|| {
+        TargetAbiError::new("target root bridge: frame Dispatch callable is not func.func_sig")
     })?;
     let mut params = callable.inputs(ctx).to_vec();
     params.insert(1, anyref);
@@ -798,7 +802,7 @@ fn dispatch_entry_function_type(
         .non_reserved_attrs(ctx)
         .map(|(key, value)| (*key, value.clone()))
         .collect();
-    Ok(core::func_with_attrs(ctx, params, results, type_attrs).as_type_ref())
+    Ok(func::func_sig_with_attrs(ctx, params, results, type_attrs).as_type_ref())
 }
 
 fn is_parameterless_dialect_type(
@@ -921,8 +925,8 @@ fn collect_functions(
             continue;
         };
         let signature = function.r#type(ctx);
-        let callable = core::Func::from_type_ref(ctx, signature).ok_or_else(|| {
-            TargetAbiError::new("target ABI: tagged function must have a core.func signature")
+        let callable = func::FuncSig::from_type_ref(ctx, signature).ok_or_else(|| {
+            TargetAbiError::new("target ABI: tagged function must have a func.func_sig signature")
         })?;
         let result = callable.single_result(ctx).ok_or_else(|| {
             TargetAbiError::new(format!(
@@ -971,7 +975,7 @@ fn validate_transfers(
                     "target ABI: direct transfer convention differs from callee",
                 ));
             }
-            let callable = core::Func::from_type_ref(ctx, identity.signature).unwrap();
+            let callable = func::FuncSig::from_type_ref(ctx, identity.signature).unwrap();
             if !operands_match(ctx, ctx.op_operands(op), callable.inputs(ctx)) {
                 return Err(TargetAbiError::new(
                     "target ABI: direct transfer operands differ from callee signature",
@@ -1013,8 +1017,8 @@ fn validate_transfers(
         let signature = signature.ok_or_else(|| {
             TargetAbiError::new("target ABI: indirect transfer lacks exact callable signature")
         })?;
-        let callable = core::Func::from_type_ref(ctx, signature).ok_or_else(|| {
-            TargetAbiError::new("target ABI: indirect callable signature is not core.func")
+        let callable = func::FuncSig::from_type_ref(ctx, signature).ok_or_else(|| {
+            TargetAbiError::new("target ABI: indirect callable signature is not func.func_sig")
         })?;
         let args = IndirectCallLikeOps::arguments(ctx, op).ok_or_else(|| {
             TargetAbiError::new("target ABI: indirect transfer has malformed operands")
@@ -1060,8 +1064,8 @@ fn is_cps_never_caller(ctx: &IrContext, op: OpRef, never: TypeRef) -> Result<boo
     while let Some(candidate) = current {
         if let Ok(function) = func::Func::from_op(ctx, candidate) {
             let callable =
-                core::Func::from_type_ref(ctx, function.r#type(ctx)).ok_or_else(|| {
-                    TargetAbiError::new("target ABI: enclosing function is not core.func")
+                func::FuncSig::from_type_ref(ctx, function.r#type(ctx)).ok_or_else(|| {
+                    TargetAbiError::new("target ABI: enclosing function is not func.func_sig")
                 })?;
             return Ok(
                 exact_convention(ctx, candidate)? == Some(CallingConvention::Cps)
@@ -1100,7 +1104,7 @@ fn validate_constant(
     identity: FunctionIdentity,
     never: TypeRef,
 ) -> Result<(), TargetAbiError> {
-    let target = core::Func::from_type_ref(ctx, identity.signature).unwrap();
+    let target = func::FuncSig::from_type_ref(ctx, identity.signature).unwrap();
     if identity.convention == CallingConvention::Cps && target.single_result(ctx) != Some(never) {
         return Err(TargetAbiError::new(
             "target ABI: Cps function reference must have logical core.never result",
@@ -1120,7 +1124,7 @@ fn validate_constant(
         .non_reserved_attrs(ctx)
         .map(|(key, value)| (*key, value.clone()))
         .collect();
-    let expected = core::func_with_attrs(ctx, params, results, type_attrs).as_type_ref();
+    let expected = func::func_sig_with_attrs(ctx, params, results, type_attrs).as_type_ref();
     if ctx.op_result_types(constant.op_ref()) != [expected] {
         return Err(TargetAbiError::new(
             "target ABI: function reference differs from target signature",
@@ -1262,8 +1266,8 @@ impl<'a> PhysicalTypeConverter<'a> {
         if let Some(&converted) = self.callable.get(&(ty, convention)) {
             return Ok(converted);
         }
-        let callable = core::Func::from_type_ref(self.ctx, ty).ok_or_else(|| {
-            TargetAbiError::new("target ABI: proven callable is not a valid core.func")
+        let callable = func::FuncSig::from_type_ref(self.ctx, ty).ok_or_else(|| {
+            TargetAbiError::new("target ABI: proven callable is not a valid func.func_sig")
         })?;
         let result = callable.single_result(self.ctx).ok_or_else(|| {
             TargetAbiError::new("target ABI: proven callable has no logical result")
@@ -1284,7 +1288,7 @@ impl<'a> PhysicalTypeConverter<'a> {
             self.convert_embedded(result)?
         };
         let attrs = self.convert_func_attributes(callable)?;
-        let converted = core::func_with_attrs(self.ctx, inputs, [result], attrs).as_type_ref();
+        let converted = func::func_sig_with_attrs(self.ctx, inputs, [result], attrs).as_type_ref();
         self.callable.insert((ty, convention), converted);
         Ok(converted)
     }
@@ -1310,16 +1314,16 @@ impl<'a> PhysicalTypeConverter<'a> {
             self.embedded.insert(ty, converted);
             return Ok(converted);
         }
-        if data.dialect == core::DIALECT_NAME() && data.name == core::FUNC() {
-            let callable = core::Func::from_type_ref(self.ctx, ty).ok_or_else(|| {
-                TargetAbiError::new("target ABI: malformed nested core.func type")
+        if data.dialect == func::DIALECT_NAME() && data.name == func::FUNC_SIG() {
+            let callable = func::FuncSig::from_type_ref(self.ctx, ty).ok_or_else(|| {
+                TargetAbiError::new("target ABI: malformed nested func.func_sig type")
             })?;
             let result = callable.single_result(self.ctx).ok_or_else(|| {
-                TargetAbiError::new("target ABI: nested core.func type has no logical result")
+                TargetAbiError::new("target ABI: nested func.func_sig type has no logical result")
             })?;
             if result == self.never {
                 return Err(TargetAbiError::new(
-                    "target ABI: untagged nested core.func<(...)->core.never>",
+                    "target ABI: untagged nested func.func_sig<(...)->core.never>",
                 ));
             }
             let source_inputs = callable.inputs(self.ctx).to_vec();
@@ -1329,7 +1333,8 @@ impl<'a> PhysicalTypeConverter<'a> {
                 .collect::<Result<Vec<_>, _>>()?;
             let result = self.convert_embedded(result)?;
             let attrs = self.convert_func_attributes(callable)?;
-            let converted = core::func_with_attrs(self.ctx, inputs, [result], attrs).as_type_ref();
+            let converted =
+                func::func_sig_with_attrs(self.ctx, inputs, [result], attrs).as_type_ref();
             self.embedded.insert(ty, converted);
             return Ok(converted);
         }
@@ -1345,7 +1350,7 @@ impl<'a> PhysicalTypeConverter<'a> {
 
     fn convert_func_attributes(
         &mut self,
-        callable: core::Func,
+        callable: func::FuncSig,
     ) -> Result<AttributeMap, TargetAbiError> {
         let attributes = callable
             .non_reserved_attrs(self.ctx)
@@ -1423,12 +1428,12 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  !cps = closure.closure(core.func(core.never, core.i32, core.i32, core.i32, core.i32)) {tribute.calling_convention = 2}
+  !cps = closure.closure(func.func_sig<(core.i32, core.i32, core.i32, core.i32) -> core.never>) {tribute.calling_convention = 2}
   func.func @direct() -> core.never attributes {tribute.calling_convention = 0} { func.unreachable }
   func.func @evidence() -> core.never attributes {tribute.calling_convention = 1} { func.unreachable }
   func.func @cps() -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
   func.func @run(%callee: core.i32, %evidence: core.i32, %env: tribute_rt.anyref, %done: core.i32, %dispatch: core.i32, %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %evidence, %env, %done, %dispatch, %value {signature = core.func(core.never, core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %evidence, %env, %done, %dispatch, %value {signature = func.func_sig<(core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32) -> core.never>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -1445,7 +1450,7 @@ mod tests {
         ] {
             let signature = function(&ctx, module, name).r#type(&ctx);
             assert_eq!(
-                core::Func::from_type_ref(&ctx, signature)
+                func::FuncSig::from_type_ref(&ctx, signature)
                     .unwrap()
                     .single_result(&ctx)
                     .unwrap(),
@@ -1455,13 +1460,13 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains(
-                "signature = core.func<(core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32) -> core.nil>"
+                "signature = func.func_sig<(core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32) -> core.nil>"
             ),
             "{printed}"
         );
         assert!(
             printed.contains(
-                "closure.closure(core.func<(core.i32, core.i32, core.i32, core.i32) -> core.nil>)"
+                "closure.closure(func.func_sig<(core.i32, core.i32, core.i32, core.i32) -> core.nil>)"
             ),
             "{printed}"
         );
@@ -1474,7 +1479,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @run(%callee: core.i32, %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %value {signature = core.func(core.never, core.i32), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.never>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -1493,7 +1498,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("untagged nested core.func<(...)->core.never>"),
+                .contains("untagged nested func.func_sig<(...)->core.never>"),
             "{error}"
         );
         assert_eq!(print_module(&ctx, module.op()), before);
@@ -1513,7 +1518,7 @@ mod tests {
         let nil = core::nil(&mut ctx).as_type_ref();
         let never = core::never(&mut ctx).as_type_ref();
         let evidence = ability::evidence_adt_type_ref(&mut ctx);
-        let done_callable = core::func(&mut ctx, [nil], [never]).as_type_ref();
+        let done_callable = func::func_sig(&mut ctx, [nil], [never]).as_type_ref();
         let done = tribute_core::calling_convention::physical_closure_type_with_environment_index(
             &mut ctx,
             done_callable,
@@ -1535,7 +1540,7 @@ mod tests {
             &mut ctx, frame_name, nil, done, dispatch,
         );
         ctx.register_type_alias(frame_name, layout);
-        let worker = core::func(&mut ctx, [evidence, frame], [never]).as_type_ref();
+        let worker = func::func_sig(&mut ctx, [evidence, frame], [never]).as_type_ref();
         ctx.op_mut(main.op_ref())
             .attributes
             .insert(Symbol::new("type"), Attribute::Type(worker));
@@ -1574,7 +1579,7 @@ mod tests {
                 Some(CallingConvention::Cps)
             );
             assert_eq!(
-                core::Func::from_type_ref(&ctx, function.r#type(&ctx))
+                func::FuncSig::from_type_ref(&ctx, function.r#type(&ctx))
                     .unwrap()
                     .single_result(&ctx)
                     .unwrap(),
@@ -1614,7 +1619,7 @@ mod tests {
             ctx.op(call).attributes.get_symbol("callee"),
             Some(Symbol::new(CPS_MAIN_SYMBOL))
         );
-        let worker_callable = core::Func::from_type_ref(&ctx, worker.r#type(&ctx)).unwrap();
+        let worker_callable = func::FuncSig::from_type_ref(&ctx, worker.r#type(&ctx)).unwrap();
         let [worker_evidence, worker_frame] = worker_callable.inputs(&ctx) else {
             panic!("root worker must have Evidence and ContinuationFrame parameters");
         };
@@ -1770,7 +1775,7 @@ mod tests {
                 );
                 ctx.register_type_alias(frame_name, wrong);
             }
-            let worker = core::func(&mut ctx, [evidence, frame], [never]).as_type_ref();
+            let worker = func::func_sig(&mut ctx, [evidence, frame], [never]).as_type_ref();
             ctx.op_mut(main.op_ref())
                 .attributes
                 .insert(Symbol::new("type"), Attribute::Type(worker));
@@ -1831,7 +1836,7 @@ mod tests {
             &mut ctx, frame_name, nil, done, dispatch,
         );
         ctx.register_type_alias(frame_name, layout);
-        let worker = core::func(&mut ctx, [evidence, frame], [never]).as_type_ref();
+        let worker = func::func_sig(&mut ctx, [evidence, frame], [never]).as_type_ref();
         ctx.op_mut(main.op_ref())
             .attributes
             .insert(Symbol::new("type"), Attribute::Type(worker));
@@ -1876,7 +1881,7 @@ mod tests {
     func.tail_call_indirect %callee {signature = core.i32, tribute.calling_convention = 2}
   }
 }"#,
-                "indirect callable signature is not core.func",
+                "indirect callable signature is not func.func_sig",
             ),
             (
                 r#"core.module @test {
@@ -1889,7 +1894,7 @@ mod tests {
             ),
             (
                 r#"core.module @test {
-  !ambiguous = closure.closure(core.func(core.never))
+  !ambiguous = closure.closure(func.func_sig<() -> core.never>)
 }"#,
                 "no exact convention metadata",
             ),
@@ -1911,7 +1916,7 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  !semantic = closure.closure(core.func(core.i32)) {tribute.calling_convention = 0}
+  !semantic = closure.closure(func.func_sig<() -> core.i32>) {tribute.calling_convention = 0}
   !_closure = adt.struct(core.i32, tribute_rt.anyref) {name = @_closure}
   func.func @factory(%callback: !semantic) -> core.i32 attributes {tribute.calling_convention = 0} {
     func.unreachable
@@ -1941,8 +1946,8 @@ mod tests {
     func.unreachable
   }
   func.func @holder() -> core.i32 {
-    %external = func.constant {func_ref = @external} : core.func(core.never, core.i32, core.i32)
-    %defined = func.constant {func_ref = @defined} : core.func(core.never, core.i32, core.i32)
+    %external = func.constant {func_ref = @external} : func.func_sig<(core.i32, core.i32) -> core.never>
+    %defined = func.constant {func_ref = @defined} : func.func_sig<(core.i32, core.i32) -> core.never>
     func.unreachable
   }
 }"#,
@@ -1960,7 +1965,7 @@ mod tests {
         assert!(
             printed.contains("func.func @defined")
                 && printed.matches("func.constant").count() == 2
-                && printed.contains("!t0 = core.func<(core.i32, core.i32) -> core.nil>")
+                && printed.contains("!t0 = func.func_sig<(core.i32, core.i32) -> core.nil>")
                 && printed.matches(": !t0").count() == 2,
             "{printed}"
         );
@@ -1979,8 +1984,8 @@ mod tests {
     func.unreachable
   }
   func.func @holder() -> core.i32 {
-    %zero = func.constant {func_ref = @generated_zero} : core.func(core.never)
-    %one = func.constant {func_ref = @generated_one} : core.func(core.never, core.i32)
+    %zero = func.constant {func_ref = @generated_zero} : func.func_sig<() -> core.never>
+    %one = func.constant {func_ref = @generated_one} : func.func_sig<(core.i32) -> core.never>
     func.unreachable
   }
 }"#,
@@ -1992,15 +1997,18 @@ mod tests {
         let nil = core::nil(&mut ctx).as_type_ref();
         for (name, parameter_count) in [("generated_zero", 1), ("generated_one", 2)] {
             let function = function(&ctx, module, name);
-            let signature = core::Func::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
+            let signature = func::FuncSig::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
             assert_eq!(signature.single_result(&ctx).unwrap(), nil);
             assert_eq!(signature.inputs(&ctx).len(), parameter_count);
             assert_eq!(signature.inputs(&ctx)[0], anyref);
         }
         let printed = print_module(&ctx, module.op());
-        assert!(printed.contains(": core.func<() -> core.nil>"), "{printed}");
         assert!(
-            printed.contains(": core.func<(core.i32) -> core.nil>"),
+            printed.contains(": func.func_sig<() -> core.nil>"),
+            "{printed}"
+        );
+        assert!(
+            printed.contains(": func.func_sig<(core.i32) -> core.nil>"),
             "{printed}"
         );
     }
@@ -2036,7 +2044,7 @@ mod tests {
                     r#"core.module @test {{
   {function}
   func.func @holder() -> core.i32 {{
-    %function = func.constant {{func_ref = @external}} : core.func(core.never, core.i32, core.i32)
+    %function = func.constant {{func_ref = @external}} : func.func_sig<(core.i32, core.i32) -> core.never>
     func.unreachable
   }}
 }}"#
@@ -2061,7 +2069,7 @@ mod tests {
     func.unreachable
   }
   func.func @holder() -> core.i32 {
-    %function = func.constant {func_ref = @external} : core.func(core.never, tribute_rt.anyref)
+    %function = func.constant {func_ref = @external} : func.func_sig<(tribute_rt.anyref) -> core.never>
     func.unreachable
   }
 }"#,
@@ -2084,11 +2092,12 @@ mod tests {
     }
 
     #[test]
-    fn malformed_zero_parameter_core_func_fails_without_panicking() {
+    fn malformed_zero_parameter_func_sig_fails_without_panicking() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, "core.module @test {}");
         let malformed = ctx.types.intern(
-            trunk_ir::types::TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func")).build(),
+            trunk_ir::types::TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                .build(),
         );
         ctx.op_mut(module.op()).attributes.insert(
             Symbol::new("malformed_callable"),
@@ -2099,7 +2108,7 @@ mod tests {
         let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
 
         assert!(
-            error.to_string().contains("malformed nested core.func"),
+            error.to_string().contains("malformed nested func.func_sig"),
             "{error}"
         );
         assert_eq!(print_module(&ctx, module.op()), before);
@@ -2115,7 +2124,7 @@ mod tests {
 }"#,
         );
         let broken = function(&ctx, module, "broken");
-        let resultless = core::func(&mut ctx, [], []).as_type_ref();
+        let resultless = func::func_sig(&mut ctx, [], []).as_type_ref();
         ctx.op_mut(broken.op_ref())
             .attributes
             .insert(Symbol::new("type"), Attribute::Type(resultless));
@@ -2140,7 +2149,7 @@ mod tests {
             r#"core.module @test {
   func.func @external(%value: core.i32) -> core.i32
   func.func @holder() -> core.i32 {
-    %function = func.constant {func_ref = @external} : core.func(core.i32, core.i32)
+    %function = func.constant {func_ref = @external} : func.func_sig<(core.i32) -> core.i32>
     func.unreachable
   }
 }"#,
@@ -2157,7 +2166,7 @@ mod tests {
             r#"core.module @test {
   func.func @external(%value: core.i32) -> core.never attributes {tribute.calling_convention = 2}
   func.func @holder() -> core.i32 {
-    %function = func.constant {func_ref = @external} : core.func(core.never, core.bool)
+    %function = func.constant {func_ref = @external} : func.func_sig<(core.bool) -> core.never>
     func.unreachable
   }
 }"#,

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -145,7 +145,7 @@ fn walk_type(
     let data = ctx.types.get(ty);
     let forbidden = match boundary {
         TypeBoundary::Pre => {
-            type_is(ctx, ty, "core", "func")
+            type_is(ctx, ty, "func", "func_sig")
                 || type_is(ctx, ty, "closure", "closure")
                 || data.dialect == Symbol::new("ability")
                 || data.dialect == Symbol::new("effect")
@@ -239,7 +239,7 @@ fn verify_final_handle_dispatch_types(ctx: &IrContext, module: Module) -> Vec<Bo
             && closure_ty.name == Symbol::new("closure")
             && closure_ty.params.len() == 1
         {
-            core::Func::from_type_ref(ctx, closure_ty.params[0]).is_some_and(|function| {
+            func::FuncSig::from_type_ref(ctx, closure_ty.params[0]).is_some_and(|function| {
                 let params = function.inputs(ctx);
                 let result = function.single_result(ctx);
                 if general {
@@ -409,7 +409,7 @@ fn verify_physical_callable_graph(ctx: &IrContext, module: Module) -> Vec<Bounda
                 });
                 return;
             };
-            let function = core::Func::from_type_ref(ctx, *func_ty);
+            let function = func::FuncSig::from_type_ref(ctx, *func_ty);
             let valid_never = function
                 .and_then(|function| function.single_result(ctx))
                 .is_some_and(|result| type_is(ctx, result, "core", "never"));
@@ -846,12 +846,12 @@ impl<'a> Converter<'a> {
                 "CPS indirect tail callee has no exact provenance-bearing closure contract",
             )
         })?;
-        let callable = core::Func::from_type_ref(self.ctx, signature).ok_or_else(|| {
+        let callable = func::FuncSig::from_type_ref(self.ctx, signature).ok_or_else(|| {
             TributeControlToCpsError::one(
                 POST_CPS_BOUNDARY,
                 None,
                 Some(location),
-                "CPS indirect tail callee contract is not core.func",
+                "CPS indirect tail callee contract is not func.func_sig",
             )
         })?;
         let never = self.never_type();
@@ -1068,7 +1068,7 @@ impl<'a> Converter<'a> {
         let completion_type = self.completion_type(value_type, boundary);
         let outer_dispatch_type = self.frame_types(boundary).dispatch;
         let dispatch_type = self.frame_types(value_type).dispatch;
-        let factory_type = core::func(
+        let factory_type = func::func_sig(
             self.ctx,
             [completion_type, outer_dispatch_type],
             [dispatch_type],
@@ -1241,15 +1241,15 @@ impl<'a> Converter<'a> {
             } else {
                 result
             };
-            let function = core::func(self.ctx, lowered_params, [lowered_result]).as_type_ref();
+            let function = func::func_sig(self.ctx, lowered_params, [lowered_result]).as_type_ref();
             let converted = physical_closure_type(self.ctx, function, convention);
             self.converted_types.insert(ty, converted);
             return converted;
         }
         let data = self.ctx.types.get(ty).clone();
-        if data.dialect == core::DIALECT_NAME() && data.name == core::FUNC() {
-            let function = core::Func::from_type_ref(self.ctx, ty)
-                .expect("pre-CPS validation must reject malformed core.func types");
+        if data.dialect == func::DIALECT_NAME() && data.name == func::FUNC_SIG() {
+            let function = func::FuncSig::from_type_ref(self.ctx, ty)
+                .expect("pre-CPS validation must reject malformed func.func_sig types");
             let source_inputs = function.inputs(self.ctx).to_vec();
             let source_results = function.results(self.ctx).to_vec();
             let inputs = source_inputs
@@ -1261,11 +1261,12 @@ impl<'a> Converter<'a> {
                 .map(|result| self.convert_type(result))
                 .collect::<Vec<_>>();
             let mut attrs = data.attrs;
-            core::Func::remove_reserved_attrs(&mut attrs);
+            func::FuncSig::remove_reserved_attrs(&mut attrs);
             for value in attrs.values_mut() {
                 *value = self.convert_attribute(value);
             }
-            let converted = core::func_with_attrs(self.ctx, inputs, results, attrs).as_type_ref();
+            let converted =
+                func::func_sig_with_attrs(self.ctx, inputs, results, attrs).as_type_ref();
             self.converted_types.insert(ty, converted);
             return converted;
         }
@@ -1330,7 +1331,7 @@ impl<'a> Converter<'a> {
         } else {
             result
         };
-        core::func(self.ctx, params, [result]).as_type_ref()
+        func::func_sig(self.ctx, params, [result]).as_type_ref()
     }
 
     fn copy_extra_attrs(&mut self, source: OpRef, target: OpRef, excluded: &[&str]) {
@@ -1936,7 +1937,7 @@ impl<'a> Converter<'a> {
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
         let never = self.never_type();
-        let function = core::func(self.ctx, [evidence_type, frame_type], [never]).as_type_ref();
+        let function = func::func_sig(self.ctx, [evidence_type, frame_type], [never]).as_type_ref();
         let closure_type = self.generated_continuation_type(function);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), CallingConvention::Cps);
@@ -2136,7 +2137,7 @@ impl<'a> Converter<'a> {
             result
         };
         let adapter_ty =
-            core::func(self.ctx, physical_params.clone(), [physical_result]).as_type_ref();
+            func::func_sig(self.ctx, physical_params.clone(), [physical_result]).as_type_ref();
         let block = self.make_block(location, &physical_params);
         let args = self.ctx.block_args(block).to_vec();
         let evidence_offset = usize::from(result_convention.needs_evidence());
@@ -2362,7 +2363,7 @@ impl<'a> Converter<'a> {
         let dispatch_type = self.frame_types(body_type).dispatch;
         let mut params = vec![completion_type, parent_dispatch_type, i32_type];
         params.extend(arms.iter().map(|arm| self.ctx.value_ty(arm.value)));
-        let factory_type = core::func(self.ctx, params.clone(), [dispatch_type]).as_type_ref();
+        let factory_type = func::func_sig(self.ctx, params.clone(), [dispatch_type]).as_type_ref();
         let factory_block = self.make_block(location, &params);
         let factory_args = self.ctx.block_args(factory_block).to_vec();
         let mut factory_arms = arms.to_vec();
@@ -2530,7 +2531,7 @@ impl<'a> Converter<'a> {
             if arm.has_resume_token {
                 let input_type = *arm.params.last().expect("resumptive arm has a token");
                 let token_input = cps_closure_function_type(self.ctx, input_type)
-                    .and_then(|function| core::Func::from_type_ref(self.ctx, function))
+                    .and_then(|function| func::FuncSig::from_type_ref(self.ctx, function))
                     .and_then(|function| function.inputs(self.ctx).get(2).copied())
                     .ok_or_else(|| {
                         TributeControlToCpsError::one(
@@ -2984,7 +2985,7 @@ impl<'a> Converter<'a> {
         } else {
             self.convert_type(operation_result)
         };
-        let function = core::func(self.ctx, params, [result]).as_type_ref();
+        let function = func::func_sig(self.ctx, params, [result]).as_type_ref();
         let closure_type = physical_closure_type(self.ctx, function, convention);
         let lambda = closure::lambda(self.ctx, location, captures, closure_type, region);
         set_calling_convention(self.ctx, lambda.op_ref(), convention);
@@ -3151,7 +3152,7 @@ impl<'a> Converter<'a> {
 
         let region = self.single_block_region(location, block);
         let captures = ordered_external_values(self.ctx, region);
-        let function = core::func(self.ctx, params, [result]).as_type_ref();
+        let function = func::func_sig(self.ctx, params, [result]).as_type_ref();
         let convention = if general {
             CallingConvention::Cps
         } else {
@@ -4001,8 +4002,9 @@ mod tests {
                 Symbol::new("nested"),
                 Attribute::Type(source_callable),
             )]);
-            let source = core::func_with_attrs(&mut ctx, [source_callable], results.clone(), attrs)
-                .as_type_ref();
+            let source =
+                func::func_sig_with_attrs(&mut ctx, [source_callable], results.clone(), attrs)
+                    .as_type_ref();
             let mut converter = Converter::new(&mut ctx, block, HashMap::new(), module.op());
             let converted = converter.convert_type(source);
             assert_eq!(
@@ -4011,7 +4013,7 @@ mod tests {
                 "cached conversion must be stable"
             );
             let converted_callable = converter.convert_type(source_callable);
-            let function = core::Func::from_type_ref(converter.ctx, converted).unwrap();
+            let function = func::FuncSig::from_type_ref(converter.ctx, converted).unwrap();
             assert_ne!(converted_callable, source_callable);
             assert_eq!(function.inputs(converter.ctx), [converted_callable]);
             assert_eq!(function.results(converter.ctx).len(), results.len());
@@ -4224,7 +4226,7 @@ mod tests {
             let closure_ty = ctx.op_result_types(*lambda)[0];
             tribute_core::get_calling_convention(&ctx, *lambda) == Some(CallingConvention::Cps)
                 && closure::Closure::from_type_ref(&ctx, closure_ty)
-                    .and_then(|closure| core::Func::from_type_ref(&ctx, closure.func_type(&ctx)))
+                    .and_then(|closure| func::FuncSig::from_type_ref(&ctx, closure.func_type(&ctx)))
                     .is_some_and(|callable| callable.inputs(&ctx).len() == 1)
         });
         let lambda =
@@ -4315,7 +4317,7 @@ mod tests {
         tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("name = @CallbackRecord"));
-        assert!(printed.contains("closure.closure(core.func<(core.i32) -> core.i32>)"));
+        assert!(printed.contains("closure.closure(func.func_sig<(core.i32) -> core.i32>)"));
         assert!(!printed.contains("tribute_control."));
 
         let mut reparsed = IrContext::new();
@@ -4598,10 +4600,20 @@ mod tests {
     #[test]
     fn post_boundary_rejects_recursively_nested_control_types() {
         let input = r#"core.module @test {
-  !nested = core.tuple(closure.closure(core.func(core.i32, tribute_control.resume_token(core.i32, core.i32))))
+  !nested = core.tuple(closure.closure(func.func_sig<(tribute_control.resume_token(core.i32, core.i32)) -> core.i32>))
 }"#;
         let (ctx, module) = parse(input);
         let error = verify_tribute_control_post_cps(&ctx, module).unwrap_err();
+        assert!(error.to_string().contains("forbidden type"), "{error}");
+    }
+
+    #[test]
+    fn pre_boundary_rejects_recursively_nested_physical_signatures() {
+        let input = r#"core.module @test {
+  !nested = core.tuple(func.func_sig<(core.i32) -> core.i32>)
+}"#;
+        let (ctx, module) = parse(input);
+        let error = verify_tribute_control_pre_cps(&ctx, module, &[], &[]).unwrap_err();
         assert!(error.to_string().contains("forbidden type"), "{error}");
     }
 
@@ -4673,7 +4685,7 @@ mod tests {
             ),
             (
                 r#"core.module @test {
-  func.func @caller(%callee: closure.closure(core.func(core.never, core.i32)), %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @caller(%callee: closure.closure(func.func_sig<(core.i32) -> core.never>), %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     func.tail_call_indirect %callee, %value
   }
 }"#,
@@ -4702,7 +4714,7 @@ mod tests {
             ),
             (
                 r#"core.module @test {
-  func.func @caller(%callee: closure.closure(core.func(core.never, core.i32)), %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @caller(%callee: closure.closure(func.func_sig<(core.i32) -> core.never>), %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
     %result = func.call_indirect %callee, %value {tribute.calling_convention = 2} : core.never
     func.unreachable
   }
@@ -4721,8 +4733,8 @@ mod tests {
     fn post_boundary_rejects_nonphysical_dispatchers_and_residual_control_ops() {
         let dispatcher_input = r#"core.module @test {
   !evidence = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !tr = closure.closure(core.func(tribute_rt.anyref, !evidence, core.i32, tribute_rt.anyref))
-  !general = closure.closure(core.func(core.never, !evidence, tribute_rt.anyref, core.i32, tribute_rt.anyref))
+  !tr = closure.closure(func.func_sig<(!evidence, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>)
+  !general = closure.closure(func.func_sig<(!evidence, tribute_rt.anyref, core.i32, tribute_rt.anyref) -> core.never>)
   func.func @caller(%ev: !evidence, %prompt: core.i32, %tr: !tr, %general: !general) -> core.never attributes {tribute.calling_convention = 2} {
     ability.handle_dispatch %ev, %prompt, %tr, %general {ability_refs = [core.ability_ref() {name = @State}]} {
       ^body(%inner: !evidence):
@@ -4871,7 +4883,7 @@ mod tests {
         let perform_resume = perform_resume.expect("resumptive handler emits ability.perform");
         let erased_function = cps_closure_function_type(&ctx, ctx.value_ty(perform_resume))
             .expect("ability.perform resume has CPS callable provenance");
-        let erased = core::Func::from_type_ref(&ctx, erased_function)
+        let erased = func::FuncSig::from_type_ref(&ctx, erased_function)
             .expect("ability.perform resume has a function signature");
         assert_eq!(erased.inputs(&ctx).len(), 3);
         assert!(
@@ -4886,7 +4898,7 @@ mod tests {
         assert!(
             ctx.op_operands(wrapper_op).iter().copied().any(|capture| {
                 cps_closure_function_type(&ctx, ctx.value_ty(capture))
-                    .and_then(|function| core::Func::from_type_ref(&ctx, function))
+                    .and_then(|function| func::FuncSig::from_type_ref(&ctx, function))
                     .is_some_and(|function| {
                         function.inputs(&ctx).len() == 3
                             && type_is(&ctx, function.inputs(&ctx)[2], "core", "i32")
@@ -5046,8 +5058,8 @@ mod tests {
             let signature =
                 trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, tail)
                     .expect("every emitted CPS indirect tail has its exact closure contract");
-            let callable = core::Func::from_type_ref(&ctx, signature)
-                .expect("the indirect tail signature is a core.func");
+            let callable = func::FuncSig::from_type_ref(&ctx, signature)
+                .expect("the indirect tail signature is a func.func_sig");
             assert_eq!(
                 callable.single_result(&ctx).unwrap(),
                 core::never(&mut ctx).as_type_ref()
@@ -5200,8 +5212,8 @@ mod tests {
             let signature =
                 trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, tail)
                     .expect("every emitted CPS indirect tail has its exact closure contract");
-            let callable = core::Func::from_type_ref(&ctx, signature)
-                .expect("the indirect tail signature is a core.func");
+            let callable = func::FuncSig::from_type_ref(&ctx, signature)
+                .expect("the indirect tail signature is a func.func_sig");
             assert_eq!(
                 callable.single_result(&ctx).unwrap(),
                 core::never(&mut ctx).as_type_ref()
@@ -5234,7 +5246,7 @@ mod tests {
                 Some(CallingConvention::Cps)
             );
             let callable = closure::Closure::from_type_ref(&ctx, closure_ty)
-                .and_then(|closure| core::Func::from_type_ref(&ctx, closure.func_type(&ctx)))
+                .and_then(|closure| func::FuncSig::from_type_ref(&ctx, closure.func_type(&ctx)))
                 .unwrap();
             generated_param_counts.push(callable.inputs(&ctx).len());
         }
@@ -5265,7 +5277,7 @@ mod tests {
         let module_block = ctx.region(module.body(&ctx).unwrap()).blocks[0];
         let location = ctx.op(module.op()).location;
         let never = core::never(&mut ctx).as_type_ref();
-        let raw_type = core::func(&mut ctx, [], [never]).as_type_ref();
+        let raw_type = func::func_sig(&mut ctx, [], [never]).as_type_ref();
         let raw = func::constant(&mut ctx, location, raw_type, Symbol::new("raw"));
         let before = ctx.block(module_block).ops.to_vec();
         let mut converter = Converter::new(&mut ctx, module_block, HashMap::new(), module.op());

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -25,8 +25,8 @@ use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
-use trunk_ir::dialect::core;
 use trunk_ir::dialect::wasm as wasm_dialect;
+use trunk_ir::dialect::{core, func};
 use trunk_ir::ops::DialectOp;
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
@@ -513,7 +513,7 @@ fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
         .map(|&value| ctx.value_ty(value))
         .collect::<Vec<_>>();
     let result = core::nil(ctx).as_type_ref();
-    let signature = core::func(ctx, parameters, [result]).as_type_ref();
+    let signature = func::func_sig(ctx, parameters, [result]).as_type_ref();
     let _ = wasm_dialect::set_indirect_call_signature(ctx, call, signature);
 }
 
@@ -1388,9 +1388,9 @@ fn intern_i32(ctx: &mut IrContext) -> TypeRef {
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
 }
 
-/// Intern a `core.func` type with the given parameter and return types.
+/// Intern a `func.func_sig` type with the given parameter and return types.
 fn intern_func_type(ctx: &mut IrContext, params: &[TypeRef], ret: TypeRef) -> TypeRef {
-    trunk_ir::dialect::core::func(ctx, params.iter().copied(), [ret]).as_type_ref()
+    trunk_ir::dialect::func::func_sig(ctx, params.iter().copied(), [ret]).as_type_ref()
 }
 
 /// Compute a stable ability ID as a WASM i32 immediate.

--- a/crates/tribute-passes/src/wasm/io.rs
+++ b/crates/tribute-passes/src/wasm/io.rs
@@ -206,7 +206,7 @@ fn build_write_helper(ctx: &mut IrContext, loc: Location, analysis: &IoAnalysis)
         blocks: smallvec![body],
         parent_op: None,
     });
-    let fn_ty = core::func(ctx, [bytes_ty, i32_ty], [nil_ty]).as_type_ref();
+    let fn_ty = func::func_sig(ctx, [bytes_ty, i32_ty], [nil_ty]).as_type_ref();
     func::func(ctx, loc, Symbol::new(WRITE_HELPER), fn_ty, body).op_ref()
 }
 

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -250,7 +250,7 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
             // Check for func.func or wasm.func operations
             if data.dialect == func::DIALECT_NAME() && data.name == Symbol::new("func") {
                 if let Some(fn_ty) = data.attributes.get_type("type") {
-                    let Some(function) = core::Func::from_type_ref(ctx, fn_ty) else {
+                    let Some(function) = func::FuncSig::from_type_ref(ctx, fn_ty) else {
                         continue;
                     };
                     let params: Vec<_> = function
@@ -272,7 +272,7 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
                 && data.name == Symbol::new("func")
                 && let Some(fn_ty) = data.attributes.get_type("type")
             {
-                let Some(function) = core::Func::from_type_ref(ctx, fn_ty) else {
+                let Some(function) = func::FuncSig::from_type_ref(ctx, fn_ty) else {
                     continue;
                 };
                 let params: Vec<_> = function
@@ -323,7 +323,7 @@ fn intern_type(ctx: &mut IrContext, dialect: &'static str, name: &'static str) -
 }
 
 fn intern_func_type(ctx: &mut IrContext, params: Vec<TypeRef>, result: TypeRef) -> TypeRef {
-    core::func(ctx, params, [result]).as_type_ref()
+    func::func_sig(ctx, params, [result]).as_type_ref()
 }
 
 fn is_type(ctx: &IrContext, ty: TypeRef, dialect: &'static str, name: &'static str) -> bool {
@@ -485,7 +485,7 @@ impl<'a> WasmLowerer<'a> {
         self.main_exports.main_convention = get_calling_convention(ctx, op).unwrap_or_default();
 
         if let Some(fn_ty) = data.attributes.get_type("type")
-            && let Some(function) = core::Func::from_type_ref(ctx, fn_ty)
+            && let Some(function) = func::FuncSig::from_type_ref(ctx, fn_ty)
         {
             self.main_exports.main_result_type = function.single_result(ctx);
             self.main_exports.main_param_types = function.inputs(ctx).to_vec();
@@ -819,7 +819,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
-            "core.module @m { wasm.func {sym_name = @main, type = core.func<(wasm.arrayref) -> ()>, tribute.calling_convention = 1} {} }",
+            "core.module @m { wasm.func {sym_name = @main, type = func.func_sig<(wasm.arrayref) -> ()>, tribute.calling_convention = 1} {} }",
         );
         let main = module.ops(&ctx)[0];
         let const_analysis = ConstAnalysis {

--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -11,7 +11,7 @@ use cranelift_codegen::isa::CallConv;
 use cranelift_frontend::FunctionBuilder;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{clif, core};
+use trunk_ir::dialect::{clif, func};
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 
@@ -38,7 +38,7 @@ pub(crate) fn call_conv_for_cps_signature(
 }
 
 fn has_physical_empty_result(ctx: &IrContext, signature: TypeRef) -> bool {
-    core::Func::from_type_ref(ctx, signature)
+    func::FuncSig::from_type_ref(ctx, signature)
         .and_then(|function| function.single_result(ctx))
         .is_some_and(|result| is_nil_type(ctx, result))
 }
@@ -136,7 +136,7 @@ pub(crate) fn translate_type(
     )))
 }
 
-/// Translate a TrunkIR `core.func` type to a Cranelift `Signature`.
+/// Translate a TrunkIR `func.func_sig` type to a Cranelift `Signature`.
 ///
 /// `ptr_ty` is the platform pointer type, obtained from `target_config().pointer_type()`.
 pub(crate) fn translate_signature(
@@ -145,15 +145,15 @@ pub(crate) fn translate_signature(
     call_conv: CallConv,
     ptr_ty: cl_types::Type,
 ) -> CompilationResult<cl_ir::Signature> {
-    let function = core::Func::from_type_ref(ctx, func_ty_ref).ok_or_else(|| {
-        CompilationError::type_error("expected valid core.func type for signature translation")
+    let function = func::FuncSig::from_type_ref(ctx, func_ty_ref).ok_or_else(|| {
+        CompilationError::type_error("expected valid func.func_sig type for signature translation")
     })?;
 
     let mut sig = cl_ir::Signature::new(call_conv);
 
     let ret_type = function.single_result(ctx).ok_or_else(|| {
         CompilationError::type_error(
-            "Cranelift signature translation currently requires one core.func result",
+            "Cranelift signature translation currently requires one func.func_sig result",
         )
     })?;
     let param_types = function.inputs(ctx);
@@ -794,7 +794,7 @@ mod tests {
         let i32_ty = make_core_type(&mut ctx, "i32");
         let i64_ty = make_core_type(&mut ctx, "i64");
 
-        let func_ty = core::func(&mut ctx, [i32_ty, i32_ty], [i64_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [i32_ty, i32_ty], [i64_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(sig.params.len(), 2);
@@ -810,7 +810,7 @@ mod tests {
         let i64_ty = make_core_type(&mut ctx, "i64");
         let nil_ty = make_core_type(&mut ctx, "nil");
 
-        let func_ty = core::func(&mut ctx, [i64_ty], [nil_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [i64_ty], [nil_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(sig.params.len(), 1);
@@ -825,7 +825,7 @@ mod tests {
         let i64_ty = make_core_type(&mut ctx, "i64");
         let nil_ty = make_core_type(&mut ctx, "nil");
 
-        let func_ty = core::func(&mut ctx, [i32_ty, nil_ty, i64_ty], [i32_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [i32_ty, nil_ty, i64_ty], [i32_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(
@@ -844,7 +844,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let i64_ty = make_core_type(&mut ctx, "i64");
 
-        let func_ty = core::func(&mut ctx, [], [i64_ty]).as_type_ref();
+        let func_ty = func::func_sig(&mut ctx, [], [i64_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(sig.params.len(), 0);
@@ -857,8 +857,8 @@ mod tests {
         let mut ctx = IrContext::new();
         let i32_ty = make_core_type(&mut ctx, "i32");
         let nil_ty = make_core_type(&mut ctx, "nil");
-        let logical_signature = core::func(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
-        let physical_signature = core::func(&mut ctx, [i32_ty], [nil_ty]).as_type_ref();
+        let logical_signature = func::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
+        let physical_signature = func::func_sig(&mut ctx, [i32_ty], [nil_ty]).as_type_ref();
 
         assert_eq!(
             call_conv_for_cps_signature(&ctx, logical_signature, true, CallConv::SystemV),
@@ -877,13 +877,13 @@ mod result_list_tests {
     #[test]
     fn unsupported_resultless_signature_is_rejected_without_panicking() {
         let mut ctx = IrContext::new();
-        let signature = core::func(&mut ctx, [], []).as_type_ref();
+        let signature = func::func_sig(&mut ctx, [], []).as_type_ref();
         let error =
             translate_signature(&ctx, signature, CallConv::SystemV, cl_types::I64).unwrap_err();
         assert!(
             error
                 .to_string()
-                .contains("currently requires one core.func result")
+                .contains("currently requires one func.func_sig result")
         );
     }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -254,7 +254,7 @@ impl RewritePattern for FuncCallIndirectPattern {
             else {
                 return false;
             };
-            let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
+            let Some(callable) = func::FuncSig::from_type_ref(ctx, signature) else {
                 return false;
             };
             let Some(callable_result) = callable.single_result(ctx) else {
@@ -285,7 +285,7 @@ impl RewritePattern for FuncCallIndirectPattern {
                 .first()
                 .copied()
                 .unwrap_or_else(|| core::nil(ctx).as_type_ref());
-            core::func(ctx, param_types, [result]).as_type_ref()
+            func::func_sig(ctx, param_types, [result]).as_type_ref()
         };
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
@@ -393,7 +393,7 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         else {
             return false;
         };
-        let Some(callable) = core::Func::from_type_ref(ctx, signature) else {
+        let Some(callable) = func::FuncSig::from_type_ref(ctx, signature) else {
             return false;
         };
         if callable.single_result(ctx) != Some(core::nil(ctx).as_type_ref())
@@ -553,7 +553,7 @@ mod tests {
     func.tail_call %value {callee = @direct_target, tribute.calling_convention = 2}
   }
   func.func @indirect_caller(%callee: core.ptr, %value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.nil>, tribute.calling_convention = 2}
   }
 }"#;
 
@@ -576,9 +576,9 @@ mod tests {
             );
             let op = module.ops(&ctx)[0];
             if malformed {
-                let ty = ctx
-                    .types
-                    .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func")).build());
+                let ty = ctx.types.intern(
+                    TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig")).build(),
+                );
                 ctx.op_mut(op)
                     .attributes
                     .insert(Symbol::new("type"), trunk_ir::Attribute::Type(ty));
@@ -659,14 +659,14 @@ mod tests {
         let result = run_pass(
             r#"core.module @test {
   func.func @test_fn(%callee: core.ptr) -> core.nil {
-    func.call_indirect %callee {signature = core.func(core.nil)}
+    func.call_indirect %callee {signature = func.func_sig<() -> core.nil>}
     func.return
   }
 }"#,
         );
 
         assert!(
-            result.contains("clif.call_indirect %0 {sig = core.func<() -> core.nil>}"),
+            result.contains("clif.call_indirect %0 {sig = func.func_sig<() -> core.nil>}"),
             "{result}"
         );
         assert!(!result.contains("func.call_indirect"), "{result}");
@@ -686,7 +686,7 @@ mod tests {
             r#"core.module @test {
   !evidence = core.array(core.i32)
   func.func @caller(%callee: core.ptr, %evidence: !evidence) -> core.nil attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %evidence {signature = core.func(core.nil, !evidence), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %evidence {signature = func.func_sig<(!evidence) -> core.nil>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -702,11 +702,11 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains("clif.return_call_indirect")
-                && printed.contains("sig = core.func<(core.ptr) -> core.nil>"),
+                && printed.contains("sig = func.func_sig<(core.ptr) -> core.nil>"),
             "{printed}"
         );
         assert!(
-            !printed.contains("sig = core.func<(!evidence) -> core.nil>"),
+            !printed.contains("sig = func.func_sig<(!evidence) -> core.nil>"),
             "{printed}"
         );
     }
@@ -719,11 +719,11 @@ mod tests {
             r#"core.module @test {
   !evidence = core.array(core.i32)
   func.func @physical(%callee: core.ptr, %evidence: core.ptr) -> core.i32 {
-    %result = func.call_indirect %callee, %evidence {signature = core.func(core.i32, !evidence)} : core.i32
+    %result = func.call_indirect %callee, %evidence {signature = func.func_sig<(!evidence) -> core.i32>} : core.i32
     func.return %result
   }
   func.func @mismatch(%callee: core.ptr, %value: core.i32) -> core.i32 {
-    %result = func.call_indirect %callee, %value {signature = core.func(core.i32, !evidence)} : core.i32
+    %result = func.call_indirect %callee, %value {signature = func.func_sig<(!evidence) -> core.i32>} : core.i32
     func.return %result
   }
 }"#,
@@ -742,12 +742,12 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains("clif.call_indirect")
-                && printed.contains("sig = core.func<(core.ptr) -> core.i32>"),
+                && printed.contains("sig = func.func_sig<(core.ptr) -> core.i32>"),
             "{printed}"
         );
         assert!(
             printed.contains(
-                "func.call_indirect %0, %1 {signature = core.func<(!evidence) -> core.i32>} : core.i32"
+                "func.call_indirect %0, %1 {signature = func.func_sig<(!evidence) -> core.i32>} : core.i32"
             ),
             "the mismatched call must remain unchanged: {printed}"
         );
@@ -760,7 +760,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i64), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i64) -> core.nil>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -811,7 +811,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {signature = core.func(core.i32, core.i32), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.i32>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -830,7 +830,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32)}
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.nil>}
   }
 }"#,
         );
@@ -851,7 +851,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%callee: core.ptr, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32), tribute.calling_convention = 0}
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.nil>, tribute.calling_convention = 0}
   }
 }"#,
         );

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__call_indirect_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__call_indirect_to_clif.snap
@@ -4,10 +4,10 @@ assertion_line: 486
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @test_fn, type = core.func<() -> core.i32>} {
+  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.i32>} {
       %0 = arith.const {value = 0} : core.i32
       %1 = arith.const {value = 42} : core.i32
-      %2 = clif.call_indirect %0, %1 {sig = core.func<(core.i32) -> core.i32>} : core.i32
+      %2 = clif.call_indirect %0, %1 {sig = func.func_sig<(core.i32) -> core.i32>} : core.i32
       clif.return %2
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_adaptation.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_adaptation.snap
@@ -6,13 +6,13 @@ expression: result
 core.module @test {
   !_closure = adt.struct(core.i64, core.ptr) {fields = [[@func_ptr, core.i64], [@env, core.ptr]], name = @_closure}
 
-  clif.func {sym_name = @test_fn, type = core.func<() -> core.i32>} {
+  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.i32>} {
       %0 = clif.symbol_addr {sym = @lifted_fn} : core.ptr
       %1 = arith.const {value = 0} : core.ptr
       %2 = adt.struct_new %0, %1 {type = !_closure} : !_closure
       %3 = adt.struct_get %2 {field = 0, type = !_closure} : core.i64
       %4 = adt.struct_get %2 {field = 1, type = !_closure} : core.ptr
-      %5 = clif.call_indirect %3, %4 {sig = core.func<(core.ptr) -> core.i32>} : core.i32
+      %5 = clif.call_indirect %3, %4 {sig = func.func_sig<(core.ptr) -> core.i32>} : core.i32
       clif.return %5
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_anyref_adaptation.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_anyref_adaptation.snap
@@ -6,13 +6,13 @@ expression: result
 core.module @test {
   !_closure = adt.struct(core.i64, core.ptr) {fields = [[@func_ptr, core.i64], [@env, core.ptr]], name = @_closure}
 
-  clif.func {sym_name = @test_fn, type = core.func<() -> core.i32>} {
+  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.i32>} {
       %0 = clif.symbol_addr {sym = @lifted_fn} : core.ptr
       %1 = arith.const {value = 0} : wasm.anyref
       %2 = adt.struct_new %0, %1 {type = !_closure} : !_closure
       %3 = adt.struct_get %2 {field = 0, type = !_closure} : core.i64
       %4 = adt.struct_get %2 {field = 1, type = !_closure} : core.ptr
-      %5 = clif.call_indirect %3, %4 {sig = core.func<(core.ptr) -> core.i32>} : core.i32
+      %5 = clif.call_indirect %3, %4 {sig = func.func_sig<(core.ptr) -> core.i32>} : core.i32
       clif.return %5
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__func_func_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__func_func_to_clif.snap
@@ -4,7 +4,7 @@ assertion_line: 471
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @test_fn, type = core.func<() -> core.nil>} {
+  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.nil>} {
       clif.return
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
@@ -3,7 +3,7 @@ source: crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
 expression: result
 ---
 core.module @test {
-  !t0 = core.func<(core.i32) -> core.nil>
+  !t0 = func.func_sig<(core.i32) -> core.nil>
 
   clif.func {sym_name = @direct_target, tribute.calling_convention = 2, type = !t0} {
     ^bb0(%0: core.i32):
@@ -13,7 +13,7 @@ core.module @test {
     ^bb0(%0: core.i32):
       clif.return_call %0 {callee = @direct_target, tribute.calling_convention = 2}
   }
-  clif.func {sym_name = @indirect_caller, tribute.calling_convention = 2, type = core.func<(core.ptr, core.i32) -> core.nil>} {
+  clif.func {sym_name = @indirect_caller, tribute.calling_convention = 2, type = func.func_sig<(core.ptr, core.i32) -> core.nil>} {
     ^bb0(%0: core.ptr, %1: core.i32):
       clif.return_call_indirect %0, %1 {sig = !t0, tribute.calling_convention = 2}
   }

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -749,29 +749,29 @@ mod tests {
     use trunk_ir::parser::parse_test_module;
 
     const NIL_ZERO_WIDTH_NATIVE: &str = r#"core.module @test {
-  clif.func {sym_name = @call_target, type = core.func(core.i32, core.i32, core.nil, core.i64)} {
+  clif.func {sym_name = @call_target, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       clif.return %value
   }
-  clif.func {sym_name = @direct_call, type = core.func(core.i32, core.i32, core.nil, core.i64)} {
+  clif.func {sym_name = @direct_call, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       %result = clif.call %value, %unit, %last {callee = @call_target} : core.i32
       clif.return %result
   }
-  clif.func {sym_name = @indirect_call, type = core.func(core.i32, core.ptr, core.i32, core.nil, core.i64)} {
+  clif.func {sym_name = @indirect_call, type = func.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> core.i32>} {
     ^entry(%callee: core.ptr, %value: core.i32, %unit: core.nil, %last: core.i64):
-      %result = clif.call_indirect %callee, %value, %unit, %last {sig = core.func(core.i32, core.i32, core.nil, core.i64)} : core.i32
+      %result = clif.call_indirect %callee, %value, %unit, %last {sig = func.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} : core.i32
       clif.return %result
   }
-  clif.func {sym_name = @direct_tail, tribute.calling_convention = 2, type = core.func(core.nil, core.i32, core.nil, core.i64)} {
+  clif.func {sym_name = @direct_tail, tribute.calling_convention = 2, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       clif.return_call %value, %unit, %last {callee = @direct_tail}
   }
-  clif.func {sym_name = @indirect_tail, tribute.calling_convention = 2, type = core.func(core.nil, core.ptr, core.i32, core.nil, core.i64)} {
+  clif.func {sym_name = @indirect_tail, tribute.calling_convention = 2, type = func.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> core.nil>} {
     ^entry(%callee: core.ptr, %value: core.i32, %unit: core.nil, %last: core.i64):
-      clif.return_call_indirect %callee, %value, %unit, %last {sig = core.func(core.nil, core.i32, core.nil, core.i64)}
+      clif.return_call_indirect %callee, %value, %unit, %last {sig = func.func_sig<(core.i32, core.nil, core.i64) -> core.nil>}
   }
-  clif.func {sym_name = @jump, type = core.func(core.nil, core.i32, core.nil, core.i64)} {
+  clif.func {sym_name = @jump, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       clif.jump %value, %unit, %last [^merge]
     ^merge(%next_value: core.i32, %next_unit: core.nil, %next_last: core.i64):

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -221,14 +221,14 @@ struct ModuleInfo {
     globals: Vec<GlobalDef>,
     gc_types: Vec<GcTypeDef>,
     type_idx_by_type: HashMap<TypeRef, u32>,
-    /// Function type lookup map (core.func TypeRef).
+    /// Function type lookup map (func.func_sig TypeRef).
     func_types: HashMap<Symbol, TypeRef>,
     /// Function index lookup map (import index or func index).
     func_indices: HashMap<Symbol, u32>,
     /// Functions referenced via ref.func that need declarative elem segment.
     ref_funcs: HashSet<Symbol>,
     /// Additional function types from call_indirect that need to be added to type section.
-    /// Stored as (type_idx, core.func TypeRef) pairs.
+    /// Stored as (type_idx, func.func_sig TypeRef) pairs.
     call_indirect_types: Vec<(u32, TypeRef)>,
     /// Pre-interned common types for use in handlers.
     common_types: CommonTypes,
@@ -314,7 +314,7 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
 
     for import_def in module_info.imports.iter() {
         let (params_refs, result_ref) = func_type_parts(ctx, import_def.func_type)
-            .ok_or_else(|| CompilationError::type_error("import func type is not core.func"))?;
+            .ok_or_else(|| CompilationError::type_error("import func type is not func.func_sig"))?;
         let params = params_refs
             .iter()
             .map(|ty| type_to_valtype(ctx, *ty, &module_info.type_idx_by_type))
@@ -333,7 +333,7 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
     for func_def in module_info.funcs.iter() {
         debug!("Processing function type for: {:?}", func_def.name);
         let (params_refs, declared_result) = func_type_parts(ctx, func_def.func_type)
-            .ok_or_else(|| CompilationError::type_error("func type is not core.func"))?;
+            .ok_or_else(|| CompilationError::type_error("func type is not func.func_sig"))?;
         let params = params_refs
             .iter()
             .map(|ty| type_to_valtype(ctx, *ty, &module_info.type_idx_by_type))
@@ -348,7 +348,7 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
         let effective_result = {
             let regions = &ctx.op(func_def.op).regions;
             if let Some(&body_region) = regions.first() {
-                if is_type(ctx, declared_result, "core", "func")
+                if is_type(ctx, declared_result, "func", "func_sig")
                     || is_type(ctx, declared_result, "wasm", "funcref")
                 {
                     debug!("  checking funcref function for handler dispatch...");
@@ -388,8 +388,9 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
 
     // Emit call_indirect function types
     for (type_idx, func_ty) in &module_info.call_indirect_types {
-        let (params_refs, result_ref) = func_type_parts(ctx, *func_ty)
-            .ok_or_else(|| CompilationError::type_error("call_indirect type is not core.func"))?;
+        let (params_refs, result_ref) = func_type_parts(ctx, *func_ty).ok_or_else(|| {
+            CompilationError::type_error("call_indirect type is not func.func_sig")
+        })?;
         debug!(
             "Emitting call_indirect type idx={}: params={:?}, result={}.{}",
             type_idx,
@@ -724,7 +725,7 @@ fn emit_function(
         .ok_or_else(|| CompilationError::invalid_module("wasm.func has no entry block"))?;
 
     let (params_refs, result_ref) = func_type_parts(ctx, func_def.func_type)
-        .ok_or_else(|| CompilationError::type_error("func type is not core.func"))?;
+        .ok_or_else(|| CompilationError::type_error("func type is not func.func_sig"))?;
     let block_args = ctx.block_args(block);
     if params_refs.len() != block_args.len() {
         return Err(CompilationError::invalid_module(
@@ -940,7 +941,8 @@ fn emit_op_nested(
         if let Some(&result_ty) = ctx.op_result_types(op).first() {
             let ty_data = ctx.types.get(result_ty);
             debug!("wasm.nop: result_ty={}.{}", ty_data.dialect, ty_data.name);
-            if is_type(ctx, result_ty, "core", "func") || is_type(ctx, result_ty, "wasm", "funcref")
+            if is_type(ctx, result_ty, "func", "func_sig")
+                || is_type(ctx, result_ty, "wasm", "funcref")
             {
                 debug!("wasm.nop: emitting ref.null func");
                 function.instruction(&Instruction::RefNull(HeapType::Abstract {
@@ -1235,7 +1237,7 @@ mod tests {
     wasm.return
   }
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.export_func {name = "caller", func = @caller}
 }"#,
@@ -1254,7 +1256,7 @@ mod tests {
     wasm.return
   }
   wasm.func @caller(%table_index: core.i32, %value: adt.typeref) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.structref), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.structref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.export_func {name = "caller", func = @caller}
 }"#,
@@ -1312,13 +1314,34 @@ mod tests {
     }
 
     #[test]
+    fn emits_signature_valued_nop_as_null_funcref() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @main() -> func.func_sig<() -> core.nil> {
+    %null = wasm.nop : func.func_sig<() -> core.nil>
+    wasm.return %null
+  }
+}"#,
+        );
+
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("signature-valued wasm.nop must emit")
+            .bytes;
+        Validator::new()
+            .validate_all(&bytes)
+            .expect("signature-valued wasm.nop must validate");
+    }
+
+    #[test]
     fn collects_and_encodes_tableless_return_call_indirect_exact_signature() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
         );
@@ -1360,7 +1383,7 @@ mod tests {
             r#"core.module @test {
   wasm.table {reftype = @funcref, min = 1, max = 1}
   wasm.func @caller(%table_index: core.i32, %value: wasm.structref) -> core.i32 {
-    %result = wasm.call_indirect %table_index, %value {signature = core.func(core.i32, wasm.anyref), table = 0, type_idx = 0} : core.i32
+    %result = wasm.call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.i32>, table = 0, type_idx = 0} : core.i32
     wasm.return %result
   }
 }"#,
@@ -1371,7 +1394,7 @@ mod tests {
             panic!("expected one collected exact signature")
         };
         let Some((params, result)) = helpers::func_type_parts(&ctx, *signature) else {
-            panic!("expected core.func signature")
+            panic!("expected func.func_sig signature")
         };
         assert_eq!(ctx.types.get(params[0]).name, Symbol::new("anyref"));
         assert_eq!(ctx.types.get(result).name, Symbol::new("i32"));
@@ -1385,6 +1408,53 @@ mod tests {
     }
 
     #[test]
+    fn signature_valued_enclosing_result_upgrades_indirect_anyref_result() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.func @caller(%table_index: core.i32) -> func.func_sig<() -> core.nil> {
+    %result = wasm.call_indirect %table_index : wasm.anyref
+    wasm.return %result
+  }
+}"#,
+        );
+
+        let info = collect_module_info(&mut ctx, module).expect("collect module info");
+        let [(_, signature)] = info.call_indirect_types.as_slice() else {
+            panic!("expected one collected exact signature")
+        };
+        let Some((_, result)) = helpers::func_type_parts(&ctx, *signature) else {
+            panic!("expected func.func_sig signature")
+        };
+        assert!(helpers::is_type(&ctx, result, "wasm", "funcref"));
+    }
+
+    #[test]
+    fn exact_anyref_indirect_result_is_not_overridden_by_funcref_context() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.func @caller(%table_index: core.i32) -> wasm.funcref {
+    %ignored = wasm.call_indirect %table_index {signature = func.func_sig<() -> wasm.anyref>, table = 0, type_idx = 0} : wasm.anyref
+    %result = wasm.nop : wasm.funcref
+    wasm.return %result
+  }
+}"#,
+        );
+
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("exact anyref result must not inherit its enclosing funcref return type")
+            .bytes;
+        Validator::new()
+            .validate_all(&bytes)
+            .expect("exact anyref call result must remain a valid local");
+    }
+
+    #[test]
     fn region_contains_call_indirect_recognizes_return_call_indirect() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
@@ -1392,7 +1462,7 @@ mod tests {
             r#"core.module @test {
   wasm.func @tail_indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
     wasm.block {
-      wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+      wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
     }
   }
   wasm.func @tail_direct(%value: core.i32) -> core.nil {

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -9,7 +9,6 @@ use tracing::debug;
 use trunk_ir::IrContext;
 use trunk_ir::Module;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::op_interface::IndirectCallLikeOps;
@@ -22,9 +21,9 @@ use crate::errors::{CompilationError, CompilationResult};
 
 use super::helpers::{self, intern_named_adt_struct};
 
-/// Intern a core.func type from params and result type.
+/// Intern a func.func_sig type from params and result type.
 fn intern_func_type(ctx: &mut IrContext, params: &[TypeRef], result_ty: TypeRef) -> TypeRef {
-    core::func(ctx, params.iter().copied(), [result_ty]).as_type_ref()
+    func::func_sig(ctx, params.iter().copied(), [result_ty]).as_type_ref()
 }
 
 /// Intern a simple wasm type with no params or attrs.
@@ -91,7 +90,7 @@ pub(crate) fn collect_call_indirect_types(
                     let (_, ret_ty) =
                         helpers::func_type_parts(ctx, func_type).ok_or_else(|| {
                             CompilationError::type_error(
-                                "Wasm indirect-call collection requires valid one-result core.func",
+                                "Wasm indirect-call collection requires valid one-result func.func_sig",
                             )
                         })?;
                     Some(ret_ty)
@@ -99,7 +98,7 @@ pub(crate) fn collect_call_indirect_types(
                     let (_, ret_ty) =
                         helpers::func_type_parts(ctx, func.r#type(ctx)).ok_or_else(|| {
                             CompilationError::type_error(
-                                "Wasm indirect-call collection requires valid one-result core.func",
+                                "Wasm indirect-call collection requires valid one-result func.func_sig",
                             )
                         })?;
                     Some(ret_ty)
@@ -228,7 +227,7 @@ pub(crate) fn collect_call_indirect_types(
                         let is_anyref_result = helpers::is_type(ctx, result_ty, "wasm", "anyref");
                         let func_returns_funcref =
                             helpers::is_type(ctx, func_ret_ty, "wasm", "funcref")
-                                || helpers::is_type(ctx, func_ret_ty, "core", "func");
+                                || helpers::is_type(ctx, func_ret_ty, "func", "func_sig");
                         // Check for Step type (trampoline-based effect system)
                         let func_returns_step = helpers::is_step_type(ctx, func_ret_ty);
                         debug!(
@@ -400,21 +399,21 @@ mod result_list_tests {
             let mut ctx = IrContext::new();
             let text = format!(
                 "core.module @m {{
-                wasm.func {{sym_name = @good, type = core.func<() -> core.i32>}} {{
+                wasm.func {{sym_name = @good, type = func.func_sig<() -> core.i32>}} {{
                     %callee = wasm.i32_const {{value = 0}} : core.i32
                     %value = wasm.call_indirect %callee : core.i32
                     wasm.return %value
                 }}
-                {dialect}.func {{sym_name = @bad, type = core.func<() -> ()>}} {{}}
+                {dialect}.func {{sym_name = @bad, type = func.func_sig<() -> ()>}} {{}}
             }}"
             );
             let module = trunk_ir::parser::parse_test_module(&mut ctx, &text);
-            let seed = core::func(&mut ctx, [], []).as_type_ref();
+            let seed = func::func_sig(&mut ctx, [], []).as_type_ref();
             let mut indices = HashMap::from([(seed, 7)]);
             let before = indices.clone();
             let error =
                 collect_call_indirect_types(&mut ctx, module, &mut indices, 8, 0).unwrap_err();
-            assert!(error.to_string().contains("one-result core.func"));
+            assert!(error.to_string().contains("one-result func.func_sig"));
             assert_eq!(indices, before);
             let bad = module.ops(&ctx)[1];
             trunk_ir::rewrite::erase_op(&mut ctx, bad);
@@ -434,12 +433,12 @@ mod result_list_tests {
         let mut ctx = IrContext::new();
         let module = trunk_ir::parser::parse_test_module(
             &mut ctx,
-            "core.module @m { wasm.func {sym_name = @f, type = core.func<() -> ()>} { wasm.return } }",
+            "core.module @m { wasm.func {sym_name = @f, type = func.func_sig<() -> ()>} { wasm.return } }",
         );
         let before = trunk_ir::printer::print_module(&ctx, module.op());
         let mut indices = HashMap::new();
         let error = collect_call_indirect_types(&mut ctx, module, &mut indices, 0, 0).unwrap_err();
-        assert!(error.to_string().contains("one-result core.func"));
+        assert!(error.to_string().contains("one-result func.func_sig"));
         assert!(indices.is_empty());
         assert_eq!(trunk_ir::printer::print_module(&ctx, module.op()), before);
     }

--- a/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
@@ -8,7 +8,6 @@ use tracing::debug;
 
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::core;
 use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::{DialectOp, DialectType};
@@ -25,7 +24,7 @@ use crate::{CompilationError, CompilationResult};
 #[derive(Debug)]
 pub(crate) struct FunctionDef {
     pub name: Symbol,
-    /// Validated `core.func` signature.
+    /// Validated `func.func_sig` signature.
     pub func_type: TypeRef,
     pub op: OpRef,
 }
@@ -35,7 +34,7 @@ pub(crate) struct ImportFuncDef {
     pub sym: Symbol,
     pub module: Symbol,
     pub name: Symbol,
-    /// core.func TypeRef
+    /// func.func_sig TypeRef
     pub func_type: TypeRef,
 }
 
@@ -99,8 +98,9 @@ pub(crate) fn extract_function_def(
     let name = func_op.sym_name(ctx);
     let ty = func_op.r#type(ctx);
 
-    let function = core::Func::from_type_ref(ctx, ty)
-        .ok_or_else(|| CompilationError::type_error("wasm.func requires valid core.func type"))?;
+    let function = func::FuncSig::from_type_ref(ctx, ty).ok_or_else(|| {
+        CompilationError::type_error("wasm.func requires valid func.func_sig type")
+    })?;
 
     if let Some(result_ty) = function.single_result(ctx) {
         let result_data = ctx.types.get(result_ty);
@@ -136,9 +136,9 @@ pub(crate) fn extract_import_def(
     let sym = import_op.sym_name(ctx);
     let ty = import_op.r#type(ctx);
 
-    if core::Func::from_type_ref(ctx, ty).is_none() {
+    if func::FuncSig::from_type_ref(ctx, ty).is_none() {
         return Err(CompilationError::type_error(
-            "wasm.import_func requires valid core.func type",
+            "wasm.import_func requires valid func.func_sig type",
         ));
     }
 
@@ -312,12 +312,12 @@ mod tests {
     use trunk_ir::types::{Location, TypeDataBuilder};
 
     #[test]
-    fn import_function_requires_valid_core_func_counts() {
+    fn import_function_requires_valid_func_sig_counts() {
         let mut ctx = IrContext::new();
         let location = Location::new(PathRef::from_u32(0), Span::default());
         let malformed = ctx
             .types
-            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func")).build());
+            .intern(TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig")).build());
         let import = wasm_dialect::import_func(
             &mut ctx,
             location,
@@ -329,7 +329,9 @@ mod tests {
 
         let error = extract_import_def(&ctx, import).expect_err("malformed import signature");
         assert!(
-            error.to_string().contains("requires valid core.func type"),
+            error
+                .to_string()
+                .contains("requires valid func.func_sig type"),
             "{error}"
         );
     }

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -182,7 +182,7 @@ pub(crate) fn handle_call_indirect(
     if let Some(func_ret_ty) = emit_ctx.func_return_type {
         let is_anyref_result = helpers::is_type(ctx, result_ty, "wasm", "anyref");
         let func_returns_funcref = helpers::is_type(ctx, func_ret_ty, "wasm", "funcref")
-            || helpers::is_type(ctx, func_ret_ty, "core", "func");
+            || helpers::is_type(ctx, func_ret_ty, "func", "func_sig");
         // Check for Step type (trampoline-based effect system)
         let func_returns_step = helpers::is_step_type(ctx, func_ret_ty);
         if is_anyref_result && func_returns_funcref {
@@ -339,10 +339,10 @@ pub(crate) fn handle_return_call_indirect(
 
 use super::super::helpers::attr_u32;
 
-/// Find a core.func type in the `type_idx_by_type` / `func_types` registries by
+/// Find a func.func_sig type in the `type_idx_by_type` / `func_types` registries by
 /// matching params and result.
 ///
-/// `core.func` stores inputs followed by its single result in `TypeData.params`;
+/// `func.func_sig` stores inputs followed by its single result in `TypeData.params`;
 /// callers use the validated accessor rather than depending on that flat layout.
 ///
 /// This performs a linear O(n) scan over the registries to avoid requiring

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::core;
+use trunk_ir::dialect::func;
 use trunk_ir::op_interface::IndirectCallLikeOps;
 use trunk_ir::ops::DialectType;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
@@ -93,10 +93,10 @@ pub(crate) fn should_normalize_to_anyref(ctx: &IrContext, ty: TypeRef) -> bool {
 // Type conversion
 // ============================================================================
 
-/// Get the params and return type of a core.func TypeRef.
-/// Returns (param_types, return_type) or None if not a core.func.
+/// Get the params and return type of a func.func_sig TypeRef.
+/// Returns (param_types, return_type) or None if not a func.func_sig.
 pub(crate) fn func_type_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], TypeRef)> {
-    let function = core::Func::from_type_ref(ctx, ty)?;
+    let function = func::FuncSig::from_type_ref(ctx, ty)?;
     Some((function.inputs(ctx), function.single_result(ctx)?))
 }
 
@@ -161,7 +161,7 @@ pub(crate) fn exact_call_indirect_signature_with(
     signature: TypeRef,
 ) -> CompilationResult<TypeRef> {
     let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
-        CompilationError::invalid_module("wasm.call_indirect signature must be core.func")
+        CompilationError::invalid_module("wasm.call_indirect signature must be func.func_sig")
     })?;
     let Some(_table_index) = IndirectCallLikeOps::callee(ctx, op) else {
         return Err(CompilationError::invalid_module(
@@ -213,7 +213,9 @@ pub(crate) fn exact_return_call_indirect_signature_with(
     signature: TypeRef,
 ) -> CompilationResult<TypeRef> {
     let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
-        CompilationError::invalid_module("wasm.return_call_indirect signature must be core.func")
+        CompilationError::invalid_module(
+            "wasm.return_call_indirect signature must be func.func_sig",
+        )
     })?;
     if !is_nil_type(ctx, result) {
         return Err(CompilationError::invalid_module(
@@ -323,7 +325,7 @@ pub(crate) fn type_to_valtype(
                 ty: AbstractHeapType::Array,
             },
         }))
-    } else if is_type(ctx, ty, "core", "func") {
+    } else if is_type(ctx, ty, "func", "func_sig") {
         Ok(ValType::Ref(RefType::FUNCREF))
     } else if is_closure_struct_type(ctx, ty) {
         Ok(ValType::Ref(RefType {
@@ -520,6 +522,21 @@ mod tests {
                     ty: AbstractHeapType::Array,
                 },
             })
+        );
+    }
+
+    #[test]
+    fn func_sig_uses_nullable_funcref_value_type() {
+        let mut ctx = IrContext::new();
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let signature = func::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
+
+        assert_eq!(
+            type_to_valtype(&ctx, signature, &HashMap::new())
+                .expect("func.func_sig is a supported Wasm value type"),
+            ValType::Ref(RefType::FUNCREF)
         );
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -551,7 +551,7 @@ mod tests {
 
         let output = print_module(&ctx, module.op());
         assert!(
-            output.contains("!t0 = core.func<(core.i32) -> core.i32>")
+            output.contains("!t0 = func.func_sig<(core.i32) -> core.i32>")
                 && output.contains("wasm.func {custom = 7, sym_name = @external, type = !t0}"),
             "{output}"
         );
@@ -602,7 +602,7 @@ mod tests {
     func.tail_call %value {callee = @target}
   }
   func.func @indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32)}
+    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>}
   }
   func.func @ordinary(%table_index: core.i32, %value: core.i32) -> core.i32 {
     %result = func.call_indirect %table_index, %value : core.i32
@@ -624,7 +624,7 @@ mod tests {
         );
         assert!(output.contains(" = wasm.call_indirect "), "{output}");
         assert!(
-            output.contains("!t0 = core.func<(core.i32) -> core.nil>")
+            output.contains("!t0 = func.func_sig<(core.i32) -> core.nil>")
                 && output.contains("signature = !t0"),
             "{output}"
         );
@@ -637,7 +637,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @caller(%table_index: core.i32) -> core.nil {
-    func.call_indirect %table_index {signature = core.func(core.nil)}
+    func.call_indirect %table_index {signature = func.func_sig<() -> core.nil>}
     func.return
   }
 }"#,
@@ -648,7 +648,7 @@ mod tests {
         let output = print_module(&ctx, module.op());
         assert!(
             output.contains(
-                "wasm.call_indirect %0 {signature = core.func<() -> core.nil>, table = 0, type_idx = 0}"
+                "wasm.call_indirect %0 {signature = func.func_sig<() -> core.nil>, table = 0, type_idx = 0}"
             ),
             "{output}"
         );
@@ -666,7 +666,7 @@ mod tests {
   }
   func.func @caller(%value: core.i32) -> core.nil {
     %table_index = func.constant {func_ref = @target} : core.i32
-    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32)}
+    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>}
   }
 }"#,
         );
@@ -691,10 +691,10 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @physical(%table_index: core.i32, %value: wasm.anyref) -> core.nil {
-    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, tribute_rt.anyref), table = 7, tribute.calling_convention = 2, type_idx = 9}
+    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.anyref) -> core.nil>, table = 7, tribute.calling_convention = 2, type_idx = 9}
   }
   func.func @mismatch(%table_index: core.i32, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %table_index, %value {signature = core.func(core.nil, tribute_rt.float), tribute.calling_convention = 2}
+    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.float) -> core.nil>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -721,16 +721,16 @@ mod tests {
         let output = print_module(&ctx, module.op());
         assert!(
             output.contains(
-                "wasm.return_call_indirect %0, %1 {signature = core.func<(wasm.anyref) -> core.nil>"
+                "wasm.return_call_indirect %0, %1 {signature = func.func_sig<(wasm.anyref) -> core.nil>"
             ),
             "{output}"
         );
         assert!(
-            output.contains("wasm.return_call_indirect %0, %1 {signature = core.func<(wasm.anyref) -> core.nil>, table = 0, tribute.calling_convention = 2, type_idx = 0}"),
+            output.contains("wasm.return_call_indirect %0, %1 {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, tribute.calling_convention = 2, type_idx = 0}"),
             "the converted transfer must retain its calling convention: {output}"
         );
         assert!(
-            !output.contains("signature = core.func<(tribute_rt.anyref) -> core.nil>"),
+            !output.contains("signature = func.func_sig<(tribute_rt.anyref) -> core.nil>"),
             "{output}"
         );
         assert!(
@@ -738,7 +738,7 @@ mod tests {
             "stale source table metadata must not reach Wasm: {output}"
         );
         assert!(
-            output.contains("func.tail_call_indirect %0, %1 {signature = core.func<(tribute_rt.float) -> core.nil>, tribute.calling_convention = 2}"),
+            output.contains("func.tail_call_indirect %0, %1 {signature = func.func_sig<(tribute_rt.float) -> core.nil>, tribute.calling_convention = 2}"),
             "the mismatched transfer must remain unchanged: {output}"
         );
     }
@@ -750,11 +750,11 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   func.func @physical(%table_index: core.i32, %value: wasm.anyref) -> core.i32 {
-    %result = func.call_indirect %table_index, %value {signature = core.func(core.i32, tribute_rt.anyref), table = 7, type_idx = 9} : core.i32
+    %result = func.call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.anyref) -> core.i32>, table = 7, type_idx = 9} : core.i32
     func.return %result
   }
   func.func @mismatch(%table_index: core.i32, %value: core.i32) -> core.i32 {
-    %result = func.call_indirect %table_index, %value {signature = core.func(core.i32, tribute_rt.float)} : core.i32
+    %result = func.call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.float) -> core.i32>} : core.i32
     func.return %result
   }
 }"#,
@@ -782,7 +782,7 @@ mod tests {
         let output = print_module(&ctx, module.op());
         assert!(
             output.contains(
-                "wasm.call_indirect %0, %1 {signature = core.func<(wasm.anyref) -> core.i32>, table = 0, type_idx = 0}"
+                "wasm.call_indirect %0, %1 {signature = func.func_sig<(wasm.anyref) -> core.i32>, table = 0, type_idx = 0}"
             ),
             "{output}"
         );
@@ -791,12 +791,12 @@ mod tests {
             "stale source table metadata must not reach Wasm: {output}"
         );
         assert!(
-            !output.contains("signature = core.func<(tribute_rt.anyref) -> core.i32>"),
+            !output.contains("signature = func.func_sig<(tribute_rt.anyref) -> core.i32>"),
             "{output}"
         );
         assert!(
             output.contains(
-                "func.call_indirect %0, %1 {signature = core.func<(tribute_rt.float) -> core.i32>} : core.i32"
+                "func.call_indirect %0, %1 {signature = func.func_sig<(tribute_rt.float) -> core.i32>} : core.i32"
             ),
             "the mismatched call must remain unchanged: {output}"
         );
@@ -812,7 +812,7 @@ mod tests {
     func.tail_call_indirect %table_index, %value
   }
   func.func @malformed(%table_index: core.i32, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %table_index, %value {signature = core.func(core.i32, core.i32)}
+    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.i32>}
   }
 }"#,
         );

--- a/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/scf_to_wasm.rs
@@ -606,10 +606,10 @@ mod tests {
     fn lowers_resultless_switch_with_explicit_default() {
         let output = lower_text(
             r#"core.module @test {
-  func.func @main(%choice: core.i32, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%choice: core.i32, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     scf.switch %choice {
       scf.case {value = 0} {
-        func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+        func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
       }
       scf.default {
         func.unreachable
@@ -680,17 +680,17 @@ mod tests {
     fn lowers_nested_proper_tail_switch_arms() {
         let output = lower_text(
             r#"core.module @test {
-  func.func @main(%choice: core.i32, %cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%choice: core.i32, %cond: core.i1, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     scf.switch %choice {
       scf.case {value = 0} {
         %never = scf.if %cond : core.never {
           func.unreachable
         } {
-          func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+          func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
         }
       }
       scf.default {
-        func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+        func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
       }
     }
   }

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -149,13 +149,13 @@ mod tests {
     wasm.return_call_indirect %table_index, %value {signature = core.i32, table = 0, type_idx = 0}
   }
 }"#,
-            "signature must be core.func",
+            "signature must be func.func_sig",
         );
 
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.i32, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.i32>, table = 0, type_idx = 0}
   }
 }"#,
             "must have an empty result",
@@ -164,7 +164,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller() -> core.nil {
-    wasm.return_call_indirect {signature = core.func(core.nil), table = 0, type_idx = 0}
+    wasm.return_call_indirect {signature = func.func_sig<() -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
             "requires a table index operand",
@@ -173,7 +173,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i64, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
             "first operand must be an i32 table index",
@@ -182,7 +182,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i64) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
             "operands do not match its exact signature",
@@ -198,16 +198,16 @@ mod tests {
   !Array = core.array(core.i32)
   !Struct = adt.struct() {fields = [[@value, core.i32]], name = @Struct}
   wasm.func @typeref(%table_index: core.i32, %value: adt.typeref) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.anyref), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @struct(%table_index: core.i32, %value: !Struct) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.anyref), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @array(%table_index: core.i32, %value: !Array) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.arrayref), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.arrayref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @i31(%table_index: core.i32, %value: wasm.i31ref) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.anyref), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
         );
@@ -225,7 +225,7 @@ mod tests {
             assert_rejects_tail_signature(&format!(
                 r#"core.module @test {{
   wasm.func @caller(%table_index: core.i32, %value: {value_ty}) -> core.nil {{
-    wasm.return_call_indirect %table_index, %value {{signature = core.func(core.nil, {parameter_ty}), table = 0, type_idx = 0}}
+    wasm.return_call_indirect %table_index, %value {{signature = func.func_sig<({parameter_ty}) -> core.nil>, table = 0, type_idx = 0}}
   }}
 }}"#
             ));
@@ -238,7 +238,7 @@ mod tests {
             r#"core.module @test {
   !Struct = adt.struct() {fields = [[@value, core.i32]], name = @Struct}
   wasm.func @caller(%table_index: core.i32, %value: !Struct) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = core.func(core.nil, wasm.structref), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.structref) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
         );

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -150,13 +150,13 @@ inventory::submit! {
 /// Attach the required exact callable contract to a `clif` indirect transfer.
 ///
 /// Returns `false` without mutation when the operation is not a `clif`
-/// indirect call or the supplied type is not a `core.func` contract.
+/// indirect call or the supplied type is not a `func.func_sig` contract.
 pub fn set_indirect_call_signature(
     ctx: &mut crate::IrContext,
     op: crate::OpRef,
     signature: crate::TypeRef,
 ) -> bool {
-    if crate::dialect::core::Func::from_type_ref(ctx, signature).is_none()
+    if crate::dialect::func::FuncSig::from_type_ref(ctx, signature).is_none()
         || (CallIndirect::from_op(ctx, op).is_err()
             && ReturnCallIndirect::from_op(ctx, op).is_err())
     {
@@ -189,11 +189,11 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   clif.func @ordinary(%callee: core.ptr, %value: core.i32) -> core.i32 {
-    %result = clif.call_indirect %callee, %value {sig = core.func(core.i32, core.i32)} : core.i32
+    %result = clif.call_indirect %callee, %value {sig = func.func_sig<(core.i32) -> core.i32>} : core.i32
     clif.return %result
   }
   clif.func @tail(%callee: core.ptr, %value: core.i32) -> core.nil {
-    clif.return_call_indirect %callee, %value {sig = core.func(core.nil, core.i32)}
+    clif.return_call_indirect %callee, %value {sig = func.func_sig<(core.i32) -> core.nil>}
   }
   clif.func @direct() -> core.nil {
     clif.return
@@ -225,6 +225,6 @@ mod tests {
 
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("clif.call_indirect"));
-        assert!(printed.contains("sig = core.func<(core.i32) -> core.i32>"));
+        assert!(printed.contains("sig = func.func_sig<(core.i32) -> core.i32>"));
     }
 }

--- a/crates/trunk-ir/src/dialect/core.rs
+++ b/crates/trunk-ir/src/dialect/core.rs
@@ -1,5 +1,7 @@
 //! Arena-based core dialect.
 
+use crate::IrContext;
+
 // === Operation registrations ===
 crate::register_isolated_op!(core.module);
 
@@ -21,215 +23,6 @@ mod core {
     #[attr(nullable: bool)]
     struct Ref<Pointee>;
     struct Tuple<#[rest] Elements>;
-}
-
-use crate::ops::DialectType;
-use crate::{Attribute, AttributeMap, IrContext, Symbol, TypeDataBuilder, TypeRef};
-
-/// Reserved delimiter attribute for the number of function inputs.
-pub const NUM_INPUTS_ATTR: &str = "num_inputs";
-
-/// Reserved delimiter attribute for the number of function results.
-pub const NUM_RESULTS_ATTR: &str = "num_results";
-
-/// Return the interned name of the `core.func` type.
-#[allow(non_snake_case)]
-#[inline]
-pub fn FUNC() -> Symbol {
-    Symbol::new("func")
-}
-
-/// Why a name-matching `core.func` does not satisfy its storage invariant.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum FuncTypeError {
-    MissingCount(&'static str),
-    InvalidCount(&'static str),
-    CountOverflow,
-    LengthMismatch {
-        num_inputs: u32,
-        num_results: u32,
-        params: usize,
-    },
-    UnsupportedResultCount(u32),
-}
-
-impl std::fmt::Display for FuncTypeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::MissingCount(name) => write!(f, "missing required `{name}` u32 attribute"),
-            Self::InvalidCount(name) => write!(f, "`{name}` must be a u32 attribute"),
-            Self::CountOverflow => write!(f, "input and result counts overflow u32"),
-            Self::LengthMismatch {
-                num_inputs,
-                num_results,
-                params,
-            } => write!(
-                f,
-                "num_inputs ({num_inputs}) + num_results ({num_results}) must equal params length ({params})"
-            ),
-            Self::UnsupportedResultCount(count) => {
-                write!(f, "currently supports at most one result, found {count}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for FuncTypeError {}
-
-/// Validated wrapper for an input-first, zero-or-one-result `core.func` type.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Func(TypeRef);
-
-impl Func {
-    /// Validate a name-matching `core.func`, including both delimiter counts.
-    pub(crate) fn validate(ctx: &IrContext, ty: TypeRef) -> Result<Self, FuncTypeError> {
-        let data = ctx.types.get(ty);
-        debug_assert!(data.dialect == DIALECT_NAME() && data.name == FUNC());
-
-        let num_inputs = read_count(&data.attrs, NUM_INPUTS_ATTR)?;
-        let num_results = read_count(&data.attrs, NUM_RESULTS_ATTR)?;
-        if num_results > 1 {
-            return Err(FuncTypeError::UnsupportedResultCount(num_results));
-        }
-        let total = num_inputs
-            .checked_add(num_results)
-            .ok_or(FuncTypeError::CountOverflow)?;
-        if usize::try_from(total).ok() != Some(data.params.len()) {
-            return Err(FuncTypeError::LengthMismatch {
-                num_inputs,
-                num_results,
-                params: data.params.len(),
-            });
-        }
-        Ok(Self(ty))
-    }
-
-    fn counts(self, ctx: &IrContext) -> (usize, usize) {
-        let data = ctx.types.get(self.0);
-        let num_inputs = read_count(&data.attrs, NUM_INPUTS_ATTR)
-            .expect("validated core.func must retain a valid num_inputs attribute");
-        let num_results = read_count(&data.attrs, NUM_RESULTS_ATTR)
-            .expect("validated core.func must retain a valid num_results attribute");
-        (
-            usize::try_from(num_inputs).expect("u32 must fit usize"),
-            usize::try_from(num_results).expect("u32 must fit usize"),
-        )
-    }
-
-    pub fn as_type_ref(&self) -> TypeRef {
-        self.0
-    }
-
-    pub fn inputs<'a>(&self, ctx: &'a IrContext) -> &'a [TypeRef] {
-        let (num_inputs, _) = self.counts(ctx);
-        &ctx.types.get(self.0).params[..num_inputs]
-    }
-
-    pub fn results<'a>(&self, ctx: &'a IrContext) -> &'a [TypeRef] {
-        let (num_inputs, num_results) = self.counts(ctx);
-        &ctx.types.get(self.0).params[num_inputs..num_inputs + num_results]
-    }
-
-    pub fn single_result(&self, ctx: &IrContext) -> Option<TypeRef> {
-        self.results(ctx).first().copied()
-    }
-
-    /// Iterate function metadata without the input/result count delimiters.
-    pub fn non_reserved_attrs<'a>(
-        &self,
-        ctx: &'a IrContext,
-    ) -> impl Iterator<Item = (&'a Symbol, &'a Attribute)> {
-        ctx.types.get(self.0).attrs.iter().filter(|(key, _)| {
-            **key != Symbol::new(NUM_INPUTS_ATTR) && **key != Symbol::new(NUM_RESULTS_ATTR)
-        })
-    }
-
-    /// Remove input/result count delimiters from owned function metadata before rebuilding it.
-    pub fn remove_reserved_attrs(attrs: &mut AttributeMap) {
-        attrs.remove(NUM_INPUTS_ATTR);
-        attrs.remove(NUM_RESULTS_ATTR);
-    }
-
-    pub fn is_resultless(&self, ctx: &IrContext) -> bool {
-        self.results(ctx).is_empty()
-    }
-}
-
-impl DialectType for Func {
-    const DIALECT_NAME: &'static str = "core";
-    const TYPE_NAME: &'static str = "func";
-
-    fn from_type_ref(ctx: &IrContext, ty: TypeRef) -> Option<Self> {
-        if !Self::matches(ctx, ty) {
-            return None;
-        }
-        Self::validate(ctx, ty).ok()
-    }
-
-    fn as_type_ref(&self) -> TypeRef {
-        self.0
-    }
-}
-
-impl From<Func> for TypeRef {
-    fn from(ty: Func) -> Self {
-        ty.0
-    }
-}
-
-fn read_count(attrs: &AttributeMap, name: &'static str) -> Result<u32, FuncTypeError> {
-    match attrs.get(name) {
-        None => Err(FuncTypeError::MissingCount(name)),
-        Some(Attribute::Int(value)) => {
-            u32::try_from(*value).map_err(|_| FuncTypeError::InvalidCount(name))
-        }
-        Some(_) => Err(FuncTypeError::InvalidCount(name)),
-    }
-}
-
-/// Construct a canonical `core.func` with zero or one result.
-pub fn func(
-    ctx: &mut IrContext,
-    inputs: impl IntoIterator<Item = TypeRef>,
-    results: impl IntoIterator<Item = TypeRef>,
-) -> Func {
-    func_with_attrs(ctx, inputs, results, AttributeMap::new())
-}
-
-/// Construct a canonical `core.func` while preserving non-reserved attributes.
-pub fn func_with_attrs(
-    ctx: &mut IrContext,
-    inputs: impl IntoIterator<Item = TypeRef>,
-    results: impl IntoIterator<Item = TypeRef>,
-    attrs: AttributeMap,
-) -> Func {
-    assert!(
-        !attrs.contains_key(NUM_INPUTS_ATTR) && !attrs.contains_key(NUM_RESULTS_ATTR),
-        "core.func count attributes are reserved"
-    );
-
-    let inputs: Vec<_> = inputs.into_iter().collect();
-    let results: Vec<_> = results.into_iter().collect();
-    assert!(
-        results.len() <= 1,
-        "core.func currently supports at most one result"
-    );
-    let num_inputs = u32::try_from(inputs.len()).expect("core.func input count exceeds u32");
-    let num_results = u32::try_from(results.len()).expect("core.func result count exceeds u32");
-
-    let mut builder = TypeDataBuilder::new(DIALECT_NAME(), FUNC())
-        .params(inputs)
-        .params(results);
-    for (key, value) in attrs {
-        builder = builder.attr(key, value);
-    }
-    let ty = ctx.types.intern(
-        builder
-            .attr(NUM_INPUTS_ATTR, Attribute::from(num_inputs))
-            .attr(NUM_RESULTS_ATTR, Attribute::from(num_results))
-            .build(),
-    );
-    Func::validate(ctx, ty).expect("core.func constructor must produce a valid type")
 }
 
 // =========================================================================
@@ -292,11 +85,12 @@ pub(crate) fn fold_unrealized_conversion_cast(ctx: &IrContext, op: OpRef) -> Opt
 #[cfg(test)]
 mod canonicalize_tests {
     use super::*;
+    use crate::dialect::func::{FuncSig, NUM_INPUTS_ATTR, NUM_RESULTS_ATTR};
     use crate::parser::parse_test_module;
     use crate::printer::print_module;
     use crate::rewrite::{ApplyResult, Module, PatternApplicator, TypeConverter};
-    use crate::symbol::Symbol;
     use crate::walk::{WalkAction, walk_op};
+    use crate::{Attribute, AttributeMap, Symbol};
     use std::ops::ControlFlow;
 
     use crate::transforms::canonicalize::{FoldDispatchPattern, folds_for_dialect};
@@ -325,7 +119,7 @@ mod canonicalize_tests {
     #[test]
     fn remove_reserved_attrs_preserves_metadata_and_is_idempotent() {
         let mut attrs = AttributeMap::new();
-        Func::remove_reserved_attrs(&mut attrs);
+        FuncSig::remove_reserved_attrs(&mut attrs);
         assert!(attrs.is_empty());
 
         let mut ctx = IrContext::new();
@@ -340,9 +134,9 @@ mod canonicalize_tests {
         attrs = metadata.clone();
         attrs.insert(Symbol::new(NUM_INPUTS_ATTR), Attribute::from(2u32));
         attrs.insert(Symbol::new(NUM_RESULTS_ATTR), Attribute::from(1u32));
-        Func::remove_reserved_attrs(&mut attrs);
+        FuncSig::remove_reserved_attrs(&mut attrs);
         assert_eq!(attrs, metadata);
-        Func::remove_reserved_attrs(&mut attrs);
+        FuncSig::remove_reserved_attrs(&mut attrs);
         assert_eq!(attrs, metadata);
     }
 

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -2,6 +2,7 @@
 
 use crate::op_interface::{IndirectCallLikeModel, IndirectCallLikeOps};
 use crate::ops::{DialectOp, DialectType};
+use crate::{Attribute, AttributeMap, IrContext, Symbol, TypeDataBuilder, TypeRef};
 
 /// The optional exact callable signature retained after a typed indirect callee
 /// becomes a runtime function or table index.
@@ -64,6 +65,212 @@ mod func {
     fn constant() -> result {}
 
     fn unreachable() {}
+}
+
+/// Reserved delimiter attribute for the number of function inputs.
+pub const NUM_INPUTS_ATTR: &str = "num_inputs";
+
+/// Reserved delimiter attribute for the number of function results.
+pub const NUM_RESULTS_ATTR: &str = "num_results";
+
+/// Return the interned name of the `func.func_sig` type.
+#[allow(non_snake_case)]
+#[inline]
+pub fn FUNC_SIG() -> Symbol {
+    Symbol::new("func_sig")
+}
+
+/// Why a name-matching `func.func_sig` does not satisfy its storage invariant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FuncSigTypeError {
+    MissingCount(&'static str),
+    InvalidCount(&'static str),
+    CountOverflow,
+    LengthMismatch {
+        num_inputs: u32,
+        num_results: u32,
+        params: usize,
+    },
+    UnsupportedResultCount(u32),
+}
+
+impl std::fmt::Display for FuncSigTypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingCount(name) => write!(f, "missing required `{name}` u32 attribute"),
+            Self::InvalidCount(name) => write!(f, "`{name}` must be a u32 attribute"),
+            Self::CountOverflow => write!(f, "input and result counts overflow u32"),
+            Self::LengthMismatch {
+                num_inputs,
+                num_results,
+                params,
+            } => write!(
+                f,
+                "num_inputs ({num_inputs}) + num_results ({num_results}) must equal params length ({params})"
+            ),
+            Self::UnsupportedResultCount(count) => {
+                write!(f, "currently supports at most one result, found {count}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FuncSigTypeError {}
+
+/// Validated wrapper for an input-first, zero-or-one-result `func.func_sig` type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FuncSig(TypeRef);
+
+impl FuncSig {
+    /// Validate a name-matching `func.func_sig`, including both delimiter counts.
+    pub(crate) fn validate(ctx: &IrContext, ty: TypeRef) -> Result<Self, FuncSigTypeError> {
+        let data = ctx.types.get(ty);
+        debug_assert!(data.dialect == DIALECT_NAME() && data.name == FUNC_SIG());
+
+        let num_inputs = read_count(&data.attrs, NUM_INPUTS_ATTR)?;
+        let num_results = read_count(&data.attrs, NUM_RESULTS_ATTR)?;
+        if num_results > 1 {
+            return Err(FuncSigTypeError::UnsupportedResultCount(num_results));
+        }
+        let total = num_inputs
+            .checked_add(num_results)
+            .ok_or(FuncSigTypeError::CountOverflow)?;
+        if usize::try_from(total).ok() != Some(data.params.len()) {
+            return Err(FuncSigTypeError::LengthMismatch {
+                num_inputs,
+                num_results,
+                params: data.params.len(),
+            });
+        }
+        Ok(Self(ty))
+    }
+
+    fn counts(self, ctx: &IrContext) -> (usize, usize) {
+        let data = ctx.types.get(self.0);
+        let num_inputs = read_count(&data.attrs, NUM_INPUTS_ATTR)
+            .expect("validated func.func_sig must retain a valid num_inputs attribute");
+        let num_results = read_count(&data.attrs, NUM_RESULTS_ATTR)
+            .expect("validated func.func_sig must retain a valid num_results attribute");
+        (
+            usize::try_from(num_inputs).expect("u32 must fit usize"),
+            usize::try_from(num_results).expect("u32 must fit usize"),
+        )
+    }
+
+    pub fn as_type_ref(&self) -> TypeRef {
+        self.0
+    }
+
+    pub fn inputs<'a>(&self, ctx: &'a IrContext) -> &'a [TypeRef] {
+        let (num_inputs, _) = self.counts(ctx);
+        &ctx.types.get(self.0).params[..num_inputs]
+    }
+
+    pub fn results<'a>(&self, ctx: &'a IrContext) -> &'a [TypeRef] {
+        let (num_inputs, num_results) = self.counts(ctx);
+        &ctx.types.get(self.0).params[num_inputs..num_inputs + num_results]
+    }
+
+    pub fn single_result(&self, ctx: &IrContext) -> Option<TypeRef> {
+        self.results(ctx).first().copied()
+    }
+
+    /// Iterate function metadata without the input/result count delimiters.
+    pub fn non_reserved_attrs<'a>(
+        &self,
+        ctx: &'a IrContext,
+    ) -> impl Iterator<Item = (&'a Symbol, &'a Attribute)> {
+        ctx.types.get(self.0).attrs.iter().filter(|(key, _)| {
+            **key != Symbol::new(NUM_INPUTS_ATTR) && **key != Symbol::new(NUM_RESULTS_ATTR)
+        })
+    }
+
+    /// Remove input/result count delimiters from owned function metadata before rebuilding it.
+    pub fn remove_reserved_attrs(attrs: &mut AttributeMap) {
+        attrs.remove(NUM_INPUTS_ATTR);
+        attrs.remove(NUM_RESULTS_ATTR);
+    }
+
+    pub fn is_resultless(&self, ctx: &IrContext) -> bool {
+        self.results(ctx).is_empty()
+    }
+}
+
+impl DialectType for FuncSig {
+    const DIALECT_NAME: &'static str = "func";
+    const TYPE_NAME: &'static str = "func_sig";
+
+    fn from_type_ref(ctx: &IrContext, ty: TypeRef) -> Option<Self> {
+        if !Self::matches(ctx, ty) {
+            return None;
+        }
+        Self::validate(ctx, ty).ok()
+    }
+
+    fn as_type_ref(&self) -> TypeRef {
+        self.0
+    }
+}
+
+impl From<FuncSig> for TypeRef {
+    fn from(ty: FuncSig) -> Self {
+        ty.0
+    }
+}
+
+fn read_count(attrs: &AttributeMap, name: &'static str) -> Result<u32, FuncSigTypeError> {
+    match attrs.get(name) {
+        None => Err(FuncSigTypeError::MissingCount(name)),
+        Some(Attribute::Int(value)) => {
+            u32::try_from(*value).map_err(|_| FuncSigTypeError::InvalidCount(name))
+        }
+        Some(_) => Err(FuncSigTypeError::InvalidCount(name)),
+    }
+}
+
+/// Construct a canonical `func.func_sig` with zero or one result.
+pub fn func_sig(
+    ctx: &mut IrContext,
+    inputs: impl IntoIterator<Item = TypeRef>,
+    results: impl IntoIterator<Item = TypeRef>,
+) -> FuncSig {
+    func_sig_with_attrs(ctx, inputs, results, AttributeMap::new())
+}
+
+/// Construct a canonical `func.func_sig` while preserving non-reserved attributes.
+pub fn func_sig_with_attrs(
+    ctx: &mut IrContext,
+    inputs: impl IntoIterator<Item = TypeRef>,
+    results: impl IntoIterator<Item = TypeRef>,
+    attrs: AttributeMap,
+) -> FuncSig {
+    assert!(
+        !attrs.contains_key(NUM_INPUTS_ATTR) && !attrs.contains_key(NUM_RESULTS_ATTR),
+        "func.func_sig count attributes are reserved"
+    );
+
+    let inputs: Vec<_> = inputs.into_iter().collect();
+    let results: Vec<_> = results.into_iter().collect();
+    assert!(
+        results.len() <= 1,
+        "func.func_sig currently supports at most one result"
+    );
+    let num_inputs = u32::try_from(inputs.len()).expect("func.func_sig input count exceeds u32");
+    let num_results = u32::try_from(results.len()).expect("func.func_sig result count exceeds u32");
+
+    let mut builder = TypeDataBuilder::new(DIALECT_NAME(), FUNC_SIG())
+        .params(inputs)
+        .params(results);
+    for (key, value) in attrs {
+        builder = builder.attr(key, value);
+    }
+    let ty = ctx.types.intern(
+        builder
+            .attr(NUM_INPUTS_ATTR, Attribute::from(num_inputs))
+            .attr(NUM_RESULTS_ATTR, Attribute::from(num_results))
+            .build(),
+    );
+    FuncSig::validate(ctx, ty).expect("func.func_sig constructor must produce a valid type")
 }
 
 // One-result source producers use these explicit convenience accessors. Generic
@@ -149,13 +356,13 @@ inventory::submit! {
 /// Attach an exact callable contract to a `func` indirect transfer.
 ///
 /// Returns `false` without mutation when the operation is not a `func`
-/// indirect call or the supplied type is not a `core.func` contract.
+/// indirect call or the supplied type is not a `func.func_sig` contract.
 pub fn set_indirect_call_signature(
     ctx: &mut crate::IrContext,
     op: crate::OpRef,
     signature: crate::TypeRef,
 ) -> bool {
-    if crate::dialect::core::Func::from_type_ref(ctx, signature).is_none()
+    if crate::dialect::func::FuncSig::from_type_ref(ctx, signature).is_none()
         || (CallIndirect::from_op(ctx, op).is_err() && TailCallIndirect::from_op(ctx, op).is_err())
     {
         return false;
@@ -237,12 +444,12 @@ fn print_func(
         data.regions.first().copied()
     };
 
-    // Extract the validated input/result lists from the core.func type attribute.
+    // Extract the validated input/result lists from the func.func_sig type attribute.
     let type_info = {
         let data = h.ctx().op(op);
         data.attributes
             .get_type("type")
-            .and_then(|ty| crate::dialect::core::Func::from_type_ref(h.ctx(), ty))
+            .and_then(|ty| crate::dialect::func::FuncSig::from_type_ref(h.ctx(), ty))
             .map(|func| (func.single_result(h.ctx()), func.inputs(h.ctx()).to_vec()))
     };
 
@@ -297,8 +504,8 @@ fn print_func(
         .get_type("type")
         .is_some_and(|ty| {
             h.ctx().types.get(ty).attrs.keys().any(|key| {
-                *key != crate::Symbol::new(crate::dialect::core::NUM_INPUTS_ATTR)
-                    && *key != crate::Symbol::new(crate::dialect::core::NUM_RESULTS_ATTR)
+                *key != crate::Symbol::new(crate::dialect::func::NUM_INPUTS_ATTR)
+                    && *key != crate::Symbol::new(crate::dialect::func::NUM_RESULTS_ATTR)
             })
         });
     let extra_attrs: Vec<_> = {
@@ -397,11 +604,11 @@ inventory::submit! {
 }
 
 impl crate::op_interface::CallableOwnerModel for Func {
-    fn callable_signature(self, ctx: &crate::IrContext) -> Option<crate::dialect::core::Func> {
+    fn callable_signature(self, ctx: &crate::IrContext) -> Option<crate::dialect::func::FuncSig> {
         ctx.op(self.op_ref())
             .attributes
             .get_type("type")
-            .and_then(|ty| crate::dialect::core::Func::from_type_ref(ctx, ty))
+            .and_then(|ty| crate::dialect::func::FuncSig::from_type_ref(ctx, ty))
     }
 }
 inventory::submit! { crate::op_interface::CallableOwnerOps::register::<Func>() }
@@ -417,8 +624,8 @@ mod tests {
     #[test]
     fn indirect_signature_is_declared_and_round_trips() {
         let input = r#"core.module @test {
-  func.func @run(%callee: core.func(core.i32, core.i32), %value: core.i32) -> core.i32 {
-    %result = func.call_indirect %callee, %value {signature = core.func(core.i32, core.i32)} : core.i32
+  func.func @run(%callee: func.func_sig<(core.i32) -> core.i32>, %value: core.i32) -> core.i32 {
+    %result = func.call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.i32>} : core.i32
     func.return %result
   }
 }"#;
@@ -433,7 +640,7 @@ mod tests {
 
         let printed = print_module(&ctx, module.op());
         assert!(
-            printed.contains("!t0 = core.func<(core.i32) -> core.i32>"),
+            printed.contains("!t0 = func.func_sig<(core.i32) -> core.i32>"),
             "{printed}"
         );
         assert!(printed.contains("signature = !t0"), "{printed}");
@@ -446,12 +653,12 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @ordinary(%callee: core.func(core.i32, core.i32), %value: core.i32) -> core.i32 {
-    %result = func.call_indirect %callee, %value {signature = core.func(core.i32, core.i32)} : core.i32
+  func.func @ordinary(%callee: func.func_sig<(core.i32) -> core.i32>, %value: core.i32) -> core.i32 {
+    %result = func.call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.i32>} : core.i32
     func.return %result
   }
-  func.func @tail(%callee: core.func(core.nil, core.i32), %value: core.i32) -> core.nil {
-    func.tail_call_indirect %callee, %value {signature = core.func(core.nil, core.i32)}
+  func.func @tail(%callee: func.func_sig<(core.i32) -> core.nil>, %value: core.i32) -> core.nil {
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.nil>}
   }
   func.func @direct() -> core.nil {
     func.return
@@ -523,8 +730,8 @@ mod result_list_tests {
             }
         }
         for input in [
-            "core.module @m { func.func {sym_name = @f, type = core.func<(core.i32) -> ()> {tag = @kept, nested = [core.i64]}} }",
-            "core.module @m { func.func @f(%x: core.i32) attributes {type = core.func<(core.i32) -> ()> {tag = @kept, nested = [core.i64]}} { func.return } }",
+            "core.module @m { func.func {sym_name = @f, type = func.func_sig<(core.i32) -> ()> {tag = @kept, nested = [core.i64]}} }",
+            "core.module @m { func.func @f(%x: core.i32) attributes {type = func.func_sig<(core.i32) -> ()> {tag = @kept, nested = [core.i64]}} { func.return } }",
         ] {
             let mut ctx = IrContext::new();
             let op = parse_module(&mut ctx, input).unwrap();
@@ -542,7 +749,7 @@ mod result_list_tests {
         assert!(
             parse_module(
                 &mut ctx,
-                "core.module @m { func.func @f() attributes {type = core.func<() -> core.nil>} }"
+                "core.module @m { func.func @f() attributes {type = func.func_sig<() -> core.nil>} }"
             )
             .is_err()
         );
@@ -554,7 +761,7 @@ mod result_list_tests {
         let module = crate::parser::parse_test_module(&mut ctx, "core.module @m {}");
         let loc = ctx.op(module.op()).location;
         let nil = core::nil(&mut ctx).as_type_ref();
-        let signature = core::func(&mut ctx, [], []).as_type_ref();
+        let signature = func_sig(&mut ctx, [], []).as_type_ref();
         let callee = constant(&mut ctx, loc, signature, Symbol::new("f")).result(&ctx);
         for results in [vec![], vec![nil]] {
             let direct = call(&mut ctx, loc, [], results.clone(), Symbol::new("f"));
@@ -576,17 +783,17 @@ mod result_list_tests {
         let valid = "core.module @m {
           func.func @sink(%x: core.i32)
           func.func @value(%x: core.i32) -> core.i32
-          func.func @run(%k: core.func<(core.i32) -> ()>, %x: core.i32) {
+          func.func @run(%k: func.func_sig<(core.i32) -> ()>, %x: core.i32) {
             func.call %x {callee = @sink}
-            func.call_indirect %k, %x {signature = core.func<(core.i32) -> ()>}
+            func.call_indirect %k, %x {signature = func.func_sig<(core.i32) -> ()>}
             %r = func.call %x {callee = @value} : core.i32
             func.return
           }
           func.func @tail(%x: core.i32) { func.tail_call %x {callee = @sink} }
-          func.func @logical(%k: core.func<(core.i32) -> core.never>, %x: core.i32) -> core.never {
+          func.func @logical(%k: func.func_sig<(core.i32) -> core.never>, %x: core.i32) -> core.never {
             func.tail_call_indirect %k, %x
           }
-          func.func @one(%k: core.func<(core.i32) -> core.i32>, %x: core.i32) -> core.i32 {
+          func.func @one(%k: func.func_sig<(core.i32) -> core.i32>, %x: core.i32) -> core.i32 {
             %r = func.call_indirect %k, %x : core.i32
             func.return %r
           }
@@ -615,8 +822,8 @@ mod result_list_tests {
                 "tail caller/callee result lists differ",
             ),
             (
-                "signature = core.func<(core.i32) -> ()>",
-                "signature = core.func<(core.i64) -> ()>",
+                "signature = func.func_sig<(core.i32) -> ()>",
+                "signature = func.func_sig<(core.i64) -> ()>",
                 "exact indirect signature differs",
             ),
             (
@@ -649,8 +856,8 @@ mod owner_identity_tests {
         let module = crate::parser::parse_test_module(
             &mut ctx,
             "core.module @m {
-          func.func @f(%k: core.func<() -> core.never>) -> core.never {
-            test.lambda {type = core.func<() -> core.nil>} { func.tail_call_indirect %k }
+          func.func @f(%k: func.func_sig<() -> core.never>) -> core.never {
+            test.lambda {type = func.func_sig<() -> core.nil>} { func.tail_call_indirect %k }
             func.unreachable
           }
         }",
@@ -706,7 +913,7 @@ mod normal_validation_regressions {
         ] {
             let mut ctx = crate::IrContext::new();
             let input = format!(
-                "core.module @m {{ func.func @sink() func.func @run(%k: core.func<() -> ()>) {{ func.call {{callee = @runtime}} {body} }} }}"
+                "core.module @m {{ func.func @sink() func.func @run(%k: func.func_sig<() -> ()>) {{ func.call {{callee = @runtime}} {body} }} }}"
             );
             let module = crate::parser::parse_test_module(&mut ctx, &input);
             let result = crate::validation::validate_all(&ctx, module);

--- a/crates/trunk-ir/src/dialect/mod.rs
+++ b/crates/trunk-ir/src/dialect/mod.rs
@@ -34,7 +34,7 @@ mod tests {
 
     fn make_func_type(ctx: &mut IrContext) -> crate::TypeRef {
         let nil_ty = super::core::nil(ctx).as_type_ref();
-        super::core::func(ctx, [], [nil_ty]).as_type_ref()
+        super::func::func_sig(ctx, [], [nil_ty]).as_type_ref()
     }
 
     // ================================================================
@@ -517,9 +517,9 @@ mod tests {
         let i32_ty = make_i32_type(&mut ctx.types);
 
         // func(i32, i32) -> i32  (no effect)
-        let f = super::core::func(&mut ctx, [i32_ty, i32_ty], [i32_ty]);
+        let f = super::func::func_sig(&mut ctx, [i32_ty, i32_ty], [i32_ty]);
 
-        assert!(super::core::Func::matches(&ctx, f.as_type_ref()));
+        assert!(super::func::FuncSig::matches(&ctx, f.as_type_ref()));
         assert_eq!(f.results(&ctx), &[i32_ty]);
         assert_eq!(f.inputs(&ctx), &[i32_ty, i32_ty]);
     }
@@ -529,7 +529,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let i32_ty = make_i32_type(&mut ctx.types);
 
-        let f = super::core::func(&mut ctx, [i32_ty], [i32_ty]);
+        let f = super::func::func_sig(&mut ctx, [i32_ty], [i32_ty]);
 
         assert_eq!(f.single_result(&ctx), Some(i32_ty));
         assert_eq!(f.inputs(&ctx), &[i32_ty]);
@@ -540,7 +540,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let nil_ty = super::core::nil(&mut ctx);
 
-        let f = super::core::func(&mut ctx, [], [nil_ty.as_type_ref()]);
+        let f = super::func::func_sig(&mut ctx, [], [nil_ty.as_type_ref()]);
 
         assert_eq!(f.results(&ctx), &[nil_ty.as_type_ref()]);
         assert!(f.inputs(&ctx).is_empty());
@@ -550,8 +550,8 @@ mod tests {
     fn test_func_type_result_lists_are_distinct() {
         let mut ctx = IrContext::new();
         let nil_ty = super::core::nil(&mut ctx).as_type_ref();
-        let resultless = super::core::func(&mut ctx, [], []);
-        let unit = super::core::func(&mut ctx, [], [nil_ty]);
+        let resultless = super::func::func_sig(&mut ctx, [], []);
+        let unit = super::func::func_sig(&mut ctx, [], [nil_ty]);
 
         assert_ne!(resultless.as_type_ref(), unit.as_type_ref());
         assert!(resultless.is_resultless(&ctx));
@@ -563,8 +563,8 @@ mod tests {
     fn test_func_type_counts_distinguish_the_same_flat_params() {
         let mut ctx = IrContext::new();
         let i32_ty = make_i32_type(&mut ctx.types);
-        let one_input = super::core::func(&mut ctx, [i32_ty], []);
-        let one_result = super::core::func(&mut ctx, [], [i32_ty]);
+        let one_input = super::func::func_sig(&mut ctx, [i32_ty], []);
+        let one_result = super::func::func_sig(&mut ctx, [], [i32_ty]);
 
         assert_ne!(one_input.as_type_ref(), one_result.as_type_ref());
         assert_eq!(
@@ -584,7 +584,7 @@ mod tests {
     #[test]
     fn test_func_type_zero_input_zero_result() {
         let mut ctx = IrContext::new();
-        let function = super::core::func(&mut ctx, [], []);
+        let function = super::func::func_sig(&mut ctx, [], []);
         assert!(function.inputs(&ctx).is_empty());
         assert!(function.results(&ctx).is_empty());
     }
@@ -593,23 +593,23 @@ mod tests {
     fn test_func_type_inputs_zero_one_result() {
         let mut ctx = IrContext::new();
         let i32_ty = make_i32_type(&mut ctx.types);
-        let function = super::core::func(&mut ctx, [], [i32_ty]);
+        let function = super::func::func_sig(&mut ctx, [], [i32_ty]);
         assert!(function.inputs(&ctx).is_empty());
         assert_eq!(function.results(&ctx), [i32_ty]);
     }
 
     #[test]
-    #[should_panic(expected = "core.func currently supports at most one result")]
+    #[should_panic(expected = "func.func_sig currently supports at most one result")]
     fn test_func_type_constructor_rejects_multiple_results() {
         let mut ctx = IrContext::new();
         let i32_ty = make_i32_type(&mut ctx.types);
-        let _ = super::core::func(&mut ctx, [], [i32_ty, i32_ty]);
+        let _ = super::func::func_sig(&mut ctx, [], [i32_ty, i32_ty]);
     }
 
     #[test]
     fn test_type_name_constants_extended() {
         assert_eq!(super::core::TUPLE(), Symbol::new("tuple"));
-        assert_eq!(super::core::FUNC(), Symbol::new("func"));
+        assert_eq!(super::func::FUNC_SIG(), Symbol::new("func_sig"));
         assert_eq!(super::core::BYTES(), Symbol::new("bytes"));
     }
 }

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -416,13 +416,13 @@ inventory::submit! {
 /// Attach an exact callable contract to a `wasm` indirect transfer.
 ///
 /// Returns `false` without mutation when the operation is not a `wasm`
-/// indirect call or the supplied type is not a `core.func` contract.
+/// indirect call or the supplied type is not a `func.func_sig` contract.
 pub fn set_indirect_call_signature(
     ctx: &mut crate::IrContext,
     op: crate::OpRef,
     signature: crate::TypeRef,
 ) -> bool {
-    if crate::dialect::core::Func::from_type_ref(ctx, signature).is_none()
+    if crate::dialect::func::FuncSig::from_type_ref(ctx, signature).is_none()
         || (CallIndirect::from_op(ctx, op).is_err()
             && ReturnCallIndirect::from_op(ctx, op).is_err())
     {
@@ -455,7 +455,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   wasm.func @ordinary(%table: core.i32, %value: core.i32) -> core.i32 {
-    %result = wasm.call_indirect %table, %value {signature = core.func(core.i32, core.i32), table = 0, type_idx = 0} : core.i32
+    %result = wasm.call_indirect %table, %value {signature = func.func_sig<(core.i32) -> core.i32>, table = 0, type_idx = 0} : core.i32
     wasm.return %result
   }
   wasm.func @plain(%table: core.i32, %value: core.i32) -> core.i32 {
@@ -463,7 +463,7 @@ mod tests {
     wasm.return %result
   }
   wasm.func @tail(%table: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table, %value {signature = core.func(core.nil, core.i32), table = 0, type_idx = 0}
+    wasm.return_call_indirect %table, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @direct() -> core.nil {
     wasm.return
@@ -500,6 +500,6 @@ mod tests {
 
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("wasm.call_indirect"));
-        assert!(printed.contains("signature = core.func<(core.i32) -> core.i32>"));
+        assert!(printed.contains("signature = func.func_sig<(core.i32) -> core.i32>"));
     }
 }

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -402,19 +402,19 @@ pub struct RegionValueTransfer {
 /// Exact callable region signature supplied by the owning dialect.
 /// A registered owner with an invalid signature is still an ownership boundary.
 pub trait CallableOwnerModel: DialectOp {
-    fn callable_signature(self, ctx: &IrContext) -> Option<crate::dialect::core::Func>;
+    fn callable_signature(self, ctx: &IrContext) -> Option<crate::dialect::func::FuncSig>;
 }
 
 pub struct CallableOwnerRegistration {
     dialect: &'static str,
     op_name: &'static str,
-    signature: fn(&IrContext, OpRef) -> Option<crate::dialect::core::Func>,
+    signature: fn(&IrContext, OpRef) -> Option<crate::dialect::func::FuncSig>,
 }
 
 fn callable_owner_signature<T: CallableOwnerModel>(
     ctx: &IrContext,
     op: OpRef,
-) -> Option<crate::dialect::core::Func> {
+) -> Option<crate::dialect::func::FuncSig> {
     T::from_op(ctx, op).ok()?.callable_signature(ctx)
 }
 
@@ -448,7 +448,7 @@ impl CallableOwnerOps {
     }
 
     /// Outer None means unregistered; Some(None) means a malformed owner.
-    pub fn signature(ctx: &IrContext, op: OpRef) -> Option<Option<crate::dialect::core::Func>> {
+    pub fn signature(ctx: &IrContext, op: OpRef) -> Option<Option<crate::dialect::func::FuncSig>> {
         let data = ctx.op(op);
         CALLABLE_OWNER_REGISTRY
             .get(&(data.dialect, data.name))

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -123,7 +123,7 @@ impl<'a> ArenaIrBuilder<'a> {
         if results.len() > 1 {
             return Err(ParseError {
                 message: format!(
-                    "core.func currently does not support multiple results (found {})",
+                    "func.func_sig currently does not support multiple results (found {})",
                     results.len()
                 ),
                 offset: 0,
@@ -132,11 +132,11 @@ impl<'a> ArenaIrBuilder<'a> {
         if let Some((name, _)) = attrs.iter().find(|(name, _)| {
             matches!(
                 *name,
-                crate::dialect::core::NUM_INPUTS_ATTR | crate::dialect::core::NUM_RESULTS_ATTR
+                crate::dialect::func::NUM_INPUTS_ATTR | crate::dialect::func::NUM_RESULTS_ATTR
             )
         }) {
             return Err(ParseError {
-                message: format!("`{name}` is reserved by core.func"),
+                message: format!("`{name}` is reserved by func.func_sig"),
                 offset: 0,
             });
         }
@@ -153,7 +153,10 @@ impl<'a> ArenaIrBuilder<'a> {
             .iter()
             .map(|(name, value)| Ok((Symbol::from_dynamic(name), self.build_attribute(value)?)))
             .collect::<Result<AttributeMap, ParseError>>()?;
-        Ok(crate::dialect::core::func_with_attrs(self.ctx, inputs, results, attrs).as_type_ref())
+        Ok(
+            crate::dialect::func::func_sig_with_attrs(self.ctx, inputs, results, attrs)
+                .as_type_ref(),
+        )
     }
 
     fn build_attribute(&mut self, raw: &RawAttribute<'_>) -> Result<Attribute, ParseError> {
@@ -432,7 +435,7 @@ impl<'a> ArenaIrBuilder<'a> {
             );
         }
 
-        // Handle func-style signature → core.func type
+        // Handle func-style signature → func.func_sig type
         let has_func_signature =
             raw.has_func_signature || raw.return_type.is_some() || !raw.func_params.is_empty();
         if has_func_signature {
@@ -447,7 +450,8 @@ impl<'a> ArenaIrBuilder<'a> {
                 .map(|(_, raw_ty)| self.build_type(raw_ty))
                 .collect::<Result<_, _>>()?;
 
-            let func_ty = crate::dialect::core::func(self.ctx, param_types, results).as_type_ref();
+            let func_ty =
+                crate::dialect::func::func_sig(self.ctx, param_types, results).as_type_ref();
             if attributes.contains_key("type") && attributes.get_type("type").is_none() {
                 return Err(ParseError {
                     message: "explicit function type attribute must be a type".into(),
@@ -455,9 +459,9 @@ impl<'a> ArenaIrBuilder<'a> {
                 });
             }
             if let Some(explicit) = attributes.get_type("type") {
-                let signature = crate::dialect::core::Func::from_type_ref(self.ctx, explicit);
+                let signature = crate::dialect::func::FuncSig::from_type_ref(self.ctx, explicit);
                 let synthesized =
-                    crate::dialect::core::Func::from_type_ref(self.ctx, func_ty).unwrap();
+                    crate::dialect::func::FuncSig::from_type_ref(self.ctx, func_ty).unwrap();
                 if signature.is_none_or(|signature| {
                     signature.inputs(self.ctx) != synthesized.inputs(self.ctx)
                         || signature.results(self.ctx) != synthesized.results(self.ctx)
@@ -647,7 +651,7 @@ mod tests {
     }
 
     fn make_func_type(ctx: &mut IrContext, params: &[TypeRef], ret: TypeRef) -> TypeRef {
-        core::func(ctx, params.iter().copied(), [ret]).as_type_ref()
+        func::func_sig(ctx, params.iter().copied(), [ret]).as_type_ref()
     }
 
     fn wrap_in_module(ctx: &mut IrContext, loc: Location, func_ops: Vec<OpRef>) -> OpRef {
@@ -1207,7 +1211,7 @@ core.module @test {
     fn review_function_result_type_preserves_empty_body() {
         for attrs in ["", " {effect = core.nil}"] {
             let input = format!(
-                "core.module @test {{ func.func @f() -> core.func<() -> ()>{attrs} {{}} }}"
+                "core.module @test {{ func.func @f() -> func.func_sig<() -> ()>{attrs} {{}} }}"
             );
             let mut ctx = IrContext::new();
             let module = parse_module(&mut ctx, &input).unwrap();
@@ -1234,10 +1238,10 @@ core.module @test {
     #[test]
     fn test_canonical_func_type_roundtrips_all_supported_arities() {
         let input = r#"core.module @test {
-  !zero_zero = core.func<() -> ()>
-  !many_zero = core.func<(core.i32, core.i64) -> ()>
-  !zero_one = core.func<() -> core.i32>
-  !many_one = core.func<(core.i32, core.i64) -> core.i32>
+  !zero_zero = func.func_sig<() -> ()>
+  !many_zero = func.func_sig<(core.i32, core.i64) -> ()>
+  !zero_one = func.func_sig<() -> core.i32>
+  !many_one = func.func_sig<(core.i32, core.i64) -> core.i32>
 }"#;
         let mut ctx = IrContext::new();
         let module = parse_module(&mut ctx, input).expect("canonical function types should parse");
@@ -1251,7 +1255,7 @@ core.module @test {
             let ty = ctx
                 .type_alias_by_name(Symbol::from_dynamic(name))
                 .expect("function alias");
-            let function = core::Func::from_type_ref(&ctx, ty).expect("validated core.func");
+            let function = func::FuncSig::from_type_ref(&ctx, ty).expect("validated func.func_sig");
             assert_eq!(function.inputs(&ctx).len(), input_count);
             assert_eq!(function.results(&ctx).len(), result_count);
         }
@@ -1262,12 +1266,14 @@ core.module @test {
     fn test_legacy_func_type_normalizes_to_canonical_storage_and_text() {
         let input = r#"core.module @test {
   !legacy = core.func(core.i64, core.i32)
+  !legacy_canonical = core.func<(core.i32) -> core.i64>
+  !canonical = func.func_sig<(core.i32) -> core.i64>
 }"#;
         let mut ctx = IrContext::new();
         let module = parse_module(&mut ctx, input).expect("legacy function type should parse");
         let printed = print_module(&ctx, module);
         assert!(
-            printed.contains("!legacy = core.func<(core.i32) -> core.i64>"),
+            printed.contains("!legacy = func.func_sig<(core.i32) -> core.i64>"),
             "{printed}"
         );
         assert!(!printed.contains("core.func(core.i64"), "{printed}");
@@ -1275,23 +1281,34 @@ core.module @test {
         let ty = ctx
             .type_alias_by_name(Symbol::new("legacy"))
             .expect("legacy alias");
+        assert_eq!(
+            Some(ty),
+            ctx.type_alias_by_name(Symbol::new("legacy_canonical")),
+            "legacy core.func canonical syntax must intern as func.func_sig"
+        );
+        assert_eq!(
+            Some(ty),
+            ctx.type_alias_by_name(Symbol::new("canonical")),
+            "all accepted legacy spellings must normalize to one identity"
+        );
         let data = ctx.types.get(ty);
         assert_eq!(data.params.len(), 2);
-        assert_eq!(data.attrs.get_u32(core::NUM_INPUTS_ATTR), Ok(Some(1)));
-        assert_eq!(data.attrs.get_u32(core::NUM_RESULTS_ATTR), Ok(Some(1)));
+        assert_eq!(data.attrs.get_u32(func::NUM_INPUTS_ATTR), Ok(Some(1)));
+        assert_eq!(data.attrs.get_u32(func::NUM_RESULTS_ATTR), Ok(Some(1)));
         assert_roundtrip(&ctx, module);
     }
 
     #[test]
     fn test_func_type_preserves_non_reserved_attributes() {
         let input = r#"core.module @test {
-  !with_attr = core.func<(core.i32) -> core.i64> {effect = core.nil}
+  !with_attr = func.func_sig<(core.i32) -> core.i64> {effect = core.nil}
 }"#;
         let mut ctx = IrContext::new();
         let module = parse_module(&mut ctx, input).expect("function type attribute should parse");
         let printed = print_module(&ctx, module);
         assert!(
-            printed.contains("!with_attr = core.func<(core.i32) -> core.i64> {effect = core.nil}"),
+            printed
+                .contains("!with_attr = func.func_sig<(core.i32) -> core.i64> {effect = core.nil}"),
             "{printed}"
         );
         assert!(!printed.contains("num_inputs"), "{printed}");
@@ -1301,20 +1318,27 @@ core.module @test {
 
     #[test]
     fn test_func_type_rejects_reserved_textual_attributes() {
-        for reserved in [core::NUM_INPUTS_ATTR, core::NUM_RESULTS_ATTR] {
-            for form in ["core.func<() -> ()>", "core.func(core.nil)"] {
+        for reserved in [func::NUM_INPUTS_ATTR, func::NUM_RESULTS_ATTR] {
+            for form in [
+                "core.func(core.nil)",
+                "core.func<() -> core.nil>",
+                "func.func_sig<() -> core.nil>",
+            ] {
                 let input = format!("core.module @test {{ !bad = {form} {{{reserved} = 0}} }}");
                 let mut ctx = IrContext::new();
                 let error =
                     parse_module(&mut ctx, &input).expect_err("reserved key must be rejected");
-                assert!(error.message.contains("reserved by core.func"), "{error}");
+                assert!(
+                    error.message.contains("reserved by func.func_sig"),
+                    "{error}"
+                );
             }
         }
     }
 
     #[test]
     fn test_func_type_rejects_multiple_results_after_recognizing_syntax() {
-        let input = "core.module @test { !bad = core.func<() -> (core.i32, core.i64)> }";
+        let input = "core.module @test { !bad = func.func_sig<() -> (core.i32, core.i64)> }";
         let mut ctx = IrContext::new();
         let error = parse_module(&mut ctx, input).expect_err("multi-result must be rejected");
         assert!(error.message.contains("multiple results"), "{error}");
@@ -1337,7 +1361,7 @@ core.module @test {
 
         let module_view = crate::rewrite::Module::new(&ctx, module).unwrap();
         let function = func::Func::from_op(&ctx, module_view.ops(&ctx)[0]).unwrap();
-        let signature = core::Func::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
+        let signature = func::FuncSig::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
         assert_eq!(signature.inputs(&ctx).len(), 1);
         assert!(signature.is_resultless(&ctx));
         assert_roundtrip(&ctx, module);
@@ -1410,7 +1434,7 @@ core.module @test {
     fn test_nested_type_alias() {
         let input = r#"core.module @test {
   !inner = core.tuple(core.i32, core.i32)
-  !outer = core.func(!inner)
+  !outer = func.func_sig<() -> !inner>
 
   func.func @foo(%0: !inner) -> !inner {
     func.return %0

--- a/crates/trunk-ir/src/parser/raw.rs
+++ b/crates/trunk-ir/src/parser/raw.rs
@@ -72,7 +72,7 @@ pub enum RawType<'a> {
         params: Vec<RawType<'a>>,
         attrs: Vec<(&'a str, RawAttribute<'a>)>,
     },
-    /// Canonical `core.func<(inputs...) -> results>` syntax.
+    /// Canonical `func.func_sig<(inputs...) -> results>` syntax.
     Function {
         inputs: Vec<RawType<'a>>,
         results: Vec<RawType<'a>>,
@@ -278,7 +278,9 @@ pub fn raw_type<'a>(input: &mut &'a str) -> ModalResult<RawType<'a>> {
 
     let (dialect, name) = qualified_name.parse_next(input)?;
 
-    if dialect == "core" && name == "func" && input.starts_with('<') {
+    if ((dialect == "func" && name == "func_sig") || (dialect == "core" && name == "func"))
+        && input.starts_with('<')
+    {
         '<'.parse_next(input)?;
         ws.parse_next(input)?;
         let inputs = delimited(
@@ -789,7 +791,7 @@ mod tests {
 
     #[test]
     fn test_parse_canonical_function_type() {
-        let mut input = "core.func<(core.i32, core.i64) -> core.never>";
+        let mut input = "func.func_sig<(core.i32, core.i64) -> core.never>";
         let raw = raw_type.parse_next(&mut input).expect("should parse type");
         let RawType::Function {
             inputs,
@@ -807,7 +809,7 @@ mod tests {
 
     #[test]
     fn test_parse_canonical_function_type_with_empty_results() {
-        let mut input = "core.func<(core.i32) -> ()>";
+        let mut input = "func.func_sig<(core.i32) -> ()>";
         let raw = raw_type.parse_next(&mut input).expect("should parse type");
         let RawType::Function {
             inputs, results, ..
@@ -822,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_parse_canonical_function_type_recognizes_multiple_results() {
-        let mut input = "core.func<() -> (core.i32, core.i64)>";
+        let mut input = "func.func_sig<() -> (core.i32, core.i64)>";
         let raw = raw_type.parse_next(&mut input).expect("should parse type");
         let RawType::Function { results, .. } = raw else {
             panic!("expected canonical Function")

--- a/crates/trunk-ir/src/pass.rs
+++ b/crates/trunk-ir/src/pass.rs
@@ -527,7 +527,7 @@ mod tests {
         name: &'static str,
     ) -> OpRef {
         let nil_ty = core::nil(ctx).as_type_ref();
-        let func_ty = core::func(ctx, [], [nil_ty]).as_type_ref();
+        let func_ty = func::func_sig(ctx, [], [nil_ty]).as_type_ref();
         let op_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
             .attr("sym_name", Attribute::Symbol(Symbol::new(name)))
             .attr("type", Attribute::Type(func_ty))

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -107,7 +107,7 @@ impl<'a> PrintState<'a> {
         if let Some(alias_name) = self.type_alias_names.get(&ty) {
             return write_type_alias_name(f, alias_name);
         }
-        if let Some(func) = crate::dialect::core::Func::from_type_ref(self.ctx, ty) {
+        if let Some(func) = crate::dialect::func::FuncSig::from_type_ref(self.ctx, ty) {
             return self.write_func_type(f, func);
         }
         let data = self.ctx.types.get(ty);
@@ -138,8 +138,12 @@ impl<'a> PrintState<'a> {
         Ok(())
     }
 
-    fn write_func_type(&self, f: &mut dyn Write, func: crate::dialect::core::Func) -> fmt::Result {
-        f.write_str("core.func<(")?;
+    fn write_func_type(
+        &self,
+        f: &mut dyn Write,
+        func: crate::dialect::func::FuncSig,
+    ) -> fmt::Result {
+        f.write_str("func.func_sig<(")?;
         for (index, &input) in func.inputs(self.ctx).iter().enumerate() {
             if index > 0 {
                 f.write_str(", ")?;
@@ -455,7 +459,7 @@ fn collect_module_types(ctx: &IrContext, region: RegionRef) -> HashMap<TypeRef, 
 
         // Attributes containing types.
         // Skip func.func — its `type` attribute holds the function signature
-        // (core.func), which would otherwise dominate alias candidates.
+        // (func.func_sig), which would otherwise dominate alias candidates.
         let is_func_decl =
             data.dialect == crate::Symbol::new("func") && data.name == crate::Symbol::new("func");
         if !is_func_decl {
@@ -955,9 +959,9 @@ mod tests {
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
     }
 
-    /// Create a one-result `core.func` type.
+    /// Create a one-result `func.func_sig` type.
     fn make_func_type(ctx: &mut IrContext, params: &[TypeRef], ret: TypeRef) -> TypeRef {
-        crate::dialect::core::func(ctx, params.iter().copied(), [ret]).as_type_ref()
+        crate::dialect::func::func_sig(ctx, params.iter().copied(), [ret]).as_type_ref()
     }
 
     #[test]
@@ -982,7 +986,7 @@ mod tests {
             let input = format!(
                 "core.module @m {{
                 !scalar = core.i32
-                !callable = core.func<(!scalar) -> {result}> {{nested = [!scalar]}}
+                !callable = func.func_sig<(!scalar) -> {result}> {{nested = [!scalar]}}
                 func.func @f(%x: !callable) {{ func.return }}
             }}"
             );
@@ -991,12 +995,12 @@ mod tests {
             let expanded_result = if result == "()" { "()" } else { "core.i32" };
             assert_eq!(
                 print_type(&ctx, callable),
-                format!("core.func<(core.i32) -> {expanded_result}> {{nested = [core.i32]}}")
+                format!("func.func_sig<(core.i32) -> {expanded_result}> {{nested = [core.i32]}}")
             );
             let printed = print_module(&ctx, module);
             assert!(
                 printed.contains(&format!(
-                    "core.func<(!scalar) -> {result}> {{nested = [!scalar]}}"
+                    "func.func_sig<(!scalar) -> {result}> {{nested = [!scalar]}}"
                 )),
                 "{printed}"
             );
@@ -1010,20 +1014,20 @@ mod tests {
     fn test_print_func_type_uses_canonical_result_list_syntax() {
         let mut ctx = IrContext::new();
         let i32_ty = make_i32_type(&mut ctx);
-        let zero_zero = core::func(&mut ctx, [], []).as_type_ref();
-        let many_zero = core::func(&mut ctx, [i32_ty, i32_ty], []).as_type_ref();
-        let zero_one = core::func(&mut ctx, [], [i32_ty]).as_type_ref();
-        let many_one = core::func(&mut ctx, [i32_ty, i32_ty], [i32_ty]).as_type_ref();
+        let zero_zero = func::func_sig(&mut ctx, [], []).as_type_ref();
+        let many_zero = func::func_sig(&mut ctx, [i32_ty, i32_ty], []).as_type_ref();
+        let zero_one = func::func_sig(&mut ctx, [], [i32_ty]).as_type_ref();
+        let many_one = func::func_sig(&mut ctx, [i32_ty, i32_ty], [i32_ty]).as_type_ref();
 
-        assert_eq!(print_type(&ctx, zero_zero), "core.func<() -> ()>");
+        assert_eq!(print_type(&ctx, zero_zero), "func.func_sig<() -> ()>");
         assert_eq!(
             print_type(&ctx, many_zero),
-            "core.func<(core.i32, core.i32) -> ()>"
+            "func.func_sig<(core.i32, core.i32) -> ()>"
         );
-        assert_eq!(print_type(&ctx, zero_one), "core.func<() -> core.i32>");
+        assert_eq!(print_type(&ctx, zero_one), "func.func_sig<() -> core.i32>");
         assert_eq!(
             print_type(&ctx, many_one),
-            "core.func<(core.i32, core.i32) -> core.i32>"
+            "func.func_sig<(core.i32, core.i32) -> core.i32>"
         );
     }
 
@@ -1438,7 +1442,7 @@ mod tests {
         let output = print_module(&ctx, module);
 
         // No auto aliases should be generated — core.i32 is a leaf type and
-        // core.func has no dialect-provided name hint
+        // func.func_sig has no dialect-provided name hint
         assert!(
             !output.contains('!'),
             "No types should be aliased:\n{output}"

--- a/crates/trunk-ir/src/rewrite/applicator.rs
+++ b/crates/trunk-ir/src/rewrite/applicator.rs
@@ -481,7 +481,7 @@ mod tests {
             parent_op: None,
         });
         let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-        let func_ty = crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref();
+        let func_ty = crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref();
         let func_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
             .attr("sym_name", Attribute::Symbol(Symbol::new(name)))
             .attr("type", Attribute::Type(func_ty))
@@ -512,7 +512,7 @@ mod tests {
             parent_op: None,
         });
         let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-        let func_ty = crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref();
+        let func_ty = crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref();
         wasm::func(ctx, loc, Symbol::new(name), func_ty, region)
     }
 
@@ -523,7 +523,7 @@ mod tests {
         name: &'static str,
     ) -> OpRef {
         let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-        let func_ty = crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref();
+        let func_ty = crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref();
         let op_data = OperationDataBuilder::new(loc, Symbol::new(dialect), Symbol::new("func"))
             .attr("sym_name", Attribute::Symbol(Symbol::new(name)))
             .attr("type", Attribute::Type(func_ty))

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -7,7 +7,7 @@
 //! - [`WasmFuncSignatureConversionPattern`]: Converts `wasm.func` signatures
 
 use crate::context::{IrContext, OperationDataBuilder};
-use crate::dialect::{core, func, wasm};
+use crate::dialect::{func, wasm};
 use crate::ops::{DialectOp, DialectType};
 use crate::refs::{OpRef, RegionRef, TypeRef};
 use crate::rewrite::clone_attrs_except;
@@ -16,7 +16,7 @@ use crate::rewrite::rewriter::PatternRewriter;
 use crate::rewrite::type_converter::TypeConverter;
 use crate::types::Attribute;
 
-/// Result of converting a `core.func` type's params and result.
+/// Result of converting a `func.func_sig` type's params and result.
 struct ConvertedSignature {
     new_params: Vec<TypeRef>,
     new_results: Vec<TypeRef>,
@@ -24,15 +24,15 @@ struct ConvertedSignature {
     changed: bool,
 }
 
-/// Analyze a `core.func` TypeRef and convert params/result via the type converter.
+/// Analyze a `func.func_sig` TypeRef and convert params/result via the type converter.
 ///
-/// Returns `None` when `func_type` is not a well-formed `core.func` type.
+/// Returns `None` when `func_type` is not a well-formed `func.func_sig` type.
 fn convert_func_signature(
     ctx: &IrContext,
     func_type: TypeRef,
     converter: &TypeConverter,
 ) -> Option<ConvertedSignature> {
-    let func = core::Func::from_type_ref(ctx, func_type)?;
+    let func = func::FuncSig::from_type_ref(ctx, func_type)?;
     let data = ctx.types.get(func_type);
     let type_attrs = func
         .non_reserved_attrs(ctx)
@@ -85,9 +85,9 @@ fn convert_attribute_types(
     }
 }
 
-/// Build a new `core.func` TypeRef from converted params/result.
+/// Build a new `func.func_sig` TypeRef from converted params/result.
 fn rebuild_func_type(ctx: &mut IrContext, sig: &ConvertedSignature) -> TypeRef {
-    crate::dialect::core::func_with_attrs(
+    crate::dialect::func::func_sig_with_attrs(
         ctx,
         sig.new_params.iter().copied(),
         sig.new_results.iter().copied(),
@@ -96,7 +96,7 @@ fn rebuild_func_type(ctx: &mut IrContext, sig: &ConvertedSignature) -> TypeRef {
     .as_type_ref()
 }
 
-/// Convert the parameter and result types of a `core.func` type.
+/// Convert the parameter and result types of a `func.func_sig` type.
 ///
 /// This is the type-only counterpart to the function-signature rewrite
 /// patterns. It is for exact callable attributes whose source operation does
@@ -312,7 +312,7 @@ mod tests {
     }
 
     fn make_func_type(ctx: &mut IrContext, params: &[TypeRef], ret: TypeRef) -> TypeRef {
-        crate::dialect::core::func(ctx, params.iter().copied(), [ret]).as_type_ref()
+        crate::dialect::func::func_sig(ctx, params.iter().copied(), [ret]).as_type_ref()
     }
 
     fn make_module(ctx: &mut IrContext, loc: crate::types::Location, ops: Vec<OpRef>) -> Module {
@@ -422,7 +422,8 @@ mod tests {
 
         let mut type_attrs = crate::AttributeMap::new();
         type_attrs.insert(Symbol::new("metadata_type"), Attribute::Type(i32_ty));
-        let func_ty = core::func_with_attrs(&mut ctx, [i32_ty], [i32_ty], type_attrs).as_type_ref();
+        let func_ty =
+            func::func_sig_with_attrs(&mut ctx, [i32_ty], [i32_ty], type_attrs).as_type_ref();
         let func_op = make_func_op(&mut ctx, loc, "test_fn", func_ty, &[i32_ty]);
         let module = make_module(&mut ctx, loc, vec![func_op]);
 
@@ -443,7 +444,7 @@ mod tests {
         assert_eq!(ops.len(), 1);
         let new_func = func::Func::from_op(&ctx, ops[0]).unwrap();
         let new_type = new_func.r#type(&ctx);
-        let function = core::Func::from_type_ref(&ctx, new_type).unwrap();
+        let function = func::FuncSig::from_type_ref(&ctx, new_type).unwrap();
         assert_eq!(function.inputs(&ctx), &[i64_ty]);
         assert_eq!(function.single_result(&ctx), Some(i64_ty));
         assert_eq!(
@@ -487,13 +488,13 @@ mod tests {
         let (mut ctx, _) = test_ctx();
         let i32_ty = i32_type(&mut ctx);
         let i64_ty = i64_type(&mut ctx);
-        let resultless = core::func(&mut ctx, [i32_ty, i32_ty], []).as_type_ref();
+        let resultless = func::func_sig(&mut ctx, [i32_ty, i32_ty], []).as_type_ref();
         let before = ctx.types.get(resultless).clone();
         let converter = i32_to_i64_converter(i32_ty, i64_ty);
 
         let converted = convert_function_type(&mut ctx, resultless, &converter).unwrap();
         assert_eq!(ctx.types.get(resultless), &before);
-        let function = core::Func::from_type_ref(&ctx, converted).unwrap();
+        let function = func::FuncSig::from_type_ref(&ctx, converted).unwrap();
         assert_eq!(function.inputs(&ctx), [i64_ty, i64_ty]);
         assert!(function.is_resultless(&ctx));
     }
@@ -527,7 +528,7 @@ mod tests {
         let ops = module.ops(&ctx);
         let new_func = wasm::Func::from_op(&ctx, ops[0]).unwrap();
         let new_type = new_func.r#type(&ctx);
-        let function = core::Func::from_type_ref(&ctx, new_type).unwrap();
+        let function = func::FuncSig::from_type_ref(&ctx, new_type).unwrap();
         assert_eq!(function.inputs(&ctx), &[i64_ty, i64_ty]);
         assert_eq!(function.single_result(&ctx), Some(i64_ty));
         assert_eq!(
@@ -555,7 +556,7 @@ mod tests {
             } else {
                 vec![i32_ty]
             };
-            let func_ty = core::func(&mut ctx, [i32_ty], results).as_type_ref();
+            let func_ty = func::func_sig(&mut ctx, [i32_ty], results).as_type_ref();
 
             let func_decl = make_bodyless_function_op(
                 &mut ctx,
@@ -596,7 +597,7 @@ mod tests {
                 let data = ctx.op(ops[index]);
                 assert_eq!(data.regions.len(), expected_regions);
                 let func_ty = data.attributes.get_type("type").unwrap();
-                let function = core::Func::from_type_ref(&ctx, func_ty).unwrap();
+                let function = func::FuncSig::from_type_ref(&ctx, func_ty).unwrap();
                 assert_eq!(function.inputs(&ctx), [i64_ty]);
                 assert_eq!(function.results(&ctx), vec![i64_ty; result_count]);
             }
@@ -610,7 +611,7 @@ mod tests {
             let result = if result_count == 0 { "()" } else { "core.i64" };
             assert!(text.contains(&format!("func.func @external(%arg0: core.i64){arrow}\n")));
             assert!(
-                text.contains(&format!("!t0 = core.func<(core.i64) -> {result}>")),
+                text.contains(&format!("!t0 = func.func_sig<(core.i64) -> {result}>")),
                 "{text}"
             );
             assert!(
@@ -645,7 +646,7 @@ mod tests {
 
         let ops = module.ops(&ctx);
         let new_func = func::Func::from_op(&ctx, ops[0]).unwrap();
-        let function = core::Func::from_type_ref(&ctx, new_func.r#type(&ctx)).unwrap();
+        let function = func::FuncSig::from_type_ref(&ctx, new_func.r#type(&ctx)).unwrap();
         assert_eq!(function.inputs(&ctx), &[i64_ty]);
         assert_eq!(function.single_result(&ctx), Some(i64_ty));
     }
@@ -716,6 +717,7 @@ mod tests {
 #[cfg(test)]
 mod result_list_tests {
     use super::*;
+    use crate::dialect::core;
     use crate::{Symbol, ops::DialectOp, parser::parse_test_module};
 
     #[test]
@@ -731,13 +733,17 @@ mod result_list_tests {
                     Attribute::List(vec![Attribute::List(vec![Attribute::Type(nil)])]),
                 );
                 attrs.insert(Symbol::new("tag"), Attribute::Symbol(Symbol::new("keep")));
-                let signature =
-                    core::func_with_attrs(&mut ctx, vec![nil; inputs], vec![nil; results], attrs)
-                        .as_type_ref();
+                let signature = func::func_sig_with_attrs(
+                    &mut ctx,
+                    vec![nil; inputs],
+                    vec![nil; results],
+                    attrs,
+                )
+                .as_type_ref();
                 let mut converter = TypeConverter::new();
                 converter.add_conversion(move |_, ty| (ty == nil).then_some(ptr));
                 let converted = convert_function_type(&mut ctx, signature, &converter).unwrap();
-                let function = core::Func::from_type_ref(&ctx, converted).unwrap();
+                let function = func::FuncSig::from_type_ref(&ctx, converted).unwrap();
                 assert_eq!(function.inputs(&ctx), vec![ptr; inputs]);
                 assert_eq!(function.results(&ctx), vec![ptr; results]);
                 assert_eq!(
@@ -765,7 +771,7 @@ mod result_list_tests {
         let function = func::Func::from_op(&ctx, op).unwrap();
         let nil = core::nil(&mut ctx).as_type_ref();
         let ptr = core::ptr(&mut ctx).as_type_ref();
-        let bad_signature = core::func(&mut ctx, [nil, nil], []).as_type_ref();
+        let bad_signature = func::func_sig(&mut ctx, [nil, nil], []).as_type_ref();
         ctx.op_mut(op)
             .attributes
             .insert(Symbol::new("type"), Attribute::Type(bad_signature));

--- a/crates/trunk-ir/src/transforms/call_graph.rs
+++ b/crates/trunk-ir/src/transforms/call_graph.rs
@@ -334,7 +334,7 @@ mod tests {
 
     fn fn_type(ctx: &mut IrContext) -> TypeRef {
         let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-        crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref()
+        crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref()
     }
 
     fn i32_type(ctx: &mut IrContext) -> TypeRef {

--- a/crates/trunk-ir/src/transforms/dce.rs
+++ b/crates/trunk-ir/src/transforms/dce.rs
@@ -189,7 +189,7 @@ mod tests {
 
     fn fn_type(ctx: &mut IrContext) -> TypeRef {
         let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-        crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref()
+        crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref()
     }
 
     /// Build a minimal module wrapping the given function ops.
@@ -413,7 +413,7 @@ mod tests {
 
             // Outer op that owns the inner region (use func.func as container)
             let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-            let fn_ty = crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref();
+            let fn_ty = crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref();
             let nested_func = func::func(ctx, loc, Symbol::new("nested"), fn_ty, inner_region);
             ctx.push_op(entry, nested_func.op_ref());
 
@@ -477,7 +477,7 @@ mod tests {
             });
 
             let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-            let fn_ty = crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref();
+            let fn_ty = crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref();
             let nested_func = func::func(ctx, loc, Symbol::new("nested"), fn_ty, inner_region);
             ctx.push_op(entry, nested_func.op_ref());
 

--- a/crates/trunk-ir/src/transforms/global_dce.rs
+++ b/crates/trunk-ir/src/transforms/global_dce.rs
@@ -411,7 +411,7 @@ mod tests {
 
     fn fn_type(ctx: &mut IrContext) -> TypeRef {
         let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-        crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref()
+        crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref()
     }
 
     fn i32_type(ctx: &mut IrContext) -> TypeRef {

--- a/crates/trunk-ir/src/transforms/inline.rs
+++ b/crates/trunk-ir/src/transforms/inline.rs
@@ -485,7 +485,7 @@ mod mechanics {
         F: FnOnce(&mut IrContext, BlockRef, &[ValueRef]),
     {
         let fn_ty =
-            crate::dialect::core::func(ctx, param_tys.iter().copied(), std::iter::once(ret_ty))
+            crate::dialect::func::func_sig(ctx, param_tys.iter().copied(), std::iter::once(ret_ty))
                 .as_type_ref();
         let entry = ctx.create_block(BlockData {
             location: loc,
@@ -853,7 +853,7 @@ mod pass {
         F: FnOnce(&mut IrContext, BlockRef, &[ValueRef]),
     {
         let fn_ty =
-            crate::dialect::core::func(ctx, param_tys.iter().copied(), std::iter::once(ret_ty))
+            crate::dialect::func::func_sig(ctx, param_tys.iter().copied(), std::iter::once(ret_ty))
                 .as_type_ref();
         let entry = ctx.create_block(BlockData {
             location: loc,
@@ -1099,7 +1099,7 @@ mod pass {
             parent_op: None,
         });
 
-        let fn_ty = crate::dialect::core::func(&mut ctx, [], [i32_ty]).as_type_ref();
+        let fn_ty = crate::dialect::func::func_sig(&mut ctx, [], [i32_ty]).as_type_ref();
         let helper_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
             .attr("sym_name", Attribute::Symbol(Symbol::new("helper")))
             .attr("type", Attribute::Type(fn_ty))

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -760,7 +760,7 @@ mod tests {
 
     fn fn_type(ctx: &mut IrContext) -> TypeRef {
         let nil_ty = crate::dialect::core::nil(ctx).as_type_ref();
-        crate::dialect::core::func(ctx, [], [nil_ty]).as_type_ref()
+        crate::dialect::func::func_sig(ctx, [], [nil_ty]).as_type_ref()
     }
 
     fn build_module(ctx: &mut IrContext, loc: Location, func_ops: Vec<OpRef>) -> Module {
@@ -1141,7 +1141,7 @@ mod tests {
 
         let printed = crate::printer::print_module(&ctx, module.op());
         assert!(
-            printed.contains("!t0 = core.func<(core.nil) -> core.never>"),
+            printed.contains("!t0 = func.func_sig<(core.nil) -> core.never>"),
             "{printed}"
         );
         assert!(printed.contains("signature = !t0"), "{printed}");
@@ -1152,13 +1152,13 @@ mod tests {
     fn lower_scf_if_preserves_used_nil_result_for_tail_transfer() {
         assert_lowered_unit_tail_transfer(
             r#"core.module @test {
-  func.func @main(%cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%cond: core.i1, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     %selected = scf.if %cond : core.nil {
       scf.yield %unit
     } {
       scf.yield %unit
     }
-    func.tail_call_indirect %callee, %selected {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %selected {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
   }
 }"#,
             1,
@@ -1168,11 +1168,11 @@ mod tests {
     #[test]
     fn lower_scf_if_drops_unused_never_result_for_tail_transfers() {
         let input = r#"core.module @test {
-  func.func @main(%cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%cond: core.i1, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     %discarded = scf.if %cond : core.never {
       func.unreachable
     } {
-      func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+      func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
     }
   }
 }"#;
@@ -1225,13 +1225,13 @@ mod tests {
     #[test]
     fn lower_terminal_scf_switch_without_empty_merge_block() {
         let input = r#"core.module @test {
-  func.func @main(%choice: core.i32, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%choice: core.i32, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     scf.switch %choice {
       scf.case {value = 0} {
         func.unreachable
       }
       scf.default {
-        func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+        func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
       }
     }
   }
@@ -1272,17 +1272,17 @@ mod tests {
     #[test]
     fn lower_terminal_scf_switch_with_nested_never_if_has_no_merge_block() {
         let input = r#"core.module @test {
-  func.func @main(%choice: core.i32, %cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%choice: core.i32, %cond: core.i1, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     scf.switch %choice {
       scf.case {value = 0} {
         %discarded = scf.if %cond : core.never {
           func.unreachable
         } {
-          func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+          func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
         }
       }
       scf.default {
-        func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+        func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
       }
     }
   }
@@ -1320,7 +1320,7 @@ mod tests {
     #[test]
     fn lower_terminal_scf_switch_with_nested_terminal_switch_has_no_empty_merge_block() {
         let input = r#"core.module @test {
-  func.func @main(%choice: core.i32, %nested_choice: core.i32, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%choice: core.i32, %nested_choice: core.i32, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     scf.switch %choice {
       scf.case {value = 0} {
         scf.switch %nested_choice {
@@ -1328,12 +1328,12 @@ mod tests {
             func.unreachable
           }
           scf.default {
-            func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+            func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
           }
         }
       }
       scf.default {
-        func.tail_call_indirect %callee, %unit {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+        func.tail_call_indirect %callee, %unit {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
       }
     }
   }
@@ -1470,7 +1470,7 @@ mod tests {
     fn lower_nested_nil_results_preserves_each_merge_value() {
         assert_lowered_unit_tail_transfer(
             r#"core.module @test {
-  func.func @main(%cond: core.i1, %callee: core.func(core.never, core.nil), %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
+  func.func @main(%cond: core.i1, %callee: func.func_sig<(core.nil) -> core.never>, %unit: core.nil) -> core.never attributes {tribute.calling_convention = 2} {
     %inner = scf.if %cond : core.nil {
       scf.yield %unit
     } {
@@ -1481,7 +1481,7 @@ mod tests {
     } {
       scf.yield %inner
     }
-    func.tail_call_indirect %callee, %outer {signature = core.func(core.never, core.nil), tribute.calling_convention = 2}
+    func.tail_call_indirect %callee, %outer {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
   }
 }"#,
             2,

--- a/crates/trunk-ir/src/validation.rs
+++ b/crates/trunk-ir/src/validation.rs
@@ -320,7 +320,7 @@ pub fn validate_use_chains(ctx: &IrContext, module: Module) -> ValidationResult 
 pub fn validate_operation_verifiers(ctx: &IrContext, module: Module) -> ValidationResult {
     let mut errors = Vec::new();
 
-    validate_core_func_types(ctx, &mut errors);
+    validate_func_sig_types(ctx, &mut errors);
 
     let body = match module.body(ctx) {
         Some(r) => r,
@@ -348,16 +348,25 @@ pub fn validate_operation_verifiers(ctx: &IrContext, module: Module) -> Validati
     ValidationResult { errors }
 }
 
-fn validate_core_func_types(ctx: &IrContext, errors: &mut Vec<ValidationError>) {
+fn validate_func_sig_types(ctx: &IrContext, errors: &mut Vec<ValidationError>) {
     for (ty, data) in ctx.types.iter() {
-        if data.dialect != crate::dialect::core::DIALECT_NAME()
-            || data.name != crate::dialect::core::FUNC()
+        if data.dialect == crate::dialect::core::DIALECT_NAME() && data.name == Symbol::new("func")
+        {
+            errors.push(ValidationError::Operation {
+                message: format!(
+                    "type verifier rejected retired core.func identity ({ty}); use func.func_sig"
+                ),
+            });
+            continue;
+        }
+        if data.dialect != crate::dialect::func::DIALECT_NAME()
+            || data.name != crate::dialect::func::FUNC_SIG()
         {
             continue;
         }
-        if let Err(error) = crate::dialect::core::Func::validate(ctx, ty) {
+        if let Err(error) = crate::dialect::func::FuncSig::validate(ctx, ty) {
             errors.push(ValidationError::Operation {
-                message: format!("type verifier failed for core.func ({ty}): {error}"),
+                message: format!("type verifier failed for func.func_sig ({ty}): {error}"),
             });
         }
     }
@@ -399,11 +408,11 @@ fn validate_func_indirect_call(ctx: &IrContext, op: OpRef, errors: &mut Vec<Vali
     } else {
         ctx.value_ty(callee)
     };
-    let typed = crate::dialect::core::Func::from_type_ref(ctx, func_ty);
+    let typed = crate::dialect::func::FuncSig::from_type_ref(ctx, func_ty);
     let exact = data
         .attributes
         .get_type("signature")
-        .and_then(|ty| crate::dialect::core::Func::from_type_ref(ctx, ty));
+        .and_then(|ty| crate::dialect::func::FuncSig::from_type_ref(ctx, ty));
     if data.attributes.contains_key("signature") && exact.is_none() {
         errors.push(operation_verifier_error(
             ctx,
@@ -428,7 +437,7 @@ fn validate_func_indirect_call(ctx: &IrContext, op: OpRef, errors: &mut Vec<Vali
         errors.push(operation_verifier_error(
             ctx,
             op,
-            "callee must have core.func or closure.closure<core.func> type",
+            "callee must have func.func_sig or closure.closure<func.func_sig> type",
         ));
         return;
     };
@@ -443,19 +452,19 @@ fn validate_func_indirect_call(ctx: &IrContext, op: OpRef, errors: &mut Vec<Vali
 }
 
 fn validate_func_shapes(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) {
-    use crate::dialect::{core, func};
+    use crate::dialect::func;
     use crate::ops::DialectOp;
     if func::Func::matches(ctx, op) {
         let Some(signature) = ctx
             .op(op)
             .attributes
             .get_type("type")
-            .and_then(|ty| core::Func::from_type_ref(ctx, ty))
+            .and_then(|ty| func::FuncSig::from_type_ref(ctx, ty))
         else {
             errors.push(operation_verifier_error(
                 ctx,
                 op,
-                "requires valid core.func type",
+                "requires valid func.func_sig type",
             ));
             return;
         };
@@ -532,7 +541,10 @@ fn validate_func_shapes(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationE
 }
 
 /// Nearest dialect-registered owner, including a malformed owner boundary.
-fn enclosing_func_signature(ctx: &IrContext, mut op: OpRef) -> Option<crate::dialect::core::Func> {
+fn enclosing_func_signature(
+    ctx: &IrContext,
+    mut op: OpRef,
+) -> Option<crate::dialect::func::FuncSig> {
     loop {
         let block = ctx.op(op).parent_block?;
         let region = ctx.block(block).parent_region?;
@@ -546,7 +558,10 @@ fn enclosing_func_signature(ctx: &IrContext, mut op: OpRef) -> Option<crate::dia
     }
 }
 
-fn typed_callee_signature(ctx: &IrContext, value: ValueRef) -> Option<crate::dialect::core::Func> {
+fn typed_callee_signature(
+    ctx: &IrContext,
+    value: ValueRef,
+) -> Option<crate::dialect::func::FuncSig> {
     let ty = ctx.value_ty(value);
     let data = ctx.types.get(ty);
     let ty = if data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure") {
@@ -557,7 +572,7 @@ fn typed_callee_signature(ctx: &IrContext, value: ValueRef) -> Option<crate::dia
     } else {
         ty
     };
-    crate::dialect::core::Func::from_type_ref(ctx, ty)
+    crate::dialect::func::FuncSig::from_type_ref(ctx, ty)
 }
 
 fn check_value_types(
@@ -604,7 +619,7 @@ pub fn validate_function_contracts(ctx: &IrContext, module: Module) -> Validatio
     };
     // None is genuinely undeclared. A found but invalid/ambiguous declaration
     // is Some(None), so compatibility cannot hide malformed known contracts.
-    fn resolve(ctx: &IrContext, mut op: OpRef, name: Symbol) -> Option<Option<core::Func>> {
+    fn resolve(ctx: &IrContext, mut op: OpRef, name: Symbol) -> Option<Option<func::FuncSig>> {
         loop {
             let region = ctx.block(ctx.op(op).parent_block?).parent_region?;
             let parent = ctx.region(region).parent_op?;
@@ -625,7 +640,7 @@ pub fn validate_function_contracts(ctx: &IrContext, module: Module) -> Validatio
                         ctx.op(found)
                             .attributes
                             .get_type("type")
-                            .and_then(|ty| core::Func::from_type_ref(ctx, ty)),
+                            .and_then(|ty| func::FuncSig::from_type_ref(ctx, ty)),
                     );
                 }
             }
@@ -694,7 +709,7 @@ pub fn validate_function_contracts(ctx: &IrContext, module: Module) -> Validatio
                     .op(op)
                     .attributes
                     .get_type("signature")
-                    .and_then(|ty| core::Func::from_type_ref(ctx, ty))
+                    .and_then(|ty| func::FuncSig::from_type_ref(ctx, ty))
                     .or_else(|| typed_callee_signature(ctx, callee));
                 let Some(signature) = signature else {
                     return;
@@ -1313,7 +1328,7 @@ fn collect_function_signatures(ctx: &IrContext, module_body: RegionRef) -> HashM
                 continue;
             };
 
-            let Some(func_ty) = crate::dialect::core::Func::from_type_ref(ctx, func_ty) else {
+            let Some(func_ty) = crate::dialect::func::FuncSig::from_type_ref(ctx, func_ty) else {
                 continue;
             };
             signatures.insert(sym_name, func_ty.inputs(ctx).len());
@@ -1470,7 +1485,7 @@ mod tests {
         params: &[super::super::refs::TypeRef],
         ret: super::super::refs::TypeRef,
     ) -> super::super::refs::TypeRef {
-        crate::dialect::core::func(ctx, params.iter().copied(), [ret]).as_type_ref()
+        crate::dialect::func::func_sig(ctx, params.iter().copied(), [ret]).as_type_ref()
     }
 
     fn stale_value_errors(result: &ValidationResult) -> Vec<(&str, &str, &str)> {
@@ -1516,77 +1531,77 @@ mod tests {
     }
 
     #[test]
-    fn malformed_core_func_counts_are_rejected_by_typed_and_whole_ir_validation() {
+    fn malformed_func_sig_counts_are_rejected_by_typed_and_whole_ir_validation() {
         let cases = [
             (
                 "missing num_inputs",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
-                    .attr(core::NUM_RESULTS_ATTR, Attribute::Int(0)),
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                    .attr(func::NUM_RESULTS_ATTR, Attribute::Int(0)),
                 "missing required `num_inputs`",
             ),
             (
                 "missing num_results",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
-                    .attr(core::NUM_INPUTS_ATTR, Attribute::Int(0)),
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                    .attr(func::NUM_INPUTS_ATTR, Attribute::Int(0)),
                 "missing required `num_results`",
             ),
             (
                 "wrong num_inputs type",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
-                    .attr(core::NUM_INPUTS_ATTR, Attribute::String("zero".to_string()))
-                    .attr(core::NUM_RESULTS_ATTR, Attribute::Int(0)),
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                    .attr(func::NUM_INPUTS_ATTR, Attribute::String("zero".to_string()))
+                    .attr(func::NUM_RESULTS_ATTR, Attribute::Int(0)),
                 "`num_inputs` must be a u32",
             ),
             (
                 "wrong num_results type",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
-                    .attr(core::NUM_INPUTS_ATTR, Attribute::Int(0))
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                    .attr(func::NUM_INPUTS_ATTR, Attribute::Int(0))
                     .attr(
-                        core::NUM_RESULTS_ATTR,
+                        func::NUM_RESULTS_ATTR,
                         Attribute::String("zero".to_string()),
                     ),
                 "`num_results` must be a u32",
             ),
             (
                 "count sum mismatch",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
-                    .attr(core::NUM_INPUTS_ATTR, Attribute::Int(1))
-                    .attr(core::NUM_RESULTS_ATTR, Attribute::Int(0)),
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                    .attr(func::NUM_INPUTS_ATTR, Attribute::Int(1))
+                    .attr(func::NUM_RESULTS_ATTR, Attribute::Int(0)),
                 "must equal params length",
             ),
             (
                 "negative input",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
                     .attr("num_inputs", Attribute::Int(-1))
                     .attr("num_results", Attribute::Int(0)),
                 "`num_inputs` must be a u32",
             ),
             (
                 "negative result",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
                     .attr("num_results", Attribute::Int(-1))
                     .attr("num_inputs", Attribute::Int(0)),
                 "`num_results` must be a u32",
             ),
             (
                 "input outside u32",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
                     .attr("num_inputs", Attribute::Int(u32::MAX as i128 + 1))
                     .attr("num_results", Attribute::Int(0)),
                 "`num_inputs` must be a u32",
             ),
             (
                 "result outside u32",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
                     .attr("num_results", Attribute::Int(u32::MAX as i128 + 1))
                     .attr("num_inputs", Attribute::Int(0)),
                 "`num_results` must be a u32",
             ),
             (
                 "multiple results",
-                TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func"))
-                    .attr(core::NUM_INPUTS_ATTR, Attribute::Int(0))
-                    .attr(core::NUM_RESULTS_ATTR, Attribute::Int(2)),
+                TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                    .attr(func::NUM_INPUTS_ATTR, Attribute::Int(0))
+                    .attr(func::NUM_RESULTS_ATTR, Attribute::Int(2)),
                 "supports at most one result",
             ),
         ];
@@ -1596,14 +1611,41 @@ mod tests {
             let module = empty_module(&mut ctx);
             let malformed = ctx.types.intern(builder.build());
             assert!(
-                core::Func::from_type_ref(&ctx, malformed).is_none(),
+                func::FuncSig::from_type_ref(&ctx, malformed).is_none(),
                 "{case} must fail typed validation"
             );
-            let result = validate_operation_verifiers(&ctx, module);
+            for result in [
+                validate_operation_verifiers(&ctx, module),
+                validate_all(&ctx, module),
+            ] {
+                let messages = operation_error_messages(&result);
+                assert!(
+                    messages.iter().any(|message| message.contains(expected)),
+                    "{case}: {result}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn retired_raw_core_func_identity_is_rejected_by_whole_ir_validation() {
+        let mut ctx = IrContext::new();
+        let module = empty_module(&mut ctx);
+        let legacy = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("func")).build());
+
+        assert!(func::FuncSig::from_type_ref(&ctx, legacy).is_none());
+        for result in [
+            validate_operation_verifiers(&ctx, module),
+            validate_all(&ctx, module),
+        ] {
             let messages = operation_error_messages(&result);
             assert!(
-                messages.iter().any(|message| message.contains(expected)),
-                "{case}: {result}"
+                messages
+                    .iter()
+                    .any(|message| message.contains("retired core.func identity")),
+                "{result}"
             );
         }
     }
@@ -2346,7 +2388,7 @@ mod tests {
     #[test]
     fn tail_call_indirect_typed_cps_transfer_passes() {
         let input = r#"core.module @test {
-  func.func @main(%k: closure.closure(core.func(core.never, core.i32)), %value: core.i32) -> core.never {
+  func.func @main(%k: closure.closure(func.func_sig<(core.i32) -> core.never>), %value: core.i32) -> core.never {
     func.tail_call_indirect %k, %value
   }
 }"#;
@@ -2359,7 +2401,7 @@ mod tests {
     #[test]
     fn tail_call_indirect_rejects_non_cps_result_and_bad_arguments() {
         let input = r#"core.module @test {
-  func.func @main(%k: closure.closure(core.func(core.i32, core.i32)), %value: core.bool) -> core.never {
+  func.func @main(%k: closure.closure(func.func_sig<(core.i32) -> core.i32>), %value: core.bool) -> core.never {
     func.tail_call_indirect %k, %value
   }
 }"#;
@@ -2374,7 +2416,7 @@ mod tests {
     #[test]
     fn tail_call_indirect_rejects_malformed_shapes_and_accepts_bare_function() {
         let input = r#"core.module @test {
-  func.func @result(%k: closure.closure(core.func(core.never))) -> core.never {
+  func.func @result(%k: closure.closure(func.func_sig<() -> core.never>)) -> core.never {
     %bad = func.tail_call_indirect %k : core.i32
     func.unreachable
   }
@@ -2387,10 +2429,10 @@ mod tests {
   func.func @not_callable(%value: core.i32) -> core.never {
     func.tail_call_indirect %value
   }
-  func.func @direct_function(%k: core.func(core.never)) -> core.never {
+  func.func @direct_function(%k: func.func_sig<() -> core.never>) -> core.never {
     func.tail_call_indirect %k
   }
-  func.func @arity(%k: closure.closure(core.func(core.never, core.i32))) -> core.never {
+  func.func @arity(%k: closure.closure(func.func_sig<(core.i32) -> core.never>)) -> core.never {
     func.tail_call_indirect %k
   }
 }"#;
@@ -2404,7 +2446,7 @@ mod tests {
             text.contains("closure type must contain exactly one function type"),
             "{text}"
         );
-        assert!(text.contains("callee must have core.func"), "{text}");
+        assert!(text.contains("callee must have func.func_sig"), "{text}");
         assert!(
             text.contains("call argument count mismatch: expected 1, found 0"),
             "{text}"

--- a/crates/trunk-ir/src/walk.rs
+++ b/crates/trunk-ir/src/walk.rs
@@ -201,7 +201,7 @@ mod tests {
 
         // Outer func op containing inner region
         let nil_ty = crate::dialect::core::nil(&mut ctx).as_type_ref();
-        let func_ty = crate::dialect::core::func(&mut ctx, [], [nil_ty]).as_type_ref();
+        let func_ty = crate::dialect::func::func_sig(&mut ctx, [], [nil_ty]).as_type_ref();
         let func_op_data = OperationDataBuilder::new(loc, Symbol::new("func"), Symbol::new("func"))
             .result(func_ty)
             .region(inner_region)

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -55,9 +55,9 @@ Conversion은 먼저 모든 logical callable type, definition, lambda, `func_ref
 direct/indirect call, return의 대응 관계를 검증하고 physical symbol과 type을
 계산한 뒤 함께 rewrite한다:
 
-- `tribute_control.func`는 `func.func`와 physical `core.func`를 만든다.
+- `tribute_control.func`는 `func.func`와 physical `func.func_sig`를 만든다.
 - `tribute_control.lambda`는 physical `closure.lambda`와
-  `closure.closure<core.func<...>>`를 만든다. 이 단계의 signature에는
+  `closure.closure<func.func_sig<...>>`를 만든다. 이 단계의 signature에는
   `CallableAbi` hidden parameter가 있지만 environment는 없으며, 기존 closure
   lowering이 environment를 interpose한다.
 - `tribute_control.func_ref`는 빈 environment의 `closure.new`와 env-bearing
@@ -193,7 +193,7 @@ sentinel, 임의의 `anyref`는 대체할 수 없으며 호출되면 trap한다.
 
 `tribute-control-pre-cps` named boundary는 검증된 `tribute_control.*`과 일반
 value/structured dialect만 허용한다. Frontend 적합성 검사는 `func.*`,
-`closure.*`, `core.func`, `closure.closure`, 기존 `ability.*`, `effect.*`,
+`closure.*`, `func.func_sig`, `closure.closure`, 기존 `ability.*`, `effect.*`,
 legacy CPS-dispatch operation을 모두 거부한다. Partial rewrite
 도중에는 logical/physical operation이 일시적으로 공존할 수 있지만 이 상태는
 named pre-CPS boundary가 아니다.
@@ -203,7 +203,7 @@ named pre-CPS boundary가 아니다.
 `tribute-control-post-cps` target과 Tribute type walk를 검증한다. 남은
 `tribute_control` operation 또는 `callable`/`resume_token` type은 source
 location에서 conversion failure가 된다. 이 경계에는 일관된 physical
-`func.*`/`closure.*`/`core.func` graph와 logical `ability.*` dispatch 표면만
+`func.*`/`closure.*`/`func.func_sig` graph와 logical `ability.*` dispatch 표면만
 남는다. `lower_closure_lambda`와 `prepare_closure_lowering`은 이 shared graph를
 준비하지만 `closure.new`, `closure.func`, `closure.env`와 convention-proven closure
 type은 target ABI validation까지 유지한다. `lower_ability_perform`,
@@ -345,7 +345,7 @@ machinery처럼 target이 지원하는 표현을 사용한다. Root `done_k`는 
 cell에 정확히 한 번 쓰고 terminal dispatch는 root 밖 general operation transfer를
 끝내며, wrapper는 이 둘을 immutable `ContinuationFrame<R>`로 materialize해 worker에
 전달한 뒤 proper-tail-call chain이 끝나면 cell을 읽어 source result로 반환한다.
-Shared `core.func` and `func.call` support zero or one result. Logical CPS
+Shared `func.func_sig` and `func.call` support zero or one result. Logical CPS
 producers retain `[core.never]`; current target ABI uses temporary `[core.nil]`
 until the later atomic empty-result switch. No second control carrier is
 introduced. 이 adapter는 answer-type polymorphism, trampoline, in-band sentinel 또는

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -40,8 +40,8 @@ cannot express a required invariant.
 
 ### Function type representation
 
-The physical callable type remains `core.func`; no separate ABI dialect or
-marker type is introduced. `core.func` flattens its independently modeled input
+The shared callable type is `func.func_sig`; no separate ABI dialect or
+marker type is introduced. `func.func_sig` flattens its independently modeled input
 and result lists as `[inputs..., results...]` in `TypeData.params` and stores
 mandatory `num_inputs: u32` and `num_results: u32` attributes. The counts are
 interning delimiters, not ABI state. Construction and typed access validate
@@ -52,7 +52,7 @@ Generic type traversal and conversion continue over every flat parameter, so
 nested input and result types cannot be skipped. Conversion preserves the
 input/result cardinalities and all non-reserved type attributes. Only the
 target ABI conversion may later change logical CPS `[core.never]` into the
-physical empty result list. Malformed raw `core.func` types are permitted only
+physical empty result list. Malformed raw `func.func_sig` types are permitted only
 in verifier tests and are rejected by whole-IR validation.
 
 ## 직접형 제어 소유권
@@ -73,7 +73,7 @@ tribute        -> tribute-front + tribute-passes
 같다:
 
 - `tribute-front`는 [논리 callable/control 계약](ir.md#direct-style-control)을
-  emit하고 `func.*`, `closure.*`, `core.func` 또는 dispatch representation을
+  emit하고 `func.*`, `closure.*`, `func.func_sig` 또는 dispatch representation을
   만들지 않는다.
 - `tribute-ir`는 callable/control type과 operation, custom assembly, local
   verifier와 Tribute-specific whole-IR verifier를 소유한다.
@@ -995,7 +995,7 @@ flowchart TB
 | **직접형 제어** | `ast_to_ir` | typed AST | 검증된 `tribute_control` callable/control + 일반 value IR | frontend |
 | | `tribute_control_to_cps` | logical callable/control + typechecked metadata | physical func/closure/tail-call + logical `ability.*`; `effect.*` 없음 | shared |
 | **Closure (공유 후속)** | `lower_closure_lambda` | closure.lambda | func.func + closure.new | module-wide |
-| | `prepare_closure_lowering` | core.func params | closure signatures | module-wide |
+| | `prepare_closure_lowering` | func.func_sig params | closure signatures | module-wide |
 | **Closure (target storage)** | `lower_closures_in_func` | closure.new/func/env after target ABI validation | indirect transfer + `_closure` storage ops | function-anchored |
 | | `finalize_closure_storage_layout` | remaining closure type surfaces | canonical `_closure` layout in aliases, signatures, values, and type attributes | module-wide |
 | **Ability/evidence (공유 후속)** | `lower_ability_perform` | ability.perform/call | effect.dispatch_* + evidence lookup | function-anchored |

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -52,8 +52,8 @@ operations.
 
 | 경계 | `ConversionTarget` mode | 필수 적법성 |
 | ---- | ---- | ---- |
-| `tribute-control-pre-cps` | frontend 적합성 검사에는 full, 변환 중에는 partial | `tribute_control.*`은 `core.module`, `core.never`와 일반 `core` 값 type, `scf`, `arith`, `adt`, `list`, `tribute_rt`, `tribute_io`와 공존할 수 있다. `func.*`, `closure.*`, `core.func`, 기존 `ability.*`, `effect.*`, legacy CPS 구성 operation은 illegal이다. |
-| `tribute-control-post-cps` | shared CPS 변환 뒤 partial | `tribute_control` dialect의 모든 operation과 type이 illegal이다. Physical `func.*`, `closure.*`, `core.func`, 기존 `ability.*`, `effect.*`, 일반 dialect는 이후 pass를 위해 공존할 수 있다. |
+| `tribute-control-pre-cps` | frontend 적합성 검사에는 full, 변환 중에는 partial | `tribute_control.*`은 `core.module`, `core.never`와 일반 `core` 값 type, `scf`, `arith`, `adt`, `list`, `tribute_rt`, `tribute_io`와 공존할 수 있다. `func.*`, `closure.*`, `func.func_sig`, 기존 `ability.*`, `effect.*`, legacy CPS 구성 operation은 illegal이다. |
+| `tribute-control-post-cps` | shared CPS 변환 뒤 partial | `tribute_control` dialect의 모든 operation과 type이 illegal이다. Physical `func.*`, `closure.*`, `func.func_sig`, 기존 `ability.*`, `effect.*`, 일반 dialect는 이후 pass를 위해 공존할 수 있다. |
 | `tribute-backend-ready-native` | Tribute full 경계 뒤 generic Cranelift 경계 | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, conversion cast가 없다. 명시적으로 열거한 native infrastructure와 `clif.*` operation만 남는다. |
 | `tribute-backend-ready-wasm` | emission-ready full 경계 | `tribute_control`, `ability`, `effect`, `closure`, `list`, `tribute_io`, `wasm_gc`, `core.unrealized_conversion_cast`가 없다. 명시적으로 열거한 Wasm infrastructure와 `wasm.*` operation만 legal이며 unknown operation은 illegal이다. |
 
@@ -63,7 +63,7 @@ verification을 조합한다. Full mode에서는
 unknown operation이 legal하지 않으므로 frontend 적합성 target과 backend full
 target이 legal dialect와 operation을 열거해야 한다. `ConversionTarget`은
 operation 적법성만 검사하므로 Tribute whole-IR type walk가 pre-CPS의
-`core.func`/`closure.closure`와 post-CPS의
+`func.func_sig`/`closure.closure`와 post-CPS의
 `tribute_control.callable`/`resume_token`을 별도로 거부한다. 같은 walk는
 `tribute-backend-ready-native`와 `tribute-backend-ready-wasm`에서도 필수이며
 남은 두 `tribute_control` type을 거부한다. 함수·호출 signature, operand/result,
@@ -171,7 +171,7 @@ target-independent 직접형 경계다. Dialect identifier는 정확히
 이 dialect는 CPS legalization 전의 Tribute 고유 callable과 effect-control
 의미를 함께 소유한다. ANF는 input invariant이지 dialect의 정체성이 아니다.
 산술, ADT/list/tuple/record 구성과 structured selection은 기존 dialect에 남지만,
-`func.*`, `closure.*`, `core.func`는 physical 표현이므로 이 경계에 나타나지
+`func.*`, `closure.*`, `func.func_sig`는 physical 표현이므로 이 경계에 나타나지
 않는다.
 
 논리 callable type은
@@ -179,10 +179,10 @@ target-independent 직접형 경계다. Dialect identifier는 정확히
 `Result`와 `Params`는 source-logical type이며 기존 code `Direct = 0`,
 `EvidenceDirect = 1`, `Cps = 2`를 그대로 사용한다. 이 metadata는 typechecking
 결과를 복사한 것으로 body에서 추론하지 않는다. Legalization은 이를 기존
-`CallableAbi`와 physical `core.func`, `closure.closure` 및
+`CallableAbi`와 physical `func.func_sig`, `closure.closure` 및
 `tribute.calling_convention` operation attribute로 바꾼다. Type verifier는
 result 하나와 parameter 0개 이상, convention domain, 모든 component type의
-resolution을 검사하며 physical `core.func`나 `closure.closure`를 component로
+resolution을 검사하며 physical `func.func_sig`나 `closure.closure`를 component로
 허용하지 않는다. 전체 규칙은
 [cps-effects.md](cps-effects.md#pre-cps-callable-shape)에 있다.
 
@@ -691,7 +691,7 @@ make these attributes round-trip explicitly.
 `func.*` represents function definitions, direct calls, indirect calls, function
 references, returns, tail calls, and unreachable control flow.
 `func.call_indirect`와 `func.tail_call_indirect`는 선택적 `signature: TypeRef`
-attribute로 erased callee/table index 이전의 exact `core.func` contract를 보존할 수
+attribute로 erased callee/table index 이전의 exact `func.func_sig` contract를 보존할 수
 있다. 일반 pre-contract indirect call은 이 attribute 없이 존재할 수 있지만,
 `tribute.calling_convention`이 붙은 indirect transfer는 exact `signature`를 반드시
 가지며 verifier가 operand/result 및 convention과 대조한다. Physical operand type,
@@ -791,16 +791,16 @@ opaque nominal builtin whose shared construction and sequence-view observations
 use `list.*`; target-specific passes choose and eliminate its private
 representation.
 
-### `core.func` function type
+### `func.func_sig` function type
 
-`core.func` stores inputs and results as separate logical lists while keeping a
-flat interned parameter vector. Its canonical textual form follows MLIR
+`func.func_sig` stores inputs and results as separate logical lists. It keeps a
+flat interned parameter vector, and its canonical textual form follows MLIR
 FunctionType syntax:
 
 ```text
-core.func<() -> ()>
-core.func<(core.i32) -> core.i64>
-core.func<(Evidence, Frame, core.i32) -> core.never>
+func.func_sig<() -> ()>
+func.func_sig<(core.i32) -> core.i64>
+func.func_sig<(Evidence, Frame, core.i32) -> core.never>
 ```
 
 The input list is always parenthesized. An empty result list is printed as
@@ -812,8 +812,8 @@ The interned representation is:
 
 ```text
 TypeData {
-  dialect: core,
-  name: func,
+  dialect: func,
+  name: func_sig,
   params: [input_0, ..., input_n, result_0?],
   attrs: {
     num_inputs: n,
@@ -831,10 +831,11 @@ two reserved attributes and preserves every other type attribute; textual type
 attribute dictionaries may not specify either reserved key.
 
 During the compatibility window the reader also accepts legacy
-`core.func(Return, Params...)`, immediately normalizes it to the new input-first
+`core.func(Return, Params...)`, immediately normalizes it to the new `func.func_sig`
+identity and input-first
 storage, and never interns the legacy layout. The printer always emits the
 canonical form. Production code constructs function types only through the
-validated `core::func` API; direct `TypeData` construction is reserved for
+validated `func::func_sig` API; direct `TypeData` construction is reserved for
 malformed-type verifier tests.
 
 The three result states have distinct meanings:

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -123,7 +123,7 @@ result matching을 정의한다. Tribute는 다음 경로를 구현한다:
 | `func.tail_call_indirect` | `wasm.return_call_indirect` | `wasm_encoder::Instruction::ReturnCallIndirect { type_index, table_index }` |
 
 `func.tail_call_indirect` lowering은 callee table index와 argument를 기존
-`call_indirect`와 같은 순서로 평가하고, callee `core.func`에서 `type_index`를
+`call_indirect`와 같은 순서로 평가하고, callee `func.func_sig`에서 `type_index`를
 결정한다. CPS caller/callee의 result vector는 모두 비어 있어야 하며
 `wasm.return_call_indirect`는 result local을 만들지 않는다. 일반 source-data
 indirect call만 `wasm.call_indirect`를 유지한다.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1760,7 +1760,7 @@ mod tests {
         let dispatch = cps_dispatch_type(&mut ctx, evidence, frame, anyref, i32_ty);
         let layout = cps_continuation_frame_layout_type(&mut ctx, frame_name, nil, done, dispatch);
         ctx.register_type_alias(frame_name, layout);
-        let worker = core_dialect::func(&mut ctx, [evidence, frame], [never]).as_type_ref();
+        let worker = func_dialect::func_sig(&mut ctx, [evidence, frame], [never]).as_type_ref();
         ctx.op_mut(main.op_ref()).attributes.insert(
             trunk_ir::Symbol::new("type"),
             trunk_ir::Attribute::Type(worker),

--- a/tests/evidence_lambda.rs
+++ b/tests/evidence_lambda.rs
@@ -12,7 +12,7 @@ use tribute::database::parse_with_thread_local;
 use tribute_front::SourceCst;
 use tribute_passes::evidence::has_evidence_first_param;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{core, func};
+use trunk_ir::dialect::func;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::rewrite::Module;
 
@@ -56,7 +56,8 @@ fn function_abi(ctx: &IrContext, module: &Module, target: &str) -> (usize, bool,
         })
         .unwrap_or_else(|| panic!("missing function '{target}'"));
     let func_ty = func_op.r#type(ctx);
-    let function = core::Func::from_type_ref(ctx, func_ty).expect("valid core.func signature");
+    let function =
+        func::FuncSig::from_type_ref(ctx, func_ty).expect("valid func.func_sig signature");
     let params = function.inputs(ctx);
     let has_evidence = params
         .first()

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_direct_fn_ability_call.snap
@@ -5,10 +5,10 @@ expression: ir_text
 core.module @direct_fn_native {
   !_closure = adt.struct() {fields = [[@func_ptr, core.i32], [@env, tribute_rt.anyref]], name = @_closure}
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
-  !t1 = core.func<(tribute_rt.anyref) -> tribute_rt.anyref>
+  !t1 = func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>
   !t2 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t0 = core.func<(!t2, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t3 = core.func<(!t2, tribute_rt.anyref, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t0 = func.func_sig<(!t2, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t3 = func.func_sig<(!t2, tribute_rt.anyref, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
 
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
@@ -58,17 +58,17 @@ core.module @direct_fn_native {
       %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
       %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
       %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = func.constant {func_ref = @"run::__clam_1"} : core.func<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %14 = func.constant {func_ref = @"run::__clam_1"} : func.func_sig<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
       %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %17 = func.constant {func_ref = @"run::__clam_2"} : core.func<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %17 = func.constant {func_ref = @"run::__clam_2"} : func.func_sig<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
       %19 = func.call {callee = @__tribute_next_tag} : core.i32
       %20 = arith.const {value = 1361557906} : core.i32
       %21 = tribute_rt.into_raw %18 : core.ptr
       %22 = tribute_rt.into_raw %15 : core.ptr
       %23 = func.call %0, %20, %19, %21, %22 {callee = @__tribute_evidence_extend} : core.ptr
-      %24 = func.call_indirect %11, %23, %12, %9 {signature = core.func<(!t2, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
+      %24 = func.call_indirect %11, %23, %12, %9 {signature = func.func_sig<(!t2, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
       %25 = adt.variant_is %24 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %26 = scf.if %25 : tribute_rt.anyref {
           %27 = adt.variant_cast %24 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_mixed_nested_handler_boundary.snap
@@ -5,18 +5,18 @@ expression: ir_text
 core.module @mixed_nested_native {
   !_closure = adt.struct() {fields = [[@func_ptr, core.i32], [@env, tribute_rt.anyref]], name = @_closure}
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
-  !t1 = core.func<(tribute_rt.anyref) -> tribute_rt.anyref>
+  !t1 = func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>
   !t2 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t0 = core.func<(!t2, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t0 = func.func_sig<(!t2, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
   !"step::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"step::__clam_0::env"}
   !"run_state_with_console::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state_with_console::__clam_1::__clam_0::env"}
   !"run_state_with_console::__clam_1::__clam_1::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state_with_console::__clam_1::__clam_1::env"}
   !t3 = closure.closure(!t1)
-  !t4 = core.func<(!t2, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>
-  !t5 = core.func<(!t2, tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t6 = core.func<(!t2, tribute_rt.anyref, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t7 = core.func<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t4 = func.func_sig<(!t2, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>
+  !t5 = func.func_sig<(!t2, tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t6 = func.func_sig<(!t2, tribute_rt.anyref, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t7 = func.func_sig<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
 
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
@@ -69,7 +69,7 @@ core.module @mixed_nested_native {
       %14 = func.constant {func_ref = @"run_all::__clam_1"} : !t7
       %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
       %16 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %17 = func.constant {func_ref = @"run_all::__clam_2"} : core.func<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %17 = func.constant {func_ref = @"run_all::__clam_2"} : func.func_sig<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %18 = adt.struct_new %17, %16 {type = !_closure} : !_closure
       %19 = func.call {callee = @__tribute_next_tag} : core.i32
       %20 = arith.const {value = 1361557906} : core.i32

--- a/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__native_pipeline_resumptive_op_continuation.snap
@@ -6,14 +6,14 @@ core.module @resumptive_op_native {
   !_closure = adt.struct() {fields = [[@func_ptr, core.i32], [@env, tribute_rt.anyref]], name = @_closure}
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
   !t0 = core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})
-  !t1 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t2 = core.func<(tribute_rt.anyref) -> tribute_rt.anyref>
+  !t1 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t2 = func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
   !"run_state::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state::__clam_1::__clam_0::env"}
   !"run_state::__clam_1::__clam_1::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state::__clam_1::__clam_1::env"}
   !"bump::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"bump::__clam_0::env"}
   !t3 = closure.closure(!t2)
-  !t4 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t4 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
 
   func.func @__tribute_evidence_lookup_handler(%0: core.ptr, %1: core.i32) -> core.ptr attributes {abi = "C"} {
       func.unreachable
@@ -63,7 +63,7 @@ core.module @resumptive_op_native {
       %11 = adt.struct_get %6 {field = 0, type = !_closure} : core.i32
       %12 = adt.struct_get %6 {field = 1, type = !_closure} : tribute_rt.anyref
       %13 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %14 = func.constant {func_ref = @"run_state::__clam_1"} : core.func<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %14 = func.constant {func_ref = @"run_state::__clam_1"} : func.func_sig<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %15 = adt.struct_new %14, %13 {type = !_closure} : !_closure
       %16 = arith.const {value = 0} : tribute_rt.anyref
       %17 = func.call {callee = @__tribute_next_tag} : core.i32
@@ -71,7 +71,7 @@ core.module @resumptive_op_native {
       %19 = core.unrealized_conversion_cast %16 : core.ptr
       %20 = tribute_rt.into_raw %15 : core.ptr
       %21 = func.call %0, %18, %17, %19, %20 {callee = @__tribute_evidence_extend} : core.ptr
-      %22 = func.call_indirect %11, %21, %12, %9 {signature = core.func<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
+      %22 = func.call_indirect %11, %21, %12, %9 {signature = func.func_sig<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
       %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %24 = scf.if %23 : tribute_rt.anyref {
           %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_direct_fn_ability_call.snap
@@ -9,7 +9,7 @@ core.module @direct_fn {
   !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
-  !t3 = core.func<(tribute_rt.anyref) -> tribute_rt.anyref>
+  !t3 = func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>
   !t2 = closure.closure(!t3)
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
   !"Result::map_err::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map_err::__clam_0::env"}
@@ -20,10 +20,10 @@ core.module @direct_fn {
   !t6 = core.ability_ref() {name = @"abilities::Throw"}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t1 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t1 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !t4 = closure.closure(!t1)
-  !t5 = core.func<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t7 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t5 = func.func_sig<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t7 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
 
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
@@ -74,14 +74,14 @@ core.module @direct_fn {
       %12 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
       %13 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
       %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run::__clam_1"} : core.func<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %15 = func.constant {func_ref = @"run::__clam_1"} : func.func_sig<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %18 = func.constant {func_ref = @"run::__clam_2"} : core.func<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %18 = func.constant {func_ref = @"run::__clam_2"} : func.func_sig<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
       %20 = func.call {callee = @__tribute_next_tag} : core.i32
       %21 = effect.extend %1, %20, %19, %16 {ability_ref = core.ability_ref() {name = @Console}} : !t0
-      %22 = func.call_indirect %12, %21, %13, %10 {signature = core.func<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
+      %22 = func.call_indirect %12, %21, %13, %10 {signature = func.func_sig<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
       %23 = adt.variant_is %22 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %24 = scf.if %23 : tribute_rt.anyref {
           %25 = adt.variant_cast %22 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_float_comparison_predicates.snap
@@ -14,16 +14,16 @@ core.module @float_comparisons {
   !"Result::map::__clam_0::env" = adt.struct() {fields = [[@_0, tribute_rt.anyref]], name = @"Result::map::__clam_0::env"}
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
-  !t5 = core.func<(tribute_rt.anyref) -> tribute_rt.anyref>
+  !t5 = func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>
   !t2 = closure.closure(!t5)
   !t6 = core.ability_ref() {name = @"abilities::Throw"}
   !__tuple_i1_i1_i1_i1_i1_i1 = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__tuple_i1_i1_i1_i1_i1_i1}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t1 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t1 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !t3 = closure.closure(!t1)
-  !t4 = core.func<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t7 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t4 = func.func_sig<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t7 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
   !__tuple_i1_i1_i1_i1_i1_i1_1 = adt.typeref() {name = @__tuple_i1_i1_i1_i1_i1_i1}
 

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_mixed_nested_handler_boundary.snap
@@ -9,7 +9,7 @@ core.module @mixed_nested {
   !String = adt.enum() {name = @String, tribute.definition.end = 11022, tribute.definition.source = 4923843560778033168, tribute.definition.start = 10957, variants = [[@Leaf, [core.bytes]], [@Branch, [tribute_rt.anyref, tribute_rt.anyref, core.i32]]]}
   !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
-  !t2 = core.func<(tribute_rt.anyref) -> tribute_rt.anyref>
+  !t2 = func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
   !t3 = closure.closure(!t2)
   !"step::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, core.i32], [@_2, tribute_rt.anyref]], name = @"step::__clam_0::__clam_0::env"}
@@ -22,14 +22,14 @@ core.module @mixed_nested {
   !"Int::ParseError" = adt.enum() {name = @"Int::ParseError", variants = [[@InvalidSyntax, []], [@OutOfRange, []]]}
   !"std::io::Error" = adt.enum() {name = @"std::io::Error", variants = [[@EndOfFile, []], [@InvalidEncoding, []], [@System, [tribute_rt.anyref]]]}
   !t6 = core.ability_ref() {name = @"abilities::Throw"}
-  !t9 = core.func<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t9 = func.func_sig<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t1 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t1 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !t4 = closure.closure(!t1)
-  !t5 = core.func<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t7 = core.func<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>
-  !t8 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t5 = func.func_sig<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t7 = func.func_sig<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>
+  !t8 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
 
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
@@ -134,7 +134,7 @@ core.module @mixed_nested {
       %15 = func.constant {func_ref = @"run_all::__clam_1"} : !t9
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %18 = func.constant {func_ref = @"run_all::__clam_2"} : core.func<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %18 = func.constant {func_ref = @"run_all::__clam_2"} : func.func_sig<(core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %19 = adt.struct_new %18, %17 {type = !_closure} : !_closure
       %20 = func.call {callee = @__tribute_next_tag} : core.i32
       %21 = effect.extend %1, %20, %19, %16 {ability_ref = core.ability_ref() {name = @Console}} : !t0

--- a/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
+++ b/tests/snapshots/active_pipeline_goldens__shared_pipeline_resumptive_op_continuation.snap
@@ -10,7 +10,7 @@ core.module @resumptive_op {
   !Option = adt.enum() {name = @Option, variants = [[@None, []], [@Some, [tribute_rt.anyref]]]}
   !__tribute_cps_control = adt.enum() {name = @__tribute_cps_control, variants = [[@Normal, [tribute_rt.anyref]], [@Escape, [core.i32, tribute_rt.anyref]]]}
   !"std::io::ReadLineResult" = adt.enum() {name = @"std::io::ReadLineResult", variants = [[@ReadLine, [core.bytes]], [@ReadEndOfFile, []], [@ReadInvalidEncoding, []], [@ReadSystem, [core.i32, core.bytes]]]}
-  !t3 = core.func<(tribute_rt.anyref) -> tribute_rt.anyref>
+  !t3 = func.func_sig<(tribute_rt.anyref) -> tribute_rt.anyref>
   !t2 = closure.closure(!t3)
   !"bump::__clam_0::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32], [@_1, tribute_rt.anyref]], name = @"bump::__clam_0::__clam_0::env"}
   !"run_state::__clam_1::__clam_0::env" = adt.struct() {fields = [[@_0, core.i32]], name = @"run_state::__clam_1::__clam_0::env"}
@@ -24,10 +24,10 @@ core.module @resumptive_op {
   !t6 = core.ability_ref() {name = @"abilities::Throw"}
   !_Marker = adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker}
   !t0 = core.array(!_Marker)
-  !t1 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t1 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !t4 = closure.closure(!t1)
-  !t5 = core.func<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
-  !t7 = core.func<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t5 = func.func_sig<(!t0, tribute_rt.anyref, !_closure, tribute_rt.anyref) -> tribute_rt.anyref>
+  !t7 = func.func_sig<(!t0, tribute_rt.anyref, tribute_rt.anyref, tribute_rt.anyref) -> tribute_rt.anyref>
   !"std::io::SystemError" = adt.struct() {fields = [[@code, core.i32], [@message, tribute_rt.anyref]], name = @"std::io::SystemError"}
 
   func.func @__tribute_next_tag() -> core.i32 attributes {abi = "C"} {
@@ -78,12 +78,12 @@ core.module @resumptive_op {
       %12 = adt.struct_get %7 {field = 0, type = !_closure} : core.i32
       %13 = adt.struct_get %7 {field = 1, type = !_closure} : tribute_rt.anyref
       %14 = adt.ref_null {type = tribute_rt.anyref} : tribute_rt.anyref
-      %15 = func.constant {func_ref = @"run_state::__clam_1"} : core.func<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
+      %15 = func.constant {func_ref = @"run_state::__clam_1"} : func.func_sig<(tribute_rt.anyref, core.i32, core.i32, tribute_rt.anyref) -> tribute_rt.anyref>
       %16 = adt.struct_new %15, %14 {type = !_closure} : !_closure
       %17 = arith.const {value = 0} : tribute_rt.anyref
       %18 = func.call {callee = @__tribute_next_tag} : core.i32
       %19 = effect.extend %1, %18, %17, %16 {ability_ref = core.ability_ref() {name = @State}} : !t0
-      %20 = func.call_indirect %12, %19, %13, %10 {signature = core.func<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
+      %20 = func.call_indirect %12, %19, %13, %10 {signature = func.func_sig<(!t0, tribute_rt.anyref, !_closure) -> tribute_rt.anyref>} : tribute_rt.anyref
       %21 = adt.variant_is %20 {tag = @Normal, type = !__tribute_cps_control} : core.i1
       %22 = scf.if %21 : tribute_rt.anyref {
           %23 = adt.variant_cast %20 {tag = @Normal, type = !__tribute_cps_control} : tribute_rt.anyref


### PR DESCRIPTION
## Summary

Move the shared function-signature type from `core.func` to `func.func_sig`, with
the validated `func::FuncSig`, `func::func_sig`, and attribute-preserving APIs.
Keep the `func.func` operation and existing zero-or-one-result semantics unchanged.

This is an independent prerequisite for #825; it does not complete or close that
issue. Source `tribute_control.func_sig`, target-owned Wasm/Clif signatures, and
the atomic physical CPS empty-result transition remain separate follow-up units.

## Changes

- Preserve flat input/result storage, count validation and interning identity,
  non-reserved attributes, and the distinction between `[]`, `[nil]`, and `[never]`.
- Print canonical `func.func_sig` syntax. During the existing compatibility
  window, normalize both old `core.func` textual forms directly into the new
  identity. Reject retired raw `core.func` identities at validation boundaries.
- Migrate shared interfaces, conversions, frontend/pass/backend consumers, and
  exact qualified-identity checks, including recursive pre-CPS and backend-ready
  verification and Wasm function-reference handling.
- Add regressions for legacy normalization/reserved keys, retired raw types,
  nested boundary checks, signature-valued Wasm emission, and preservation of an
  exact anyref indirect-call result in a funcref-returning caller.
- Update authoritative design references. All 19 snapshot changes are exact
  type-name substitutions; no operation or SSA changes are included in them.

## Scope

No source callable representation, ownership, specialization, pipeline ordering,
or target ABI redesign. The temporary physical CPS `[nil]` encoding is unchanged.
The pre-existing signature-less Wasm contextual-result/local mismatch is not
repaired here; exact indirect signatures remain authoritative.

## Validation

- Supervisor independently ran `cargo nextest run --workspace`: **2,089 passed,
  1 skipped**, with **1 leaky report** and exit status 0. Baseline attribution of
  that report is unverified; this is not a leak-free claim.
- Affected crate suites and focused migration/Wasm/pre-CPS regressions passed.
- Supervisor independently ran `cargo clippy --workspace --all-targets -- -D warnings`.
- `cargo fmt --all --check`, `git diff --check`, and Markdown lint passed.
- Normal commit hooks passed; snapshot/artifact audits passed; worktree is clean.

Reviewed base: `3e07346bd1b4106e3bef77f6a212cada7c8cd0b4`.
Reviewed atomic commit: `b48c660287dbed43dcd6a5231abed03d6da8bea7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `func.func_sig` as the canonical function-signature representation across IR tooling, closure handling, native and WebAssembly backends, Cranelift, CPS, and indirect calls.
  - Legacy function-type syntax remains parseable where supported and is normalized to the canonical format.

- **Bug Fixes**
  - Improved validation and diagnostics for malformed or outdated signatures.
  - Expanded coverage for nested signatures, signature-valued types, and WebAssembly function references.

- **Documentation**
  - Updated architecture and implementation documentation to reflect the canonical format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->