### PR TITLE
feat(wasm): add target-owned function signatures

### DIFF
--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -25,9 +25,10 @@ use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
+use trunk_ir::dialect::core;
 use trunk_ir::dialect::wasm as wasm_dialect;
-use trunk_ir::dialect::{core, func};
 use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::DialectType;
 use trunk_ir::pass::{Pass, PassRunResult};
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
@@ -513,7 +514,7 @@ fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
         .map(|&value| ctx.value_ty(value))
         .collect::<Vec<_>>();
     let result = core::nil(ctx).as_type_ref();
-    let signature = func::func_sig(ctx, parameters, [result]).as_type_ref();
+    let signature = wasm_dialect::func_sig(ctx, parameters, [result]).as_type_ref();
     let _ = wasm_dialect::set_indirect_call_signature(ctx, call, signature);
 }
 
@@ -1388,9 +1389,9 @@ fn intern_i32(ctx: &mut IrContext) -> TypeRef {
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build())
 }
 
-/// Intern a `func.func_sig` type with the given parameter and return types.
+/// Intern a target-owned `wasm.func_sig` type with the given parameter and return types.
 fn intern_func_type(ctx: &mut IrContext, params: &[TypeRef], ret: TypeRef) -> TypeRef {
-    trunk_ir::dialect::func::func_sig(ctx, params.iter().copied(), [ret]).as_type_ref()
+    wasm_dialect::func_sig(ctx, params.iter().copied(), [ret]).as_type_ref()
 }
 
 /// Compute a stable ability ID as a WASM i32 immediate.

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -819,7 +819,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
-            "core.module @m { wasm.func {sym_name = @main, type = func.func_sig<(wasm.arrayref) -> ()>, tribute.calling_convention = 1} {} }",
+            "core.module @m { wasm.func {sym_name = @main, type = wasm.func_sig<(wasm.arrayref) -> ()>, tribute.calling_convention = 1} {} }",
         );
         let main = module.ops(&ctx)[0];
         let const_analysis = ConstAnalysis {

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -272,7 +272,7 @@ fn debug_func_params(ctx: &IrContext, module: Module, phase: &str) {
                 && data.name == Symbol::new("func")
                 && let Some(fn_ty) = data.attributes.get_type("type")
             {
-                let Some(function) = func::FuncSig::from_type_ref(ctx, fn_ty) else {
+                let Some(function) = wasm_dialect::FuncSig::from_type_ref(ctx, fn_ty) else {
                     continue;
                 };
                 let params: Vec<_> = function
@@ -323,7 +323,7 @@ fn intern_type(ctx: &mut IrContext, dialect: &'static str, name: &'static str) -
 }
 
 fn intern_func_type(ctx: &mut IrContext, params: Vec<TypeRef>, result: TypeRef) -> TypeRef {
-    func::func_sig(ctx, params, [result]).as_type_ref()
+    wasm_dialect::func_sig(ctx, params, [result]).as_type_ref()
 }
 
 fn is_type(ctx: &IrContext, ty: TypeRef, dialect: &'static str, name: &'static str) -> bool {
@@ -485,7 +485,7 @@ impl<'a> WasmLowerer<'a> {
         self.main_exports.main_convention = get_calling_convention(ctx, op).unwrap_or_default();
 
         if let Some(fn_ty) = data.attributes.get_type("type")
-            && let Some(function) = func::FuncSig::from_type_ref(ctx, fn_ty)
+            && let Some(function) = wasm_dialect::FuncSig::from_type_ref(ctx, fn_ty)
         {
             self.main_exports.main_result_type = function.single_result(ctx);
             self.main_exports.main_param_types = function.inputs(ctx).to_vec();
@@ -815,7 +815,7 @@ mod tests {
     }
 
     #[test]
-    fn review_resultless_evidence_main_preserves_inputs() {
+    fn resultless_evidence_main_preserves_inputs_and_reaches_body_validation() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
@@ -856,8 +856,8 @@ mod tests {
         let before = print_module(&ctx, module.op());
         let error = trunk_ir_wasm_backend::emit_module_to_wasm(&mut ctx, module)
             .err()
-            .expect("resultless emission remains unsupported");
-        assert!(error.to_string().contains("one-result"), "{error}");
+            .expect("bodyless emission remains unsupported");
+        assert!(error.to_string().contains("entry block"), "{error}");
         assert_eq!(print_module(&ctx, module.op()), before);
     }
 

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -19,10 +19,10 @@ use trunk_ir::pass::{PassError, PassManager};
 use trunk_ir::refs::{BlockRef, OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{
     ConversionError, ConversionTarget, Module, PatternApplicator, TypeConverter,
-    WasmFuncSignatureConversionPattern,
 };
 use trunk_ir::smallvec::smallvec;
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
+use trunk_ir_wasm_backend::passes::signature_conversion::WasmFuncSignatureConversionPattern;
 
 use super::const_to_wasm::ConstAnalysis;
 use super::io::IoAnalysis;

--- a/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
+++ b/crates/tribute-passes/src/wasm/normalize_primitive_types.rs
@@ -34,8 +34,8 @@ use trunk_ir::ops::DialectOp;
 use trunk_ir::refs::{OpRef, TypeRef};
 use trunk_ir::rewrite::{
     FuncSignatureConversionPattern, Module, PatternApplicator, PatternRewriter, RewritePattern,
-    WasmFuncSignatureConversionPattern,
 };
+use trunk_ir_wasm_backend::passes::signature_conversion::WasmFuncSignatureConversionPattern;
 
 /// Normalize tribute_rt primitive types to core types.
 ///

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -722,7 +722,12 @@ fn emit_function(
         ));
     }
 
-    let func_return_type = signature_results.first().copied();
+    // Legacy indirect-call inference is scalar-only. A multi-result caller
+    // must not make its first result look like an authoritative context.
+    let func_return_type = match signature_results {
+        [result] => Some(*result),
+        _ => None,
+    };
     let mut emit_ctx = FunctionEmitContext {
         value_locals: HashMap::new(),
         effective_types: HashMap::new(),
@@ -1377,6 +1382,30 @@ mod tests {
         Validator::new()
             .validate_all(&bytes)
             .expect("two-result exact indirect call must validate");
+    }
+
+    #[test]
+    fn legacy_indirect_call_in_a_multi_result_caller_does_not_inherit_its_first_result() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.func {sym_name = @caller, type = wasm.func_sig<(core.i32) -> (wasm.funcref, core.i32)>} {
+    ^entry(%index: core.i32):
+      %ignored = wasm.call_indirect %index : wasm.anyref
+      %function = wasm.nop : wasm.funcref
+      %integer = wasm.i32_const {value = 0} : core.i32
+      wasm.return %function, %integer
+  }
+}"#,
+        );
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("multi-result caller must not change a legacy call signature")
+            .bytes;
+        Validator::new()
+            .validate_all(&bytes)
+            .expect("legacy indirect type section must match its emitted instruction");
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -221,7 +221,7 @@ struct ModuleInfo {
     globals: Vec<GlobalDef>,
     gc_types: Vec<GcTypeDef>,
     type_idx_by_type: HashMap<TypeRef, u32>,
-    /// Function type lookup map (func.func_sig TypeRef).
+    /// Function type lookup map (wasm.func_sig TypeRef).
     func_types: HashMap<Symbol, TypeRef>,
     /// Function index lookup map (import index or func index).
     func_indices: HashMap<Symbol, u32>,
@@ -1227,7 +1227,7 @@ mod tests {
     wasm.return
   }
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.export_func {name = "caller", func = @caller}
 }"#,
@@ -1246,7 +1246,7 @@ mod tests {
     wasm.return
   }
   wasm.func @caller(%table_index: core.i32, %value: adt.typeref) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.structref) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(wasm.structref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.export_func {name = "caller", func = @caller}
 }"#,
@@ -1411,7 +1411,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
         );
@@ -1453,7 +1453,7 @@ mod tests {
             r#"core.module @test {
   wasm.table {reftype = @funcref, min = 1, max = 1}
   wasm.func @caller(%table_index: core.i32, %value: wasm.structref) -> core.i32 {
-    %result = wasm.call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.i32>, table = 0, type_idx = 0} : core.i32
+    %result = wasm.call_indirect %table_index, %value {signature = wasm.func_sig<(wasm.anyref) -> core.i32>, table = 0, type_idx = 0} : core.i32
     wasm.return %result
   }
 }"#,
@@ -1464,7 +1464,7 @@ mod tests {
             panic!("expected one collected exact signature")
         };
         let Some((params, result)) = helpers::func_type_parts(&ctx, *signature) else {
-            panic!("expected func.func_sig signature")
+            panic!("expected wasm.func_sig signature")
         };
         assert_eq!(ctx.types.get(params[0]).name, Symbol::new("anyref"));
         assert_eq!(result.len(), 1);
@@ -1485,7 +1485,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   wasm.table {reftype = @funcref, min = 1, max = 1}
-  wasm.func @caller(%table_index: core.i32) -> func.func_sig<() -> core.nil> {
+  wasm.func @caller(%table_index: core.i32) -> wasm.func_sig<() -> core.nil> {
     %result = wasm.call_indirect %table_index : wasm.anyref
     wasm.return %result
   }
@@ -1497,7 +1497,7 @@ mod tests {
             panic!("expected one collected exact signature")
         };
         let Some((_, result)) = helpers::func_type_parts(&ctx, *signature) else {
-            panic!("expected func.func_sig signature")
+            panic!("expected wasm.func_sig signature")
         };
         assert_eq!(result.len(), 1);
         assert!(helpers::is_type(&ctx, result[0], "wasm", "funcref"));
@@ -1511,7 +1511,7 @@ mod tests {
             r#"core.module @test {
   wasm.table {reftype = @funcref, min = 1, max = 1}
   wasm.func @caller(%table_index: core.i32) -> wasm.funcref {
-    %ignored = wasm.call_indirect %table_index {signature = func.func_sig<() -> wasm.anyref>, table = 0, type_idx = 0} : wasm.anyref
+    %ignored = wasm.call_indirect %table_index {signature = wasm.func_sig<() -> wasm.anyref>, table = 0, type_idx = 0} : wasm.anyref
     %result = wasm.nop : wasm.funcref
     wasm.return %result
   }
@@ -1534,7 +1534,7 @@ mod tests {
             r#"core.module @test {
   wasm.func @tail_indirect(%table_index: core.i32, %value: core.i32) -> core.nil {
     wasm.block {
-      wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
+      wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
     }
   }
   wasm.func @tail_direct(%value: core.i32) -> core.nil {
@@ -1573,5 +1573,72 @@ mod tests {
             .status()
             .expect("run Wasmtime");
         assert!(status.success(), "Wasmtime returned {status}");
+    }
+
+    #[test]
+    #[ignore = "requires the Wasmtime CLI runtime"]
+    fn multi_result_direct_and_exact_indirect_calls_execute_in_wasmtime() {
+        let invoke = |source: &str, export: &str, args: &[&str]| {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, source);
+            let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+                .expect("multi-result module must emit")
+                .bytes;
+            let file = tempfile::NamedTempFile::new().expect("temporary Wasm file");
+            fs::write(file.path(), bytes).expect("write Wasm module");
+            let output = Command::new("wasmtime")
+                .args(["-W", "gc=y", "--invoke", export])
+                .arg(file.path())
+                .args(args)
+                .output()
+                .expect("run Wasmtime");
+            assert!(
+                output.status.success(),
+                "Wasmtime failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                String::from_utf8(output.stdout).expect("Wasmtime stdout is UTF-8"),
+                "7\n9\n"
+            );
+        };
+
+        invoke(
+            r#"core.module @test {
+  wasm.func {sym_name = @pair, type = wasm.func_sig<() -> (core.i32, core.i64)>} {
+    %a = wasm.i32_const {value = 7} : core.i32
+    %b = wasm.i64_const {value = 9} : core.i64
+    wasm.return %a, %b
+  }
+  wasm.func {sym_name = @caller, type = wasm.func_sig<() -> (core.i32, core.i64)>} {
+    %a, %b = wasm.call {callee = @pair} : core.i32, core.i64
+    wasm.return %a, %b
+  }
+  wasm.export_func {name = "direct_pair", func = @caller}
+}"#,
+            "direct_pair",
+            &[],
+        );
+        invoke(
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.elem {table = 0, offset = 0} {
+    wasm.ref_func {func_name = @pair} : wasm.funcref
+  }
+  wasm.func {sym_name = @pair, type = wasm.func_sig<() -> (core.i32, core.i64)>} {
+    %a = wasm.i32_const {value = 7} : core.i32
+    %b = wasm.i64_const {value = 9} : core.i64
+    wasm.return %a, %b
+  }
+  wasm.func {sym_name = @caller, type = wasm.func_sig<(core.i32) -> (core.i32, core.i64)>} {
+    ^entry(%table_index: core.i32):
+      %a, %b = wasm.call_indirect %table_index {signature = wasm.func_sig<() -> (core.i32, core.i64)>, table = 0, type_idx = 0} : core.i32, core.i64
+      wasm.return %a, %b
+  }
+  wasm.export_func {name = "indirect_pair", func = @caller}
+}"#,
+            "indirect_pair",
+            &["0"],
+        );
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/emit.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit.rs
@@ -227,8 +227,8 @@ struct ModuleInfo {
     func_indices: HashMap<Symbol, u32>,
     /// Functions referenced via ref.func that need declarative elem segment.
     ref_funcs: HashSet<Symbol>,
-    /// Additional function types from call_indirect that need to be added to type section.
-    /// Stored as (type_idx, func.func_sig TypeRef) pairs.
+    /// Additional target function types from call_indirect that need to be added to the type section.
+    /// Stored as (type_idx, wasm.func_sig TypeRef) pairs.
     call_indirect_types: Vec<(u32, TypeRef)>,
     /// Pre-interned common types for use in handlers.
     common_types: CommonTypes,
@@ -313,13 +313,14 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
     }
 
     for import_def in module_info.imports.iter() {
-        let (params_refs, result_ref) = func_type_parts(ctx, import_def.func_type)
-            .ok_or_else(|| CompilationError::type_error("import func type is not func.func_sig"))?;
+        let (params_refs, signature_results) = func_type_parts(ctx, import_def.func_type)
+            .ok_or_else(|| CompilationError::type_error("import func type is not wasm.func_sig"))?;
         let params = params_refs
             .iter()
             .map(|ty| type_to_valtype(ctx, *ty, &module_info.type_idx_by_type))
             .collect::<CompilationResult<Vec<_>>>()?;
-        let results = result_types(ctx, result_ref, &module_info.type_idx_by_type)?;
+        let results =
+            signature_result_types(ctx, signature_results, &module_info.type_idx_by_type)?;
         type_section.ty().function(params, results);
         let type_index = next_type_index;
         next_type_index += 1;
@@ -332,53 +333,38 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
 
     for func_def in module_info.funcs.iter() {
         debug!("Processing function type for: {:?}", func_def.name);
-        let (params_refs, declared_result) = func_type_parts(ctx, func_def.func_type)
-            .ok_or_else(|| CompilationError::type_error("func type is not func.func_sig"))?;
+        let (params_refs, declared_results) = func_type_parts(ctx, func_def.func_type)
+            .ok_or_else(|| CompilationError::type_error("func type is not wasm.func_sig"))?;
         let params = params_refs
             .iter()
             .map(|ty| type_to_valtype(ctx, *ty, &module_info.type_idx_by_type))
             .collect::<CompilationResult<Vec<_>>>()?;
 
-        let declared_result_data = ctx.types.get(declared_result);
-        debug!(
-            "  checking return type adjustment for {}: declared={}.{}",
-            func_def.name, declared_result_data.dialect, declared_result_data.name
-        );
-
-        let effective_result = {
+        let mut effective_results = declared_results.to_vec();
+        // The legacy handler workaround remains deliberately confined to a
+        // one-result function; it must not rewrite arbitrary result vectors.
+        if let [declared_result] = declared_results {
             let regions = &ctx.op(func_def.op).regions;
-            if let Some(&body_region) = regions.first() {
-                if is_type(ctx, declared_result, "func", "func_sig")
-                    || is_type(ctx, declared_result, "wasm", "funcref")
-                {
-                    debug!("  checking funcref function for handler dispatch...");
-                    if should_adjust_handler_return_to_i32(ctx, body_region) {
-                        debug!(
-                            "  adjusting return type from funcref to i32 for computation lambda: {}",
-                            func_def.name
-                        );
-                        intern_simple_type(ctx, "core", "i32")
-                    } else {
-                        declared_result
-                    }
-                } else {
-                    declared_result
-                }
-            } else {
-                declared_result
+            if let Some(&body_region) = regions.first()
+                && (is_type(ctx, *declared_result, "func", "func_sig")
+                    || is_type(ctx, *declared_result, "wasm", "funcref"))
+                && should_adjust_handler_return_to_i32(ctx, body_region)
+            {
+                effective_results[0] = intern_simple_type(ctx, "core", "i32");
             }
-        };
+        }
 
-        let results = match result_types(ctx, effective_result, &module_info.type_idx_by_type) {
-            Ok(r) => {
-                debug!("  results: {:?}", r);
-                r
-            }
-            Err(e) => {
-                debug!("Function results conversion failed: {:?}", e);
-                return Err(e);
-            }
-        };
+        let results =
+            match signature_result_types(ctx, &effective_results, &module_info.type_idx_by_type) {
+                Ok(r) => {
+                    debug!("  results: {:?}", r);
+                    r
+                }
+                Err(e) => {
+                    debug!("Function results conversion failed: {:?}", e);
+                    return Err(e);
+                }
+            };
         type_section.ty().function(params, results);
         let type_index = next_type_index;
         next_type_index += 1;
@@ -388,11 +374,11 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
 
     // Emit call_indirect function types
     for (type_idx, func_ty) in &module_info.call_indirect_types {
-        let (params_refs, result_ref) = func_type_parts(ctx, *func_ty).ok_or_else(|| {
-            CompilationError::type_error("call_indirect type is not func.func_sig")
+        let (params_refs, signature_results) = func_type_parts(ctx, *func_ty).ok_or_else(|| {
+            CompilationError::type_error("call_indirect type is not wasm.func_sig")
         })?;
         debug!(
-            "Emitting call_indirect type idx={}: params={:?}, result={}.{}",
+            "Emitting call_indirect type idx={}: params={:?}, results={:?}",
             type_idx,
             params_refs
                 .iter()
@@ -401,14 +387,17 @@ pub(crate) fn emit_wasm(ctx: &mut IrContext, module: IrModule) -> CompilationRes
                     format!("{}.{}", d.dialect, d.name)
                 })
                 .collect::<Vec<_>>(),
-            ctx.types.get(result_ref).dialect,
-            ctx.types.get(result_ref).name
+            signature_results
+                .iter()
+                .map(|ty| format!("{}.{}", ctx.types.get(*ty).dialect, ctx.types.get(*ty).name))
+                .collect::<Vec<_>>()
         );
         let params = params_refs
             .iter()
             .map(|ty| type_to_valtype(ctx, *ty, &module_info.type_idx_by_type))
             .collect::<CompilationResult<Vec<_>>>()?;
-        let results = result_types(ctx, result_ref, &module_info.type_idx_by_type)?;
+        let results =
+            signature_result_types(ctx, signature_results, &module_info.type_idx_by_type)?;
         type_section.ty().function(params, results);
         assert_eq!(
             *type_idx, next_type_index,
@@ -724,8 +713,8 @@ fn emit_function(
         .first()
         .ok_or_else(|| CompilationError::invalid_module("wasm.func has no entry block"))?;
 
-    let (params_refs, result_ref) = func_type_parts(ctx, func_def.func_type)
-        .ok_or_else(|| CompilationError::type_error("func type is not func.func_sig"))?;
+    let (params_refs, signature_results) = func_type_parts(ctx, func_def.func_type)
+        .ok_or_else(|| CompilationError::type_error("func type is not wasm.func_sig"))?;
     let block_args = ctx.block_args(block);
     if params_refs.len() != block_args.len() {
         return Err(CompilationError::invalid_module(
@@ -733,7 +722,7 @@ fn emit_function(
         ));
     }
 
-    let func_return_type = Some(result_ref);
+    let func_return_type = signature_results.first().copied();
     let mut emit_ctx = FunctionEmitContext {
         value_locals: HashMap::new(),
         effective_types: HashMap::new(),
@@ -804,10 +793,7 @@ fn assign_locals_in_region(
             }
 
             let result_types = ctx.op_result_types(op);
-            if result_types.len() > 1 {
-                return Err(CompilationError::unsupported_feature("multi-result ops"));
-            }
-            if let Some(&result_ty) = result_types.first() {
+            for (index, &result_ty) in result_types.iter().enumerate() {
                 let effective_ty = result_ty;
                 let val_type =
                     match type_to_valtype(ctx, effective_ty, &module_info.type_idx_by_type) {
@@ -822,7 +808,7 @@ fn assign_locals_in_region(
                         }
                     };
                 let local_index = param_count + locals.len() as u32;
-                let result_value = ctx.op_result(op, 0);
+                let result_value = ctx.op_result(op, index as u32);
                 emit_ctx.value_locals.insert(result_value, local_index);
                 emit_ctx.effective_types.insert(result_value, effective_ty);
                 locals.push(val_type);
@@ -941,7 +927,7 @@ fn emit_op_nested(
         if let Some(&result_ty) = ctx.op_result_types(op).first() {
             let ty_data = ctx.types.get(result_ty);
             debug!("wasm.nop: result_ty={}.{}", ty_data.dialect, ty_data.name);
-            if is_type(ctx, result_ty, "func", "func_sig")
+            if is_type(ctx, result_ty, "wasm", "func_sig")
                 || is_type(ctx, result_ty, "wasm", "funcref")
             {
                 debug!("wasm.nop: emitting ref.null func");
@@ -1122,14 +1108,18 @@ fn set_result_local(
     function: &mut Function,
 ) -> CompilationResult<()> {
     let results = ctx.op_result_types(op);
-    if results.is_empty() || helpers::is_nil_type(ctx, results[0]) {
-        return Ok(());
+    // Wasm leaves the final declared result at the top of the stack.
+    // Consume every result in reverse order so SSA result i keeps its slot.
+    for index in (0..results.len()).rev() {
+        if is_nil_type(ctx, results[index]) {
+            continue;
+        }
+        let local = emit_ctx
+            .value_locals
+            .get(&ctx.op_result(op, index as u32))
+            .ok_or_else(|| CompilationError::invalid_module("result missing local mapping"))?;
+        function.instruction(&Instruction::LocalSet(*local));
     }
-    let local = emit_ctx
-        .value_locals
-        .get(&ctx.op_result(op, 0))
-        .ok_or_else(|| CompilationError::invalid_module("result missing local mapping"))?;
-    function.instruction(&Instruction::LocalSet(*local));
     Ok(())
 }
 
@@ -1319,8 +1309,8 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  wasm.func @main() -> func.func_sig<() -> core.nil> {
-    %null = wasm.nop : func.func_sig<() -> core.nil>
+  wasm.func @main() -> wasm.func_sig<() -> core.nil> {
+    %null = wasm.nop : wasm.func_sig<() -> core.nil>
     wasm.return %null
   }
 }"#,
@@ -1332,6 +1322,86 @@ mod tests {
         Validator::new()
             .validate_all(&bytes)
             .expect("signature-valued wasm.nop must validate");
+    }
+
+    #[test]
+    fn emits_and_validates_two_result_direct_call_with_both_results_used() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func {sym_name = @pair, type = wasm.func_sig<() -> (core.i32, core.i64)>} {
+    %a = wasm.i32_const {value = 7} : core.i32
+    %b = wasm.i64_const {value = 9} : core.i64
+    wasm.return %a, %b
+  }
+  wasm.func {sym_name = @use_pair, type = wasm.func_sig<() -> (core.i32, core.i64)>} {
+    %a, %b = wasm.call {callee = @pair} : core.i32, core.i64
+    wasm.return %a, %b
+  }
+}"#,
+        );
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("two-result direct call must emit")
+            .bytes;
+        Validator::new()
+            .validate_all(&bytes)
+            .expect("two-result direct call must validate");
+    }
+
+    #[test]
+    fn emits_and_validates_two_result_exact_indirect_call() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.table {reftype = @funcref, min = 1, max = 1}
+  wasm.elem {table = 0, offset = 0} {
+    wasm.ref_func {func_name = @pair} : wasm.funcref
+  }
+  wasm.func {sym_name = @pair, type = wasm.func_sig<() -> (core.i32, core.i64)>} {
+    %a = wasm.i32_const {value = 7} : core.i32
+    %b = wasm.i64_const {value = 9} : core.i64
+    wasm.return %a, %b
+  }
+  wasm.func {sym_name = @caller, type = wasm.func_sig<(core.i32) -> (core.i32, core.i64)>} {
+    ^entry(%table_index: core.i32):
+      %a, %b = wasm.call_indirect %table_index {signature = wasm.func_sig<() -> (core.i32, core.i64)>, table = 0, type_idx = 0} : core.i32, core.i64
+      wasm.return %a, %b
+  }
+}"#,
+        );
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("two-result exact indirect call must emit")
+            .bytes;
+        Validator::new()
+            .validate_all(&bytes)
+            .expect("two-result exact indirect call must validate");
+    }
+
+    #[test]
+    fn omits_nil_result_slots_without_reordering_other_results() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func {sym_name = @pair, type = wasm.func_sig<() -> (core.i32, core.nil, core.i64)>} {
+    %a = wasm.i32_const {value = 7} : core.i32
+    %b = wasm.i64_const {value = 9} : core.i64
+    wasm.return %a, %b
+  }
+  wasm.func {sym_name = @use_pair, type = wasm.func_sig<() -> (core.i32, core.i64)>} {
+    %a, %unit, %b = wasm.call {callee = @pair} : core.i32, core.nil, core.i64
+    wasm.return %a, %b
+  }
+}"#,
+        );
+        let bytes = crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("nil result slot compatibility must emit")
+            .bytes;
+        Validator::new()
+            .validate_all(&bytes)
+            .expect("nil result slot compatibility must validate");
     }
 
     #[test]
@@ -1397,7 +1467,8 @@ mod tests {
             panic!("expected func.func_sig signature")
         };
         assert_eq!(ctx.types.get(params[0]).name, Symbol::new("anyref"));
-        assert_eq!(ctx.types.get(result).name, Symbol::new("i32"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(ctx.types.get(result[0]).name, Symbol::new("i32"));
 
         let bytes = crate::emit_module_to_wasm(&mut ctx, module)
             .expect("exact ordinary indirect call must emit")
@@ -1428,7 +1499,8 @@ mod tests {
         let Some((_, result)) = helpers::func_type_parts(&ctx, *signature) else {
             panic!("expected func.func_sig signature")
         };
-        assert!(helpers::is_type(&ctx, result, "wasm", "funcref"));
+        assert_eq!(result.len(), 1);
+        assert!(helpers::is_type(&ctx, result[0], "wasm", "funcref"));
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -12,7 +12,7 @@ use trunk_ir::Symbol;
 use trunk_ir::dialect::func;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::op_interface::IndirectCallLikeOps;
-use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{RegionRef, TypeRef};
 use trunk_ir::smallvec::SmallVec;
 use trunk_ir::types::TypeData;
@@ -21,9 +21,9 @@ use crate::errors::{CompilationError, CompilationResult};
 
 use super::helpers::{self, intern_named_adt_struct};
 
-/// Intern a func.func_sig type from params and result type.
+/// Intern a target-owned `wasm.func_sig` type from params and result type.
 fn intern_func_type(ctx: &mut IrContext, params: &[TypeRef], result_ty: TypeRef) -> TypeRef {
-    func::func_sig(ctx, params.iter().copied(), [result_ty]).as_type_ref()
+    wasm_dialect::func_sig(ctx, params.iter().copied(), [result_ty]).as_type_ref()
 }
 
 /// Intern a simple wasm type with no params or attrs.
@@ -87,21 +87,16 @@ pub(crate) fn collect_call_indirect_types(
                         "collect_call_indirect_types: found wasm.func, type={}",
                         fmt_type(ctx, func_type)
                     );
-                    let (_, ret_ty) =
+                    let (_, results) =
                         helpers::func_type_parts(ctx, func_type).ok_or_else(|| {
                             CompilationError::type_error(
-                                "Wasm indirect-call collection requires valid one-result func.func_sig",
+                                "Wasm indirect-call collection requires valid wasm.func_sig",
                             )
                         })?;
-                    Some(ret_ty)
+                    results.first().copied()
                 } else if let Ok(func) = func::Func::from_op(ctx, op) {
-                    let (_, ret_ty) =
-                        helpers::func_type_parts(ctx, func.r#type(ctx)).ok_or_else(|| {
-                            CompilationError::type_error(
-                                "Wasm indirect-call collection requires valid one-result func.func_sig",
-                            )
-                        })?;
-                    Some(ret_ty)
+                    func::FuncSig::from_type_ref(ctx, func.r#type(ctx))
+                        .and_then(|signature| signature.single_result(ctx))
                 } else {
                     None
                 };
@@ -385,7 +380,7 @@ mod tests {
 
         assert_eq!(
             helpers::func_type_parts(&ctx, func_ty),
-            Some((&[first, second][..], result))
+            Some((&[first, second][..], &[result][..]))
         );
     }
 }
@@ -394,42 +389,26 @@ mod tests {
 mod result_list_tests {
     use super::*;
     #[test]
-    fn review_late_signature_error_preserves_seeded_indices() {
-        for dialect in ["wasm", "func"] {
-            let mut ctx = IrContext::new();
-            let text = format!(
-                "core.module @m {{
-                wasm.func {{sym_name = @good, type = func.func_sig<() -> core.i32>}} {{
-                    %callee = wasm.i32_const {{value = 0}} : core.i32
+    fn resultless_target_functions_do_not_abort_indirect_collection() {
+        let mut ctx = IrContext::new();
+        let text = "core.module @m {
+                wasm.func {sym_name = @good, type = func.func_sig<() -> core.i32>} {
+                    %callee = wasm.i32_const {value = 0} : core.i32
                     %value = wasm.call_indirect %callee : core.i32
                     wasm.return %value
-                }}
-                {dialect}.func {{sym_name = @bad, type = func.func_sig<() -> ()>}} {{}}
-            }}"
-            );
-            let module = trunk_ir::parser::parse_test_module(&mut ctx, &text);
-            let seed = func::func_sig(&mut ctx, [], []).as_type_ref();
-            let mut indices = HashMap::from([(seed, 7)]);
-            let before = indices.clone();
-            let error =
-                collect_call_indirect_types(&mut ctx, module, &mut indices, 8, 0).unwrap_err();
-            assert!(error.to_string().contains("one-result func.func_sig"));
-            assert_eq!(indices, before);
-            let bad = module.ops(&ctx)[1];
-            trunk_ir::rewrite::erase_op(&mut ctx, bad);
-            let added = collect_call_indirect_types(&mut ctx, module, &mut indices, 8, 0).unwrap();
-            assert_eq!(
-                added.len(),
-                1,
-                "the earlier call must register a new signature"
-            );
-            assert_eq!(indices.len(), 2);
-            assert_eq!(indices[&seed], 7);
-        }
+                }
+                wasm.func {sym_name = @zero, type = wasm.func_sig<() -> ()>} { wasm.return }
+            }";
+        let module = trunk_ir::parser::parse_test_module(&mut ctx, text);
+        let seed = wasm_dialect::func_sig(&mut ctx, [], []).as_type_ref();
+        let mut indices = HashMap::from([(seed, 7)]);
+        let added = collect_call_indirect_types(&mut ctx, module, &mut indices, 8, 0).unwrap();
+        assert_eq!(added.len(), 1);
+        assert_eq!(indices[&seed], 7);
     }
 
     #[test]
-    fn unsupported_resultless_function_is_rejected_before_collection() {
+    fn resultless_function_is_a_legal_target_contract() {
         let mut ctx = IrContext::new();
         let module = trunk_ir::parser::parse_test_module(
             &mut ctx,
@@ -437,8 +416,8 @@ mod result_list_tests {
         );
         let before = trunk_ir::printer::print_module(&ctx, module.op());
         let mut indices = HashMap::new();
-        let error = collect_call_indirect_types(&mut ctx, module, &mut indices, 0, 0).unwrap_err();
-        assert!(error.to_string().contains("one-result func.func_sig"));
+        let added = collect_call_indirect_types(&mut ctx, module, &mut indices, 0, 0).unwrap();
+        assert!(added.is_empty());
         assert!(indices.is_empty());
         assert_eq!(trunk_ir::printer::print_module(&ctx, module.op()), before);
     }

--- a/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/call_indirect_collection.rs
@@ -93,7 +93,10 @@ pub(crate) fn collect_call_indirect_types(
                                 "Wasm indirect-call collection requires valid wasm.func_sig",
                             )
                         })?;
-                    results.first().copied()
+                    match results {
+                        [result] => Some(*result),
+                        _ => None,
+                    }
                 } else if let Ok(func) = func::Func::from_op(ctx, op) {
                     func::FuncSig::from_type_ref(ctx, func.r#type(ctx))
                         .and_then(|signature| signature.single_result(ctx))
@@ -201,11 +204,13 @@ pub(crate) fn collect_call_indirect_types(
                     // and the call_indirect has anyref result. This is needed because
                     // WebAssembly GC has separate type hierarchies for anyref and funcref,
                     // so we can't cast between them.
-                    let result_types: Vec<_> = ctx.op_result_types(op).to_vec();
-                    let mut result_ty = match result_types.first().copied() {
-                        Some(ty) => ty,
-                        None => continue, // Skip if no result
+                    let result_types = ctx.op_result_types(op);
+                    let [result_ty] = result_types else {
+                        return Err(CompilationError::invalid_module(
+                            "legacy wasm.call_indirect requires exactly one result; attach an exact wasm.func_sig for zero or multiple results",
+                        ));
                     };
+                    let mut result_ty = *result_ty;
 
                     // If result type is anyref but enclosing function returns funcref,
                     // use funcref as the result type. This is needed because WebAssembly GC has
@@ -222,7 +227,7 @@ pub(crate) fn collect_call_indirect_types(
                         let is_anyref_result = helpers::is_type(ctx, result_ty, "wasm", "anyref");
                         let func_returns_funcref =
                             helpers::is_type(ctx, func_ret_ty, "wasm", "funcref")
-                                || helpers::is_type(ctx, func_ret_ty, "func", "func_sig");
+                                || helpers::is_type(ctx, func_ret_ty, "wasm", "func_sig");
                         // Check for Step type (trampoline-based effect system)
                         let func_returns_step = helpers::is_step_type(ctx, func_ret_ty);
                         debug!(
@@ -392,7 +397,7 @@ mod result_list_tests {
     fn resultless_target_functions_do_not_abort_indirect_collection() {
         let mut ctx = IrContext::new();
         let text = "core.module @m {
-                wasm.func {sym_name = @good, type = func.func_sig<() -> core.i32>} {
+                wasm.func {sym_name = @good, type = wasm.func_sig<() -> core.i32>} {
                     %callee = wasm.i32_const {value = 0} : core.i32
                     %value = wasm.call_indirect %callee : core.i32
                     wasm.return %value
@@ -412,7 +417,7 @@ mod result_list_tests {
         let mut ctx = IrContext::new();
         let module = trunk_ir::parser::parse_test_module(
             &mut ctx,
-            "core.module @m { wasm.func {sym_name = @f, type = func.func_sig<() -> ()>} { wasm.return } }",
+            "core.module @m { wasm.func {sym_name = @f, type = wasm.func_sig<() -> ()>} { wasm.return } }",
         );
         let before = trunk_ir::printer::print_module(&ctx, module.op());
         let mut indices = HashMap::new();
@@ -420,5 +425,53 @@ mod result_list_tests {
         assert!(added.is_empty());
         assert!(indices.is_empty());
         assert_eq!(trunk_ir::printer::print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn legacy_indirect_call_rejects_zero_or_multiple_results_before_collection() {
+        for source in [
+            r#"core.module @m {
+  wasm.func {sym_name = @caller, type = wasm.func_sig<(core.i32) -> ()>} {
+    ^entry(%table_index: core.i32):
+      wasm.call_indirect %table_index
+  }
+}"#,
+            r#"core.module @m {
+  wasm.func {sym_name = @caller, type = wasm.func_sig<(core.i32) -> ()>} {
+    ^entry(%table_index: core.i32):
+      %first, %second = wasm.call_indirect %table_index : core.i32, core.i64
+  }
+}"#,
+        ] {
+            let mut ctx = IrContext::new();
+            let module = trunk_ir::parser::parse_test_module(&mut ctx, source);
+            let error = collect_call_indirect_types(&mut ctx, module, &mut HashMap::new(), 0, 1)
+                .expect_err("legacy non-scalar result list must fail before type collection");
+            assert!(
+                error.to_string().contains("requires exactly one result"),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_indirect_call_does_not_infer_from_a_multi_result_caller() {
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(
+            &mut ctx,
+            "core.module @m {
+  wasm.func {sym_name = @caller, type = wasm.func_sig<(core.i32) -> (wasm.funcref, core.i32)>} {
+    ^entry(%table_index: core.i32):
+      %result = wasm.call_indirect %table_index : wasm.anyref
+  }
+}",
+        );
+        let added = collect_call_indirect_types(&mut ctx, module, &mut HashMap::new(), 0, 1)
+            .expect("multi-result caller must not make legacy inference malformed");
+        let [(_, signature)] = added.as_slice() else {
+            panic!("expected one inferred legacy signature")
+        };
+        let (_, results) = helpers::func_type_parts(&ctx, *signature).unwrap();
+        assert!(helpers::is_type(&ctx, results[0], "wasm", "anyref"));
     }
 }

--- a/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/definitions.rs
@@ -24,7 +24,7 @@ use crate::{CompilationError, CompilationResult};
 #[derive(Debug)]
 pub(crate) struct FunctionDef {
     pub name: Symbol,
-    /// Validated `func.func_sig` signature.
+    /// Validated target-owned `wasm.func_sig` signature.
     pub func_type: TypeRef,
     pub op: OpRef,
 }
@@ -34,7 +34,7 @@ pub(crate) struct ImportFuncDef {
     pub sym: Symbol,
     pub module: Symbol,
     pub name: Symbol,
-    /// func.func_sig TypeRef
+    /// wasm.func_sig TypeRef
     pub func_type: TypeRef,
 }
 
@@ -98,8 +98,8 @@ pub(crate) fn extract_function_def(
     let name = func_op.sym_name(ctx);
     let ty = func_op.r#type(ctx);
 
-    let function = func::FuncSig::from_type_ref(ctx, ty).ok_or_else(|| {
-        CompilationError::type_error("wasm.func requires valid func.func_sig type")
+    let function = wasm_dialect::FuncSig::from_type_ref(ctx, ty).ok_or_else(|| {
+        CompilationError::type_error("wasm.func requires valid wasm.func_sig type")
     })?;
 
     if let Some(result_ty) = function.single_result(ctx) {
@@ -136,9 +136,9 @@ pub(crate) fn extract_import_def(
     let sym = import_op.sym_name(ctx);
     let ty = import_op.r#type(ctx);
 
-    if func::FuncSig::from_type_ref(ctx, ty).is_none() {
+    if wasm_dialect::FuncSig::from_type_ref(ctx, ty).is_none() {
         return Err(CompilationError::type_error(
-            "wasm.import_func requires valid func.func_sig type",
+            "wasm.import_func requires valid wasm.func_sig type",
         ));
     }
 
@@ -317,7 +317,7 @@ mod tests {
         let location = Location::new(PathRef::from_u32(0), Span::default());
         let malformed = ctx
             .types
-            .intern(TypeDataBuilder::new(Symbol::new("func"), Symbol::new("func_sig")).build());
+            .intern(TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("func_sig")).build());
         let import = wasm_dialect::import_func(
             &mut ctx,
             location,
@@ -331,7 +331,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("requires valid func.func_sig type"),
+                .contains("requires valid wasm.func_sig type"),
             "{error}"
         );
     }

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -162,15 +162,20 @@ pub(crate) fn handle_call_indirect(
         })
         .collect();
 
+    // The legacy inference path is scalar-only. Exact `wasm.func_sig`
+    // contracts own zero and multiple results.
+    let result_types = ctx.op_result_types(op);
+    let [result_ty] = result_types else {
+        return Err(CompilationError::invalid_module(
+            "legacy wasm.call_indirect requires exactly one result; attach an exact wasm.func_sig for zero or multiple results",
+        ));
+    };
+    let mut result_ty = *result_ty;
+
     // Get result type - use enclosing function's return type if it's funcref
     // and the call_indirect has anyref result. This is needed because
     // WebAssembly GC has separate type hierarchies for anyref and funcref,
     // so we can't cast between them.
-    let result_types = ctx.op_result_types(op);
-    let mut result_ty = result_types.first().copied().ok_or_else(|| {
-        CompilationError::invalid_module("wasm.call_indirect must have a result type")
-    })?;
-
     // If result type is anyref but enclosing function returns funcref or Step,
     // upgrade the result type accordingly. This is needed because WebAssembly GC has separate
     // type hierarchies, and effectful functions return Step for yield bubbling.
@@ -182,7 +187,7 @@ pub(crate) fn handle_call_indirect(
     if let Some(func_ret_ty) = emit_ctx.func_return_type {
         let is_anyref_result = helpers::is_type(ctx, result_ty, "wasm", "anyref");
         let func_returns_funcref = helpers::is_type(ctx, func_ret_ty, "wasm", "funcref")
-            || helpers::is_type(ctx, func_ret_ty, "func", "func_sig");
+            || helpers::is_type(ctx, func_ret_ty, "wasm", "func_sig");
         // Check for Step type (trampoline-based effect system)
         let func_returns_step = helpers::is_step_type(ctx, func_ret_ty);
         if is_anyref_result && func_returns_funcref {
@@ -339,10 +344,10 @@ pub(crate) fn handle_return_call_indirect(
 
 use super::super::helpers::attr_u32;
 
-/// Find a func.func_sig type in the `type_idx_by_type` / `func_types` registries by
+/// Find a scalar `wasm.func_sig` type in the `type_idx_by_type` / `func_types` registries by
 /// matching params and result.
 ///
-/// `func.func_sig` stores inputs followed by its single result in `TypeData.params`;
+/// `wasm.func_sig` stores inputs followed by its single result in `TypeData.params`;
 /// callers use the validated accessor rather than depending on that flat layout.
 ///
 /// This performs a linear O(n) scan over the registries to avoid requiring

--- a/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/handlers/call_handlers.rs
@@ -359,7 +359,7 @@ fn find_func_type_in_registry(
     // Search through registered func types (from imports, funcs, and call_indirect collection)
     for &ty_ref in module_info.type_idx_by_type.keys() {
         if helpers::func_type_parts(ctx, ty_ref)
-            .is_some_and(|(ty_params, ty_result)| ty_result == result && ty_params == params)
+            .is_some_and(|(ty_params, ty_results)| ty_results == [result] && ty_params == params)
         {
             return Ok(ty_ref);
         }
@@ -367,7 +367,7 @@ fn find_func_type_in_registry(
     // Also check func_types map
     for &ty_ref in module_info.func_types.values() {
         if helpers::func_type_parts(ctx, ty_ref)
-            .is_some_and(|(ty_params, ty_result)| ty_result == result && ty_params == params)
+            .is_some_and(|(ty_params, ty_results)| ty_results == [result] && ty_params == params)
         {
             return Ok(ty_ref);
         }

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use trunk_ir::IrContext;
 use trunk_ir::Symbol;
-use trunk_ir::dialect::func;
+use trunk_ir::dialect::wasm;
 use trunk_ir::op_interface::IndirectCallLikeOps;
 use trunk_ir::ops::DialectType;
 use trunk_ir::refs::{OpRef, TypeRef, ValueRef};
@@ -93,11 +93,10 @@ pub(crate) fn should_normalize_to_anyref(ctx: &IrContext, ty: TypeRef) -> bool {
 // Type conversion
 // ============================================================================
 
-/// Get the params and return type of a func.func_sig TypeRef.
-/// Returns (param_types, return_type) or None if not a func.func_sig.
-pub(crate) fn func_type_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], TypeRef)> {
-    let function = func::FuncSig::from_type_ref(ctx, ty)?;
-    Some((function.inputs(ctx), function.single_result(ctx)?))
+/// Get the ordered params and results of a target-owned `wasm.func_sig`.
+pub(crate) fn func_type_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], &[TypeRef])> {
+    let function = wasm::FuncSig::from_type_ref(ctx, ty)?;
+    Some((function.inputs(ctx), function.results(ctx)))
 }
 
 /// Whether an argument can satisfy an indirect-tail parameter after the Wasm
@@ -160,8 +159,8 @@ pub(crate) fn exact_call_indirect_signature_with(
     op: OpRef,
     signature: TypeRef,
 ) -> CompilationResult<TypeRef> {
-    let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
-        CompilationError::invalid_module("wasm.call_indirect signature must be func.func_sig")
+    let (params, signature_results) = func_type_parts(ctx, signature).ok_or_else(|| {
+        CompilationError::invalid_module("wasm.call_indirect signature must be wasm.func_sig")
     })?;
     let Some(_table_index) = IndirectCallLikeOps::callee(ctx, op) else {
         return Err(CompilationError::invalid_module(
@@ -174,11 +173,12 @@ pub(crate) fn exact_call_indirect_signature_with(
         ));
     };
     let results = ctx.op_result_types(op);
-    let results_match = if is_nil_type(ctx, result) {
-        results.is_empty()
-    } else {
-        results == [result]
-    };
+    // The established omitted-result-slot compatibility allows a `[nil]`
+    // target signature for a resultless transfer. Ordinary empty signatures
+    // match only an empty result list; nil operands remain nullable refs.
+    let results_match = results == signature_results
+        || (results.is_empty()
+            && matches!(signature_results, [result] if is_nil_type(ctx, *result)));
     if params.len() != args.len()
         || params.iter().zip(args).any(|(param, arg)| {
             !is_wasm_physical_argument_assignable(ctx, value_type(ctx, *arg), *param)
@@ -212,12 +212,12 @@ pub(crate) fn exact_return_call_indirect_signature_with(
     op: OpRef,
     signature: TypeRef,
 ) -> CompilationResult<TypeRef> {
-    let (params, result) = func_type_parts(ctx, signature).ok_or_else(|| {
+    let (params, results) = func_type_parts(ctx, signature).ok_or_else(|| {
         CompilationError::invalid_module(
-            "wasm.return_call_indirect signature must be func.func_sig",
+            "wasm.return_call_indirect signature must be wasm.func_sig",
         )
     })?;
-    if !is_nil_type(ctx, result) {
+    if !matches!(results, [result] if is_nil_type(ctx, *result)) {
         return Err(CompilationError::invalid_module(
             "wasm.return_call_indirect signature must have an empty result",
         ));
@@ -281,6 +281,8 @@ pub(crate) fn type_to_valtype(
             nullable: true,
             heap_type: HeapType::Concrete(type_idx),
         }))
+    } else if is_type(ctx, ty, "wasm", "func_sig") {
+        Ok(ValType::Ref(RefType::FUNCREF))
     } else if ctx.types.get(ty).dialect == Symbol::new("wasm") {
         let name = ctx.types.get(ty).name;
         if name == Symbol::new("structref") {
@@ -325,8 +327,6 @@ pub(crate) fn type_to_valtype(
                 ty: AbstractHeapType::Array,
             },
         }))
-    } else if is_type(ctx, ty, "func", "func_sig") {
-        Ok(ValType::Ref(RefType::FUNCREF))
     } else if is_closure_struct_type(ctx, ty) {
         Ok(ValType::Ref(RefType {
             nullable: true,
@@ -374,18 +374,20 @@ fn is_bytes_array_ref(ctx: &IrContext, ty: TypeRef) -> bool {
         && is_type(ctx, array.params[0], "core", "i8")
 }
 
-/// Convert an IR return type to WebAssembly result types.
-/// Returns an empty vector for nil types (void functions).
-pub(crate) fn result_types(
+/// Convert an ordered Wasm signature result list to machine result slots.
+///
+/// Result `core.nil` remains the established omitted target slot rule. Nil in
+/// value or input positions is separately lowered as a nullable reference.
+pub(crate) fn signature_result_types(
     ctx: &IrContext,
-    ty: TypeRef,
+    results: &[TypeRef],
     type_idx_by_type: &HashMap<TypeRef, u32>,
 ) -> CompilationResult<Vec<ValType>> {
-    if is_nil_type(ctx, ty) {
-        Ok(Vec::new())
-    } else {
-        Ok(vec![type_to_valtype(ctx, ty, type_idx_by_type)?])
-    }
+    results
+        .iter()
+        .filter(|ty| !is_nil_type(ctx, **ty))
+        .map(|ty| type_to_valtype(ctx, *ty, type_idx_by_type))
+        .collect()
 }
 
 // ============================================================================
@@ -531,7 +533,7 @@ mod tests {
         let i32_ty = ctx
             .types
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
-        let signature = func::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
+        let signature = wasm::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
 
         assert_eq!(
             type_to_valtype(&ctx, signature, &HashMap::new())

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -101,12 +101,17 @@ pub(crate) fn func_type_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef
 
 /// Whether an argument can satisfy an indirect-tail parameter after the Wasm
 /// backend's physical type mapping.
-fn is_wasm_physical_argument_assignable(
+pub(crate) fn is_wasm_physical_argument_assignable(
     ctx: &IrContext,
     argument: TypeRef,
     parameter: TypeRef,
 ) -> bool {
     if argument == parameter {
+        return true;
+    }
+
+    // `core.i1` is represented by an i32 in the Wasm value space.
+    if is_type(ctx, argument, "core", "i1") && is_type(ctx, parameter, "core", "i32") {
         return true;
     }
 

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -26,7 +26,6 @@ use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, clone_attrs_except,
-    convert_function_type,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
 use trunk_ir::{BlockData, RegionData};
@@ -180,19 +179,161 @@ struct FuncFuncPattern;
 /// Convert the complete shared callable contract once at the Wasm boundary.
 /// The shared type remains zero-or-one result; only the target-owned type may
 /// subsequently carry multiple results from low-level Wasm fixtures.
+fn convert_attribute_to_wasm(
+    ctx: &mut IrContext,
+    attribute: &Attribute,
+    converter: &TypeConverter,
+) -> Option<Attribute> {
+    match attribute {
+        Attribute::Type(ty) => Some(Attribute::Type(convert_type_to_wasm(ctx, *ty, converter)?)),
+        Attribute::List(values) => Some(Attribute::List(
+            values
+                .iter()
+                .map(|value| convert_attribute_to_wasm(ctx, value, converter))
+                .collect::<Option<_>>()?,
+        )),
+        other => Some(other.clone()),
+    }
+}
+
+/// Recurse through a composite type only to materialize nested callable
+/// contracts. Rewriting every nested physical type would desynchronize an ADT
+/// layout from already-typed values that use that layout.
+fn convert_nested_callable_type(
+    ctx: &mut IrContext,
+    ty: TypeRef,
+    converter: &TypeConverter,
+) -> Option<TypeRef> {
+    if func::FuncSig::from_type_ref(ctx, ty).is_some() {
+        return convert_type_to_wasm(ctx, ty, converter);
+    }
+    let data = ctx.types.get(ty).clone();
+    let params = data
+        .params
+        .iter()
+        .map(|parameter| convert_nested_callable_type(ctx, *parameter, converter))
+        .collect::<Option<Vec<_>>>()?;
+    let attrs = data
+        .attrs
+        .iter()
+        .map(|(key, value)| {
+            Some((
+                *key,
+                convert_nested_callable_attribute(ctx, value, converter)?,
+            ))
+        })
+        .collect::<Option<_>>()?;
+    if params.as_slice() == data.params.as_slice() && attrs == data.attrs {
+        return Some(ty);
+    }
+    let mut converted_data = data;
+    converted_data.params = params.into();
+    converted_data.attrs = attrs;
+    Some(ctx.types.intern(converted_data))
+}
+
+fn convert_nested_callable_attribute(
+    ctx: &mut IrContext,
+    attribute: &Attribute,
+    converter: &TypeConverter,
+) -> Option<Attribute> {
+    match attribute {
+        Attribute::Type(ty) => Some(Attribute::Type(convert_nested_callable_type(
+            ctx, *ty, converter,
+        )?)),
+        Attribute::List(values) => Some(Attribute::List(
+            values
+                .iter()
+                .map(|value| convert_nested_callable_attribute(ctx, value, converter))
+                .collect::<Option<_>>()?,
+        )),
+        other => Some(other.clone()),
+    }
+}
+
+/// Recursively materialize target types, including shared callable values and
+/// type-bearing attributes nested inside another Wasm type.
+fn convert_type_to_wasm(
+    ctx: &mut IrContext,
+    ty: TypeRef,
+    converter: &TypeConverter,
+) -> Option<TypeRef> {
+    let converted = converter.convert_type_or_identity(ctx, ty);
+    if converted != ty {
+        return convert_type_to_wasm(ctx, converted, converter);
+    }
+
+    if let Some(shared) = func::FuncSig::from_type_ref(ctx, ty) {
+        let input_types = shared.inputs(ctx).to_vec();
+        let result_types = shared.results(ctx).to_vec();
+        let type_attrs = shared
+            .non_reserved_attrs(ctx)
+            .map(|(key, value)| (*key, value.clone()))
+            .collect::<Vec<_>>();
+        let inputs = input_types
+            .iter()
+            .map(|ty| convert_type_to_wasm(ctx, *ty, converter))
+            .collect::<Option<Vec<_>>>()?;
+        let results = result_types
+            .iter()
+            .map(|ty| convert_type_to_wasm(ctx, *ty, converter))
+            .collect::<Option<Vec<_>>>()?;
+        let attrs = type_attrs
+            .iter()
+            .map(|(key, value)| Some((*key, convert_attribute_to_wasm(ctx, value, converter)?)))
+            .collect::<Option<_>>()?;
+        return Some(wasm_dialect::func_sig_with_attrs(ctx, inputs, results, attrs).as_type_ref());
+    }
+
+    let data = ctx.types.get(ty).clone();
+    let params = data
+        .params
+        .iter()
+        .map(|parameter| convert_nested_callable_type(ctx, *parameter, converter))
+        .collect::<Option<Vec<_>>>()?;
+    let attrs = data
+        .attrs
+        .iter()
+        .map(|(key, value)| {
+            Some((
+                *key,
+                convert_nested_callable_attribute(ctx, value, converter)?,
+            ))
+        })
+        .collect::<Option<_>>()?;
+    if params.as_slice() == data.params.as_slice() && attrs == data.attrs {
+        return Some(ty);
+    }
+    let mut converted_data = data;
+    converted_data.params = params.into();
+    converted_data.attrs = attrs;
+    Some(ctx.types.intern(converted_data))
+}
+
 fn convert_to_wasm_func_type(
     ctx: &mut IrContext,
     signature: TypeRef,
     converter: &TypeConverter,
 ) -> Option<TypeRef> {
-    let converted = convert_function_type(ctx, signature, converter)?;
-    let shared = func::FuncSig::from_type_ref(ctx, converted)?;
-    let inputs = shared.inputs(ctx).to_vec();
-    let results = shared.results(ctx).to_vec();
-    let attrs = shared
+    let shared = func::FuncSig::from_type_ref(ctx, signature)?;
+    let input_types = shared.inputs(ctx).to_vec();
+    let result_types = shared.results(ctx).to_vec();
+    let type_attrs = shared
         .non_reserved_attrs(ctx)
         .map(|(key, value)| (*key, value.clone()))
-        .collect();
+        .collect::<Vec<_>>();
+    let inputs = input_types
+        .iter()
+        .map(|ty| convert_type_to_wasm(ctx, *ty, converter))
+        .collect::<Option<Vec<_>>>()?;
+    let results = result_types
+        .iter()
+        .map(|ty| convert_type_to_wasm(ctx, *ty, converter))
+        .collect::<Option<Vec<_>>>()?;
+    let attrs = type_attrs
+        .iter()
+        .map(|(key, value)| Some((*key, convert_attribute_to_wasm(ctx, value, converter)?)))
+        .collect::<Option<_>>()?;
     Some(wasm_dialect::func_sig_with_attrs(ctx, inputs, results, attrs).as_type_ref())
 }
 
@@ -533,6 +674,63 @@ mod tests {
             ctx.op(lowered).attributes.get("custom"),
             Some(&Attribute::Int(7))
         );
+    }
+
+    #[test]
+    fn func_to_wasm_recursively_converts_nested_callable_types_and_attributes() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main() -> core.nil { func.return }
+}"#,
+        );
+        let function = module.ops(&ctx)[0];
+        let nil = ctx
+            .op(function)
+            .attributes
+            .get_type("type")
+            .and_then(|ty| func::FuncSig::from_type_ref(&ctx, ty))
+            .unwrap()
+            .results(&ctx)[0];
+        let nested = func::func_sig(&mut ctx, [], [nil]).as_type_ref();
+        let nested_container = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("array"))
+                .param(nested)
+                .build(),
+        );
+        let mut attrs = trunk_ir::AttributeMap::new();
+        attrs.insert(
+            Symbol::new("metadata"),
+            Attribute::List(vec![Attribute::Type(nested)]),
+        );
+        let outer =
+            func::func_sig_with_attrs(&mut ctx, [nested_container], [nested], attrs).as_type_ref();
+        ctx.op_mut(function)
+            .attributes
+            .insert(Symbol::new("type"), Attribute::Type(outer));
+
+        lower(&mut ctx, module, TypeConverter::new());
+
+        let lowered = module.ops(&ctx)[0];
+        let signature = wasm_dialect::Func::from_op(&ctx, lowered)
+            .unwrap()
+            .r#type(&ctx);
+        let signature = wasm_dialect::FuncSig::from_type_ref(&ctx, signature).unwrap();
+        let nested_input = ctx.types.get(signature.inputs(&ctx)[0]).params[0];
+        assert!(wasm_dialect::FuncSig::from_type_ref(&ctx, nested_input).is_some());
+        assert!(wasm_dialect::FuncSig::from_type_ref(&ctx, signature.results(&ctx)[0]).is_some());
+        let metadata = signature
+            .non_reserved_attrs(&ctx)
+            .find_map(|(key, value)| (*key == Symbol::new("metadata")).then_some(value))
+            .unwrap();
+        let Attribute::List(values) = metadata else {
+            panic!("metadata must remain a list")
+        };
+        let Attribute::Type(nested_attribute) = &values[0] else {
+            panic!("nested metadata must remain a type")
+        };
+        assert!(wasm_dialect::FuncSig::from_type_ref(&ctx, *nested_attribute).is_some());
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -22,7 +22,7 @@ use trunk_ir::context::{IrContext, OperationDataBuilder};
 use trunk_ir::dialect::func::{self, CallLike, TailCallLike};
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::op_interface::IndirectCallLikeModel;
-use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{OpRef, RegionRef, TypeRef};
 use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, clone_attrs_except,
@@ -177,6 +177,25 @@ fn add_function_table(ctx: &mut IrContext, module: Module, funcs: &[Symbol], tab
 /// Pattern for `func.func` -> `wasm.func`
 struct FuncFuncPattern;
 
+/// Convert the complete shared callable contract once at the Wasm boundary.
+/// The shared type remains zero-or-one result; only the target-owned type may
+/// subsequently carry multiple results from low-level Wasm fixtures.
+fn convert_to_wasm_func_type(
+    ctx: &mut IrContext,
+    signature: TypeRef,
+    converter: &TypeConverter,
+) -> Option<TypeRef> {
+    let converted = convert_function_type(ctx, signature, converter)?;
+    let shared = func::FuncSig::from_type_ref(ctx, converted)?;
+    let inputs = shared.inputs(ctx).to_vec();
+    let results = shared.results(ctx).to_vec();
+    let attrs = shared
+        .non_reserved_attrs(ctx)
+        .map(|(key, value)| (*key, value.clone()))
+        .collect();
+    Some(wasm_dialect::func_sig_with_attrs(ctx, inputs, results, attrs).as_type_ref())
+}
+
 impl RewritePattern for FuncFuncPattern {
     fn match_and_rewrite(
         &self,
@@ -190,7 +209,11 @@ impl RewritePattern for FuncFuncPattern {
 
         let loc = ctx.op(op).location;
         let sym_name = func_op.sym_name(ctx);
-        let func_type = func_op.r#type(ctx);
+        let Some(func_type) =
+            convert_to_wasm_func_type(ctx, func_op.r#type(ctx), rewriter.type_converter())
+        else {
+            return false;
+        };
         let attrs_to_preserve = clone_attrs_except(ctx, op, &["sym_name", "type"]);
 
         // Generated Func::body() asserts for valid bodyless declarations.
@@ -271,7 +294,8 @@ impl RewritePattern for FuncCallIndirectPattern {
         let result_types = CallLike::call_result_types(&call, ctx).to_vec();
 
         let signature = if let Some(signature) = call.exact_signature(ctx) {
-            let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())
+            let Some(signature) =
+                convert_to_wasm_func_type(ctx, signature, rewriter.type_converter())
             else {
                 return false;
             };
@@ -366,7 +390,7 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         let Some(signature) = tail.exact_signature(ctx) else {
             return false;
         };
-        let Some(signature) = convert_function_type(ctx, signature, rewriter.type_converter())
+        let Some(signature) = convert_to_wasm_func_type(ctx, signature, rewriter.type_converter())
         else {
             return false;
         };
@@ -551,7 +575,7 @@ mod tests {
 
         let output = print_module(&ctx, module.op());
         assert!(
-            output.contains("!t0 = func.func_sig<(core.i32) -> core.i32>")
+            output.contains("!t0 = wasm.func_sig<(core.i32) -> core.i32>")
                 && output.contains("wasm.func {custom = 7, sym_name = @external, type = !t0}"),
             "{output}"
         );
@@ -624,7 +648,7 @@ mod tests {
         );
         assert!(output.contains(" = wasm.call_indirect "), "{output}");
         assert!(
-            output.contains("!t0 = func.func_sig<(core.i32) -> core.nil>")
+            output.contains("!t0 = wasm.func_sig<(core.i32) -> core.nil>")
                 && output.contains("signature = !t0"),
             "{output}"
         );
@@ -648,7 +672,7 @@ mod tests {
         let output = print_module(&ctx, module.op());
         assert!(
             output.contains(
-                "wasm.call_indirect %0 {signature = func.func_sig<() -> core.nil>, table = 0, type_idx = 0}"
+                "wasm.call_indirect %0 {signature = wasm.func_sig<() -> core.nil>, table = 0, type_idx = 0}"
             ),
             "{output}"
         );
@@ -721,12 +745,12 @@ mod tests {
         let output = print_module(&ctx, module.op());
         assert!(
             output.contains(
-                "wasm.return_call_indirect %0, %1 {signature = func.func_sig<(wasm.anyref) -> core.nil>"
+                "wasm.return_call_indirect %0, %1 {signature = wasm.func_sig<(wasm.anyref) -> core.nil>"
             ),
             "{output}"
         );
         assert!(
-            output.contains("wasm.return_call_indirect %0, %1 {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, tribute.calling_convention = 2, type_idx = 0}"),
+            output.contains("wasm.return_call_indirect %0, %1 {signature = wasm.func_sig<(wasm.anyref) -> core.nil>, table = 0, tribute.calling_convention = 2, type_idx = 0}"),
             "the converted transfer must retain its calling convention: {output}"
         );
         assert!(
@@ -782,7 +806,7 @@ mod tests {
         let output = print_module(&ctx, module.op());
         assert!(
             output.contains(
-                "wasm.call_indirect %0, %1 {signature = func.func_sig<(wasm.anyref) -> core.i32>, table = 0, type_idx = 0}"
+                "wasm.call_indirect %0, %1 {signature = wasm.func_sig<(wasm.anyref) -> core.i32>, table = 0, type_idx = 0}"
             ),
             "{output}"
         );

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -16,6 +16,7 @@
 //! - Generates `wasm.table` and `wasm.elem` operations
 
 use std::collections::HashMap;
+use std::ops::ControlFlow;
 
 use trunk_ir::Symbol;
 use trunk_ir::context::{IrContext, OperationDataBuilder};
@@ -28,6 +29,7 @@ use trunk_ir::rewrite::{
     Module, PatternApplicator, PatternRewriter, RewritePattern, TypeConverter, clone_attrs_except,
 };
 use trunk_ir::types::{Attribute, TypeDataBuilder};
+use trunk_ir::walk::{WalkAction, walk_op};
 use trunk_ir::{BlockData, RegionData};
 
 use trunk_ir::smallvec::smallvec;
@@ -37,6 +39,8 @@ use trunk_ir::smallvec::smallvec;
 /// The `type_converter` parameter allows language-specific backends to provide
 /// their own type conversion rules.
 pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter) {
+    materialize_nested_callable_value_types(ctx, module, &type_converter);
+
     // 1. Collect all functions referenced by func.constant operations
     let func_refs = collect_func_constant_refs(ctx, module);
 
@@ -85,6 +89,74 @@ pub fn lower(ctx: &mut IrContext, module: Module, type_converter: TypeConverter)
 
     // 4. Add wasm.table and wasm.elem to the module
     add_function_table(ctx, module, &sorted_funcs, table_size);
+}
+
+/// The outer function signature is not the only type-bearing surface of a
+/// callable value. Before rewriting operations, materialize nested callable
+/// types consistently on block arguments, produced values, and attributes so
+/// a `func.func_sig` value can cross the boundary without leaving its body in
+/// the shared type system.
+fn materialize_nested_callable_value_types(
+    ctx: &mut IrContext,
+    module: Module,
+    converter: &TypeConverter,
+) {
+    let mut ops = Vec::new();
+    let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
+        ops.push(op);
+        ControlFlow::Continue(WalkAction::Advance)
+    });
+    for op in ops {
+        let result_types = ctx.op_result_types(op).to_vec();
+        for (index, ty) in result_types.into_iter().enumerate() {
+            let Some(converted) = convert_nested_callable_type(ctx, ty, converter) else {
+                continue;
+            };
+            if converted != ty {
+                ctx.set_op_result_type(op, index as u32, converted);
+            }
+        }
+
+        let attributes = ctx.op(op).attributes.clone();
+        let is_func = func::Func::matches(ctx, op);
+        let is_indirect =
+            func::CallIndirect::matches(ctx, op) || func::TailCallIndirect::matches(ctx, op);
+        let converted_attributes =
+            convert_nested_callable_attributes(ctx, &attributes, converter, |key| {
+                (key == Symbol::new("type") && is_func)
+                    || (key == Symbol::new("signature") && is_indirect)
+            });
+        if let Some(converted_attributes) = converted_attributes
+            && converted_attributes != attributes
+        {
+            ctx.op_mut(op).attributes = converted_attributes;
+        }
+
+        let regions = ctx.op(op).regions.to_vec();
+        for region in regions {
+            let blocks = ctx.region(region).blocks.to_vec();
+            for block in blocks {
+                let arguments = ctx.block_args(block).to_vec();
+                for (index, argument) in arguments.into_iter().enumerate() {
+                    let ty = ctx.value_ty(argument);
+                    let Some(converted) = convert_nested_callable_type(ctx, ty, converter) else {
+                        continue;
+                    };
+                    if converted != ty {
+                        ctx.set_block_arg_type(block, index as u32, converted);
+                    }
+                    let attributes = ctx.block(block).args[index].attrs.clone();
+                    let converted_attributes =
+                        convert_nested_callable_attributes(ctx, &attributes, converter, |_| false);
+                    if let Some(converted_attributes) = converted_attributes
+                        && converted_attributes != attributes
+                    {
+                        ctx.block_mut(block).args[index].attrs = converted_attributes;
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Collect all function symbols referenced by func.constant operations.
@@ -249,6 +321,27 @@ fn convert_nested_callable_attribute(
         )),
         other => Some(other.clone()),
     }
+}
+
+fn convert_nested_callable_attributes(
+    ctx: &mut IrContext,
+    attributes: &trunk_ir::AttributeMap,
+    converter: &TypeConverter,
+    skip: impl Fn(Symbol) -> bool,
+) -> Option<trunk_ir::AttributeMap> {
+    attributes
+        .iter()
+        .map(|(key, value)| {
+            Some((
+                *key,
+                if skip(*key) {
+                    value.clone()
+                } else {
+                    convert_nested_callable_attribute(ctx, value, converter)?
+                },
+            ))
+        })
+        .collect()
 }
 
 /// Recursively materialize target types, including shared callable values and
@@ -682,33 +775,39 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @main() -> core.nil { func.return }
+  func.func @identity(%f: func.func_sig<() -> core.nil>) -> func.func_sig<() -> core.nil> {
+    func.return %f
+  }
+  func.func @caller(%f: func.func_sig<() -> core.nil>) -> func.func_sig<() -> core.nil> {
+    %result = func.call %f {callee = @identity} : func.func_sig<() -> core.nil>
+    func.return %result
+  }
 }"#,
         );
         let function = module.ops(&ctx)[0];
-        let nil = ctx
+        let original = ctx
             .op(function)
             .attributes
             .get_type("type")
             .and_then(|ty| func::FuncSig::from_type_ref(&ctx, ty))
-            .unwrap()
-            .results(&ctx)[0];
-        let nested = func::func_sig(&mut ctx, [], [nil]).as_type_ref();
-        let nested_container = ctx.types.intern(
-            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("array"))
-                .param(nested)
-                .build(),
-        );
+            .unwrap();
+        let inputs = original.inputs(&ctx).to_vec();
+        let results = original.results(&ctx).to_vec();
+        let nested = inputs[0];
         let mut attrs = trunk_ir::AttributeMap::new();
         attrs.insert(
             Symbol::new("metadata"),
             Attribute::List(vec![Attribute::Type(nested)]),
         );
-        let outer =
-            func::func_sig_with_attrs(&mut ctx, [nested_container], [nested], attrs).as_type_ref();
+        let outer = func::func_sig_with_attrs(&mut ctx, inputs, results, attrs).as_type_ref();
         ctx.op_mut(function)
             .attributes
             .insert(Symbol::new("type"), Attribute::Type(outer));
+        let original_body = ctx.op(function).regions[0];
+        let original_block = ctx.region(original_body).blocks[0];
+        ctx.block_mut(original_block).args[0]
+            .attrs
+            .insert(Symbol::new("metadata"), Attribute::Type(nested));
 
         lower(&mut ctx, module, TypeConverter::new());
 
@@ -717,9 +816,14 @@ mod tests {
             .unwrap()
             .r#type(&ctx);
         let signature = wasm_dialect::FuncSig::from_type_ref(&ctx, signature).unwrap();
-        let nested_input = ctx.types.get(signature.inputs(&ctx)[0]).params[0];
+        let nested_input = signature.inputs(&ctx)[0];
         assert!(wasm_dialect::FuncSig::from_type_ref(&ctx, nested_input).is_some());
         assert!(wasm_dialect::FuncSig::from_type_ref(&ctx, signature.results(&ctx)[0]).is_some());
+        let body = ctx.op(lowered).regions[0];
+        let block = ctx.region(body).blocks[0];
+        assert_eq!(ctx.value_ty(ctx.block_args(block)[0]), nested_input);
+        let block_metadata = ctx.block(block).args[0].attrs.get_type("metadata").unwrap();
+        assert!(wasm_dialect::FuncSig::from_type_ref(&ctx, block_metadata).is_some());
         let metadata = signature
             .non_reserved_attrs(&ctx)
             .find_map(|(key, value)| (*key == Symbol::new("metadata")).then_some(value))
@@ -731,6 +835,9 @@ mod tests {
             panic!("nested metadata must remain a type")
         };
         assert!(wasm_dialect::FuncSig::from_type_ref(&ctx, *nested_attribute).is_some());
+        crate::validate_wasm_ir(&ctx, module).expect("nested callable identity must validate");
+        crate::emit_module_to_wasm(&mut ctx, module)
+            .expect("nested callable identity and call must emit");
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/passes/mod.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/mod.rs
@@ -6,4 +6,5 @@ pub mod adt_to_wasm;
 pub mod arith_to_wasm;
 pub mod func_to_wasm;
 pub mod scf_to_wasm;
+pub mod signature_conversion;
 pub mod wasm_gc_to_wasm;

--- a/crates/trunk-ir-wasm-backend/src/passes/signature_conversion.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/signature_conversion.rs
@@ -162,8 +162,8 @@ mod tests {
     }
 
     #[test]
-    fn converts_wasm_zero_and_multiple_results_with_nested_metadata() {
-        for results in [0, 2] {
+    fn converts_wasm_results_inputs_and_metadata() {
+        for results in [0, 1, 2] {
             let (mut ctx, loc) = test_ctx();
             let i32 = type_ref(&mut ctx, "i32");
             let i64 = type_ref(&mut ctx, "i64");
@@ -179,12 +179,20 @@ mod tests {
             attrs.insert(Symbol::new("tag"), Attribute::Symbol(Symbol::new("keep")));
             let signature = wasm::func_sig_with_attrs(
                 &mut ctx,
-                [i32],
-                (results == 2).then_some(vec![i32, ptr]).unwrap_or_default(),
+                [i32, ptr],
+                match results {
+                    0 => vec![],
+                    1 => vec![i32],
+                    2 => vec![i32, ptr],
+                    _ => unreachable!(),
+                },
                 attrs,
             )
             .as_type_ref();
-            let func = make_wasm_func(&mut ctx, loc, "f", signature, &[i32]);
+            let func = make_wasm_func(&mut ctx, loc, "f", signature, &[i32, ptr]);
+            ctx.op_mut(func)
+                .attributes
+                .insert(Symbol::new("custom"), Attribute::Int(7));
             let module = make_module(&mut ctx, loc, vec![func]);
 
             let result = PatternApplicator::new(i32_to_i64(i32, i64))
@@ -195,10 +203,15 @@ mod tests {
             assert!(result.reached_fixpoint);
             let function = wasm::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
             let signature = wasm::FuncSig::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
-            assert_eq!(signature.inputs(&ctx), [i64]);
+            assert_eq!(signature.inputs(&ctx), [i64, ptr]);
             assert_eq!(
                 signature.results(&ctx),
-                (results == 2).then_some(vec![i64, ptr]).unwrap_or_default()
+                match results {
+                    0 => vec![],
+                    1 => vec![i64],
+                    2 => vec![i64, ptr],
+                    _ => unreachable!(),
+                }
             );
             let attrs = signature
                 .non_reserved_attrs(&ctx)
@@ -213,6 +226,13 @@ mod tests {
             );
             assert_eq!(attrs.get_symbol("tag"), Some(Symbol::new("keep")),);
             assert_eq!(ctx.types.get(function.r#type(&ctx)).attrs.len(), 4);
+            assert_eq!(
+                ctx.op(module.ops(&ctx)[0]).attributes.get("custom"),
+                Some(&Attribute::Int(7))
+            );
+            let entry = ctx.region(function.body(&ctx)).blocks[0];
+            assert_eq!(ctx.value_ty(ctx.block_arg(entry, 0)), i64);
+            assert_eq!(ctx.value_ty(ctx.block_arg(entry, 1)), ptr);
         }
     }
 
@@ -221,11 +241,27 @@ mod tests {
         let (mut ctx, loc) = test_ctx();
         let i32 = type_ref(&mut ctx, "i32");
         let i64 = type_ref(&mut ctx, "i64");
-        let changed = wasm::func_sig(&mut ctx, [i32], [i32, i32]).as_type_ref();
         let unchanged = wasm::func_sig(&mut ctx, [i64], []).as_type_ref();
-        let declaration = make_bodyless_wasm_func(&mut ctx, loc, Symbol::new("extern"), changed);
+        let declarations: Vec<OpRef> = [vec![], vec![i32], vec![i32, i32]]
+            .into_iter()
+            .enumerate()
+            .map(|(index, results)| {
+                let signature = wasm::func_sig(&mut ctx, [i32], results).as_type_ref();
+                let name = match index {
+                    0 => "extern_zero",
+                    1 => "extern_one",
+                    2 => "extern_many",
+                    _ => unreachable!(),
+                };
+                make_bodyless_wasm_func(&mut ctx, loc, Symbol::new(name), signature)
+            })
+            .collect();
         let unchanged_func = make_wasm_func(&mut ctx, loc, "unchanged", unchanged, &[i64]);
-        let module = make_module(&mut ctx, loc, vec![declaration, unchanged_func]);
+        let module = make_module(
+            &mut ctx,
+            loc,
+            declarations.into_iter().chain([unchanged_func]).collect(),
+        );
 
         let result = PatternApplicator::new(i32_to_i64(i32, i64))
             .add_pattern(WasmFuncSignatureConversionPattern)
@@ -234,17 +270,21 @@ mod tests {
             .unwrap();
         assert!(result.reached_fixpoint);
         let ops = module.ops(&ctx);
-        assert!(ctx.op(ops[0]).regions.is_empty());
-        let converted =
-            wasm::FuncSig::from_type_ref(&ctx, ctx.op(ops[0]).attributes.get_type("type").unwrap())
-                .unwrap();
-        assert_eq!(converted.inputs(&ctx), [i64]);
-        assert_eq!(converted.results(&ctx), [i64, i64]);
+        for (op, results) in ops.iter().take(3).zip([vec![], vec![i64], vec![i64, i64]]) {
+            assert!(ctx.op(*op).regions.is_empty());
+            let converted = wasm::FuncSig::from_type_ref(
+                &ctx,
+                ctx.op(*op).attributes.get_type("type").unwrap(),
+            )
+            .unwrap();
+            assert_eq!(converted.inputs(&ctx), [i64]);
+            assert_eq!(converted.results(&ctx), results);
+        }
         assert_eq!(
-            wasm::Func::from_op(&ctx, ops[1]).unwrap().r#type(&ctx),
+            wasm::Func::from_op(&ctx, ops[3]).unwrap().r#type(&ctx),
             unchanged
         );
-        assert_eq!(result.total_changes, 1);
+        assert_eq!(result.total_changes, 3);
     }
 
     #[test]

--- a/crates/trunk-ir-wasm-backend/src/passes/signature_conversion.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/signature_conversion.rs
@@ -1,0 +1,297 @@
+//! Wasm-owned callable signature conversion.
+
+use trunk_ir::context::{IrContext, OperationDataBuilder};
+use trunk_ir::dialect::wasm;
+use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::refs::{OpRef, TypeRef};
+use trunk_ir::rewrite::{
+    PatternRewriter, RewritePattern, convert_signature_components, rewrite_function_signature,
+};
+use trunk_ir::types::Attribute;
+
+/// Converts validated `wasm.func` signatures through a `TypeConverter`.
+pub struct WasmFuncSignatureConversionPattern;
+
+impl RewritePattern for WasmFuncSignatureConversionPattern {
+    fn match_and_rewrite(
+        &self,
+        ctx: &mut IrContext,
+        op: OpRef,
+        rewriter: &mut PatternRewriter<'_>,
+    ) -> bool {
+        let Ok(wasm_func) = wasm::Func::from_op(ctx, op) else {
+            return false;
+        };
+        let func_type = wasm_func.r#type(ctx);
+        let Some(signature) = wasm::FuncSig::from_type_ref(ctx, func_type) else {
+            return false;
+        };
+        let converted = convert_signature_components(
+            ctx,
+            rewriter.type_converter(),
+            signature.inputs(ctx),
+            signature.results(ctx),
+            signature.non_reserved_attrs(ctx),
+        );
+        if !converted.changed {
+            return false;
+        }
+        let new_func_type = wasm::func_sig_with_attrs(
+            ctx,
+            converted.inputs.iter().copied(),
+            converted.results.iter().copied(),
+            converted.attrs,
+        )
+        .as_type_ref();
+        let body = ctx.op(op).regions.first().copied();
+        let sym_name = wasm_func.sym_name(ctx);
+        let loc = ctx.op(op).location;
+
+        rewrite_function_signature(
+            ctx,
+            op,
+            rewriter,
+            body,
+            new_func_type,
+            &converted.inputs,
+            |ctx, ty, body| match body {
+                Some(body) => wasm::func(ctx, loc, sym_name, ty, body).op_ref(),
+                None => make_bodyless_wasm_func(ctx, loc, sym_name, ty),
+            },
+        )
+    }
+
+    fn name(&self) -> &'static str {
+        "WasmFuncSignatureConversionPattern"
+    }
+}
+
+fn make_bodyless_wasm_func(
+    ctx: &mut IrContext,
+    loc: trunk_ir::types::Location,
+    sym_name: trunk_ir::Symbol,
+    func_type: TypeRef,
+) -> OpRef {
+    let data = OperationDataBuilder::new(
+        loc,
+        trunk_ir::Symbol::new("wasm"),
+        trunk_ir::Symbol::new("func"),
+    )
+    .attr("sym_name", Attribute::Symbol(sym_name))
+    .attr("type", Attribute::Type(func_type))
+    .build(ctx);
+    ctx.create_op(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::Symbol;
+    use trunk_ir::context::{BlockArgData, BlockData, RegionData};
+    use trunk_ir::location::Span;
+    use trunk_ir::rewrite::{ConversionTarget, Module, PatternApplicator, TypeConverter};
+    use trunk_ir::smallvec::smallvec;
+    use trunk_ir::types::TypeDataBuilder;
+
+    fn test_ctx() -> (IrContext, trunk_ir::types::Location) {
+        let mut ctx = IrContext::new();
+        let path = ctx.paths.intern("test.trb".to_owned());
+        let loc = trunk_ir::types::Location::new(path, Span::new(0, 0));
+        (ctx, loc)
+    }
+
+    fn type_ref(ctx: &mut IrContext, name: &'static str) -> TypeRef {
+        ctx.types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new(name)).build())
+    }
+
+    fn make_module(ctx: &mut IrContext, loc: trunk_ir::types::Location, ops: Vec<OpRef>) -> Module {
+        let block = ctx.create_block(BlockData {
+            location: loc,
+            args: vec![],
+            ops: smallvec![],
+            parent_region: None,
+        });
+        for op in ops {
+            ctx.push_op(block, op);
+        }
+        let region = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![block],
+            parent_op: None,
+        });
+        let module = OperationDataBuilder::new(loc, Symbol::new("core"), Symbol::new("module"))
+            .attr("sym_name", Attribute::Symbol(Symbol::new("test")))
+            .region(region)
+            .build(ctx);
+        let module = ctx.create_op(module);
+        Module::new(ctx, module).unwrap()
+    }
+
+    fn make_wasm_func(
+        ctx: &mut IrContext,
+        loc: trunk_ir::types::Location,
+        name: &'static str,
+        signature: TypeRef,
+        inputs: &[TypeRef],
+    ) -> OpRef {
+        let entry = ctx.create_block(BlockData {
+            location: loc,
+            args: inputs
+                .iter()
+                .map(|&ty| BlockArgData {
+                    ty,
+                    attrs: Default::default(),
+                })
+                .collect(),
+            ops: smallvec![],
+            parent_region: None,
+        });
+        let body = ctx.create_region(RegionData {
+            location: loc,
+            blocks: smallvec![entry],
+            parent_op: None,
+        });
+        wasm::func(ctx, loc, Symbol::new(name), signature, body).op_ref()
+    }
+
+    fn i32_to_i64(i32: TypeRef, i64: TypeRef) -> TypeConverter {
+        let mut converter = TypeConverter::new();
+        converter.add_conversion(move |_, ty| (ty == i32).then_some(i64));
+        converter
+    }
+
+    #[test]
+    fn converts_wasm_zero_and_multiple_results_with_nested_metadata() {
+        for results in [0, 2] {
+            let (mut ctx, loc) = test_ctx();
+            let i32 = type_ref(&mut ctx, "i32");
+            let i64 = type_ref(&mut ctx, "i64");
+            let ptr = type_ref(&mut ctx, "ptr");
+            let mut attrs = trunk_ir::AttributeMap::new();
+            attrs.insert(
+                Symbol::new("nested"),
+                Attribute::List(vec![
+                    Attribute::Type(i32),
+                    Attribute::List(vec![Attribute::Type(i32)]),
+                ]),
+            );
+            attrs.insert(Symbol::new("tag"), Attribute::Symbol(Symbol::new("keep")));
+            let signature = wasm::func_sig_with_attrs(
+                &mut ctx,
+                [i32],
+                (results == 2).then_some(vec![i32, ptr]).unwrap_or_default(),
+                attrs,
+            )
+            .as_type_ref();
+            let func = make_wasm_func(&mut ctx, loc, "f", signature, &[i32]);
+            let module = make_module(&mut ctx, loc, vec![func]);
+
+            let result = PatternApplicator::new(i32_to_i64(i32, i64))
+                .add_pattern(WasmFuncSignatureConversionPattern)
+                .with_target(ConversionTarget::new())
+                .apply_partial_conversion(&mut ctx, module, "wasm-test")
+                .unwrap();
+            assert!(result.reached_fixpoint);
+            let function = wasm::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+            let signature = wasm::FuncSig::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
+            assert_eq!(signature.inputs(&ctx), [i64]);
+            assert_eq!(
+                signature.results(&ctx),
+                (results == 2).then_some(vec![i64, ptr]).unwrap_or_default()
+            );
+            let attrs = signature
+                .non_reserved_attrs(&ctx)
+                .map(|(key, value)| (*key, value.clone()))
+                .collect::<trunk_ir::AttributeMap>();
+            assert_eq!(
+                attrs.get("nested"),
+                Some(&Attribute::List(vec![
+                    Attribute::Type(i64),
+                    Attribute::List(vec![Attribute::Type(i64)]),
+                ])),
+            );
+            assert_eq!(attrs.get_symbol("tag"), Some(Symbol::new("keep")),);
+            assert_eq!(ctx.types.get(function.r#type(&ctx)).attrs.len(), 4);
+        }
+    }
+
+    #[test]
+    fn preserves_bodyless_declarations_and_avoids_noop_rewrites() {
+        let (mut ctx, loc) = test_ctx();
+        let i32 = type_ref(&mut ctx, "i32");
+        let i64 = type_ref(&mut ctx, "i64");
+        let changed = wasm::func_sig(&mut ctx, [i32], [i32, i32]).as_type_ref();
+        let unchanged = wasm::func_sig(&mut ctx, [i64], []).as_type_ref();
+        let declaration = make_bodyless_wasm_func(&mut ctx, loc, Symbol::new("extern"), changed);
+        let unchanged_func = make_wasm_func(&mut ctx, loc, "unchanged", unchanged, &[i64]);
+        let module = make_module(&mut ctx, loc, vec![declaration, unchanged_func]);
+
+        let result = PatternApplicator::new(i32_to_i64(i32, i64))
+            .add_pattern(WasmFuncSignatureConversionPattern)
+            .with_target(ConversionTarget::new())
+            .apply_partial_conversion(&mut ctx, module, "wasm-test")
+            .unwrap();
+        assert!(result.reached_fixpoint);
+        let ops = module.ops(&ctx);
+        assert!(ctx.op(ops[0]).regions.is_empty());
+        let converted =
+            wasm::FuncSig::from_type_ref(&ctx, ctx.op(ops[0]).attributes.get_type("type").unwrap())
+                .unwrap();
+        assert_eq!(converted.inputs(&ctx), [i64]);
+        assert_eq!(converted.results(&ctx), [i64, i64]);
+        assert_eq!(
+            wasm::Func::from_op(&ctx, ops[1]).unwrap().r#type(&ctx),
+            unchanged
+        );
+        assert_eq!(result.total_changes, 1);
+    }
+
+    #[test]
+    fn rejects_entry_arity_mismatch_without_mutating() {
+        let (mut ctx, loc) = test_ctx();
+        let i32 = type_ref(&mut ctx, "i32");
+        let i64 = type_ref(&mut ctx, "i64");
+        let signature = wasm::func_sig(&mut ctx, [i32, i32], []).as_type_ref();
+        let func = make_wasm_func(&mut ctx, loc, "bad", signature, &[i32]);
+        let module = make_module(&mut ctx, loc, vec![func]);
+        let before = trunk_ir::printer::print_module(&ctx, module.op());
+
+        let result = PatternApplicator::new(i32_to_i64(i32, i64))
+            .add_pattern(WasmFuncSignatureConversionPattern)
+            .with_target(ConversionTarget::new())
+            .apply_partial_conversion(&mut ctx, module, "wasm-test")
+            .unwrap();
+        assert!(result.reached_fixpoint);
+        let function = wasm::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        assert_eq!(function.r#type(&ctx), signature);
+        let entry = ctx.region(function.body(&ctx)).blocks[0];
+        assert_eq!(ctx.value_ty(ctx.block_arg(entry, 0)), i32);
+        assert_eq!(trunk_ir::printer::print_module(&ctx, module.op()), before);
+    }
+
+    #[test]
+    fn rejects_malformed_wasm_signature_without_mutating() {
+        let (mut ctx, loc) = test_ctx();
+        let i32 = type_ref(&mut ctx, "i32");
+        let i64 = type_ref(&mut ctx, "i64");
+        let malformed = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("wasm"), Symbol::new("func_sig")).build());
+        let func = make_bodyless_wasm_func(&mut ctx, loc, Symbol::new("bad"), malformed);
+        let module = make_module(&mut ctx, loc, vec![func]);
+        let before = trunk_ir::printer::print_module(&ctx, module.op());
+
+        let result = PatternApplicator::new(i32_to_i64(i32, i64))
+            .add_pattern(WasmFuncSignatureConversionPattern)
+            .with_target(ConversionTarget::new())
+            .apply_partial_conversion(&mut ctx, module, "wasm-test")
+            .unwrap();
+        assert!(result.reached_fixpoint);
+        assert_eq!(
+            ctx.op(module.ops(&ctx)[0]).attributes.get_type("type"),
+            Some(malformed)
+        );
+        assert_eq!(trunk_ir::printer::print_module(&ctx, module.op()), before);
+    }
+}

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -149,7 +149,7 @@ mod tests {
     wasm.return_call_indirect %table_index, %value {signature = core.i32, table = 0, type_idx = 0}
   }
 }"#,
-            "signature must be func.func_sig",
+            "signature must be wasm.func_sig",
         );
 
         rejects(

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -141,22 +141,45 @@ fn is_nil(ctx: &IrContext, ty: TypeRef) -> bool {
     data.dialect == Symbol::new("core") && data.name == Symbol::new("nil")
 }
 
-/// `core.nil` occupies a logical result slot but has no physical Wasm value;
-/// every non-nil result must remain in its original order and type.
-fn result_list_matches(ctx: &IrContext, actual: &[TypeRef], expected: &[TypeRef]) -> bool {
-    let expected = if actual.len() == expected.len() {
-        expected.to_vec()
-    } else {
-        expected
-            .iter()
-            .copied()
-            .filter(|&result| !is_nil(ctx, result))
-            .collect()
-    };
-    actual.len() == expected.len()
-        && actual.iter().zip(expected).all(|(&actual, expected)| {
-            crate::emit::helpers::is_wasm_physical_argument_assignable(ctx, actual, expected)
+/// `core.nil` occupies a logical result slot but has no physical Wasm value.
+/// The first list produces values consumed by the second, so assignability is
+/// directional: a value may be widened but never narrowed.
+fn result_list_matches(ctx: &IrContext, produced: &[TypeRef], received: &[TypeRef]) -> bool {
+    let produced = produced
+        .iter()
+        .copied()
+        .filter(|&result| !is_nil(ctx, result))
+        .collect::<Vec<_>>();
+    let received = received
+        .iter()
+        .copied()
+        .filter(|&result| !is_nil(ctx, result))
+        .collect::<Vec<_>>();
+    produced.len() == received.len()
+        && produced.iter().zip(received).all(|(&produced, received)| {
+            is_wasm_physical_result_assignable(ctx, produced, received)
         })
+}
+
+/// `core.array` is emitted as the same abstract array reference as
+/// `wasm.arrayref`; accepting that physical equivalence here does not permit
+/// a reference downcast such as `wasm.anyref -> wasm.structref`.
+fn is_wasm_physical_result_assignable(
+    ctx: &IrContext,
+    produced: TypeRef,
+    received: TypeRef,
+) -> bool {
+    let produced_data = ctx.types.get(produced);
+    let received_data = ctx.types.get(received);
+    (produced_data.dialect == Symbol::new("wasm")
+        && produced_data.name == Symbol::new("arrayref")
+        && received_data.dialect == Symbol::new("core")
+        && received_data.name == Symbol::new("array"))
+        || (produced_data.dialect == Symbol::new("core")
+            && produced_data.name == Symbol::new("i32")
+            && received_data.dialect == Symbol::new("core")
+            && received_data.name == Symbol::new("i1"))
+        || crate::emit::helpers::is_wasm_physical_argument_assignable(ctx, produced, received)
 }
 
 fn check_value_types(
@@ -217,6 +240,10 @@ fn validate_direct_callable_contracts(ctx: &IrContext, op: OpRef, errors: &mut V
         return;
     }
     let Some(callee) = ctx.op(op).attributes.get_symbol("callee") else {
+        errors.push(format!(
+            "wasm.{} requires a symbol callee attribute",
+            ctx.op(op).name
+        ));
         return;
     };
     let Some(resolved) = resolve_wasm_callee(ctx, op, callee) else {
@@ -266,8 +293,22 @@ fn validate_direct_callable_contracts(ctx: &IrContext, op: OpRef, errors: &mut V
         if caller.results(ctx) != signature.results(ctx) {
             errors.push("wasm.return_call tail caller/callee result lists differ".into());
         }
-    } else if !result_list_matches(ctx, ctx.op_result_types(op), signature.results(ctx)) {
-        errors.push("wasm.call result list mismatch".into());
+    } else if !result_list_matches(ctx, signature.results(ctx), ctx.op_result_types(op)) {
+        let format_types = |types: &[TypeRef]| {
+            types
+                .iter()
+                .map(|&ty| {
+                    let data = ctx.types.get(ty);
+                    format!("{}.{}", data.dialect, data.name)
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        errors.push(format!(
+            "wasm.call result list mismatch: callee produces [{}], call declares [{}]",
+            format_types(signature.results(ctx)),
+            format_types(ctx.op_result_types(op))
+        ));
     }
 }
 
@@ -279,6 +320,25 @@ fn validate_return_call_indirect(ctx: &IrContext, op: OpRef, errors: &mut Vec<St
     }
     if let Err(error) = crate::emit::helpers::exact_return_call_indirect_signature(ctx, op) {
         errors.push(error.to_string());
+        return;
+    }
+    let Some(caller) = enclosing_wasm_func_signature(ctx, op) else {
+        errors.push(
+            "wasm.return_call_indirect requires a valid enclosing wasm.func signature".into(),
+        );
+        return;
+    };
+    let Some(signature) = ctx
+        .op(op)
+        .attributes
+        .get_type("signature")
+        .and_then(|ty| wasm_dialect::FuncSig::from_type_ref(ctx, ty))
+    else {
+        // The exact helper above already produced the local diagnostic.
+        return;
+    };
+    if caller.results(ctx) != signature.results(ctx) {
+        errors.push("wasm.return_call_indirect tail caller/callee result lists differ".into());
     }
 }
 
@@ -483,6 +543,58 @@ mod tests {
     }
 
     #[test]
+    fn rejects_direct_result_narrowing_and_missing_callee_contracts() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @source() -> wasm.anyref {
+    %value = wasm.nop : wasm.anyref
+    wasm.return %value
+  }
+  wasm.func @caller() -> wasm.structref {
+    %value = wasm.call {callee = @source} : wasm.structref
+    wasm.return %value
+  }
+}"#,
+        );
+        let error = validate_wasm_ir(&ctx, module).expect_err("anyref cannot narrow to structref");
+        assert!(
+            error.to_string().contains("wasm.call result list mismatch"),
+            "{error}"
+        );
+        let Err(error) = crate::emit_module_to_wasm(&mut ctx, module) else {
+            panic!("the invalid direct result must not reach binary emission")
+        };
+        assert!(
+            error.to_string().contains("wasm.call result list mismatch"),
+            "{error}"
+        );
+
+        for callee in ["", " {callee = 0}"] {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    "core.module @test {{
+  wasm.func @caller() -> core.nil {{
+    wasm.call{callee}
+    wasm.return
+  }}
+}}"
+                ),
+            );
+            let error = validate_wasm_ir(&ctx, module).expect_err("callee must be a symbol");
+            assert!(
+                error
+                    .to_string()
+                    .contains("wasm.call requires a symbol callee attribute"),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
     fn resolves_tail_call_against_the_nearest_module_owner() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
@@ -503,6 +615,28 @@ mod tests {
             error
                 .to_string()
                 .contains("wasm.return_call tail caller/callee result lists differ"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn rejects_return_call_indirect_with_a_mismatched_enclosing_result_list() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @outer {
+  core.module @inner {
+    wasm.func @caller(%index: core.i32) -> core.i32 {
+      wasm.return_call_indirect %index {signature = wasm.func_sig<() -> core.nil>, table = 0, type_idx = 0}
+    }
+  }
+}"#,
+        );
+        let error = validate_wasm_ir(&ctx, module).expect_err("tail result mismatch");
+        assert!(
+            error
+                .to_string()
+                .contains("wasm.return_call_indirect tail caller/callee result lists differ"),
             "{error}"
         );
     }

--- a/crates/trunk-ir-wasm-backend/src/validation.rs
+++ b/crates/trunk-ir-wasm-backend/src/validation.rs
@@ -8,9 +8,10 @@
 use trunk_ir::IrContext;
 use trunk_ir::Module;
 use trunk_ir::Symbol;
+use trunk_ir::dialect::core;
 use trunk_ir::dialect::wasm as wasm_dialect;
-use trunk_ir::ops::DialectOp;
-use trunk_ir::refs::{OpRef, RegionRef};
+use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
 
 use crate::{CompilationError, CompilationResult};
 
@@ -72,10 +73,201 @@ fn validate_operation(ctx: &IrContext, op: OpRef, depth: usize, errors: &mut Vec
         errors.push(format!("Non-wasm operation found: {}.{}", dialect, name));
     }
     validate_return_call_indirect(ctx, op, errors);
+    validate_direct_callable_contracts(ctx, op, errors);
 
     // Recursively validate nested regions
     for &region in &op_data.regions {
         validate_region(ctx, region, depth + 1, errors);
+    }
+}
+
+/// Find the nearest lexical `wasm.func` that owns `op`.
+fn enclosing_wasm_func_signature(ctx: &IrContext, mut op: OpRef) -> Option<wasm_dialect::FuncSig> {
+    loop {
+        let region = ctx.block(ctx.op(op).parent_block?).parent_region?;
+        let parent = ctx.region(region).parent_op?;
+        if wasm_dialect::Func::matches(ctx, parent) {
+            return ctx
+                .op(parent)
+                .attributes
+                .get_type("type")
+                .and_then(|ty| wasm_dialect::FuncSig::from_type_ref(ctx, ty));
+        }
+        op = parent;
+    }
+}
+
+/// Resolve a direct target from the nearest enclosing module outwards. A known
+/// malformed or ambiguous target returns `Some(None)` so it cannot be treated
+/// as an undeclared runtime import.
+fn resolve_wasm_callee(
+    ctx: &IrContext,
+    mut op: OpRef,
+    name: Symbol,
+) -> Option<Option<wasm_dialect::FuncSig>> {
+    loop {
+        let region = ctx.block(ctx.op(op).parent_block?).parent_region?;
+        let parent = ctx.region(region).parent_op?;
+        if core::Module::matches(ctx, parent) {
+            let mut matches = ctx
+                .region(region)
+                .blocks
+                .iter()
+                .flat_map(|&block| ctx.block(block).ops.iter().copied())
+                .filter(|&candidate| {
+                    ctx.op(candidate).attributes.get_symbol("sym_name") == Some(name)
+                });
+            if let Some(found) = matches.next() {
+                if matches.next().is_some()
+                    || (!wasm_dialect::Func::matches(ctx, found)
+                        && !wasm_dialect::ImportFunc::matches(ctx, found))
+                {
+                    return Some(None);
+                }
+                return Some(
+                    ctx.op(found)
+                        .attributes
+                        .get_type("type")
+                        .and_then(|ty| wasm_dialect::FuncSig::from_type_ref(ctx, ty)),
+                );
+            }
+        }
+        op = parent;
+    }
+}
+
+fn is_nil(ctx: &IrContext, ty: TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    data.dialect == Symbol::new("core") && data.name == Symbol::new("nil")
+}
+
+/// `core.nil` occupies a logical result slot but has no physical Wasm value;
+/// every non-nil result must remain in its original order and type.
+fn result_list_matches(ctx: &IrContext, actual: &[TypeRef], expected: &[TypeRef]) -> bool {
+    let expected = if actual.len() == expected.len() {
+        expected.to_vec()
+    } else {
+        expected
+            .iter()
+            .copied()
+            .filter(|&result| !is_nil(ctx, result))
+            .collect()
+    };
+    actual.len() == expected.len()
+        && actual.iter().zip(expected).all(|(&actual, expected)| {
+            crate::emit::helpers::is_wasm_physical_argument_assignable(ctx, actual, expected)
+        })
+}
+
+fn check_value_types(
+    ctx: &IrContext,
+    op: OpRef,
+    values: &[ValueRef],
+    expected: &[TypeRef],
+    role: &str,
+    errors: &mut Vec<String>,
+) {
+    if values.len() != expected.len() {
+        errors.push(format!(
+            "wasm.{} {role} count mismatch: expected {}, found {}",
+            ctx.op(op).name,
+            expected.len(),
+            values.len()
+        ));
+        return;
+    }
+    for (index, (&value, &ty)) in values.iter().zip(expected).enumerate() {
+        if ctx.value_ty(value) != ty {
+            errors.push(format!(
+                "wasm.{} {role} #{index} type mismatch",
+                ctx.op(op).name
+            ));
+        }
+    }
+}
+
+/// Validate direct calls and returns against the target-owned Wasm signature.
+/// This boundary is deliberately independent of binary validation: a malformed
+/// IR program must not be emitted just because a later section happens to have
+/// a compatible shape.
+fn validate_direct_callable_contracts(ctx: &IrContext, op: OpRef, errors: &mut Vec<String>) {
+    if wasm_dialect::Return::matches(ctx, op) {
+        let Some(caller) = enclosing_wasm_func_signature(ctx, op) else {
+            errors.push("wasm.return requires a valid enclosing wasm.func signature".into());
+            return;
+        };
+        let expected = caller.results(ctx);
+        let operands = ctx.op_operands(op);
+        if !result_list_matches(
+            ctx,
+            &operands
+                .iter()
+                .map(|&value| ctx.value_ty(value))
+                .collect::<Vec<_>>(),
+            expected,
+        ) {
+            check_value_types(ctx, op, operands, expected, "return", errors);
+        }
+        return;
+    }
+
+    let is_tail = wasm_dialect::ReturnCall::matches(ctx, op);
+    let is_direct = wasm_dialect::Call::matches(ctx, op) || is_tail;
+    if !is_direct {
+        return;
+    }
+    let Some(callee) = ctx.op(op).attributes.get_symbol("callee") else {
+        return;
+    };
+    let Some(resolved) = resolve_wasm_callee(ctx, op, callee) else {
+        return;
+    };
+    let Some(signature) = resolved else {
+        errors.push(format!(
+            "wasm.{} requires a uniquely resolved valid wasm.func_sig",
+            ctx.op(op).name
+        ));
+        return;
+    };
+    let operands = ctx.op_operands(op);
+    let inputs = signature.inputs(ctx);
+    if operands.len() != inputs.len() {
+        errors.push(format!(
+            "wasm.{} call argument count mismatch: expected {}, found {}",
+            ctx.op(op).name,
+            inputs.len(),
+            operands.len()
+        ));
+    } else {
+        for (index, (&operand, &input)) in operands.iter().zip(inputs).enumerate() {
+            if !crate::emit::helpers::is_wasm_physical_argument_assignable(
+                ctx,
+                ctx.value_ty(operand),
+                input,
+            ) {
+                let actual = ctx.types.get(ctx.value_ty(operand));
+                let expected = ctx.types.get(input);
+                errors.push(format!(
+                    "wasm.{} call argument #{index} type mismatch: found {}.{}, expected {}.{}",
+                    ctx.op(op).name,
+                    actual.dialect,
+                    actual.name,
+                    expected.dialect,
+                    expected.name
+                ));
+            }
+        }
+    }
+    if is_tail {
+        let Some(caller) = enclosing_wasm_func_signature(ctx, op) else {
+            errors.push("wasm.return_call requires a valid enclosing wasm.func signature".into());
+            return;
+        };
+        if caller.results(ctx) != signature.results(ctx) {
+            errors.push("wasm.return_call tail caller/callee result lists differ".into());
+        }
+    } else if !result_list_matches(ctx, ctx.op_result_types(op), signature.results(ctx)) {
+        errors.push("wasm.call result list mismatch".into());
     }
 }
 
@@ -155,7 +347,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.i32>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(core.i32) -> core.i32>, table = 0, type_idx = 0}
   }
 }"#,
             "must have an empty result",
@@ -164,7 +356,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller() -> core.nil {
-    wasm.return_call_indirect {signature = func.func_sig<() -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect {signature = wasm.func_sig<() -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
             "requires a table index operand",
@@ -173,7 +365,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i64, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
             "first operand must be an i32 table index",
@@ -182,7 +374,7 @@ mod tests {
         rejects(
             r#"core.module @test {
   wasm.func @caller(%table_index: core.i32, %value: core.i64) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
             "operands do not match its exact signature",
@@ -198,16 +390,16 @@ mod tests {
   !Array = core.array(core.i32)
   !Struct = adt.struct() {fields = [[@value, core.i32]], name = @Struct}
   wasm.func @typeref(%table_index: core.i32, %value: adt.typeref) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @struct(%table_index: core.i32, %value: !Struct) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @array(%table_index: core.i32, %value: !Array) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.arrayref) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(wasm.arrayref) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @i31(%table_index: core.i32, %value: wasm.i31ref) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(wasm.anyref) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
         );
@@ -225,7 +417,7 @@ mod tests {
             assert_rejects_tail_signature(&format!(
                 r#"core.module @test {{
   wasm.func @caller(%table_index: core.i32, %value: {value_ty}) -> core.nil {{
-    wasm.return_call_indirect %table_index, %value {{signature = func.func_sig<({parameter_ty}) -> core.nil>, table = 0, type_idx = 0}}
+    wasm.return_call_indirect %table_index, %value {{signature = wasm.func_sig<({parameter_ty}) -> core.nil>, table = 0, type_idx = 0}}
   }}
 }}"#
             ));
@@ -238,9 +430,80 @@ mod tests {
             r#"core.module @test {
   !Struct = adt.struct() {fields = [[@value, core.i32]], name = @Struct}
   wasm.func @caller(%table_index: core.i32, %value: !Struct) -> core.nil {
-    wasm.return_call_indirect %table_index, %value {signature = func.func_sig<(wasm.structref) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table_index, %value {signature = wasm.func_sig<(wasm.structref) -> core.nil>, table = 0, type_idx = 0}
   }
 }"#,
+        );
+    }
+
+    #[test]
+    fn validates_direct_call_and_return_result_contracts() {
+        let rejects = |source: &str, diagnostic: &str| {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, source);
+            let error = validate_wasm_ir(&ctx, module).expect_err("mismatched direct contract");
+            assert!(error.to_string().contains(diagnostic), "{error}");
+        };
+
+        rejects(
+            r#"core.module @test {
+  wasm.func @callee() -> core.i32 {
+    %value = wasm.i32_const {value = 1} : core.i32
+    wasm.return %value
+  }
+  wasm.func @caller() -> core.nil {
+    %value = wasm.call {callee = @callee} : core.i64
+    wasm.return
+  }
+}"#,
+            "wasm.call result list mismatch",
+        );
+        rejects(
+            r#"core.module @test {
+  wasm.func @caller() -> core.i32 {
+    %value = wasm.i64_const {value = 1} : core.i64
+    wasm.return %value
+  }
+}"#,
+            "wasm.return return #0 type mismatch",
+        );
+
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  wasm.func @unit() -> core.nil { wasm.return }
+  wasm.func @caller() -> core.nil {
+    wasm.call {callee = @unit}
+    wasm.return
+  }
+}"#,
+        );
+        validate_wasm_ir(&ctx, module).expect("Unit direct call and return omit a physical result");
+    }
+
+    #[test]
+    fn resolves_tail_call_against_the_nearest_module_owner() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @outer {
+  wasm.func @target() -> core.i32 {
+    %value = wasm.i32_const {value = 1} : core.i32
+    wasm.return %value
+  }
+  core.module @inner {
+    wasm.func @target() -> core.nil { wasm.return }
+    wasm.func @caller() -> core.i32 { wasm.return_call {callee = @target} }
+  }
+}"#,
+        );
+        let error = validate_wasm_ir(&ctx, module).expect_err("nearest target has Unit result");
+        assert!(
+            error
+                .to_string()
+                .contains("wasm.return_call tail caller/callee result lists differ"),
+            "{error}"
         );
     }
 }

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -2,6 +2,7 @@
 
 use crate::op_interface::{IndirectCallLikeModel, IndirectCallLikeOps};
 use crate::ops::{DialectOp, DialectType};
+use crate::{Attribute, AttributeMap, IrContext, Symbol, TypeDataBuilder, TypeRef};
 
 crate::register_isolated_op!(wasm.func);
 
@@ -383,6 +384,192 @@ mod wasm {
     fn i64_store32(addr: (), value: ()) {}
 }
 
+/// Reserved delimiter attribute for the number of Wasm signature inputs.
+pub const NUM_INPUTS_ATTR: &str = "num_inputs";
+/// Reserved delimiter attribute for the number of Wasm signature results.
+pub const NUM_RESULTS_ATTR: &str = "num_results";
+
+#[allow(non_snake_case)]
+#[inline]
+pub fn FUNC_SIG() -> Symbol {
+    Symbol::new("func_sig")
+}
+
+/// Why a name-matching `wasm.func_sig` does not satisfy its storage invariant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FuncSigTypeError {
+    MissingCount(&'static str),
+    InvalidCount(&'static str),
+    CountOverflow,
+    LengthMismatch {
+        num_inputs: u32,
+        num_results: u32,
+        params: usize,
+    },
+}
+
+impl std::fmt::Display for FuncSigTypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingCount(name) => write!(f, "missing required `{name}` u32 attribute"),
+            Self::InvalidCount(name) => write!(f, "`{name}` must be a u32 attribute"),
+            Self::CountOverflow => write!(f, "input and result counts overflow u32"),
+            Self::LengthMismatch {
+                num_inputs,
+                num_results,
+                params,
+            } => write!(
+                f,
+                "num_inputs ({num_inputs}) + num_results ({num_results}) must equal params length ({params})",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FuncSigTypeError {}
+
+/// Validated wrapper for an input-first, zero-or-more-result `wasm.func_sig`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FuncSig(TypeRef);
+
+impl FuncSig {
+    pub(crate) fn validate(ctx: &IrContext, ty: TypeRef) -> Result<Self, FuncSigTypeError> {
+        let data = ctx.types.get(ty);
+        debug_assert!(data.dialect == DIALECT_NAME() && data.name == FUNC_SIG());
+        let num_inputs = read_count(&data.attrs, NUM_INPUTS_ATTR)?;
+        let num_results = read_count(&data.attrs, NUM_RESULTS_ATTR)?;
+        let total = num_inputs
+            .checked_add(num_results)
+            .ok_or(FuncSigTypeError::CountOverflow)?;
+        if usize::try_from(total).ok() != Some(data.params.len()) {
+            return Err(FuncSigTypeError::LengthMismatch {
+                num_inputs,
+                num_results,
+                params: data.params.len(),
+            });
+        }
+        Ok(Self(ty))
+    }
+
+    fn counts(self, ctx: &IrContext) -> (usize, usize) {
+        let data = ctx.types.get(self.0);
+        let inputs = usize::try_from(
+            read_count(&data.attrs, NUM_INPUTS_ATTR)
+                .expect("validated wasm.func_sig must retain num_inputs"),
+        )
+        .expect("u32 must fit usize");
+        let results = usize::try_from(
+            read_count(&data.attrs, NUM_RESULTS_ATTR)
+                .expect("validated wasm.func_sig must retain num_results"),
+        )
+        .expect("u32 must fit usize");
+        (inputs, results)
+    }
+
+    pub fn inputs(self, ctx: &IrContext) -> &[TypeRef] {
+        let (inputs, _) = self.counts(ctx);
+        &ctx.types.get(self.0).params[..inputs]
+    }
+
+    pub fn results(self, ctx: &IrContext) -> &[TypeRef] {
+        let (inputs, results) = self.counts(ctx);
+        &ctx.types.get(self.0).params[inputs..inputs + results]
+    }
+
+    pub fn is_resultless(self, ctx: &IrContext) -> bool {
+        self.results(ctx).is_empty()
+    }
+
+    pub fn single_result(self, ctx: &IrContext) -> Option<TypeRef> {
+        let results = self.results(ctx);
+        (results.len() == 1).then(|| results[0])
+    }
+
+    pub fn non_reserved_attrs(
+        self,
+        ctx: &IrContext,
+    ) -> impl Iterator<Item = (&Symbol, &Attribute)> {
+        ctx.types.get(self.0).attrs.iter().filter(|(key, _)| {
+            **key != Symbol::new(NUM_INPUTS_ATTR) && **key != Symbol::new(NUM_RESULTS_ATTR)
+        })
+    }
+
+    pub fn remove_reserved_attrs(attrs: &mut AttributeMap) {
+        attrs.remove(NUM_INPUTS_ATTR);
+        attrs.remove(NUM_RESULTS_ATTR);
+    }
+}
+
+impl DialectType for FuncSig {
+    const DIALECT_NAME: &'static str = "wasm";
+    const TYPE_NAME: &'static str = "func_sig";
+
+    fn from_type_ref(ctx: &IrContext, ty: TypeRef) -> Option<Self> {
+        Self::matches(ctx, ty)
+            .then(|| Self::validate(ctx, ty).ok())
+            .flatten()
+    }
+
+    fn as_type_ref(&self) -> TypeRef {
+        self.0
+    }
+}
+
+impl From<FuncSig> for TypeRef {
+    fn from(value: FuncSig) -> Self {
+        value.0
+    }
+}
+
+fn read_count(attrs: &AttributeMap, name: &'static str) -> Result<u32, FuncSigTypeError> {
+    match attrs.get(name) {
+        None => Err(FuncSigTypeError::MissingCount(name)),
+        Some(Attribute::Int(value)) => {
+            u32::try_from(*value).map_err(|_| FuncSigTypeError::InvalidCount(name))
+        }
+        Some(_) => Err(FuncSigTypeError::InvalidCount(name)),
+    }
+}
+
+/// Construct a canonical target-owned `wasm.func_sig`.
+pub fn func_sig(
+    ctx: &mut IrContext,
+    inputs: impl IntoIterator<Item = TypeRef>,
+    results: impl IntoIterator<Item = TypeRef>,
+) -> FuncSig {
+    func_sig_with_attrs(ctx, inputs, results, AttributeMap::new())
+}
+
+/// Construct a canonical target signature while preserving non-reserved attributes.
+pub fn func_sig_with_attrs(
+    ctx: &mut IrContext,
+    inputs: impl IntoIterator<Item = TypeRef>,
+    results: impl IntoIterator<Item = TypeRef>,
+    attrs: AttributeMap,
+) -> FuncSig {
+    assert!(
+        !attrs.contains_key(NUM_INPUTS_ATTR) && !attrs.contains_key(NUM_RESULTS_ATTR),
+        "wasm.func_sig count attributes are reserved"
+    );
+    let inputs: Vec<_> = inputs.into_iter().collect();
+    let results: Vec<_> = results.into_iter().collect();
+    let num_inputs = u32::try_from(inputs.len()).expect("wasm.func_sig input count exceeds u32");
+    let num_results = u32::try_from(results.len()).expect("wasm.func_sig result count exceeds u32");
+    let mut builder = TypeDataBuilder::new(DIALECT_NAME(), FUNC_SIG())
+        .params(inputs)
+        .params(results);
+    for (key, value) in attrs {
+        builder = builder.attr(key, value);
+    }
+    let ty = ctx.types.intern(
+        builder
+            .attr(NUM_INPUTS_ATTR, Attribute::from(num_inputs))
+            .attr(NUM_RESULTS_ATTR, Attribute::from(num_results))
+            .build(),
+    );
+    FuncSig(ty)
+}
+
 const INDIRECT_CALL_SIGNATURE_ATTR: &str = "signature";
 
 impl IndirectCallLikeModel for CallIndirect {
@@ -416,13 +603,13 @@ inventory::submit! {
 /// Attach an exact callable contract to a `wasm` indirect transfer.
 ///
 /// Returns `false` without mutation when the operation is not a `wasm`
-/// indirect call or the supplied type is not a `func.func_sig` contract.
+/// indirect call or the supplied type is not a `wasm.func_sig` contract.
 pub fn set_indirect_call_signature(
     ctx: &mut crate::IrContext,
     op: crate::OpRef,
     signature: crate::TypeRef,
 ) -> bool {
-    if crate::dialect::func::FuncSig::from_type_ref(ctx, signature).is_none()
+    if FuncSig::from_type_ref(ctx, signature).is_none()
         || (CallIndirect::from_op(ctx, op).is_err()
             && ReturnCallIndirect::from_op(ctx, op).is_err())
     {
@@ -444,7 +631,9 @@ fn set_indirect_call_signature_attribute(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::op_interface::IndirectCallLikeOps;
+    use crate::ops::DialectType;
     use crate::parser::parse_test_module;
     use crate::printer::print_module;
 
@@ -500,6 +689,55 @@ mod tests {
 
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("wasm.call_indirect"));
-        assert!(printed.contains("signature = func.func_sig<(core.i32) -> core.i32>"));
+        assert!(printed.contains("signature = wasm.func_sig<(core.i32) -> core.i32>"));
+    }
+
+    #[test]
+    fn func_sig_owns_zero_and_multiple_result_lists_and_metadata() {
+        let mut ctx = crate::IrContext::new();
+        let i32 = ctx.types.intern(
+            crate::TypeDataBuilder::new(crate::Symbol::new("core"), crate::Symbol::new("i32"))
+                .build(),
+        );
+        let i64 = ctx.types.intern(
+            crate::TypeDataBuilder::new(crate::Symbol::new("core"), crate::Symbol::new("i64"))
+                .build(),
+        );
+        let mut attrs = crate::AttributeMap::new();
+        attrs.insert(crate::Symbol::new("kept"), crate::Attribute::Type(i64));
+        let zero = func_sig(&mut ctx, [i32], []).as_type_ref();
+        let many = func_sig_with_attrs(&mut ctx, [i32], [i32, i64], attrs).as_type_ref();
+        assert!(
+            FuncSig::from_type_ref(&ctx, zero)
+                .unwrap()
+                .is_resultless(&ctx)
+        );
+        let many_sig = FuncSig::from_type_ref(&ctx, many).unwrap();
+        assert_eq!(many_sig.inputs(&ctx), [i32]);
+        assert_eq!(many_sig.results(&ctx), [i32, i64]);
+        assert_eq!(many_sig.non_reserved_attrs(&ctx).count(), 1);
+        let mut same_attrs = crate::AttributeMap::new();
+        same_attrs.insert(crate::Symbol::new("kept"), crate::Attribute::Type(i64));
+        assert_eq!(
+            many,
+            func_sig_with_attrs(&mut ctx, [i32], [i32, i64], same_attrs).as_type_ref()
+        );
+    }
+
+    #[test]
+    fn func_sig_rejects_malformed_delimiters_without_slicing() {
+        let mut ctx = crate::IrContext::new();
+        let i32 = ctx.types.intern(
+            crate::TypeDataBuilder::new(crate::Symbol::new("core"), crate::Symbol::new("i32"))
+                .build(),
+        );
+        let malformed = ctx.types.intern(
+            crate::TypeDataBuilder::new(crate::Symbol::new("wasm"), FUNC_SIG())
+                .param(i32)
+                .attr(NUM_INPUTS_ATTR, crate::Attribute::Int(2))
+                .attr(NUM_RESULTS_ATTR, crate::Attribute::Int(1))
+                .build(),
+        );
+        assert!(FuncSig::from_type_ref(&ctx, malformed).is_none());
     }
 }

--- a/crates/trunk-ir/src/dialect/wasm.rs
+++ b/crates/trunk-ir/src/dialect/wasm.rs
@@ -644,7 +644,7 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   wasm.func @ordinary(%table: core.i32, %value: core.i32) -> core.i32 {
-    %result = wasm.call_indirect %table, %value {signature = func.func_sig<(core.i32) -> core.i32>, table = 0, type_idx = 0} : core.i32
+    %result = wasm.call_indirect %table, %value {signature = wasm.func_sig<(core.i32) -> core.i32>, table = 0, type_idx = 0} : core.i32
     wasm.return %result
   }
   wasm.func @plain(%table: core.i32, %value: core.i32) -> core.i32 {
@@ -652,7 +652,7 @@ mod tests {
     wasm.return %result
   }
   wasm.func @tail(%table: core.i32, %value: core.i32) -> core.nil {
-    wasm.return_call_indirect %table, %value {signature = func.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
+    wasm.return_call_indirect %table, %value {signature = wasm.func_sig<(core.i32) -> core.nil>, table = 0, type_idx = 0}
   }
   wasm.func @direct() -> core.nil {
     wasm.return
@@ -706,11 +706,20 @@ mod tests {
         let mut attrs = crate::AttributeMap::new();
         attrs.insert(crate::Symbol::new("kept"), crate::Attribute::Type(i64));
         let zero = func_sig(&mut ctx, [i32], []).as_type_ref();
+        let one = func_sig(&mut ctx, [i32], [i64]).as_type_ref();
         let many = func_sig_with_attrs(&mut ctx, [i32], [i32, i64], attrs).as_type_ref();
         assert!(
             FuncSig::from_type_ref(&ctx, zero)
                 .unwrap()
                 .is_resultless(&ctx)
+        );
+        assert_eq!(
+            FuncSig::from_type_ref(&ctx, one).unwrap().inputs(&ctx),
+            [i32]
+        );
+        assert_eq!(
+            FuncSig::from_type_ref(&ctx, one).unwrap().results(&ctx),
+            [i64]
         );
         let many_sig = FuncSig::from_type_ref(&ctx, many).unwrap();
         assert_eq!(many_sig.inputs(&ctx), [i32]);
@@ -739,5 +748,51 @@ mod tests {
                 .build(),
         );
         assert!(FuncSig::from_type_ref(&ctx, malformed).is_none());
+
+        let missing = ctx.types.intern(
+            crate::TypeDataBuilder::new(crate::Symbol::new("wasm"), FUNC_SIG())
+                .param(i32)
+                .attr(NUM_INPUTS_ATTR, crate::Attribute::Int(1))
+                .build(),
+        );
+        assert_eq!(
+            FuncSig::validate(&ctx, missing),
+            Err(FuncSigTypeError::MissingCount(NUM_RESULTS_ATTR))
+        );
+
+        let wrong_kind = ctx.types.intern(
+            crate::TypeDataBuilder::new(crate::Symbol::new("wasm"), FUNC_SIG())
+                .param(i32)
+                .attr(
+                    NUM_INPUTS_ATTR,
+                    crate::Attribute::Symbol(crate::Symbol::new("one")),
+                )
+                .attr(NUM_RESULTS_ATTR, crate::Attribute::Int(0))
+                .build(),
+        );
+        assert_eq!(
+            FuncSig::validate(&ctx, wrong_kind),
+            Err(FuncSigTypeError::InvalidCount(NUM_INPUTS_ATTR))
+        );
+
+        let overflow = ctx.types.intern(
+            crate::TypeDataBuilder::new(crate::Symbol::new("wasm"), FUNC_SIG())
+                .attr(NUM_INPUTS_ATTR, crate::Attribute::Int(i128::from(u32::MAX)))
+                .attr(NUM_RESULTS_ATTR, crate::Attribute::Int(1))
+                .build(),
+        );
+        assert_eq!(
+            FuncSig::validate(&ctx, overflow),
+            Err(FuncSigTypeError::CountOverflow)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "count attributes are reserved")]
+    fn func_sig_constructor_rejects_reserved_count_attributes() {
+        let mut ctx = crate::IrContext::new();
+        let mut attrs = crate::AttributeMap::new();
+        attrs.insert(NUM_INPUTS_ATTR.into(), crate::Attribute::Int(0));
+        let _ = func_sig_with_attrs(&mut ctx, [], [], attrs);
     }
 }

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -616,35 +616,6 @@ impl<'a> ArenaIrBuilder<'a> {
             }
         }
 
-        // Generic wasm.func assembly still has one authoritative `type`
-        // attribute. Normalize a shared parsed type at this target boundary.
-        if raw.dialect == "wasm"
-            && matches!(
-                raw.op_name,
-                "func" | "import_func" | "call_indirect" | "return_call_indirect"
-            )
-        {
-            let key = if matches!(raw.op_name, "func" | "import_func") {
-                "type"
-            } else {
-                "signature"
-            };
-            if let Some(ty) = attributes.get_type(key)
-                && let Some(shared) = crate::dialect::func::FuncSig::from_type_ref(self.ctx, ty)
-            {
-                let inputs = shared.inputs(self.ctx).to_vec();
-                let results = shared.results(self.ctx).to_vec();
-                let attrs = shared
-                    .non_reserved_attrs(self.ctx)
-                    .map(|(key, value)| (*key, value.clone()))
-                    .collect();
-                let target =
-                    crate::dialect::wasm::func_sig_with_attrs(self.ctx, inputs, results, attrs)
-                        .as_type_ref();
-                attributes.insert(Symbol::new(key), Attribute::Type(target));
-            }
-        }
-
         // Resolve successors
         let successors: Vec<BlockRef> = raw
             .successors
@@ -1449,6 +1420,25 @@ core.module @test {
         assert_eq!(
             ctx.op(function).attributes.get_type("type"),
             ctx.type_alias_by_name(Symbol::new("signature"))
+        );
+    }
+
+    #[test]
+    fn wasm_assembly_keeps_an_explicit_shared_signature_shared() {
+        let input = r#"core.module @test {
+  wasm.func {sym_name = @unlowered, type = func.func_sig<() -> core.nil>} { wasm.return }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_module(&mut ctx, input).expect("explicit assembly should parse");
+        let function = ctx
+            .block(ctx.region(ctx.op(module).regions[0]).blocks[0])
+            .ops[0];
+        let signature = ctx.op(function).attributes.get_type("type").unwrap();
+        assert!(func::FuncSig::from_type_ref(&ctx, signature).is_some());
+        assert!(crate::dialect::wasm::FuncSig::from_type_ref(&ctx, signature).is_none());
+        assert!(
+            print_module(&ctx, module).contains("type = func.func_sig<() -> core.nil>"),
+            "the parser must not apply an implicit target conversion"
         );
     }
 

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -133,7 +133,45 @@ impl<'a> ArenaIrBuilder<'a> {
         if (dialect == "func" && name == "func_sig") || (dialect == "core" && name == "func") {
             return self.build_shared_function_type(inputs, results, attrs);
         }
+        if dialect == "wasm" && name == "func_sig" {
+            return self.build_wasm_function_type(inputs, results, attrs);
+        }
         self.build_foreign_function_type(dialect, name, inputs, results, attrs)
+    }
+
+    fn build_wasm_function_type(
+        &mut self,
+        inputs: &[RawType<'_>],
+        results: &[RawType<'_>],
+        attrs: &[(&str, RawAttribute<'_>)],
+    ) -> Result<TypeRef, ParseError> {
+        if let Some((name, _)) = attrs.iter().find(|(name, _)| {
+            matches!(
+                *name,
+                crate::dialect::wasm::NUM_INPUTS_ATTR | crate::dialect::wasm::NUM_RESULTS_ATTR
+            )
+        }) {
+            return Err(ParseError {
+                message: format!("`{name}` is reserved by wasm.func_sig"),
+                offset: 0,
+            });
+        }
+        let inputs = inputs
+            .iter()
+            .map(|ty| self.build_type(ty))
+            .collect::<Result<Vec<_>, _>>()?;
+        let results = results
+            .iter()
+            .map(|ty| self.build_type(ty))
+            .collect::<Result<Vec<_>, _>>()?;
+        let attrs = attrs
+            .iter()
+            .map(|(name, value)| Ok((Symbol::from_dynamic(name), self.build_attribute(value)?)))
+            .collect::<Result<AttributeMap, ParseError>>()?;
+        Ok(
+            crate::dialect::wasm::func_sig_with_attrs(self.ctx, inputs, results, attrs)
+                .as_type_ref(),
+        )
     }
 
     /// Build the existing shared signature through its owning validated API.
@@ -535,8 +573,11 @@ impl<'a> ArenaIrBuilder<'a> {
                 .map(|(_, raw_ty)| self.build_type(raw_ty))
                 .collect::<Result<_, _>>()?;
 
-            let func_ty =
-                crate::dialect::func::func_sig(self.ctx, param_types, results).as_type_ref();
+            let func_ty = if raw.dialect == "wasm" && raw.op_name == "func" {
+                crate::dialect::wasm::func_sig(self.ctx, param_types, results).as_type_ref()
+            } else {
+                crate::dialect::func::func_sig(self.ctx, param_types, results).as_type_ref()
+            };
             if attributes.contains_key("type") && attributes.get_type("type").is_none() {
                 return Err(ParseError {
                     message: "explicit function type attribute must be a type".into(),
@@ -544,13 +585,27 @@ impl<'a> ArenaIrBuilder<'a> {
                 });
             }
             if let Some(explicit) = attributes.get_type("type") {
-                let signature = crate::dialect::func::FuncSig::from_type_ref(self.ctx, explicit);
-                let synthesized =
-                    crate::dialect::func::FuncSig::from_type_ref(self.ctx, func_ty).unwrap();
-                if signature.is_none_or(|signature| {
-                    signature.inputs(self.ctx) != synthesized.inputs(self.ctx)
-                        || signature.results(self.ctx) != synthesized.results(self.ctx)
-                }) {
+                let matches =
+                    if raw.dialect == "wasm" && raw.op_name == "func" {
+                        crate::dialect::wasm::FuncSig::from_type_ref(self.ctx, explicit)
+                            .is_some_and(|signature| {
+                                let synthesized =
+                                    crate::dialect::wasm::FuncSig::from_type_ref(self.ctx, func_ty)
+                                        .unwrap();
+                                signature.inputs(self.ctx) == synthesized.inputs(self.ctx)
+                                    && signature.results(self.ctx) == synthesized.results(self.ctx)
+                            })
+                    } else {
+                        crate::dialect::func::FuncSig::from_type_ref(self.ctx, explicit)
+                            .is_some_and(|signature| {
+                                let synthesized =
+                                    crate::dialect::func::FuncSig::from_type_ref(self.ctx, func_ty)
+                                        .unwrap();
+                                signature.inputs(self.ctx) == synthesized.inputs(self.ctx)
+                                    && signature.results(self.ctx) == synthesized.results(self.ctx)
+                            })
+                    };
+                if !matches {
                     return Err(ParseError {
                         message: "explicit function type does not match custom signature".into(),
                         offset: 0,
@@ -558,6 +613,35 @@ impl<'a> ArenaIrBuilder<'a> {
                 }
             } else {
                 attributes.insert(Symbol::new("type"), Attribute::Type(func_ty));
+            }
+        }
+
+        // Generic wasm.func assembly still has one authoritative `type`
+        // attribute. Normalize a shared parsed type at this target boundary.
+        if raw.dialect == "wasm"
+            && matches!(
+                raw.op_name,
+                "func" | "import_func" | "call_indirect" | "return_call_indirect"
+            )
+        {
+            let key = if matches!(raw.op_name, "func" | "import_func") {
+                "type"
+            } else {
+                "signature"
+            };
+            if let Some(ty) = attributes.get_type(key)
+                && let Some(shared) = crate::dialect::func::FuncSig::from_type_ref(self.ctx, ty)
+            {
+                let inputs = shared.inputs(self.ctx).to_vec();
+                let results = shared.results(self.ctx).to_vec();
+                let attrs = shared
+                    .non_reserved_attrs(self.ctx)
+                    .map(|(key, value)| (*key, value.clone()))
+                    .collect();
+                let target =
+                    crate::dialect::wasm::func_sig_with_attrs(self.ctx, inputs, results, attrs)
+                        .as_type_ref();
+                attributes.insert(Symbol::new(key), Attribute::Type(target));
             }
         }
 

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -242,6 +242,11 @@ fn func_sig_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], &[TypeRef
     {
         return None;
     }
+    if data.dialect == crate::Symbol::new("wasm")
+        && crate::dialect::wasm::FuncSig::from_type_ref(ctx, ty).is_none()
+    {
+        return None;
+    }
     let num_inputs = match data.attrs.get(crate::dialect::func::NUM_INPUTS_ATTR) {
         Some(Attribute::Int(value)) => usize::try_from(u32::try_from(*value).ok()?).ok()?,
         _ => return None,

--- a/crates/trunk-ir/src/rewrite/mod.rs
+++ b/crates/trunk-ir/src/rewrite/mod.rs
@@ -19,7 +19,8 @@ pub use helpers::{clone_attrs_except, erase_op, inline_region_blocks, split_bloc
 pub use pattern::RewritePattern;
 pub use rewriter::PatternRewriter;
 pub use signature_conversion::{
-    FuncSignatureConversionPattern, WasmFuncSignatureConversionPattern, convert_function_type,
+    ConvertedSignatureComponents, FuncSignatureConversionPattern, convert_function_type,
+    convert_signature_components, rewrite_function_signature,
 };
 pub use type_converter::TypeConverter;
 

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -4,10 +4,9 @@
 //! function parameter and return types using a `TypeConverter`.
 //!
 //! - [`FuncSignatureConversionPattern`]: Converts `func.func` signatures
-//! - [`WasmFuncSignatureConversionPattern`]: Converts `wasm.func` signatures
 
 use crate::context::{IrContext, OperationDataBuilder};
-use crate::dialect::{func, wasm};
+use crate::dialect::func;
 use crate::ops::{DialectOp, DialectType};
 use crate::refs::{OpRef, RegionRef, TypeRef};
 use crate::rewrite::clone_attrs_except;
@@ -16,97 +15,53 @@ use crate::rewrite::rewriter::PatternRewriter;
 use crate::rewrite::type_converter::TypeConverter;
 use crate::types::Attribute;
 
-/// Result of converting a `func.func_sig` type's params and result.
-struct ConvertedSignature {
-    new_params: Vec<TypeRef>,
-    new_results: Vec<TypeRef>,
-    type_attrs: crate::AttributeMap,
-    changed: bool,
-}
-
-/// Analyze a `func.func_sig` TypeRef and convert params/result via the type converter.
+/// Converted components of a validated callable signature.
 ///
-/// Returns `None` when `func_type` is not a well-formed `func.func_sig` type.
-fn convert_func_signature(
-    ctx: &IrContext,
-    func_type: TypeRef,
-    converter: &TypeConverter,
-) -> Option<ConvertedSignature> {
-    let func = func::FuncSig::from_type_ref(ctx, func_type)?;
-    let data = ctx.types.get(func_type);
-    let type_attrs = func
-        .non_reserved_attrs(ctx)
-        .map(|(key, value)| (*key, convert_attribute_types(ctx, converter, value)))
-        .collect::<crate::AttributeMap>();
-    let attrs_changed = type_attrs
-        .iter()
-        .any(|(key, value)| data.attrs.get(key) != Some(value));
-
-    let old_results = func.results(ctx);
-    let old_params = func.inputs(ctx);
-
-    let new_results: Vec<_> = old_results
-        .iter()
-        .map(|&ty| converter.convert_type_or_identity(ctx, ty))
-        .collect();
-    let new_params: Vec<TypeRef> = old_params
-        .iter()
-        .map(|&ty| converter.convert_type_or_identity(ctx, ty))
-        .collect();
-
-    let params_changed = new_params
-        .iter()
-        .zip(old_params.iter())
-        .any(|(new, old)| new != old);
-    let result_changed = new_results != old_results;
-
-    Some(ConvertedSignature {
-        new_params,
-        new_results,
-        type_attrs,
-        changed: params_changed || result_changed || attrs_changed,
-    })
+/// The caller owns dialect-specific validation and reconstruction. This helper
+/// only maps the supplied components and non-reserved attributes.
+pub struct ConvertedSignatureComponents {
+    pub inputs: Vec<TypeRef>,
+    pub results: Vec<TypeRef>,
+    pub attrs: crate::AttributeMap,
+    pub changed: bool,
 }
 
-/// Analyze a target-owned `wasm.func_sig` and convert all of its parameter and
-/// result types through the supplied converter.
-fn convert_wasm_func_signature(
+/// Convert validated signature components through a type converter.
+///
+/// Type-bearing attributes are traversed recursively. The callback remains
+/// immutable and is applied at most once to each type occurrence.
+pub fn convert_signature_components<'a>(
     ctx: &IrContext,
-    func_type: TypeRef,
     converter: &TypeConverter,
-) -> Option<ConvertedSignature> {
-    let func = wasm::FuncSig::from_type_ref(ctx, func_type)?;
-    let data = ctx.types.get(func_type);
-    let type_attrs = func
-        .non_reserved_attrs(ctx)
-        .map(|(key, value)| (*key, convert_attribute_types(ctx, converter, value)))
-        .collect::<crate::AttributeMap>();
-    let attrs_changed = type_attrs
-        .iter()
-        .any(|(key, value)| data.attrs.get(key) != Some(value));
-
-    let old_results = func.results(ctx);
-    let old_params = func.inputs(ctx);
-    let new_results: Vec<_> = old_results
+    old_inputs: &[TypeRef],
+    old_results: &[TypeRef],
+    attrs: impl IntoIterator<Item = (&'a crate::Symbol, &'a Attribute)>,
+) -> ConvertedSignatureComponents {
+    let inputs: Vec<_> = old_inputs
         .iter()
         .map(|&ty| converter.convert_type_or_identity(ctx, ty))
         .collect();
-    let new_params: Vec<_> = old_params
+    let results: Vec<_> = old_results
         .iter()
         .map(|&ty| converter.convert_type_or_identity(ctx, ty))
         .collect();
-    let params_changed = new_params
-        .iter()
-        .zip(old_params.iter())
-        .any(|(new, old)| new != old);
-    let result_changed = new_results != old_results;
+    let mut attrs_changed = false;
+    let attrs = attrs
+        .into_iter()
+        .map(|(key, value)| {
+            let converted = convert_attribute_types(ctx, converter, value);
+            attrs_changed |= converted != *value;
+            (*key, converted)
+        })
+        .collect();
+    let changed = inputs != old_inputs || results != old_results;
 
-    Some(ConvertedSignature {
-        new_params,
-        new_results,
-        type_attrs,
-        changed: params_changed || result_changed || attrs_changed,
-    })
+    ConvertedSignatureComponents {
+        changed: changed || attrs_changed,
+        inputs,
+        results,
+        attrs,
+    }
 }
 
 fn convert_attribute_types(
@@ -126,54 +81,6 @@ fn convert_attribute_types(
     }
 }
 
-/// Build a new `func.func_sig` TypeRef from converted params/result.
-fn rebuild_func_type(ctx: &mut IrContext, sig: &ConvertedSignature) -> TypeRef {
-    crate::dialect::func::func_sig_with_attrs(
-        ctx,
-        sig.new_params.iter().copied(),
-        sig.new_results.iter().copied(),
-        sig.type_attrs.clone(),
-    )
-    .as_type_ref()
-}
-
-fn rebuild_wasm_func_type(ctx: &mut IrContext, sig: &ConvertedSignature) -> TypeRef {
-    crate::dialect::wasm::func_sig_with_attrs(
-        ctx,
-        sig.new_params.iter().copied(),
-        sig.new_results.iter().copied(),
-        sig.type_attrs.clone(),
-    )
-    .as_type_ref()
-}
-
-#[derive(Clone, Copy)]
-enum SignatureDialect {
-    Shared,
-    Wasm,
-}
-
-impl SignatureDialect {
-    fn convert(
-        self,
-        ctx: &IrContext,
-        func_type: TypeRef,
-        converter: &TypeConverter,
-    ) -> Option<ConvertedSignature> {
-        match self {
-            Self::Shared => convert_func_signature(ctx, func_type, converter),
-            Self::Wasm => convert_wasm_func_signature(ctx, func_type, converter),
-        }
-    }
-
-    fn rebuild(self, ctx: &mut IrContext, signature: &ConvertedSignature) -> TypeRef {
-        match self {
-            Self::Shared => rebuild_func_type(ctx, signature),
-            Self::Wasm => rebuild_wasm_func_type(ctx, signature),
-        }
-    }
-}
-
 /// Convert the parameter and result types of a `func.func_sig` type.
 ///
 /// This is the type-only counterpart to the function-signature rewrite
@@ -184,35 +91,54 @@ pub fn convert_function_type(
     func_type: TypeRef,
     converter: &TypeConverter,
 ) -> Option<TypeRef> {
-    let signature = convert_func_signature(ctx, func_type, converter)?;
-    Some(rebuild_func_type(ctx, &signature))
+    let func = func::FuncSig::from_type_ref(ctx, func_type)?;
+    let signature = convert_signature_components(
+        ctx,
+        converter,
+        func.inputs(ctx),
+        func.results(ctx),
+        func.non_reserved_attrs(ctx),
+    );
+    Some(
+        func::func_sig_with_attrs(ctx, signature.inputs, signature.results, signature.attrs)
+            .as_type_ref(),
+    )
 }
 
-/// Update entry block argument types in-place to match converted params.
-///
-/// Returns `false` if there is an arity mismatch between the entry block args
-/// and the new params, leaving the IR unchanged to avoid partial updates.
-fn update_entry_block_args(ctx: &mut IrContext, op: OpRef, new_params: &[TypeRef]) -> bool {
+/// Validate the entry block arity before changing callable signature state.
+fn entry_block_for_signature_update(
+    ctx: &IrContext,
+    op: OpRef,
+    new_inputs: &[TypeRef],
+) -> Option<Option<crate::BlockRef>> {
     let regions = &ctx.op(op).regions;
     if regions.is_empty() {
         // Declarations have no entry block whose arguments need updating.
-        return true;
+        return Some(None);
     }
     let body = regions[0];
     let blocks = &ctx.region(body).blocks;
     if blocks.is_empty() {
-        return new_params.is_empty();
+        return new_inputs.is_empty().then_some(None);
     }
     let entry_block = blocks[0];
 
     let num_args = ctx.block(entry_block).args.len();
-    if num_args != new_params.len() {
-        return false;
-    }
-    for (i, &new_ty) in new_params.iter().enumerate() {
+    (num_args == new_inputs.len()).then_some(Some(entry_block))
+}
+
+/// Update a previously validated entry block to match converted inputs.
+fn update_entry_block_args(
+    ctx: &mut IrContext,
+    entry_block: Option<crate::BlockRef>,
+    new_inputs: &[TypeRef],
+) {
+    let Some(entry_block) = entry_block else {
+        return;
+    };
+    for (i, &new_ty) in new_inputs.iter().enumerate() {
         ctx.set_block_arg_type(entry_block, i as u32, new_ty);
     }
-    true
 }
 
 /// Create a bodyless function declaration for a dialect whose generated
@@ -236,33 +162,22 @@ fn make_bodyless_function_op(
 /// Converts parameter and result types using the type converter, updates
 /// entry block argument types, rebuilds the function type, and replaces
 /// the operation. Accepts a constructor closure to create the replacement op,
-/// allowing reuse across `func.func` and `wasm.func` patterns.
-fn rewrite_function_signature(
+/// allowing dialect adapters to reuse the operation update sequence.
+pub fn rewrite_function_signature(
     ctx: &mut IrContext,
     op: OpRef,
     rewriter: &mut PatternRewriter<'_>,
-    func_type: TypeRef,
     body: Option<RegionRef>,
-    signature_dialect: SignatureDialect,
+    new_func_type: TypeRef,
+    new_inputs: &[TypeRef],
     make_op: impl FnOnce(&mut IrContext, TypeRef, Option<RegionRef>) -> OpRef,
 ) -> bool {
-    let converter = rewriter.type_converter();
     let attrs_to_preserve = clone_attrs_except(ctx, op, &["sym_name", "type"]);
-
-    let Some(sig) = signature_dialect.convert(ctx, func_type, converter) else {
+    let Some(entry_block) = entry_block_for_signature_update(ctx, op, new_inputs) else {
         return false;
     };
-    if !sig.changed {
-        return false;
-    }
 
-    // Update entry block args in-place
-    if !update_entry_block_args(ctx, op, &sig.new_params) {
-        return false;
-    }
-
-    // Build new func type
-    let new_func_type = signature_dialect.rebuild(ctx, &sig);
+    update_entry_block_args(ctx, entry_block, new_inputs);
 
     // Detach body region so it can be reused in the new op
     if let Some(body) = body {
@@ -298,6 +213,26 @@ impl RewritePattern for FuncSignatureConversionPattern {
         };
 
         let func_type = func_op.r#type(ctx);
+        let Some(signature) = func::FuncSig::from_type_ref(ctx, func_type) else {
+            return false;
+        };
+        let converted = convert_signature_components(
+            ctx,
+            rewriter.type_converter(),
+            signature.inputs(ctx),
+            signature.results(ctx),
+            signature.non_reserved_attrs(ctx),
+        );
+        if !converted.changed {
+            return false;
+        }
+        let new_func_type = func::func_sig_with_attrs(
+            ctx,
+            converted.inputs.iter().copied(),
+            converted.results.iter().copied(),
+            converted.attrs,
+        )
+        .as_type_ref();
         let body = ctx.op(op).regions.first().copied();
         let sym_name = func_op.sym_name(ctx);
         let loc = ctx.op(op).location;
@@ -306,9 +241,9 @@ impl RewritePattern for FuncSignatureConversionPattern {
             ctx,
             op,
             rewriter,
-            func_type,
             body,
-            SignatureDialect::Shared,
+            new_func_type,
+            &converted.inputs,
             |ctx, ty, body| match body {
                 Some(body) => func::func(ctx, loc, sym_name, ty, body).op_ref(),
                 None => {
@@ -320,48 +255,6 @@ impl RewritePattern for FuncSignatureConversionPattern {
 
     fn name(&self) -> &'static str {
         "FuncSignatureConversionPattern"
-    }
-}
-
-/// Pattern that converts `wasm.func` operation signatures using a `TypeConverter`.
-///
-/// Identical to [`FuncSignatureConversionPattern`] but targets `wasm.func` operations.
-pub struct WasmFuncSignatureConversionPattern;
-
-impl RewritePattern for WasmFuncSignatureConversionPattern {
-    fn match_and_rewrite(
-        &self,
-        ctx: &mut IrContext,
-        op: OpRef,
-        rewriter: &mut PatternRewriter<'_>,
-    ) -> bool {
-        let Ok(wasm_func_op) = wasm::Func::from_op(ctx, op) else {
-            return false;
-        };
-
-        let func_type = wasm_func_op.r#type(ctx);
-        let body = ctx.op(op).regions.first().copied();
-        let sym_name = wasm_func_op.sym_name(ctx);
-        let loc = ctx.op(op).location;
-
-        rewrite_function_signature(
-            ctx,
-            op,
-            rewriter,
-            func_type,
-            body,
-            SignatureDialect::Wasm,
-            |ctx, ty, body| match body {
-                Some(body) => wasm::func(ctx, loc, sym_name, ty, body).op_ref(),
-                None => {
-                    make_bodyless_function_op(ctx, loc, crate::Symbol::new("wasm"), sym_name, ty)
-                }
-            },
-        )
-    }
-
-    fn name(&self) -> &'static str {
-        "WasmFuncSignatureConversionPattern"
     }
 }
 
@@ -446,35 +339,6 @@ mod tests {
             parent_op: None,
         });
         let f = func::func(ctx, loc, Symbol::new(name), func_type, body);
-        f.op_ref()
-    }
-
-    /// Create a wasm.func op with a body region containing an entry block with args.
-    fn make_wasm_func_op(
-        ctx: &mut IrContext,
-        loc: crate::types::Location,
-        name: &'static str,
-        func_type: TypeRef,
-        param_types: &[TypeRef],
-    ) -> OpRef {
-        let entry_block = ctx.create_block(BlockData {
-            location: loc,
-            args: param_types
-                .iter()
-                .map(|&ty| BlockArgData {
-                    ty,
-                    attrs: Default::default(),
-                })
-                .collect(),
-            ops: smallvec![],
-            parent_region: None,
-        });
-        let body = ctx.create_region(RegionData {
-            location: loc,
-            blocks: smallvec![entry_block],
-            parent_op: None,
-        });
-        let f = wasm::func(ctx, loc, Symbol::new(name), func_type, body);
         f.op_ref()
     }
 
@@ -581,52 +445,6 @@ mod tests {
     }
 
     #[test]
-    fn wasm_func_signature_conversion() {
-        let (mut ctx, loc) = test_ctx();
-        let i32_ty = i32_type(&mut ctx);
-        let i64_ty = i64_type(&mut ctx);
-
-        let func_ty = wasm::func_sig(&mut ctx, [i32_ty, i32_ty], [i32_ty]).as_type_ref();
-        let func_op = make_wasm_func_op(&mut ctx, loc, "wasm_fn", func_ty, &[i32_ty, i32_ty]);
-        ctx.op_mut(func_op)
-            .attributes
-            .insert(Symbol::new("custom"), Attribute::Int(7));
-        let module = make_module(&mut ctx, loc, vec![func_op]);
-
-        let tc = i32_to_i64_converter(i32_ty, i64_ty);
-        let applicator = PatternApplicator::new(tc).add_pattern(WasmFuncSignatureConversionPattern);
-        let target = ConversionTarget::new();
-
-        let result = applicator
-            .with_target(target)
-            .apply_partial_conversion(&mut ctx, module, "test-boundary")
-            .unwrap();
-        assert!(result.reached_fixpoint);
-        // 2 block args converted by applicator + 1 pattern match
-        assert!(result.total_changes >= 1);
-
-        // Verify converted wasm.func
-        let ops = module.ops(&ctx);
-        let new_func = wasm::Func::from_op(&ctx, ops[0]).unwrap();
-        let new_type = new_func.r#type(&ctx);
-        let function = wasm::FuncSig::from_type_ref(&ctx, new_type).unwrap();
-        assert_eq!(function.inputs(&ctx), &[i64_ty, i64_ty]);
-        assert_eq!(function.single_result(&ctx), Some(i64_ty));
-        assert_eq!(
-            ctx.op(ops[0]).attributes.get("custom"),
-            Some(&Attribute::Int(7)),
-            "signature conversion should preserve custom metadata"
-        );
-
-        // Verify entry block args
-        let body = new_func.body(&ctx);
-        let entry = ctx.region(body).blocks[0];
-        assert_eq!(ctx.block(entry).args.len(), 2);
-        assert_eq!(ctx.value_ty(ctx.block_arg(entry, 0)), i64_ty);
-        assert_eq!(ctx.value_ty(ctx.block_arg(entry, 1)), i64_ty);
-    }
-
-    #[test]
     fn bodyless_signatures_convert_without_inventing_bodies() {
         for result_count in [0, 1] {
             let (mut ctx, loc) = test_ctx();
@@ -638,7 +456,6 @@ mod tests {
                 vec![i32_ty]
             };
             let func_ty = func::func_sig(&mut ctx, [i32_ty], results.clone()).as_type_ref();
-            let wasm_ty = wasm::func_sig(&mut ctx, [i32_ty], results).as_type_ref();
 
             let func_decl = make_bodyless_function_op(
                 &mut ctx,
@@ -647,47 +464,27 @@ mod tests {
                 Symbol::new("external"),
                 func_ty,
             );
-            let wasm_decl = make_bodyless_function_op(
-                &mut ctx,
-                loc,
-                Symbol::new("wasm"),
-                Symbol::new("wasm_external"),
-                wasm_ty,
-            );
             let func_def = make_func_op(&mut ctx, loc, "defined", func_ty, &[i32_ty]);
-            let wasm_def = make_wasm_func_op(&mut ctx, loc, "wasm_defined", wasm_ty, &[i32_ty]);
-            let module = make_module(
-                &mut ctx,
-                loc,
-                vec![func_decl, wasm_decl, func_def, wasm_def],
-            );
+            let module = make_module(&mut ctx, loc, vec![func_decl, func_def]);
 
             let tc = i32_to_i64_converter(i32_ty, i64_ty);
-            let applicator = PatternApplicator::new(tc)
-                .add_pattern(FuncSignatureConversionPattern)
-                .add_pattern(WasmFuncSignatureConversionPattern);
+            let applicator = PatternApplicator::new(tc).add_pattern(FuncSignatureConversionPattern);
             let result = applicator
                 .with_target(ConversionTarget::new())
                 .apply_partial_conversion(&mut ctx, module, "test-boundary")
                 .unwrap();
 
             assert!(result.reached_fixpoint);
-            assert!(result.total_changes >= 4);
+            assert!(result.total_changes >= 2);
 
             let ops = module.ops(&ctx);
-            for (index, expected_regions) in [(0, 0), (1, 0), (2, 1), (3, 1)] {
+            for (index, expected_regions) in [(0, 0), (1, 1)] {
                 let data = ctx.op(ops[index]);
                 assert_eq!(data.regions.len(), expected_regions);
                 let func_ty = data.attributes.get_type("type").unwrap();
-                if data.dialect == Symbol::new("wasm") {
-                    let function = wasm::FuncSig::from_type_ref(&ctx, func_ty).unwrap();
-                    assert_eq!(function.inputs(&ctx), [i64_ty]);
-                    assert_eq!(function.results(&ctx), vec![i64_ty; result_count]);
-                } else {
-                    let function = func::FuncSig::from_type_ref(&ctx, func_ty).unwrap();
-                    assert_eq!(function.inputs(&ctx), [i64_ty]);
-                    assert_eq!(function.results(&ctx), vec![i64_ty; result_count]);
-                }
+                let function = func::FuncSig::from_type_ref(&ctx, func_ty).unwrap();
+                assert_eq!(function.inputs(&ctx), [i64_ty]);
+                assert_eq!(function.results(&ctx), vec![i64_ty; result_count]);
             }
 
             let text = print_module(&ctx, module.op());
@@ -696,16 +493,7 @@ mod tests {
             } else {
                 " -> core.i64"
             };
-            let result = if result_count == 0 { "()" } else { "core.i64" };
             assert!(text.contains(&format!("func.func @external(%arg0: core.i64){arrow}\n")));
-            assert!(
-                text.contains("wasm.func {sym_name = @wasm_external, type = !t"),
-                "{text}"
-            );
-            assert!(
-                text.contains(&format!("wasm.func_sig<(core.i64) -> {result}>")),
-                "{text}"
-            );
             assert!(text.contains(&format!("func.func @defined(%0: core.i64){arrow} {{")));
         }
     }
@@ -737,37 +525,6 @@ mod tests {
         let function = func::FuncSig::from_type_ref(&ctx, new_func.r#type(&ctx)).unwrap();
         assert_eq!(function.inputs(&ctx), &[i64_ty]);
         assert_eq!(function.single_result(&ctx), Some(i64_ty));
-    }
-
-    #[test]
-    fn arity_mismatch_returns_unchanged_for_wasm() {
-        let (mut ctx, loc) = test_ctx();
-        let i32_ty = i32_type(&mut ctx);
-        let i64_ty = i64_type(&mut ctx);
-
-        // Signature has 2 params, but entry block has only 1 arg (arity mismatch)
-        let func_ty = wasm::func_sig(&mut ctx, [i32_ty, i32_ty], [i32_ty]).as_type_ref();
-        let func_op = make_wasm_func_op(&mut ctx, loc, "mismatched_wasm", func_ty, &[i32_ty]);
-        let module = make_module(&mut ctx, loc, vec![func_op]);
-
-        let tc = i32_to_i64_converter(i32_ty, i64_ty);
-        let applicator = PatternApplicator::new(tc).add_pattern(WasmFuncSignatureConversionPattern);
-        let target = ConversionTarget::new();
-
-        let result = applicator
-            .with_target(target)
-            .apply_partial_conversion(&mut ctx, module, "test-boundary")
-            .unwrap();
-        // Pattern should not match due to arity mismatch.
-        // Default shared signature conversion leaves entry arguments unchanged.
-        assert!(result.reached_fixpoint);
-
-        // Verify original func type attribute is preserved (pattern didn't match)
-        let ops = module.ops(&ctx);
-        let original_func = wasm::Func::from_op(&ctx, ops[0]).unwrap();
-        assert_eq!(original_func.r#type(&ctx), func_ty);
-        let entry = ctx.region(original_func.body(&ctx)).blocks[0];
-        assert_eq!(ctx.value_ty(ctx.block_arg(entry, 0)), i32_ty);
     }
 
     #[test]

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -157,12 +157,13 @@ fn make_bodyless_function_op(
     ctx.create_op(data)
 }
 
-/// Shared implementation for function signature conversion.
+/// Replace a callable operation after its adapter has prepared a signature.
 ///
-/// Converts parameter and result types using the type converter, updates
-/// entry block argument types, rebuilds the function type, and replaces
-/// the operation. Accepts a constructor closure to create the replacement op,
-/// allowing dialect adapters to reuse the operation update sequence.
+/// The caller must validate and decode the callable type, provide a prepared
+/// type whose inputs match `new_inputs`, and pass the callable's owned body
+/// region when it has one. This helper validates entry arity before mutation,
+/// updates entry arguments, preserves operation attributes, and transfers the
+/// body to the replacement created by `make_op`.
 pub fn rewrite_function_signature(
     ctx: &mut IrContext,
     op: OpRef,

--- a/crates/trunk-ir/src/rewrite/signature_conversion.rs
+++ b/crates/trunk-ir/src/rewrite/signature_conversion.rs
@@ -68,6 +68,47 @@ fn convert_func_signature(
     })
 }
 
+/// Analyze a target-owned `wasm.func_sig` and convert all of its parameter and
+/// result types through the supplied converter.
+fn convert_wasm_func_signature(
+    ctx: &IrContext,
+    func_type: TypeRef,
+    converter: &TypeConverter,
+) -> Option<ConvertedSignature> {
+    let func = wasm::FuncSig::from_type_ref(ctx, func_type)?;
+    let data = ctx.types.get(func_type);
+    let type_attrs = func
+        .non_reserved_attrs(ctx)
+        .map(|(key, value)| (*key, convert_attribute_types(ctx, converter, value)))
+        .collect::<crate::AttributeMap>();
+    let attrs_changed = type_attrs
+        .iter()
+        .any(|(key, value)| data.attrs.get(key) != Some(value));
+
+    let old_results = func.results(ctx);
+    let old_params = func.inputs(ctx);
+    let new_results: Vec<_> = old_results
+        .iter()
+        .map(|&ty| converter.convert_type_or_identity(ctx, ty))
+        .collect();
+    let new_params: Vec<_> = old_params
+        .iter()
+        .map(|&ty| converter.convert_type_or_identity(ctx, ty))
+        .collect();
+    let params_changed = new_params
+        .iter()
+        .zip(old_params.iter())
+        .any(|(new, old)| new != old);
+    let result_changed = new_results != old_results;
+
+    Some(ConvertedSignature {
+        new_params,
+        new_results,
+        type_attrs,
+        changed: params_changed || result_changed || attrs_changed,
+    })
+}
+
 fn convert_attribute_types(
     ctx: &IrContext,
     converter: &TypeConverter,
@@ -94,6 +135,43 @@ fn rebuild_func_type(ctx: &mut IrContext, sig: &ConvertedSignature) -> TypeRef {
         sig.type_attrs.clone(),
     )
     .as_type_ref()
+}
+
+fn rebuild_wasm_func_type(ctx: &mut IrContext, sig: &ConvertedSignature) -> TypeRef {
+    crate::dialect::wasm::func_sig_with_attrs(
+        ctx,
+        sig.new_params.iter().copied(),
+        sig.new_results.iter().copied(),
+        sig.type_attrs.clone(),
+    )
+    .as_type_ref()
+}
+
+#[derive(Clone, Copy)]
+enum SignatureDialect {
+    Shared,
+    Wasm,
+}
+
+impl SignatureDialect {
+    fn convert(
+        self,
+        ctx: &IrContext,
+        func_type: TypeRef,
+        converter: &TypeConverter,
+    ) -> Option<ConvertedSignature> {
+        match self {
+            Self::Shared => convert_func_signature(ctx, func_type, converter),
+            Self::Wasm => convert_wasm_func_signature(ctx, func_type, converter),
+        }
+    }
+
+    fn rebuild(self, ctx: &mut IrContext, signature: &ConvertedSignature) -> TypeRef {
+        match self {
+            Self::Shared => rebuild_func_type(ctx, signature),
+            Self::Wasm => rebuild_wasm_func_type(ctx, signature),
+        }
+    }
 }
 
 /// Convert the parameter and result types of a `func.func_sig` type.
@@ -165,12 +243,13 @@ fn rewrite_function_signature(
     rewriter: &mut PatternRewriter<'_>,
     func_type: TypeRef,
     body: Option<RegionRef>,
+    signature_dialect: SignatureDialect,
     make_op: impl FnOnce(&mut IrContext, TypeRef, Option<RegionRef>) -> OpRef,
 ) -> bool {
     let converter = rewriter.type_converter();
     let attrs_to_preserve = clone_attrs_except(ctx, op, &["sym_name", "type"]);
 
-    let Some(sig) = convert_func_signature(ctx, func_type, converter) else {
+    let Some(sig) = signature_dialect.convert(ctx, func_type, converter) else {
         return false;
     };
     if !sig.changed {
@@ -183,7 +262,7 @@ fn rewrite_function_signature(
     }
 
     // Build new func type
-    let new_func_type = rebuild_func_type(ctx, &sig);
+    let new_func_type = signature_dialect.rebuild(ctx, &sig);
 
     // Detach body region so it can be reused in the new op
     if let Some(body) = body {
@@ -229,6 +308,7 @@ impl RewritePattern for FuncSignatureConversionPattern {
             rewriter,
             func_type,
             body,
+            SignatureDialect::Shared,
             |ctx, ty, body| match body {
                 Some(body) => func::func(ctx, loc, sym_name, ty, body).op_ref(),
                 None => {
@@ -270,6 +350,7 @@ impl RewritePattern for WasmFuncSignatureConversionPattern {
             rewriter,
             func_type,
             body,
+            SignatureDialect::Wasm,
             |ctx, ty, body| match body {
                 Some(body) => wasm::func(ctx, loc, sym_name, ty, body).op_ref(),
                 None => {
@@ -505,7 +586,7 @@ mod tests {
         let i32_ty = i32_type(&mut ctx);
         let i64_ty = i64_type(&mut ctx);
 
-        let func_ty = make_func_type(&mut ctx, &[i32_ty, i32_ty], i32_ty);
+        let func_ty = wasm::func_sig(&mut ctx, [i32_ty, i32_ty], [i32_ty]).as_type_ref();
         let func_op = make_wasm_func_op(&mut ctx, loc, "wasm_fn", func_ty, &[i32_ty, i32_ty]);
         ctx.op_mut(func_op)
             .attributes
@@ -528,7 +609,7 @@ mod tests {
         let ops = module.ops(&ctx);
         let new_func = wasm::Func::from_op(&ctx, ops[0]).unwrap();
         let new_type = new_func.r#type(&ctx);
-        let function = func::FuncSig::from_type_ref(&ctx, new_type).unwrap();
+        let function = wasm::FuncSig::from_type_ref(&ctx, new_type).unwrap();
         assert_eq!(function.inputs(&ctx), &[i64_ty, i64_ty]);
         assert_eq!(function.single_result(&ctx), Some(i64_ty));
         assert_eq!(
@@ -556,7 +637,8 @@ mod tests {
             } else {
                 vec![i32_ty]
             };
-            let func_ty = func::func_sig(&mut ctx, [i32_ty], results).as_type_ref();
+            let func_ty = func::func_sig(&mut ctx, [i32_ty], results.clone()).as_type_ref();
+            let wasm_ty = wasm::func_sig(&mut ctx, [i32_ty], results).as_type_ref();
 
             let func_decl = make_bodyless_function_op(
                 &mut ctx,
@@ -570,10 +652,10 @@ mod tests {
                 loc,
                 Symbol::new("wasm"),
                 Symbol::new("wasm_external"),
-                func_ty,
+                wasm_ty,
             );
             let func_def = make_func_op(&mut ctx, loc, "defined", func_ty, &[i32_ty]);
-            let wasm_def = make_wasm_func_op(&mut ctx, loc, "wasm_defined", func_ty, &[i32_ty]);
+            let wasm_def = make_wasm_func_op(&mut ctx, loc, "wasm_defined", wasm_ty, &[i32_ty]);
             let module = make_module(
                 &mut ctx,
                 loc,
@@ -597,9 +679,15 @@ mod tests {
                 let data = ctx.op(ops[index]);
                 assert_eq!(data.regions.len(), expected_regions);
                 let func_ty = data.attributes.get_type("type").unwrap();
-                let function = func::FuncSig::from_type_ref(&ctx, func_ty).unwrap();
-                assert_eq!(function.inputs(&ctx), [i64_ty]);
-                assert_eq!(function.results(&ctx), vec![i64_ty; result_count]);
+                if data.dialect == Symbol::new("wasm") {
+                    let function = wasm::FuncSig::from_type_ref(&ctx, func_ty).unwrap();
+                    assert_eq!(function.inputs(&ctx), [i64_ty]);
+                    assert_eq!(function.results(&ctx), vec![i64_ty; result_count]);
+                } else {
+                    let function = func::FuncSig::from_type_ref(&ctx, func_ty).unwrap();
+                    assert_eq!(function.inputs(&ctx), [i64_ty]);
+                    assert_eq!(function.results(&ctx), vec![i64_ty; result_count]);
+                }
             }
 
             let text = print_module(&ctx, module.op());
@@ -611,11 +699,11 @@ mod tests {
             let result = if result_count == 0 { "()" } else { "core.i64" };
             assert!(text.contains(&format!("func.func @external(%arg0: core.i64){arrow}\n")));
             assert!(
-                text.contains(&format!("!t0 = func.func_sig<(core.i64) -> {result}>")),
+                text.contains("wasm.func {sym_name = @wasm_external, type = !t"),
                 "{text}"
             );
             assert!(
-                text.contains("wasm.func {sym_name = @wasm_external, type = !t0}\n"),
+                text.contains(&format!("wasm.func_sig<(core.i64) -> {result}>")),
                 "{text}"
             );
             assert!(text.contains(&format!("func.func @defined(%0: core.i64){arrow} {{")));
@@ -658,7 +746,7 @@ mod tests {
         let i64_ty = i64_type(&mut ctx);
 
         // Signature has 2 params, but entry block has only 1 arg (arity mismatch)
-        let func_ty = make_func_type(&mut ctx, &[i32_ty, i32_ty], i32_ty);
+        let func_ty = wasm::func_sig(&mut ctx, [i32_ty, i32_ty], [i32_ty]).as_type_ref();
         let func_op = make_wasm_func_op(&mut ctx, loc, "mismatched_wasm", func_ty, &[i32_ty]);
         let module = make_module(&mut ctx, loc, vec![func_op]);
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -55,6 +55,10 @@ target ABI conversion may later change logical CPS `[core.never]` into the
 physical empty result list. Malformed raw `func.func_sig` types are permitted only
 in verifier tests and are rejected by whole-IR validation.
 
+공통 signature component 변환은 검증된 입력·결과 slice와 예약되지 않은 type
+attribute만 순회한다. 각 dialect adapter는 자기 signature를 검증·해독하고 자기
+constructor로 다시 만들므로, 공통 traversal이 dialect identity나 ABI를 선택하지 않는다.
+
 The source-logical callable type is independently owned as
 `tribute_control.func_sig`. It uses the same flat input-first storage and
 mandatory u32 delimiters, but its validated API requires exactly one source

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -71,17 +71,11 @@ keeps the complete type-bearing attribute visible. The codec reconstructs that
 type metadata before source-to-shared conversion; no operation-local signature
 metadata clause or override exists.
 
-The Wasm target owns `wasm.func_sig`, whose validated input/result lists permit
-zero or multiple results.  Wasm lowering converts a complete shared signature
-once at the target boundary and preserves nested type-bearing metadata; Wasm
-functions, imports, exact indirect signatures, collection, validation, and
-emission consume that type directly.  An empty target result list is ordinary
-and is not an ABI marker.  Binary emission preserves the established target
-slot rule by omitting every `core.nil` result and retaining each non-nil result
-in order; this includes ordinary target `Unit` and the temporary physical-CPS
-`[core.nil]` encoding.  The atomic physical-CPS transition owns the semantic
-change to `[]`.
-Value and input `core.nil` continue to map to nullable reference slots.
+Wasm 대상 변환 경계는 공통 함수 시그니처와 그 안의 중첩 타입 메타데이터를
+`wasm.func_sig`로 변환한다. 입력·결과 개수와 예약되지 않은 타입 속성을
+보존한다. 저장 형식과 타입 동일성은
+[IR 계약](ir.md#wasmfunc_sig-wasm-호출-계약), 바이너리 결과 표현은
+[Wasm 백엔드 계약](wasm-backend.md#wasm-결과-슬롯)에서 정의한다.
 
 ## 직접형 제어 소유권
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -55,9 +55,9 @@ target ABI conversion may later change logical CPS `[core.never]` into the
 physical empty result list. Malformed raw `func.func_sig` types are permitted only
 in verifier tests and are rejected by whole-IR validation.
 
-공통 signature component 변환은 검증된 입력·결과 slice와 예약되지 않은 type
-attribute만 순회한다. 각 dialect adapter는 자기 signature를 검증·해독하고 자기
-constructor로 다시 만들므로, 공통 traversal이 dialect identity나 ABI를 선택하지 않는다.
+공통 시그니처 구성요소 변환은 검증된 입력·결과 목록과 예약되지 않은 타입 속성만
+순회한다. 각 dialect 어댑터는 자신의 시그니처를 검증하고 해독한 뒤 자신의 생성자로
+다시 만들므로, 공통 순회가 dialect 정체성이나 ABI를 선택하지 않는다.
 
 The source-logical callable type is independently owned as
 `tribute_control.func_sig`. It uses the same flat input-first storage and

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -71,6 +71,18 @@ keeps the complete type-bearing attribute visible. The codec reconstructs that
 type metadata before source-to-shared conversion; no operation-local signature
 metadata clause or override exists.
 
+The Wasm target owns `wasm.func_sig`, whose validated input/result lists permit
+zero or multiple results.  Wasm lowering converts a complete shared signature
+once at the target boundary and preserves nested type-bearing metadata; Wasm
+functions, imports, exact indirect signatures, collection, validation, and
+emission consume that type directly.  An empty target result list is ordinary
+and is not an ABI marker.  Binary emission preserves the established target
+slot rule by omitting every `core.nil` result and retaining each non-nil result
+in order; this includes ordinary target `Unit` and the temporary physical-CPS
+`[core.nil]` encoding.  The atomic physical-CPS transition owns the semantic
+change to `[]`.
+Value and input `core.nil` continue to map to nullable reference slots.
+
 ## 직접형 제어 소유권
 
 구조와 의미의 source of truth는

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -892,6 +892,30 @@ the `[core.never]` to `[]` target switch follow in later atomic changes. Current
 target ABI lowering still uses temporary `[core.nil]` encoding for physical CPS;
 this migration state is not the final physical contract.
 
+### `wasm.func_sig` target function type
+
+`wasm.func_sig` is the Wasm-owned callable contract.  Like the shared and
+source signatures it stores an input-first flat parameter vector and mandatory
+`num_inputs`/`num_results` `u32` delimiters, but it validates zero or more
+results.  The delimiters participate in interning and must exactly cover the
+flat vector; they are storage delimiters, not evidence of an ABI convention.
+Non-reserved type attributes remain part of the complete type identity and are
+preserved by parsing, printing, aliases, and recursive conversion.
+
+Wasm functions, imports, direct and indirect calls, returns, type-section
+collection, and binary emission all consume this one target-owned type.  A
+multi-result call has one SSA result and one local per declared result; local
+stores consume Wasm's result stack in reverse result order.  Exact indirect
+contracts are `wasm.func_sig`, never reconstructed from an erased table index.
+Ordinary empty result lists are legal and do not imply CPS.  The existing Wasm
+slot rule omits every `core.nil` result from the binary result vector, while
+retaining the order of all non-nil results; this preserves ordinary target
+`Unit` compatibility as well as the temporary CPS `[core.nil]` encoding.
+Nil in an input or value position remains a nullable reference value and is not
+omitted.  The later atomic CPS switch changes the semantic CPS contract to an
+empty target result list; it does not make the Wasm emitter infer CPS from a
+function body or a call-site shape.
+
 ## Open Questions
 
 - Final closure environment representation for each backend.

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -887,34 +887,20 @@ nearest registered owner is authoritative, including when its signature is
 malformed. Shared validation does not infer a lambda signature from an attribute
 or an outer function, and does not select a physical CPS ABI.
 
-Existing source producers remain one-result. Backend zero-result readiness and
-the `[core.never]` to `[]` target switch follow in later atomic changes. Current
-target ABI lowering still uses temporary `[core.nil]` encoding for physical CPS;
-this migration state is not the final physical contract.
+### `wasm.func_sig` Wasm 호출 계약
 
-### `wasm.func_sig` target function type
+`wasm.func_sig`는 Wasm이 소유하는 함수 호출 계약이다. 공통 및 소스 시그니처와
+마찬가지로 입력 우선의 평탄한 `[inputs..., results...]` 벡터와 필수 `u32` 속성
+`num_inputs`·`num_results`를 사용하며, 결과는 0개 이상을 허용한다. 두 개수의
+합은 벡터 길이와 같아야 하고, 두 속성은 타입 동일성에 참여한다. 이 속성은 저장
+경계이지 ABI나 호출 규약의 증거가 아니다. 예약되지 않은 타입 속성도 타입
+동일성에 포함되며 파싱·출력·별칭·재귀 변환에서 보존된다.
 
-`wasm.func_sig` is the Wasm-owned callable contract.  Like the shared and
-source signatures it stores an input-first flat parameter vector and mandatory
-`num_inputs`/`num_results` `u32` delimiters, but it validates zero or more
-results.  The delimiters participate in interning and must exactly cover the
-flat vector; they are storage delimiters, not evidence of an ABI convention.
-Non-reserved type attributes remain part of the complete type identity and are
-preserved by parsing, printing, aliases, and recursive conversion.
-
-Wasm functions, imports, direct and indirect calls, returns, type-section
-collection, and binary emission all consume this one target-owned type.  A
-multi-result call has one SSA result and one local per declared result; local
-stores consume Wasm's result stack in reverse result order.  Exact indirect
-contracts are `wasm.func_sig`, never reconstructed from an erased table index.
-Ordinary empty result lists are legal and do not imply CPS.  The existing Wasm
-slot rule omits every `core.nil` result from the binary result vector, while
-retaining the order of all non-nil results; this preserves ordinary target
-`Unit` compatibility as well as the temporary CPS `[core.nil]` encoding.
-Nil in an input or value position remains a nullable reference value and is not
-omitted.  The later atomic CPS switch changes the semantic CPS contract to an
-empty target result list; it does not make the Wasm emitter infer CPS from a
-function body or a call-site shape.
+Wasm 함수와 가져오기 선언, 직접·간접 호출, 반환, 타입 섹션 수집, 검증 및 코드
+생성은 이 타입을 사용한다. 간접 호출의 명시적 시그니처는 `wasm.func_sig`이며,
+타입 정보가 지워진 테이블 인덱스에서 재구성하지 않는다. 빈 결과 목록만으로
+CPS를 판정하지 않는다. 논리적 Unit 함수, 논리적 CPS 함수, 물리적 CPS 함수의
+결과 구분은 [공통 `func.func_sig` 계약](#funcfunc_sig-function-type)을 따른다.
 
 ## Open Questions
 

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -90,6 +90,30 @@ Effect lowering은 target별로 수행한다. Shared ability lowering은 `effect
 `(table_idx, env)`를 풀어 semantic role에 맞는 일반 호출 또는 proper-tail call을
 emit하여 해당 operation을 제거하는 Wasm 경계다.
 
+### Wasm function signatures and result slots
+
+`wasm.func_sig` is the sole Wasm callable contract.  It owns separate ordered
+input and result lists, represented by `[inputs..., results...]` plus mandatory
+`num_inputs` and `num_results` `u32` storage delimiters.  It permits zero or
+multiple results and preserves non-reserved type attributes through all target
+conversion and assembly paths.  Counts delimit the interned vector only; they
+do not establish an ABI or calling convention.
+
+The target type is shared by `wasm.func`, `wasm.import_func`, calls, returns,
+exact indirect-call attributes, type-section collection, validation, and the
+encoder.  Each declared non-omitted Wasm result receives an SSA value and local;
+after a multi-result call locals are stored in reverse result order because the
+last result is on top of the Wasm stack.  Exact indirect signatures remain
+authoritative rather than being inferred from a table index.
+
+The established target slot mapping omits every `core.nil` result from binary
+result slots, including ordinary target `Unit` and the temporary physical-CPS
+`wasm.func_sig<(...)-> core.nil>` encoding.  It preserves the order of every
+non-nil result, while nil inputs and values still encode as nullable references.
+Ordinary empty result signatures are independently valid.  The atomic Cps
+`[core.nil]` to `[]` semantic change is deferred to the later physical-CPS
+stage and is checked at the Tribute boundary, not inferred by Wasm emission.
+
 ### Entrypoint contract
 
 The frontend accepts `main` only when its declared result is `Nil`. A frontend

--- a/new-plans/wasm-backend.md
+++ b/new-plans/wasm-backend.md
@@ -90,29 +90,16 @@ Effect lowering은 target별로 수행한다. Shared ability lowering은 `effect
 `(table_idx, env)`를 풀어 semantic role에 맞는 일반 호출 또는 proper-tail call을
 emit하여 해당 operation을 제거하는 Wasm 경계다.
 
-### Wasm function signatures and result slots
+### Wasm 결과 슬롯
 
-`wasm.func_sig` is the sole Wasm callable contract.  It owns separate ordered
-input and result lists, represented by `[inputs..., results...]` plus mandatory
-`num_inputs` and `num_results` `u32` storage delimiters.  It permits zero or
-multiple results and preserves non-reserved type attributes through all target
-conversion and assembly paths.  Counts delimit the interned vector only; they
-do not establish an ABI or calling convention.
+`wasm.func_sig`의 저장 형식과 간접 호출의 명시적 시그니처는
+[IR 호출 계약](ir.md#wasmfunc_sig-wasm-호출-계약)을 따른다.
 
-The target type is shared by `wasm.func`, `wasm.import_func`, calls, returns,
-exact indirect-call attributes, type-section collection, validation, and the
-encoder.  Each declared non-omitted Wasm result receives an SSA value and local;
-after a multi-result call locals are stored in reverse result order because the
-last result is on top of the Wasm stack.  Exact indirect signatures remain
-authoritative rather than being inferred from a table index.
-
-The established target slot mapping omits every `core.nil` result from binary
-result slots, including ordinary target `Unit` and the temporary physical-CPS
-`wasm.func_sig<(...)-> core.nil>` encoding.  It preserves the order of every
-non-nil result, while nil inputs and values still encode as nullable references.
-Ordinary empty result signatures are independently valid.  The atomic Cps
-`[core.nil]` to `[]` semantic change is deferred to the later physical-CPS
-stage and is checked at the Tribute boundary, not inferred by Wasm emission.
+바이너리 코드 생성은 결과 위치의 `core.nil`만 생략하고 나머지 결과의 선언 순서를
+보존한다. 생략되지 않는 각 결과에는 SSA 값과 지역 변수를 할당한다. 다중 결과
+호출 후에는 마지막 결과가 스택 맨 위에 있으므로 지역 변수에 역순으로 저장한다.
+입력이나 값 위치의 `core.nil`은 생략하지 않고 널을 허용하는 참조로 표현한다.
+Wasm 코드 생성기는 함수 본문이나 테이블 인덱스에서 CPS 여부를 추론하지 않는다.
 
 ### Entrypoint contract
 


### PR DESCRIPTION
## Summary

Introduce target-owned `wasm.func_sig` with ordered zero-or-more results, while keeping shared `func.func_sig` at zero-or-one and source `tribute_control.func_sig` at exactly one result.

- Preserve validated input/result delimiters, complete type metadata, and canonical assembly.
- Convert callable types consistently across signatures, values, block arguments, and nested metadata at the Wasm boundary.
- Support multi-result function types, direct/exact-indirect calls, and ordered SSA local mapping; reject invalid call/return/tail contracts before emission.
- Preserve existing nil result-slot omission and the temporary physical-CPS `[core.nil]` contract. The atomic CPS switch to `[]` remains a later prerequisite.

This is an independent stage-3 prerequisite for #825, following #955 and #957. It does not complete or close #825. Native/Cranelift semantics, ownership, production pipeline ordering, and the protected #825 checkpoint are unchanged.

## Validation

Verified independently at `c86d90e2b2ed452f6bc3d863ff0e14b145508d19`:

- `cargo nextest run --workspace --status-level fail --final-status-level fail`: 2,114 passed, 2 skipped.
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check` and `git diff --check`
- Explicitly executed the ignored Wasmtime multi-result direct/exact-indirect regression: both results are checked as `7`, then `9`.
- Canonical native and Wasm CLI examples compiled and executed with exact expected-output comparisons.
- Canonical type roundtrips and independent reproductions verified nested callable conversion, rejection of result narrowing, nearest-caller tail validation, and legacy indirect calls inside multi-result callers.
- Constructor and CPS dispatch regressions included in the full workspace suite.

No snapshot updates or generated/debug artifacts. Three logical commits are retained. No merge is authorized by this PR's publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - WebAssembly functions and calls now support zero, one, or multiple results.
  - Indirect calls can use exact function signatures for reliable type handling.
  - Nested callable types and metadata are preserved during WebAssembly conversion.
  - WebAssembly validation now checks function, call, return, and tail-call contracts more thoroughly.
  - Nil-only result slots are handled without emitting unnecessary binary results.

- **Documentation**
  - Updated documentation for WebAssembly signatures, result handling, validation, and backend behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->