### PR TITLE
fix(native): require exact Cranelift callable slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,7 @@ dependencies = [
  "insta",
  "rustc-hash",
  "target-lexicon",
+ "tempfile",
  "tracing",
  "trunk-ir",
 ]

--- a/crates/tribute-passes/src/native/rtti.rs
+++ b/crates/tribute-passes/src/native/rtti.rs
@@ -34,9 +34,8 @@ use trunk_ir::adt_layout::{
 };
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::clif;
-use trunk_ir::dialect::func;
 use trunk_ir::location::Span;
-use trunk_ir::ops::DialectOp;
+use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::rewrite::{Module, TypeConverter};
 use trunk_ir::smallvec::smallvec;
 use trunk_ir::types::Location;
@@ -234,7 +233,7 @@ fn generate_fixed_release_function(
     loc: Location,
 ) -> OpRef {
     let tys = ClifTypes::intern(ctx);
-    let func_ty = func::func_sig(ctx, [tys.ptr], [tys.nil]).as_type_ref();
+    let func_ty = clif::func_sig(ctx, [tys.ptr], [tys.nil]).as_type_ref();
     let entry_block = ctx.create_block(BlockData {
         location: loc,
         args: vec![BlockArgData {
@@ -293,7 +292,7 @@ fn generate_release_function_for_struct(
     let func_name = format!("{}{}", RELEASE_FN_PREFIX, rtti_idx);
 
     // Function type: (core.ptr) -> core.nil
-    let func_ty = func::func_sig(ctx, [ptr_ty], [nil_ty]).as_type_ref();
+    let func_ty = clif::func_sig(ctx, [ptr_ty], [nil_ty]).as_type_ref();
 
     assert_eq!(fields.len(), managed_fields.len());
     let managed_field_offsets: Vec<i32> = fields
@@ -516,7 +515,7 @@ fn generate_release_function_for_enum(
     let i8_ty = tys.i8;
 
     let func_name = format!("{}{}", RELEASE_FN_PREFIX, rtti_idx);
-    let func_ty = func::func_sig(ctx, [ptr_ty], [nil_ty]).as_type_ref();
+    let func_ty = clif::func_sig(ctx, [ptr_ty], [nil_ty]).as_type_ref();
 
     let entry_block = ctx.create_block(BlockData {
         location: loc,

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_empty.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_empty.snap
@@ -17,7 +17,7 @@ core.module @test {
       %7 = clif.iadd %5, %6 : core.ptr
       func.return %7
   }
-  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = clif.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 8} : core.i64
       %2 = clif.isub %0, %1 : core.ptr

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_to_clif.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__adt_rc_header__tests__struct_new_to_clif.snap
@@ -18,7 +18,7 @@ core.module @test {
       %9 = clif.iadd %7, %8 : core.ptr
       func.return %9
   }
-  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = clif.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 8} : core.i64
       %2 = clif.isub %0, %1 : core.ptr

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_release.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_release.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/tribute-passes/src/native/rc_lowering.rs
+assertion_line: 479
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @f, type = func.func_sig<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @f, type = clif.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 0} : core.ptr
       %2 = clif.icmp %0, %1 {cond = @eq} : core.i8

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/tribute-passes/src/native/rc_lowering.rs
+assertion_line: 466
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @f, type = func.func_sig<(core.ptr) -> core.ptr>} {
+  clif.func {sym_name = @f, type = clif.func_sig<(core.ptr) -> core.ptr>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 0} : core.ptr
       %2 = clif.icmp %0, %1 {cond = @eq} : core.i8

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain_and_release.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rc_lowering__tests__snapshot_retain_and_release.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/tribute-passes/src/native/rc_lowering.rs
+assertion_line: 493
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @f, type = func.func_sig<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @f, type = clif.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 0} : core.ptr
       %2 = clif.icmp %0, %1 {cond = @eq} : core.i8

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_no_ptr_fields.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_no_ptr_fields.snap
@@ -9,7 +9,7 @@ core.module @test {
       %2 = adt.struct_new %0, %1 {type = !t0} : !t0
       func.return %2
   }
-  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = clif.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.iconst {value = 8} : core.i64
       %2 = clif.isub %0, %1 : core.ptr

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_with_ptr_fields.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__rtti__tests__struct_with_ptr_fields.snap
@@ -9,7 +9,7 @@ core.module @test {
       %2 = adt.struct_new %0, %1 {type = !t0} : !t0
       func.return %2
   }
-  clif.func {sym_name = @__tribute_release_32, type = func.func_sig<(core.ptr) -> core.nil>} {
+  clif.func {sym_name = @__tribute_release_32, type = clif.func_sig<(core.ptr) -> core.nil>} {
     ^bb0(%0: core.ptr):
       %1 = clif.load %0 {offset = 8} : core.ptr
       %2 = clif.iconst {value = 0} : core.ptr

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_bool_to_clif.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_bool_to_clif.snap
@@ -14,7 +14,7 @@ core.module @test {
       %6 = clif.iadd %2, %5 : core.ptr
       clif.store %0, %6 {offset = 0}
       %7 = clif.iconst {value = 0} : core.ptr
-      %8 = clif.iadd %6, %7 : tribute_rt.anyref
+      %8 = clif.iadd %6, %7 : core.ptr
       func.return %8
   }
 }

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_float_to_clif.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_float_to_clif.snap
@@ -14,7 +14,7 @@ core.module @test {
       %6 = clif.iadd %2, %5 : core.ptr
       clif.store %0, %6 {offset = 0}
       %7 = clif.iconst {value = 0} : core.ptr
-      %8 = clif.iadd %6, %7 : tribute_rt.anyref
+      %8 = clif.iadd %6, %7 : core.ptr
       func.return %8
   }
 }

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_int_to_clif.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_int_to_clif.snap
@@ -14,7 +14,7 @@ core.module @test {
       %6 = clif.iadd %2, %5 : core.ptr
       clif.store %0, %6 {offset = 0}
       %7 = clif.iconst {value = 0} : core.ptr
-      %8 = clif.iadd %6, %7 : tribute_rt.anyref
+      %8 = clif.iadd %6, %7 : core.ptr
       func.return %8
   }
 }

--- a/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_nat_to_clif.snap
+++ b/crates/tribute-passes/src/native/snapshots/tribute_passes__native__tribute_rt_to_clif__tests__box_nat_to_clif.snap
@@ -14,7 +14,7 @@ core.module @test {
       %6 = clif.iadd %2, %5 : core.ptr
       clif.store %0, %6 {offset = 0}
       %7 = clif.iconst {value = 0} : core.ptr
-      %8 = clif.iadd %6, %7 : tribute_rt.anyref
+      %8 = clif.iadd %6, %7 : core.ptr
       func.return %8
   }
 }

--- a/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
+++ b/crates/tribute-passes/src/native/tribute_rt_to_clif.rs
@@ -115,7 +115,6 @@ pub fn lower(
 ) -> Result<(), ConversionError> {
     // Pre-intern types for patterns
     let ptr_ty = core::ptr(ctx).as_type_ref();
-    let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
     let i64_ty = ctx
         .types
         .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i64")).build());
@@ -131,28 +130,24 @@ pub fn lower(
             ptr_ty,
             i64_ty,
             i32_ty,
-            anyref_ty,
         })
         .add_pattern(UnboxIntPattern { i32_ty })
         .add_pattern(BoxNatPattern {
             ptr_ty,
             i64_ty,
             i32_ty,
-            anyref_ty,
         })
         .add_pattern(UnboxNatPattern { i32_ty })
         .add_pattern(BoxFloatPattern {
             ptr_ty,
             i64_ty,
             i32_ty,
-            anyref_ty,
         })
         .add_pattern(UnboxFloatPattern { f64_ty })
         .add_pattern(BoxBoolPattern {
             ptr_ty,
             i64_ty,
             i32_ty,
-            anyref_ty,
         })
         .add_pattern(UnboxBoolPattern { i32_ty })
         .add_pattern(IntoRawPattern { ptr_ty });
@@ -211,7 +206,6 @@ struct BoxIntPattern {
     ptr_ty: TypeRef,
     i64_ty: TypeRef,
     i32_ty: TypeRef,
-    anyref_ty: TypeRef,
 }
 
 impl RewritePattern for BoxIntPattern {
@@ -235,7 +229,7 @@ impl RewritePattern for BoxIntPattern {
             self.ptr_ty,
             self.i64_ty,
             self.i32_ty,
-            self.anyref_ty,
+            self.ptr_ty,
         );
         let last = ops.pop().unwrap();
         for o in ops {
@@ -250,7 +244,6 @@ struct BoxNatPattern {
     ptr_ty: TypeRef,
     i64_ty: TypeRef,
     i32_ty: TypeRef,
-    anyref_ty: TypeRef,
 }
 
 impl RewritePattern for BoxNatPattern {
@@ -274,7 +267,7 @@ impl RewritePattern for BoxNatPattern {
             self.ptr_ty,
             self.i64_ty,
             self.i32_ty,
-            self.anyref_ty,
+            self.ptr_ty,
         );
         let last = ops.pop().unwrap();
         for o in ops {
@@ -289,7 +282,6 @@ struct BoxBoolPattern {
     ptr_ty: TypeRef,
     i64_ty: TypeRef,
     i32_ty: TypeRef,
-    anyref_ty: TypeRef,
 }
 
 impl RewritePattern for BoxBoolPattern {
@@ -313,7 +305,7 @@ impl RewritePattern for BoxBoolPattern {
             self.ptr_ty,
             self.i64_ty,
             self.i32_ty,
-            self.anyref_ty,
+            self.ptr_ty,
         );
         let last = ops.pop().unwrap();
         for o in ops {
@@ -328,7 +320,6 @@ struct BoxFloatPattern {
     ptr_ty: TypeRef,
     i64_ty: TypeRef,
     i32_ty: TypeRef,
-    anyref_ty: TypeRef,
 }
 
 impl RewritePattern for BoxFloatPattern {
@@ -352,7 +343,7 @@ impl RewritePattern for BoxFloatPattern {
             self.ptr_ty,
             self.i64_ty,
             self.i32_ty,
-            self.anyref_ty,
+            self.ptr_ty,
         );
         let last = ops.pop().unwrap();
         for o in ops {

--- a/crates/tribute-passes/src/native/type_converter.rs
+++ b/crates/tribute-passes/src/native/type_converter.rs
@@ -514,7 +514,7 @@ struct NativeTypeRefsCopy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use trunk_ir::dialect::{clif, func};
+    use trunk_ir::dialect::clif;
     use trunk_ir::ops::{DialectOp, DialectType};
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
@@ -563,10 +563,10 @@ mod tests {
 
         assert_eq!(ctx.op(declaration.op_ref()).regions.len(), 0);
         let declaration_type =
-            func::FuncSig::from_type_ref(&ctx, declaration.r#type(&ctx)).unwrap();
+            clif::FuncSig::from_type_ref(&ctx, declaration.r#type(&ctx)).unwrap();
         assert_eq!(declaration_type.inputs(&ctx), [refs.core_ptr]);
         assert_eq!(declaration_type.single_result(&ctx), Some(refs.core_ptr));
-        let definition_type = func::FuncSig::from_type_ref(&ctx, definition.r#type(&ctx)).unwrap();
+        let definition_type = clif::FuncSig::from_type_ref(&ctx, definition.r#type(&ctx)).unwrap();
         assert_eq!(definition_type.inputs(&ctx), [refs.core_ptr]);
         assert_eq!(definition_type.single_result(&ctx), Some(refs.core_ptr));
 

--- a/crates/trunk-ir-cranelift-backend/Cargo.toml
+++ b/crates/trunk-ir-cranelift-backend/Cargo.toml
@@ -19,3 +19,4 @@ trunk-ir.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+tempfile.workspace = true

--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -11,7 +11,7 @@ use cranelift_codegen::isa::CallConv;
 use cranelift_frontend::FunctionBuilder;
 use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
-use trunk_ir::dialect::{clif, func};
+use trunk_ir::dialect::clif;
 use trunk_ir::ops::{DialectOp, DialectType};
 use trunk_ir::refs::{BlockRef, OpRef, TypeRef, ValueRef};
 
@@ -38,7 +38,7 @@ pub(crate) fn call_conv_for_cps_signature(
 }
 
 fn has_physical_empty_result(ctx: &IrContext, signature: TypeRef) -> bool {
-    func::FuncSig::from_type_ref(ctx, signature)
+    clif::FuncSig::from_type_ref(ctx, signature)
         .and_then(|function| function.single_result(ctx))
         .is_some_and(|result| is_nil_type(ctx, result))
 }
@@ -136,7 +136,7 @@ pub(crate) fn translate_type(
     )))
 }
 
-/// Translate a TrunkIR `func.func_sig` type to a Cranelift `Signature`.
+/// Translate a target-owned `clif.func_sig` type to a Cranelift `Signature`.
 ///
 /// `ptr_ty` is the platform pointer type, obtained from `target_config().pointer_type()`.
 pub(crate) fn translate_signature(
@@ -145,17 +145,12 @@ pub(crate) fn translate_signature(
     call_conv: CallConv,
     ptr_ty: cl_types::Type,
 ) -> CompilationResult<cl_ir::Signature> {
-    let function = func::FuncSig::from_type_ref(ctx, func_ty_ref).ok_or_else(|| {
-        CompilationError::type_error("expected valid func.func_sig type for signature translation")
+    let function = clif::FuncSig::from_type_ref(ctx, func_ty_ref).ok_or_else(|| {
+        CompilationError::type_error("expected valid clif.func_sig type for signature translation")
     })?;
 
     let mut sig = cl_ir::Signature::new(call_conv);
 
-    let ret_type = function.single_result(ctx).ok_or_else(|| {
-        CompilationError::type_error(
-            "Cranelift signature translation currently requires one func.func_sig result",
-        )
-    })?;
     let param_types = function.inputs(ctx);
 
     for &param_ty in param_types {
@@ -166,10 +161,12 @@ pub(crate) fn translate_signature(
         sig.params.push(cl_ir::AbiParam::new(cl_ty));
     }
 
-    // Nil return type means void — no return values.
-    let ret_td = ctx.types.get(ret_type);
-    if !(ret_td.dialect == Symbol::new("core") && ret_td.name == Symbol::new("nil")) {
-        let cl_ty = translate_type(ctx, ret_type, ptr_ty)?;
+    // Nil results are zero-width; preserve every non-nil result in order.
+    for &result_ty in function.results(ctx) {
+        if is_nil_type(ctx, result_ty) {
+            continue;
+        }
+        let cl_ty = translate_type(ctx, result_ty, ptr_ty)?;
         sig.returns.push(cl_ir::AbiParam::new(cl_ty));
     }
 
@@ -248,6 +245,28 @@ impl<'a> FunctionTranslator<'a> {
     /// Check if a value has `core.nil` type.
     fn is_nil_typed(&self, val: ValueRef) -> bool {
         is_nil_type(self.ctx, self.ctx.value_ty(val))
+    }
+
+    fn map_call_results(&mut self, op: OpRef, results: &[cl_ir::Value]) -> CompilationResult<()> {
+        let mut runtime_results = results.iter().copied();
+        for index in 0..self.ctx.op_result_types(op).len() {
+            let ir_result = self.ctx.op_result(op, index as u32);
+            if self.is_nil_typed(ir_result) {
+                continue;
+            }
+            let Some(result) = runtime_results.next() else {
+                return Err(CompilationError::codegen(
+                    "call result count does not match non-Nil TrunkIR results",
+                ));
+            };
+            self.values.insert(ir_result, result);
+        }
+        if runtime_results.next().is_some() {
+            return Err(CompilationError::codegen(
+                "call produced more Cranelift results than TrunkIR declares",
+            ));
+        }
+        Ok(())
     }
 
     fn runtime_values(&self, values: &[ValueRef]) -> CompilationResult<Vec<cl_ir::Value>> {
@@ -364,12 +383,8 @@ impl<'a> FunctionTranslator<'a> {
             let args = self.runtime_values(operands)?;
 
             let inst = self.builder.ins().call(func_ref, &args);
-            let results = self.builder.inst_results(inst);
-            if !results.is_empty() {
-                let ir_result = ctx.op_result(op, 0);
-                self.values.insert(ir_result, results[0]);
-            }
-            return Ok(());
+            let results = self.builder.inst_results(inst).to_vec();
+            return self.map_call_results(op, &results);
         }
 
         // === Return ===
@@ -571,12 +586,8 @@ impl<'a> FunctionTranslator<'a> {
             let sig_ref = self.builder.import_signature(sig);
 
             let inst = self.builder.ins().call_indirect(sig_ref, callee, &args);
-            let results = self.builder.inst_results(inst);
-            if !results.is_empty() {
-                let ir_result = ctx.op_result(op, 0);
-                self.values.insert(ir_result, results[0]);
-            }
-            return Ok(());
+            let results = self.builder.inst_results(inst).to_vec();
+            return self.map_call_results(op, &results);
         }
 
         // === Type Conversions ===
@@ -794,7 +805,7 @@ mod tests {
         let i32_ty = make_core_type(&mut ctx, "i32");
         let i64_ty = make_core_type(&mut ctx, "i64");
 
-        let func_ty = func::func_sig(&mut ctx, [i32_ty, i32_ty], [i64_ty]).as_type_ref();
+        let func_ty = clif::func_sig(&mut ctx, [i32_ty, i32_ty], [i64_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(sig.params.len(), 2);
@@ -810,7 +821,7 @@ mod tests {
         let i64_ty = make_core_type(&mut ctx, "i64");
         let nil_ty = make_core_type(&mut ctx, "nil");
 
-        let func_ty = func::func_sig(&mut ctx, [i64_ty], [nil_ty]).as_type_ref();
+        let func_ty = clif::func_sig(&mut ctx, [i64_ty], [nil_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(sig.params.len(), 1);
@@ -825,7 +836,7 @@ mod tests {
         let i64_ty = make_core_type(&mut ctx, "i64");
         let nil_ty = make_core_type(&mut ctx, "nil");
 
-        let func_ty = func::func_sig(&mut ctx, [i32_ty, nil_ty, i64_ty], [i32_ty]).as_type_ref();
+        let func_ty = clif::func_sig(&mut ctx, [i32_ty, nil_ty, i64_ty], [i32_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(
@@ -844,7 +855,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let i64_ty = make_core_type(&mut ctx, "i64");
 
-        let func_ty = func::func_sig(&mut ctx, [], [i64_ty]).as_type_ref();
+        let func_ty = clif::func_sig(&mut ctx, [], [i64_ty]).as_type_ref();
 
         let sig = translate_signature(&ctx, func_ty, CallConv::SystemV, cl_types::I64).unwrap();
         assert_eq!(sig.params.len(), 0);
@@ -857,8 +868,8 @@ mod tests {
         let mut ctx = IrContext::new();
         let i32_ty = make_core_type(&mut ctx, "i32");
         let nil_ty = make_core_type(&mut ctx, "nil");
-        let logical_signature = func::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
-        let physical_signature = func::func_sig(&mut ctx, [i32_ty], [nil_ty]).as_type_ref();
+        let logical_signature = clif::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
+        let physical_signature = clif::func_sig(&mut ctx, [i32_ty], [nil_ty]).as_type_ref();
 
         assert_eq!(
             call_conv_for_cps_signature(&ctx, logical_signature, true, CallConv::SystemV),
@@ -874,16 +885,33 @@ mod tests {
 #[cfg(test)]
 mod result_list_tests {
     use super::*;
+    use trunk_ir::types::TypeData;
+
+    fn make_core_type(ctx: &mut IrContext, name: &'static str) -> TypeRef {
+        ctx.types.intern(TypeData {
+            dialect: Symbol::new("core"),
+            name: Symbol::new(name),
+            params: Default::default(),
+            attrs: Default::default(),
+        })
+    }
+
     #[test]
-    fn unsupported_resultless_signature_is_rejected_without_panicking() {
+    fn translates_resultless_and_ordered_multi_result_signatures() {
         let mut ctx = IrContext::new();
-        let signature = func::func_sig(&mut ctx, [], []).as_type_ref();
-        let error =
-            translate_signature(&ctx, signature, CallConv::SystemV, cl_types::I64).unwrap_err();
+        let i32 = make_core_type(&mut ctx, "i32");
+        let i64 = make_core_type(&mut ctx, "i64");
+        let resultless = clif::func_sig(&mut ctx, [], []).as_type_ref();
+        let multiple = clif::func_sig(&mut ctx, [i32], [i64, i32]).as_type_ref();
         assert!(
-            error
-                .to_string()
-                .contains("currently requires one func.func_sig result")
+            translate_signature(&ctx, resultless, CallConv::SystemV, cl_types::I64)
+                .unwrap()
+                .returns
+                .is_empty()
         );
+        let translated =
+            translate_signature(&ctx, multiple, CallConv::SystemV, cl_types::I64).unwrap();
+        assert_eq!(translated.returns[0].value_type, cl_types::I64);
+        assert_eq!(translated.returns[1].value_type, cl_types::I32);
     }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -403,7 +403,8 @@ impl RewritePattern for FuncCallIndirectPattern {
                 .iter()
                 .zip(CallLike::call_args(&call, ctx))
                 .any(|(&param, &arg)| param != ctx.value_ty(arg))
-            || runtime_result_types != result_types
+            || (result_types.as_slice() != callable.results(ctx)
+                && result_types != runtime_result_types)
         {
             return false;
         }
@@ -838,6 +839,75 @@ mod tests {
             "{result}"
         );
         assert!(!result.contains("func.call_indirect"), "{result}");
+    }
+
+    #[test]
+    fn indirect_call_preserves_live_logical_nil_result() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr) -> core.nil {
+    %unit = func.call_indirect %callee {signature = func.func_sig<() -> core.nil>} : core.nil
+    func.return %unit
+  }
+}"#,
+        );
+
+        super::lower(&mut ctx, module, TypeConverter::new()).expect("func-to-clif lowering");
+        crate::validate_clif_ir(&ctx, module).expect("logical nil call result is valid native IR");
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            printed
+                .contains("clif.call_indirect %0 {sig = clif.func_sig<() -> core.nil>} : core.nil"),
+            "{printed}"
+        );
+        assert!(printed.contains("clif.return %1"), "{printed}");
+        assert!(
+            !crate::emit_module_to_native(&ctx, module, &[])
+                .expect("native emitter projects nil to zero-width")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn indirect_call_without_exact_signature_is_rejected_before_mutation() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr) -> core.nil {
+    %unit = func.call_indirect %callee : core.nil
+    func.return %unit
+  }
+}"#,
+        );
+
+        let error = super::lower(&mut ctx, module, TypeConverter::new()).unwrap_err();
+        assert!(error.to_string().contains("func.call_indirect"), "{error}");
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("func.call_indirect"), "{printed}");
+        assert!(!printed.contains("clif.call_indirect"), "{printed}");
+    }
+
+    #[test]
+    fn indirect_call_does_not_equate_nil_contract_with_no_result() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @caller(%callee: core.ptr) -> core.nil {
+    %unit = func.call_indirect %callee {signature = func.func_sig<() -> ()>} : core.nil
+    func.return %unit
+  }
+}"#,
+        );
+
+        let error = super::lower(&mut ctx, module, TypeConverter::new()).unwrap_err();
+        assert!(error.to_string().contains("func.call_indirect"), "{error}");
+        let printed = print_module(&ctx, module.op());
+        assert!(printed.contains("func.call_indirect"), "{printed}");
+        assert!(!printed.contains("clif.call_indirect"), "{printed}");
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -55,10 +55,10 @@ pub fn lower(
     module: Module,
     type_converter: TypeConverter,
 ) -> Result<LoweringResult, ConversionError> {
-    // Phase 1: Adapt closure structs for native backend
+    // Phase 1: Adapt closure structs for native backend. This identity rewrite
+    // must see the semantic layout recorded by the typed ownership plan.
     let rtti_layout_rewrites = adapt_closure_structs(ctx, module);
 
-    // Phase 2: Lower func dialect to clif dialect
     let applicator = PatternApplicator::new(type_converter)
         .with_auto_type_conversion(true)
         .add_pattern(FuncFuncPattern)
@@ -74,6 +74,139 @@ pub fn lower(
     Ok(LoweringResult {
         rtti_layout_rewrites,
     })
+}
+
+fn convert_attribute_to_clif(
+    ctx: &mut IrContext,
+    attribute: &Attribute,
+    converter: &TypeConverter,
+) -> Option<Attribute> {
+    match attribute {
+        Attribute::Type(ty) => Some(Attribute::Type(convert_type_to_clif(ctx, *ty, converter)?)),
+        Attribute::List(values) => Some(Attribute::List(
+            values
+                .iter()
+                .map(|value| convert_attribute_to_clif(ctx, value, converter))
+                .collect::<Option<_>>()?,
+        )),
+        other => Some(other.clone()),
+    }
+}
+
+fn convert_nested_callable_type(
+    ctx: &mut IrContext,
+    ty: TypeRef,
+    converter: &TypeConverter,
+) -> Option<TypeRef> {
+    if func::FuncSig::from_type_ref(ctx, ty).is_some() {
+        return convert_type_to_clif(ctx, ty, converter);
+    }
+    let data = ctx.types.get(ty).clone();
+    let params = data
+        .params
+        .iter()
+        .map(|parameter| convert_nested_callable_type(ctx, *parameter, converter))
+        .collect::<Option<Vec<_>>>()?;
+    let attrs = data
+        .attrs
+        .iter()
+        .map(|(key, value)| {
+            Some((
+                *key,
+                convert_nested_callable_attribute(ctx, value, converter)?,
+            ))
+        })
+        .collect::<Option<_>>()?;
+    if params.as_slice() == data.params.as_slice() && attrs == data.attrs {
+        return Some(ty);
+    }
+    let mut converted_data = data;
+    converted_data.params = params.into();
+    converted_data.attrs = attrs;
+    Some(ctx.types.intern(converted_data))
+}
+
+fn convert_nested_callable_attribute(
+    ctx: &mut IrContext,
+    attribute: &Attribute,
+    converter: &TypeConverter,
+) -> Option<Attribute> {
+    match attribute {
+        Attribute::Type(ty) => Some(Attribute::Type(convert_nested_callable_type(
+            ctx, *ty, converter,
+        )?)),
+        Attribute::List(values) => Some(Attribute::List(
+            values
+                .iter()
+                .map(|value| convert_nested_callable_attribute(ctx, value, converter))
+                .collect::<Option<_>>()?,
+        )),
+        other => Some(other.clone()),
+    }
+}
+
+fn convert_type_to_clif(
+    ctx: &mut IrContext,
+    ty: TypeRef,
+    converter: &TypeConverter,
+) -> Option<TypeRef> {
+    if let Some(shared) = func::FuncSig::from_type_ref(ctx, ty) {
+        let inputs = shared.inputs(ctx).to_vec();
+        let results = shared.results(ctx).to_vec();
+        let type_attrs = shared
+            .non_reserved_attrs(ctx)
+            .map(|(key, value)| (*key, value.clone()))
+            .collect::<Vec<_>>();
+        let attrs = type_attrs
+            .into_iter()
+            .map(|(key, value)| Some((key, convert_attribute_to_clif(ctx, &value, converter)?)))
+            .collect::<Option<_>>()?;
+        let inputs = inputs
+            .into_iter()
+            .map(|ty| convert_type_to_clif(ctx, ty, converter))
+            .collect::<Option<Vec<_>>>()?;
+        let results = results
+            .into_iter()
+            .map(|ty| convert_type_to_clif(ctx, ty, converter))
+            .collect::<Option<Vec<_>>>()?;
+        return Some(clif::func_sig_with_attrs(ctx, inputs, results, attrs).as_type_ref());
+    }
+    let converted = converter.convert_type_or_identity(ctx, ty);
+    if converted != ty {
+        return convert_type_to_clif(ctx, converted, converter);
+    }
+    let data = ctx.types.get(ty).clone();
+    let params = data
+        .params
+        .iter()
+        .map(|parameter| convert_nested_callable_type(ctx, *parameter, converter))
+        .collect::<Option<Vec<_>>>()?;
+    let attrs = data
+        .attrs
+        .iter()
+        .map(|(key, value)| {
+            Some((
+                *key,
+                convert_nested_callable_attribute(ctx, value, converter)?,
+            ))
+        })
+        .collect::<Option<_>>()?;
+    if params.as_slice() == data.params.as_slice() && attrs == data.attrs {
+        return Some(ty);
+    }
+    let mut converted_data = data;
+    converted_data.params = params.into();
+    converted_data.attrs = attrs;
+    Some(ctx.types.intern(converted_data))
+}
+
+fn convert_to_clif_func_type(
+    ctx: &mut IrContext,
+    signature: TypeRef,
+    converter: &TypeConverter,
+) -> Option<TypeRef> {
+    func::FuncSig::from_type_ref(ctx, signature)?;
+    convert_type_to_clif(ctx, signature, converter)
 }
 
 fn func_to_clif_target() -> ConversionTarget {
@@ -182,7 +315,7 @@ impl RewritePattern for FuncFuncPattern {
         let Some(func_ty) = func_type_attr else {
             return false;
         };
-        let Some(new_func_ty) = trunk_ir::rewrite::convert_function_type(ctx, func_ty, tc) else {
+        let Some(new_func_ty) = convert_to_clif_func_type(ctx, func_ty, tc) else {
             return false;
         };
         new_attrs.insert(Symbol::new("type"), Attribute::Type(new_func_ty));
@@ -248,45 +381,32 @@ impl RewritePattern for FuncCallIndirectPattern {
         };
 
         let result_types = rewriter.result_types(ctx, op);
-        let sig_ty = if let Some(signature) = call.exact_signature(ctx) {
-            let Some(signature) =
-                trunk_ir::rewrite::convert_function_type(ctx, signature, rewriter.type_converter())
-            else {
-                return false;
-            };
-            let Some(callable) = func::FuncSig::from_type_ref(ctx, signature) else {
-                return false;
-            };
-            let Some(callable_result) = callable.single_result(ctx) else {
-                return false;
-            };
-            let results_match = if crate::function::is_nil_type(ctx, callable_result) {
-                result_types.is_empty()
-            } else {
-                result_types == [callable_result]
-            };
-            if callable.inputs(ctx).len() != CallLike::call_args(&call, ctx).len()
-                || callable
-                    .inputs(ctx)
-                    .iter()
-                    .zip(CallLike::call_args(&call, ctx))
-                    .any(|(&param, &arg)| param != ctx.value_ty(arg))
-                || !results_match
-            {
-                return false;
-            }
-            signature
-        } else {
-            let param_types: Vec<TypeRef> = CallLike::call_args(&call, ctx)
-                .iter()
-                .map(|&value| ctx.value_ty(value))
-                .collect();
-            let result = result_types
-                .first()
-                .copied()
-                .unwrap_or_else(|| core::nil(ctx).as_type_ref());
-            func::func_sig(ctx, param_types, [result]).as_type_ref()
+        let Some(signature) = call.exact_signature(ctx) else {
+            return false;
         };
+        let Some(sig_ty) = convert_to_clif_func_type(ctx, signature, rewriter.type_converter())
+        else {
+            return false;
+        };
+        let Some(callable) = clif::FuncSig::from_type_ref(ctx, sig_ty) else {
+            return false;
+        };
+        let runtime_result_types = callable
+            .results(ctx)
+            .iter()
+            .copied()
+            .filter(|ty| !crate::function::is_nil_type(ctx, *ty))
+            .collect::<Vec<_>>();
+        if callable.inputs(ctx).len() != CallLike::call_args(&call, ctx).len()
+            || callable
+                .inputs(ctx)
+                .iter()
+                .zip(CallLike::call_args(&call, ctx))
+                .any(|(&param, &arg)| param != ctx.value_ty(arg))
+            || runtime_result_types != result_types
+        {
+            return false;
+        }
 
         let new_op = crate::passes::cf_to_clif::rebuild_op_as(
             ctx,
@@ -388,12 +508,11 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         let Some(signature) = tail.exact_signature(ctx) else {
             return false;
         };
-        let Some(signature) =
-            trunk_ir::rewrite::convert_function_type(ctx, signature, rewriter.type_converter())
+        let Some(signature) = convert_to_clif_func_type(ctx, signature, rewriter.type_converter())
         else {
             return false;
         };
-        let Some(callable) = func::FuncSig::from_type_ref(ctx, signature) else {
+        let Some(callable) = clif::FuncSig::from_type_ref(ctx, signature) else {
             return false;
         };
         if callable.single_result(ctx) != Some(core::nil(ctx).as_type_ref())
@@ -537,13 +656,14 @@ impl RewritePattern for ClosureStructAdaptPattern {
 
 #[cfg(test)]
 mod tests {
-    use trunk_ir::Symbol;
     use trunk_ir::context::IrContext;
-    use trunk_ir::dialect::core;
+    use trunk_ir::dialect::{clif, core, func};
+    use trunk_ir::ops::DialectType;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
     use trunk_ir::rewrite::TypeConverter;
     use trunk_ir::types::TypeDataBuilder;
+    use trunk_ir::{Attribute, AttributeMap, Symbol};
 
     const TAIL_TRANSFERS: &str = r#"core.module @test {
   func.func @direct_target(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
@@ -640,13 +760,61 @@ mod tests {
     }
 
     #[test]
+    fn nested_callable_metadata_uses_the_native_owned_signature() {
+        let mut ctx = IrContext::new();
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let i64_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i64")).build());
+        let mut type_converter = TypeConverter::new();
+        type_converter.add_conversion(move |_, ty| (ty == i32_ty).then_some(i64_ty));
+
+        let mut inner_attrs = AttributeMap::new();
+        inner_attrs.insert(
+            Symbol::new("tag"),
+            Attribute::Symbol(Symbol::new("preserved")),
+        );
+        inner_attrs.insert(
+            Symbol::new("nested"),
+            Attribute::List(vec![Attribute::Type(i32_ty)]),
+        );
+        let nested =
+            func::func_sig_with_attrs(&mut ctx, [i32_ty], [i32_ty], inner_attrs).as_type_ref();
+        let mut attrs = AttributeMap::new();
+        attrs.insert(
+            Symbol::new("evidence"),
+            Attribute::List(vec![Attribute::Type(nested)]),
+        );
+        let source = func::func_sig_with_attrs(&mut ctx, [i32_ty], [i32_ty], attrs).as_type_ref();
+        let converted = super::convert_to_clif_func_type(&mut ctx, source, &type_converter)
+            .expect("target callable contract");
+        let signature = clif::FuncSig::from_type_ref(&ctx, converted).expect("clif.func_sig");
+        assert!(signature.inputs(&ctx) == [i64_ty] && signature.results(&ctx) == [i64_ty]);
+        let Some(Attribute::List(evidence)) = signature
+            .non_reserved_attrs(&ctx)
+            .find_map(|(key, value)| (*key == Symbol::new("evidence")).then_some(value))
+        else {
+            panic!("missing nested target contract");
+        };
+        let [Attribute::Type(nested)] = evidence.as_slice() else {
+            panic!("nested target contract must be a one-element type list");
+        };
+        let nested = clif::FuncSig::from_type_ref(&ctx, *nested).expect("nested clif.func_sig");
+        assert_eq!(nested.inputs(&ctx), [i64_ty]);
+        assert_eq!(nested.results(&ctx), [i64_ty]);
+        assert_eq!(nested.non_reserved_attrs(&ctx).count(), 2);
+    }
+
+    #[test]
     fn test_call_indirect_to_clif() {
         let result = run_pass(
             r#"core.module @test {
   func.func @test_fn() -> core.i32 {
     %0 = arith.const {value = 0} : core.i32
     %1 = arith.const {value = 42} : core.i32
-    %2 = func.call_indirect %0, %1 : core.i32
+    %2 = func.call_indirect %0, %1 {signature = func.func_sig<(core.i32) -> core.i32>} : core.i32
     func.return %2
   }
 }"#,
@@ -666,7 +834,7 @@ mod tests {
         );
 
         assert!(
-            result.contains("clif.call_indirect %0 {sig = func.func_sig<() -> core.nil>}"),
+            result.contains("clif.call_indirect %0 {sig = clif.func_sig<() -> core.nil>}"),
             "{result}"
         );
         assert!(!result.contains("func.call_indirect"), "{result}");
@@ -702,11 +870,11 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains("clif.return_call_indirect")
-                && printed.contains("sig = func.func_sig<(core.ptr) -> core.nil>"),
+                && printed.contains("sig = clif.func_sig<(core.ptr) -> core.nil>"),
             "{printed}"
         );
         assert!(
-            !printed.contains("sig = func.func_sig<(!evidence) -> core.nil>"),
+            !printed.contains("sig = clif.func_sig<(!evidence) -> core.nil>"),
             "{printed}"
         );
     }
@@ -742,7 +910,7 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains("clif.call_indirect")
-                && printed.contains("sig = func.func_sig<(core.ptr) -> core.i32>"),
+                && printed.contains("sig = clif.func_sig<(core.ptr) -> core.i32>"),
             "{printed}"
         );
         assert!(
@@ -875,7 +1043,7 @@ mod tests {
     %2 = adt.struct_new %0, %1 {type = adt.struct(core.i32, core.ptr) {name = @_closure, fields = [@table_idx, @env]}} : adt.struct(core.i32, core.ptr) {name = @_closure, fields = [@table_idx, @env]}
     %3 = adt.struct_get %2 {field = 0, type = adt.struct(core.i32, core.ptr) {name = @_closure, fields = [@table_idx, @env]}} : core.i32
     %4 = adt.struct_get %2 {field = 1, type = adt.struct(core.i32, core.ptr) {name = @_closure, fields = [@table_idx, @env]}} : core.ptr
-    %5 = func.call_indirect %3, %4 : core.i32
+    %5 = func.call_indirect %3, %4 {signature = func.func_sig<(core.ptr) -> core.i32>} : core.i32
     func.return %5
   }
 }"#,
@@ -893,7 +1061,7 @@ mod tests {
     %2 = adt.struct_new %0, %1 {type = adt.struct(core.i32, wasm.anyref) {name = @_closure, fields = [@table_idx, @env]}} : adt.struct(core.i32, wasm.anyref) {name = @_closure, fields = [@table_idx, @env]}
     %3 = adt.struct_get %2 {field = 0, type = adt.struct(core.i32, wasm.anyref) {name = @_closure, fields = [@table_idx, @env]}} : core.i32
     %4 = adt.struct_get %2 {field = 1, type = adt.struct(core.i32, wasm.anyref) {name = @_closure, fields = [@table_idx, @env]}} : wasm.anyref
-    %5 = func.call_indirect %3, %4 : core.i32
+    %5 = func.call_indirect %3, %4 {signature = func.func_sig<(core.ptr) -> core.i32>} : core.i32
     func.return %5
   }
 }"#,

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -841,6 +841,36 @@ mod tests {
     }
 
     #[test]
+    fn callable_value_is_erased_while_its_exact_contract_stays_target_owned() {
+        let result = run_pass(
+            r#"core.module @test {
+  func.func @target() -> core.i32 {
+    %value = arith.const {value = 7} : core.i32
+    func.return %value
+  }
+  func.func @caller() -> core.i32 {
+    %callee = func.constant {func_ref = @target} : func.func_sig<() -> core.i32>
+    %value = func.call_indirect %callee {signature = func.func_sig<() -> core.i32>} : core.i32
+    func.return %value
+  }
+}"#,
+        );
+        assert!(
+            result.contains("clif.symbol_addr {sym = @target} : core.ptr"),
+            "{result}"
+        );
+        assert!(
+            result.contains("clif.call_indirect %0 {sig = !t0} : core.i32"),
+            "{result}"
+        );
+        assert!(
+            result.contains("!t0 = clif.func_sig<() -> core.i32>"),
+            "{result}"
+        );
+        assert!(!result.contains("func.func_sig"), "{result}");
+    }
+
+    #[test]
     fn test_tail_transfers_to_clif() {
         let result = run_pass(TAIL_TRANSFERS);
         insta::assert_snapshot!(result);

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__call_indirect_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__call_indirect_to_clif.snap
@@ -4,10 +4,10 @@ assertion_line: 486
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.i32>} {
+  clif.func {sym_name = @test_fn, type = clif.func_sig<() -> core.i32>} {
       %0 = arith.const {value = 0} : core.i32
       %1 = arith.const {value = 42} : core.i32
-      %2 = clif.call_indirect %0, %1 {sig = func.func_sig<(core.i32) -> core.i32>} : core.i32
+      %2 = clif.call_indirect %0, %1 {sig = clif.func_sig<(core.i32) -> core.i32>} : core.i32
       clif.return %2
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_adaptation.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_adaptation.snap
@@ -6,13 +6,13 @@ expression: result
 core.module @test {
   !_closure = adt.struct(core.i64, core.ptr) {fields = [[@func_ptr, core.i64], [@env, core.ptr]], name = @_closure}
 
-  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.i32>} {
+  clif.func {sym_name = @test_fn, type = clif.func_sig<() -> core.i32>} {
       %0 = clif.symbol_addr {sym = @lifted_fn} : core.ptr
       %1 = arith.const {value = 0} : core.ptr
       %2 = adt.struct_new %0, %1 {type = !_closure} : !_closure
       %3 = adt.struct_get %2 {field = 0, type = !_closure} : core.i64
       %4 = adt.struct_get %2 {field = 1, type = !_closure} : core.ptr
-      %5 = clif.call_indirect %3, %4 {sig = func.func_sig<(core.ptr) -> core.i32>} : core.i32
+      %5 = clif.call_indirect %3, %4 {sig = clif.func_sig<(core.ptr) -> core.i32>} : core.i32
       clif.return %5
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_anyref_adaptation.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__closure_struct_anyref_adaptation.snap
@@ -6,13 +6,13 @@ expression: result
 core.module @test {
   !_closure = adt.struct(core.i64, core.ptr) {fields = [[@func_ptr, core.i64], [@env, core.ptr]], name = @_closure}
 
-  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.i32>} {
+  clif.func {sym_name = @test_fn, type = clif.func_sig<() -> core.i32>} {
       %0 = clif.symbol_addr {sym = @lifted_fn} : core.ptr
       %1 = arith.const {value = 0} : wasm.anyref
       %2 = adt.struct_new %0, %1 {type = !_closure} : !_closure
       %3 = adt.struct_get %2 {field = 0, type = !_closure} : core.i64
       %4 = adt.struct_get %2 {field = 1, type = !_closure} : core.ptr
-      %5 = clif.call_indirect %3, %4 {sig = func.func_sig<(core.ptr) -> core.i32>} : core.i32
+      %5 = clif.call_indirect %3, %4 {sig = clif.func_sig<(core.ptr) -> core.i32>} : core.i32
       clif.return %5
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__func_func_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__func_func_to_clif.snap
@@ -4,7 +4,7 @@ assertion_line: 471
 expression: result
 ---
 core.module @test {
-  clif.func {sym_name = @test_fn, type = func.func_sig<() -> core.nil>} {
+  clif.func {sym_name = @test_fn, type = clif.func_sig<() -> core.nil>} {
       clif.return
   }
 }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
@@ -3,7 +3,7 @@ source: crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
 expression: result
 ---
 core.module @test {
-  !t0 = func.func_sig<(core.i32) -> core.nil>
+  !t0 = clif.func_sig<(core.i32) -> core.nil>
 
   clif.func {sym_name = @direct_target, tribute.calling_convention = 2, type = !t0} {
     ^bb0(%0: core.i32):
@@ -13,7 +13,7 @@ core.module @test {
     ^bb0(%0: core.i32):
       clif.return_call %0 {callee = @direct_target, tribute.calling_convention = 2}
   }
-  clif.func {sym_name = @indirect_caller, tribute.calling_convention = 2, type = func.func_sig<(core.ptr, core.i32) -> core.nil>} {
+  clif.func {sym_name = @indirect_caller, tribute.calling_convention = 2, type = clif.func_sig<(core.ptr, core.i32) -> core.nil>} {
     ^bb0(%0: core.ptr, %1: core.i32):
       clif.return_call_indirect %0, %1 {sig = !t0, tribute.calling_convention = 2}
   }

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -745,36 +745,8 @@ fn declare_runtime_functions(
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use super::*;
     use trunk_ir::parser::parse_test_module;
-
-    struct TestTempDir(PathBuf);
-
-    impl TestTempDir {
-        fn new(prefix: &str) -> Self {
-            let unique = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("system time after epoch")
-                .as_nanos();
-            let path =
-                std::env::temp_dir().join(format!("{prefix}-{}-{unique}", std::process::id()));
-            std::fs::create_dir_all(&path).expect("create test directory");
-            Self(path)
-        }
-
-        fn path(&self) -> &Path {
-            &self.0
-        }
-    }
-
-    impl Drop for TestTempDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
 
     const NIL_ZERO_WIDTH_NATIVE: &str = r#"core.module @test {
   clif.func {sym_name = @call_target, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
@@ -894,7 +866,10 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ORDERED_RESULT_LISTS_NATIVE);
         let object = emit_module_to_native(&ctx, module, &[]).unwrap();
-        let temp = TestTempDir::new("tribute-ordered-results");
+        let temp = tempfile::Builder::new()
+            .prefix("tribute-ordered-results")
+            .tempdir()
+            .expect("create isolated temporary directory");
         let object_path = temp.path().join("ordered-results.o");
         let executable = temp.path().join("ordered-results");
         let runtime_shim = temp.path().join("runtime-shim.c");
@@ -911,7 +886,7 @@ mod tests {
                 .arg("-o")
                 .arg(&executable)
                 .status()
-                .unwrap()
+                .expect("C toolchain `cc` is required to link the native execution witness")
                 .success()
         );
         let status = std::process::Command::new(&executable).status().unwrap();

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -749,33 +749,54 @@ mod tests {
     use trunk_ir::parser::parse_test_module;
 
     const NIL_ZERO_WIDTH_NATIVE: &str = r#"core.module @test {
-  clif.func {sym_name = @call_target, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
+  clif.func {sym_name = @call_target, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       clif.return %value
   }
-  clif.func {sym_name = @direct_call, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
+  clif.func {sym_name = @direct_call, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       %result = clif.call %value, %unit, %last {callee = @call_target} : core.i32
       clif.return %result
   }
-  clif.func {sym_name = @indirect_call, type = func.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> core.i32>} {
+  clif.func {sym_name = @indirect_call, type = clif.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> core.i32>} {
     ^entry(%callee: core.ptr, %value: core.i32, %unit: core.nil, %last: core.i64):
-      %result = clif.call_indirect %callee, %value, %unit, %last {sig = func.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} : core.i32
+      %result = clif.call_indirect %callee, %value, %unit, %last {sig = clif.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} : core.i32
       clif.return %result
   }
-  clif.func {sym_name = @direct_tail, tribute.calling_convention = 2, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
+  clif.func {sym_name = @direct_tail, tribute.calling_convention = 2, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       clif.return_call %value, %unit, %last {callee = @direct_tail}
   }
-  clif.func {sym_name = @indirect_tail, tribute.calling_convention = 2, type = func.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> core.nil>} {
+  clif.func {sym_name = @indirect_tail, tribute.calling_convention = 2, type = clif.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> core.nil>} {
     ^entry(%callee: core.ptr, %value: core.i32, %unit: core.nil, %last: core.i64):
-      clif.return_call_indirect %callee, %value, %unit, %last {sig = func.func_sig<(core.i32, core.nil, core.i64) -> core.nil>}
+      clif.return_call_indirect %callee, %value, %unit, %last {sig = clif.func_sig<(core.i32, core.nil, core.i64) -> core.nil>}
   }
-  clif.func {sym_name = @jump, type = func.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
+  clif.func {sym_name = @jump, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       clif.jump %value, %unit, %last [^merge]
     ^merge(%next_value: core.i32, %next_unit: core.nil, %next_last: core.i64):
       clif.return
+  }
+}"#;
+
+    const ORDERED_RESULT_LISTS_NATIVE: &str = r#"core.module @test {
+  clif.func {sym_name = @sink, type = clif.func_sig<() -> ()>} {
+    clif.return
+  }
+  clif.func {sym_name = @pair, type = clif.func_sig<() -> (core.i32, core.i32)>} {
+    %first = clif.iconst {value = 2} : core.i32
+    %second = clif.iconst {value = 40} : core.i32
+    clif.return %first, %second
+  }
+  clif.func {sym_name = @main, type = clif.func_sig<() -> core.i32>} {
+    %first, %second = clif.call {callee = @pair} : core.i32, core.i32
+    clif.call {callee = @sink}
+    %callee = clif.symbol_addr {sym = @pair} : core.ptr
+    %other_first, %other_second = clif.call_indirect %callee {sig = clif.func_sig<() -> (core.i32, core.i32)>} : core.i32, core.i32
+    %direct_pair = clif.iadd %first, %first : core.i32
+    %indirect_pair = clif.iadd %other_second, %other_second : core.i32
+    %sum = clif.iadd %direct_pair, %indirect_pair : core.i32
+    clif.return %sum
   }
 }"#;
 
@@ -812,5 +833,37 @@ mod tests {
         let module = parse_test_module(&mut ctx, NIL_ZERO_WIDTH_NATIVE);
         let object = emit_module_to_native(&ctx, module, &[]).unwrap();
         assert!(!object.is_empty());
+    }
+
+    #[test]
+    fn native_emission_preserves_zero_and_ordered_multiple_results() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, ORDERED_RESULT_LISTS_NATIVE);
+        let object = emit_module_to_native(&ctx, module, &[]).unwrap();
+        let temp =
+            std::env::temp_dir().join(format!("tribute-ordered-results-{}", std::process::id()));
+        std::fs::create_dir_all(&temp).unwrap();
+        let object_path = temp.join("ordered-results.o");
+        let executable = temp.join("ordered-results");
+        let runtime_shim = temp.join("runtime-shim.c");
+        std::fs::write(&object_path, object).unwrap();
+        std::fs::write(
+            &runtime_shim,
+            "void __tribute_dealloc(void *ptr, long size) {}\n",
+        )
+        .unwrap();
+        assert!(
+            std::process::Command::new("cc")
+                .arg(&object_path)
+                .arg(&runtime_shim)
+                .arg("-o")
+                .arg(&executable)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let status = std::process::Command::new(&executable).status().unwrap();
+        std::fs::remove_dir_all(temp).unwrap();
+        assert_eq!(status.code(), Some(84));
     }
 }

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -745,8 +745,36 @@ fn declare_runtime_functions(
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
     use trunk_ir::parser::parse_test_module;
+
+    struct TestTempDir(PathBuf);
+
+    impl TestTempDir {
+        fn new(prefix: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time after epoch")
+                .as_nanos();
+            let path =
+                std::env::temp_dir().join(format!("{prefix}-{}-{unique}", std::process::id()));
+            std::fs::create_dir_all(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
 
     const NIL_ZERO_WIDTH_NATIVE: &str = r#"core.module @test {
   clif.func {sym_name = @call_target, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} {
@@ -783,18 +811,28 @@ mod tests {
   clif.func {sym_name = @sink, type = clif.func_sig<() -> ()>} {
     clif.return
   }
-  clif.func {sym_name = @pair, type = clif.func_sig<() -> (core.i32, core.i32)>} {
-    %first = clif.iconst {value = 2} : core.i32
-    %second = clif.iconst {value = 40} : core.i32
+  clif.func {sym_name = @pair, type = clif.func_sig<() -> (core.i32, core.nil, core.i32)>} {
+    %first = clif.iconst {value = 3} : core.i32
+    %second = clif.iconst {value = 17} : core.i32
     clif.return %first, %second
   }
   clif.func {sym_name = @main, type = clif.func_sig<() -> core.i32>} {
     %first, %second = clif.call {callee = @pair} : core.i32, core.i32
     clif.call {callee = @sink}
+    %sink = clif.symbol_addr {sym = @sink} : core.ptr
+    clif.call_indirect %sink {sig = clif.func_sig<() -> ()>}
     %callee = clif.symbol_addr {sym = @pair} : core.ptr
-    %other_first, %other_second = clif.call_indirect %callee {sig = clif.func_sig<() -> (core.i32, core.i32)>} : core.i32, core.i32
-    %direct_pair = clif.iadd %first, %first : core.i32
-    %indirect_pair = clif.iadd %other_second, %other_second : core.i32
+    %other_first, %other_second = clif.call_indirect %callee {sig = clif.func_sig<() -> (core.i32, core.nil, core.i32)>} : core.i32, core.i32
+    %seven = clif.iconst {value = 7} : core.i32
+    %eleven = clif.iconst {value = 11} : core.i32
+    %thirteen = clif.iconst {value = 13} : core.i32
+    %seventeen = clif.iconst {value = 17} : core.i32
+    %direct_left = clif.imul %first, %seven : core.i32
+    %direct_right = clif.imul %second, %eleven : core.i32
+    %direct_pair = clif.iadd %direct_left, %direct_right : core.i32
+    %indirect_left = clif.imul %other_first, %thirteen : core.i32
+    %indirect_right = clif.imul %other_second, %seventeen : core.i32
+    %indirect_pair = clif.iadd %indirect_left, %indirect_right : core.i32
     %sum = clif.iadd %direct_pair, %indirect_pair : core.i32
     clif.return %sum
   }
@@ -836,16 +874,30 @@ mod tests {
     }
 
     #[test]
+    fn native_emission_accepts_short_form_clif_function_signature() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @main() -> core.i32 {
+    %result = clif.iconst {value = 0} : core.i32
+    clif.return %result
+  }
+}"#,
+        );
+        let object = emit_module_to_native(&ctx, module, &[]).unwrap();
+        assert!(!object.is_empty());
+    }
+
+    #[test]
     fn native_emission_preserves_zero_and_ordered_multiple_results() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ORDERED_RESULT_LISTS_NATIVE);
         let object = emit_module_to_native(&ctx, module, &[]).unwrap();
-        let temp =
-            std::env::temp_dir().join(format!("tribute-ordered-results-{}", std::process::id()));
-        std::fs::create_dir_all(&temp).unwrap();
-        let object_path = temp.join("ordered-results.o");
-        let executable = temp.join("ordered-results");
-        let runtime_shim = temp.join("runtime-shim.c");
+        let temp = TestTempDir::new("tribute-ordered-results");
+        let object_path = temp.path().join("ordered-results.o");
+        let executable = temp.path().join("ordered-results");
+        let runtime_shim = temp.path().join("runtime-shim.c");
         std::fs::write(&object_path, object).unwrap();
         std::fs::write(
             &runtime_shim,
@@ -863,7 +915,6 @@ mod tests {
                 .success()
         );
         let status = std::process::Command::new(&executable).status().unwrap();
-        std::fs::remove_dir_all(temp).unwrap();
-        assert_eq!(status.code(), Some(84));
+        assert_eq!(status.code(), Some(24));
     }
 }

--- a/crates/trunk-ir-cranelift-backend/src/validation.rs
+++ b/crates/trunk-ir-cranelift-backend/src/validation.rs
@@ -175,11 +175,11 @@ fn check_result_types(
     }
 }
 
-/// Direct calls and returns may retain their logical `core.nil` slots from
+/// Calls and returns may retain their logical `core.nil` slots from
 /// source-level `func` operations. The emitter treats those slots as
 /// zero-width, so hand-written native IR may instead use the projected runtime
 /// result list. Both forms must otherwise match the declared contract exactly.
-fn check_direct_result_types(
+fn check_call_result_types(
     ctx: &IrContext,
     op: OpRef,
     expected: &[TypeRef],
@@ -200,7 +200,7 @@ fn values_match_types(ctx: &IrContext, values: &[ValueRef], expected: &[TypeRef]
             .all(|(&value, &ty)| ty == ctx.value_ty(value))
 }
 
-/// See [`check_direct_result_types`]. A direct return may use the full logical
+/// See [`check_call_result_types`]. A direct return may use the full logical
 /// result list or its zero-width `core.nil` projection.
 fn check_direct_return_types(
     ctx: &IrContext,
@@ -311,7 +311,7 @@ fn validate_clif_region(
                         "call argument",
                         errors,
                     );
-                    check_direct_result_types(
+                    check_call_result_types(
                         ctx,
                         op,
                         signature.results(ctx),
@@ -333,10 +333,10 @@ fn validate_clif_region(
                         "call argument",
                         errors,
                     );
-                    check_result_types(
+                    check_call_result_types(
                         ctx,
                         op,
-                        &runtime_types(ctx, signature.results(ctx)),
+                        signature.results(ctx),
                         "call result list",
                         errors,
                     );

--- a/crates/trunk-ir-cranelift-backend/src/validation.rs
+++ b/crates/trunk-ir-cranelift-backend/src/validation.rs
@@ -120,35 +120,8 @@ fn runtime_types(ctx: &IrContext, types: &[TypeRef]) -> Vec<TypeRef> {
         .collect()
 }
 
-/// Whether a value retains a semantic type whose native ABI representation is
-/// a raw pointer. These values can flow into a `core.ptr` slot in a target
-/// callable contract without a runtime cast; native lowering records that
-/// representation change in the contract, not in every SSA value.
-fn has_native_pointer_representation(ctx: &IrContext, ty: TypeRef) -> bool {
-    let data = ctx.types.get(ty);
-    let core = Symbol::new("core");
-    let tribute_rt = Symbol::new("tribute_rt");
-
-    (data.dialect == core
-        && (data.name == Symbol::new("ptr")
-            || data.name == Symbol::new("bytes")
-            || data.name == Symbol::new("array")))
-        || (data.dialect == tribute_rt
-            && (data.name == Symbol::new("anyref") || data.name == Symbol::new("intref")))
-        || (data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig"))
-        || (data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure"))
-        || (data.dialect == Symbol::new("adt")
-            && (data.name == Symbol::new("typeref")
-                || data.attrs.contains_key("fields")
-                || data.attrs.contains_key("variants")
-                || data.attrs.get_bool("is_variant") == Some(true)))
-}
-
-fn types_match_native_abi(ctx: &IrContext, expected: TypeRef, actual: TypeRef) -> bool {
+fn types_match_native_abi(_ctx: &IrContext, expected: TypeRef, actual: TypeRef) -> bool {
     expected == actual
-        || (ctx.types.get(expected).dialect == Symbol::new("core")
-            && ctx.types.get(expected).name == Symbol::new("ptr")
-            && has_native_pointer_representation(ctx, actual))
 }
 
 fn type_lists_match_native_abi(ctx: &IrContext, expected: &[TypeRef], actual: &[TypeRef]) -> bool {
@@ -583,21 +556,37 @@ mod tests {
     }
 
     #[test]
-    fn native_boundary_accepts_semantic_values_in_pointer_contract_slots() {
-        let mut ctx = IrContext::new();
-        let module = parse_test_module(
-            &mut ctx,
+    fn native_boundary_rejects_semantic_and_shape_matched_values_in_pointer_slots() {
+        let error = validation_error(
             r#"core.module @test {
+  !shaped = adt.struct() {fields = [[@field, core.i32]], name = @Impostor}
   clif.func @target(%value: core.ptr) -> core.ptr { clif.return %value }
-  clif.func @caller(%callee: core.ptr, %value: tribute_rt.anyref) -> core.ptr {
+  clif.func @semantic(%callee: core.ptr, %value: tribute_rt.anyref) -> core.ptr {
     %direct = clif.call %value {callee = @target} : tribute_rt.anyref
     %indirect = clif.call_indirect %callee, %direct {sig = clif.func_sig<(core.ptr) -> core.ptr>} : tribute_rt.anyref
     clif.return %indirect
   }
+  clif.func @shaped(%value: !shaped) -> core.ptr {
+    %direct = clif.call %value {callee = @target} : !shaped
+    clif.return %direct
+  }
 }"#,
         );
 
-        validate_clif_ir(&ctx, module).unwrap();
+        assert!(
+            error.contains("clif.call call argument #0 type mismatch: expected core.ptr, found tribute_rt.anyref"),
+            "{error}"
+        );
+        assert!(
+            error.contains("clif.call_indirect call argument #0 type mismatch: expected core.ptr, found tribute_rt.anyref"),
+            "{error}"
+        );
+        assert!(
+            error.contains(
+                "clif.call call argument #0 type mismatch: expected core.ptr, found adt.struct()"
+            ),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/trunk-ir-cranelift-backend/src/validation.rs
+++ b/crates/trunk-ir-cranelift-backend/src/validation.rs
@@ -120,16 +120,12 @@ fn runtime_types(ctx: &IrContext, types: &[TypeRef]) -> Vec<TypeRef> {
         .collect()
 }
 
-fn types_match_native_abi(_ctx: &IrContext, expected: TypeRef, actual: TypeRef) -> bool {
-    expected == actual
-}
-
-fn type_lists_match_native_abi(ctx: &IrContext, expected: &[TypeRef], actual: &[TypeRef]) -> bool {
+fn type_lists_match(expected: &[TypeRef], actual: &[TypeRef]) -> bool {
     expected.len() == actual.len()
         && expected
             .iter()
             .zip(actual)
-            .all(|(&expected, &actual)| types_match_native_abi(ctx, expected, actual))
+            .all(|(&expected, &actual)| expected == actual)
 }
 
 fn check_value_types(
@@ -150,7 +146,7 @@ fn check_value_types(
         return;
     }
     for (index, (&value, &ty)) in values.iter().zip(expected).enumerate() {
-        if !types_match_native_abi(ctx, ty, ctx.value_ty(value)) {
+        if ty != ctx.value_ty(value) {
             errors.push(format!(
                 "clif.{} {role} #{index} type mismatch: expected {}, found {}",
                 ctx.op(op).name,
@@ -169,7 +165,7 @@ fn check_result_types(
     errors: &mut Vec<String>,
 ) {
     let actual = ctx.op_result_types(op);
-    if !type_lists_match_native_abi(ctx, expected, actual) {
+    if !type_lists_match(expected, actual) {
         errors.push(format!(
             "clif.{} {role} mismatch: expected {:?}, found {:?}",
             ctx.op(op).name,
@@ -190,7 +186,7 @@ fn check_direct_result_types(
     role: &str,
     errors: &mut Vec<String>,
 ) {
-    if type_lists_match_native_abi(ctx, expected, ctx.op_result_types(op)) {
+    if type_lists_match(expected, ctx.op_result_types(op)) {
         return;
     }
     check_result_types(ctx, op, &runtime_types(ctx, expected), role, errors);
@@ -201,7 +197,7 @@ fn values_match_types(ctx: &IrContext, values: &[ValueRef], expected: &[TypeRef]
         && values
             .iter()
             .zip(expected)
-            .all(|(&value, &ty)| types_match_native_abi(ctx, ty, ctx.value_ty(value)))
+            .all(|(&value, &ty)| ty == ctx.value_ty(value))
 }
 
 /// See [`check_direct_result_types`]. A direct return may use the full logical

--- a/crates/trunk-ir-cranelift-backend/src/validation.rs
+++ b/crates/trunk-ir-cranelift-backend/src/validation.rs
@@ -5,7 +5,14 @@
 //!
 //! Dialect validation errors prevent emission from proceeding.
 
+use std::collections::HashMap;
+
+use trunk_ir::Symbol;
 use trunk_ir::context::IrContext;
+use trunk_ir::dialect::clif;
+use trunk_ir::ops::{DialectOp, DialectType};
+use trunk_ir::printer::print_type;
+use trunk_ir::refs::{OpRef, RegionRef, TypeRef, ValueRef};
 use trunk_ir::rewrite::{ConversionTarget, Module};
 
 use crate::{CompilationError, CompilationResult};
@@ -38,20 +45,398 @@ pub fn validate_clif_ir(ctx: &IrContext, module: Module) -> CompilationResult<()
     let target = native_backend_ready_target();
     let failures = target.verify_full(ctx, body);
 
-    if failures.is_empty() {
-        return Ok(());
-    }
-
-    let errors: Vec<String> = failures
+    let mut errors: Vec<String> = failures
         .into_iter()
         .map(|op| format!("{} in boundary {}", op, NATIVE_BACKEND_READY_BOUNDARY))
         .collect();
+    errors.extend(validate_clif_contracts(ctx, module));
+
+    if errors.is_empty() {
+        return Ok(());
+    }
     let message = format!(
         "IR validation failed for boundary {NATIVE_BACKEND_READY_BOUNDARY} with {} error(s):\n  - {}",
         errors.len(),
         errors.join("\n  - ")
     );
     Err(CompilationError::ir_validation(message))
+}
+
+/// Validate native callable contracts before instruction selection can erase
+/// their TrunkIR type identity.
+fn validate_clif_contracts(ctx: &IrContext, module: Module) -> Vec<String> {
+    let Some(body) = module.body(ctx) else {
+        return Vec::new();
+    };
+    let mut errors = Vec::new();
+    let mut functions = HashMap::new();
+    collect_clif_function_signatures(ctx, body, &mut functions, &mut errors);
+    validate_clif_region(ctx, body, None, &functions, &mut errors);
+    errors
+}
+
+fn collect_clif_function_signatures(
+    ctx: &IrContext,
+    region: RegionRef,
+    functions: &mut HashMap<Symbol, clif::FuncSig>,
+    errors: &mut Vec<String>,
+) {
+    for &block in &ctx.region(region).blocks {
+        for &op in &ctx.block(block).ops {
+            if clif::Func::matches(ctx, op) {
+                let Some(name) = ctx.op(op).attributes.get_symbol("sym_name") else {
+                    errors.push("clif.func requires a symbol name".into());
+                    continue;
+                };
+                let Some(signature) = ctx
+                    .op(op)
+                    .attributes
+                    .get_type("type")
+                    .and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty))
+                else {
+                    errors.push(format!(
+                        "clif.func @{name} requires a valid clif.func_sig type"
+                    ));
+                    continue;
+                };
+                if functions.insert(name, signature).is_some() {
+                    errors.push(format!(
+                        "clif.func @{name} has a duplicate symbol definition"
+                    ));
+                }
+            }
+            for &nested in &ctx.op(op).regions {
+                collect_clif_function_signatures(ctx, nested, functions, errors);
+            }
+        }
+    }
+}
+
+fn runtime_types(ctx: &IrContext, types: &[TypeRef]) -> Vec<TypeRef> {
+    types
+        .iter()
+        .copied()
+        .filter(|ty| !crate::function::is_nil_type(ctx, *ty))
+        .collect()
+}
+
+/// Whether a value retains a semantic type whose native ABI representation is
+/// a raw pointer. These values can flow into a `core.ptr` slot in a target
+/// callable contract without a runtime cast; native lowering records that
+/// representation change in the contract, not in every SSA value.
+fn has_native_pointer_representation(ctx: &IrContext, ty: TypeRef) -> bool {
+    let data = ctx.types.get(ty);
+    let core = Symbol::new("core");
+    let tribute_rt = Symbol::new("tribute_rt");
+
+    (data.dialect == core
+        && (data.name == Symbol::new("ptr")
+            || data.name == Symbol::new("bytes")
+            || data.name == Symbol::new("array")))
+        || (data.dialect == tribute_rt
+            && (data.name == Symbol::new("anyref") || data.name == Symbol::new("intref")))
+        || (data.dialect == Symbol::new("func") && data.name == Symbol::new("func_sig"))
+        || (data.dialect == Symbol::new("closure") && data.name == Symbol::new("closure"))
+        || (data.dialect == Symbol::new("adt")
+            && (data.name == Symbol::new("typeref")
+                || data.attrs.contains_key("fields")
+                || data.attrs.contains_key("variants")
+                || data.attrs.get_bool("is_variant") == Some(true)))
+}
+
+fn types_match_native_abi(ctx: &IrContext, expected: TypeRef, actual: TypeRef) -> bool {
+    expected == actual
+        || (ctx.types.get(expected).dialect == Symbol::new("core")
+            && ctx.types.get(expected).name == Symbol::new("ptr")
+            && has_native_pointer_representation(ctx, actual))
+}
+
+fn type_lists_match_native_abi(ctx: &IrContext, expected: &[TypeRef], actual: &[TypeRef]) -> bool {
+    expected.len() == actual.len()
+        && expected
+            .iter()
+            .zip(actual)
+            .all(|(&expected, &actual)| types_match_native_abi(ctx, expected, actual))
+}
+
+fn check_value_types(
+    ctx: &IrContext,
+    op: OpRef,
+    values: &[ValueRef],
+    expected: &[TypeRef],
+    role: &str,
+    errors: &mut Vec<String>,
+) {
+    if values.len() != expected.len() {
+        errors.push(format!(
+            "clif.{} {role} count mismatch: expected {}, found {}",
+            ctx.op(op).name,
+            expected.len(),
+            values.len()
+        ));
+        return;
+    }
+    for (index, (&value, &ty)) in values.iter().zip(expected).enumerate() {
+        if !types_match_native_abi(ctx, ty, ctx.value_ty(value)) {
+            errors.push(format!(
+                "clif.{} {role} #{index} type mismatch: expected {}, found {}",
+                ctx.op(op).name,
+                print_type(ctx, ty),
+                print_type(ctx, ctx.value_ty(value))
+            ));
+        }
+    }
+}
+
+fn check_result_types(
+    ctx: &IrContext,
+    op: OpRef,
+    expected: &[TypeRef],
+    role: &str,
+    errors: &mut Vec<String>,
+) {
+    let actual = ctx.op_result_types(op);
+    if !type_lists_match_native_abi(ctx, expected, actual) {
+        errors.push(format!(
+            "clif.{} {role} mismatch: expected {:?}, found {:?}",
+            ctx.op(op).name,
+            expected,
+            actual
+        ));
+    }
+}
+
+/// Direct calls and returns may retain their logical `core.nil` slots from
+/// source-level `func` operations. The emitter treats those slots as
+/// zero-width, so hand-written native IR may instead use the projected runtime
+/// result list. Both forms must otherwise match the declared contract exactly.
+fn check_direct_result_types(
+    ctx: &IrContext,
+    op: OpRef,
+    expected: &[TypeRef],
+    role: &str,
+    errors: &mut Vec<String>,
+) {
+    if type_lists_match_native_abi(ctx, expected, ctx.op_result_types(op)) {
+        return;
+    }
+    check_result_types(ctx, op, &runtime_types(ctx, expected), role, errors);
+}
+
+fn values_match_types(ctx: &IrContext, values: &[ValueRef], expected: &[TypeRef]) -> bool {
+    values.len() == expected.len()
+        && values
+            .iter()
+            .zip(expected)
+            .all(|(&value, &ty)| types_match_native_abi(ctx, ty, ctx.value_ty(value)))
+}
+
+/// See [`check_direct_result_types`]. A direct return may use the full logical
+/// result list or its zero-width `core.nil` projection.
+fn check_direct_return_types(
+    ctx: &IrContext,
+    op: OpRef,
+    values: &[ValueRef],
+    expected: &[TypeRef],
+    errors: &mut Vec<String>,
+) {
+    if values_match_types(ctx, values, expected) {
+        return;
+    }
+    check_value_types(
+        ctx,
+        op,
+        values,
+        &runtime_types(ctx, expected),
+        "return",
+        errors,
+    );
+}
+
+fn signature_for_exact_indirect(
+    ctx: &IrContext,
+    op: OpRef,
+    errors: &mut Vec<String>,
+) -> Option<clif::FuncSig> {
+    let signature = ctx.op(op).attributes.get_type("sig");
+    let valid = signature.and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty));
+    if valid.is_none() {
+        errors.push(format!(
+            "clif.{} requires a valid exact clif.func_sig",
+            ctx.op(op).name
+        ));
+    }
+    valid
+}
+
+fn validate_clif_function(
+    ctx: &IrContext,
+    op: OpRef,
+    errors: &mut Vec<String>,
+) -> Option<clif::FuncSig> {
+    clif::Func::from_op(ctx, op).ok()?;
+    let Some(name) = ctx.op(op).attributes.get_symbol("sym_name") else {
+        errors.push("clif.func requires a symbol name".into());
+        return None;
+    };
+    let signature = ctx
+        .op(op)
+        .attributes
+        .get_type("type")
+        .and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty));
+    let Some(signature) = signature else {
+        errors.push(format!(
+            "clif.func @{name} requires a valid clif.func_sig type"
+        ));
+        return None;
+    };
+    if ctx.op(op).regions.len() > 1 {
+        errors.push(format!("clif.func @{name} has more than one body region"));
+    }
+    if let Some(&body) = ctx.op(op).regions.first() {
+        let Some(&entry) = ctx.region(body).blocks.first() else {
+            errors.push(format!("clif.func @{name} body requires an entry block"));
+            return Some(signature);
+        };
+        check_value_types(
+            ctx,
+            op,
+            ctx.block_args(entry),
+            signature.inputs(ctx),
+            "entry argument",
+            errors,
+        );
+    }
+    Some(signature)
+}
+
+fn validate_clif_region(
+    ctx: &IrContext,
+    region: RegionRef,
+    owner: Option<clif::FuncSig>,
+    functions: &HashMap<Symbol, clif::FuncSig>,
+    errors: &mut Vec<String>,
+) {
+    for &block in &ctx.region(region).blocks {
+        for &op in &ctx.block(block).ops {
+            if clif::Func::matches(ctx, op) {
+                let function = validate_clif_function(ctx, op, errors);
+                for &body in &ctx.op(op).regions {
+                    validate_clif_region(ctx, body, function, functions, errors);
+                }
+                continue;
+            }
+
+            let operands = ctx.op_operands(op);
+            if clif::Call::matches(ctx, op) {
+                let Some(name) = ctx.op(op).attributes.get_symbol("callee") else {
+                    errors.push("clif.call requires a symbol callee".into());
+                    continue;
+                };
+                if let Some(signature) = functions.get(&name) {
+                    check_value_types(
+                        ctx,
+                        op,
+                        operands,
+                        signature.inputs(ctx),
+                        "call argument",
+                        errors,
+                    );
+                    check_direct_result_types(
+                        ctx,
+                        op,
+                        signature.results(ctx),
+                        "call result list",
+                        errors,
+                    );
+                }
+            } else if clif::CallIndirect::matches(ctx, op) {
+                if operands.is_empty() {
+                    errors.push("clif.call_indirect requires a callee operand".into());
+                }
+                if let Some(signature) = signature_for_exact_indirect(ctx, op, errors) {
+                    let args = operands.get(1..).unwrap_or_default();
+                    check_value_types(
+                        ctx,
+                        op,
+                        args,
+                        signature.inputs(ctx),
+                        "call argument",
+                        errors,
+                    );
+                    check_result_types(
+                        ctx,
+                        op,
+                        &runtime_types(ctx, signature.results(ctx)),
+                        "call result list",
+                        errors,
+                    );
+                }
+            } else if clif::Return::matches(ctx, op) {
+                let Some(signature) = owner else {
+                    errors.push("clif.return requires a nearest clif.func owner".into());
+                    continue;
+                };
+                check_direct_return_types(ctx, op, operands, signature.results(ctx), errors);
+            } else if clif::ReturnCall::matches(ctx, op) {
+                let Some(caller) = owner else {
+                    errors.push("clif.return_call requires a nearest clif.func owner".into());
+                    continue;
+                };
+                let Some(callee) = ctx.op(op).attributes.get_symbol("callee") else {
+                    errors.push("clif.return_call requires a symbol callee".into());
+                    continue;
+                };
+                if let Some(signature) = functions.get(&callee) {
+                    check_value_types(
+                        ctx,
+                        op,
+                        operands,
+                        signature.inputs(ctx),
+                        "tail argument",
+                        errors,
+                    );
+                    if runtime_types(ctx, caller.results(ctx))
+                        != runtime_types(ctx, signature.results(ctx))
+                    {
+                        errors.push("clif.return_call caller/callee result lists differ".into());
+                    }
+                }
+            } else if clif::ReturnCallIndirect::matches(ctx, op) {
+                let Some(caller) = owner else {
+                    errors.push(
+                        "clif.return_call_indirect requires a nearest clif.func owner".into(),
+                    );
+                    continue;
+                };
+                if operands.is_empty() {
+                    errors.push("clif.return_call_indirect requires a callee operand".into());
+                }
+                if let Some(signature) = signature_for_exact_indirect(ctx, op, errors) {
+                    let args = operands.get(1..).unwrap_or_default();
+                    check_value_types(
+                        ctx,
+                        op,
+                        args,
+                        signature.inputs(ctx),
+                        "tail argument",
+                        errors,
+                    );
+                    if runtime_types(ctx, caller.results(ctx))
+                        != runtime_types(ctx, signature.results(ctx))
+                    {
+                        errors.push(
+                            "clif.return_call_indirect caller/callee result lists differ".into(),
+                        );
+                    }
+                }
+            }
+
+            for &nested in &ctx.op(op).regions {
+                validate_clif_region(ctx, nested, owner, functions, errors);
+            }
+        }
+    }
 }
 
 /// Conversion target for IR that is ready for Cranelift emission.
@@ -68,6 +453,7 @@ mod tests {
     use trunk_ir::OperationDataBuilder;
     use trunk_ir::context::{BlockData, IrContext, RegionData};
     use trunk_ir::location::Span;
+    use trunk_ir::parser::parse_test_module;
     use trunk_ir::smallvec::smallvec;
     use trunk_ir::symbol::Symbol;
     use trunk_ir::types::{Attribute, Location};
@@ -109,10 +495,21 @@ mod tests {
         Module::new(ctx, module_op).expect("test module should be valid")
     }
 
+    fn validation_error(input: &str) -> String {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(&mut ctx, input);
+        validate_clif_ir(&ctx, module)
+            .expect_err("native contract must fail closed")
+            .to_string()
+    }
+
     #[test]
     fn native_backend_ready_allows_clif_ops() {
-        let (mut ctx, loc) = test_ctx();
-        let module = make_module(&mut ctx, loc, "clif", "func");
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            "core.module @test { clif.func @f() { clif.return } }",
+        );
 
         validate_clif_ir(&ctx, module).unwrap();
     }
@@ -126,5 +523,126 @@ mod tests {
         assert!(err.contains("native-backend-ready"));
         assert!(err.contains("arith.add"));
         assert!(err.contains("Unknown"));
+    }
+
+    #[test]
+    fn native_boundary_rejects_malformed_target_signature_storage() {
+        let error = validation_error(
+            r#"core.module @test {
+  clif.func {sym_name = @bad, type = clif.func_sig(core.i32) {num_inputs = 2, num_results = 1}}
+}"#,
+        );
+        assert!(
+            error.contains("@bad requires a valid clif.func_sig type"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn native_boundary_rejects_unused_direct_and_exact_indirect_result_mismatches() {
+        let error = validation_error(
+            r#"core.module @test {
+  clif.func @direct_target(%value: core.i32) -> core.i32 { clif.return %value }
+  clif.func @direct_caller() {
+    %value = clif.iconst {value = 1} : core.i32
+    %unused = clif.call %value {callee = @direct_target} : core.i64
+    clif.return
+  }
+  clif.func @indirect_caller() {
+    %callee = clif.iconst {value = 0} : core.ptr
+    %first, %second = clif.call_indirect %callee {sig = clif.func_sig<() -> (core.i32, core.i64)>} : core.i64, core.i32
+    clif.return
+  }
+}"#,
+        );
+        assert!(
+            error.contains("clif.call call result list mismatch"),
+            "{error}"
+        );
+        assert!(
+            error.contains("clif.call_indirect call result list mismatch"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn native_boundary_accepts_direct_logical_nil_result_slots() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @unit(%unit: core.nil) -> core.nil { clif.return %unit }
+  clif.func @caller(%unit: core.nil) {
+    %unused = clif.call %unit {callee = @unit} : core.nil
+    clif.return
+  }
+}"#,
+        );
+
+        validate_clif_ir(&ctx, module).unwrap();
+    }
+
+    #[test]
+    fn native_boundary_accepts_semantic_values_in_pointer_contract_slots() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  clif.func @target(%value: core.ptr) -> core.ptr { clif.return %value }
+  clif.func @caller(%callee: core.ptr, %value: tribute_rt.anyref) -> core.ptr {
+    %direct = clif.call %value {callee = @target} : tribute_rt.anyref
+    %indirect = clif.call_indirect %callee, %direct {sig = clif.func_sig<(core.ptr) -> core.ptr>} : tribute_rt.anyref
+    clif.return %indirect
+  }
+}"#,
+        );
+
+        validate_clif_ir(&ctx, module).unwrap();
+    }
+
+    #[test]
+    fn native_boundary_rejects_argument_return_and_tail_contract_mismatches() {
+        let error = validation_error(
+            r#"core.module @test {
+  clif.func @takes_i64(%value: core.i64) -> core.i32 {
+    %result = clif.iconst {value = 1} : core.i32
+    clif.return %result
+  }
+  clif.func @tail_target() -> core.i32 {
+    %result = clif.iconst {value = 1} : core.i32
+    clif.return %result
+  }
+  clif.func @bad_return() -> core.i32 { clif.return }
+  clif.func @bad_argument() {
+    %value = clif.iconst {value = 1} : core.i32
+    %unused = clif.call %value {callee = @takes_i64} : core.i32
+    clif.return
+  }
+  clif.func @bad_tail() { clif.return_call {callee = @tail_target} }
+  clif.func @bad_indirect_tail(%callee: core.ptr, %value: core.i32) {
+    clif.return_call_indirect %callee, %value {sig = clif.func_sig<(core.i64) -> core.i32>}
+  }
+}"#,
+        );
+        assert!(
+            error.contains("clif.return return count mismatch"),
+            "{error}"
+        );
+        assert!(
+            error.contains("clif.call call argument #0 type mismatch"),
+            "{error}"
+        );
+        assert!(
+            error.contains("clif.return_call caller/callee result lists differ"),
+            "{error}"
+        );
+        assert!(
+            error.contains("clif.return_call_indirect tail argument #0 type mismatch"),
+            "{error}"
+        );
+        assert!(
+            error.contains("clif.return_call_indirect caller/callee result lists differ"),
+            "{error}"
+        );
     }
 }

--- a/crates/trunk-ir/src/dialect/clif.rs
+++ b/crates/trunk-ir/src/dialect/clif.rs
@@ -2,6 +2,7 @@
 
 use crate::op_interface::{IndirectCallLikeModel, IndirectCallLikeOps};
 use crate::ops::{DialectOp, DialectType};
+use crate::types::{Attribute, AttributeMap, TypeDataBuilder};
 
 #[trunk_ir::dialect]
 mod clif {
@@ -119,6 +120,194 @@ mod clif {
 
 const INDIRECT_CALL_SIGNATURE_ATTR: &str = "sig";
 
+pub const NUM_INPUTS_ATTR: &str = "num_inputs";
+pub const NUM_RESULTS_ATTR: &str = "num_results";
+
+#[allow(non_snake_case)]
+#[inline]
+pub fn FUNC_SIG() -> crate::Symbol {
+    crate::Symbol::new("func_sig")
+}
+
+/// Why a name-matching `clif.func_sig` does not satisfy its storage invariant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FuncSigTypeError {
+    MissingCount(&'static str),
+    InvalidCount(&'static str),
+    CountOverflow,
+    LengthMismatch {
+        num_inputs: u32,
+        num_results: u32,
+        params: usize,
+    },
+}
+
+impl std::fmt::Display for FuncSigTypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingCount(name) => write!(f, "missing required `{name}` u32 attribute"),
+            Self::InvalidCount(name) => write!(f, "`{name}` must be a u32 attribute"),
+            Self::CountOverflow => write!(f, "input and result counts overflow u32"),
+            Self::LengthMismatch {
+                num_inputs,
+                num_results,
+                params,
+            } => write!(
+                f,
+                "num_inputs ({num_inputs}) + num_results ({num_results}) must equal params length ({params})",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FuncSigTypeError {}
+
+/// Validated wrapper for an input-first, zero-or-more-result `clif.func_sig`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FuncSig(crate::TypeRef);
+
+impl FuncSig {
+    pub(crate) fn validate(
+        ctx: &crate::IrContext,
+        ty: crate::TypeRef,
+    ) -> Result<Self, FuncSigTypeError> {
+        let data = ctx.types.get(ty);
+        debug_assert!(data.dialect == DIALECT_NAME() && data.name == FUNC_SIG());
+        let num_inputs = read_count(&data.attrs, NUM_INPUTS_ATTR)?;
+        let num_results = read_count(&data.attrs, NUM_RESULTS_ATTR)?;
+        let total = num_inputs
+            .checked_add(num_results)
+            .ok_or(FuncSigTypeError::CountOverflow)?;
+        if usize::try_from(total).ok() != Some(data.params.len()) {
+            return Err(FuncSigTypeError::LengthMismatch {
+                num_inputs,
+                num_results,
+                params: data.params.len(),
+            });
+        }
+        Ok(Self(ty))
+    }
+
+    fn counts(self, ctx: &crate::IrContext) -> (usize, usize) {
+        let data = ctx.types.get(self.0);
+        let inputs = usize::try_from(
+            read_count(&data.attrs, NUM_INPUTS_ATTR)
+                .expect("validated clif.func_sig must retain num_inputs"),
+        )
+        .expect("u32 must fit usize");
+        let results = usize::try_from(
+            read_count(&data.attrs, NUM_RESULTS_ATTR)
+                .expect("validated clif.func_sig must retain num_results"),
+        )
+        .expect("u32 must fit usize");
+        (inputs, results)
+    }
+
+    pub fn inputs(self, ctx: &crate::IrContext) -> &[crate::TypeRef] {
+        let (inputs, _) = self.counts(ctx);
+        &ctx.types.get(self.0).params[..inputs]
+    }
+
+    pub fn results(self, ctx: &crate::IrContext) -> &[crate::TypeRef] {
+        let (inputs, results) = self.counts(ctx);
+        &ctx.types.get(self.0).params[inputs..inputs + results]
+    }
+
+    pub fn is_resultless(self, ctx: &crate::IrContext) -> bool {
+        self.results(ctx).is_empty()
+    }
+
+    pub fn single_result(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
+        let results = self.results(ctx);
+        (results.len() == 1).then(|| results[0])
+    }
+
+    pub fn non_reserved_attrs(
+        self,
+        ctx: &crate::IrContext,
+    ) -> impl Iterator<Item = (&crate::Symbol, &Attribute)> {
+        ctx.types.get(self.0).attrs.iter().filter(|(key, _)| {
+            **key != crate::Symbol::new(NUM_INPUTS_ATTR)
+                && **key != crate::Symbol::new(NUM_RESULTS_ATTR)
+        })
+    }
+
+    pub fn remove_reserved_attrs(attrs: &mut AttributeMap) {
+        attrs.remove(NUM_INPUTS_ATTR);
+        attrs.remove(NUM_RESULTS_ATTR);
+    }
+}
+
+impl DialectType for FuncSig {
+    const DIALECT_NAME: &'static str = "clif";
+    const TYPE_NAME: &'static str = "func_sig";
+
+    fn from_type_ref(ctx: &crate::IrContext, ty: crate::TypeRef) -> Option<Self> {
+        Self::matches(ctx, ty)
+            .then(|| Self::validate(ctx, ty).ok())
+            .flatten()
+    }
+
+    fn as_type_ref(&self) -> crate::TypeRef {
+        self.0
+    }
+}
+
+impl From<FuncSig> for crate::TypeRef {
+    fn from(value: FuncSig) -> Self {
+        value.0
+    }
+}
+
+fn read_count(attrs: &AttributeMap, name: &'static str) -> Result<u32, FuncSigTypeError> {
+    match attrs.get(name) {
+        None => Err(FuncSigTypeError::MissingCount(name)),
+        Some(Attribute::Int(value)) => {
+            u32::try_from(*value).map_err(|_| FuncSigTypeError::InvalidCount(name))
+        }
+        Some(_) => Err(FuncSigTypeError::InvalidCount(name)),
+    }
+}
+
+/// Construct a canonical target-owned `clif.func_sig`.
+pub fn func_sig(
+    ctx: &mut crate::IrContext,
+    inputs: impl IntoIterator<Item = crate::TypeRef>,
+    results: impl IntoIterator<Item = crate::TypeRef>,
+) -> FuncSig {
+    func_sig_with_attrs(ctx, inputs, results, AttributeMap::new())
+}
+
+/// Construct a canonical target signature while preserving non-reserved attributes.
+pub fn func_sig_with_attrs(
+    ctx: &mut crate::IrContext,
+    inputs: impl IntoIterator<Item = crate::TypeRef>,
+    results: impl IntoIterator<Item = crate::TypeRef>,
+    attrs: AttributeMap,
+) -> FuncSig {
+    assert!(
+        !attrs.contains_key(NUM_INPUTS_ATTR) && !attrs.contains_key(NUM_RESULTS_ATTR),
+        "clif.func_sig count attributes are reserved"
+    );
+    let inputs: Vec<_> = inputs.into_iter().collect();
+    let results: Vec<_> = results.into_iter().collect();
+    let num_inputs = u32::try_from(inputs.len()).expect("clif.func_sig input count exceeds u32");
+    let num_results = u32::try_from(results.len()).expect("clif.func_sig result count exceeds u32");
+    let mut builder = TypeDataBuilder::new(DIALECT_NAME(), FUNC_SIG())
+        .params(inputs)
+        .params(results);
+    for (key, value) in attrs {
+        builder = builder.attr(key, value);
+    }
+    let ty = ctx.types.intern(
+        builder
+            .attr(NUM_INPUTS_ATTR, Attribute::from(num_inputs))
+            .attr(NUM_RESULTS_ATTR, Attribute::from(num_results))
+            .build(),
+    );
+    FuncSig(ty)
+}
+
 impl IndirectCallLikeModel for CallIndirect {
     fn exact_signature(self, ctx: &crate::IrContext) -> Option<crate::TypeRef> {
         Some(self.sig(ctx))
@@ -150,13 +339,13 @@ inventory::submit! {
 /// Attach the required exact callable contract to a `clif` indirect transfer.
 ///
 /// Returns `false` without mutation when the operation is not a `clif`
-/// indirect call or the supplied type is not a `func.func_sig` contract.
+/// indirect call or the supplied type is not a `clif.func_sig` contract.
 pub fn set_indirect_call_signature(
     ctx: &mut crate::IrContext,
     op: crate::OpRef,
     signature: crate::TypeRef,
 ) -> bool {
-    if crate::dialect::func::FuncSig::from_type_ref(ctx, signature).is_none()
+    if FuncSig::from_type_ref(ctx, signature).is_none()
         || (CallIndirect::from_op(ctx, op).is_err()
             && ReturnCallIndirect::from_op(ctx, op).is_err())
     {
@@ -178,7 +367,10 @@ fn set_indirect_call_signature_attribute(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::dialect::func;
     use crate::op_interface::IndirectCallLikeOps;
+    use crate::ops::DialectType;
     use crate::parser::parse_test_module;
     use crate::printer::print_module;
 
@@ -189,11 +381,11 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   clif.func @ordinary(%callee: core.ptr, %value: core.i32) -> core.i32 {
-    %result = clif.call_indirect %callee, %value {sig = func.func_sig<(core.i32) -> core.i32>} : core.i32
+    %result = clif.call_indirect %callee, %value {sig = clif.func_sig<(core.i32) -> core.i32>} : core.i32
     clif.return %result
   }
   clif.func @tail(%callee: core.ptr, %value: core.i32) -> core.nil {
-    clif.return_call_indirect %callee, %value {sig = func.func_sig<(core.i32) -> core.nil>}
+    clif.return_call_indirect %callee, %value {sig = clif.func_sig<(core.i32) -> core.nil>}
   }
   clif.func @direct() -> core.nil {
     clif.return
@@ -211,6 +403,12 @@ mod tests {
         let direct = body_op(2);
         assert!(IndirectCallLikeOps::exact_signature(&ctx, ordinary).is_some());
         assert!(IndirectCallLikeOps::exact_signature(&ctx, tail).is_some());
+        let nil = crate::dialect::core::nil(&mut ctx).as_type_ref();
+        let shared_sig = func::func_sig(&mut ctx, [], [nil]).as_type_ref();
+        assert!(
+            !set_indirect_call_signature(&mut ctx, ordinary, shared_sig),
+            "a shared signature must not replace the target-owned contract"
+        );
         for op in [ordinary, tail] {
             let operands = ctx.op_operands(op);
             assert_eq!(IndirectCallLikeOps::callee(&ctx, op), Some(operands[0]));
@@ -225,6 +423,129 @@ mod tests {
 
         let printed = print_module(&ctx, module.op());
         assert!(printed.contains("clif.call_indirect"));
-        assert!(printed.contains("sig = func.func_sig<(core.i32) -> core.i32>"));
+        assert!(printed.contains("sig = clif.func_sig<(core.i32) -> core.i32>"));
+    }
+
+    #[test]
+    fn func_sig_owns_zero_and_multiple_result_lists_and_metadata() {
+        let mut ctx = crate::IrContext::new();
+        let i32 = ctx.types.intern(
+            TypeDataBuilder::new(crate::Symbol::new("core"), crate::Symbol::new("i32")).build(),
+        );
+        let i64 = ctx.types.intern(
+            TypeDataBuilder::new(crate::Symbol::new("core"), crate::Symbol::new("i64")).build(),
+        );
+        let mut attrs = AttributeMap::new();
+        attrs.insert(crate::Symbol::new("kept"), Attribute::Type(i64));
+        let zero = func_sig(&mut ctx, [i32], []).as_type_ref();
+        let one = func_sig(&mut ctx, [i32], [i64]).as_type_ref();
+        let many = func_sig_with_attrs(&mut ctx, [i32], [i32, i64], attrs).as_type_ref();
+        assert!(
+            FuncSig::from_type_ref(&ctx, zero)
+                .unwrap()
+                .is_resultless(&ctx)
+        );
+        assert_eq!(
+            FuncSig::from_type_ref(&ctx, one).unwrap().inputs(&ctx),
+            [i32]
+        );
+        assert_eq!(
+            FuncSig::from_type_ref(&ctx, one).unwrap().results(&ctx),
+            [i64]
+        );
+        assert_ne!(one, func::func_sig(&mut ctx, [i32], [i64]).as_type_ref());
+        let many_sig = FuncSig::from_type_ref(&ctx, many).unwrap();
+        assert_eq!(many_sig.inputs(&ctx), [i32]);
+        assert_eq!(many_sig.results(&ctx), [i32, i64]);
+        assert_eq!(many_sig.non_reserved_attrs(&ctx).count(), 1);
+        let mut same_attrs = AttributeMap::new();
+        same_attrs.insert(crate::Symbol::new("kept"), Attribute::Type(i64));
+        assert_eq!(
+            many,
+            func_sig_with_attrs(&mut ctx, [i32], [i32, i64], same_attrs).as_type_ref()
+        );
+    }
+
+    #[test]
+    fn func_sig_round_trips_through_type_aliases() {
+        let mut ctx = crate::IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  !scalar = core.i32
+  !callable = clif.func_sig<(!scalar) -> (!scalar, !scalar)> {nested = [!scalar]}
+}"#,
+        );
+        let printed = print_module(&ctx, module.op());
+        assert!(
+            printed.contains(
+                "!callable = clif.func_sig<(!scalar) -> (!scalar, !scalar)> {nested = [!scalar]}"
+            ),
+            "{printed}"
+        );
+        let mut reparsed = crate::IrContext::new();
+        let copy = parse_test_module(&mut reparsed, &printed);
+        assert_eq!(print_module(&reparsed, copy.op()), printed);
+    }
+
+    #[test]
+    fn func_sig_rejects_malformed_delimiters_without_slicing() {
+        let mut ctx = crate::IrContext::new();
+        let i32 = ctx.types.intern(
+            TypeDataBuilder::new(crate::Symbol::new("core"), crate::Symbol::new("i32")).build(),
+        );
+        let malformed = ctx.types.intern(
+            TypeDataBuilder::new(DIALECT_NAME(), FUNC_SIG())
+                .param(i32)
+                .attr(NUM_INPUTS_ATTR, Attribute::Int(2))
+                .attr(NUM_RESULTS_ATTR, Attribute::Int(1))
+                .build(),
+        );
+        assert!(FuncSig::from_type_ref(&ctx, malformed).is_none());
+        let missing = ctx.types.intern(
+            TypeDataBuilder::new(DIALECT_NAME(), FUNC_SIG())
+                .param(i32)
+                .attr(NUM_INPUTS_ATTR, Attribute::Int(1))
+                .build(),
+        );
+        assert_eq!(
+            FuncSig::validate(&ctx, missing),
+            Err(FuncSigTypeError::MissingCount(NUM_RESULTS_ATTR))
+        );
+
+        let wrong_kind = ctx.types.intern(
+            TypeDataBuilder::new(DIALECT_NAME(), FUNC_SIG())
+                .param(i32)
+                .attr(
+                    NUM_INPUTS_ATTR,
+                    Attribute::Symbol(crate::Symbol::new("one")),
+                )
+                .attr(NUM_RESULTS_ATTR, Attribute::Int(0))
+                .build(),
+        );
+        assert_eq!(
+            FuncSig::validate(&ctx, wrong_kind),
+            Err(FuncSigTypeError::InvalidCount(NUM_INPUTS_ATTR))
+        );
+
+        let overflow = ctx.types.intern(
+            TypeDataBuilder::new(DIALECT_NAME(), FUNC_SIG())
+                .attr(NUM_INPUTS_ATTR, Attribute::Int(i128::from(u32::MAX)))
+                .attr(NUM_RESULTS_ATTR, Attribute::Int(1))
+                .build(),
+        );
+        assert_eq!(
+            FuncSig::validate(&ctx, overflow),
+            Err(FuncSigTypeError::CountOverflow)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "count attributes are reserved")]
+    fn func_sig_constructor_rejects_reserved_count_attributes() {
+        let mut ctx = crate::IrContext::new();
+        let mut attrs = AttributeMap::new();
+        attrs.insert(NUM_INPUTS_ATTR.into(), Attribute::Int(0));
+        let _ = func_sig_with_attrs(&mut ctx, [], [], attrs);
     }
 }

--- a/crates/trunk-ir/src/parser/builder.rs
+++ b/crates/trunk-ir/src/parser/builder.rs
@@ -136,6 +136,9 @@ impl<'a> ArenaIrBuilder<'a> {
         if dialect == "wasm" && name == "func_sig" {
             return self.build_wasm_function_type(inputs, results, attrs);
         }
+        if dialect == "clif" && name == "func_sig" {
+            return self.build_clif_function_type(inputs, results, attrs);
+        }
         self.build_foreign_function_type(dialect, name, inputs, results, attrs)
     }
 
@@ -170,6 +173,42 @@ impl<'a> ArenaIrBuilder<'a> {
             .collect::<Result<AttributeMap, ParseError>>()?;
         Ok(
             crate::dialect::wasm::func_sig_with_attrs(self.ctx, inputs, results, attrs)
+                .as_type_ref(),
+        )
+    }
+
+    /// Build the native target signature through its owning validated API.
+    fn build_clif_function_type(
+        &mut self,
+        inputs: &[RawType<'_>],
+        results: &[RawType<'_>],
+        attrs: &[(&str, RawAttribute<'_>)],
+    ) -> Result<TypeRef, ParseError> {
+        if let Some((name, _)) = attrs.iter().find(|(name, _)| {
+            matches!(
+                *name,
+                crate::dialect::clif::NUM_INPUTS_ATTR | crate::dialect::clif::NUM_RESULTS_ATTR
+            )
+        }) {
+            return Err(ParseError {
+                message: format!("`{name}` is reserved by clif.func_sig"),
+                offset: 0,
+            });
+        }
+        let inputs = inputs
+            .iter()
+            .map(|ty| self.build_type(ty))
+            .collect::<Result<Vec<_>, _>>()?;
+        let results = results
+            .iter()
+            .map(|ty| self.build_type(ty))
+            .collect::<Result<Vec<_>, _>>()?;
+        let attrs = attrs
+            .iter()
+            .map(|(name, value)| Ok((Symbol::from_dynamic(name), self.build_attribute(value)?)))
+            .collect::<Result<AttributeMap, ParseError>>()?;
+        Ok(
+            crate::dialect::clif::func_sig_with_attrs(self.ctx, inputs, results, attrs)
                 .as_type_ref(),
         )
     }
@@ -573,10 +612,14 @@ impl<'a> ArenaIrBuilder<'a> {
                 .map(|(_, raw_ty)| self.build_type(raw_ty))
                 .collect::<Result<_, _>>()?;
 
-            let func_ty = if raw.dialect == "wasm" && raw.op_name == "func" {
-                crate::dialect::wasm::func_sig(self.ctx, param_types, results).as_type_ref()
-            } else {
-                crate::dialect::func::func_sig(self.ctx, param_types, results).as_type_ref()
+            let func_ty = match (raw.dialect, raw.op_name) {
+                ("wasm", "func") => {
+                    crate::dialect::wasm::func_sig(self.ctx, param_types, results).as_type_ref()
+                }
+                ("clif", "func") => {
+                    crate::dialect::clif::func_sig(self.ctx, param_types, results).as_type_ref()
+                }
+                _ => crate::dialect::func::func_sig(self.ctx, param_types, results).as_type_ref(),
             };
             if attributes.contains_key("type") && attributes.get_type("type").is_none() {
                 return Err(ParseError {
@@ -591,6 +634,15 @@ impl<'a> ArenaIrBuilder<'a> {
                             .is_some_and(|signature| {
                                 let synthesized =
                                     crate::dialect::wasm::FuncSig::from_type_ref(self.ctx, func_ty)
+                                        .unwrap();
+                                signature.inputs(self.ctx) == synthesized.inputs(self.ctx)
+                                    && signature.results(self.ctx) == synthesized.results(self.ctx)
+                            })
+                    } else if raw.dialect == "clif" && raw.op_name == "func" {
+                        crate::dialect::clif::FuncSig::from_type_ref(self.ctx, explicit)
+                            .is_some_and(|signature| {
+                                let synthesized =
+                                    crate::dialect::clif::FuncSig::from_type_ref(self.ctx, func_ty)
                                         .unwrap();
                                 signature.inputs(self.ctx) == synthesized.inputs(self.ctx)
                                     && signature.results(self.ctx) == synthesized.results(self.ctx)
@@ -761,7 +813,7 @@ pub fn parse_test_module(ctx: &mut IrContext, input: &str) -> Module {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dialect::{arith, core, func};
+    use crate::dialect::{arith, clif, core, func};
     use crate::ops::{DialectOp, DialectType};
     use crate::printer::print_module;
     use crate::validation;
@@ -1439,6 +1491,39 @@ core.module @test {
         assert!(
             print_module(&ctx, module).contains("type = func.func_sig<() -> core.nil>"),
             "the parser must not apply an implicit target conversion"
+        );
+    }
+
+    #[test]
+    fn clif_syntax_uses_the_target_owned_signature() {
+        let input = r#"core.module @test {
+  !contract = clif.func_sig<(core.i32) -> (core.i32, core.i64)> {tag = @native}
+  clif.func @id(%value: core.i32) -> core.i32 {
+    clif.return %value
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = parse_module(&mut ctx, input).expect("native assembly should parse");
+        let contract = ctx.type_alias_by_name(Symbol::new("contract")).unwrap();
+        assert!(clif::FuncSig::from_type_ref(&ctx, contract).is_some());
+        assert!(func::FuncSig::from_type_ref(&ctx, contract).is_none());
+        let function = ctx
+            .block(ctx.region(ctx.op(module).regions[0]).blocks[0])
+            .ops[0];
+        let signature = ctx.op(function).attributes.get_type("type").unwrap();
+        assert!(clif::FuncSig::from_type_ref(&ctx, signature).is_some());
+        assert!(func::FuncSig::from_type_ref(&ctx, signature).is_none());
+        assert_roundtrip(&ctx, module);
+
+        let mut rejected = IrContext::new();
+        let error = parse_module(
+            &mut rejected,
+            "core.module @test { !bad = clif.func_sig<() -> ()> {num_inputs = 0} }",
+        )
+        .expect_err("target count delimiters are constructor-owned");
+        assert!(
+            error.message.contains("reserved by clif.func_sig"),
+            "{error}"
         );
     }
 

--- a/crates/trunk-ir/src/printer.rs
+++ b/crates/trunk-ir/src/printer.rs
@@ -247,6 +247,11 @@ fn func_sig_parts(ctx: &IrContext, ty: TypeRef) -> Option<(&[TypeRef], &[TypeRef
     {
         return None;
     }
+    if data.dialect == crate::Symbol::new("clif")
+        && crate::dialect::clif::FuncSig::from_type_ref(ctx, ty).is_none()
+    {
+        return None;
+    }
     let num_inputs = match data.attrs.get(crate::dialect::func::NUM_INPUTS_ATTR) {
         Some(Attribute::Int(value)) => usize::try_from(u32::try_from(*value).ok()?).ok()?,
         _ => return None,

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -140,27 +140,29 @@ Cranelift IR과 1:1 대응하는 저수준 연산. 전체 연산 목록은 [ir.m
 - **스택 할당**: stack_slot으로 로컬 메모리 할당 가능
 - **함수 포인터**: funcref 대신 symbol_addr로 함수 주소 획득
 
-### `clif.func_sig` Native callable contract
+### `clif.func_sig` 네이티브 호출 계약
 
-Native lowering은 공통 callable type을 유지하지 않고 `clif.func_sig`를 소유한다.
+네이티브 lowering은 공통 callable type을 유지하지 않고 `clif.func_sig`를 소유한다.
 계약은 순서 있는 입력 뒤에 순서 있는 결과를 평탄한 벡터에 저장하고, 필수 `u32`
-`num_inputs`와 `num_results` 속성으로 경계를 구분한다. 두 delimiter와 모든
-non-reserved type 속성은 identity에 참여하며, delimiter는 ABI나 CPS marker가 아니다.
-Native 함수 정의와 declaration, 직접·exact indirect call, return, tail transfer,
-emission은 이 target-owned contract를 소비한다. Conversion은 중첩 type-bearing
-metadata를 보존하고 erased function pointer, symbol, ABI string, storage shape에서
-exact contract를 추론하지 않는다.
+`num_inputs`와 `num_results` 속성으로 경계를 구분한다. 두 delimiter와 예약되지 않은
+타입 속성은 타입 동일성에 참여하며, delimiter는 ABI나 CPS marker가 아니다. 네이티브
+함수 정의와 선언, 직접·exact indirect call, return, tail transfer, emission은 이
+target-owned contract를 소비한다. 호출 계약 변환은 그 내부의 중첩 타입 메타데이터를
+보존하고, 타입이 지워진 함수 포인터, 심볼, ABI 문자열, 저장 형태에서 exact contract를
+추론하지 않는다.
+
+계약의 `core.ptr` slot에는 native representation이 pointer인 semantic SSA 값이 올 수
+있다. 이 값은 개별 use마다 type을 지워서 바꾸지 않으며, 검증과 emission은 이 제한된
+ABI 동치를 `core.ptr` 계약에만 적용한다. 다른 계약 type과의 동치는 허용하지 않는다.
 
 ### Zero-width `core.nil`
 
-`core.nil` is a logical TrunkIR `Unit` SSA value but has no runtime
-representation in Cranelift. The native emitter therefore omits nil values
-from function signatures, entry and non-entry block parameters, CFG edge
-operands, direct and indirect call operands, and direct and indirect tail-call
-operands. It preserves the ordering of all non-nil parameters and operands,
-including the non-nil indirect callee, while leaving logical TrunkIR
-unchanged. Nil returns, constants, and return operands follow the same
-zero-width convention.
+`core.nil`은 논리 TrunkIR `Unit` SSA 값이지만 Cranelift runtime representation은 없다.
+따라서 native emitter는 함수 시그니처, entry와 non-entry block parameter, CFG edge
+operand, 직접·간접 call operand, 직접·간접 tail-call operand에서 nil을 생략한다.
+논리 TrunkIR는 바꾸지 않은 채 non-nil parameter와 operand의 순서(간접 호출의 non-nil
+callee 포함)를 보존한다. Nil return, constant, return operand에도 같은 zero-width
+규칙이 적용된다.
 
 ---
 

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -140,6 +140,17 @@ Cranelift IR과 1:1 대응하는 저수준 연산. 전체 연산 목록은 [ir.m
 - **스택 할당**: stack_slot으로 로컬 메모리 할당 가능
 - **함수 포인터**: funcref 대신 symbol_addr로 함수 주소 획득
 
+### `clif.func_sig` Native callable contract
+
+Native lowering은 공통 callable type을 유지하지 않고 `clif.func_sig`를 소유한다.
+계약은 순서 있는 입력 뒤에 순서 있는 결과를 평탄한 벡터에 저장하고, 필수 `u32`
+`num_inputs`와 `num_results` 속성으로 경계를 구분한다. 두 delimiter와 모든
+non-reserved type 속성은 identity에 참여하며, delimiter는 ABI나 CPS marker가 아니다.
+Native 함수 정의와 declaration, 직접·exact indirect call, return, tail transfer,
+emission은 이 target-owned contract를 소비한다. Conversion은 중첩 type-bearing
+metadata를 보존하고 erased function pointer, symbol, ABI string, storage shape에서
+exact contract를 추론하지 않는다.
+
 ### Zero-width `core.nil`
 
 `core.nil` is a logical TrunkIR `Unit` SSA value but has no runtime

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -151,9 +151,13 @@ target-owned contract를 소비한다. 호출 계약 변환은 그 내부의 중
 보존하고, 타입이 지워진 함수 포인터, 심볼, ABI 문자열, 저장 형태에서 exact contract를
 추론하지 않는다.
 
-계약의 `core.ptr` slot에는 native representation이 pointer인 semantic SSA 값이 올 수
-있다. 이 값은 개별 use마다 type을 지워서 바꾸지 않으며, 검증과 emission은 이 제한된
-ABI 동치를 `core.ptr` 계약에만 적용한다. 다른 계약 type과의 동치는 허용하지 않는다.
+Native 최종 호출 계약의 각 operand와 result slot은 `clif.func_sig`의 같은 순서 slot과
+정확히 같은 TrunkIR type이어야 한다. semantic reference SSA 값은 native lowering이 그
+producer 또는 block argument를 `core.ptr`로 명시적으로 낮춘 뒤에만 `core.ptr` slot을
+채울 수 있다. 검증과 emission은 dialect 이름, type attribute, ABI 문자열, symbol,
+erased representation으로 pointer 동치를 추론하지 않는다. 이 규칙은 `core.nil`의
+정해진 zero-width projection과 별개이며, 다른 contract type 사이의 호환성 규칙을
+만들지 않는다.
 
 ### Zero-width `core.nil`
 

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -151,13 +151,13 @@ target-owned contract를 소비한다. 호출 계약 변환은 그 내부의 중
 보존하고, 타입이 지워진 함수 포인터, 심볼, ABI 문자열, 저장 형태에서 exact contract를
 추론하지 않는다.
 
-Native 최종 호출 계약의 각 operand와 result slot은 `clif.func_sig`의 같은 순서 slot과
-정확히 같은 TrunkIR type이어야 한다. semantic reference SSA 값은 native lowering이 그
-producer 또는 block argument를 `core.ptr`로 명시적으로 낮춘 뒤에만 `core.ptr` slot을
-채울 수 있다. 검증과 emission은 dialect 이름, type attribute, ABI 문자열, symbol,
-erased representation으로 pointer 동치를 추론하지 않는다. 이 규칙은 `core.nil`의
-정해진 zero-width projection과 별개이며, 다른 contract type 사이의 호환성 규칙을
-만들지 않는다.
+네이티브 최종 호출 계약의 각 operand와 result slot은 `clif.func_sig`의 같은 순서
+slot과 정확히 같은 TrunkIR type이어야 한다. semantic reference SSA 값은 native
+lowering이 그 producer 또는 block argument를 `core.ptr`로 명시적으로 낮춘 뒤에만
+`core.ptr` slot을 채울 수 있다. 검증과 emission은 dialect 이름, type attribute, ABI
+문자열, symbol, erased representation에서 pointer 동치를 추론하지 않는다. 이 규칙은
+`core.nil`의 정해진 zero-width projection과 별개이며, 다른 contract type 사이의
+호환성 규칙을 만들지 않는다.
 
 ### Zero-width `core.nil`
 

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -81,6 +81,13 @@ Wasm 대상 변환 경계는 공통 함수 시그니처와 그 안의 중첩 타
 [IR 계약](ir.md#wasmfunc_sig-wasm-호출-계약), 바이너리 결과 표현은
 [Wasm 백엔드 계약](wasm-backend.md#wasm-결과-슬롯)에서 정의한다.
 
+Native 대상 변환 경계도 같은 공통 callable과 중첩 type-bearing metadata를
+`clif.func_sig`로 변환한다. 입력·결과의 순서와 개수, 예약되지 않은 타입 속성을
+보존하며, type을 지운 함수 포인터나 symbol 이름에서 callable contract를 다시
+구성하지 않는다. `clif.func_sig`의 저장 형식과 type identity는
+[IR 계약](ir.md#cliffunc_sig-native-호출-계약), nil의 machine 표현은
+[Cranelift 백엔드 계약](cranelift-backend.md#zero-width-corenil)을 따른다.
+
 ## 직접형 제어 소유권
 
 구조와 의미의 source of truth는

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -81,11 +81,11 @@ Wasm 대상 변환 경계는 공통 함수 시그니처와 그 안의 중첩 타
 [IR 계약](ir.md#wasmfunc_sig-wasm-호출-계약), 바이너리 결과 표현은
 [Wasm 백엔드 계약](wasm-backend.md#wasm-결과-슬롯)에서 정의한다.
 
-Native 대상 변환 경계도 같은 공통 callable과 중첩 type-bearing metadata를
+네이티브 대상 변환 경계도 공통 callable과 그 호출 계약 내부의 중첩 타입 메타데이터를
 `clif.func_sig`로 변환한다. 입력·결과의 순서와 개수, 예약되지 않은 타입 속성을
-보존하며, type을 지운 함수 포인터나 symbol 이름에서 callable contract를 다시
-구성하지 않는다. `clif.func_sig`의 저장 형식과 type identity는
-[IR 계약](ir.md#cliffunc_sig-native-호출-계약), nil의 machine 표현은
+보존하며, 타입이 지워진 함수 포인터나 심볼 이름에서 callable contract를 다시
+구성하지 않는다. `clif.func_sig`의 저장 형식과 타입 동일성은
+[IR 계약](ir.md#cliffunc_sig-네이티브-호출-계약), nil의 machine 표현은
 [Cranelift 백엔드 계약](cranelift-backend.md#zero-width-corenil)을 따른다.
 
 ## 직접형 제어 소유권

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -902,6 +902,23 @@ Wasm 함수와 가져오기 선언, 직접·간접 호출, 반환, 타입 섹션
 CPS를 판정하지 않는다. 논리적 Unit 함수, 논리적 CPS 함수, 물리적 CPS 함수의
 결과 구분은 [공통 `func.func_sig` 계약](#funcfunc_sig-function-type)을 따른다.
 
+### `clif.func_sig` Native 호출 계약
+
+`clif.func_sig`는 Native가 소유하는 함수 호출 계약이다. 입력 우선의 평탄한
+`[inputs..., results...]` 벡터와 필수 `u32` 속성 `num_inputs`·`num_results`를
+사용하고 결과는 0개 이상을 허용한다. 두 개수의 합은 벡터 길이와 같아야 하며,
+두 속성과 예약되지 않은 type 속성은 모두 type 동일성에 참여한다. count는 저장
+경계일 뿐 ABI 또는 calling convention의 증거가 아니다. parser, printer, alias,
+재귀 type conversion은 예약되지 않은 속성과 중첩된 type-bearing metadata를 그
+소유 type에 보존한다.
+
+Native 함수와 declaration, 직접·간접 호출, 반환, proper tail transfer 및
+Cranelift code generation은 이 type을 사용한다. 간접 호출의 `sig`는 정확한
+`clif.func_sig`이어야 하며 erased function pointer, symbol, ABI 문자열 또는
+storage shape에서 재구성하지 않는다. 결과가 비었다는 사실만으로 CPS를 판정하지
+않는다. 논리 Unit `[core.nil]`, 논리 CPS `[core.never]`, 물리 CPS `[]`의 구분은
+[공통 `func.func_sig` 계약](#funcfunc_sig-function-type)을 따른다.
+
 ## Open Questions
 
 - Final closure environment representation for each backend.

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -902,22 +902,26 @@ Wasm 함수와 가져오기 선언, 직접·간접 호출, 반환, 타입 섹션
 CPS를 판정하지 않는다. 논리적 Unit 함수, 논리적 CPS 함수, 물리적 CPS 함수의
 결과 구분은 [공통 `func.func_sig` 계약](#funcfunc_sig-function-type)을 따른다.
 
-### `clif.func_sig` Native 호출 계약
+### `clif.func_sig` 네이티브 호출 계약
 
-`clif.func_sig`는 Native가 소유하는 함수 호출 계약이다. 입력 우선의 평탄한
+`clif.func_sig`는 네이티브가 소유하는 함수 호출 계약이다. 입력 우선의 평탄한
 `[inputs..., results...]` 벡터와 필수 `u32` 속성 `num_inputs`·`num_results`를
 사용하고 결과는 0개 이상을 허용한다. 두 개수의 합은 벡터 길이와 같아야 하며,
-두 속성과 예약되지 않은 type 속성은 모두 type 동일성에 참여한다. count는 저장
-경계일 뿐 ABI 또는 calling convention의 증거가 아니다. parser, printer, alias,
-재귀 type conversion은 예약되지 않은 속성과 중첩된 type-bearing metadata를 그
-소유 type에 보존한다.
+두 속성과 예약되지 않은 타입 속성은 모두 타입 동일성에 참여한다. count는 저장
+경계일 뿐 ABI 또는 calling convention의 증거가 아니다. parser, printer, alias는
+예약되지 않은 속성을 보존하며, 호출 계약 내부의 재귀 타입 변환도 중첩 메타데이터를
+그 소유 타입에 보존한다.
 
-Native 함수와 declaration, 직접·간접 호출, 반환, proper tail transfer 및
-Cranelift code generation은 이 type을 사용한다. 간접 호출의 `sig`는 정확한
-`clif.func_sig`이어야 하며 erased function pointer, symbol, ABI 문자열 또는
-storage shape에서 재구성하지 않는다. 결과가 비었다는 사실만으로 CPS를 판정하지
-않는다. 논리 Unit `[core.nil]`, 논리 CPS `[core.never]`, 물리 CPS `[]`의 구분은
+네이티브 함수와 선언, 직접·간접 호출, 반환, proper tail transfer 및 Cranelift 코드
+생성은 이 타입을 사용한다. 간접 호출의 `sig`는 정확한 `clif.func_sig`이어야 하며,
+타입이 지워진 함수 포인터, 심볼, ABI 문자열 또는 저장 형태에서 재구성하지 않는다.
+결과가 비었다는 사실만으로 CPS를 판정하지 않는다. 논리 Unit `[core.nil]`, 논리
+CPS `[core.never]`, 물리 CPS `[]`의 구분은
 [공통 `func.func_sig` 계약](#funcfunc_sig-function-type)을 따른다.
+
+Native contract의 `core.ptr` 입력·결과 slot은 pointer representation을 공유하는
+semantic SSA type과 ABI 동치일 수 있다. 이 예외는 `core.ptr` contract에만 적용하며,
+다른 target contract type은 exact type 일치를 요구한다.
 
 ## Open Questions
 

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -919,9 +919,13 @@ CPS를 판정하지 않는다. 논리적 Unit 함수, 논리적 CPS 함수, 물�
 CPS `[core.never]`, 물리 CPS `[]`의 구분은
 [공통 `func.func_sig` 계약](#funcfunc_sig-function-type)을 따른다.
 
-Native contract의 `core.ptr` 입력·결과 slot은 pointer representation을 공유하는
-semantic SSA type과 ABI 동치일 수 있다. 이 예외는 `core.ptr` contract에만 적용하며,
-다른 target contract type은 exact type 일치를 요구한다.
+네이티브 최종 호출 계약의 각 operand와 result slot은 `clif.func_sig`의 같은 순서
+slot과 정확히 같은 TrunkIR type이어야 한다. semantic reference SSA 값은 native
+lowering이 그 producer 또는 block argument를 `core.ptr`로 명시적으로 낮춘 뒤에만
+`core.ptr` slot을 채울 수 있다. 검증과 emission은 dialect 이름, type attribute, ABI
+문자열, symbol, erased representation에서 pointer 동치를 추론하지 않는다. 이 규칙은
+`core.nil`의 정해진 zero-width projection과 별개이며, 다른 contract type 사이의
+호환성 규칙을 만들지 않는다.
 
 ## Open Questions
 

--- a/new-plans/types.md
+++ b/new-plans/types.md
@@ -47,6 +47,10 @@ empty function result lists, distinct from both
 logical types. An empty list alone does not prove physical CPS: that requires
 the Cps calling convention together with the exact empty result list.
 
+타겟 callable contract는 각각 독립적으로 소유한다. 특히 Native 타겟은
+`clif.func_sig`로 순서 있는 0개 이상의 결과 목록을 표현할 수 있지만, 이것이
+source function의 결과 하나 또는 공통 `func.func_sig` 계약을 넓히지는 않는다.
+
 ### Struct (Product Type)
 
 ```rust

--- a/new-plans/types.md
+++ b/new-plans/types.md
@@ -47,9 +47,9 @@ empty function result lists, distinct from both
 logical types. An empty list alone does not prove physical CPS: that requires
 the Cps calling convention together with the exact empty result list.
 
-타겟 callable contract는 각각 독립적으로 소유한다. 특히 Native 타겟은
-`clif.func_sig`로 순서 있는 0개 이상의 결과 목록을 표현할 수 있지만, 이것이
-source function의 결과 하나 또는 공통 `func.func_sig` 계약을 넓히지는 않는다.
+각 타겟은 callable contract를 독립적으로 소유한다. 특히 네이티브 타겟은
+`clif.func_sig`로 순서 있는 0개 이상의 결과 목록을 표현할 수 있지만, 이 사실이
+소스 함수의 단일 결과나 공통 `func.func_sig` 계약을 넓히지는 않는다.
 
 ### Struct (Product Type)
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1723,10 +1723,13 @@ pub fn link_native_binary(object_bytes: &[u8], output: &Path) -> Result<(), Link
 mod tests {
     use super::*;
     use salsa_test_macros::salsa_test;
+    use std::collections::HashMap;
     use tribute_core::calling_convention::{
         cps_continuation_frame_layout_type, cps_continuation_frame_ref_type, cps_dispatch_type,
         cps_done_type,
     };
+    use trunk_ir::dialect::clif;
+    use trunk_ir::ops::DialectType;
 
     fn source_logical_cps_root_module() -> (IrContext, Module) {
         let mut ctx = IrContext::new();
@@ -1866,6 +1869,171 @@ mod tests {
     fn source_from_str(path: &str, text: &str) -> SourceCst {
         salsa::with_attached_database(|db| SourceCst::from_source_str(db, path, text))
             .expect("attached db")
+    }
+
+    fn assert_exact_indirect_call_operands(
+        ctx: &IrContext,
+        region: trunk_ir::RegionRef,
+        pointer_type: trunk_ir::TypeRef,
+        saw_pointer_argument: &mut bool,
+        ir: &str,
+    ) {
+        for &block in &ctx.region(region).blocks {
+            for &op in &ctx.block(block).ops {
+                if clif::CallIndirect::matches(ctx, op) {
+                    let signature = ctx
+                        .op(op)
+                        .attributes
+                        .get_type("sig")
+                        .and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty))
+                        .expect("prepared clif.call_indirect must retain an exact signature");
+                    let operands = ctx.op_operands(op);
+                    let arguments = operands
+                        .get(1..)
+                        .expect("clif.call_indirect must retain its callee operand");
+                    assert_eq!(arguments.len(), signature.inputs(ctx).len());
+                    for (index, (argument, expected)) in
+                        arguments.iter().zip(signature.inputs(ctx)).enumerate()
+                    {
+                        assert_eq!(
+                            ctx.value_ty(*argument),
+                            *expected,
+                            "clif.call_indirect argument #{index}: expected {:?}, found {:?}\n{ir}",
+                            ctx.types.get(*expected),
+                            ctx.types.get(ctx.value_ty(*argument)),
+                        );
+                        if *expected == pointer_type {
+                            *saw_pointer_argument = true;
+                        }
+                    }
+                    let expected_results = signature
+                        .results(ctx)
+                        .iter()
+                        .copied()
+                        .filter(|ty| {
+                            let data = ctx.types.get(*ty);
+                            data.dialect != trunk_ir::Symbol::new("core")
+                                || data.name != trunk_ir::Symbol::new("nil")
+                        })
+                        .collect::<Vec<_>>();
+                    assert_eq!(ctx.op_result_types(op), expected_results, "{ir}");
+                }
+                for &nested in &ctx.op(op).regions {
+                    assert_exact_indirect_call_operands(
+                        ctx,
+                        nested,
+                        pointer_type,
+                        saw_pointer_argument,
+                        ir,
+                    );
+                }
+            }
+        }
+    }
+
+    fn collect_clif_function_signatures(
+        ctx: &IrContext,
+        region: trunk_ir::RegionRef,
+        functions: &mut HashMap<trunk_ir::Symbol, clif::FuncSig>,
+    ) {
+        for &block in &ctx.region(region).blocks {
+            for &op in &ctx.block(block).ops {
+                if clif::Func::matches(ctx, op) {
+                    let name = ctx
+                        .op(op)
+                        .attributes
+                        .get_symbol("sym_name")
+                        .expect("prepared clif.func must have a symbol name");
+                    let signature = ctx
+                        .op(op)
+                        .attributes
+                        .get_type("type")
+                        .and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty))
+                        .expect("prepared clif.func must have a valid signature");
+                    functions.insert(name, signature);
+                }
+                for &nested in &ctx.op(op).regions {
+                    collect_clif_function_signatures(ctx, nested, functions);
+                }
+            }
+        }
+    }
+
+    fn assert_exact_direct_call_operands(
+        ctx: &IrContext,
+        region: trunk_ir::RegionRef,
+        functions: &HashMap<trunk_ir::Symbol, clif::FuncSig>,
+        ir: &str,
+    ) {
+        for &block in &ctx.region(region).blocks {
+            for &op in &ctx.block(block).ops {
+                if clif::Call::matches(ctx, op) {
+                    let callee = ctx
+                        .op(op)
+                        .attributes
+                        .get_symbol("callee")
+                        .expect("prepared clif.call must have a symbol callee");
+                    if let Some(signature) = functions.get(&callee) {
+                        let arguments = ctx.op_operands(op);
+                        assert_eq!(arguments.len(), signature.inputs(ctx).len(), "{ir}");
+                        for (argument, expected) in arguments.iter().zip(signature.inputs(ctx)) {
+                            assert_eq!(ctx.value_ty(*argument), *expected, "{ir}");
+                        }
+                        assert_eq!(ctx.op_result_types(op), signature.results(ctx), "{ir}");
+                    }
+                }
+                for &nested in &ctx.op(op).regions {
+                    assert_exact_direct_call_operands(ctx, nested, functions, ir);
+                }
+            }
+        }
+    }
+
+    #[salsa_test]
+    fn native_preparation_closure_call_slots_are_exact(db: &crate::TributeDatabaseImpl) {
+        let source = source_from_str(
+            "closure_exec_simple.trb",
+            r#"
+extern "C" fn __tribute_print_nat(value: Nat) -> Nil
+
+fn main() {
+    let f = fn(x) { x + 1 }
+    __tribute_print_nat(f(41))
+}
+"#,
+        );
+        let (mut ctx, module) = run_shared_pipeline(db, source)
+            .expect("shared pipeline must succeed")
+            .expect("fixture must lower");
+        validate_and_report_arity(db, &ctx, module);
+        run_native_target_pipeline(&mut ctx, module).expect("native target lowering must succeed");
+        prepare_module_to_native(
+            &mut ctx,
+            module,
+            false,
+            NativeOptimizationOptions::production(),
+            None,
+        )
+        .expect("native preparation must succeed");
+
+        let pointer_type = core_dialect::ptr(&mut ctx).as_type_ref();
+        let prepared_ir = trunk_ir::printer::print_module(&ctx, module.op());
+        let mut functions = HashMap::new();
+        let body = module.body(&ctx).expect("module must have a body");
+        collect_clif_function_signatures(&ctx, body, &mut functions);
+        let mut saw_pointer_argument = false;
+        assert_exact_indirect_call_operands(
+            &ctx,
+            body,
+            pointer_type,
+            &mut saw_pointer_argument,
+            &prepared_ir,
+        );
+        assert_exact_direct_call_operands(&ctx, body, &functions, &prepared_ir);
+        assert!(
+            saw_pointer_argument,
+            "closure execution fixture must exercise a core.ptr indirect-call slot"
+        );
     }
 
     #[cfg(unix)]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1723,13 +1723,14 @@ pub fn link_native_binary(object_bytes: &[u8], output: &Path) -> Result<(), Link
 mod tests {
     use super::*;
     use salsa_test_macros::salsa_test;
-    use std::collections::HashMap;
+    use std::ops::ControlFlow;
     use tribute_core::calling_convention::{
         cps_continuation_frame_layout_type, cps_continuation_frame_ref_type, cps_dispatch_type,
         cps_done_type,
     };
     use trunk_ir::dialect::clif;
     use trunk_ir::ops::DialectType;
+    use trunk_ir::walk::{WalkAction, walk_region};
 
     fn source_logical_cps_root_module() -> (IrContext, Module) {
         let mut ctx = IrContext::new();
@@ -1871,122 +1872,38 @@ mod tests {
             .expect("attached db")
     }
 
-    fn assert_exact_indirect_call_operands(
+    fn has_boxed_closure_call_pointer_witness(
         ctx: &IrContext,
-        region: trunk_ir::RegionRef,
+        module: Module,
         pointer_type: trunk_ir::TypeRef,
-        saw_pointer_argument: &mut bool,
-        ir: &str,
-    ) {
-        for &block in &ctx.region(region).blocks {
-            for &op in &ctx.block(block).ops {
-                if clif::CallIndirect::matches(ctx, op) {
-                    let signature = ctx
-                        .op(op)
-                        .attributes
-                        .get_type("sig")
-                        .and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty))
-                        .expect("prepared clif.call_indirect must retain an exact signature");
-                    let operands = ctx.op_operands(op);
-                    let arguments = operands
-                        .get(1..)
-                        .expect("clif.call_indirect must retain its callee operand");
-                    assert_eq!(arguments.len(), signature.inputs(ctx).len());
-                    for (index, (argument, expected)) in
-                        arguments.iter().zip(signature.inputs(ctx)).enumerate()
-                    {
-                        assert_eq!(
-                            ctx.value_ty(*argument),
-                            *expected,
-                            "clif.call_indirect argument #{index}: expected {:?}, found {:?}\n{ir}",
-                            ctx.types.get(*expected),
-                            ctx.types.get(ctx.value_ty(*argument)),
-                        );
-                        if *expected == pointer_type {
-                            *saw_pointer_argument = true;
-                        }
-                    }
-                    let expected_results = signature
-                        .results(ctx)
-                        .iter()
-                        .copied()
-                        .filter(|ty| {
-                            let data = ctx.types.get(*ty);
-                            data.dialect != trunk_ir::Symbol::new("core")
-                                || data.name != trunk_ir::Symbol::new("nil")
-                        })
-                        .collect::<Vec<_>>();
-                    assert_eq!(ctx.op_result_types(op), expected_results, "{ir}");
-                }
-                for &nested in &ctx.op(op).regions {
-                    assert_exact_indirect_call_operands(
-                        ctx,
-                        nested,
-                        pointer_type,
-                        saw_pointer_argument,
-                        ir,
-                    );
+    ) -> bool {
+        let body = module.body(ctx).expect("module must have a body");
+        let mut found = false;
+        let _ = walk_region::<()>(ctx, body, &mut |op| {
+            if clif::CallIndirect::matches(ctx, op) {
+                let signature = ctx
+                    .op(op)
+                    .attributes
+                    .get_type("sig")
+                    .and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty));
+                let operands = ctx.op_operands(op);
+                if let (Some(signature), Some(&argument)) = (signature, operands.get(3))
+                    && operands.len() == 4
+                    && signature.inputs(ctx).len() == 3
+                    && signature.inputs(ctx)[2] == pointer_type
+                    && ctx.value_ty(argument) == pointer_type
+                    && matches!(
+                        ctx.value_def(argument),
+                        trunk_ir::refs::ValueDef::OpResult(producer, _)
+                            if clif::Iadd::matches(ctx, producer)
+                    )
+                {
+                    found = true;
                 }
             }
-        }
-    }
-
-    fn collect_clif_function_signatures(
-        ctx: &IrContext,
-        region: trunk_ir::RegionRef,
-        functions: &mut HashMap<trunk_ir::Symbol, clif::FuncSig>,
-    ) {
-        for &block in &ctx.region(region).blocks {
-            for &op in &ctx.block(block).ops {
-                if clif::Func::matches(ctx, op) {
-                    let name = ctx
-                        .op(op)
-                        .attributes
-                        .get_symbol("sym_name")
-                        .expect("prepared clif.func must have a symbol name");
-                    let signature = ctx
-                        .op(op)
-                        .attributes
-                        .get_type("type")
-                        .and_then(|ty| clif::FuncSig::from_type_ref(ctx, ty))
-                        .expect("prepared clif.func must have a valid signature");
-                    functions.insert(name, signature);
-                }
-                for &nested in &ctx.op(op).regions {
-                    collect_clif_function_signatures(ctx, nested, functions);
-                }
-            }
-        }
-    }
-
-    fn assert_exact_direct_call_operands(
-        ctx: &IrContext,
-        region: trunk_ir::RegionRef,
-        functions: &HashMap<trunk_ir::Symbol, clif::FuncSig>,
-        ir: &str,
-    ) {
-        for &block in &ctx.region(region).blocks {
-            for &op in &ctx.block(block).ops {
-                if clif::Call::matches(ctx, op) {
-                    let callee = ctx
-                        .op(op)
-                        .attributes
-                        .get_symbol("callee")
-                        .expect("prepared clif.call must have a symbol callee");
-                    if let Some(signature) = functions.get(&callee) {
-                        let arguments = ctx.op_operands(op);
-                        assert_eq!(arguments.len(), signature.inputs(ctx).len(), "{ir}");
-                        for (argument, expected) in arguments.iter().zip(signature.inputs(ctx)) {
-                            assert_eq!(ctx.value_ty(*argument), *expected, "{ir}");
-                        }
-                        assert_eq!(ctx.op_result_types(op), signature.results(ctx), "{ir}");
-                    }
-                }
-                for &nested in &ctx.op(op).regions {
-                    assert_exact_direct_call_operands(ctx, nested, functions, ir);
-                }
-            }
-        }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        found
     }
 
     #[salsa_test]
@@ -2016,23 +1933,12 @@ fn main() {
         )
         .expect("native preparation must succeed");
 
+        trunk_ir_cranelift_backend::validate_clif_ir(&ctx, module)
+            .expect("prepared native IR must satisfy exact callable slot contracts");
         let pointer_type = core_dialect::ptr(&mut ctx).as_type_ref();
-        let prepared_ir = trunk_ir::printer::print_module(&ctx, module.op());
-        let mut functions = HashMap::new();
-        let body = module.body(&ctx).expect("module must have a body");
-        collect_clif_function_signatures(&ctx, body, &mut functions);
-        let mut saw_pointer_argument = false;
-        assert_exact_indirect_call_operands(
-            &ctx,
-            body,
-            pointer_type,
-            &mut saw_pointer_argument,
-            &prepared_ir,
-        );
-        assert_exact_direct_call_operands(&ctx, body, &functions, &prepared_ir);
         assert!(
-            saw_pointer_argument,
-            "closure execution fixture must exercise a core.ptr indirect-call slot"
+            has_boxed_closure_call_pointer_witness(&ctx, module, pointer_type),
+            "closure execution fixture must pass a core.ptr boxed value to its indirect call"
         );
     }
 


### PR DESCRIPTION
## Summary
- require exact TrunkIR type equality for native callable arguments and results
- lower boxed primitive results to `core.ptr` before they fill native pointer slots
- document the contract and keep the closure regression focused on the production validator

## Validation
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace` (2118 passed, 2 skipped)
- Negative control: restoring the old boxed `tribute_rt.anyref` result fails with the expected `clif.call_indirect` argument #2 mismatch; the production lowering was restored afterward.

## Scope
Native #960 only. This preserves the existing `core.nil` zero-width and CPS contracts. It introduces no dialect, operation, pipeline, or ownership redesign, and intentionally leaves #961 and #825 out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Native function signatures support zero or multiple ordered results, including `nil` values.
  - Direct and indirect native calls preserve result ordering and enforce exact type contracts.
  - Native lowering consistently uses dedicated CLIF function signatures.

- **Bug Fixes**
  - Improved validation detects malformed signatures and mismatched call, return, and pointer types.
  - Boxed native values now use consistent pointer representations.

- **Documentation**
  - Added and updated guidance for native signatures, result handling, and type contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->