### PR TITLE
refactor(tribute-control): use source function signatures

### DIFF
--- a/crates/tribute-front/src/ast_to_ir/context.rs
+++ b/crates/tribute-front/src/ast_to_ir/context.rs
@@ -703,7 +703,7 @@ impl<'db> IrLoweringCtx<'db> {
                 let convention = self
                     .calling_convention_for_type(ty)
                     .unwrap_or(crate::ast::CallingConvention::Cps);
-                tribute_ir::dialect::tribute_control::callable(
+                tribute_ir::dialect::tribute_control::func_sig(
                     ir,
                     result,
                     params,
@@ -755,7 +755,7 @@ impl<'db> IrLoweringCtx<'db> {
 
     /// Canonical nominal name for a source-logical tuple layout.  Do not use
     /// arena dialect type names here: distinct callable signatures all share
-    /// the `tribute_control.callable` dialect name.
+    /// the `tribute_control.func_sig` dialect name.
     pub fn logical_tuple_name(&self, ty: crate::ast::Type<'db>) -> Symbol {
         Symbol::from_dynamic(&format!("__logical_tuple_{}", self.logical_type_key(ty)))
     }
@@ -1329,12 +1329,12 @@ mod tests {
         let logical_callable = ctx.convert_logical_type(&mut ir, callable);
         let i32_ty = ctx.i32_type(&mut ir);
         let signature =
-            tribute_ir::dialect::tribute_control::Callable::from_type_ref(&ir, logical_callable)
+            tribute_ir::dialect::tribute_control::FuncSig::from_type_ref(&ir, logical_callable)
                 .expect("logical function type must be a control callable");
         assert_eq!(signature.result(&ir), i32_ty);
-        assert_eq!(signature.params(&ir), &[i32_ty]);
+        assert_eq!(signature.inputs(&ir), &[i32_ty]);
         assert_eq!(
-            tribute_ir::dialect::tribute_control::callable_convention(&ir, logical_callable),
+            tribute_ir::dialect::tribute_control::func_sig_convention(&ir, logical_callable),
             Some(tribute_ir::dialect::tribute_control::CallingConvention::Direct)
         );
 
@@ -1473,11 +1473,11 @@ mod tests {
         let evidence_ir = ctx.convert_logical_type(&mut ir, evidence_callable);
         let cps_ir = ctx.convert_logical_type(&mut ir, cps_callable);
         assert_eq!(
-            tribute_ir::dialect::tribute_control::callable_convention(&ir, evidence_ir),
+            tribute_ir::dialect::tribute_control::func_sig_convention(&ir, evidence_ir),
             Some(tribute_ir::dialect::tribute_control::CallingConvention::EvidenceDirect)
         );
         assert_eq!(
-            tribute_ir::dialect::tribute_control::callable_convention(&ir, cps_ir),
+            tribute_ir::dialect::tribute_control::func_sig_convention(&ir, cps_ir),
             Some(tribute_ir::dialect::tribute_control::CallingConvention::Cps)
         );
 

--- a/crates/tribute-front/src/ast_to_ir/lower/logical.rs
+++ b/crates/tribute-front/src/ast_to_ir/lower/logical.rs
@@ -117,13 +117,13 @@ fn control_convention(convention: CallingConvention) -> tribute_control::Calling
     }
 }
 
-fn callable_type(
+fn func_sig_type(
     ir: &mut IrContext,
     result: TypeRef,
     params: impl IntoIterator<Item = TypeRef>,
     convention: CallingConvention,
 ) -> TypeRef {
-    tribute_control::callable(ir, result, params, control_convention(convention)).as_type_ref()
+    tribute_control::func_sig(ir, result, params, control_convention(convention)).as_type_ref()
 }
 
 fn declaration_name(prefix: &mut String, name: Symbol) -> Symbol {
@@ -632,7 +632,7 @@ fn lower_struct_accessors<'db>(
             blocks: trunk_ir::smallvec::smallvec![entry],
             parent_op: None,
         });
-        let callable = callable_type(ir, field_type, [struct_type], CallingConvention::Direct);
+        let callable = func_sig_type(ir, field_type, [struct_type], CallingConvention::Direct);
         let getter = tribute_control::func_declaration(ir, location, getter_name, callable);
         ir.op_mut(getter.op_ref()).regions.push(body);
         ir.region_mut(body).parent_op = Some(getter.op_ref());
@@ -684,7 +684,7 @@ fn lower_function<'db>(
                 .expect("root main has a function type")
         });
     let signature = function_signature(ctx, ir, &function);
-    let callable = callable_type(
+    let callable = func_sig_type(
         ir,
         signature.return_type,
         signature.param_types.iter().copied(),
@@ -773,7 +773,7 @@ fn lower_extern<'db>(
             decl.name
         )
     });
-    let callable = callable_type(
+    let callable = func_sig_type(
         ir,
         signature.return_type,
         signature.param_types,
@@ -814,7 +814,7 @@ fn ensure_prelude_declaration(
     {
         return;
     }
-    let callable = callable_type(
+    let callable = func_sig_type(
         builder.ir,
         signature.return_type,
         signature.param_types.iter().copied(),
@@ -1051,7 +1051,7 @@ fn lower_expr<'db>(
                     .function_calling_convention(name)
                     .unwrap_or(signature.convention);
                 ensure_prelude_declaration(builder, location, name, &signature);
-                let ty = callable_type(
+                let ty = func_sig_type(
                     builder.ir,
                     signature.return_type,
                     signature.param_types,
@@ -1755,9 +1755,9 @@ fn lower_call<'db>(
                     .unwrap_or_else(|| panic!("missing logical callable binding for local {id:?}"));
                 let callable_ty = builder.ir.value_ty(callable);
                 let callable_signature =
-                    tribute_control::Callable::from_type_ref(builder.ir, callable_ty)
+                    tribute_control::FuncSig::from_type_ref(builder.ir, callable_ty)
                         .unwrap_or_else(|| panic!("local call target is not a logical callable"));
-                let parameters = callable_signature.params(builder.ir).to_vec();
+                let parameters = callable_signature.inputs(builder.ir).to_vec();
                 if values.len() != parameters.len() {
                     panic!("typechecked indirect call arity disagrees with logical callable");
                 }
@@ -1788,9 +1788,9 @@ fn lower_call<'db>(
         let callable = indirect_callee
             .expect("non-variable logical callee must be evaluated before its arguments");
         let callable_ty = builder.ir.value_ty(callable);
-        let callable_signature = tribute_control::Callable::from_type_ref(builder.ir, callable_ty)
+        let callable_signature = tribute_control::FuncSig::from_type_ref(builder.ir, callable_ty)
             .unwrap_or_else(|| panic!("indirect call target is not a logical callable"));
-        let parameters = callable_signature.params(builder.ir).to_vec();
+        let parameters = callable_signature.inputs(builder.ir).to_vec();
         if values.len() != parameters.len() {
             panic!("typechecked indirect call arity disagrees with logical callable");
         }
@@ -1896,7 +1896,7 @@ fn lower_lambda<'db>(
         blocks: trunk_ir::smallvec::smallvec![entry],
         parent_op: None,
     });
-    let callable = callable_type(builder.ir, result_type, param_types, convention);
+    let callable = func_sig_type(builder.ir, result_type, param_types, convention);
     let lambda = op(builder.ir, builder.block, location, "lambda", |builder| {
         builder.operands(captures).result(callable).region(region)
     });

--- a/crates/tribute-front/tests/cps_lowering.rs
+++ b/crates/tribute-front/tests/cps_lowering.rs
@@ -469,7 +469,7 @@ pub mod Nested {
         "field access must call the matching logical accessor:\n{read}"
     );
     assert!(
-        ir_text.contains("tribute_control.callable(core.i32, core.i32)")
+        ir_text.contains("tribute_control.func_sig<(core.i32) -> core.i32>")
             && !ir_text.contains("func.func_sig"),
         "nested callable fields must remain source-logical:\n{ir_text}"
     );
@@ -1568,8 +1568,8 @@ fn from_list(callback: fn(Int) -> Int) -> Int {
     );
     let ir = run_ast_pipeline_with_ir(db, source);
     assert_logical_boundary(&ir);
-    assert!(ir.contains("tribute_control.callable(core.i32, core.i32)"));
-    assert!(ir.contains("tribute_control.callable(core.i1, core.i1)"));
+    assert!(ir.contains("tribute_control.func_sig<(core.i32) -> core.i32>"));
+    assert!(ir.contains("tribute_control.func_sig<(core.i1) -> core.i1>"));
     let tuple_layout = |function: &str| {
         logical_function(&ir, function)
             .split("adt.struct_new")
@@ -1630,7 +1630,8 @@ fn inspect(choice: Choice, fallback: fn(Int) -> Int) -> fn(Int) -> Int {
     assert_logical_boundary(&ir);
     let accessor = checked_logical_function(&ir, "Holder::callback");
     assert!(
-        accessor.contains("-> !t") && ir.contains("= tribute_control.callable(core.i32, core.i32)"),
+        accessor.contains("-> !t")
+            && ir.contains("= tribute_control.func_sig<(core.i32) -> core.i32>"),
         "generated accessor must retain its callable field type:\n{accessor}"
     );
     let inspect = checked_logical_function(&ir, "inspect");
@@ -1668,7 +1669,7 @@ fn first_or(values: List(fn(Int) -> Int), fallback: fn(Int) -> Int) -> fn(Int) -
         first_or.contains("list.is_empty")
             && first_or.contains("list.head")
             && first_or.contains("list.tail")
-            && ir.contains("tribute_control.callable(core.i32, core.i32)"),
+            && ir.contains("tribute_control.func_sig<(core.i32) -> core.i32>"),
         "callable list pattern extraction must retain its logical element type:\n{first_or}"
     );
     assert!(!first_or.contains("func.func_sig"));

--- a/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
+++ b/crates/tribute-front/tests/snapshots/evidence_lowering__effectful_call_passes_evidence.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/evidence_lowering.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @get_count() -> core.i32 convention(cps) {
       %0 = tribute_control.perform {ability_ref = core.ability_ref() {name = @Counter}, op_name = @inc, operation_kind = @op} : core.i32

--- a/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__float_comparison_operators.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i1, core.f64, core.f64) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(core.f64, core.f64) -> core.i1> {tribute.calling_convention = 0}
   !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool = adt.struct() {fields = [[@0, core.i1], [@1, core.i1], [@2, core.i1], [@3, core.i1], [@4, core.i1], [@5, core.i1]], name = @__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool}
   !__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool_1 = adt.typeref() {name = @__logical_tuple_tuple_7_1_6_4_bool_4_bool_4_bool_4_bool_4_bool_4_bool}
 

--- a/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__function_reference_as_value.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
 
   tribute_control.func @id(%0: core.i32) -> core.i32 convention(direct) {
       tribute_control.return %0

--- a/crates/tribute-front/tests/snapshots/expr_coverage__lambda_as_argument.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__lambda_as_argument.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @apply(%0: !t0, %1: core.i32) -> core.i32 convention(cps) {
       %2 = tribute_control.call_indirect %0, %1 : core.i32

--- a/crates/tribute-front/tests/snapshots/expr_coverage__list_literals_use_shared_sequence_ops.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__list_literals_use_shared_sequence_ops.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<() -> tribute_rt.anyref> {tribute.calling_convention = 0}
 
   tribute_control.func @empty() -> tribute_rt.anyref convention(direct) {
       %0 = list.empty {element_type = tribute_rt.anyref} : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/expr_coverage__string_equality_operators.snap
+++ b/crates/tribute-front/tests/snapshots/expr_coverage__string_equality_operators.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/expr_coverage.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i1, tribute_rt.anyref, tribute_rt.anyref) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<(tribute_rt.anyref, tribute_rt.anyref) -> core.i1> {tribute.calling_convention = 2}
   !__logical_tuple_tuple_3_1_2_4_bool_4_bool = adt.struct() {fields = [[@0, core.i1], [@1, core.i1]], name = @__logical_tuple_tuple_3_1_2_4_bool_4_bool}
   !__logical_tuple_tuple_3_1_2_4_bool_4_bool_1 = adt.typeref() {name = @__logical_tuple_tuple_3_1_2_4_bool_4_bool}
 

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__ability_core_full_pattern.snap
@@ -3,8 +3,8 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
-  !t1 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> tribute_rt.anyref> {tribute.calling_convention = 2}
+  !t1 = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 2}
   !t2 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
   tribute_control.func @"Int::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_direct_ability_call.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @run_with_state(%0: !t0) -> core.i32 convention(cps) {
       %1 = tribute_control.handle : core.i32 {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_indirect_effect_call.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @"Int::+"(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct)
   tribute_control.func @counter() -> core.i32 convention(cps) {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__effectful_lambda_multiple_operations.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @run_with_state(%0: !t0) -> core.i32 convention(cps) {
       %1 = tribute_control.handle : core.i32 {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__handler_arm_continuation_lambda.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> tribute_rt.anyref> {tribute.calling_convention = 2}
   !t1 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
   tribute_control.func @run_state(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref convention(cps) {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__lambda_effect_row_unification.snap
@@ -3,8 +3,8 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(tribute_rt.anyref) {tribute.calling_convention = 2}
-  !t1 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> tribute_rt.anyref> {tribute.calling_convention = 2}
+  !t1 = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 2}
   !t2 = core.ability_ref(tribute_rt.anyref) {name = @State}
 
   tribute_control.func @with_state(%0: !t0, %1: tribute_rt.anyref) -> tribute_rt.anyref convention(cps) {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__nested_lambda_inner_effectful.snap
@@ -3,8 +3,8 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32) {tribute.calling_convention = 2}
-  !t1 = tribute_control.callable(core.i32, !t0) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 2}
+  !t1 = tribute_control.func_sig<(!t0) -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @run_with_state(%0: !t0) -> core.i32 convention(cps) {
       %1 = tribute_control.handle : core.i32 {

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_no_effect.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @apply(%0: !t0, %1: core.i32) -> core.i32 convention(cps) {
       %2 = tribute_control.call_indirect %0, %1 : core.i32

--- a/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
+++ b/crates/tribute-front/tests/snapshots/lambda_effect_type__pure_lambda_with_capture_no_effect.snap
@@ -3,7 +3,7 @@ source: crates/tribute-front/tests/lambda_effect_type.rs
 expression: ir_text
 ---
 core.module @test {
-  !t0 = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  !t0 = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 2}
 
   tribute_control.func @apply(%0: !t0, %1: core.i32) -> core.i32 convention(cps) {
       %2 = tribute_control.call_indirect %0, %1 : core.i32

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_construction.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Point = adt.struct() {fields = [[@x, core.i32], [@y, core.i32]], name = @Point}
   !Point_1 = adt.typeref() {name = @Point}
-  !t0 = tribute_control.callable(core.i32, !Point_1) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(!Point_1) -> core.i32> {tribute.calling_convention = 0}
 
   tribute_control.func @"Point::x"(%0: !Point_1) -> core.i32 convention(direct) {
       %1 = adt.struct_get %0 {field = 0, type = !Point} : core.i32

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_generic.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Pair = adt.struct() {fields = [[@first, tribute_rt.anyref], [@second, tribute_rt.anyref]], name = @Pair}
   !Pair_1 = adt.typeref() {name = @Pair}
-  !t0 = tribute_control.callable(tribute_rt.anyref, !Pair_1) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(!Pair_1) -> tribute_rt.anyref> {tribute.calling_convention = 0}
 
   tribute_control.func @"Pair::first"(%0: !Pair_1) -> tribute_rt.anyref convention(direct) {
       %1 = adt.struct_get %0 {field = 0, type = !Pair} : tribute_rt.anyref

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Point = adt.struct() {fields = [[@x, core.i32], [@y, core.i32]], name = @Point}
   !Point_1 = adt.typeref() {name = @Point}
-  !t0 = tribute_control.callable(core.i32, !Point_1) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(!Point_1) -> core.i32> {tribute.calling_convention = 0}
 
   tribute_control.func @"Point::x"(%0: !Point_1) -> core.i32 convention(direct) {
       %1 = adt.struct_get %0 {field = 0, type = !Point} : core.i32

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_all_fields_explicit.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Point = adt.typeref() {name = @Point}
   !Point_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32]], name = @Point}
-  !t0 = tribute_control.callable(core.i32, !Point) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(!Point) -> core.i32> {tribute.calling_convention = 0}
 
   tribute_control.func @"Point::x"(%0: !Point) -> core.i32 convention(direct) {
       %1 = adt.struct_get %0 {field = 0, type = !Point_1} : core.i32

--- a/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
+++ b/crates/tribute-front/tests/snapshots/record_field_type__snapshot_record_spread_only.snap
@@ -5,7 +5,7 @@ expression: ir_text
 core.module @test {
   !Config = adt.struct() {fields = [[@debug, core.i1], [@verbose, core.i1]], name = @Config}
   !Config_1 = adt.typeref() {name = @Config}
-  !t0 = tribute_control.callable(core.i1, !Config_1) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(!Config_1) -> core.i1> {tribute.calling_convention = 0}
 
   tribute_control.func @"Config::debug"(%0: !Config_1) -> core.i1 convention(direct) {
       %1 = adt.struct_get %0 {field = 0, type = !Config} : core.i1

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_chained_multi_arg.snap
@@ -4,10 +4,10 @@ expression: ir_text
 ---
 core.module @test {
   !Triple = adt.typeref() {name = @Triple}
-  !t0 = tribute_control.callable(core.i32, !Triple) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(!Triple) -> core.i32> {tribute.calling_convention = 0}
   !Triple_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32], [@z, core.i32]], name = @Triple}
   !Pair = adt.typeref() {name = @Pair}
-  !t1 = tribute_control.callable(core.i32, !Pair) {tribute.calling_convention = 0}
+  !t1 = tribute_control.func_sig<(!Pair) -> core.i32> {tribute.calling_convention = 0}
   !Pair_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32]], name = @Pair}
 
   tribute_control.func @"Pair::x"(%0: !Pair) -> core.i32 convention(direct) {

--- a/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
+++ b/crates/tribute-front/tests/snapshots/ufcs_method_call__snapshot_ufcs_single_extra_arg.snap
@@ -6,8 +6,8 @@ core.module @test {
   !Triple = adt.typeref() {name = @Triple}
   !Triple_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32], [@z, core.i32]], name = @Triple}
   !Pair = adt.typeref() {name = @Pair}
-  !t0 = tribute_control.callable(core.i32, !Triple) {tribute.calling_convention = 0}
-  !t1 = tribute_control.callable(core.i32, !Pair) {tribute.calling_convention = 0}
+  !t0 = tribute_control.func_sig<(!Triple) -> core.i32> {tribute.calling_convention = 0}
+  !t1 = tribute_control.func_sig<(!Pair) -> core.i32> {tribute.calling_convention = 0}
   !Pair_1 = adt.struct() {fields = [[@x, core.i32], [@y, core.i32]], name = @Pair}
 
   tribute_control.func @"Pair::x"(%0: !Pair) -> core.i32 convention(direct) {

--- a/crates/tribute-ir/src/dialect/closure.rs
+++ b/crates/tribute-ir/src/dialect/closure.rs
@@ -218,6 +218,8 @@ fn parse_closure_lambda<'a>(
     let param_raw_types: Vec<RawType<'a>> = params.iter().map(|(_, ty)| ty.clone()).collect();
 
     let func_raw_ty = RawType::Function {
+        dialect: "func",
+        name: "func_sig",
         inputs: param_raw_types,
         results: ret_ty.into_iter().collect(),
         attrs: vec![],

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -212,6 +212,16 @@ impl FuncSig {
         )
         .expect("validated source func_sig retains convention domain")
     }
+
+    /// Remove the storage delimiters and source-only convention metadata.
+    ///
+    /// Consumers rebuilding an equivalent signature in another dialect retain
+    /// every other attribute through their owning typed constructor.
+    pub fn remove_reserved_attrs(attrs: &mut AttributeMap) {
+        attrs.remove(trunk_ir::dialect::func::NUM_INPUTS_ATTR);
+        attrs.remove(trunk_ir::dialect::func::NUM_RESULTS_ATTR);
+        attrs.remove(CALLING_CONVENTION_ATTR);
+    }
 }
 
 fn read_count(attrs: &AttributeMap, key: &'static str) -> Result<u32, FuncSigTypeError> {

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -13,7 +13,7 @@ use trunk_ir::op_interface::{RegionBranchOps, RegionBranchPoint, RegionSuccessor
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueDef, ValueRef};
 use trunk_ir::rewrite::Module;
-use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
+use trunk_ir::types::{Attribute, AttributeMap, Location, TypeDataBuilder};
 use trunk_ir::{IrContext, Symbol};
 
 use super::list;
@@ -70,7 +70,7 @@ mod tribute_control {
     // Types
     struct ResumeToken<Input, Answer>;
 
-    // Callable operations
+    // FuncSig operations
     #[attr(sym_name: Symbol, r#type: Type)]
     fn func() {
         #[region(body)]
@@ -121,16 +121,29 @@ mod tribute_control {
     fn r#yield(value: ()) {}
 }
 
-/// Typed wrapper for `tribute_control.callable(Result, Params...)`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Callable(TypeRef);
+/// Why a name-matching source signature does not satisfy its storage contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FuncSigTypeError {
+    MissingCount(&'static str),
+    InvalidCount(&'static str),
+    CountOverflow,
+    LengthMismatch,
+    ResultCount(u32),
+    Convention,
+}
 
-impl DialectType for Callable {
+/// Typed wrapper for an input-first, exactly-one-result source signature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FuncSig(TypeRef);
+
+impl DialectType for FuncSig {
     const DIALECT_NAME: &'static str = "tribute_control";
-    const TYPE_NAME: &'static str = "callable";
+    const TYPE_NAME: &'static str = "func_sig";
 
     fn from_type_ref(ctx: &IrContext, ty: TypeRef) -> Option<Self> {
-        (Self::matches(ctx, ty) && !ctx.types.get(ty).params.is_empty()).then_some(Self(ty))
+        Self::matches(ctx, ty)
+            .then(|| Self::validate(ctx, ty).ok())
+            .flatten()
     }
 
     fn as_type_ref(&self) -> TypeRef {
@@ -138,50 +151,130 @@ impl DialectType for Callable {
     }
 }
 
-impl From<Callable> for TypeRef {
-    fn from(value: Callable) -> Self {
+impl From<FuncSig> for TypeRef {
+    fn from(value: FuncSig) -> Self {
         value.0
     }
 }
 
-impl Callable {
+impl FuncSig {
+    fn validate(ctx: &IrContext, ty: TypeRef) -> Result<Self, FuncSigTypeError> {
+        let data = ctx.types.get(ty);
+        let inputs = read_count(&data.attrs, trunk_ir::dialect::func::NUM_INPUTS_ATTR)?;
+        let results = read_count(&data.attrs, trunk_ir::dialect::func::NUM_RESULTS_ATTR)?;
+        if results != 1 {
+            return Err(FuncSigTypeError::ResultCount(results));
+        }
+        let total = inputs
+            .checked_add(results)
+            .ok_or(FuncSigTypeError::CountOverflow)?;
+        if usize::try_from(total).ok() != Some(data.params.len()) {
+            return Err(FuncSigTypeError::LengthMismatch);
+        }
+        CallingConvention::try_from(
+            data.attrs
+                .get_i128(CALLING_CONVENTION_ATTR)
+                .ok_or(FuncSigTypeError::Convention)?,
+        )
+        .map_err(|_| FuncSigTypeError::Convention)?;
+        Ok(Self(ty))
+    }
+
     pub fn as_type_ref(self) -> TypeRef {
         self.0
     }
 
     pub fn result(self, ctx: &IrContext) -> TypeRef {
-        ctx.types.get(self.0).params[0]
+        self.results(ctx)[0]
     }
 
-    pub fn params(self, ctx: &IrContext) -> &[TypeRef] {
-        &ctx.types.get(self.0).params[1..]
+    pub fn inputs(self, ctx: &IrContext) -> &[TypeRef] {
+        let count = read_count(
+            &ctx.types.get(self.0).attrs,
+            trunk_ir::dialect::func::NUM_INPUTS_ATTR,
+        )
+        .expect("validated source func_sig retains input count") as usize;
+        &ctx.types.get(self.0).params[..count]
+    }
+
+    pub fn results(self, ctx: &IrContext) -> &[TypeRef] {
+        let inputs = self.inputs(ctx).len();
+        &ctx.types.get(self.0).params[inputs..]
+    }
+
+    pub fn convention(self, ctx: &IrContext) -> CallingConvention {
+        CallingConvention::try_from(
+            ctx.types
+                .get(self.0)
+                .attrs
+                .get_i128(CALLING_CONVENTION_ATTR)
+                .expect("validated source func_sig retains convention"),
+        )
+        .expect("validated source func_sig retains convention domain")
     }
 }
 
-/// Build a verified-shape logical callable type.
-pub fn callable(
+fn read_count(attrs: &AttributeMap, key: &'static str) -> Result<u32, FuncSigTypeError> {
+    match attrs.get(key) {
+        Some(Attribute::Int(value)) => {
+            u32::try_from(*value).map_err(|_| FuncSigTypeError::InvalidCount(key))
+        }
+        Some(_) => Err(FuncSigTypeError::InvalidCount(key)),
+        None => Err(FuncSigTypeError::MissingCount(key)),
+    }
+}
+
+/// Build a verified-shape logical source signature.
+pub fn func_sig(
     ctx: &mut IrContext,
     result: TypeRef,
-    params: impl IntoIterator<Item = TypeRef>,
+    inputs: impl IntoIterator<Item = TypeRef>,
     convention: CallingConvention,
-) -> Callable {
-    let data = TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new("callable"))
-        .param(result)
-        .params(params)
-        .attr(CALLING_CONVENTION_ATTR, Attribute::Int(convention as i128))
-        .build();
-    let ty = ctx.types.intern(data);
-    Callable::from_type_ref(ctx, ty).expect("newly built callable type")
+) -> FuncSig {
+    func_sig_with_attrs(ctx, result, inputs, convention, AttributeMap::new())
 }
 
-/// Read the exact convention metadata from a logical callable type.
-pub fn callable_convention(ctx: &IrContext, ty: TypeRef) -> Option<CallingConvention> {
-    let callable = Callable::from_type_ref(ctx, ty)?;
-    ctx.types
-        .get(callable.as_type_ref())
-        .attrs
-        .get_i128(CALLING_CONVENTION_ATTR)
-        .and_then(|code| CallingConvention::try_from(code).ok())
+/// Construct a source signature while preserving only non-reserved metadata.
+pub fn func_sig_with_attrs(
+    ctx: &mut IrContext,
+    result: TypeRef,
+    inputs: impl IntoIterator<Item = TypeRef>,
+    convention: CallingConvention,
+    attrs: AttributeMap,
+) -> FuncSig {
+    assert!(
+        !attrs.contains_key(trunk_ir::dialect::func::NUM_INPUTS_ATTR)
+            && !attrs.contains_key(trunk_ir::dialect::func::NUM_RESULTS_ATTR)
+            && !attrs.contains_key(CALLING_CONVENTION_ATTR),
+        "source func_sig reserves delimiters and convention metadata"
+    );
+    let inputs: Vec<_> = inputs.into_iter().collect();
+    let count = u32::try_from(inputs.len()).expect("source func_sig input count exceeds u32");
+    let mut builder = TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new("func_sig"))
+        .params(inputs)
+        .param(result);
+    for (key, value) in attrs {
+        builder = builder.attr(key, value);
+    }
+    let ty = ctx.types.intern(
+        builder
+            .attr(
+                trunk_ir::dialect::func::NUM_INPUTS_ATTR,
+                Attribute::from(count),
+            )
+            .attr(
+                trunk_ir::dialect::func::NUM_RESULTS_ATTR,
+                Attribute::from(1_u32),
+            )
+            .attr(CALLING_CONVENTION_ATTR, Attribute::Int(convention as i128))
+            .build(),
+    );
+    FuncSig::from_type_ref(ctx, ty).expect("source func_sig constructor must produce a valid type")
+}
+
+/// Read convention only through a validated source signature.
+pub fn func_sig_convention(ctx: &IrContext, ty: TypeRef) -> Option<CallingConvention> {
+    FuncSig::from_type_ref(ctx, ty).map(|signature| signature.convention(ctx))
 }
 
 /// Read the exact input and answer types carried by a resume token.
@@ -200,7 +293,7 @@ pub fn func_declaration(
     ctx: &mut IrContext,
     location: Location,
     sym_name: Symbol,
-    callable_type: TypeRef,
+    func_sig_type: TypeRef,
 ) -> Func {
     let data = trunk_ir::OperationDataBuilder::new(
         location,
@@ -208,7 +301,7 @@ pub fn func_declaration(
         Symbol::new("func"),
     )
     .attr("sym_name", Attribute::Symbol(sym_name))
-    .attr("type", Attribute::Type(callable_type))
+    .attr("type", Attribute::Type(func_sig_type))
     .build(ctx);
     let op = ctx.create_op(data);
     Func::from_op(ctx, op).expect("newly built tribute_control.func")
@@ -243,15 +336,16 @@ fn print_symbol(h: &mut trunk_ir::printer::OpPrintHelper<'_, '_>, symbol: Symbol
     h.write_attribute(&Attribute::Symbol(symbol))
 }
 
-fn callable_parts(
+fn func_sig_parts(
     ctx: &IrContext,
     ty: TypeRef,
 ) -> Option<(TypeRef, Vec<TypeRef>, CallingConvention)> {
-    let callable = Callable::from_type_ref(ctx, ty)?;
-    let data = ctx.types.get(callable.as_type_ref());
-    let (&result, params) = data.params.split_first()?;
-    let convention = callable_convention(ctx, ty)?;
-    Some((result, params.to_vec(), convention))
+    let signature = FuncSig::from_type_ref(ctx, ty)?;
+    Some((
+        signature.result(ctx),
+        signature.inputs(ctx).to_vec(),
+        signature.convention(ctx),
+    ))
 }
 
 fn print_extra_attributes(
@@ -332,7 +426,7 @@ fn print_func(
     let symbol = data.attributes.get_symbol("sym_name");
     let callable_ty = data.attributes.get_type("type");
     let region = data.regions.first().copied();
-    let parts = callable_ty.and_then(|ty| callable_parts(h.ctx(), ty));
+    let parts = callable_ty.and_then(|ty| func_sig_parts(h.ctx(), ty));
 
     write!(h, "{}tribute_control.func ", " ".repeat(indent))?;
     if let Some(symbol) = symbol {
@@ -384,18 +478,17 @@ fn parse_convention(input: &mut &str) -> winnow::ModalResult<CallingConvention> 
     Ok(convention)
 }
 
-fn callable_raw_type<'a>(
+fn func_sig_raw_type<'a>(
     result: trunk_ir::parser::raw::RawType<'a>,
     params: &[(&'a str, trunk_ir::parser::raw::RawType<'a>)],
     convention: CallingConvention,
 ) -> trunk_ir::parser::raw::RawType<'a> {
     use trunk_ir::parser::raw::{RawAttribute, RawType};
-    let mut type_params = vec![result];
-    type_params.extend(params.iter().map(|(_, ty)| ty.clone()));
-    RawType::Concrete {
+    RawType::Function {
         dialect: "tribute_control",
-        name: "callable",
-        params: type_params,
+        name: "func_sig",
+        inputs: params.iter().map(|(_, ty)| ty.clone()).collect(),
+        results: vec![result],
         attrs: vec![(
             CALLING_CONVENTION_ATTR,
             RawAttribute::Int(convention as i128),
@@ -454,9 +547,9 @@ fn parse_func<'a>(
         regions.push(region);
     }
 
-    let callable = callable_raw_type(result, &params, convention);
+    let signature = func_sig_raw_type(result, &params, convention);
     let mut attributes = attributes;
-    attributes.push(("type", RawAttribute::Type(callable)));
+    attributes.push(("type", RawAttribute::Type(signature)));
 
     Ok(RawOperation {
         results,
@@ -495,7 +588,7 @@ fn print_lambda(
     let result = h.ctx().op_results(op).first().copied();
     let result_name = result.map(|value| h.assign_value_name(value));
     let callable_ty = h.ctx().op_result_types(op).first().copied();
-    let parts = callable_ty.and_then(|ty| callable_parts(h.ctx(), ty));
+    let parts = callable_ty.and_then(|ty| func_sig_parts(h.ctx(), ty));
     let region = h.ctx().op(op).regions.first().copied();
 
     write!(h, "{}", " ".repeat(indent))?;
@@ -604,7 +697,7 @@ fn parse_lambda<'a>(
         return_type: None,
         operands: captures,
         attributes,
-        result_types: vec![callable_raw_type(result, &params, convention)],
+        result_types: vec![func_sig_raw_type(result, &params, convention)],
         regions: vec![region],
         successors: vec![],
     })
@@ -811,28 +904,13 @@ fn validate_control_types(ctx: &IrContext, errors: &mut Vec<ValidationError>) {
         if data.dialect != Symbol::new("tribute_control") {
             continue;
         }
-        if data.name == Symbol::new("callable") {
-            if data.params.is_empty() {
+        if data.name == Symbol::new("func_sig") {
+            if let Err(error) = FuncSig::validate(ctx, ty) {
                 push_type_error(
                     errors,
-                    format!("{ty}: tribute_control.callable requires one result type"),
+                    format!("{ty}: malformed tribute_control.func_sig: {error:?}"),
                 );
                 continue;
-            }
-            match data.attrs.get_i128(CALLING_CONVENTION_ATTR) {
-                Some(code) if CallingConvention::try_from(code).is_ok() => {}
-                Some(code) => push_type_error(
-                    errors,
-                    format!(
-                        "{ty}: tribute_control.callable has unsupported {CALLING_CONVENTION_ATTR} code {code}; expected 0, 1, or 2"
-                    ),
-                ),
-                None => push_type_error(
-                    errors,
-                    format!(
-                        "{ty}: tribute_control.callable requires integer {CALLING_CONVENTION_ATTR}"
-                    ),
-                ),
             }
             for component in data.params.iter().copied() {
                 if contains_forbidden_logical_component(ctx, component, &mut HashSet::new()) {
@@ -892,7 +970,7 @@ fn validate_attr_keys(
             op,
             errors,
             format!(
-                "{CALLING_CONVENTION_ATTR} belongs only on tribute_control.callable, not on the operation"
+                "{CALLING_CONVENTION_ATTR} belongs only on tribute_control.func_sig, not on the operation"
             ),
         );
     }
@@ -1096,12 +1174,12 @@ fn validate_callable_body(
     body: RegionRef,
     errors: &mut Vec<ValidationError>,
 ) {
-    let Some((result_ty, params, _)) = callable_parts(ctx, callable_ty) else {
+    let Some((result_ty, params, _)) = func_sig_parts(ctx, callable_ty) else {
         push_op_error(
             ctx,
             owner,
             errors,
-            "requires a valid tribute_control.callable signature",
+            "requires a valid tribute_control.func_sig signature",
         );
         return;
     };
@@ -1205,12 +1283,12 @@ fn validate_func(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>) 
     let Some(callable_ty) = ctx.op(op).attributes.get_type("type") else {
         return;
     };
-    if !Callable::matches(ctx, callable_ty) {
+    if !FuncSig::matches(ctx, callable_ty) {
         push_op_error(
             ctx,
             op,
             errors,
-            "type attribute must be tribute_control.callable",
+            "type attribute must be tribute_control.func_sig",
         );
     }
     match ctx.op(op).regions.as_slice() {
@@ -1234,12 +1312,12 @@ fn validate_lambda(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>
     let Some(&callable_ty) = ctx.op_result_types(op).first() else {
         return;
     };
-    if !Callable::matches(ctx, callable_ty) {
+    if !FuncSig::matches(ctx, callable_ty) {
         push_op_error(
             ctx,
             op,
             errors,
-            "result must have tribute_control.callable type",
+            "result must have tribute_control.func_sig type",
         );
     }
     if let Some(&body) = ctx.op(op).regions.first() {
@@ -1252,13 +1330,13 @@ fn validate_func_ref(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationErro
     validate_attr_keys(ctx, op, &["func_ref"], false, errors);
     validate_attr_types(ctx, op, &[("func_ref", AttributeKind::Symbol)], errors);
     if let Some(&ty) = ctx.op_result_types(op).first()
-        && !Callable::matches(ctx, ty)
+        && !FuncSig::matches(ctx, ty)
     {
         push_op_error(
             ctx,
             op,
             errors,
-            "result must have tribute_control.callable type",
+            "result must have tribute_control.func_sig type",
         );
     }
 }
@@ -1284,12 +1362,12 @@ fn validate_call_indirect(ctx: &IrContext, op: OpRef, errors: &mut Vec<Validatio
         return;
     };
     let callee_ty = ctx.value_ty(callee);
-    let Some((result, params, _)) = callable_parts(ctx, callee_ty) else {
+    let Some((result, params, _)) = func_sig_parts(ctx, callee_ty) else {
         push_op_error(
             ctx,
             op,
             errors,
-            "callee operand must have tribute_control.callable type",
+            "callee operand must have tribute_control.func_sig type",
         );
         return;
     };
@@ -1329,7 +1407,7 @@ fn validate_return(ctx: &IrContext, op: OpRef, errors: &mut Vec<ValidationError>
     } else {
         None
     };
-    let Some((result, _, _)) = callable_ty.and_then(|ty| callable_parts(ctx, ty)) else {
+    let Some((result, _, _)) = callable_ty.and_then(|ty| func_sig_parts(ctx, ty)) else {
         push_op_error(
             ctx,
             op,
@@ -1783,10 +1861,10 @@ fn collect_funcs(
 }
 
 fn same_source_signature(ctx: &IrContext, left: TypeRef, right: TypeRef) -> bool {
-    let Some((left_result, left_params, _)) = callable_parts(ctx, left) else {
+    let Some((left_result, left_params, _)) = func_sig_parts(ctx, left) else {
         return false;
     };
-    let Some((right_result, right_params, _)) = callable_parts(ctx, right) else {
+    let Some((right_result, right_params, _)) = func_sig_parts(ctx, right) else {
         return false;
     };
     left_result == right_result && left_params == right_params
@@ -1826,8 +1904,8 @@ fn validate_symbol_uses(
                     "func_ref result source signature does not match its target",
                 );
             } else if let (Some(target_cc), Some(result_cc)) = (
-                callable_convention(ctx, target_ty),
-                callable_convention(ctx, result_ty),
+                func_sig_convention(ctx, target_ty),
+                func_sig_convention(ctx, result_ty),
             ) && result_cc < target_cc
             {
                 push_op_error(
@@ -1848,7 +1926,7 @@ fn validate_symbol_uses(
             let Some(target_ty) = ctx.op(target).attributes.get_type("type") else {
                 return;
             };
-            let Some((result, params, _)) = callable_parts(ctx, target_ty) else {
+            let Some((result, params, _)) = func_sig_parts(ctx, target_ty) else {
                 return;
             };
             check_types_equal(
@@ -2300,7 +2378,7 @@ fn compiler_intrinsic_map<'a>(
             );
         }
         previous = Some(key);
-        if callable_convention(ctx, declaration.callable_type) != Some(CallingConvention::Direct) {
+        if func_sig_convention(ctx, declaration.callable_type) != Some(CallingConvention::Direct) {
             push_type_error(
                 errors,
                 format!(
@@ -2421,7 +2499,7 @@ fn callable_block_arg_has_source_contract(
     };
     let value_type = ctx.value_ty(value);
 
-    let callable_type = if is_control_op(ctx, owner, "func") {
+    let func_sig_type = if is_control_op(ctx, owner, "func") {
         (ctx.op(owner).regions.as_slice() == [region])
             .then(|| ctx.op(owner).attributes.get_type("type"))
             .flatten()
@@ -2432,7 +2510,7 @@ fn callable_block_arg_has_source_contract(
     } else {
         None
     };
-    if let Some((_, parameters, _)) = callable_type.and_then(|ty| callable_parts(ctx, ty)) {
+    if let Some((_, parameters, _)) = func_sig_type.and_then(|ty| func_sig_parts(ctx, ty)) {
         return parameters.get(index as usize) == Some(&value_type);
     }
 
@@ -2479,7 +2557,7 @@ fn callable_has_semantic_provenance(
     provenance: &CallableProvenance<'_>,
     visiting: &mut HashSet<ValueRef>,
 ) -> bool {
-    if !visiting.insert(value) || Callable::from_type_ref(ctx, ctx.value_ty(value)).is_none() {
+    if !visiting.insert(value) || FuncSig::from_type_ref(ctx, ctx.value_ty(value)).is_none() {
         return false;
     }
     match ctx.value_def(value) {
@@ -2551,7 +2629,7 @@ fn verified_callable_declaration(
     if !data.regions.is_empty() {
         return true;
     }
-    let (Some(symbol), Some(identity), Some(callable_type)) = (
+    let (Some(symbol), Some(identity), Some(func_sig_type)) = (
         data.attributes.get_symbol("sym_name"),
         Func::from_op(ctx, function)
             .ok()
@@ -2561,7 +2639,7 @@ fn verified_callable_declaration(
         return false;
     };
     registered.get(&symbol).is_some_and(|declaration| {
-        declaration.identity == identity && declaration.callable_type == callable_type
+        declaration.identity == identity && declaration.callable_type == func_sig_type
     })
 }
 
@@ -2583,7 +2661,7 @@ fn validate_callable_origins(
     walk_region_ops(ctx, body, &mut |op| {
         if is_control_op(ctx, op, "func") {
             let data = ctx.op(op);
-            let (Some(symbol), Some(callable_type)) = (
+            let (Some(symbol), Some(func_sig_type)) = (
                 data.attributes.get_symbol("sym_name"),
                 data.attributes.get_type("type"),
             ) else {
@@ -2605,7 +2683,7 @@ fn validate_callable_origins(
                 let exact_intrinsic = match (registered.get(&symbol), intrinsic_identity) {
                     (Some(expected), Some(actual))
                         if expected.identity == actual
-                            && expected.callable_type == callable_type =>
+                            && expected.callable_type == func_sig_type =>
                     {
                         seen.insert(symbol);
                         true
@@ -2630,7 +2708,7 @@ fn validate_callable_origins(
                     }
                     (None, None) => false,
                 };
-                if !exact_intrinsic && contains_adt_typeref(ctx, callable_type, &mut HashSet::new())
+                if !exact_intrinsic && contains_adt_typeref(ctx, func_sig_type, &mut HashSet::new())
                 {
                     push_op_error(
                         ctx,
@@ -2688,7 +2766,7 @@ fn validate_return_contracts(ctx: &IrContext, body: RegionRef, errors: &mut Vec<
             }
             owner = parent_op(ctx, current);
         };
-        let Some((expected, _, _)) = callable.and_then(|ty| callable_parts(ctx, ty)) else {
+        let Some((expected, _, _)) = callable.and_then(|ty| func_sig_parts(ctx, ty)) else {
             return;
         };
         if let [value] = ctx.op_operands(op)
@@ -3251,7 +3329,7 @@ mod tests {
         let loc = location(&mut ctx);
         let i32_ty = simple_type(&mut ctx, "core", "i32");
         let ability = ability_type(&mut ctx, "State");
-        let direct = callable(&mut ctx, i32_ty, [i32_ty], CallingConvention::Direct).as_type_ref();
+        let direct = func_sig(&mut ctx, i32_ty, [i32_ty], CallingConvention::Direct).as_type_ref();
 
         let id = identity_func(&mut ctx, loc, "id", direct, i32_ty);
 
@@ -3266,7 +3344,7 @@ mod tests {
         let indirect_call = call_indirect(&mut ctx, loc, function_ref_value, [x], i32_ty);
         ctx.push_op(entry, indirect_call.op_ref());
 
-        let lambda_ty = callable(&mut ctx, i32_ty, [], CallingConvention::Direct).as_type_ref();
+        let lambda_ty = func_sig(&mut ctx, i32_ty, [], CallingConvention::Direct).as_type_ref();
         let lambda_block = block(&mut ctx, loc, &[]);
         let lambda_return = r#return(&mut ctx, loc, x);
         ctx.push_op(lambda_block, lambda_return.op_ref());
@@ -3346,7 +3424,7 @@ mod tests {
     }
 
     const VALID_CONTROL_MODULE: &str = r#"core.module @test {
-  !callable = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !callable = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
 
   tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct) {
     tribute_control.return %value
@@ -3506,9 +3584,9 @@ mod tests {
             (CallingConvention::EvidenceDirect, 1),
             (CallingConvention::Cps, 2),
         ] {
-            let ty = callable(&mut ctx, i32_ty, [i32_ty], convention);
+            let ty = func_sig(&mut ctx, i32_ty, [i32_ty], convention);
             assert_eq!(ty.result(&ctx), i32_ty);
-            assert_eq!(ty.params(&ctx), &[i32_ty]);
+            assert_eq!(ty.inputs(&ctx), &[i32_ty]);
             assert_eq!(
                 ctx.types
                     .get(ty.as_type_ref())
@@ -3517,7 +3595,7 @@ mod tests {
                 Some(code)
             );
             assert_eq!(
-                callable_convention(&ctx, ty.as_type_ref()),
+                func_sig_convention(&ctx, ty.as_type_ref()),
                 Some(convention)
             );
         }
@@ -3531,18 +3609,67 @@ mod tests {
     fn callable_wrapper_rejects_missing_result_component() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !malformed = tribute_control.callable() {tribute.calling_convention = 0}
+  !malformed = tribute_control.func_sig<() -> ()> {tribute.calling_convention = 0}
 }"#,
         );
         let malformed = ctx
             .types
             .iter()
-            .find_map(|(ty, _)| Callable::matches(&ctx, ty).then_some(ty))
+            .find_map(|(ty, _)| FuncSig::matches(&ctx, ty).then_some(ty))
             .expect("malformed callable type");
-        assert!(Callable::from_type_ref(&ctx, malformed).is_none());
+        assert!(FuncSig::from_type_ref(&ctx, malformed).is_none());
 
         let result = validate_local(&ctx, module);
-        assert!(messages(&result).contains("requires one result type"));
+        assert!(messages(&result).contains("ResultCount(0)"));
+    }
+
+    #[test]
+    fn func_sig_rejects_raw_delimiter_failures_before_conversion() {
+        let (mut ctx, module) = parse_fixture("core.module @test {}");
+        let i32_ty = simple_type(&mut ctx, "core", "i32");
+        let malformed = [
+            TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new("func_sig"))
+                .param(i32_ty)
+                .attr(CALLING_CONVENTION_ATTR, Attribute::Int(0))
+                .build(),
+            TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new("func_sig"))
+                .param(i32_ty)
+                .attr(
+                    trunk_ir::dialect::func::NUM_INPUTS_ATTR,
+                    Attribute::String("bad".into()),
+                )
+                .attr(trunk_ir::dialect::func::NUM_RESULTS_ATTR, Attribute::Int(1))
+                .attr(CALLING_CONVENTION_ATTR, Attribute::Int(0))
+                .build(),
+            TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new("func_sig"))
+                .param(i32_ty)
+                .attr(trunk_ir::dialect::func::NUM_INPUTS_ATTR, Attribute::Int(2))
+                .attr(trunk_ir::dialect::func::NUM_RESULTS_ATTR, Attribute::Int(1))
+                .attr(CALLING_CONVENTION_ATTR, Attribute::Int(0))
+                .build(),
+            TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new("func_sig"))
+                .param(i32_ty)
+                .attr(
+                    trunk_ir::dialect::func::NUM_INPUTS_ATTR,
+                    Attribute::Int(i128::from(u32::MAX) + 1),
+                )
+                .attr(trunk_ir::dialect::func::NUM_RESULTS_ATTR, Attribute::Int(1))
+                .attr(CALLING_CONVENTION_ATTR, Attribute::Int(0))
+                .build(),
+            TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new("func_sig"))
+                .param(i32_ty)
+                .attr(trunk_ir::dialect::func::NUM_INPUTS_ATTR, Attribute::Int(0))
+                .attr(trunk_ir::dialect::func::NUM_RESULTS_ATTR, Attribute::Int(2))
+                .attr(CALLING_CONVENTION_ATTR, Attribute::Int(0))
+                .build(),
+        ];
+        for data in malformed {
+            let ty = ctx.types.intern(data);
+            assert!(FuncSig::matches(&ctx, ty));
+            assert!(FuncSig::from_type_ref(&ctx, ty).is_none());
+        }
+        let errors = validate_local(&ctx, module);
+        assert!(messages(&errors).contains("malformed tribute_control.func_sig"));
     }
 
     #[test]
@@ -3675,21 +3802,21 @@ mod tests {
     fn validator_rejects_invalid_convention_and_duplicate_op_metadata() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !bad = tribute_control.callable(core.i32) {tribute.calling_convention = 3}
+  !bad = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 3}
   %call = tribute_control.call {callee = @missing, tribute.calling_convention = 0} : core.i32
 }"#,
         );
         let result = validate_local(&ctx, module);
         let messages = messages(&result);
-        assert!(messages.contains("unsupported tribute.calling_convention code 3"));
-        assert!(messages.contains("belongs only on tribute_control.callable"));
+        assert!(messages.contains("malformed tribute_control.func_sig: Convention"));
+        assert!(messages.contains("belongs only on tribute_control.func_sig"));
     }
 
     #[test]
     fn validator_rejects_wrong_required_attribute_types() {
         let (mut ctx, module) = parse_fixture(
             r#"core.module @test {
-  !callable = tribute_control.callable(core.i32) {tribute.calling_convention = 0}
+  !callable = tribute_control.func_sig<() -> core.i32> {tribute.calling_convention = 0}
   tribute_control.func @malformed() -> core.i32 convention(direct)
   %ref = tribute_control.func_ref {func_ref = 1} : !callable
   %call = tribute_control.call {callee = 1} : core.i32
@@ -3839,7 +3966,7 @@ mod tests {
     fn local_validator_reports_distinct_malformed_operation_contracts() {
         let (mut ctx, module) = parse_fixture(
             r#"core.module @test {
-  !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !direct = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   !token = tribute_control.resume_token(core.i32, core.i32)
   %integer = arith.const {value = 1} : core.i32
   %boolean = arith.const {value = true} : core.bool
@@ -3949,14 +4076,14 @@ mod tests {
             &result,
             bad_func,
             &[
-                "type attribute must be tribute_control.callable",
+                "type attribute must be tribute_control.func_sig",
                 "expects zero or one body region, found 2",
             ],
         );
         assert_op_diagnostics(
             &result,
             bad_lambda,
-            &["result must have tribute_control.callable type"],
+            &["result must have tribute_control.func_sig type"],
         );
         assert_op_diagnostics(
             &result,
@@ -3965,7 +4092,7 @@ mod tests {
                 "expects 0 operand(s), found 1",
                 "expects 1 result(s), found 2",
                 "has unsupported attribute 'unexpected'",
-                "result must have tribute_control.callable type",
+                "result must have tribute_control.func_sig type",
             ],
         );
         assert_op_diagnostics(
@@ -3981,7 +4108,7 @@ mod tests {
         assert_op_diagnostics(
             &result,
             non_callable_indirect,
-            &["callee operand must have tribute_control.callable type"],
+            &["callee operand must have tribute_control.func_sig type"],
         );
         assert_op_diagnostics(
             &result,
@@ -4192,7 +4319,7 @@ mod tests {
         let (ctx, module) = parse_fixture(
             r#"core.module @outer {
   core.module @integers {
-    !callable = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+    !callable = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
     tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct) {
       tribute_control.return %value
     }
@@ -4204,7 +4331,7 @@ mod tests {
     }
   }
   core.module @booleans {
-    !callable = tribute_control.callable(core.bool, core.bool) {tribute.calling_convention = 0}
+    !callable = tribute_control.func_sig<(core.bool) -> core.bool> {tribute.calling_convention = 0}
     tribute_control.func @id(%value: core.bool) -> core.bool convention(direct) {
       tribute_control.return %value
     }
@@ -4226,9 +4353,9 @@ mod tests {
     fn whole_ir_reports_symbol_declaration_capture_and_token_contracts() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
-  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
-  !different = tribute_control.callable(core.bool) {tribute.calling_convention = 0}
+  !direct = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
+  !cps = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 2}
+  !different = tribute_control.func_sig<() -> core.bool> {tribute.calling_convention = 0}
   !token = tribute_control.resume_token(core.i32, core.i32)
 
   tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct)
@@ -4801,18 +4928,18 @@ mod tests {
 }"#,
         );
         let function = control_op(&ctx, module, "func");
-        let callable_type = ctx.op(function).attributes.get_type("type").unwrap();
+        let func_sig_type = ctx.op(function).attributes.get_type("type").unwrap();
         let exact = CompilerIntrinsicDeclaration::new(
             Symbol::new("Nat::+"),
             Symbol::new("Nat::+"),
-            callable_type,
+            func_sig_type,
         );
         assert!(validate(&ctx, module, &[], std::slice::from_ref(&exact)).is_ok());
 
         let wrong_signature = CompilerIntrinsicDeclaration::new(
             exact.symbol,
             exact.identity,
-            ctx.types.get(callable_type).params[0],
+            ctx.types.get(func_sig_type).params[0],
         );
         let result = validate(&ctx, module, &[], &[wrong_signature]);
         assert!(messages(&result).contains("complete signature"), "{result}");
@@ -4833,11 +4960,11 @@ mod tests {
 }"#,
         );
         let function = control_op(&ctx, module, "func");
-        let callable_type = ctx.op(function).attributes.get_type("type").unwrap();
+        let func_sig_type = ctx.op(function).attributes.get_type("type").unwrap();
         let declaration = CompilerIntrinsicDeclaration::new(
             Symbol::new("read"),
             Symbol::new("read"),
-            callable_type,
+            func_sig_type,
         );
 
         let result = validate(&ctx, module, &[], &[declaration]);
@@ -4851,7 +4978,7 @@ mod tests {
     fn exact_registered_intrinsic_has_indirect_callable_provenance() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32, core.i32) -> core.i32> {tribute.calling_convention = 0}
   tribute_control.func @"Nat::+"(%left: core.i32, %right: core.i32) -> core.i32 convention(direct)
     attributes {abi = "intrinsic", tribute.compiler_intrinsic = @"Nat::+"}
   tribute_control.func @caller(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) {
@@ -4865,11 +4992,11 @@ mod tests {
             .into_iter()
             .find(|op| ctx.op(*op).attributes.get_symbol("sym_name") == Some(Symbol::new("Nat::+")))
             .unwrap();
-        let callable_type = ctx.op(intrinsic).attributes.get_type("type").unwrap();
+        let func_sig_type = ctx.op(intrinsic).attributes.get_type("type").unwrap();
         let declaration = CompilerIntrinsicDeclaration::new(
             Symbol::new("Nat::+"),
             Symbol::new("Nat::+"),
-            callable_type,
+            func_sig_type,
         );
 
         let result = validate(&ctx, module, &[], &[declaration]);
@@ -5059,7 +5186,7 @@ mod tests {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
   tribute_control.func @caller(%raw: core.ptr, %value: core.i32) -> core.i32 convention(direct) {
-    %callee = core.unrealized_conversion_cast %raw : tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+    %callee = core.unrealized_conversion_cast %raw : tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
     %result = tribute_control.call_indirect %callee, %value : core.i32
     tribute_control.return %result
   }
@@ -5077,7 +5204,7 @@ mod tests {
     fn indirect_call_rejects_callable_from_uncontracted_structured_block_argument() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   tribute_control.func @caller(%condition: core.i1, %value: core.i32) -> core.i32 convention(direct) {
     %result = scf.if %condition : core.i32 {
       ^then(%callee: !F):
@@ -5103,7 +5230,7 @@ mod tests {
     fn callable_handle_completion_argument_traces_the_body_yield() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct) {
     tribute_control.return %value
   }
@@ -5131,7 +5258,7 @@ mod tests {
     fn callable_handler_parameter_requires_an_exact_operation_declaration() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   tribute_control.func @caller(%value: core.i32) -> core.i32 convention(direct) {
     %handled = tribute_control.handle : core.i32 {
       tribute_control.yield %value
@@ -5175,7 +5302,7 @@ mod tests {
     fn exact_adt_callable_projections_have_semantic_provenance() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   !Tuple = adt.struct() {name = @Tuple, fields = [[@callee, !F]]}
   !TupleRef = adt.typeref() {name = @Tuple}
   !Choice = adt.enum() {name = @Choice, variants = [[@Some, [!F]]]}
@@ -5199,7 +5326,7 @@ mod tests {
     fn adt_callable_projection_requires_matching_declared_field_type() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   !Tuple = adt.struct() {name = @Tuple, fields = [[@not_callable, core.i32]]}
   !TupleRef = adt.typeref() {name = @Tuple}
   !Choice = adt.enum() {name = @Choice, variants = [[@Some, [core.i32]]]}
@@ -5227,7 +5354,7 @@ mod tests {
     fn duplicate_nominal_layout_rejects_callable_projection_spoofing() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   !Canonical = adt.struct() {name = @Tuple, fields = [[@value, core.i32]]}
   !Spoofed = adt.struct() {name = @Tuple, fields = [[@callee, !F]]}
   !TupleRef = adt.typeref() {name = @Tuple}
@@ -5266,7 +5393,7 @@ mod tests {
     fn indirect_call_rejects_callable_from_unclassified_external() {
         let (ctx, module) = parse_fixture(
             r#"core.module @test {
-  !F = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !F = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   tribute_control.func @factory() -> !F convention(direct) attributes {abi = "C"}
   tribute_control.func @caller(%value: core.i32) -> core.i32 convention(direct) {
     %callee = tribute_control.call {callee = @factory} : !F

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -390,6 +390,42 @@ fn print_extra_attributes(
     write!(h, "}}")
 }
 
+fn print_signature_attributes(
+    h: &mut trunk_ir::printer::OpPrintHelper<'_, '_>,
+    ty: TypeRef,
+) -> fmt::Result {
+    use fmt::Write;
+
+    if FuncSig::from_type_ref(h.ctx(), ty).is_none() {
+        return Ok(());
+    }
+    let attrs: Vec<_> = h
+        .ctx()
+        .types
+        .get(ty)
+        .attrs
+        .iter()
+        .filter(|(key, _)| {
+            **key != Symbol::new(trunk_ir::dialect::func::NUM_INPUTS_ATTR)
+                && **key != Symbol::new(trunk_ir::dialect::func::NUM_RESULTS_ATTR)
+                && **key != Symbol::new(CALLING_CONVENTION_ATTR)
+        })
+        .map(|(key, value)| (*key, value.clone()))
+        .collect();
+    if attrs.is_empty() {
+        return Ok(());
+    }
+    write!(h, " signature_attributes {{")?;
+    for (index, (key, value)) in attrs.iter().enumerate() {
+        if index > 0 {
+            write!(h, ", ")?;
+        }
+        write!(h, "{key} = ")?;
+        h.write_attribute(value)?;
+    }
+    write!(h, "}}")
+}
+
 fn print_signature_params(
     h: &mut trunk_ir::printer::OpPrintHelper<'_, '_>,
     region: Option<RegionRef>,
@@ -457,6 +493,9 @@ fn print_func(
         h.write_type(result)?;
         write!(h, " convention({})", convention.keyword())?;
     }
+    if let Some(callable_ty) = callable_ty {
+        print_signature_attributes(h, callable_ty)?;
+    }
     print_extra_attributes(h, op, &["sym_name", "type", CALLING_CONVENTION_ATTR])?;
 
     if let Some(region) = region {
@@ -492,17 +531,19 @@ fn func_sig_raw_type<'a>(
     result: trunk_ir::parser::raw::RawType<'a>,
     params: &[(&'a str, trunk_ir::parser::raw::RawType<'a>)],
     convention: CallingConvention,
+    mut attrs: Vec<(&'a str, trunk_ir::parser::raw::RawAttribute<'a>)>,
 ) -> trunk_ir::parser::raw::RawType<'a> {
     use trunk_ir::parser::raw::{RawAttribute, RawType};
+    attrs.push((
+        CALLING_CONVENTION_ATTR,
+        RawAttribute::Int(convention as i128),
+    ));
     RawType::Function {
         dialect: "tribute_control",
         name: "func_sig",
         inputs: params.iter().map(|(_, ty)| ty.clone()).collect(),
         results: vec![result],
-        attrs: vec![(
-            CALLING_CONVENTION_ATTR,
-            RawAttribute::Int(convention as i128),
-        )],
+        attrs,
     }
 }
 
@@ -510,6 +551,17 @@ fn has_duplicate_convention_attr(
     attrs: &[(&str, trunk_ir::parser::raw::RawAttribute<'_>)],
 ) -> bool {
     attrs.iter().any(|(key, _)| *key == CALLING_CONVENTION_ATTR)
+}
+
+fn has_reserved_signature_attr(attrs: &[(&str, trunk_ir::parser::raw::RawAttribute<'_>)]) -> bool {
+    attrs.iter().any(|(key, _)| {
+        matches!(
+            *key,
+            trunk_ir::dialect::func::NUM_INPUTS_ATTR
+                | trunk_ir::dialect::func::NUM_RESULTS_ATTR
+                | CALLING_CONVENTION_ATTR
+        )
+    })
 }
 
 fn parse_func<'a>(
@@ -531,11 +583,16 @@ fn parse_func<'a>(
     let params = func_params.parse_next(input)?;
     let result = return_type.parse_next(input)?;
     let convention = parse_convention(input)?;
+    let signature_attributes = opt((ws, "signature_attributes", ws, raw_attr_dict))
+        .parse_next(input)?
+        .map(|(_, _, _, attrs)| attrs)
+        .unwrap_or_default();
     let attributes = opt((ws, "attributes", ws, raw_attr_dict))
         .parse_next(input)?
         .map(|(_, _, _, attrs)| attrs)
         .unwrap_or_default();
-    if has_duplicate_convention_attr(&attributes)
+    if has_reserved_signature_attr(&signature_attributes)
+        || has_duplicate_convention_attr(&attributes)
         || attributes
             .iter()
             .any(|(key, _)| *key == "sym_name" || *key == "type")
@@ -557,7 +614,7 @@ fn parse_func<'a>(
         regions.push(region);
     }
 
-    let signature = func_sig_raw_type(result, &params, convention);
+    let signature = func_sig_raw_type(result, &params, convention, signature_attributes);
     let mut attributes = attributes;
     attributes.push(("type", RawAttribute::Type(signature)));
 
@@ -616,6 +673,9 @@ fn print_lambda(
         write!(h, " -> ")?;
         h.write_type(result)?;
         write!(h, " convention({})", convention.keyword())?;
+    }
+    if let Some(callable_ty) = callable_ty {
+        print_signature_attributes(h, callable_ty)?;
     }
 
     write!(h, " captures [")?;
@@ -678,12 +738,18 @@ fn parse_lambda<'a>(
     let params = func_params.parse_next(input)?;
     let result = return_type.parse_next(input)?;
     let convention = parse_convention(input)?;
+    let signature_attributes = opt((ws, "signature_attributes", ws, raw_attr_dict))
+        .parse_next(input)?
+        .map(|(_, _, _, attrs)| attrs)
+        .unwrap_or_default();
     let captures = parse_captures(input)?;
     let attributes = opt((ws, "attributes", ws, raw_attr_dict))
         .parse_next(input)?
         .map(|(_, _, _, attrs)| attrs)
         .unwrap_or_default();
-    if has_duplicate_convention_attr(&attributes) {
+    if has_reserved_signature_attr(&signature_attributes)
+        || has_duplicate_convention_attr(&attributes)
+    {
         return Err(winnow::error::ErrMode::Backtrack(
             winnow::error::ContextError::new(),
         ));
@@ -707,7 +773,12 @@ fn parse_lambda<'a>(
         return_type: None,
         operands: captures,
         attributes,
-        result_types: vec![func_sig_raw_type(result, &params, convention)],
+        result_types: vec![func_sig_raw_type(
+            result,
+            &params,
+            convention,
+            signature_attributes,
+        )],
         regions: vec![region],
         successors: vec![],
     })
@@ -3725,12 +3796,13 @@ mod tests {
     #[test]
     fn custom_assembly_round_trips_declarations_definitions_and_lambdas() {
         let input = r#"core.module @test {
-  tribute_control.func @decl(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) attributes {visibility = @private}
+  !inner = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
+  tribute_control.func @decl(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @decl]]} attributes {visibility = @private}
   tribute_control.func @identity(%value: core.i32) -> core.i32 convention(evidence_direct) {
     tribute_control.return %value
   }
   tribute_control.func @outer(%first: core.i32, %second: core.i32) -> core.i32 convention(direct) {
-    %captured = tribute_control.lambda(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) captures [%first, %second] attributes {debug_name = "apply", inline_hint = true} {
+    %captured = tribute_control.lambda(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @lambda]]} captures [%first, %second] attributes {debug_name = "apply", inline_hint = true} {
       tribute_control.return %first
     }
     %empty = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
@@ -3743,11 +3815,15 @@ mod tests {
         let (ctx, module) = parse_fixture(input);
         let printed = assert_round_trip(&ctx, module);
         assert!(printed.contains(
-            "tribute_control.func @decl(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct) attributes {visibility = @private}"
+            "tribute_control.func @decl(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @decl]]} attributes {visibility = @private}"
         ));
         assert!(printed.contains("convention(evidence_direct)"));
         assert!(printed.contains("convention(cps) captures []"));
-        assert!(printed.contains("convention(direct) captures [%0, %1] attributes {"));
+        assert!(printed.contains("signature_attributes {metadata = [[!inner, @decl]]}"));
+        assert!(printed.contains("signature_attributes {metadata = [[!inner, @lambda]]}"));
+        assert!(printed.contains(
+            "convention(direct) signature_attributes {metadata = [[!inner, @lambda]]} captures [%0, %1] attributes {"
+        ));
         assert!(printed.contains("debug_name = \"apply\""));
         assert!(printed.contains("inline_hint = true"));
         assert!(!printed.contains("^bb"));
@@ -3786,6 +3862,15 @@ mod tests {
 }"#,
             r#"core.module @test {
   %0 = tribute_control.lambda() -> core.i32 convention(cps) captures [] attributes {tribute.calling_convention = 2} {
+    %1 = arith.const {value = 1} : core.i32
+    tribute_control.return %1
+  }
+}"#,
+            r#"core.module @test {
+  tribute_control.func @bad() -> core.i32 convention(direct) signature_attributes {num_inputs = 0}
+}"#,
+            r#"core.module @test {
+  %0 = tribute_control.lambda() -> core.i32 convention(cps) signature_attributes {tribute.calling_convention = 2} captures [] {
     %1 = arith.const {value = 1} : core.i32
     tribute_control.return %1
   }

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -222,6 +222,14 @@ impl FuncSig {
         attrs.remove(trunk_ir::dialect::func::NUM_RESULTS_ATTR);
         attrs.remove(CALLING_CONVENTION_ATTR);
     }
+
+    /// Whether this signature carries type-owned metadata beyond storage and
+    /// source convention fields.
+    pub(crate) fn has_nonreserved_attrs(self, ctx: &IrContext) -> bool {
+        let mut attrs = ctx.types.get(self.0).attrs.clone();
+        Self::remove_reserved_attrs(&mut attrs);
+        !attrs.is_empty()
+    }
 }
 
 fn read_count(attrs: &AttributeMap, key: &'static str) -> Result<u32, FuncSigTypeError> {
@@ -390,42 +398,6 @@ fn print_extra_attributes(
     write!(h, "}}")
 }
 
-fn print_signature_attributes(
-    h: &mut trunk_ir::printer::OpPrintHelper<'_, '_>,
-    ty: TypeRef,
-) -> fmt::Result {
-    use fmt::Write;
-
-    if FuncSig::from_type_ref(h.ctx(), ty).is_none() {
-        return Ok(());
-    }
-    let attrs: Vec<_> = h
-        .ctx()
-        .types
-        .get(ty)
-        .attrs
-        .iter()
-        .filter(|(key, _)| {
-            **key != Symbol::new(trunk_ir::dialect::func::NUM_INPUTS_ATTR)
-                && **key != Symbol::new(trunk_ir::dialect::func::NUM_RESULTS_ATTR)
-                && **key != Symbol::new(CALLING_CONVENTION_ATTR)
-        })
-        .map(|(key, value)| (*key, value.clone()))
-        .collect();
-    if attrs.is_empty() {
-        return Ok(());
-    }
-    write!(h, " signature_attributes {{")?;
-    for (index, (key, value)) in attrs.iter().enumerate() {
-        if index > 0 {
-            write!(h, ", ")?;
-        }
-        write!(h, "{key} = ")?;
-        h.write_attribute(value)?;
-    }
-    write!(h, "}}")
-}
-
 fn print_signature_params(
     h: &mut trunk_ir::printer::OpPrintHelper<'_, '_>,
     region: Option<RegionRef>,
@@ -472,6 +444,12 @@ fn print_func(
     let symbol = data.attributes.get_symbol("sym_name");
     let callable_ty = data.attributes.get_type("type");
     let region = data.regions.first().copied();
+    if callable_ty.is_some_and(|ty| {
+        FuncSig::from_type_ref(h.ctx(), ty)
+            .is_some_and(|signature| signature.has_nonreserved_attrs(h.ctx()))
+    }) {
+        return h.print_generic(op, indent);
+    }
     let parts = callable_ty.and_then(|ty| func_sig_parts(h.ctx(), ty));
 
     write!(h, "{}tribute_control.func ", " ".repeat(indent))?;
@@ -492,9 +470,6 @@ fn print_func(
         write!(h, " -> ")?;
         h.write_type(result)?;
         write!(h, " convention({})", convention.keyword())?;
-    }
-    if let Some(callable_ty) = callable_ty {
-        print_signature_attributes(h, callable_ty)?;
     }
     print_extra_attributes(h, op, &["sym_name", "type", CALLING_CONVENTION_ATTR])?;
 
@@ -553,17 +528,6 @@ fn has_duplicate_convention_attr(
     attrs.iter().any(|(key, _)| *key == CALLING_CONVENTION_ATTR)
 }
 
-fn has_reserved_signature_attr(attrs: &[(&str, trunk_ir::parser::raw::RawAttribute<'_>)]) -> bool {
-    attrs.iter().any(|(key, _)| {
-        matches!(
-            *key,
-            trunk_ir::dialect::func::NUM_INPUTS_ATTR
-                | trunk_ir::dialect::func::NUM_RESULTS_ATTR
-                | CALLING_CONVENTION_ATTR
-        )
-    })
-}
-
 fn parse_func<'a>(
     input: &mut &'a str,
     results: Vec<&'a str>,
@@ -583,16 +547,11 @@ fn parse_func<'a>(
     let params = func_params.parse_next(input)?;
     let result = return_type.parse_next(input)?;
     let convention = parse_convention(input)?;
-    let signature_attributes = opt((ws, "signature_attributes", ws, raw_attr_dict))
-        .parse_next(input)?
-        .map(|(_, _, _, attrs)| attrs)
-        .unwrap_or_default();
     let attributes = opt((ws, "attributes", ws, raw_attr_dict))
         .parse_next(input)?
         .map(|(_, _, _, attrs)| attrs)
         .unwrap_or_default();
-    if has_reserved_signature_attr(&signature_attributes)
-        || has_duplicate_convention_attr(&attributes)
+    if has_duplicate_convention_attr(&attributes)
         || attributes
             .iter()
             .any(|(key, _)| *key == "sym_name" || *key == "type")
@@ -614,7 +573,7 @@ fn parse_func<'a>(
         regions.push(region);
     }
 
-    let signature = func_sig_raw_type(result, &params, convention, signature_attributes);
+    let signature = func_sig_raw_type(result, &params, convention, vec![]);
     let mut attributes = attributes;
     attributes.push(("type", RawAttribute::Type(signature)));
 
@@ -658,6 +617,13 @@ fn print_lambda(
     let parts = callable_ty.and_then(|ty| func_sig_parts(h.ctx(), ty));
     let region = h.ctx().op(op).regions.first().copied();
 
+    if callable_ty.is_some_and(|ty| {
+        FuncSig::from_type_ref(h.ctx(), ty)
+            .is_some_and(|signature| signature.has_nonreserved_attrs(h.ctx()))
+    }) {
+        return h.print_generic(op, indent);
+    }
+
     write!(h, "{}", " ".repeat(indent))?;
     if let Some(name) = result_name {
         write!(h, "{name} = ")?;
@@ -674,10 +640,6 @@ fn print_lambda(
         h.write_type(result)?;
         write!(h, " convention({})", convention.keyword())?;
     }
-    if let Some(callable_ty) = callable_ty {
-        print_signature_attributes(h, callable_ty)?;
-    }
-
     write!(h, " captures [")?;
     let captures: Vec<String> = h
         .ctx()
@@ -738,18 +700,12 @@ fn parse_lambda<'a>(
     let params = func_params.parse_next(input)?;
     let result = return_type.parse_next(input)?;
     let convention = parse_convention(input)?;
-    let signature_attributes = opt((ws, "signature_attributes", ws, raw_attr_dict))
-        .parse_next(input)?
-        .map(|(_, _, _, attrs)| attrs)
-        .unwrap_or_default();
     let captures = parse_captures(input)?;
     let attributes = opt((ws, "attributes", ws, raw_attr_dict))
         .parse_next(input)?
         .map(|(_, _, _, attrs)| attrs)
         .unwrap_or_default();
-    if has_reserved_signature_attr(&signature_attributes)
-        || has_duplicate_convention_attr(&attributes)
-    {
+    if has_duplicate_convention_attr(&attributes) {
         return Err(winnow::error::ErrMode::Backtrack(
             winnow::error::ContextError::new(),
         ));
@@ -773,12 +729,7 @@ fn parse_lambda<'a>(
         return_type: None,
         operands: captures,
         attributes,
-        result_types: vec![func_sig_raw_type(
-            result,
-            &params,
-            convention,
-            signature_attributes,
-        )],
+        result_types: vec![func_sig_raw_type(result, &params, convention, vec![])],
         regions: vec![region],
         successors: vec![],
     })
@@ -3797,13 +3748,22 @@ mod tests {
     fn custom_assembly_round_trips_declarations_definitions_and_lambdas() {
         let input = r#"core.module @test {
   !inner = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
-  tribute_control.func @decl(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @decl]]} attributes {visibility = @private}
+  !shared = tribute_control.func_sig<(core.i32, core.i32) -> core.i32> {metadata = [[!inner, @signature]], tribute.calling_convention = 0}
+  !lambda = tribute_control.func_sig<(core.i32, core.i32) -> core.i32> {metadata = [[!inner, @lambda]], tribute.calling_convention = 0}
+  !distinct = tribute_control.func_sig<(core.i32, core.i32) -> core.i32> {metadata = [[!inner, @distinct]], tribute.calling_convention = 0}
+  tribute_control.func {metadata = @declaration, sym_name = @decl, type = !shared, visibility = @private}
+  tribute_control.func {metadata = @definition, sym_name = @definition, type = !shared, visibility = @private} {
+    ^bb0(%left: core.i32, %right: core.i32):
+      tribute_control.return %left
+  }
+  tribute_control.func {sym_name = @different, type = !distinct}
   tribute_control.func @identity(%value: core.i32) -> core.i32 convention(evidence_direct) {
     tribute_control.return %value
   }
   tribute_control.func @outer(%first: core.i32, %second: core.i32) -> core.i32 convention(direct) {
-    %captured = tribute_control.lambda(%left: core.i32, %right: core.i32) -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @lambda]]} captures [%first, %second] attributes {debug_name = "apply", inline_hint = true} {
-      tribute_control.return %first
+    %captured = tribute_control.lambda %first, %second {debug_name = "apply", inline_hint = true, metadata = @operation} : !lambda {
+      ^bb0(%left: core.i32, %right: core.i32):
+        tribute_control.return %first
     }
     %empty = tribute_control.lambda() -> core.i32 convention(cps) captures [] {
       %constant = arith.const {value = 1} : core.i32
@@ -3814,19 +3774,81 @@ mod tests {
 }"#;
         let (ctx, module) = parse_fixture(input);
         let printed = assert_round_trip(&ctx, module);
-        assert!(printed.contains(
-            "tribute_control.func @decl(%arg0: core.i32, %arg1: core.i32) -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @decl]]} attributes {visibility = @private}"
-        ));
+        assert!(
+            printed.contains("!shared = tribute_control.func_sig"),
+            "{printed}"
+        );
+        assert!(
+            printed.contains("metadata = [[!inner, @signature]]"),
+            "{printed}"
+        );
+        assert!(printed.contains("type = !shared"), "{printed}");
+        assert!(printed.contains("sym_name = @decl"), "{printed}");
+        assert!(printed.contains("sym_name = @definition"), "{printed}");
+        assert!(printed.contains("metadata = @declaration"), "{printed}");
+        assert!(printed.contains("metadata = @definition"), "{printed}");
+        assert!(printed.contains(" : !lambda"), "{printed}");
+        assert!(printed.contains("metadata = @operation"), "{printed}");
         assert!(printed.contains("convention(evidence_direct)"));
         assert!(printed.contains("convention(cps) captures []"));
-        assert!(printed.contains("signature_attributes {metadata = [[!inner, @decl]]}"));
-        assert!(printed.contains("signature_attributes {metadata = [[!inner, @lambda]]}"));
-        assert!(printed.contains(
-            "convention(direct) signature_attributes {metadata = [[!inner, @lambda]]} captures [%0, %1] attributes {"
-        ));
         assert!(printed.contains("debug_name = \"apply\""));
         assert!(printed.contains("inline_hint = true"));
-        assert!(!printed.contains("^bb"));
+        assert!(
+            printed.contains("^bb"),
+            "generic regions retain entry args: {printed}"
+        );
+
+        let funcs: Vec<_> = module
+            .ops(&ctx)
+            .into_iter()
+            .filter(|op| Func::matches(&ctx, *op))
+            .collect();
+        let declaration = funcs
+            .iter()
+            .copied()
+            .find(|op| ctx.op(*op).attributes.get_symbol("sym_name") == Some(Symbol::new("decl")))
+            .unwrap();
+        let definition = funcs
+            .iter()
+            .copied()
+            .find(|op| {
+                ctx.op(*op).attributes.get_symbol("sym_name") == Some(Symbol::new("definition"))
+            })
+            .unwrap();
+        let shared = ctx.op(declaration).attributes.get_type("type").unwrap();
+        assert_eq!(
+            shared,
+            ctx.op(definition).attributes.get_type("type").unwrap()
+        );
+        let distinct = funcs
+            .iter()
+            .copied()
+            .find(|op| {
+                ctx.op(*op).attributes.get_symbol("sym_name") == Some(Symbol::new("different"))
+            })
+            .and_then(|op| ctx.op(op).attributes.get_type("type"))
+            .unwrap();
+        assert_ne!(shared, distinct);
+        assert!(matches!(
+            ctx.types.get(shared).attrs.get("metadata"),
+            Some(Attribute::List(_))
+        ));
+        assert_eq!(
+            ctx.op(declaration).attributes.get_symbol("metadata"),
+            Some(Symbol::new("declaration"))
+        );
+
+        let inline = r#"core.module @test {
+  tribute_control.func {sym_name = @inline, type = tribute_control.func_sig<(core.i32) -> core.i32> {metadata = @inline, tribute.calling_convention = 0}}
+}"#;
+        let (inline_ctx, inline_module) = parse_fixture(inline);
+        let inline_printed = assert_round_trip(&inline_ctx, inline_module);
+        assert!(
+            inline_printed.contains(
+                "type = tribute_control.func_sig<(core.i32) -> core.i32> {metadata = @inline, tribute.calling_convention = 0}"
+            ),
+            "single-use attributed signature must stay inline: {inline_printed}"
+        );
     }
 
     #[test]
@@ -3867,10 +3889,10 @@ mod tests {
   }
 }"#,
             r#"core.module @test {
-  tribute_control.func @bad() -> core.i32 convention(direct) signature_attributes {num_inputs = 0}
+  tribute_control.func @bad() -> core.i32 convention(direct) signature_attributes {metadata = @retired}
 }"#,
             r#"core.module @test {
-  %0 = tribute_control.lambda() -> core.i32 convention(cps) signature_attributes {tribute.calling_convention = 2} captures [] {
+  %0 = tribute_control.lambda() -> core.i32 convention(cps) signature_attributes {metadata = @retired} captures [] {
     %1 = arith.const {value = 1} : core.i32
     tribute_control.return %1
   }

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -366,6 +366,15 @@ fn func_sig_parts(
     ))
 }
 
+/// Whether custom source assembly can represent the complete signature.
+///
+/// Invalid and metadata-bearing signatures must use generic assembly so
+/// printing never discards their storage.
+fn has_concise_func_sig(ctx: &IrContext, ty: Option<TypeRef>) -> bool {
+    ty.and_then(|ty| FuncSig::from_type_ref(ctx, ty))
+        .is_some_and(|signature| !signature.has_nonreserved_attrs(ctx))
+}
+
 fn print_extra_attributes(
     h: &mut trunk_ir::printer::OpPrintHelper<'_, '_>,
     op: OpRef,
@@ -444,10 +453,7 @@ fn print_func(
     let symbol = data.attributes.get_symbol("sym_name");
     let callable_ty = data.attributes.get_type("type");
     let region = data.regions.first().copied();
-    if callable_ty.is_some_and(|ty| {
-        FuncSig::from_type_ref(h.ctx(), ty)
-            .is_some_and(|signature| signature.has_nonreserved_attrs(h.ctx()))
-    }) {
+    if !has_concise_func_sig(h.ctx(), callable_ty) {
         return h.print_generic(op, indent);
     }
     let parts = callable_ty.and_then(|ty| func_sig_parts(h.ctx(), ty));
@@ -609,11 +615,9 @@ fn print_lambda(
 ) -> fmt::Result {
     use fmt::Write;
 
-    let callable_ty = h.ctx().op_result_types(op).first().copied();
-    if callable_ty.is_some_and(|ty| {
-        FuncSig::from_type_ref(h.ctx(), ty)
-            .is_some_and(|signature| signature.has_nonreserved_attrs(h.ctx()))
-    }) {
+    let result_types = h.ctx().op_result_types(op);
+    let callable_ty = result_types.first().copied();
+    if result_types.len() != 1 || !has_concise_func_sig(h.ctx(), callable_ty) {
         return h.print_generic(op, indent);
     }
 
@@ -3850,6 +3854,44 @@ mod tests {
                 "type = tribute_control.func_sig<(core.i32) -> core.i32> {metadata = @inline, tribute.calling_convention = 0}"
             ),
             "single-use attributed signature must stay inline: {inline_printed}"
+        );
+    }
+
+    #[test]
+    fn malformed_func_sig_storage_uses_generic_assembly_without_loss() {
+        let input = r#"core.module @test {
+  tribute_control.func {sym_name = @missing}
+  tribute_control.func {sym_name = @broken, type = tribute_control.func_sig(core.i32) {num_inputs = 2, num_results = 1, tribute.calling_convention = 0}}
+  %lambda = tribute_control.lambda : tribute_control.func_sig(core.i32) {num_inputs = 2, num_results = 1, tribute.calling_convention = 0}
+}"#;
+        let (ctx, module) = parse_fixture(input);
+        let printed = assert_round_trip(&ctx, module);
+
+        assert!(
+            printed.contains("tribute_control.func {sym_name = @missing}"),
+            "missing source signatures must use generic assembly: {printed}"
+        );
+        assert!(
+            printed.contains(
+                "!t0 = tribute_control.func_sig(core.i32) {num_inputs = 2, num_results = 1, tribute.calling_convention = 0}"
+            ),
+            "malformed signature type/count storage must remain intact: {printed}"
+        );
+        assert!(
+            printed.contains("tribute_control.func {sym_name = @broken, type = !t0}"),
+            "malformed function signature must remain attached to the function: {printed}"
+        );
+        assert!(
+            printed.contains("%0 = tribute_control.lambda : !t0"),
+            "malformed lambda signature must remain attached to the lambda: {printed}"
+        );
+
+        let errors = validate_local(&ctx, module);
+        let errors = messages(&errors);
+        assert!(errors.contains("requires 'type' attribute"), "{errors}");
+        assert!(
+            errors.contains("malformed tribute_control.func_sig"),
+            "{errors}"
         );
     }
 

--- a/crates/tribute-ir/src/dialect/tribute_control.rs
+++ b/crates/tribute-ir/src/dialect/tribute_control.rs
@@ -506,19 +506,17 @@ fn func_sig_raw_type<'a>(
     result: trunk_ir::parser::raw::RawType<'a>,
     params: &[(&'a str, trunk_ir::parser::raw::RawType<'a>)],
     convention: CallingConvention,
-    mut attrs: Vec<(&'a str, trunk_ir::parser::raw::RawAttribute<'a>)>,
 ) -> trunk_ir::parser::raw::RawType<'a> {
     use trunk_ir::parser::raw::{RawAttribute, RawType};
-    attrs.push((
-        CALLING_CONVENTION_ATTR,
-        RawAttribute::Int(convention as i128),
-    ));
     RawType::Function {
         dialect: "tribute_control",
         name: "func_sig",
         inputs: params.iter().map(|(_, ty)| ty.clone()).collect(),
         results: vec![result],
-        attrs,
+        attrs: vec![(
+            CALLING_CONVENTION_ATTR,
+            RawAttribute::Int(convention as i128),
+        )],
     }
 }
 
@@ -573,7 +571,7 @@ fn parse_func<'a>(
         regions.push(region);
     }
 
-    let signature = func_sig_raw_type(result, &params, convention, vec![]);
+    let signature = func_sig_raw_type(result, &params, convention);
     let mut attributes = attributes;
     attributes.push(("type", RawAttribute::Type(signature)));
 
@@ -611,18 +609,18 @@ fn print_lambda(
 ) -> fmt::Result {
     use fmt::Write;
 
-    let result = h.ctx().op_results(op).first().copied();
-    let result_name = result.map(|value| h.assign_value_name(value));
     let callable_ty = h.ctx().op_result_types(op).first().copied();
-    let parts = callable_ty.and_then(|ty| func_sig_parts(h.ctx(), ty));
-    let region = h.ctx().op(op).regions.first().copied();
-
     if callable_ty.is_some_and(|ty| {
         FuncSig::from_type_ref(h.ctx(), ty)
             .is_some_and(|signature| signature.has_nonreserved_attrs(h.ctx()))
     }) {
         return h.print_generic(op, indent);
     }
+
+    let result = h.ctx().op_results(op).first().copied();
+    let result_name = result.map(|value| h.assign_value_name(value));
+    let parts = callable_ty.and_then(|ty| func_sig_parts(h.ctx(), ty));
+    let region = h.ctx().op(op).regions.first().copied();
 
     write!(h, "{}", " ".repeat(indent))?;
     if let Some(name) = result_name {
@@ -729,7 +727,7 @@ fn parse_lambda<'a>(
         return_type: None,
         operands: captures,
         attributes,
-        result_types: vec![func_sig_raw_type(result, &params, convention, vec![])],
+        result_types: vec![func_sig_raw_type(result, &params, convention)],
         regions: vec![region],
         successors: vec![],
     })
@@ -3789,6 +3787,10 @@ mod tests {
         assert!(printed.contains("metadata = @definition"), "{printed}");
         assert!(printed.contains(" : !lambda"), "{printed}");
         assert!(printed.contains("metadata = @operation"), "{printed}");
+        assert!(
+            printed.contains("%2 = tribute_control.lambda %0, %1"),
+            "generic fallback must not consume an extra lambda result name: {printed}"
+        );
         assert!(printed.contains("convention(evidence_direct)"));
         assert!(printed.contains("convention(cps) captures []"));
         assert!(printed.contains("debug_name = \"apply\""));

--- a/crates/tribute-passes/src/backend_ready.rs
+++ b/crates/tribute-passes/src/backend_ready.rs
@@ -567,7 +567,7 @@ mod tests {
     fn rejects_logical_type_nested_in_textual_metadata() {
         let error = verify(
             r#"core.module @test {
-  !logical = core.array(tribute_control.callable(core.nil))
+  !logical = core.array(tribute_control.func_sig<() -> core.nil>)
   wasm.func @main() -> core.nil {
     wasm.return
   }
@@ -575,7 +575,7 @@ mod tests {
             TributeBackend::Wasm,
         )
         .expect_err("backend boundary must reject nested logical types");
-        assert!(error.contains("tribute_control.callable"), "{error}");
+        assert!(error.contains("tribute_control.func_sig"), "{error}");
     }
 
     #[test]
@@ -617,13 +617,13 @@ mod tests {
         for ir in [
             r#"core.module @test {
   clif.func @main() -> core.nil {
-    %logical = clif.unknown : tribute_control.callable(core.nil)
+    %logical = clif.unknown : tribute_control.func_sig<() -> core.nil>
     clif.return
   }
 }"#,
             r#"core.module @test {
   wasm.func @main() -> core.nil {
-    wasm.return {metadata = [core.array(tribute_control.callable(core.nil))]}
+    wasm.return {metadata = [core.array(tribute_control.func_sig<() -> core.nil>)]}
   }
 }"#,
         ] {
@@ -636,7 +636,7 @@ mod tests {
                 },
             )
             .expect_err("every type-bearing surface must be checked");
-            assert!(error.contains("tribute_control.callable"), "{error}");
+            assert!(error.contains("tribute_control.func_sig"), "{error}");
         }
     }
 

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -1241,7 +1241,14 @@ impl<'a> Converter<'a> {
             } else {
                 result
             };
-            let function = func::func_sig(self.ctx, lowered_params, [lowered_result]).as_type_ref();
+            let mut attrs = self.ctx.types.get(ty).attrs.clone();
+            tribute_control::FuncSig::remove_reserved_attrs(&mut attrs);
+            for value in attrs.values_mut() {
+                *value = self.convert_attribute(value);
+            }
+            let function =
+                func::func_sig_with_attrs(self.ctx, lowered_params, [lowered_result], attrs)
+                    .as_type_ref();
             let converted = physical_closure_type(self.ctx, function, convention);
             self.converted_types.insert(ty, converted);
             return converted;
@@ -1331,7 +1338,12 @@ impl<'a> Converter<'a> {
         } else {
             result
         };
-        func::func_sig(self.ctx, params, [result]).as_type_ref()
+        let mut attrs = self.ctx.types.get(logical).attrs.clone();
+        tribute_control::FuncSig::remove_reserved_attrs(&mut attrs);
+        for value in attrs.values_mut() {
+            *value = self.convert_attribute(value);
+        }
+        func::func_sig_with_attrs(self.ctx, params, [result], attrs).as_type_ref()
     }
 
     fn copy_extra_attrs(&mut self, source: OpRef, target: OpRef, excluded: &[&str]) {
@@ -4307,7 +4319,7 @@ mod tests {
     #[test]
     fn textual_nested_attribute_types_convert_atomically() {
         let input = r#"core.module @test {
-  !callback = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
+  !callback = tribute_control.func_sig<(core.i32) -> core.i32> {metadata = [core.array(core.i32), [7, @Callback]], tribute.calling_convention = 0}
   !record = adt.struct() {fields = [[@callback, !callback]], name = @CallbackRecord}
   tribute_control.func @identity(%value: !record) -> !record convention(direct) {
     tribute_control.return %value
@@ -4317,12 +4329,81 @@ mod tests {
         tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("name = @CallbackRecord"));
-        assert!(printed.contains("closure.closure(func.func_sig<(core.i32) -> core.i32>)"));
+        assert!(
+            printed.contains("closure.closure(func.func_sig<(core.i32) -> core.i32> {metadata"),
+            "{printed}"
+        );
+        assert!(
+            printed.contains("metadata = [core.array(core.i32), [7, @Callback]]"),
+            "{printed}"
+        );
         assert!(!printed.contains("tribute_control."));
 
         let mut reparsed = IrContext::new();
         let reparsed_module = parse_test_module(&mut reparsed, &printed);
         verify_tribute_control_post_cps(&reparsed, reparsed_module).unwrap();
+    }
+
+    #[test]
+    fn source_func_signature_metadata_survives_function_conversion() {
+        let (mut ctx, module) = parse(
+            r#"core.module @test {
+  tribute_control.func @identity(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+}"#,
+        );
+        let i32_ty = ctx
+            .types
+            .iter()
+            .find_map(|(ty, data)| {
+                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                    .then_some(ty)
+            })
+            .unwrap();
+        let metadata = Attribute::List(vec![
+            Attribute::Type(i32_ty),
+            Attribute::List(vec![
+                Attribute::Int(7),
+                Attribute::Symbol(Symbol::new("Tag")),
+            ]),
+        ]);
+        let logical = tribute_control::func_sig_with_attrs(
+            &mut ctx,
+            i32_ty,
+            [i32_ty],
+            tribute_control::CallingConvention::Direct,
+            AttributeMap::from_iter([(Symbol::new("metadata"), metadata.clone())]),
+        )
+        .as_type_ref();
+        let source = module.ops(&ctx)[0];
+        ctx.op_mut(source)
+            .attributes
+            .insert(Symbol::new("type"), Attribute::Type(logical));
+
+        tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
+        let lowered = module
+            .ops(&ctx)
+            .into_iter()
+            .find(|op| func::Func::matches(&ctx, *op))
+            .unwrap();
+        let physical = ctx.op(lowered).attributes.get_type("type").unwrap();
+        let physical = func::FuncSig::from_type_ref(&ctx, physical).unwrap();
+        assert_eq!(
+            ctx.types.get(physical.as_type_ref()).attrs.get("metadata"),
+            Some(&metadata)
+        );
+        assert!(
+            ctx.types
+                .get(physical.as_type_ref())
+                .attrs
+                .get(CALLING_CONVENTION_ATTR)
+                .is_none()
+        );
+        assert_eq!(
+            ctx.op(lowered).attributes.get_i128(CALLING_CONVENTION_ATTR),
+            Some(CallingConvention::Direct as i128)
+        );
     }
 
     #[test]
@@ -4339,6 +4420,63 @@ mod tests {
         assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
         assert!(error.to_string().contains("func.call"));
         assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn malformed_or_retired_source_signatures_fail_before_conversion() {
+        for (name, attrs, expected) in [
+            (
+                "func_sig",
+                vec![
+                    (func::NUM_INPUTS_ATTR, Attribute::Int(2)),
+                    (func::NUM_RESULTS_ATTR, Attribute::Int(1)),
+                    (CALLING_CONVENTION_ATTR, Attribute::Int(0)),
+                ],
+                "malformed tribute_control.func_sig",
+            ),
+            (
+                "callable",
+                vec![
+                    (func::NUM_INPUTS_ATTR, Attribute::Int(1)),
+                    (func::NUM_RESULTS_ATTR, Attribute::Int(1)),
+                    (CALLING_CONVENTION_ATTR, Attribute::Int(0)),
+                ],
+                "unsupported tribute_control type 'callable'",
+            ),
+        ] {
+            let (mut ctx, module) = parse(
+                r#"core.module @test {
+  tribute_control.func @identity(%value: core.i32) -> core.i32 convention(direct) {
+    tribute_control.return %value
+  }
+}"#,
+            );
+            let i32_ty = ctx
+                .types
+                .iter()
+                .find_map(|(ty, data)| {
+                    (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
+                        .then_some(ty)
+                })
+                .unwrap();
+            let mut builder =
+                TypeDataBuilder::new(Symbol::new("tribute_control"), Symbol::new(name))
+                    .params([i32_ty]);
+            for (key, value) in attrs {
+                builder = builder.attr(key, value);
+            }
+            let malformed = ctx.types.intern(builder.build());
+            let function = module.ops(&ctx)[0];
+            ctx.op_mut(function)
+                .attributes
+                .insert(Symbol::new("type"), Attribute::Type(malformed));
+
+            let before = print_module(&ctx, module.op());
+            let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
+            assert_eq!(error.boundary, PRE_CPS_BOUNDARY, "{name}: {error}");
+            assert!(error.to_string().contains(expected), "{name}: {error}");
+            assert_eq!(print_module(&ctx, module.op()), before, "{name}");
+        }
     }
 
     #[test]

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -1221,13 +1221,13 @@ impl<'a> Converter<'a> {
         if let Some(converted) = self.converted_types.get(&ty) {
             return *converted;
         }
-        if let Some(callable) = tribute_control::Callable::from_type_ref(self.ctx, ty) {
+        if let Some(callable) = tribute_control::FuncSig::from_type_ref(self.ctx, ty) {
             let convention = convert_convention(
-                tribute_control::callable_convention(self.ctx, ty)
+                tribute_control::func_sig_convention(self.ctx, ty)
                     .expect("pre-CPS validation checked callable convention"),
             );
             let result = self.convert_type(callable.result(self.ctx));
-            let source_params = callable.params(self.ctx).to_vec();
+            let source_params = callable.inputs(self.ctx).to_vec();
             let params: Vec<_> = source_params
                 .into_iter()
                 .map(|param| self.convert_type(param))
@@ -1310,14 +1310,14 @@ impl<'a> Converter<'a> {
     }
 
     fn physical_function_type(&mut self, logical: TypeRef) -> TypeRef {
-        let callable = tribute_control::Callable::from_type_ref(self.ctx, logical)
+        let callable = tribute_control::FuncSig::from_type_ref(self.ctx, logical)
             .expect("pre-CPS validation checked function type");
         let convention = convert_convention(
-            tribute_control::callable_convention(self.ctx, logical)
+            tribute_control::func_sig_convention(self.ctx, logical)
                 .expect("pre-CPS validation checked function convention"),
         );
         let result = self.convert_type(callable.result(self.ctx));
-        let source_params = callable.params(self.ctx).to_vec();
+        let source_params = callable.inputs(self.ctx).to_vec();
         let params: Vec<_> = source_params
             .into_iter()
             .map(|param| self.convert_type(param))
@@ -1951,11 +1951,11 @@ impl<'a> Converter<'a> {
     ) -> Result<OpRef, TributeControlToCpsError> {
         let location = self.ctx.op(source).location;
         let logical_ty = self.ctx.op_result_types(source)[0];
-        let callable = tribute_control::Callable::from_type_ref(self.ctx, logical_ty).unwrap();
+        let callable = tribute_control::FuncSig::from_type_ref(self.ctx, logical_ty).unwrap();
         let convention =
-            convert_convention(tribute_control::callable_convention(self.ctx, logical_ty).unwrap());
+            convert_convention(tribute_control::func_sig_convention(self.ctx, logical_ty).unwrap());
         let source_result = callable.result(self.ctx);
-        let source_params = callable.params(self.ctx).to_vec();
+        let source_params = callable.inputs(self.ctx).to_vec();
         let result = self.convert_type(source_result);
         let source_param_types: Vec<_> = source_params
             .iter()
@@ -2109,9 +2109,9 @@ impl<'a> Converter<'a> {
             .current_func(target_symbol)
             .expect("pre-CPS validation resolved func_ref target in this module");
         let result_logical_ty = self.ctx.op_result_types(source)[0];
-        let result_callable = tribute_control::Callable::from_type_ref(self.ctx, result_logical_ty)
+        let result_callable = tribute_control::FuncSig::from_type_ref(self.ctx, result_logical_ty)
             .expect("pre-CPS validation checked func_ref result type");
-        let result_convention = tribute_control::callable_convention(self.ctx, result_logical_ty)
+        let result_convention = tribute_control::func_sig_convention(self.ctx, result_logical_ty)
             .map(convert_convention)
             .expect("pre-CPS validation checked func_ref convention");
         debug_assert!(
@@ -2120,7 +2120,7 @@ impl<'a> Converter<'a> {
         );
         let result = self.convert_type(result_callable.result(self.ctx));
         let source_params: Vec<_> = result_callable
-            .params(self.ctx)
+            .inputs(self.ctx)
             .to_vec()
             .into_iter()
             .map(|ty| self.convert_type(ty))
@@ -3473,7 +3473,7 @@ impl<'a> Converter<'a> {
                 "call_indirect" => {
                     let source_callee = self.ctx.op_operands(source)[0];
                     let logical_type = self.ctx.value_ty(source_callee);
-                    let convention = tribute_control::callable_convention(self.ctx, logical_type)
+                    let convention = tribute_control::func_sig_convention(self.ctx, logical_type)
                         .map(convert_convention)
                         .expect("pre-CPS validation checked indirect callee convention");
                     let callee = mapping
@@ -3774,9 +3774,9 @@ fn collect_callable_graph(
                         .attributes
                         .get_type("type")
                         .expect("pre-CPS validation checked function type");
-                    let callable = tribute_control::Callable::from_type_ref(ctx, logical_type)
+                    let callable = tribute_control::FuncSig::from_type_ref(ctx, logical_type)
                         .expect("pre-CPS validation checked callable type");
-                    let convention = tribute_control::callable_convention(ctx, logical_type)
+                    let convention = tribute_control::func_sig_convention(ctx, logical_type)
                         .expect("pre-CPS validation checked callable convention");
                     funcs.insert(
                         symbol,
@@ -3784,7 +3784,7 @@ fn collect_callable_graph(
                             symbol,
                             convention: convert_convention(convention),
                             source_result: callable.result(ctx),
-                            source_params: callable.params(ctx).to_vec(),
+                            source_params: callable.inputs(ctx).to_vec(),
                         },
                     );
                 }
@@ -3990,7 +3990,7 @@ mod tests {
         let i32_ty = ctx.types.intern(
             trunk_ir::types::TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build(),
         );
-        let source_callable = tribute_control::callable(
+        let source_callable = tribute_control::func_sig(
             &mut ctx,
             i32_ty,
             vec![i32_ty],
@@ -4177,9 +4177,9 @@ mod tests {
     #[test]
     fn textual_direct_evidence_and_cps_transfers_preserve_exact_abis() {
         let input = r#"core.module @test {
-  !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
-  !evidence = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 1}
-  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  !direct = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
+  !evidence = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 1}
+  !cps = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 2}
   tribute_control.func @direct(%value: core.i32) -> core.i32 convention(direct) {
     tribute_control.return %value
   }
@@ -4307,7 +4307,7 @@ mod tests {
     #[test]
     fn textual_nested_attribute_types_convert_atomically() {
         let input = r#"core.module @test {
-  !callback = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !callback = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   !record = adt.struct() {fields = [[@callback, !callback]], name = @CallbackRecord}
   tribute_control.func @identity(%value: !record) -> !record convention(direct) {
     tribute_control.return %value
@@ -4369,7 +4369,7 @@ mod tests {
     tribute_control.return %result
   }
 }"#,
-                "callee operand must have tribute_control.callable type",
+                "callee operand must have tribute_control.func_sig type",
             ),
             (
                 r#"core.module @test {
@@ -4530,7 +4530,7 @@ mod tests {
     #[test]
     fn post_candidate_failure_restores_alias_maps_and_canonical_ir() {
         let input = r#"core.module @candidate {
-  !callback = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
+  !callback = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
   func.func @broken(%value: core.i32) -> core.i32 {
     func.return %value
   }
@@ -5353,7 +5353,7 @@ mod tests {
     #[test]
     fn stronger_func_ref_builds_a_cps_adapter_without_a_null_environment() {
         let input = r#"core.module @test {
-  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  !cps = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 2}
   tribute_control.func @id(%value: core.i32) -> core.i32 convention(direct) {
     tribute_control.return %value
   }
@@ -5379,9 +5379,9 @@ mod tests {
     #[test]
     fn func_ref_adapters_cover_every_legal_convention_strengthening() {
         let input = r#"core.module @test {
-  !direct = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 0}
-  !evidence = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 1}
-  !cps = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 2}
+  !direct = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
+  !evidence = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 1}
+  !cps = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 2}
   tribute_control.func @direct(%value: core.i32) -> core.i32 convention(direct) {
     tribute_control.return %value
   }
@@ -5418,7 +5418,7 @@ mod tests {
     #[test]
     fn weaker_func_ref_adapter_is_rejected_before_mutation() {
         let input = r#"core.module @test {
-  !evidence = tribute_control.callable(core.i32, core.i32) {tribute.calling_convention = 1}
+  !evidence = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 1}
   tribute_control.func @cps(%value: core.i32) -> core.i32 convention(cps) {
     tribute_control.return %value
   }

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -4345,41 +4345,29 @@ mod tests {
     }
 
     #[test]
-    fn source_func_signature_metadata_survives_function_conversion() {
-        let (mut ctx, module) = parse(
-            r#"core.module @test {
-  tribute_control.func @identity(%value: core.i32) -> core.i32 convention(direct) {
-    tribute_control.return %value
+    fn source_signature_metadata_roundtrips_before_conversion() {
+        let source = r#"core.module @test {
+  !inner = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
+  tribute_control.func @outer() -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @function]]} {
+    %lambda = tribute_control.lambda() -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @lambda]]} captures [] {
+      %inner = arith.const {value = 1} : core.i32
+      tribute_control.return %inner
+    }
+    %result = arith.const {value = 2} : core.i32
+    tribute_control.return %result
   }
-}"#,
+}"#;
+        let (ctx, module) = parse(source);
+        let printed_source = print_module(&ctx, module.op());
+        assert!(
+            printed_source.contains("signature_attributes {metadata = [[!inner, @function]]}"),
+            "{printed_source}"
         );
-        let i32_ty = ctx
-            .types
-            .iter()
-            .find_map(|(ty, data)| {
-                (data.dialect == Symbol::new("core") && data.name == Symbol::new("i32"))
-                    .then_some(ty)
-            })
-            .unwrap();
-        let metadata = Attribute::List(vec![
-            Attribute::Type(i32_ty),
-            Attribute::List(vec![
-                Attribute::Int(7),
-                Attribute::Symbol(Symbol::new("Tag")),
-            ]),
-        ]);
-        let logical = tribute_control::func_sig_with_attrs(
-            &mut ctx,
-            i32_ty,
-            [i32_ty],
-            tribute_control::CallingConvention::Direct,
-            AttributeMap::from_iter([(Symbol::new("metadata"), metadata.clone())]),
-        )
-        .as_type_ref();
-        let source = module.ops(&ctx)[0];
-        ctx.op_mut(source)
-            .attributes
-            .insert(Symbol::new("type"), Attribute::Type(logical));
+        assert!(
+            printed_source.contains("signature_attributes {metadata = [[!inner, @lambda]]}"),
+            "{printed_source}"
+        );
+        let (mut ctx, module) = parse(&printed_source);
 
         tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap();
         let lowered = module
@@ -4389,10 +4377,27 @@ mod tests {
             .unwrap();
         let physical = ctx.op(lowered).attributes.get_type("type").unwrap();
         let physical = func::FuncSig::from_type_ref(&ctx, physical).unwrap();
-        assert_eq!(
-            ctx.types.get(physical.as_type_ref()).attrs.get("metadata"),
-            Some(&metadata)
-        );
+        let Attribute::List(function_metadata) = ctx
+            .types
+            .get(physical.as_type_ref())
+            .attrs
+            .get("metadata")
+            .unwrap()
+        else {
+            panic!("function metadata must remain a list");
+        };
+        let [Attribute::List(function_pair)] = function_metadata.as_slice() else {
+            panic!("function metadata must preserve its nested pair");
+        };
+        let [
+            Attribute::Type(function_nested),
+            Attribute::Symbol(function_tag),
+        ] = function_pair.as_slice()
+        else {
+            panic!("function metadata must preserve its nested source signature");
+        };
+        assert_eq!(*function_tag, Symbol::new("function"));
+        assert!(closure::Closure::matches(&ctx, *function_nested));
         assert!(
             ctx.types
                 .get(physical.as_type_ref())
@@ -4403,6 +4408,33 @@ mod tests {
         assert_eq!(
             ctx.op(lowered).attributes.get_i128(CALLING_CONVENTION_ATTR),
             Some(CallingConvention::Direct as i128)
+        );
+
+        let mut lambdas = Vec::new();
+        collect_lambdas(&ctx, module.op(), &mut lambdas);
+        let lambda_metadata = lambdas.into_iter().find_map(|lambda| {
+            let closure_ty = ctx.op_result_types(lambda)[0];
+            let closure = closure::Closure::from_type_ref(&ctx, closure_ty)?;
+            let signature = func::FuncSig::from_type_ref(&ctx, closure.func_type(&ctx))?;
+            let Attribute::List(metadata) = ctx
+                .types
+                .get(signature.as_type_ref())
+                .attrs
+                .get("metadata")?
+            else {
+                return None;
+            };
+            let [Attribute::List(pair)] = metadata.as_slice() else {
+                return None;
+            };
+            let [Attribute::Type(nested), Attribute::Symbol(tag)] = pair.as_slice() else {
+                return None;
+            };
+            (*tag == Symbol::new("lambda")).then_some(*nested)
+        });
+        assert!(
+            lambda_metadata.is_some_and(|nested| closure::Closure::matches(&ctx, nested)),
+            "lambda metadata must retain a converted nested source signature"
         );
     }
 

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -4348,8 +4348,10 @@ mod tests {
     fn source_signature_metadata_roundtrips_before_conversion() {
         let source = r#"core.module @test {
   !inner = tribute_control.func_sig<(core.i32) -> core.i32> {tribute.calling_convention = 0}
-  tribute_control.func @outer() -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @function]]} {
-    %lambda = tribute_control.lambda() -> core.i32 convention(direct) signature_attributes {metadata = [[!inner, @lambda]]} captures [] {
+  !outer = tribute_control.func_sig<() -> core.i32> {metadata = [[!inner, @function]], tribute.calling_convention = 0}
+  !lambda = tribute_control.func_sig<() -> core.i32> {metadata = [[!inner, @lambda]], tribute.calling_convention = 0}
+  tribute_control.func {sym_name = @outer, type = !outer} {
+    %lambda = tribute_control.lambda : !lambda {
       %inner = arith.const {value = 1} : core.i32
       tribute_control.return %inner
     }
@@ -4360,11 +4362,11 @@ mod tests {
         let (ctx, module) = parse(source);
         let printed_source = print_module(&ctx, module.op());
         assert!(
-            printed_source.contains("signature_attributes {metadata = [[!inner, @function]]}"),
+            printed_source.contains("!outer = tribute_control.func_sig<() -> core.i32> {metadata = [[!inner, @function]], tribute.calling_convention = 0}"),
             "{printed_source}"
         );
         assert!(
-            printed_source.contains("signature_attributes {metadata = [[!inner, @lambda]]}"),
+            printed_source.contains("!lambda = tribute_control.func_sig<() -> core.i32> {metadata = [[!inner, @lambda]], tribute.calling_convention = 0}"),
             "{printed_source}"
         );
         let (mut ctx, module) = parse(&printed_source);

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -4514,6 +4514,25 @@ mod tests {
     }
 
     #[test]
+    fn raw_malformed_source_signature_storage_fails_before_conversion() {
+        let input = r#"core.module @test {
+  tribute_control.func {sym_name = @broken, type = tribute_control.func_sig(core.i32) {num_inputs = 2, num_results = 1, tribute.calling_convention = 0}}
+  %lambda = tribute_control.lambda : tribute_control.func_sig(core.i32) {num_inputs = 2, num_results = 1, tribute.calling_convention = 0}
+}"#;
+        let (mut ctx, module) = parse(input);
+        let before = print_module(&ctx, module.op());
+        let error = tribute_control_to_cps(&mut ctx, module, &[], &[]).unwrap_err();
+        assert_eq!(error.boundary, PRE_CPS_BOUNDARY);
+        assert!(
+            error
+                .to_string()
+                .contains("malformed tribute_control.func_sig"),
+            "{error}"
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
     fn malformed_lookup_inputs_fail_before_conversion_and_remain_unchanged() {
         let malformed = [
             (

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -84,7 +84,13 @@ impl<'a> ArenaIrBuilder<'a> {
                             offset: 0,
                         });
                     };
-                    return self.build_function_type(inputs, std::slice::from_ref(result), attrs);
+                    return self.build_function_type(
+                        "func",
+                        "func_sig",
+                        inputs,
+                        std::slice::from_ref(result),
+                        attrs,
+                    );
                 }
                 let dialect = Symbol::from_dynamic(dialect);
                 let name = Symbol::from_dynamic(name);
@@ -107,14 +113,31 @@ impl<'a> ArenaIrBuilder<'a> {
                 Ok(self.ctx.types.intern(builder.build()))
             }
             RawType::Function {
+                dialect,
+                name,
                 inputs,
                 results,
                 attrs,
-            } => self.build_function_type(inputs, results, attrs),
+            } => self.build_function_type(dialect, name, inputs, results, attrs),
         }
     }
 
     fn build_function_type(
+        &mut self,
+        dialect: &str,
+        name: &str,
+        inputs: &[RawType<'_>],
+        results: &[RawType<'_>],
+        attrs: &[(&str, RawAttribute<'_>)],
+    ) -> Result<TypeRef, ParseError> {
+        if (dialect == "func" && name == "func_sig") || (dialect == "core" && name == "func") {
+            return self.build_shared_function_type(inputs, results, attrs);
+        }
+        self.build_foreign_function_type(dialect, name, inputs, results, attrs)
+    }
+
+    /// Build the existing shared signature through its owning validated API.
+    fn build_shared_function_type(
         &mut self,
         inputs: &[RawType<'_>],
         results: &[RawType<'_>],
@@ -157,6 +180,68 @@ impl<'a> ArenaIrBuilder<'a> {
             crate::dialect::func::func_sig_with_attrs(self.ctx, inputs, results, attrs)
                 .as_type_ref(),
         )
+    }
+
+    /// Build a non-shared qualified `*.func_sig` as opaque dialect-owned storage.
+    /// Semantic result cardinality remains the owning dialect's responsibility.
+    fn build_foreign_function_type(
+        &mut self,
+        dialect: &str,
+        name: &str,
+        inputs: &[RawType<'_>],
+        results: &[RawType<'_>],
+        attrs: &[(&str, RawAttribute<'_>)],
+    ) -> Result<TypeRef, ParseError> {
+        if let Some((reserved, _)) = attrs.iter().find(|(key, _)| {
+            matches!(
+                *key,
+                crate::dialect::func::NUM_INPUTS_ATTR | crate::dialect::func::NUM_RESULTS_ATTR
+            )
+        }) {
+            return Err(ParseError {
+                message: format!("`{reserved}` is reserved by {dialect}.{name}"),
+                offset: 0,
+            });
+        }
+        let inputs = inputs
+            .iter()
+            .map(|ty| self.build_type(ty))
+            .collect::<Result<Vec<_>, _>>()?;
+        let results = results
+            .iter()
+            .map(|ty| self.build_type(ty))
+            .collect::<Result<Vec<_>, _>>()?;
+        let attrs = attrs
+            .iter()
+            .map(|(key, value)| Ok((Symbol::from_dynamic(key), self.build_attribute(value)?)))
+            .collect::<Result<AttributeMap, ParseError>>()?;
+        let num_inputs = u32::try_from(inputs.len()).map_err(|_| ParseError {
+            message: format!("{dialect}.{name} input count exceeds u32"),
+            offset: 0,
+        })?;
+        let num_results = u32::try_from(results.len()).map_err(|_| ParseError {
+            message: format!("{dialect}.{name} result count exceeds u32"),
+            offset: 0,
+        })?;
+        let mut builder =
+            TypeDataBuilder::new(Symbol::from_dynamic(dialect), Symbol::from_dynamic(name))
+                .params(inputs)
+                .params(results);
+        for (key, value) in attrs {
+            builder = builder.attr(key, value);
+        }
+        Ok(self.ctx.types.intern(
+            builder
+                .attr(
+                    crate::dialect::func::NUM_INPUTS_ATTR,
+                    Attribute::from(num_inputs),
+                )
+                .attr(
+                    crate::dialect::func::NUM_RESULTS_ATTR,
+                    Attribute::from(num_results),
+                )
+                .build(),
+        ))
     }
 
     fn build_attribute(&mut self, raw: &RawAttribute<'_>) -> Result<Attribute, ParseError> {
@@ -1342,6 +1427,38 @@ core.module @test {
         let mut ctx = IrContext::new();
         let error = parse_module(&mut ctx, input).expect_err("multi-result must be rejected");
         assert!(error.message.contains("multiple results"), "{error}");
+    }
+
+    #[test]
+    fn foreign_func_sig_roundtrips_without_changing_shared_contracts() {
+        let input = r#"core.module @test {
+  !foreign = foreign.func_sig<(core.i32, core.i64) -> (core.i1, core.i32)> {nested = core.array(core.i32)}
+  !unrelated = foreign.record(core.i32) {num_inputs = 1, num_results = 0}
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_module(&mut ctx, input).expect("foreign signature should parse");
+        let printed = print_module(&ctx, module);
+        assert!(printed.contains("!foreign = foreign.func_sig<(core.i32, core.i64) -> (core.i1, core.i32)> {nested = core.array(core.i32)}"), "{printed}");
+        assert!(
+            printed.contains(
+                "!unrelated = foreign.record(core.i32) {num_inputs = 1, num_results = 0}"
+            ),
+            "{printed}"
+        );
+        assert_roundtrip(&ctx, module);
+
+        for reserved in [func::NUM_INPUTS_ATTR, func::NUM_RESULTS_ATTR] {
+            let mut rejected = IrContext::new();
+            let error = parse_module(
+                &mut rejected,
+                &format!("core.module @test {{ !bad = foreign.func_sig<() -> core.i32> {{{reserved} = 0}} }}"),
+            )
+            .expect_err("foreign signature delimiters remain reserved");
+            assert!(
+                error.message.contains("reserved by foreign.func_sig"),
+                "{error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -1462,6 +1462,30 @@ core.module @test {
     }
 
     #[test]
+    fn malformed_func_sig_storage_roundtrips_as_concrete_type() {
+        let input = r#"core.module @test {
+  !foreign = foreign.func_sig(core.i32) {num_inputs = 2, num_results = 1}
+  !shared = func.func_sig(core.i32, core.i32, core.i32) {num_inputs = 1, num_results = 2}
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_module(&mut ctx, input).expect("raw storage should remain parseable");
+        let printed = print_module(&ctx, module);
+        assert!(
+            printed.contains(
+                "!foreign = foreign.func_sig(core.i32) {num_inputs = 2, num_results = 1}"
+            ),
+            "{printed}"
+        );
+        assert!(
+            printed.contains(
+                "!shared = func.func_sig(core.i32, core.i32, core.i32) {num_inputs = 1, num_results = 2}"
+            ),
+            "{printed}"
+        );
+        assert_roundtrip(&ctx, module);
+    }
+
+    #[test]
     fn test_no_arrow_func_op_preserves_zero_results() {
         let input = r#"core.module @test {
   func.func @consume(%value: core.i32) {

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -1348,6 +1348,27 @@ core.module @test {
     }
 
     #[test]
+    fn generic_shared_func_assembly_remains_parseable() {
+        let input = r#"core.module @test {
+  !signature = func.func_sig<(core.i32) -> core.i32>
+  func.func {sym_name = @generic, type = !signature}
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_module(&mut ctx, input).expect("generic func assembly should parse");
+        let function = ctx
+            .block(ctx.region(ctx.op(module).regions[0]).blocks[0])
+            .ops[0];
+        assert_eq!(
+            ctx.op(function).attributes.get_symbol("sym_name"),
+            Some(Symbol::new("generic"))
+        );
+        assert_eq!(
+            ctx.op(function).attributes.get_type("type"),
+            ctx.type_alias_by_name(Symbol::new("signature"))
+        );
+    }
+
+    #[test]
     fn test_legacy_func_type_normalizes_to_canonical_storage_and_text() {
         let input = r#"core.module @test {
   !legacy = core.func(core.i64, core.i32)

--- a/crates/trunk-ir/src/parser/raw.rs
+++ b/crates/trunk-ir/src/parser/raw.rs
@@ -72,8 +72,10 @@ pub enum RawType<'a> {
         params: Vec<RawType<'a>>,
         attrs: Vec<(&'a str, RawAttribute<'a>)>,
     },
-    /// Canonical `func.func_sig<(inputs...) -> results>` syntax.
+    /// Canonical qualified `*.func_sig<(inputs...) -> results>` syntax.
     Function {
+        dialect: &'a str,
+        name: &'a str,
         inputs: Vec<RawType<'a>>,
         results: Vec<RawType<'a>>,
         attrs: Vec<(&'a str, RawAttribute<'a>)>,
@@ -278,9 +280,7 @@ pub fn raw_type<'a>(input: &mut &'a str) -> ModalResult<RawType<'a>> {
 
     let (dialect, name) = qualified_name.parse_next(input)?;
 
-    if ((dialect == "func" && name == "func_sig") || (dialect == "core" && name == "func"))
-        && input.starts_with('<')
-    {
+    if (name == "func_sig" || (dialect == "core" && name == "func")) && input.starts_with('<') {
         '<'.parse_next(input)?;
         ws.parse_next(input)?;
         let inputs = delimited(
@@ -313,6 +313,8 @@ pub fn raw_type<'a>(input: &mut &'a str) -> ModalResult<RawType<'a>> {
         .parse_next(input)?
         .unwrap_or_default();
         return Ok(RawType::Function {
+            dialect,
+            name,
             inputs,
             results,
             attrs,
@@ -797,6 +799,7 @@ mod tests {
             inputs,
             results,
             attrs,
+            ..
         } = raw
         else {
             panic!("expected canonical Function")

--- a/crates/trunk-ir/src/parser/raw.rs
+++ b/crates/trunk-ir/src/parser/raw.rs
@@ -570,6 +570,10 @@ pub fn raw_operation<'a>(input: &mut &'a str) -> ModalResult<RawOperation<'a>> {
     ws.parse_next(input)?;
     // A bare attribute dictionary is generic syntax, even for func.func.
     let generic_func = dialect == "func" && op_name == "func" && input.starts_with('{');
+    // Generic operations begin with attributes or operands. Only those shapes
+    // may recover from a custom parser's Backtrack into generic parsing.
+    let generic_custom_shape =
+        input.starts_with('{') || input.starts_with('%') || input.starts_with(':');
     // Check custom assembly format registry
     if let Some(fmt) = crate::op_interface::lookup_asm_format(
         crate::Symbol::from_dynamic(dialect),
@@ -577,7 +581,14 @@ pub fn raw_operation<'a>(input: &mut &'a str) -> ModalResult<RawOperation<'a>> {
     )
     .filter(|_| !generic_func)
     {
-        return (fmt.parse_fn)(input, results, sym_name);
+        let checkpoint = *input;
+        match (fmt.parse_fn)(input, results.clone(), sym_name.clone()) {
+            Ok(operation) => return Ok(operation),
+            Err(winnow::error::ErrMode::Backtrack(_)) if generic_custom_shape => {
+                *input = checkpoint;
+            }
+            Err(error) => return Err(error),
+        }
     }
 
     // Parse either func-style params (%arg: type, ...) or operands (%val, %val)

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -17,7 +17,6 @@ use std::fmt::Write;
 use std::ops::ControlFlow;
 
 use super::context::IrContext;
-use super::ops::DialectType;
 use super::refs::*;
 use super::types::*;
 use super::walk::{WalkAction, walk_region};
@@ -107,8 +106,8 @@ impl<'a> PrintState<'a> {
         if let Some(alias_name) = self.type_alias_names.get(&ty) {
             return write_type_alias_name(f, alias_name);
         }
-        if let Some(func) = crate::dialect::func::FuncSig::from_type_ref(self.ctx, ty) {
-            return self.write_func_type(f, func);
+        if let Some((inputs, results)) = func_sig_parts(self.ctx, ty) {
+            return self.write_func_sig_type(f, ty, inputs, results);
         }
         let data = self.ctx.types.get(ty);
         write!(f, "{}.{}", data.dialect, data.name)?;
@@ -138,27 +137,40 @@ impl<'a> PrintState<'a> {
         Ok(())
     }
 
-    fn write_func_type(
+    fn write_func_sig_type(
         &self,
         f: &mut dyn Write,
-        func: crate::dialect::func::FuncSig,
+        ty: TypeRef,
+        inputs: &[TypeRef],
+        results: &[TypeRef],
     ) -> fmt::Result {
-        f.write_str("func.func_sig<(")?;
-        for (index, &input) in func.inputs(self.ctx).iter().enumerate() {
+        let data = self.ctx.types.get(ty);
+        write!(f, "{}.{}<(", data.dialect, data.name)?;
+        for (index, &input) in inputs.iter().enumerate() {
             if index > 0 {
                 f.write_str(", ")?;
             }
             self.write_type(f, input)?;
         }
         f.write_str(") -> ")?;
-        if let Some(result) = func.single_result(self.ctx) {
-            self.write_type(f, result)?;
+        if results.len() == 1 {
+            self.write_type(f, results[0])?;
         } else {
-            f.write_str("()")?;
+            f.write_char('(')?;
+            for (index, &result) in results.iter().enumerate() {
+                if index > 0 {
+                    f.write_str(", ")?;
+                }
+                self.write_type(f, result)?;
+            }
+            f.write_char(')')?;
         }
         f.write_char('>')?;
 
-        let mut visible = func.non_reserved_attrs(self.ctx);
+        let mut visible = data.attrs.iter().filter(|(key, _)| {
+            **key != crate::Symbol::new(crate::dialect::func::NUM_INPUTS_ATTR)
+                && **key != crate::Symbol::new(crate::dialect::func::NUM_RESULTS_ATTR)
+        });
         if let Some((key, value)) = visible.next() {
             write!(f, " {{{key} = ")?;
             self.write_attribute(f, value)?;
@@ -215,6 +227,25 @@ impl<'a> PrintState<'a> {
             }
         }
     }
+}
+
+/// Return the delimiter-sliced storage only for a complete `*.func_sig` shape.
+/// Other types, including malformed count-shaped data, retain concrete printing.
+fn func_sig_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], &[TypeRef])> {
+    let data = ctx.types.get(ty);
+    if data.name != crate::Symbol::new("func_sig") {
+        return None;
+    }
+    let num_inputs = match data.attrs.get(crate::dialect::func::NUM_INPUTS_ATTR) {
+        Some(Attribute::Int(value)) => usize::try_from(u32::try_from(*value).ok()?).ok()?,
+        _ => return None,
+    };
+    let num_results = match data.attrs.get(crate::dialect::func::NUM_RESULTS_ATTR) {
+        Some(Attribute::Int(value)) => usize::try_from(u32::try_from(*value).ok()?).ok()?,
+        _ => return None,
+    };
+    let end = num_inputs.checked_add(num_results)?;
+    (end == data.params.len()).then_some((&data.params[..num_inputs], &data.params[num_inputs..]))
 }
 
 // ============================================================================

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -17,6 +17,7 @@ use std::fmt::Write;
 use std::ops::ControlFlow;
 
 use super::context::IrContext;
+use super::ops::DialectType;
 use super::refs::*;
 use super::types::*;
 use super::walk::{WalkAction, walk_region};
@@ -236,6 +237,11 @@ fn func_sig_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], &[TypeRef
     if data.name != crate::Symbol::new("func_sig") {
         return None;
     }
+    if data.dialect == crate::Symbol::new("func")
+        && crate::dialect::func::FuncSig::from_type_ref(ctx, ty).is_none()
+    {
+        return None;
+    }
     let num_inputs = match data.attrs.get(crate::dialect::func::NUM_INPUTS_ATTR) {
         Some(Attribute::Int(value)) => usize::try_from(u32::try_from(*value).ok()?).ok()?,
         _ => return None,
@@ -245,7 +251,10 @@ fn func_sig_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], &[TypeRef
         _ => return None,
     };
     let end = num_inputs.checked_add(num_results)?;
-    (end == data.params.len()).then_some((&data.params[..num_inputs], &data.params[num_inputs..]))
+    if end != data.params.len() {
+        return None;
+    }
+    Some((&data.params[..num_inputs], &data.params[num_inputs..]))
 }
 
 // ============================================================================
@@ -1059,6 +1068,37 @@ mod tests {
         assert_eq!(
             print_type(&ctx, many_one),
             "func.func_sig<(core.i32, core.i32) -> core.i32>"
+        );
+    }
+
+    #[test]
+    fn malformed_func_sig_storage_prints_as_concrete_type() {
+        let mut ctx = IrContext::new();
+        let i32_ty = make_i32_type(&mut ctx);
+        let foreign = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("foreign"), Symbol::new("func_sig"))
+                .param(i32_ty)
+                .attr(func::NUM_INPUTS_ATTR, Attribute::Int(2))
+                .attr(func::NUM_RESULTS_ATTR, Attribute::Int(1))
+                .build(),
+        );
+        assert_eq!(
+            print_type(&ctx, foreign),
+            "foreign.func_sig(core.i32) {num_inputs = 2, num_results = 1}"
+        );
+
+        // Shared signatures have a stricter one-result contract, so raw
+        // multi-result storage must not be printed in arrow syntax either.
+        let shared = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig"))
+                .params([i32_ty, i32_ty, i32_ty])
+                .attr(func::NUM_INPUTS_ATTR, Attribute::Int(1))
+                .attr(func::NUM_RESULTS_ATTR, Attribute::Int(2))
+                .build(),
+        );
+        assert_eq!(
+            print_type(&ctx, shared),
+            "func.func_sig(core.i32, core.i32, core.i32) {num_inputs = 1, num_results = 2}"
         );
     }
 

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -298,6 +298,14 @@ impl<'a, 'ctx> OpPrintHelper<'a, 'ctx> {
         self.state.write_attribute(&mut *self.f, attr)
     }
 
+    /// Print an operation with generic assembly.
+    ///
+    /// Custom formats use this when their concise form cannot represent the
+    /// complete operation without loss.
+    pub fn print_generic(&mut self, op: OpRef, indent: usize) -> fmt::Result {
+        print_generic_op(self.state, &mut *self.f, op, indent)
+    }
+
     /// Reset value and block numbering (for func.func — each function restarts at %0).
     pub fn reset_numbering(&mut self) {
         self.state.reset_numbering();

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -55,6 +55,14 @@ target ABI conversion may later change logical CPS `[core.never]` into the
 physical empty result list. Malformed raw `func.func_sig` types are permitted only
 in verifier tests and are rejected by whole-IR validation.
 
+The source-logical callable type is independently owned as
+`tribute_control.func_sig`. It uses the same flat input-first storage and
+mandatory u32 delimiters, but its validated API requires exactly one source
+result (including `core.nil` and `core.never`) and owns the Direct,
+EvidenceDirect, and Cps convention metadata. Its codec retains the qualified
+type identity, so source arrow text is never interned as `func.func_sig`;
+malformed raw source signatures are rejected before conversion mutates IR.
+
 ## 직접형 제어 소유권
 
 구조와 의미의 source of truth는

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -62,6 +62,10 @@ result (including `core.nil` and `core.never`) and owns the Direct,
 EvidenceDirect, and Cps convention metadata. Its codec retains the qualified
 type identity, so source arrow text is never interned as `func.func_sig`;
 malformed raw source signatures are rejected before conversion mutates IR.
+Custom `tribute_control.func` and `tribute_control.lambda` assembly writes
+non-reserved source-signature metadata in an explicit
+`signature_attributes { ... }` clause, distinct from operation `attributes`;
+the codec reconstructs that metadata before source-to-shared conversion.
 
 ## 직접형 제어 소유권
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -62,10 +62,14 @@ result (including `core.nil` and `core.never`) and owns the Direct,
 EvidenceDirect, and Cps convention metadata. Its codec retains the qualified
 type identity, so source arrow text is never interned as `func.func_sig`;
 malformed raw source signatures are rejected before conversion mutates IR.
-Custom `tribute_control.func` and `tribute_control.lambda` assembly writes
-non-reserved source-signature metadata in an explicit
-`signature_attributes { ... }` clause, distinct from operation `attributes`;
-the codec reconstructs that metadata before source-to-shared conversion.
+Custom `tribute_control.func` and `tribute_control.lambda` assembly keeps
+non-reserved source-signature metadata on the complete
+`tribute_control.func_sig` type expression or alias definition, distinct from
+operation `attributes`. Their concise custom form is used only when it can
+represent the source signature losslessly; otherwise generic operation assembly
+keeps the complete type-bearing attribute visible. The codec reconstructs that
+type metadata before source-to-shared conversion; no operation-local signature
+metadata clause or override exists.
 
 ## 직접형 제어 소유권
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -64,7 +64,7 @@ unknown operation이 legal하지 않으므로 frontend 적합성 target과 backe
 target이 legal dialect와 operation을 열거해야 한다. `ConversionTarget`은
 operation 적법성만 검사하므로 Tribute whole-IR type walk가 pre-CPS의
 `func.func_sig`/`closure.closure`와 post-CPS의
-`tribute_control.callable`/`resume_token`을 별도로 거부한다. 같은 walk는
+`tribute_control.func_sig`/`resume_token`을 별도로 거부한다. 같은 walk는
 `tribute-backend-ready-native`와 `tribute-backend-ready-wasm`에서도 필수이며
 남은 두 `tribute_control` type을 거부한다. 함수·호출 signature, operand/result,
 block argument, type attribute와 nested type parameter를 재귀적으로 검사하며,
@@ -175,8 +175,10 @@ target-independent 직접형 경계다. Dialect identifier는 정확히
 않는다.
 
 논리 callable type은
-`tribute_control.callable(Result, Params...) {tribute.calling_convention = N}`이다.
-`Result`와 `Params`는 source-logical type이며 기존 code `Direct = 0`,
+`tribute_control.func_sig<(Params...) -> Result> {tribute.calling_convention = N}`이다.
+It uses flat `[inputs..., results...]` storage with mandatory `num_inputs` and
+`num_results` u32 delimiters; its source-owned validated API requires exactly
+one result. `Result`와 `Params`는 source-logical type이며 기존 code `Direct = 0`,
 `EvidenceDirect = 1`, `Cps = 2`를 그대로 사용한다. 이 metadata는 typechecking
 결과를 복사한 것으로 body에서 추론하지 않는다. Legalization은 이를 기존
 `CallableAbi`와 physical `func.func_sig`, `closure.closure` 및
@@ -225,7 +227,7 @@ non-resumptive case를 식별해야 하므로 `Never`용 `anyref` placeholder는
 간결한 convention 문법은 `convention(direct)`,
 `convention(evidence_direct)`, `convention(cps)`이며 각각 callable type의
 `tribute.calling_convention = 0`, `1`, `2`로 round trip한다. Parser는 signature와
-keyword로 `tribute_control.callable`을 만들고 convention을 type에만 저장한다.
+keyword로 `tribute_control.func_sig`을 만들고 convention을 type에만 저장한다.
 출력기도 type attribute만 읽으며 body에서 추론하거나 operation에 중복
 attribute를 쓰지 않는다. 추가 operation attribute에
 `tribute.calling_convention`을 다시 적으면 parser 또는 verifier가 거부한다.
@@ -267,7 +269,7 @@ tribute_control.func {sym_name = @id, type = !Callable} (%x: T) { ... }
 ```
 
 - **형상:** 피연산자와 결과는 없다. `sym_name: Symbol`과
-  `type: tribute_control.callable(Result, Params...)`가 필수다. 선언은 region이
+  `type: tribute_control.func_sig<(Params...) -> Result>`가 필수다. 선언은 region이
   없고 정의는 source parameter만 block argument로 받는 single-block `body`
   하나이며 `tribute_control.return`으로 끝난다. Foreign ABI 같은 비제어
   attribute는 보존한다.
@@ -291,7 +293,7 @@ symbol spelling, 위치 또는 printed IR만으로 origin을 복구하거나 승
 
 Frontend 경계 verifier는 metadata 전체와 module의 callable graph를 mutation 전에
 대조한다. Direct call은 module-local symbol을 유일하게 resolve하고 완전한 signature를
-맞춰야 한다. Indirect call은 exact `tribute_control.callable` signature와 source-logical
+맞춰야 한다. Indirect call은 exact `tribute_control.func_sig` signature와 source-logical
 callable producer를 요구한다. Return은 enclosing callable의 logical result와 일치해야
 한다. Body가 없는 declaration도 body traversal 없이 같은 검사를 받는다.
 
@@ -302,7 +304,7 @@ callable producer를 요구한다. Return은 enclosing callable의 logical resul
 ```
 
 - **형상:** 피연산자는 typechecking된 capture를 source 순서로 나열한다. 결과는
-  `tribute_control.callable` 하나이고 필수 attribute는 없다. Single-block body는
+  `tribute_control.func_sig` 하나이고 필수 attribute는 없다. Single-block body는
   source parameter만 block argument로 받으며 `tribute_control.return`으로 끝난다.
 - **의미:** source lambda를 만들며 body는 lexical capture와 parameter를 사용한다.
 - **검증:** local verifier는 result signature, block argument, return type을
@@ -318,7 +320,7 @@ callable producer를 요구한다. Return은 enclosing callable의 logical resul
 ```
 
 - **형상:** 피연산자와 region은 없고 terminator가 아니다. `func_ref: Symbol`이
-  필수이며 결과는 `tribute_control.callable` 하나다.
+  필수이며 결과는 `tribute_control.func_sig` 하나다.
 - **의미:** named function을 first-class source value로 만든다. Source가 named
   function을 higher-order value로 사용할 수 있으므로 필요하다. Result는 대상과
   같은 source signature이며 convention은 대상 worker와 같거나 더 강할 수 있다.
@@ -349,7 +351,7 @@ callable producer를 요구한다. Return은 enclosing callable의 logical resul
 %result = tribute_control.call_indirect %callee, %arg0, ... : Result
 ```
 
-- **형상:** `tribute_control.callable` callee, source argument, callee type의
+- **형상:** `tribute_control.func_sig` callee, source argument, callee type의
   source-logical result 하나를 가지며 attribute/region이 없는 non-terminator다.
 - **의미:** lambda, `func_ref`, parameter 또는 capture로 얻은 callable을 호출한다.
 - **검증:** local verifier는 callee signature와 argument/result type을 맞춘다.
@@ -775,7 +777,7 @@ Important stage invariants:
 | Resolution | Names, constructors, and variable references are resolved |
 | Type check | Type variables and effect rows are solved |
 | TDNR | Method-style calls are converted to resolved calls |
-| AST-to-IR | `tribute_control.callable`과 callable/control operation, valid SSA use chain |
+| AST-to-IR | `tribute_control.func_sig`과 callable/control operation, valid SSA use chain |
 | Shared CPS legalization | 전체 callable graph가 physical `CallableAbi`와 direct/indirect tail transfer를 사용하며 `tribute_control` operation/type이 남지 않음 |
 | Shared lowering | 명시된 경계에서 high-level ability dispatch operation이 제거됨 |
 | Effect ABI | `effect.*` operations preserve dispatch semantics without backend layout details |

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -258,9 +258,17 @@ tribute_control.func @decl(%x: T) -> R convention(direct)
 parameter/result, 필수 convention, 명시적 `captures [...]`, 선택적 추가
 attribute와 body를 출력하고 entry label을 생략한다. `captures [...]`는 capture가
 없어도 `captures []`로 항상 출력하며 canonical 순서는 convention, captures,
-선택적 attributes, body다. `func_ref`, `call`, `call_indirect`, `return`은
-generic assembly가 모든 정보를 손실 없이 표현하므로 custom format을 만들지
-않는다.
+선택적 attributes, body다.
+
+간결한 형식은 non-reserved type attribute가 없는 source signature에만 쓴다.
+그런 attribute가 있으면 `func`/`lambda`는 generic assembly를 써서 complete
+`type` attribute 또는 result type expression을 출력한다. Metadata의 소유자는
+항상 그 `tribute_control.func_sig` type/alias 하나이며, 같은 alias를 참조하는
+여러 operation이 operation-local override를 만들 수 없다. Alias가 없으면
+generic type-bearing 위치에 attributed `func_sig` 전체를 inline으로 출력한다.
+Operation attribute는 별개의 generic attribute dictionary에 남는다.
+`func_ref`, `call`, `call_indirect`, `return`은 generic assembly가 모든 정보를
+손실 없이 표현하므로 custom format을 만들지 않는다.
 
 #### `tribute_control.func`
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2026,7 +2026,7 @@ fn main() {
         let output = trunk_ir::printer::print_module(&ctx, module.op());
         for forbidden in [
             "tribute_control.",
-            "tribute_control.callable",
+            "tribute_control.func_sig",
             "resume_token",
         ] {
             assert!(


### PR DESCRIPTION
## Summary

- Replace source `tribute_control.callable` with `tribute_control.func_sig`, preserving exactly one source result and typed calling-convention provenance.
- Add a qualified, dialect-neutral function-signature codec. Non-reserved source metadata remains owned by the complete `tribute_control.func_sig` type or its alias; metadata-bearing functions and lambdas use generic operation assembly.
- Preserve shared alias identity, keep operation attributes separate from signature-type metadata, and add malformed-storage, retired-identity, atomic pre-CPS rejection, metadata round-trip, and generic-lambda-numbering regressions.

This is the independent second prerequisite after #955 for #825. It does not complete #825.

Refs #825

## Validation

- `cargo fmt --all --check`
- `cargo test -p trunk-ir`
- `cargo test -p tribute-ir`
- `cargo test -p tribute-passes`
- `cargo clippy --workspace --all-targets -- -D warnings`
- workspace nextest: 2098 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validated function-signature types with input/output details, calling conventions, and preserved metadata.
  - Added support for qualified function-signature types with improved parsing, printing, and round-tripping.
  - Added clearer validation and diagnostics for malformed signatures.

- **Bug Fixes**
  - Preserved user-defined signature metadata during conversions.
  - Improved handling of malformed function-signature storage and fallback formatting.
  - Updated function and lambda representations to retain signature information more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->