### PR TITLE
fix(cps): preserve dispatch answer contracts with empty physical results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,7 @@ dependencies = [
  "trunk-ir",
  "trunk-ir-cranelift-backend",
  "trunk-ir-wasm-backend",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ trunk-ir-cranelift-backend.workspace = true
 trunk-ir-wasm-backend.workspace = true
 
 [dev-dependencies]
+wasmparser.workspace = true
 insta.workspace = true
 itertools.workspace = true
 salsa-test-macros = { path = "crates/salsa-test-macros" }

--- a/crates/tribute-ir/src/dialect/effect.rs
+++ b/crates/tribute-ir/src/dialect/effect.rs
@@ -34,7 +34,7 @@ mod effect {
     /// types. `payload` is the single packed operation argument value. The
     /// operation is resultless: backend lowering performs the final proper tail
     /// transfer.
-    #[attr(ability_ref: Type, op_name: Symbol)]
+    #[attr(ability_ref: Type, op_name: Symbol, answer_type: Type)]
     fn dispatch_cps(evidence: (), dispatch: (), resume: (), payload: ()) {}
 
     /// Dispatch the explicitly legacy carrier-based general ability operation.
@@ -147,6 +147,7 @@ mod tests {
             payload,
             ability,
             Symbol::new("get"),
+            anyref_ty,
         );
 
         let tail_wrapper =

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -264,7 +264,7 @@ impl RewritePattern for LowerClosureCallArena {
                 callee,
                 convention,
                 &args,
-                caller_result_ty,
+                &[caller_result_ty],
                 anyref_ty,
             ) else {
                 return false;
@@ -398,9 +398,11 @@ impl RewritePattern for LowerClosureTailCallArena {
             .types
             .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
         let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
-        let never = core::never(ctx).as_type_ref();
+        let Some(results) = exact_tail_results(ctx, op, callee) else {
+            return false;
+        };
         let Some(contract) =
-            exact_physical_call_contract(ctx, callee, convention, args, never, anyref_ty)
+            exact_physical_call_contract(ctx, callee, convention, args, &results, anyref_ty)
         else {
             return false;
         };
@@ -440,7 +442,10 @@ fn copy_indirect_call_attributes(ctx: &mut IrContext, source: OpRef, destination
     ctx.op_mut(destination).attributes.extend(attributes);
 }
 
-fn physical_closure_type_for_callee(ctx: &IrContext, callee: ValueRef) -> Option<TypeRef> {
+pub(crate) fn physical_closure_type_for_callee(
+    ctx: &IrContext,
+    callee: ValueRef,
+) -> Option<TypeRef> {
     let ty = ctx.value_ty(callee);
     if get_physical_closure_convention(ctx, ty).is_some() {
         return Some(ty);
@@ -479,6 +484,27 @@ fn is_lowered_closure_pack(ctx: &IrContext, op: OpRef, closure_ty: TypeRef) -> b
     ctx.value_ty(*function) == closure.func_type(ctx)
 }
 
+fn exact_tail_results(ctx: &IrContext, op: OpRef, callee: ValueRef) -> Option<Vec<TypeRef>> {
+    let closure = physical_closure_type_for_callee(ctx, callee)?;
+    let signature = closure::Closure::from_type_ref(ctx, closure)?.func_type(ctx);
+    let exact = trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(ctx, op)?;
+    if exact != signature {
+        return None;
+    }
+    let results = func::FuncSig::from_type_ref(ctx, signature)?.results(ctx);
+    let mut parent = ctx.op(op).parent_block?;
+    loop {
+        let owner = ctx.region(ctx.block(parent).parent_region?).parent_op?;
+        if let Ok(function) = func::Func::from_op(ctx, owner) {
+            let caller = func::FuncSig::from_type_ref(ctx, function.r#type(ctx))?;
+            return (get_calling_convention(ctx, owner) == Some(CallingConvention::Cps)
+                && caller.results(ctx) == results)
+                .then(|| results.to_vec());
+        }
+        parent = ctx.op(owner).parent_block?;
+    }
+}
+
 struct PhysicalCallContract {
     environment_index: usize,
     signature: TypeRef,
@@ -490,14 +516,14 @@ fn exact_physical_call_contract(
     callee: ValueRef,
     convention: CallingConvention,
     args: &[ValueRef],
-    result: TypeRef,
+    results: &[TypeRef],
     environment: TypeRef,
 ) -> Option<PhysicalCallContract> {
     let closure_ty = physical_closure_type_for_callee(ctx, callee)?;
     (get_physical_closure_convention(ctx, closure_ty) == Some(convention)).then_some(())?;
     let function = closure::Closure::from_type_ref(ctx, closure_ty)?.func_type(ctx);
     let callable = func::FuncSig::from_type_ref(ctx, function)?;
-    if callable.results(ctx) != [result] || callable.inputs(ctx).len() != args.len() {
+    if callable.results(ctx) != results || callable.inputs(ctx).len() != args.len() {
         return None;
     }
     let mut casts = Vec::new();
@@ -528,7 +554,8 @@ fn exact_physical_call_contract(
     type_attrs.remove(func::NUM_RESULTS_ATTR);
     Some(PhysicalCallContract {
         environment_index,
-        signature: func::func_sig_with_attrs(ctx, params, [result], type_attrs).as_type_ref(),
+        signature: func::func_sig_with_attrs(ctx, params, results.iter().copied(), type_attrs)
+            .as_type_ref(),
         argument_casts: casts,
     })
 }
@@ -633,7 +660,6 @@ fn tagged_closure_transfers_are_legal(ctx: &mut IrContext, func_op: func::Func) 
     }
 
     let anyref = tribute_rt::anyref(ctx).as_type_ref();
-    let never = core::never(ctx).as_type_ref();
     transfers.into_iter().all(|op| {
         let operands = ctx.op_operands(op).to_vec();
         let Some((&callee, args)) = operands.split_first() else {
@@ -649,10 +675,13 @@ fn tagged_closure_transfers_are_legal(ctx: &mut IrContext, func_op: func::Func) 
             let Some(&result) = ctx.op_result_types(op).first() else {
                 return false;
             };
-            exact_physical_call_contract(ctx, callee, convention, args, result, anyref).is_some()
+            exact_physical_call_contract(ctx, callee, convention, args, &[result], anyref).is_some()
         } else {
+            let Some(results) = exact_tail_results(ctx, op, callee) else {
+                return false;
+            };
             convention == CallingConvention::Cps
-                && exact_physical_call_contract(ctx, callee, convention, args, never, anyref)
+                && exact_physical_call_contract(ctx, callee, convention, args, &results, anyref)
                     .is_some()
         }
     })
@@ -742,14 +771,35 @@ pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
 /// not a type-equivalence rule or final physical-IR contract.
 pub fn finalize_closure_storage_layout(ctx: &mut IrContext, module: Module) {
     let closure_struct = closure_struct_type_ref(ctx);
+    rewrite_closure_storage_types(ctx, module, None, closure_struct);
+}
+
+/// Convert only the exact canonical storage identity through the existing
+/// recursive closure type surfaces; target ownership remains at the caller.
+pub(crate) fn convert_canonical_closure_storage(
+    ctx: &mut IrContext,
+    module: Module,
+    source: TypeRef,
+    target: TypeRef,
+) {
+    rewrite_closure_storage_types(ctx, module, Some(source), target);
+}
+
+fn rewrite_closure_storage_types(
+    ctx: &mut IrContext,
+    module: Module,
+    source_storage: Option<TypeRef>,
+    closure_struct: TypeRef,
+) {
     let ops = collect_ops(ctx, module.op());
     let aliases = ctx.type_aliases().to_vec();
-    let mut physicalizer = ClosureTypePhysicalizer::new(ctx, closure_struct);
+    let mut physicalizer = ClosureTypePhysicalizer::new(ctx, closure_struct, source_storage);
     let mut alias_updates = Vec::new();
     let mut attribute_removals = Vec::new();
     let mut attribute_updates = Vec::new();
     let mut result_updates = Vec::new();
     let mut block_arg_updates = Vec::new();
+    let mut block_attribute_updates = Vec::new();
 
     for (name, ty) in aliases {
         let converted = physicalizer.convert_type(ty);
@@ -759,7 +809,7 @@ pub fn finalize_closure_storage_layout(ctx: &mut IrContext, module: Module) {
     }
     for op in ops {
         for (name, value) in physicalizer.ctx.op(op).attributes.clone() {
-            if name == Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR) {
+            if source_storage.is_none() && name == Symbol::new(CLOSURE_CALLABLE_TYPE_ATTR) {
                 attribute_removals.push(op);
                 continue;
             }
@@ -782,14 +832,16 @@ pub fn finalize_closure_storage_layout(ctx: &mut IrContext, module: Module) {
         }
         for region in physicalizer.ctx.op(op).regions.clone() {
             for block in physicalizer.ctx.region(region).blocks.clone() {
-                let args = physicalizer
-                    .ctx
-                    .block(block)
-                    .args
-                    .iter()
-                    .map(|argument| argument.ty)
-                    .collect::<Vec<_>>();
-                for (index, ty) in args.into_iter().enumerate() {
+                let args = physicalizer.ctx.block(block).args.to_vec();
+                for (index, argument) in args.into_iter().enumerate() {
+                    let mut attrs = argument.attrs.clone();
+                    for (name, value) in argument.attrs.iter() {
+                        attrs.insert(*name, physicalizer.convert_attribute(value.clone()));
+                    }
+                    if attrs != argument.attrs {
+                        block_attribute_updates.push((block, index, attrs));
+                    }
+                    let ty = argument.ty;
                     let converted = physicalizer.convert_type(ty);
                     if converted != ty {
                         block_arg_updates.push((block, index as u32, converted));
@@ -817,27 +869,39 @@ pub fn finalize_closure_storage_layout(ctx: &mut IrContext, module: Module) {
     for (block, index, ty) in block_arg_updates {
         ctx.set_block_arg_type(block, index, ty);
     }
+    for (block, index, attrs) in block_attribute_updates {
+        ctx.block_mut(block).args[index].attrs = attrs;
+    }
 }
 
 struct ClosureTypePhysicalizer<'a> {
     ctx: &'a mut IrContext,
     closure_struct: TypeRef,
+    source_storage: Option<TypeRef>,
     cache: HashMap<TypeRef, TypeRef>,
     visiting: HashSet<TypeRef>,
 }
 
 impl<'a> ClosureTypePhysicalizer<'a> {
-    fn new(ctx: &'a mut IrContext, closure_struct: TypeRef) -> Self {
+    fn new(
+        ctx: &'a mut IrContext,
+        closure_struct: TypeRef,
+        source_storage: Option<TypeRef>,
+    ) -> Self {
         Self {
             ctx,
             closure_struct,
+            source_storage,
             cache: HashMap::new(),
             visiting: HashSet::new(),
         }
     }
 
     fn convert_type(&mut self, ty: TypeRef) -> TypeRef {
-        if closure::Closure::matches(self.ctx, ty) {
+        if self.source_storage.map_or_else(
+            || closure::Closure::matches(self.ctx, ty),
+            |source| ty == source,
+        ) {
             return self.closure_struct;
         }
         if let Some(&converted) = self.cache.get(&ty) {
@@ -920,6 +984,16 @@ impl Pass for LowerPreparedClosures {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
+        for op in collect_ops(ctx, target.op_ref()) {
+            if let Ok(function) = func::Func::from_op(ctx, op)
+                && !tagged_closure_transfers_are_legal(ctx, function)
+            {
+                return Err(
+                    "closure lowering: exact caller/callee/indirect result contract mismatch"
+                        .into(),
+                );
+            }
+        }
         lower_prepared_closures(ctx, target.into());
         Ok(())
     }
@@ -952,6 +1026,11 @@ impl Pass for LowerClosuresInFunc {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
+        if !tagged_closure_transfers_are_legal(ctx, target) {
+            return Err(
+                "closure lowering: exact caller/callee/indirect result contract mismatch".into(),
+            );
+        }
         lower_closures_in_func(ctx, target);
         Ok(())
     }
@@ -1300,8 +1379,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn tagged_dispatch_aware_tail_retains_exact_physical_signature() {
+    fn check_tagged_dispatch_tail(physical: bool) {
         let mut ctx = IrContext::new();
         let ev = evidence_type_str();
         let module = parse_test_module(
@@ -1315,6 +1393,9 @@ mod tests {
 }}"#
             ),
         );
+        if physical {
+            crate::target_abi::lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        }
         let run = func_by_name(&ctx, module, "run");
         let entry_args = ctx.block_args(ctx.region(run.body(&ctx)).blocks[0]);
         let evidence = entry_args[1];
@@ -1334,6 +1415,7 @@ mod tests {
         let signature =
             trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, tail).unwrap();
         let callable = func::FuncSig::from_type_ref(&ctx, signature).unwrap();
+        assert_eq!(callable.results(&ctx).is_empty(), physical);
         assert_eq!(ctx.op_operands(tail).len(), 6);
         assert_eq!(ctx.op_operands(tail)[1], evidence);
         assert_eq!(
@@ -1351,6 +1433,16 @@ mod tests {
                 .collect::<Vec<_>>(),
             "the physical signature must include the inserted environment operand"
         );
+    }
+
+    #[test]
+    fn logical_dispatch_tail_preserves_never_results() {
+        check_tagged_dispatch_tail(false);
+    }
+
+    #[test]
+    fn physical_dispatch_tail_preserves_empty_results() {
+        check_tagged_dispatch_tail(true);
     }
 
     #[test]

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -249,7 +249,10 @@ impl RewritePattern for LowerClosureCallArena {
 
         let loc = ctx.op(op).location;
         let args: Vec<ValueRef> = operands[1..].to_vec();
-        let caller_result_ty = ctx.op_result_types(op)[0];
+        // Ordinary closure calls currently lower exactly one result.
+        let &[caller_result_ty] = ctx.op_result_types(op) else {
+            return false;
+        };
 
         let i32_ty = ctx
             .types
@@ -672,10 +675,10 @@ fn tagged_closure_transfers_are_legal(ctx: &mut IrContext, func_op: func::Func) 
             return false;
         };
         if func::CallIndirect::matches(ctx, op) {
-            let Some(&result) = ctx.op_result_types(op).first() else {
-                return false;
-            };
-            exact_physical_call_contract(ctx, callee, convention, args, &[result], anyref).is_some()
+            let results = ctx.op_result_types(op).to_vec();
+            results.len() == 1
+                && exact_physical_call_contract(ctx, callee, convention, args, &results, anyref)
+                    .is_some()
         } else {
             let Some(results) = exact_tail_results(ctx, op, callee) else {
                 return false;
@@ -1291,6 +1294,81 @@ mod tests {
         assert!(lower_prepared_closures(&mut ctx, module).is_err());
         assert_eq!(print_module(&ctx, module.op()), before);
         assert_eq!(collect_ops(&ctx, module.op()), ops);
+    }
+
+    #[test]
+    fn ordinary_closure_call_result_counts_are_checked_before_mutation() {
+        for (signature_results, call, supported) in [
+            (
+                "core.i32",
+                "func.call_indirect %callee {tribute.calling_convention = 0}",
+                false,
+            ),
+            (
+                "core.i32",
+                "%first, %extra = func.call_indirect %callee {tribute.calling_convention = 0} : core.i32, core.i32",
+                false,
+            ),
+            (
+                "()",
+                "func.call_indirect %callee {tribute.calling_convention = 0}",
+                false,
+            ),
+            (
+                "core.i32",
+                "%result = func.call_indirect %callee {tribute.calling_convention = 0} : core.i32",
+                true,
+            ),
+        ] {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(
+                &mut ctx,
+                &format!(
+                    r#"core.module @test {{
+            !Callback = closure.closure(func.func_sig<() -> {signature_results}>) {{tribute.calling_convention = 0, tribute.closure_environment_index = 0}}
+            func.func @invalid(%callee: !Callback) -> core.i32 {{
+                {call}
+                %zero = arith.constant {{value = 0}} : core.i32
+                func.return %zero
+            }}
+            func.func @otherwise_lowerable(%callee: !Callback) -> tribute_rt.anyref {{
+                %env = closure.env %callee : tribute_rt.anyref
+                func.return %env
+            }}
+        }}"#,
+                ),
+            );
+            let before = print_module(&ctx, module.op());
+            let ops = collect_ops(&ctx, module.op());
+            let invalid = func_by_name(&ctx, module, "invalid");
+            if supported {
+                lower_prepared_closures(&mut ctx, module).unwrap();
+                assert_module_is_structurally_valid(&ctx, module);
+                let call = collect_ops(&ctx, invalid.op_ref())
+                    .into_iter()
+                    .find(|&op| func::CallIndirect::matches(&ctx, op))
+                    .unwrap();
+                assert_eq!(ctx.op_result_types(call).len(), 1);
+                assert_eq!(ctx.op_operands(call).len(), 2);
+                assert!(print_module(&ctx, invalid.op_ref()).contains("signature"));
+                continue;
+            }
+            for error in [
+                lower_closures_in_func(&mut ctx, invalid).unwrap_err(),
+                lower_prepared_closures(&mut ctx, module).unwrap_err(),
+            ] {
+                assert_eq!(
+                    error.to_string(),
+                    "closure lowering: exact caller/callee/indirect result contract mismatch"
+                );
+            }
+            assert_eq!(print_module(&ctx, module.op()), before);
+            assert_eq!(collect_ops(&ctx, module.op()), ops);
+            // The rewrite pattern must also decline unsupported arities safely.
+            rewrite_validated_closures_in_func(&mut ctx, invalid);
+            assert_eq!(print_module(&ctx, module.op()), before);
+            assert_eq!(collect_ops(&ctx, module.op()), ops);
+        }
     }
 
     #[test]

--- a/crates/tribute-passes/src/closure_lower.rs
+++ b/crates/tribute-passes/src/closure_lower.rs
@@ -691,10 +691,10 @@ fn tagged_closure_transfers_are_legal(ctx: &mut IrContext, func_op: func::Func) 
 ///
 /// This compatibility entry point prepares module-level function signatures,
 /// then lowers every function body in the module tree.
-pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) {
+pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) -> PassRunResult {
     prepare_closure_lowering(ctx, module);
 
-    lower_prepared_closures(ctx, module);
+    lower_prepared_closures(ctx, module)
 }
 
 /// Lower every already-prepared function body in a module to closure storage.
@@ -703,26 +703,35 @@ pub(crate) fn lower_closures(ctx: &mut IrContext, module: Module) {
 /// earlier transformation are lowered once as well. Processing each function
 /// operation at most once keeps this traversal bounded without relying on
 /// function names or target-specific pipeline ordering.
-pub fn lower_prepared_closures(ctx: &mut IrContext, module: Module) {
+pub fn lower_prepared_closures(ctx: &mut IrContext, module: Module) -> PassRunResult {
     let mut lowered = HashSet::new();
     let mut worklist = Vec::new();
 
     loop {
+        let mut discovered = Vec::new();
         let _ = walk_op::<()>(ctx, module.op(), &mut |op| {
             if let Ok(func_op) = func::Func::from_op(ctx, op)
                 && lowered.insert(op)
             {
-                worklist.push(func_op);
+                discovered.push(func_op);
             }
             ControlFlow::Continue(WalkAction::Advance)
         });
+
+        // Validate the initial module as a whole before rewriting any body.
+        // Later batches include newly generated functions and follow the same gate.
+        for &function in &discovered {
+            validate_closure_transfers(ctx, function)?;
+        }
+        worklist.extend(discovered);
 
         let Some(func_op) = worklist.pop() else {
             break;
         };
 
-        lower_closures_in_func(ctx, func_op);
+        rewrite_validated_closures_in_func(ctx, func_op);
     }
+    Ok(())
 }
 
 /// Prepare module-level closure lowering state.
@@ -736,15 +745,23 @@ pub(crate) fn prepare_closure_lowering(ctx: &mut IrContext, module: Module) {
     applicator.apply_partial(ctx, module);
 }
 
-/// Lower closure operations in one function body.
-///
-/// Closure calls already carry convention-specific hidden operands. This pass
-/// only interposes the physical closure environment.
-pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
-    if ctx.op(func_op.op_ref()).regions.is_empty() {
-        return;
+fn validate_closure_transfers(ctx: &mut IrContext, func_op: func::Func) -> PassRunResult {
+    if tagged_closure_transfers_are_legal(ctx, func_op) {
+        Ok(())
+    } else {
+        Err("closure lowering: exact caller/callee/indirect result contract mismatch".into())
     }
-    if !tagged_closure_transfers_are_legal(ctx, func_op) {
+}
+
+/// Validate and lower a function's closures, interposing the physical environment.
+pub(crate) fn lower_closures_in_func(ctx: &mut IrContext, func_op: func::Func) -> PassRunResult {
+    validate_closure_transfers(ctx, func_op)?;
+    rewrite_validated_closures_in_func(ctx, func_op);
+    Ok(())
+}
+
+fn rewrite_validated_closures_in_func(ctx: &mut IrContext, func_op: func::Func) {
+    if ctx.op(func_op.op_ref()).regions.is_empty() {
         return;
     }
     let legacy_evidence = evidence_param_for_func(ctx, func_op);
@@ -967,8 +984,7 @@ impl Pass for LowerClosures {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
-        lower_closures(ctx, target.into());
-        Ok(())
+        lower_closures(ctx, target.into())
     }
 }
 
@@ -984,18 +1000,7 @@ impl Pass for LowerPreparedClosures {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: core::Module) -> PassRunResult {
-        for op in collect_ops(ctx, target.op_ref()) {
-            if let Ok(function) = func::Func::from_op(ctx, op)
-                && !tagged_closure_transfers_are_legal(ctx, function)
-            {
-                return Err(
-                    "closure lowering: exact caller/callee/indirect result contract mismatch"
-                        .into(),
-                );
-            }
-        }
-        lower_prepared_closures(ctx, target.into());
-        Ok(())
+        lower_prepared_closures(ctx, target.into())
     }
 }
 
@@ -1026,13 +1031,7 @@ impl Pass for LowerClosuresInFunc {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: func::Func) -> PassRunResult {
-        if !tagged_closure_transfers_are_legal(ctx, target) {
-            return Err(
-                "closure lowering: exact caller/callee/indirect result contract mismatch".into(),
-            );
-        }
-        lower_closures_in_func(ctx, target);
-        Ok(())
+        lower_closures_in_func(ctx, target)
     }
 }
 
@@ -1218,7 +1217,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = closure_test_module(&mut ctx);
 
-        lower_closures(&mut ctx, module);
+        lower_closures(&mut ctx, module).unwrap();
 
         let ir = print_module(&ctx, module.op());
         assert!(
@@ -1256,7 +1255,7 @@ mod tests {
         let mut ctx = IrContext::new();
         let module = nested_closure_test_module(&mut ctx);
 
-        lower_closures(&mut ctx, module);
+        lower_closures(&mut ctx, module).unwrap();
         assert_module_is_structurally_valid(&ctx, module);
 
         let inner = func_by_name_recursive(&ctx, module, "inner");
@@ -1269,6 +1268,29 @@ mod tests {
             !inner_ir.contains("closure.func") && !inner_ir.contains("closure.env"),
             "nested closure accessors must be fully lowered:\n{inner_ir}"
         );
+    }
+
+    #[test]
+    fn prepared_module_rejects_invalid_transfer_before_rewriting_other_functions() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+            !Cps = closure.closure(func.func_sig<(core.i32) -> core.never>) {tribute.calling_convention = 2, tribute.closure_environment_index = 0}
+            func.func @invalid(%callee: !Cps, %value: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
+                func.tail_call_indirect %callee, %value
+            }
+            func.func @otherwise_lowerable(%callee: !Cps) -> tribute_rt.anyref {
+                %env = closure.env %callee : tribute_rt.anyref
+                func.return %env
+            }
+        }"#,
+        );
+        let before = print_module(&ctx, module.op());
+        let ops = collect_ops(&ctx, module.op());
+        assert!(lower_prepared_closures(&mut ctx, module).is_err());
+        assert_eq!(print_module(&ctx, module.op()), before);
+        assert_eq!(collect_ops(&ctx, module.op()), ops);
     }
 
     #[test]
@@ -1359,7 +1381,7 @@ mod tests {
         let module = nested_closure_test_module(&mut ctx);
         let outer = func_by_name_recursive(&ctx, module, "outer");
 
-        lower_closures_in_func(&mut ctx, outer);
+        lower_closures_in_func(&mut ctx, outer).unwrap();
 
         let inner = func_by_name_recursive(&ctx, module, "inner");
         let inner_after_outer = print_module(&ctx, inner.op_ref());
@@ -1368,7 +1390,7 @@ mod tests {
             "outer function pass should not lower nested function body:\n{inner_after_outer}"
         );
 
-        lower_closures_in_func(&mut ctx, inner);
+        lower_closures_in_func(&mut ctx, inner).unwrap();
 
         let inner_calls = call_indirect_operands_in_func(&ctx, inner);
         assert_eq!(inner_calls.len(), 1);
@@ -1403,7 +1425,7 @@ mod tests {
         let dispatch = entry_args[3];
         let value = entry_args[4];
 
-        lower_closures_in_func(&mut ctx, run);
+        lower_closures_in_func(&mut ctx, run).unwrap();
 
         let tail = ctx
             .block(ctx.region(run.body(&ctx)).blocks[0])
@@ -1468,7 +1490,7 @@ mod tests {
         let run = func_by_name(&ctx, module, "run");
         let before = print_module(&ctx, module.op());
 
-        lower_closures_in_func(&mut ctx, run);
+        assert!(lower_closures_in_func(&mut ctx, run).is_err());
 
         assert_eq!(print_module(&ctx, module.op()), before);
     }
@@ -1485,7 +1507,7 @@ mod tests {
         let external = func_by_name(&ctx, module, "external");
         let before = print_module(&ctx, module.op());
 
-        lower_closures_in_func(&mut ctx, external);
+        lower_closures_in_func(&mut ctx, external).unwrap();
 
         assert_eq!(print_module(&ctx, module.op()), before);
     }
@@ -1507,7 +1529,7 @@ mod tests {
         let caller = func_by_name(&ctx, module, "caller");
         let before = print_module(&ctx, module.op());
 
-        lower_closures_in_func(&mut ctx, caller);
+        lower_closures_in_func(&mut ctx, caller).unwrap();
 
         assert_eq!(print_module(&ctx, module.op()), before);
     }
@@ -1540,7 +1562,7 @@ mod tests {
         let run = func_by_name(&ctx, module, "run");
         let before = print_module(&ctx, module.op());
 
-        lower_closures_in_func(&mut ctx, run);
+        assert!(lower_closures_in_func(&mut ctx, run).is_err());
 
         assert_eq!(print_module(&ctx, module.op()), before);
     }

--- a/crates/tribute-passes/src/lower_ability_perform.rs
+++ b/crates/tribute-passes/src/lower_ability_perform.rs
@@ -166,6 +166,11 @@ impl RewritePattern for LowerPerformPattern {
         let resume_val = operands[2];
         let value_operands = &operands[3..];
 
+        let Ok(answer_type) =
+            crate::target_abi::dispatch_answer_type(ctx, evidence_val, dispatch_val, resume_val)
+        else {
+            return false;
+        };
         let t = &self.types;
 
         let shift_value_val = pack_payload(
@@ -190,6 +195,7 @@ impl RewritePattern for LowerPerformPattern {
             shift_value_val,
             ability_ref_type,
             op_name_sym,
+            answer_type,
         );
         rewriter.insert_op(dispatch_op.op_ref());
         rewriter.erase_op(vec![]);
@@ -398,6 +404,7 @@ fn find_evidence_from_op(ctx: &IrContext, op: OpRef) -> Option<ValueRef> {
 mod tests {
     use super::*;
     use trunk_ir::context::IrContext;
+    use trunk_ir::ops::DialectType;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
 
@@ -409,6 +416,44 @@ mod tests {
     /// Build the canonical evidence type string for use in test IR.
     fn evidence_type_str() -> &'static str {
         "core.array(adt.struct() {fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]], name = @_Marker})"
+    }
+
+    fn attach_exact_perform_types(ctx: &mut IrContext, module: trunk_ir::rewrite::Module) {
+        use tribute_core::calling_convention::*;
+        let answer = ctx.types.intern(
+            trunk_ir::types::TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build(),
+        );
+        let evidence = ability::evidence_adt_type_ref(ctx);
+        let anyref = tribute_rt::anyref(ctx).as_type_ref();
+        let frame_name = Symbol::new("test_frame");
+        let frame = cps_continuation_frame_ref_type(ctx, frame_name, answer);
+        let done = cps_done_type(ctx, answer);
+        let dispatch = cps_dispatch_type(ctx, evidence, frame, anyref, answer);
+        let resume =
+            func::FuncSig::from_type_ref(ctx, cps_closure_function_type(ctx, dispatch).unwrap())
+                .unwrap()
+                .inputs(ctx)[1];
+        let layout = cps_continuation_frame_layout_type(ctx, frame_name, answer, done, dispatch);
+        ctx.register_type_alias(frame_name, layout);
+        let mut performs = Vec::new();
+        let _ = trunk_ir::walk::walk_op::<()>(ctx, module.op(), &mut |op| {
+            if ability::Perform::matches(ctx, op) {
+                performs.push(op);
+            }
+            std::ops::ControlFlow::Continue(trunk_ir::walk::WalkAction::Advance)
+        });
+        for op in performs {
+            for (value, ty) in [
+                (ctx.op_operands(op)[1], dispatch),
+                (ctx.op_operands(op)[2], resume),
+            ] {
+                let trunk_ir::refs::ValueDef::OpResult(producer, index) = ctx.value_def(value)
+                else {
+                    panic!("fixture constant")
+                };
+                ctx.set_op_result_type(producer, index, ty);
+            }
+        }
     }
 
     #[test]
@@ -430,6 +475,7 @@ mod tests {
             ),
         );
 
+        attach_exact_perform_types(&mut ctx, module);
         lower_ability_perform(&mut ctx, module);
 
         let ir_text = print_module(&ctx, module.op());
@@ -460,6 +506,7 @@ mod tests {
             ),
         );
 
+        attach_exact_perform_types(&mut ctx, module);
         lower_ability_perform(&mut ctx, module);
 
         let ir_text = print_module(&ctx, module.op());

--- a/crates/tribute-passes/src/native/evidence.rs
+++ b/crates/tribute-passes/src/native/evidence.rs
@@ -603,13 +603,40 @@ impl RewritePattern for LowerEffectDispatchCpsToNative {
         let loc = ctx.op(op).location;
         // A result-bearing final dispatch is malformed. Reject it before any
         // helper op is inserted so partial conversion leaves the IR unchanged.
-        if !ctx.op_result_types(op).is_empty() {
+        if !ctx.op_result_types(op).is_empty()
+            || ctx.op(op).attributes.get_type("answer_type").is_none()
+            || ctx.op_operands(op).len() != 4
+        {
             return false;
         }
         let i32_ty = core_i32_type(ctx);
         let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
         let closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
         let ability_ref = dispatch_op.ability_ref(ctx);
+        let evidence_ty = ability::evidence_adt_type_ref(ctx);
+        let signature = func::func_sig(
+            ctx,
+            [
+                evidence_ty,
+                anyref_ty,
+                closure_ty,
+                i32_ty,
+                i32_ty,
+                i32_ty,
+                anyref_ty,
+            ],
+            [],
+        )
+        .as_type_ref();
+        let (converter, _) = super::type_converter::native_type_converter(ctx);
+        let expected = [evidence_ty, closure_ty, closure_ty, anyref_ty];
+        for (value, expected) in ctx.op_operands(op).to_vec().into_iter().zip(expected) {
+            if converter.convert_type_or_identity(ctx, ctx.value_ty(value))
+                != converter.convert_type_or_identity(ctx, expected)
+            {
+                return false;
+            }
+        }
 
         let ability_id_op = ability::ability_id_const(ctx, loc, i32_ty, ability_ref);
         let ability_id_val = ability_id_op.result(ctx);
@@ -658,9 +685,8 @@ impl RewritePattern for LowerEffectDispatchCpsToNative {
                 op_idx_val,
                 dispatch_op.payload(ctx),
             ],
-            None,
+            Some(signature),
         );
-        attach_exact_indirect_signature(ctx, tail.op_ref());
         set_calling_convention(ctx, tail.op_ref(), tribute_core::CallingConvention::Cps);
         rewriter.replace_op(tail.op_ref());
         true
@@ -926,6 +952,8 @@ mod tests {
     use std::ops::ControlFlow;
     use trunk_ir::Span;
     use trunk_ir::context::{BlockArgData, BlockData, RegionData};
+    use trunk_ir::op_interface::IndirectCallLikeModel;
+    use trunk_ir::ops::DialectType;
     use trunk_ir::parser::parse_test_module;
     use trunk_ir::printer::print_module;
     use trunk_ir::smallvec::smallvec;
@@ -1224,13 +1252,64 @@ mod tests {
     }
 
     #[test]
+    fn final_dispatch_uses_one_canonical_signature_for_distinct_answers() {
+        let mut ctx = IrContext::new();
+        let source = r#"core.module @test {
+          func.func @first(%ev: core.ptr, %dispatch: tribute_rt.anyref, %resume: tribute_rt.anyref, %payload: tribute_rt.anyref) {
+            effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get, answer_type = core.i32}
+          }
+          func.func @second(%ev: core.ptr, %dispatch: tribute_rt.anyref, %resume: tribute_rt.anyref, %payload: tribute_rt.anyref) {
+            effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get, answer_type = core.i64}
+          }
+        }"#;
+        let module = parse_test_module(&mut ctx, source);
+        let mut signatures = Vec::new();
+        for name in ["first", "second"] {
+            let function = func_by_name_recursive(&ctx, module, name);
+            lower_evidence_to_native_func(&mut ctx, function);
+            let block = ctx.region(function.body(&ctx)).blocks[0];
+            let tail = *ctx.block(block).ops.last().unwrap();
+            assert!(!ctx.op(tail).attributes.contains_key("answer_type"));
+            signatures.push(
+                func::TailCallIndirect::from_op(&ctx, tail)
+                    .unwrap()
+                    .exact_signature(&ctx)
+                    .unwrap(),
+            );
+        }
+        assert_eq!(signatures[0], signatures[1]);
+        let signature = func::FuncSig::from_type_ref(&ctx, signatures[0]).unwrap();
+        assert!(signature.results(&ctx).is_empty());
+        let (converter, _) = super::super::type_converter::native_type_converter(&mut ctx);
+        let actual: Vec<_> = signature
+            .inputs(&ctx)
+            .iter()
+            .map(|ty| converter.convert_type_or_identity(&ctx, *ty))
+            .collect();
+        let ptr = core::ptr(&mut ctx).as_type_ref();
+        let i32_ty = core_i32_type(&mut ctx);
+        assert_eq!(actual, [ptr, ptr, ptr, i32_ty, i32_ty, i32_ty, ptr]);
+        for index in 0..4 {
+            let mut ctx = IrContext::new();
+            let module = parse_test_module(&mut ctx, source);
+            let function = func_by_name_recursive(&ctx, module, "first");
+            let entry = ctx.region(function.body(&ctx)).blocks[0];
+            let wrong = core_i32_type(&mut ctx);
+            ctx.set_block_arg_type(entry, index, wrong);
+            let before = print_module(&ctx, module.op());
+            assert!(try_lower_evidence_to_native_func(&mut ctx, function).is_err());
+            assert_eq!(print_module(&ctx, module.op()), before);
+        }
+    }
+
+    #[test]
     fn resultless_final_dispatch_lowers_to_a_native_proper_tail() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
   func.func @run(%ev: core.ptr, %dispatch: tribute_rt.anyref, %resume: tribute_rt.anyref, %payload: tribute_rt.anyref) -> core.never {
-    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
+    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get, answer_type = core.i32}
   }
 }"#,
         );

--- a/crates/tribute-passes/src/native/ownership_plan.rs
+++ b/crates/tribute-passes/src/native/ownership_plan.rs
@@ -888,12 +888,14 @@ fn is_defined_physical_cps_function(ctx: &IrContext, op: OpRef) -> bool {
         return false;
     };
     func::FuncSig::from_type_ref(ctx, signature).is_some_and(|callable| {
+        if callable.results(ctx).is_empty() {
+            return true;
+        }
         let Some(result) = callable.single_result(ctx) else {
             return false;
         };
         let result = ctx.types.get(result);
-        result.dialect == Symbol::new("core")
-            && (result.name == Symbol::new("nil") || result.name == Symbol::new("never"))
+        result.dialect == Symbol::new("core") && result.name == Symbol::new("never")
     })
 }
 
@@ -999,9 +1001,7 @@ fn validate_function_contract(
             validate_result_contract(
                 ctx,
                 ctx.op_operands(terminator),
-                signature.single_result(ctx).ok_or_else(|| {
-                    OwnershipPlanError::new("native ownership requires one logical result")
-                })?,
+                signature.results(ctx),
                 managed_layouts,
                 "function return",
             )?;

--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -967,7 +967,8 @@ pub(super) fn validate_result_contract(
             "{subject} differs from the exact callable signature"
         )));
     }
-    if !is_typed_managed_reference(ctx, expected, managed_layouts)
+    if values.len() == 1
+        && !is_typed_managed_reference(ctx, expected, managed_layouts)
         && !values
             .iter()
             .any(|&value| is_managed_value(ctx, value, managed_layouts))

--- a/crates/tribute-passes/src/native/ownership_plan/actions.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/actions.rs
@@ -933,9 +933,7 @@ fn validate_call_contract(
     validate_result_contract(
         ctx,
         ctx.op_results(op),
-        signature.single_result(ctx).ok_or_else(|| {
-            OwnershipPlanError::new("native ownership requires one logical result")
-        })?,
+        signature.results(ctx),
         managed_layouts,
         "call result",
     )
@@ -944,10 +942,20 @@ fn validate_call_contract(
 pub(super) fn validate_result_contract(
     ctx: &IrContext,
     values: &[ValueRef],
-    expected: TypeRef,
+    expected: &[TypeRef],
     managed_layouts: &HashSet<TypeRef>,
     subject: &str,
 ) -> Result<(), OwnershipPlanError> {
+    let [expected] = expected else {
+        return if expected.is_empty() && values.is_empty() {
+            Ok(())
+        } else {
+            Err(OwnershipPlanError::new(format!(
+                "{subject} differs from the exact callable signature"
+            )))
+        };
+    };
+    let expected = *expected;
     let expected_data = ctx.types.get(expected);
     let physically_empty = expected_data.dialect == Symbol::new("core")
         && (expected_data.name == Symbol::new("nil") || expected_data.name == Symbol::new("never"));

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -112,6 +112,36 @@ fn assert_plan_error_unchanged(ir: &str, expected: &str) {
 }
 
 #[test]
+fn ordinary_result_contract_requires_one_value_and_preserves_zero_width_results() {
+    let mut ctx = IrContext::new();
+    let module = parse_test_module(
+        &mut ctx,
+        r#"core.module @test {
+        func.func @values(%one: core.i32, %two: core.i32, %nil: core.nil, %never: core.never) { func.unreachable }
+    }"#,
+    );
+    let function = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+    let entry = ctx.region(function.body(&ctx)).blocks[0];
+    let values = ctx.block_args(entry);
+    let managed = HashSet::new();
+    let check = |values: &[ValueRef], expected: &[TypeRef]| {
+        actions::validate_result_contract(&ctx, values, expected, &managed, "test result")
+    };
+    let scalar = ctx.value_ty(values[0]);
+    assert!(check(&[], &[scalar]).is_err());
+    assert!(check(&values[..1], &[scalar]).is_ok());
+    assert!(check(&values[..2], &[scalar]).is_err());
+    assert!(check(&[], &[]).is_ok());
+    assert!(check(&values[..1], &[]).is_err());
+    for &value in &values[2..] {
+        let ty = ctx.value_ty(value);
+        assert!(check(&[], &[ty]).is_ok());
+        assert!(check(&[value], &[ty]).is_ok());
+        assert!(check(&[value, value], &[ty]).is_err());
+    }
+}
+
+#[test]
 fn typed_plan_options_preserve_or_elide_only_proven_parameter_and_field_borrows() {
     let ir = r#"core.module @test {
   !Child = adt.struct() {name = @Child, fields = [[@value, core.i32]]}
@@ -1161,7 +1191,7 @@ fn semantic_closure_release_uses_its_compiler_generated_allocation_layout() {
   }
 }"#,
     );
-    crate::closure_lower::lower_closures(&mut ctx, module);
+    crate::closure_lower::lower_closures(&mut ctx, module).unwrap();
 
     let plan = build_native_ownership_plan(&ctx, module).expect("typed ownership plan");
     materialize(&mut ctx, module, &plan).expect("typed RC materialization");

--- a/crates/tribute-passes/src/native/ownership_plan/tests.rs
+++ b/crates/tribute-passes/src/native/ownership_plan/tests.rs
@@ -992,16 +992,16 @@ fn cfg_copy_and_tail_dying_value_actions_are_complete() {
         r#"core.module @test {
   !R = adt.typeref() {name = @R}
   !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
-  func.func @branch(%value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @branch(%value: !R) attributes {tribute.calling_convention = 2} {
     ^entry:
       cf.br %value, %value [^merge]
     ^merge(%left: !R, %right: !R):
       func.unreachable
   }
-  func.func @tail(%sent: !R, %dying: !R) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @tail(%sent: !R, %dying: !R) attributes {tribute.calling_convention = 2} {
     func.tail_call %sent {callee = @sink, tribute.calling_convention = 2}
   }
-  func.func @sink(%value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @sink(%value: !R) attributes {tribute.calling_convention = 2} {
     func.unreachable
   }
 }"#,
@@ -1047,7 +1047,7 @@ fn cfg_accepts_conditional_branch_with_duplicate_successors() {
         r#"core.module @test {
   !R = adt.typeref() {name = @R}
   !Layout = adt.struct() {name = @R, fields = [[@x, core.i32]]}
-  func.func @duplicate_successor(%condition: core.i1, %value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @duplicate_successor(%condition: core.i1, %value: !R) attributes {tribute.calling_convention = 2} {
     ^entry:
       cf.cond_br %condition [^exit, ^exit]
     ^exit:
@@ -1191,10 +1191,10 @@ fn direct_indirect_return_and_tail_contracts_are_typed() {
     %indirect = func.call_indirect %callee, %direct {signature = func.func_sig<(!R) -> !R>} : !R
     func.return %indirect
   }
-  func.func @tail(%value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @tail(%value: !R) attributes {tribute.calling_convention = 2} {
     func.tail_call %value {callee = @sink, tribute.calling_convention = 2}
   }
-  func.func @sink(%value: !R) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @sink(%value: !R) attributes {tribute.calling_convention = 2} {
     func.unreachable
   }
 }"#,

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -1586,64 +1586,28 @@ mod tests {
     }
 
     fn dispatch_fixture(answer_name: &str, frame_name: &str) -> (IrContext, Module, OpRef) {
-        use tribute_core::calling_convention::*;
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
-            r#"core.module @test {
-            func.func @run(%ev: core.i32, %dispatch: core.i32, %resume: core.i32, %payload: core.i32) -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
-        }"#,
+            &format!(
+                r#"core.module @test {{
+            !Answer = core.{answer_name}
+            !Evidence = core.array(adt.struct() {{name = @_Marker, fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]]}})
+            !Frame = adt.typeref() {{name = @{frame_name}, tribute.cps_continuation_frame_result = !Answer}}
+            !Done = closure.closure(func.func_sig<(!Answer) -> core.never>) {{tribute.calling_convention = 2, tribute.closure_environment_index = 0}}
+            !Resume = closure.closure(func.func_sig<(!Evidence, !Frame, tribute_rt.anyref) -> core.never>) {{tribute.calling_convention = 2, tribute.closure_environment_index = 0}}
+            !Dispatch = closure.closure(func.func_sig<(!Evidence, !Resume, core.i32, core.i32, core.i32, tribute_rt.anyref) -> core.never>) {{tribute.calling_convention = 2, tribute.closure_environment_index = 1}}
+            !{frame_name} = adt.struct() {{name = @{frame_name}, tribute.cps_continuation_frame_result = !Answer, fields = [[@done, !Done], [@dispatch, !Dispatch]]}}
+            func.func @run(%ev: !Evidence, %dispatch: !Dispatch, %resume: !Resume, %payload: tribute_rt.anyref) -> core.never attributes {{tribute.calling_convention = 2}} {{
+                effect.dispatch_cps %ev, %dispatch, %resume, %payload {{ability_ref = core.ability_ref() {{name = @State}}, op_name = @get, answer_type = !Answer}}
+            }}
+        }}"#
+            ),
         );
-        let answer = ctx.types.intern(
-            TypeDataBuilder::new(Symbol::new("core"), Symbol::from_dynamic(answer_name)).build(),
-        );
-        let evidence = ability::evidence_adt_type_ref(&mut ctx);
-        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
-        let i32_ty = ctx
-            .types
-            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
-        let frame_name = Symbol::from_dynamic(frame_name);
-        let frame = cps_continuation_frame_ref_type(&mut ctx, frame_name, answer);
-        let done = cps_done_type(&mut ctx, answer);
-        let dispatch = cps_dispatch_type(&mut ctx, evidence, frame, anyref, i32_ty);
-        let resume =
-            func::FuncSig::from_type_ref(&ctx, cps_closure_function_type(&ctx, dispatch).unwrap())
-                .unwrap()
-                .inputs(&ctx)[1];
-        let layout =
-            cps_continuation_frame_layout_type(&mut ctx, frame_name, answer, done, dispatch);
-        ctx.register_type_alias(frame_name, layout);
-        let run = function(&ctx, module, "run");
-        let entry = ctx.region(run.body(&ctx)).blocks[0];
-        let inputs = [evidence, dispatch, resume, anyref];
-        let never = core::never(&mut ctx).as_type_ref();
-        let signature = func::func_sig(&mut ctx, inputs, [never]).as_type_ref();
-        ctx.op_mut(run.op_ref())
-            .attributes
-            .insert(Symbol::new("type"), Attribute::Type(signature));
-        for (index, ty) in inputs.into_iter().enumerate() {
-            ctx.set_block_arg_type(entry, index as u32, ty);
-        }
-        let args = ctx.block_args(entry).to_vec();
-        let loc = ctx.op(run.op_ref()).location;
-        let ability = ctx.types.intern(
-            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("ability_ref"))
-                .attr("name", Attribute::Symbol(Symbol::new("State")))
-                .build(),
-        );
-        let dispatch = effect::dispatch_cps(
-            &mut ctx,
-            loc,
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            ability,
-            Symbol::new("get"),
-            answer,
-        )
-        .op_ref();
-        ctx.push_op(entry, dispatch);
+        let dispatch = collect_ops(&ctx, module.op())
+            .into_iter()
+            .find(|&op| effect::DispatchCps::matches(&ctx, op))
+            .unwrap();
         (ctx, module, dispatch)
     }
 
@@ -1651,7 +1615,7 @@ mod tests {
     fn semantic_dispatch_reaches_the_canonical_wasm_target_signature() {
         let (mut ctx, module, _) = dispatch_fixture("i32", "frame");
         lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
-        crate::closure_lower::lower_prepared_closures(&mut ctx, module);
+        crate::closure_lower::lower_prepared_closures(&mut ctx, module).unwrap();
         crate::closure_lower::finalize_closure_storage_layout(&mut ctx, module);
         let result = crate::wasm::lower::lower_to_wasm(&mut ctx, module);
         let printed = print_module(&ctx, module.op());

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -713,9 +713,15 @@ pub(crate) fn validate_dispatch_contracts(
             continue;
         }
         let operands = ctx.op_operands(op).to_vec();
-        let [evidence, dispatch, resume, _payload] = operands.as_slice() else {
+        let [evidence, dispatch, resume, payload] = operands.as_slice() else {
             return Err(TargetAbiError::new("CPS dispatch requires four operands"));
         };
+        let packed_payload = tribute_rt::anyref(ctx).as_type_ref();
+        if ctx.value_ty(*payload) != packed_payload {
+            return Err(TargetAbiError::new(
+                "CPS dispatch packed payload must have exact tribute_rt.anyref type",
+            ));
+        }
         let answer = ctx
             .op(op)
             .attributes
@@ -1058,13 +1064,7 @@ fn collect_functions(
         let callable = func::FuncSig::from_type_ref(ctx, signature).ok_or_else(|| {
             TargetAbiError::new("target ABI: tagged function must have a func.func_sig signature")
         })?;
-        let result = callable.single_result(ctx).ok_or_else(|| {
-            TargetAbiError::new(format!(
-                "target ABI: tagged function `{}` must have one logical result",
-                function.sym_name(ctx)
-            ))
-        })?;
-        if convention == CallingConvention::Cps && result != never {
+        if convention == CallingConvention::Cps && callable.results(ctx) != [never] {
             return Err(TargetAbiError::new(format!(
                 "target ABI: Cps function `{}` must have logical core.never result",
                 function.sym_name(ctx)
@@ -1429,10 +1429,7 @@ impl<'a> PhysicalTypeConverter<'a> {
         let callable = func::FuncSig::from_type_ref(self.ctx, ty).ok_or_else(|| {
             TargetAbiError::new("target ABI: proven callable is not a valid func.func_sig")
         })?;
-        let result = callable.single_result(self.ctx).ok_or_else(|| {
-            TargetAbiError::new("target ABI: proven callable has no logical result")
-        })?;
-        if convention == CallingConvention::Cps && result != self.never {
+        if convention == CallingConvention::Cps && callable.results(self.ctx) != [self.never] {
             return Err(TargetAbiError::new(
                 "target ABI: Cps callable must have logical core.never result",
             ));
@@ -1445,7 +1442,12 @@ impl<'a> PhysicalTypeConverter<'a> {
         let results = if convention == CallingConvention::Cps {
             vec![]
         } else {
-            vec![self.convert_embedded(result)?]
+            callable
+                .results(self.ctx)
+                .to_vec()
+                .into_iter()
+                .map(|result| self.convert_embedded(result))
+                .collect::<Result<Vec<_>, _>>()?
         };
         let attrs = self.convert_func_attributes(callable)?;
         let converted = func::func_sig_with_attrs(self.ctx, inputs, results, attrs).as_type_ref();
@@ -1478,10 +1480,8 @@ impl<'a> PhysicalTypeConverter<'a> {
             let callable = func::FuncSig::from_type_ref(self.ctx, ty).ok_or_else(|| {
                 TargetAbiError::new("target ABI: malformed nested func.func_sig type")
             })?;
-            let result = callable.single_result(self.ctx).ok_or_else(|| {
-                TargetAbiError::new("target ABI: nested func.func_sig type has no logical result")
-            })?;
-            if result == self.never {
+            let source_results = callable.results(self.ctx).to_vec();
+            if source_results.contains(&self.never) {
                 return Err(TargetAbiError::new(
                     "target ABI: untagged nested func.func_sig<(...)->core.never>",
                 ));
@@ -1491,10 +1491,13 @@ impl<'a> PhysicalTypeConverter<'a> {
                 .into_iter()
                 .map(|input| self.convert_embedded(input))
                 .collect::<Result<Vec<_>, _>>()?;
-            let result = self.convert_embedded(result)?;
+            let results = source_results
+                .into_iter()
+                .map(|result| self.convert_embedded(result))
+                .collect::<Result<Vec<_>, _>>()?;
             let attrs = self.convert_func_attributes(callable)?;
             let converted =
-                func::func_sig_with_attrs(self.ctx, inputs, [result], attrs).as_type_ref();
+                func::func_sig_with_attrs(self.ctx, inputs, results, attrs).as_type_ref();
             self.embedded.insert(ty, converted);
             return Ok(converted);
         }
@@ -1679,7 +1682,7 @@ mod tests {
 
     #[test]
     fn malformed_dispatch_is_rejected_without_mutating_any_surface() {
-        for mutation in 0..7 {
+        for mutation in 0..9 {
             let (mut ctx, module, dispatch) = dispatch_fixture("i32", "frame");
             match mutation {
                 0 => {
@@ -1725,6 +1728,17 @@ mod tests {
                     let entry = ctx.op(dispatch).parent_block.unwrap();
                     ctx.set_block_arg_type(entry, index as u32, ty);
                 }
+                7 | 8 => {
+                    let ty = if mutation == 7 {
+                        ctx.types.intern(
+                            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build(),
+                        )
+                    } else {
+                        core::ptr(&mut ctx).as_type_ref()
+                    };
+                    let entry = ctx.op(dispatch).parent_block.unwrap();
+                    ctx.set_block_arg_type(entry, 3, ty);
+                }
                 _ => unreachable!(),
             }
             let before = print_module(&ctx, module.op());
@@ -1734,15 +1748,88 @@ mod tests {
                 .iter()
                 .map(|&op| ctx.op_result_types(op).to_vec())
                 .collect();
-            assert!(
-                lower_cps_signatures_to_physical(&mut ctx, module).is_err(),
-                "mutation {mutation}"
-            );
+            let error = lower_cps_signatures_to_physical(&mut ctx, module)
+                .expect_err(&format!("mutation {mutation}"));
+            if mutation >= 7 {
+                assert!(error.to_string().contains("packed payload"), "{error}");
+            }
             assert_eq!(print_module(&ctx, module.op()), before);
             assert_eq!(ctx.type_aliases(), aliases);
             assert_eq!(collect_ops(&ctx, module.op()), ops);
             for (op, expected) in ops.into_iter().zip(result_types) {
                 assert_eq!(ctx.op_result_types(op), expected);
+            }
+        }
+    }
+
+    #[test]
+    fn empty_direct_results_survive_mixed_cps_physicalization() {
+        let mut ctx = IrContext::new();
+        let evidence = ability::evidence_adt_type_ref(&mut ctx);
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+            !Evidence = core.array(adt.struct() {name = @_Marker, fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]]})
+            !direct_closure = closure.closure(func.func_sig<() -> ()>) {tribute.calling_convention = 0}
+            !evidence_closure = closure.closure(func.func_sig<(!Evidence) -> ()>) {tribute.calling_convention = 1}
+            func.func @direct() attributes {tribute.calling_convention = 0} { func.return }
+            func.func @evidence(%ev: !Evidence) attributes {tribute.calling_convention = 1} { func.return }
+            func.func @unit() -> core.nil attributes {tribute.calling_convention = 0} {
+                %nil = arith.const {value = unit} : core.nil
+                func.return %nil
+            }
+            func.func @caller(%ev: !Evidence) attributes {tribute.calling_convention = 1} {
+                func.call {callee = @direct, tribute.calling_convention = 0}
+                func.call %ev {callee = @evidence, tribute.calling_convention = 1}
+                %direct = func.constant {func_ref = @direct} : func.func_sig<() -> ()>
+                %evidence = func.constant {func_ref = @evidence} : func.func_sig<(!Evidence) -> ()>
+                func.call_indirect %direct {signature = func.func_sig<() -> ()>, tribute.calling_convention = 0}
+                func.call_indirect %evidence, %ev {signature = func.func_sig<(!Evidence) -> ()>, tribute.calling_convention = 1}
+                %nil = func.call {callee = @unit, tribute.calling_convention = 0} : core.nil
+                func.return
+            }
+            func.func @cps() -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
+        }"#,
+        );
+        assert_eq!(
+            ctx.type_alias_by_name(Symbol::new("Evidence")),
+            Some(evidence)
+        );
+        let cps = function(&ctx, module, "cps");
+        let unchanged: Vec<_> = collect_ops(&ctx, module.op())
+            .into_iter()
+            .filter(|&op| op != cps.op_ref())
+            .map(|op| {
+                (
+                    op,
+                    ctx.op(op).attributes.clone(),
+                    ctx.op_result_types(op).to_vec(),
+                )
+            })
+            .collect();
+        let aliases = ctx.type_aliases().to_vec();
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        for (op, before, results) in unchanged {
+            assert_eq!(ctx.op(op).attributes, before);
+            assert_eq!(ctx.op_result_types(op), results);
+        }
+        assert_eq!(ctx.type_aliases(), aliases);
+        assert!(
+            func::FuncSig::from_type_ref(&ctx, cps.r#type(&ctx))
+                .unwrap()
+                .results(&ctx)
+                .is_empty()
+        );
+        for op in collect_ops(&ctx, module.op()) {
+            if func::CallIndirect::matches(&ctx, op) {
+                assert!(ctx.op_result_types(op).is_empty());
+                let signature = IndirectCallLikeOps::exact_signature(&ctx, op).unwrap();
+                assert!(
+                    func::FuncSig::from_type_ref(&ctx, signature)
+                        .unwrap()
+                        .results(&ctx)
+                        .is_empty()
+                );
             }
         }
     }
@@ -2432,12 +2519,12 @@ mod tests {
     }
 
     #[test]
-    fn tagged_resultless_function_fails_before_target_abi_mutation() {
+    fn already_physical_cps_function_fails_before_target_abi_mutation() {
         let mut ctx = IrContext::new();
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @broken() -> core.nil attributes {tribute.calling_convention = 0} { func.unreachable }
+  func.func @broken() -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
 }"#,
         );
         let broken = function(&ctx, module, "broken");
@@ -2452,7 +2539,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("tagged function `broken` must have one logical result"),
+                .contains("must have logical core.never result"),
             "{error}"
         );
         assert_eq!(print_module(&ctx, module.op()), before);

--- a/crates/tribute-passes/src/target_abi.rs
+++ b/crates/tribute-passes/src/target_abi.rs
@@ -1,9 +1,8 @@
 //! Shared target-neutral physicalization of convention-proven CPS signatures.
 //!
-//! The pass is intentionally not wired into the production pipeline here. It
-//! consumes exact callable metadata, validates the whole transfer surface, and
+//! The pass consumes exact callable metadata, validates the whole transfer surface, and
 //! only then maps logical CPS `core.never` results to the shared empty-result
-//! marker used by target backends.
+//! list used by target backends.
 
 use std::collections::HashMap;
 use std::error::Error;
@@ -18,7 +17,7 @@ use tribute_core::{
     CALLING_CONVENTION_ATTR, CallingConvention, get_calling_convention,
     get_physical_closure_convention,
 };
-use tribute_ir::dialect::{ability, tribute_rt};
+use tribute_ir::dialect::{ability, effect, tribute_rt};
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
 use trunk_ir::dialect::{adt, arith, core, func};
@@ -81,19 +80,21 @@ pub fn lower_cps_signatures_to_physical(
 ) -> Result<(), TargetAbiError> {
     let ops = collect_ops(ctx, module.op());
     let never = core::never(ctx).as_type_ref();
-    let nil = core::nil(ctx).as_type_ref();
     let anyref = tribute_rt::anyref(ctx).as_type_ref();
     let functions = collect_functions(ctx, &ops, never, anyref)?;
     validate_transfers(ctx, &ops, &functions, never)?;
+    validate_dispatch_contracts(ctx, module)?;
+    validate_root_entry(ctx, module, &[never])?;
 
     let aliases = ctx.type_aliases().to_vec();
-    let mut converter = PhysicalTypeConverter::new(ctx, never, nil);
+    let mut converter = PhysicalTypeConverter::new(ctx, never);
     let mut alias_updates = Vec::new();
     let mut function_types = Vec::new();
     let mut result_types = Vec::new();
     let mut attributes = Vec::new();
     let mut indirect_signatures = Vec::new();
     let mut block_args = Vec::new();
+    let mut block_attributes = Vec::new();
 
     for (name, ty) in aliases {
         let converted = converter.convert_embedded(ty)?;
@@ -214,6 +215,13 @@ pub fn lower_cps_signatures_to_physical(
                     .into_iter()
                     .enumerate()
                 {
+                    let mut converted_attrs = argument.attrs.clone();
+                    for (name, value) in argument.attrs.iter() {
+                        converted_attrs.insert(*name, converter.convert_attribute(value.clone())?);
+                    }
+                    if converted_attrs != argument.attrs {
+                        block_attributes.push((block, index, converted_attrs));
+                    }
                     let converted = converter.convert_embedded(argument.ty)?;
                     if converted != argument.ty {
                         block_args.push((block, index as u32, converted));
@@ -244,6 +252,9 @@ pub fn lower_cps_signatures_to_physical(
     for (block, index, ty) in block_args {
         ctx.set_block_arg_type(block, index, ty);
     }
+    for (block, index, attributes) in block_attributes {
+        ctx.block_mut(block).args[index].attrs = attributes;
+    }
     Ok(())
 }
 
@@ -267,19 +278,21 @@ pub fn has_root_entry_contract(ctx: &IrContext, module: Module) -> bool {
     })
 }
 
-/// Construct the target-independent export delimiter for a root worker that
-/// was promoted from Direct or EvidenceDirect to Cps.
-///
-/// This runs after physical signature lowering: the worker and the exact
-/// `ContinuationFrame<R>` members use the target's empty `core.nil` result,
-/// while the wrapper keeps the exact source ABI and performs one ordinary
-/// call. Legacy modules carry no root metadata, so they are left unchanged.
-pub fn compose_root_entry_bridge(
+struct RootEntryContract {
+    worker_op: OpRef,
+    export_convention: CallingConvention,
+    source_result: TypeRef,
+    evidence_ty: TypeRef,
+    frame: RootFrameContract,
+}
+
+fn validate_root_entry(
     ctx: &mut IrContext,
     module: Module,
-) -> Result<(), TargetAbiError> {
+    expected_results: &[TypeRef],
+) -> Result<Option<RootEntryContract>, TargetAbiError> {
     let Some(module_block) = module.first_block(ctx) else {
-        return Ok(());
+        return Ok(None);
     };
     let top_level_ops = ctx.block(module_block).ops.to_vec();
     let roots: Vec<_> = top_level_ops
@@ -296,7 +309,7 @@ pub fn compose_root_entry_bridge(
         ));
     }
     let Some(&worker_op) = roots.first() else {
-        return Ok(());
+        return Ok(None);
     };
 
     let export_convention = root_export_convention(ctx, worker_op)?;
@@ -307,7 +320,7 @@ pub fn compose_root_entry_bridge(
         ));
     }
     let Some(export_convention) = export_convention else {
-        return Ok(());
+        return Ok(None);
     };
     let source_result = source_result.expect("paired root metadata checked above");
     if matches!(export_convention, CallingConvention::Cps) {
@@ -333,12 +346,12 @@ pub fn compose_root_entry_bridge(
         .ok_or_else(|| TargetAbiError::new("target root bridge: main is not func.func_sig"))?;
     let evidence_ty = ability::evidence_adt_type_ref(ctx);
     let worker_params = worker_callable.inputs(ctx);
-    if worker_callable.single_result(ctx) != Some(nil_ty)
+    if worker_callable.results(ctx) != expected_results
         || worker_params.len() != 2
         || worker_params[0] != evidence_ty
     {
         return Err(TargetAbiError::new(
-            "target root bridge: Cps root must have exact physical evidence and ContinuationFrame ABI",
+            "target root bridge: Cps root must have exact evidence and ContinuationFrame ABI",
         ));
     }
     let frame = validate_root_continuation_frame(
@@ -346,7 +359,7 @@ pub fn compose_root_entry_bridge(
         worker_params[1],
         source_result,
         evidence_ty,
-        nil_ty,
+        expected_results,
     )?;
     if ctx.op(worker_op).regions.is_empty() {
         return Err(TargetAbiError::new(
@@ -369,6 +382,37 @@ pub fn compose_root_entry_bridge(
         }
     }
 
+    Ok(Some(RootEntryContract {
+        worker_op,
+        export_convention,
+        source_result,
+        evidence_ty,
+        frame,
+    }))
+}
+
+/// Construct the target-independent export delimiter after physicalization.
+/// The worker and exact frame members have empty results; the wrapper retains
+/// the source ABI and performs one ordinary call. Legacy roots are unchanged.
+pub fn compose_root_entry_bridge(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), TargetAbiError> {
+    let Some(RootEntryContract {
+        worker_op,
+        export_convention,
+        source_result,
+        evidence_ty,
+        frame,
+    }) = validate_root_entry(ctx, module, &[])?
+    else {
+        return Ok(());
+    };
+    let module_block = module.first_block(ctx).expect("validated root module");
+    let top_level_ops = ctx.block(module_block).ops.to_vec();
+    let cps_main = Symbol::new(CPS_MAIN_SYMBOL);
+    let root_done_k = Symbol::new(ROOT_DONE_K_SYMBOL);
+    let root_dispatch = Symbol::new(ROOT_DISPATCH_SYMBOL);
     let location = ctx.op(worker_op).location;
     ctx.op_mut(worker_op)
         .attributes
@@ -380,8 +424,8 @@ pub fn compose_root_entry_bridge(
 
     let cell_ty = root_completion_cell_type(ctx, source_result);
     let anyref_ty = tribute_rt::anyref(ctx).as_type_ref();
-    let done_callable_ty = func::func_sig(ctx, [source_result], [nil_ty]).as_type_ref();
-    let done_function_ty = func::func_sig(ctx, [anyref_ty, source_result], [nil_ty]).as_type_ref();
+    let done_callable_ty = func::func_sig(ctx, [source_result], []).as_type_ref();
+    let done_function_ty = func::func_sig(ctx, [anyref_ty, source_result], []).as_type_ref();
     let done_entry = ctx.create_block(BlockData {
         location,
         args: vec![
@@ -402,9 +446,7 @@ pub fn compose_root_entry_bridge(
     ctx.push_op(done_entry, cell.op_ref());
     let store = adt::struct_set(ctx, location, cell.result(ctx), done_args[1], cell_ty, 0);
     ctx.push_op(done_entry, store.op_ref());
-    let done_nil = arith::r#const(ctx, location, nil_ty, Attribute::Unit);
-    ctx.push_op(done_entry, done_nil.op_ref());
-    let done_return = func::r#return(ctx, location, [done_nil.result(ctx)]);
+    let done_return = func::r#return(ctx, location, []);
     ctx.push_op(done_entry, done_return.op_ref());
     let done_region = ctx.create_region(RegionData {
         location,
@@ -538,7 +580,7 @@ pub fn compose_root_entry_bridge(
         ctx,
         location,
         [evidence, frame_value.result(ctx)],
-        [nil_ty],
+        [],
         cps_main,
     );
     set_root_convention(ctx, worker_call.op_ref(), CallingConvention::Cps);
@@ -602,12 +644,100 @@ fn root_completion_cell_type(ctx: &mut IrContext, value_ty: TypeRef) -> TypeRef 
     })
 }
 
+/// Recover semantic R only from authenticated callable and nominal frame metadata.
+pub(crate) fn dispatch_answer_type(
+    ctx: &mut IrContext,
+    evidence: ValueRef,
+    dispatch: ValueRef,
+    resume: ValueRef,
+) -> Result<TypeRef, TargetAbiError> {
+    let evidence_type = ability::evidence_adt_type_ref(ctx);
+    if ctx.value_ty(evidence) != evidence_type {
+        return Err(TargetAbiError::new(
+            "CPS dispatch evidence differs from canonical Evidence type",
+        ));
+    }
+    let dispatch = crate::closure_lower::physical_closure_type_for_callee(ctx, dispatch)
+        .ok_or_else(|| {
+            TargetAbiError::new("CPS dispatch lacks authenticated callable provenance")
+        })?;
+    let resume = crate::closure_lower::physical_closure_type_for_callee(ctx, resume)
+        .ok_or_else(|| TargetAbiError::new("CPS resume lacks authenticated callable provenance"))?;
+    let resume_signature = cps_closure_function_type(ctx, resume)
+        .and_then(|ty| func::FuncSig::from_type_ref(ctx, ty))
+        .ok_or_else(|| TargetAbiError::new("CPS resume lacks exact callable signature"))?;
+    let frame = *resume_signature
+        .inputs(ctx)
+        .get(1)
+        .ok_or_else(|| TargetAbiError::new("CPS resume lacks frame input"))?;
+    let answer = cps_continuation_frame_result_type(ctx, frame)
+        .ok_or_else(|| TargetAbiError::new("CPS resume frame lacks answer type"))?;
+    let results = resume_signature.results(ctx);
+    if !(results.is_empty()
+        || (results.len() == 1
+            && is_parameterless_dialect_type(
+                ctx,
+                results[0],
+                Symbol::new("core"),
+                Symbol::new("never"),
+            )))
+    {
+        return Err(TargetAbiError::new(
+            "CPS resume must have logical never or physical empty results",
+        ));
+    }
+    let contract =
+        validate_root_continuation_frame(ctx, frame, answer, ctx.value_ty(evidence), results)?;
+    if contract.dispatch != dispatch {
+        return Err(TargetAbiError::new(
+            "CPS dispatch differs from exact nominal frame Dispatch",
+        ));
+    }
+    let signature = dispatch_callable_function_type(ctx, dispatch)?;
+    let signature = func::FuncSig::from_type_ref(ctx, signature).unwrap();
+    if signature.inputs(ctx).get(1) != Some(&resume) {
+        return Err(TargetAbiError::new(
+            "CPS dispatch resume differs from exact required resume",
+        ));
+    }
+    Ok(answer)
+}
+
+/// Validate before closure storage erasure or physicalization changes any surface.
+pub(crate) fn validate_dispatch_contracts(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), TargetAbiError> {
+    for op in collect_ops(ctx, module.op()) {
+        if !effect::DispatchCps::matches(ctx, op) {
+            continue;
+        }
+        let operands = ctx.op_operands(op).to_vec();
+        let [evidence, dispatch, resume, _payload] = operands.as_slice() else {
+            return Err(TargetAbiError::new("CPS dispatch requires four operands"));
+        };
+        let answer = ctx
+            .op(op)
+            .attributes
+            .get_type("answer_type")
+            .ok_or_else(|| TargetAbiError::new("CPS dispatch requires answer_type: Type"))?;
+        if !ctx.op_result_types(op).is_empty()
+            || dispatch_answer_type(ctx, *evidence, *dispatch, *resume)? != answer
+        {
+            return Err(TargetAbiError::new(
+                "CPS dispatch answer_type differs from resume frame R",
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn validate_root_continuation_frame(
     ctx: &IrContext,
     frame: TypeRef,
     source_result: TypeRef,
     evidence: TypeRef,
-    physical_result: TypeRef,
+    physical_results: &[TypeRef],
 ) -> Result<RootFrameContract, TargetAbiError> {
     let reference_data = ctx.types.get(frame);
     if reference_data.dialect != Symbol::new("adt") || reference_data.name != Symbol::new("typeref")
@@ -666,8 +796,8 @@ fn validate_root_continuation_frame(
             "target root bridge: worker frame field roles must be exact Done then Dispatch",
         ));
     }
-    validate_root_done_type(ctx, *done, source_result, physical_result)?;
-    validate_root_dispatch_type(ctx, *dispatch, frame, evidence, physical_result)?;
+    validate_root_done_type(ctx, *done, source_result, physical_results)?;
+    validate_root_dispatch_type(ctx, *dispatch, frame, evidence, physical_results)?;
     Ok(RootFrameContract {
         reference: frame,
         layout,
@@ -680,7 +810,7 @@ fn validate_root_done_type(
     ctx: &IrContext,
     done: TypeRef,
     source_result: TypeRef,
-    physical_result: TypeRef,
+    physical_results: &[TypeRef],
 ) -> Result<(), TargetAbiError> {
     if get_physical_closure_convention(ctx, done) != Some(CallingConvention::Cps)
         || get_physical_closure_environment_index(ctx, done) != Some(0)
@@ -695,9 +825,7 @@ fn validate_root_done_type(
     let callable = func::FuncSig::from_type_ref(ctx, callable).ok_or_else(|| {
         TargetAbiError::new("target root bridge: frame Done callable is not func.func_sig")
     })?;
-    if callable.single_result(ctx) != Some(physical_result)
-        || callable.inputs(ctx) != [source_result]
-    {
+    if callable.results(ctx) != physical_results || callable.inputs(ctx) != [source_result] {
         return Err(TargetAbiError::new(
             "target root bridge: frame Done must accept the exact source result and return empty",
         ));
@@ -710,7 +838,7 @@ fn validate_root_dispatch_type(
     dispatch: TypeRef,
     frame: TypeRef,
     evidence: TypeRef,
-    physical_result: TypeRef,
+    physical_results: &[TypeRef],
 ) -> Result<(), TargetAbiError> {
     if get_physical_closure_convention(ctx, dispatch) != Some(CallingConvention::Cps)
         || get_physical_closure_environment_index(ctx, dispatch) != Some(1)
@@ -728,7 +856,7 @@ fn validate_root_dispatch_type(
             "target root bridge: frame Dispatch must have the exact terminal dispatch ABI",
         ));
     };
-    if callable.single_result(ctx) != Some(physical_result)
+    if callable.results(ctx) != physical_results
         || *actual_evidence != evidence
         || !is_parameterless_dialect_type(ctx, *prompt, Symbol::new("core"), Symbol::new("i32"))
         || !is_parameterless_dialect_type(ctx, *ability, Symbol::new("core"), Symbol::new("i32"))
@@ -759,7 +887,7 @@ fn validate_root_dispatch_type(
             "target root bridge: frame Dispatch resume callable is not func.func_sig",
         )
     })?;
-    if resume.single_result(ctx) != Some(physical_result)
+    if resume.results(ctx) != physical_results
         || resume.inputs(ctx).len() != 3
         || resume.inputs(ctx)[0] != evidence
         || resume.inputs(ctx)[1] != frame
@@ -811,7 +939,9 @@ fn is_parameterless_dialect_type(
     dialect: Symbol,
     name: Symbol,
 ) -> bool {
-    ctx.types.is_dialect(ty, dialect, name) && ctx.types.get(ty).params.is_empty()
+    ctx.types.is_dialect(ty, dialect, name)
+        && ctx.types.get(ty).params.is_empty()
+        && ctx.types.get(ty).attrs.is_empty()
 }
 
 fn root_export_convention(
@@ -963,12 +1093,20 @@ fn validate_transfers(
 ) -> Result<(), TargetAbiError> {
     for &op in ops {
         if func::Call::matches(ctx, op) || func::TailCall::matches(ctx, op) {
-            let Some(convention) = exact_convention(ctx, op)? else {
-                continue;
-            };
+            let convention = exact_convention(ctx, op)?;
             let callee = ctx.op(op).attributes.get_symbol("callee").ok_or_else(|| {
                 TargetAbiError::new("target ABI: direct transfer lacks callee metadata")
             })?;
+            let Some(convention) = convention else {
+                if function_for_symbol_optional(ctx, op, callee, functions)?
+                    .is_some_and(|identity| identity.convention == CallingConvention::Cps)
+                {
+                    return Err(TargetAbiError::new(
+                        "target ABI: transfer to Cps callee lacks convention metadata",
+                    ));
+                }
+                continue;
+            };
             let identity = function_for_symbol(ctx, op, callee, functions)?;
             if identity.convention != convention {
                 return Err(TargetAbiError::new(
@@ -1020,6 +1158,30 @@ fn validate_transfers(
         let callable = func::FuncSig::from_type_ref(ctx, signature).ok_or_else(|| {
             TargetAbiError::new("target ABI: indirect callable signature is not func.func_sig")
         })?;
+        let callee = IndirectCallLikeOps::callee(ctx, op)
+            .ok_or_else(|| TargetAbiError::new("target ABI: indirect transfer lacks callee"))?;
+        let callee_type = ctx.value_ty(callee);
+        if let Some(closure_type) =
+            crate::closure_lower::physical_closure_type_for_callee(ctx, callee)
+        {
+            let closure_signature =
+                tribute_ir::dialect::closure::Closure::from_type_ref(ctx, closure_type)
+                    .unwrap()
+                    .func_type(ctx);
+            if closure_signature != signature
+                || get_physical_closure_convention(ctx, closure_type) != Some(convention)
+            {
+                return Err(TargetAbiError::new(
+                    "target ABI: indirect signature differs from exact closure contract",
+                ));
+            }
+        } else if func::FuncSig::from_type_ref(ctx, callee_type).is_some()
+            && callee_type != signature
+        {
+            return Err(TargetAbiError::new(
+                "target ABI: indirect signature differs from typed callee",
+            ));
+        }
         let args = IndirectCallLikeOps::arguments(ctx, op).ok_or_else(|| {
             TargetAbiError::new("target ABI: indirect transfer has malformed operands")
         })?;
@@ -1242,17 +1404,15 @@ fn parent_op(ctx: &IrContext, op: OpRef) -> Option<OpRef> {
 struct PhysicalTypeConverter<'a> {
     ctx: &'a mut IrContext,
     never: TypeRef,
-    nil: TypeRef,
     embedded: HashMap<TypeRef, TypeRef>,
     callable: HashMap<(TypeRef, CallingConvention), TypeRef>,
 }
 
 impl<'a> PhysicalTypeConverter<'a> {
-    fn new(ctx: &'a mut IrContext, never: TypeRef, nil: TypeRef) -> Self {
+    fn new(ctx: &'a mut IrContext, never: TypeRef) -> Self {
         Self {
             ctx,
             never,
-            nil,
             embedded: HashMap::new(),
             callable: HashMap::new(),
         }
@@ -1282,13 +1442,13 @@ impl<'a> PhysicalTypeConverter<'a> {
             .into_iter()
             .map(|input| self.convert_embedded(input))
             .collect::<Result<Vec<_>, _>>()?;
-        let result = if convention == CallingConvention::Cps {
-            self.nil
+        let results = if convention == CallingConvention::Cps {
+            vec![]
         } else {
-            self.convert_embedded(result)?
+            vec![self.convert_embedded(result)?]
         };
         let attrs = self.convert_func_attributes(callable)?;
-        let converted = func::func_sig_with_attrs(self.ctx, inputs, [result], attrs).as_type_ref();
+        let converted = func::func_sig_with_attrs(self.ctx, inputs, results, attrs).as_type_ref();
         self.callable.insert((ty, convention), converted);
         Ok(converted)
     }
@@ -1422,6 +1582,171 @@ mod tests {
             .unwrap()
     }
 
+    fn dispatch_fixture(answer_name: &str, frame_name: &str) -> (IrContext, Module, OpRef) {
+        use tribute_core::calling_convention::*;
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+            func.func @run(%ev: core.i32, %dispatch: core.i32, %resume: core.i32, %payload: core.i32) -> core.never attributes {tribute.calling_convention = 2} { func.unreachable }
+        }"#,
+        );
+        let answer = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::from_dynamic(answer_name)).build(),
+        );
+        let evidence = ability::evidence_adt_type_ref(&mut ctx);
+        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let i32_ty = ctx
+            .types
+            .intern(TypeDataBuilder::new(Symbol::new("core"), Symbol::new("i32")).build());
+        let frame_name = Symbol::from_dynamic(frame_name);
+        let frame = cps_continuation_frame_ref_type(&mut ctx, frame_name, answer);
+        let done = cps_done_type(&mut ctx, answer);
+        let dispatch = cps_dispatch_type(&mut ctx, evidence, frame, anyref, i32_ty);
+        let resume =
+            func::FuncSig::from_type_ref(&ctx, cps_closure_function_type(&ctx, dispatch).unwrap())
+                .unwrap()
+                .inputs(&ctx)[1];
+        let layout =
+            cps_continuation_frame_layout_type(&mut ctx, frame_name, answer, done, dispatch);
+        ctx.register_type_alias(frame_name, layout);
+        let run = function(&ctx, module, "run");
+        let entry = ctx.region(run.body(&ctx)).blocks[0];
+        let inputs = [evidence, dispatch, resume, anyref];
+        let never = core::never(&mut ctx).as_type_ref();
+        let signature = func::func_sig(&mut ctx, inputs, [never]).as_type_ref();
+        ctx.op_mut(run.op_ref())
+            .attributes
+            .insert(Symbol::new("type"), Attribute::Type(signature));
+        for (index, ty) in inputs.into_iter().enumerate() {
+            ctx.set_block_arg_type(entry, index as u32, ty);
+        }
+        let args = ctx.block_args(entry).to_vec();
+        let loc = ctx.op(run.op_ref()).location;
+        let ability = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("ability_ref"))
+                .attr("name", Attribute::Symbol(Symbol::new("State")))
+                .build(),
+        );
+        let dispatch = effect::dispatch_cps(
+            &mut ctx,
+            loc,
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            ability,
+            Symbol::new("get"),
+            answer,
+        )
+        .op_ref();
+        ctx.push_op(entry, dispatch);
+        (ctx, module, dispatch)
+    }
+
+    #[test]
+    fn semantic_dispatch_reaches_the_canonical_wasm_target_signature() {
+        let (mut ctx, module, _) = dispatch_fixture("i32", "frame");
+        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+        crate::closure_lower::lower_prepared_closures(&mut ctx, module);
+        crate::closure_lower::finalize_closure_storage_layout(&mut ctx, module);
+        let result = crate::wasm::lower::lower_to_wasm(&mut ctx, module);
+        let printed = print_module(&ctx, module.op());
+        assert!(result.is_ok(), "{result:?}\n{printed}");
+        assert!(!printed.contains("effect.dispatch_cps"), "{printed}");
+    }
+
+    #[test]
+    fn dispatch_answer_contract_survives_atomic_physicalization() {
+        for answer in ["i32", "i64", "nil"] {
+            let (mut ctx, module, dispatch) = dispatch_fixture(answer, "frame");
+            let semantic_answer = ctx.op(dispatch).attributes.get_type("answer_type").unwrap();
+            validate_dispatch_contracts(&mut ctx, module).unwrap();
+            lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
+            validate_dispatch_contracts(&mut ctx, module).unwrap();
+            assert_eq!(
+                ctx.op(dispatch).attributes.get_type("answer_type"),
+                Some(semantic_answer)
+            );
+            assert!(
+                func::FuncSig::from_type_ref(&ctx, function(&ctx, module, "run").r#type(&ctx))
+                    .unwrap()
+                    .results(&ctx)
+                    .is_empty()
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_dispatch_is_rejected_without_mutating_any_surface() {
+        for mutation in 0..7 {
+            let (mut ctx, module, dispatch) = dispatch_fixture("i32", "frame");
+            match mutation {
+                0 => {
+                    ctx.op_mut(dispatch).attributes.remove("answer_type");
+                }
+                1 => {
+                    ctx.op_mut(dispatch)
+                        .attributes
+                        .insert(Symbol::new("answer_type"), Attribute::Int(0));
+                }
+                2 => {
+                    let wrong = core::nil(&mut ctx).as_type_ref();
+                    ctx.op_mut(dispatch)
+                        .attributes
+                        .insert(Symbol::new("answer_type"), Attribute::Type(wrong));
+                }
+                3..=6 => {
+                    let index = if mutation == 3 { 1 } else { 2 };
+                    let value = ctx.op_operands(dispatch)[index];
+                    let mut ty = ctx.types.get(ctx.value_ty(value)).clone();
+                    if mutation == 3 || mutation == 4 {
+                        ty.attrs.insert(
+                            Symbol::new(CLOSURE_ENVIRONMENT_INDEX_ATTR),
+                            Attribute::Int(9),
+                        );
+                    } else if mutation == 5 {
+                        ty.attrs
+                            .insert(Symbol::new(CALLING_CONVENTION_ATTR), Attribute::Int(0));
+                    } else {
+                        let signature = func::FuncSig::from_type_ref(&ctx, ty.params[0]).unwrap();
+                        let mut inputs = signature.inputs(&ctx).to_vec();
+                        let answer = ctx.op(dispatch).attributes.get_type("answer_type").unwrap();
+                        inputs[1] =
+                            tribute_core::calling_convention::cps_continuation_frame_ref_type(
+                                &mut ctx,
+                                Symbol::new("other_nominal_frame"),
+                                answer,
+                            );
+                        let results = signature.results(&ctx).to_vec();
+                        ty.params[0] = func::func_sig(&mut ctx, inputs, results).as_type_ref();
+                    }
+                    let ty = ctx.types.intern(ty);
+                    let entry = ctx.op(dispatch).parent_block.unwrap();
+                    ctx.set_block_arg_type(entry, index as u32, ty);
+                }
+                _ => unreachable!(),
+            }
+            let before = print_module(&ctx, module.op());
+            let aliases = ctx.type_aliases().to_vec();
+            let ops = collect_ops(&ctx, module.op());
+            let result_types: Vec<_> = ops
+                .iter()
+                .map(|&op| ctx.op_result_types(op).to_vec())
+                .collect();
+            assert!(
+                lower_cps_signatures_to_physical(&mut ctx, module).is_err(),
+                "mutation {mutation}"
+            );
+            assert_eq!(print_module(&ctx, module.op()), before);
+            assert_eq!(ctx.type_aliases(), aliases);
+            assert_eq!(collect_ops(&ctx, module.op()), ops);
+            for (op, expected) in ops.into_iter().zip(result_types) {
+                assert_eq!(ctx.op_result_types(op), expected);
+            }
+        }
+    }
+
     #[test]
     fn physicalizes_dispatch_aware_exact_cps_contracts_only() {
         let mut ctx = IrContext::new();
@@ -1441,32 +1766,30 @@ mod tests {
         lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
 
         let never = core::never(&mut ctx).as_type_ref();
-        let nil = core::nil(&mut ctx).as_type_ref();
         for (name, expected) in [
-            ("direct", never),
-            ("evidence", never),
-            ("cps", nil),
-            ("run", nil),
+            ("direct", Some(never)),
+            ("evidence", Some(never)),
+            ("cps", None),
+            ("run", None),
         ] {
             let signature = function(&ctx, module, name).r#type(&ctx);
             assert_eq!(
                 func::FuncSig::from_type_ref(&ctx, signature)
                     .unwrap()
-                    .single_result(&ctx)
-                    .unwrap(),
+                    .single_result(&ctx),
                 expected
             );
         }
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains(
-                "signature = func.func_sig<(core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32) -> core.nil>"
+                "signature = func.func_sig<(core.i32, tribute_rt.anyref, core.i32, core.i32, core.i32) -> ()>"
             ),
             "{printed}"
         );
         assert!(
             printed.contains(
-                "closure.closure(func.func_sig<(core.i32, core.i32, core.i32, core.i32) -> core.nil>)"
+                "closure.closure(func.func_sig<(core.i32, core.i32, core.i32, core.i32) -> ()>)"
             ),
             "{printed}"
         );
@@ -1562,8 +1885,7 @@ mod tests {
 
     #[test]
     fn promoted_direct_root_uses_typed_completion_and_ordinary_call() {
-        let (mut ctx, module) = compose_promoted_root(CallingConvention::Direct);
-        let nil = core::nil(&mut ctx).as_type_ref();
+        let (ctx, module) = compose_promoted_root(CallingConvention::Direct);
         let wrapper = function(&ctx, module, "main");
         let worker = function(&ctx, module, CPS_MAIN_SYMBOL);
         let done_k = function(&ctx, module, ROOT_DONE_K_SYMBOL);
@@ -1578,12 +1900,11 @@ mod tests {
                 get_calling_convention(&ctx, function.op_ref()),
                 Some(CallingConvention::Cps)
             );
-            assert_eq!(
+            assert!(
                 func::FuncSig::from_type_ref(&ctx, function.r#type(&ctx))
                     .unwrap()
-                    .single_result(&ctx)
-                    .unwrap(),
-                nil
+                    .results(&ctx)
+                    .is_empty()
             );
         }
         assert_eq!(
@@ -1790,12 +2111,13 @@ mod tests {
                 .attributes
                 .insert(Symbol::new(ROOT_SOURCE_RESULT_ATTR), Attribute::Type(nil));
 
-            lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
             let before = print_module(&ctx, module.op());
-            let error = compose_root_entry_bridge(&mut ctx, module).unwrap_err();
+            let aliases = ctx.type_aliases().to_vec();
+            let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
 
             assert!(error.to_string().contains(expected), "{error}");
             assert_eq!(print_module(&ctx, module.op()), before);
+            assert_eq!(ctx.type_aliases(), aliases);
         }
     }
 
@@ -1851,9 +2173,8 @@ mod tests {
             .attributes
             .insert(Symbol::new(ROOT_SOURCE_RESULT_ATTR), Attribute::Type(nil));
 
-        lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
         let before = print_module(&ctx, module.op());
-        let error = compose_root_entry_bridge(&mut ctx, module).unwrap_err();
+        let error = lower_cps_signatures_to_physical(&mut ctx, module).unwrap_err();
 
         assert!(
             error
@@ -1958,14 +2279,14 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains(
-                "func.func @external(%arg0: core.i32, %arg1: tribute_rt.anyref, %arg2: core.i32) -> core.nil"
+                "func.func @external(%arg0: core.i32, %arg1: tribute_rt.anyref, %arg2: core.i32)"
             ),
             "{printed}"
         );
         assert!(
             printed.contains("func.func @defined")
                 && printed.matches("func.constant").count() == 2
-                && printed.contains("!t0 = func.func_sig<(core.i32, core.i32) -> core.nil>")
+                && printed.contains("!t0 = func.func_sig<(core.i32, core.i32) -> ()>")
                 && printed.matches(": !t0").count() == 2,
             "{printed}"
         );
@@ -1994,21 +2315,17 @@ mod tests {
         lower_cps_signatures_to_physical(&mut ctx, module).unwrap();
 
         let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
-        let nil = core::nil(&mut ctx).as_type_ref();
         for (name, parameter_count) in [("generated_zero", 1), ("generated_one", 2)] {
             let function = function(&ctx, module, name);
             let signature = func::FuncSig::from_type_ref(&ctx, function.r#type(&ctx)).unwrap();
-            assert_eq!(signature.single_result(&ctx).unwrap(), nil);
+            assert!(signature.results(&ctx).is_empty());
             assert_eq!(signature.inputs(&ctx).len(), parameter_count);
             assert_eq!(signature.inputs(&ctx)[0], anyref);
         }
         let printed = print_module(&ctx, module.op());
+        assert!(printed.contains(": func.func_sig<() -> ()>"), "{printed}");
         assert!(
-            printed.contains(": func.func_sig<() -> core.nil>"),
-            "{printed}"
-        );
-        assert!(
-            printed.contains(": func.func_sig<(core.i32) -> core.nil>"),
+            printed.contains(": func.func_sig<(core.i32) -> ()>"),
             "{printed}"
         );
     }

--- a/crates/tribute-passes/src/tribute_control_to_cps.rs
+++ b/crates/tribute-passes/src/tribute_control_to_cps.rs
@@ -4251,7 +4251,7 @@ mod tests {
             Some(0)
         );
         crate::lower_closure_lambda::lower_closure_lambda(&mut ctx, module);
-        crate::closure_lower::lower_closures(&mut ctx, module);
+        crate::closure_lower::lower_closures(&mut ctx, module).unwrap();
         let lowered = print_module(&ctx, module.op());
         assert!(
             !lowered.contains("closure.lambda") && !lowered.contains("closure.new"),
@@ -5450,7 +5450,7 @@ mod tests {
             lifted.contains("tribute.closure_environment_index = 0"),
             "{lifted}"
         );
-        crate::closure_lower::lower_closures(&mut ctx, module);
+        crate::closure_lower::lower_closures(&mut ctx, module).unwrap();
         let lowered = print_module(&ctx, module.op());
         assert!(!lowered.contains("closure.new"), "{lowered}");
         assert!(lowered.contains("signature"), "{lowered}");

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -43,14 +43,20 @@ use trunk_ir_wasm_backend::gc_types::{CLOSURE_STRUCT_IDX, EVIDENCE_IDX, MARKER_I
 /// 1. Replaces stub function declarations with real binary search implementations
 /// 2. Lowers `effect.extend` and remaining legacy `ability.evidence_lookup` /
 ///    `ability.evidence_extend` operations to calls to the generated functions.
-pub fn lower_evidence_to_wasm(ctx: &mut IrContext, module: Module) {
-    prepare_wasm_evidence_runtime(ctx, module);
+pub fn lower_evidence_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), &'static str> {
+    prepare_wasm_evidence_runtime(ctx, module)?;
     rewrite_evidence_ops_in_scope(ctx, module);
+    Ok(())
 }
 
 /// Prepare module-scope WASM evidence runtime helper functions.
-pub fn prepare_wasm_evidence_runtime(ctx: &mut IrContext, module: Module) {
+pub fn prepare_wasm_evidence_runtime(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), &'static str> {
+    validate_final_dispatches(ctx, module.op())?;
     replace_evidence_function_stubs(ctx, module);
+    Ok(())
 }
 
 /// Lower evidence operations in one WASM function body.
@@ -58,8 +64,13 @@ pub fn prepare_wasm_evidence_runtime(ctx: &mut IrContext, module: Module) {
 /// Precondition: [`prepare_wasm_evidence_runtime`] must already have run for
 /// the containing module so the `__tribute_evidence_lookup` and
 /// `__tribute_evidence_extend` stubs exist as WASM runtime helpers.
-pub fn lower_evidence_to_wasm_func(ctx: &mut IrContext, func_op: wasm_dialect::Func) {
+pub fn lower_evidence_to_wasm_func(
+    ctx: &mut IrContext,
+    func_op: wasm_dialect::Func,
+) -> Result<(), &'static str> {
+    validate_final_dispatches(ctx, func_op.op_ref())?;
     rewrite_evidence_ops_in_scope(ctx, func_op);
+    Ok(())
 }
 
 /// PassManager-friendly WASM evidence lowering pass.
@@ -77,8 +88,7 @@ impl Pass for LowerEvidenceToWasm {
     }
 
     fn run(&mut self, ctx: &mut IrContext, target: wasm_dialect::Func) -> PassRunResult {
-        lower_evidence_to_wasm_func(ctx, target);
-        Ok(())
+        lower_evidence_to_wasm_func(ctx, target).map_err(Into::into)
     }
 }
 
@@ -436,6 +446,58 @@ impl RewritePattern for EffectDispatchTailPattern {
 /// lookup plus a wasm indirect call through the stored CPS dispatch closure.
 struct EffectDispatchCpsPattern;
 
+fn validate_final_dispatches(ctx: &mut IrContext, root: OpRef) -> Result<(), &'static str> {
+    let mut dispatches = Vec::new();
+    let _ = trunk_ir::walk::walk_op::<()>(ctx, root, &mut |op| {
+        if effect::DispatchCps::matches(ctx, op) {
+            dispatches.push(op);
+        }
+        std::ops::ControlFlow::Continue(trunk_ir::walk::WalkAction::Advance)
+    });
+    for op in dispatches {
+        final_dispatch_signature(ctx, op)?;
+    }
+    Ok(())
+}
+
+fn final_dispatch_signature(ctx: &mut IrContext, op: OpRef) -> Result<TypeRef, &'static str> {
+    if !ctx.op_result_types(op).is_empty()
+        || ctx.op(op).attributes.get_type("answer_type").is_none()
+        || ctx.op(op).attributes.get_type("ability_ref").is_none()
+        || ctx.op(op).attributes.get_symbol("op_name").is_none()
+        || ctx.op_operands(op).len() != 4
+    {
+        return Err("Wasm CPS dispatch requires four operands, no results and typed metadata");
+    }
+    let evidence_ty = evidence_ref_type(ctx);
+    let anyref_ty = wasm_dialect::anyref(ctx).as_type_ref();
+    let closure_ty = super::type_converter::closure_adt_type(ctx);
+    let i32_ty = intern_i32(ctx);
+    let expected = [evidence_ty, closure_ty, closure_ty, anyref_ty];
+    if ctx
+        .op_operands(op)
+        .iter()
+        .zip(expected)
+        .any(|(value, expected)| ctx.value_ty(*value) != expected)
+    {
+        return Err("Wasm CPS dispatch operands differ from the fixed target ABI");
+    }
+    Ok(wasm_dialect::func_sig(
+        ctx,
+        [
+            evidence_ty,
+            anyref_ty,
+            closure_ty,
+            i32_ty,
+            i32_ty,
+            i32_ty,
+            anyref_ty,
+        ],
+        [],
+    )
+    .as_type_ref())
+}
+
 impl RewritePattern for EffectDispatchCpsPattern {
     fn match_and_rewrite(
         &self,
@@ -448,39 +510,9 @@ impl RewritePattern for EffectDispatchCpsPattern {
         };
 
         let loc = ctx.op(op).location;
-        if !ctx.op_result_types(op).is_empty()
-            || ctx.op(op).attributes.get_type("answer_type").is_none()
-            || ctx.op_operands(op).len() != 4
-        {
+        let Ok(signature) = final_dispatch_signature(ctx, op) else {
             return false;
-        }
-        let evidence_ty = evidence_ref_type(ctx);
-        let anyref_ty = wasm_dialect::anyref(ctx).as_type_ref();
-        let closure_ty = super::type_converter::closure_adt_type(ctx);
-        let i32_ty = intern_i32(ctx);
-        let expected = [evidence_ty, closure_ty, closure_ty, anyref_ty];
-        if ctx
-            .op_operands(op)
-            .iter()
-            .zip(expected)
-            .any(|(value, expected)| ctx.value_ty(*value) != expected)
-        {
-            return false;
-        }
-        let signature = wasm_dialect::func_sig(
-            ctx,
-            [
-                evidence_ty,
-                anyref_ty,
-                closure_ty,
-                i32_ty,
-                i32_ty,
-                i32_ty,
-                anyref_ty,
-            ],
-            [],
-        )
-        .as_type_ref();
+        };
         let ability_ref = dispatch_op.ability_ref(ctx);
         let (table_idx, env) = insert_closure_parts(ctx, loc, dispatch_op.dispatch(ctx), rewriter);
         let i32_ty = intern_i32(ctx);
@@ -1430,7 +1462,7 @@ mod tests {
     fn lower_text(ir: &str) -> String {
         let mut ctx = IrContext::new();
         let module = parse_test_module(&mut ctx, ir);
-        lower_evidence_to_wasm(&mut ctx, module);
+        lower_evidence_to_wasm(&mut ctx, module).unwrap();
         print_module(&ctx, module.op())
     }
 
@@ -1483,6 +1515,14 @@ mod tests {
         assert_eq!(first, second);
         assert!(first.contains("wasm.func_sig<(wasm.arrayref, wasm.anyref, !closure, core.i32, core.i32, core.i32, wasm.anyref) -> ()>"), "{first}");
         assert!(!first.contains("answer_type"));
+        let mut invalid_inputs = vec![
+            source.replace("answer_type = core.i32", "answer_type = 0"),
+            source.replace(", answer_type = core.i32", ""),
+            source.replace(
+                "%ev, %dispatch, %resume, %payload",
+                "%ev, %dispatch, %resume",
+            ),
+        ];
         for original in [
             "%ev: wasm.arrayref",
             "%dispatch: !closure",
@@ -1493,9 +1533,23 @@ mod tests {
                 original,
                 &format!("{}: core.i64", original.split(':').next().unwrap()),
             );
-            let output = lower_text(&changed);
-            assert!(output.contains("effect.dispatch_cps"), "{output}");
-            assert!(!output.contains("wasm.return_call_indirect"), "{output}");
+            invalid_inputs.push(changed);
+        }
+        for changed in invalid_inputs {
+            for stub in [
+                "",
+                "func.func @__tribute_evidence_lookup(%ev: wasm.arrayref, %id: core.i32) -> core.i32 { func.unreachable }",
+            ] {
+                let source =
+                    changed.replacen("func.func @run", &format!("{stub}\nfunc.func @run"), 1);
+                let mut ctx = IrContext::new();
+                let module = parse_test_module(&mut ctx, &source);
+                let before = print_module(&ctx, module.op());
+                let ops = module.ops(&ctx);
+                assert!(lower_evidence_to_wasm(&mut ctx, module).is_err());
+                assert_eq!(print_module(&ctx, module.op()), before);
+                assert_eq!(module.ops(&ctx), ops);
+            }
         }
     }
 
@@ -1611,7 +1665,7 @@ mod tests {
             .next()
             .expect("test module should contain a selected wasm function");
 
-        lower_evidence_to_wasm_func(&mut ctx, selected);
+        lower_evidence_to_wasm_func(&mut ctx, selected).unwrap();
 
         let output = print_module(&ctx, module.op());
         assert_eq!(output.matches("effect.dispatch_tail").count(), 1);

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -25,7 +25,6 @@ use tribute_ir::dialect::ability::{self as ability, MarkerField, evidence_abi};
 use tribute_ir::dialect::effect;
 use trunk_ir::Symbol;
 use trunk_ir::context::{BlockArgData, BlockData, IrContext, RegionData};
-use trunk_ir::dialect::core;
 use trunk_ir::dialect::wasm as wasm_dialect;
 use trunk_ir::ops::DialectOp;
 use trunk_ir::ops::DialectType;
@@ -449,9 +448,39 @@ impl RewritePattern for EffectDispatchCpsPattern {
         };
 
         let loc = ctx.op(op).location;
-        if !ctx.op_result_types(op).is_empty() {
+        if !ctx.op_result_types(op).is_empty()
+            || ctx.op(op).attributes.get_type("answer_type").is_none()
+            || ctx.op_operands(op).len() != 4
+        {
             return false;
         }
+        let evidence_ty = evidence_ref_type(ctx);
+        let anyref_ty = wasm_dialect::anyref(ctx).as_type_ref();
+        let closure_ty = super::type_converter::closure_adt_type(ctx);
+        let i32_ty = intern_i32(ctx);
+        let expected = [evidence_ty, closure_ty, closure_ty, anyref_ty];
+        if ctx
+            .op_operands(op)
+            .iter()
+            .zip(expected)
+            .any(|(value, expected)| ctx.value_ty(*value) != expected)
+        {
+            return false;
+        }
+        let signature = wasm_dialect::func_sig(
+            ctx,
+            [
+                evidence_ty,
+                anyref_ty,
+                closure_ty,
+                i32_ty,
+                i32_ty,
+                i32_ty,
+                anyref_ty,
+            ],
+            [],
+        )
+        .as_type_ref();
         let ability_ref = dispatch_op.ability_ref(ctx);
         let (table_idx, env) = insert_closure_parts(ctx, loc, dispatch_op.dispatch(ctx), rewriter);
         let i32_ty = intern_i32(ctx);
@@ -495,9 +524,8 @@ impl RewritePattern for EffectDispatchCpsPattern {
             ],
             0,
             0,
-            None,
+            Some(signature),
         );
-        attach_exact_indirect_signature(ctx, tail.op_ref());
         set_calling_convention(ctx, tail.op_ref(), CallingConvention::Cps);
         rewriter.replace_op(tail.op_ref());
         true
@@ -506,16 +534,6 @@ impl RewritePattern for EffectDispatchCpsPattern {
     fn name(&self) -> &'static str {
         "EffectDispatchCpsPattern"
     }
-}
-
-fn attach_exact_indirect_signature(ctx: &mut IrContext, call: OpRef) {
-    let parameters = ctx.op_operands(call)[1..]
-        .iter()
-        .map(|&value| ctx.value_ty(value))
-        .collect::<Vec<_>>();
-    let result = core::nil(ctx).as_type_ref();
-    let signature = wasm_dialect::func_sig(ctx, parameters, [result]).as_type_ref();
-    let _ = wasm_dialect::set_indirect_call_signature(ctx, call, signature);
 }
 
 /// Pattern that matches `ability.evidence_extend` and replaces it with
@@ -1452,11 +1470,42 @@ mod tests {
     }
 
     #[test]
+    fn fixed_dispatch_signature_is_independent_of_answer_and_rejects_operand_mutations() {
+        let source = r#"core.module @test {
+          !closure = adt.struct() {fields = [[@table_idx, core.i32], [@env, wasm.anyref]], name = @_closure}
+          func.func @run(%ev: wasm.arrayref, %dispatch: !closure, %resume: !closure, %payload: wasm.anyref) {
+            effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get, answer_type = core.i32}
+          }
+        }"#;
+        let first = lower_text(source);
+        let second =
+            lower_text(&source.replace("answer_type = core.i32", "answer_type = core.i64"));
+        assert_eq!(first, second);
+        assert!(first.contains("wasm.func_sig<(wasm.arrayref, wasm.anyref, !closure, core.i32, core.i32, core.i32, wasm.anyref) -> ()>"), "{first}");
+        assert!(!first.contains("answer_type"));
+        for original in [
+            "%ev: wasm.arrayref",
+            "%dispatch: !closure",
+            "%resume: !closure",
+            "%payload: wasm.anyref",
+        ] {
+            let changed = source.replace(
+                original,
+                &format!("{}: core.i64", original.split(':').next().unwrap()),
+            );
+            let output = lower_text(&changed);
+            assert!(output.contains("effect.dispatch_cps"), "{output}");
+            assert!(!output.contains("wasm.return_call_indirect"), "{output}");
+        }
+    }
+
+    #[test]
     fn textual_dispatch_cps_lowers_to_wasm_indirect_call() {
         let output = lower_text(
             r#"core.module @test {
-  func.func @run(%ev: wasm.arrayref, %dispatch: wasm.anyref, %resume: wasm.anyref, %payload: wasm.anyref) -> core.never {
-    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get}
+          !closure = adt.struct() {fields = [[@table_idx, core.i32], [@env, wasm.anyref]], name = @_closure}
+  func.func @run(%ev: wasm.arrayref, %dispatch: !closure, %resume: !closure, %payload: wasm.anyref) {
+    effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get, answer_type = core.i32}
   }
 }"#,
         );

--- a/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
+++ b/crates/tribute-passes/src/wasm/evidence_to_wasm.rs
@@ -37,13 +37,37 @@ use trunk_ir::smallvec::smallvec;
 use trunk_ir::types::{Attribute, Location, TypeDataBuilder};
 use trunk_ir_wasm_backend::gc_types::{CLOSURE_STRUCT_IDX, EVIDENCE_IDX, MARKER_IDX};
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum EvidenceValidationError {
+    InvalidDispatchMetadata,
+    DispatchOperandMismatch,
+}
+
+impl std::fmt::Display for EvidenceValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidDispatchMetadata => f.write_str(
+                "Wasm CPS dispatch requires four operands, no results and typed metadata",
+            ),
+            Self::DispatchOperandMismatch => {
+                f.write_str("Wasm CPS dispatch operands differ from the fixed target ABI")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EvidenceValidationError {}
+
 /// Lower evidence runtime functions to WASM implementations.
 ///
 /// This pass:
 /// 1. Replaces stub function declarations with real binary search implementations
 /// 2. Lowers `effect.extend` and remaining legacy `ability.evidence_lookup` /
 ///    `ability.evidence_extend` operations to calls to the generated functions.
-pub fn lower_evidence_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), &'static str> {
+pub fn lower_evidence_to_wasm(
+    ctx: &mut IrContext,
+    module: Module,
+) -> Result<(), EvidenceValidationError> {
     prepare_wasm_evidence_runtime(ctx, module)?;
     rewrite_evidence_ops_in_scope(ctx, module);
     Ok(())
@@ -53,7 +77,7 @@ pub fn lower_evidence_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(),
 pub fn prepare_wasm_evidence_runtime(
     ctx: &mut IrContext,
     module: Module,
-) -> Result<(), &'static str> {
+) -> Result<(), EvidenceValidationError> {
     validate_final_dispatches(ctx, module.op())?;
     replace_evidence_function_stubs(ctx, module);
     Ok(())
@@ -67,7 +91,7 @@ pub fn prepare_wasm_evidence_runtime(
 pub fn lower_evidence_to_wasm_func(
     ctx: &mut IrContext,
     func_op: wasm_dialect::Func,
-) -> Result<(), &'static str> {
+) -> Result<(), EvidenceValidationError> {
     validate_final_dispatches(ctx, func_op.op_ref())?;
     rewrite_evidence_ops_in_scope(ctx, func_op);
     Ok(())
@@ -446,7 +470,10 @@ impl RewritePattern for EffectDispatchTailPattern {
 /// lookup plus a wasm indirect call through the stored CPS dispatch closure.
 struct EffectDispatchCpsPattern;
 
-fn validate_final_dispatches(ctx: &mut IrContext, root: OpRef) -> Result<(), &'static str> {
+fn validate_final_dispatches(
+    ctx: &mut IrContext,
+    root: OpRef,
+) -> Result<(), EvidenceValidationError> {
     let mut dispatches = Vec::new();
     let _ = trunk_ir::walk::walk_op::<()>(ctx, root, &mut |op| {
         if effect::DispatchCps::matches(ctx, op) {
@@ -460,14 +487,17 @@ fn validate_final_dispatches(ctx: &mut IrContext, root: OpRef) -> Result<(), &'s
     Ok(())
 }
 
-fn final_dispatch_signature(ctx: &mut IrContext, op: OpRef) -> Result<TypeRef, &'static str> {
+fn final_dispatch_signature(
+    ctx: &mut IrContext,
+    op: OpRef,
+) -> Result<TypeRef, EvidenceValidationError> {
     if !ctx.op_result_types(op).is_empty()
         || ctx.op(op).attributes.get_type("answer_type").is_none()
         || ctx.op(op).attributes.get_type("ability_ref").is_none()
         || ctx.op(op).attributes.get_symbol("op_name").is_none()
         || ctx.op_operands(op).len() != 4
     {
-        return Err("Wasm CPS dispatch requires four operands, no results and typed metadata");
+        return Err(EvidenceValidationError::InvalidDispatchMetadata);
     }
     let evidence_ty = evidence_ref_type(ctx);
     let anyref_ty = wasm_dialect::anyref(ctx).as_type_ref();
@@ -480,7 +510,7 @@ fn final_dispatch_signature(ctx: &mut IrContext, op: OpRef) -> Result<TypeRef, &
         .zip(expected)
         .any(|(value, expected)| ctx.value_ty(*value) != expected)
     {
-        return Err("Wasm CPS dispatch operands differ from the fixed target ABI");
+        return Err(EvidenceValidationError::DispatchOperandMismatch);
     }
     Ok(wasm_dialect::func_sig(
         ctx,
@@ -1515,14 +1545,17 @@ mod tests {
         assert_eq!(first, second);
         assert!(first.contains("wasm.func_sig<(wasm.arrayref, wasm.anyref, !closure, core.i32, core.i32, core.i32, wasm.anyref) -> ()>"), "{first}");
         assert!(!first.contains("answer_type"));
-        let mut invalid_inputs = vec![
+        let mut invalid_inputs: Vec<_> = [
             source.replace("answer_type = core.i32", "answer_type = 0"),
             source.replace(", answer_type = core.i32", ""),
             source.replace(
                 "%ev, %dispatch, %resume, %payload",
                 "%ev, %dispatch, %resume",
             ),
-        ];
+        ]
+        .into_iter()
+        .map(|source| (source, EvidenceValidationError::InvalidDispatchMetadata))
+        .collect();
         for original in [
             "%ev: wasm.arrayref",
             "%dispatch: !closure",
@@ -1533,9 +1566,9 @@ mod tests {
                 original,
                 &format!("{}: core.i64", original.split(':').next().unwrap()),
             );
-            invalid_inputs.push(changed);
+            invalid_inputs.push((changed, EvidenceValidationError::DispatchOperandMismatch));
         }
-        for changed in invalid_inputs {
+        for (changed, expected) in invalid_inputs {
             for stub in [
                 "",
                 "func.func @__tribute_evidence_lookup(%ev: wasm.arrayref, %id: core.i32) -> core.i32 { func.unreachable }",
@@ -1546,11 +1579,40 @@ mod tests {
                 let module = parse_test_module(&mut ctx, &source);
                 let before = print_module(&ctx, module.op());
                 let ops = module.ops(&ctx);
-                assert!(lower_evidence_to_wasm(&mut ctx, module).is_err());
+                assert_eq!(
+                    prepare_wasm_evidence_runtime(&mut ctx, module).unwrap_err(),
+                    expected
+                );
+                assert_eq!(
+                    lower_evidence_to_wasm(&mut ctx, module).unwrap_err(),
+                    expected
+                );
                 assert_eq!(print_module(&ctx, module.op()), before);
                 assert_eq!(module.ops(&ctx), ops);
             }
         }
+    }
+
+    #[test]
+    fn pass_adapter_preserves_concrete_validation_error() {
+        let mut ctx = IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+            !Closure = adt.struct() {name = @_closure, fields = [[@table_idx, core.i32], [@env, wasm.anyref]]}
+            wasm.func @run(%ev: wasm.arrayref, %dispatch: !Closure, %resume: !Closure, %payload: core.i64) {
+                effect.dispatch_cps %ev, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get, answer_type = core.i32}
+            }
+        }"#,
+        );
+        let function = wasm_dialect::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        let before = print_module(&ctx, module.op());
+        let error = LowerEvidenceToWasm.run(&mut ctx, function).unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<EvidenceValidationError>(),
+            Some(&EvidenceValidationError::DispatchOperandMismatch)
+        );
+        assert_eq!(print_module(&ctx, module.op()), before);
     }
 
     #[test]

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -36,7 +36,7 @@ pub enum WasmLowerError {
     Conversion(ConversionError),
     Pass(PassError),
     Const(super::const_to_wasm::ConstValidationError),
-    Evidence(&'static str),
+    Evidence(super::evidence_to_wasm::EvidenceValidationError),
 }
 
 impl fmt::Display for WasmLowerError {
@@ -45,7 +45,7 @@ impl fmt::Display for WasmLowerError {
             Self::Conversion(error) => error.fmt(f),
             Self::Pass(error) => error.fmt(f),
             Self::Const(error) => error.fmt(f),
-            Self::Evidence(error) => f.write_str(error),
+            Self::Evidence(error) => error.fmt(f),
         }
     }
 }
@@ -56,7 +56,7 @@ impl std::error::Error for WasmLowerError {
             Self::Conversion(error) => Some(error),
             Self::Pass(error) => Some(error),
             Self::Const(error) => Some(error),
-            Self::Evidence(_) => None,
+            Self::Evidence(error) => Some(error),
         }
     }
 }
@@ -76,6 +76,12 @@ impl From<PassError> for WasmLowerError {
 impl From<super::const_to_wasm::ConstValidationError> for WasmLowerError {
     fn from(error: super::const_to_wasm::ConstValidationError) -> Self {
         Self::Const(error)
+    }
+}
+
+impl From<super::evidence_to_wasm::EvidenceValidationError> for WasmLowerError {
+    fn from(error: super::evidence_to_wasm::EvidenceValidationError) -> Self {
+        Self::Evidence(error)
     }
 }
 
@@ -171,15 +177,13 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowe
     {
         let _span = tracing::info_span!("evidence_to_wasm").entered();
         if let Ok(core_module) = core::Module::from_op(ctx, module.op()) {
-            super::evidence_to_wasm::prepare_wasm_evidence_runtime(ctx, module)
-                .map_err(WasmLowerError::Evidence)?;
+            super::evidence_to_wasm::prepare_wasm_evidence_runtime(ctx, module)?;
             let mut pm = PassManager::new();
             pm.nest::<wasm_dialect::Func>()
                 .add_pass(super::evidence_to_wasm::LowerEvidenceToWasm);
             pm.run(ctx, core_module)?;
         } else {
-            super::evidence_to_wasm::lower_evidence_to_wasm(ctx, module)
-                .map_err(WasmLowerError::Evidence)?;
+            super::evidence_to_wasm::lower_evidence_to_wasm(ctx, module)?;
         }
     }
 
@@ -1331,6 +1335,33 @@ mod tests {
         assert!(!output.contains("effect.dispatch_tail"), "{output}");
         assert!(output.contains("__tribute_evidence_lookup"), "{output}");
         assert!(output.contains("wasm.call_indirect"), "{output}");
+    }
+
+    #[test]
+    fn wasm_lower_error_preserves_evidence_source_and_diagnostics() {
+        use super::super::evidence_to_wasm::EvidenceValidationError;
+        for (validation, message) in [
+            (
+                EvidenceValidationError::InvalidDispatchMetadata,
+                "Wasm CPS dispatch requires four operands, no results and typed metadata",
+            ),
+            (
+                EvidenceValidationError::DispatchOperandMismatch,
+                "Wasm CPS dispatch operands differ from the fixed target ABI",
+            ),
+        ] {
+            let error = WasmLowerError::from(validation);
+            let WasmLowerError::Evidence(expected) = &error else {
+                panic!("evidence variant");
+            };
+            let source = std::error::Error::source(&error).unwrap();
+            assert_eq!(
+                source.downcast_ref::<EvidenceValidationError>(),
+                Some(expected)
+            );
+            assert_eq!(error.to_string(), message);
+            assert_eq!(source.to_string(), message);
+        }
     }
 
     #[test]

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -92,6 +92,7 @@ pub fn wasm_emission_ready_target() -> ConversionTarget {
 /// Run the full WASM lowering pipeline on arena IR.
 pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowerError> {
     trunk_ir_wasm_backend::passes::scf_to_wasm::validate_lowerable_switches(ctx, module)?;
+    super::type_converter::convert_canonical_closure_storage(ctx, module);
 
     let const_analysis = super::const_to_wasm::analyze_consts(ctx, module);
     let io_analysis = IoAnalysis::analyze(ctx, module, const_analysis.total_size());

--- a/crates/tribute-passes/src/wasm/lower.rs
+++ b/crates/tribute-passes/src/wasm/lower.rs
@@ -36,6 +36,7 @@ pub enum WasmLowerError {
     Conversion(ConversionError),
     Pass(PassError),
     Const(super::const_to_wasm::ConstValidationError),
+    Evidence(&'static str),
 }
 
 impl fmt::Display for WasmLowerError {
@@ -44,6 +45,7 @@ impl fmt::Display for WasmLowerError {
             Self::Conversion(error) => error.fmt(f),
             Self::Pass(error) => error.fmt(f),
             Self::Const(error) => error.fmt(f),
+            Self::Evidence(error) => f.write_str(error),
         }
     }
 }
@@ -54,6 +56,7 @@ impl std::error::Error for WasmLowerError {
             Self::Conversion(error) => Some(error),
             Self::Pass(error) => Some(error),
             Self::Const(error) => Some(error),
+            Self::Evidence(_) => None,
         }
     }
 }
@@ -168,13 +171,15 @@ pub fn lower_to_wasm(ctx: &mut IrContext, module: Module) -> Result<(), WasmLowe
     {
         let _span = tracing::info_span!("evidence_to_wasm").entered();
         if let Ok(core_module) = core::Module::from_op(ctx, module.op()) {
-            super::evidence_to_wasm::prepare_wasm_evidence_runtime(ctx, module);
+            super::evidence_to_wasm::prepare_wasm_evidence_runtime(ctx, module)
+                .map_err(WasmLowerError::Evidence)?;
             let mut pm = PassManager::new();
             pm.nest::<wasm_dialect::Func>()
                 .add_pass(super::evidence_to_wasm::LowerEvidenceToWasm);
             pm.run(ctx, core_module)?;
         } else {
-            super::evidence_to_wasm::lower_evidence_to_wasm(ctx, module);
+            super::evidence_to_wasm::lower_evidence_to_wasm(ctx, module)
+                .map_err(WasmLowerError::Evidence)?;
         }
     }
 

--- a/crates/tribute-passes/src/wasm/type_converter.rs
+++ b/crates/tribute-passes/src/wasm/type_converter.rs
@@ -321,6 +321,17 @@ fn unbox_via_i31(
 // Main entry point
 // =============================================================================
 
+/// Keep exact compiler-owned closure storage consistent across ADT layouts,
+/// aliases, signatures, attributes, and SSA types before target instructions.
+pub(crate) fn convert_canonical_closure_storage(
+    ctx: &mut IrContext,
+    module: trunk_ir::rewrite::Module,
+) {
+    let source = crate::closure_lower::closure_struct_type_ref(ctx);
+    let target = closure_adt_type(ctx);
+    crate::closure_lower::convert_canonical_closure_storage(ctx, module, source, target);
+}
+
 /// Create a TypeConverter configured for WASM backend type conversions.
 ///
 /// This converter handles the IR-level type transformations needed during
@@ -335,6 +346,7 @@ pub fn wasm_type_converter(ctx: &mut IrContext) -> TypeConverter {
     let structref_ty = intern_type(ctx, Symbol::new("wasm"), Symbol::new("structref"));
     let arrayref_ty = intern_type(ctx, Symbol::new("wasm"), Symbol::new("arrayref"));
     let closure_ty = closure_adt_type(ctx);
+    let shared_closure_ty = crate::closure_lower::closure_struct_type_ref(ctx);
     let step_ty = step_adt_type(ctx);
     let cont_ty = continuation_adt_type(ctx);
     let rw_ty = resume_wrapper_adt_type(ctx);
@@ -455,6 +467,10 @@ pub fn wasm_type_converter(ctx: &mut IrContext) -> TypeConverter {
             None
         }
     });
+
+    // Exact compiler-owned shared closure storage has the same target contract
+    // as a semantic closure. Do not infer this identity from ADT names or shape.
+    tc.add_conversion(move |_, ty| (ty == shared_closure_ty).then_some(closure_ty));
 
     // Convert closure.closure -> adt.struct(name="_closure")
     // This ensures emit can identify closures by ADT name rather than tribute-ir type
@@ -862,4 +878,72 @@ pub fn wasm_type_converter(ctx: &mut IrContext) -> TypeConverter {
     });
 
     tc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trunk_ir::ops::DialectOp;
+
+    #[test]
+    fn canonical_storage_conversion_updates_nested_block_argument_attributes() {
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+            func.func @test(%value: core.i32) -> core.i32 { func.return %value }
+        }"#,
+        );
+        let function = trunk_ir::dialect::func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        let block = ctx.region(function.body(&ctx)).blocks[0];
+        let source = crate::closure_lower::closure_struct_type_ref(&mut ctx);
+        let target = closure_adt_type(&mut ctx);
+        let nested = |ty| Attribute::List(vec![Attribute::List(vec![Attribute::Type(ty)])]);
+        ctx.block_mut(block).args[0]
+            .attrs
+            .insert(Symbol::new("storage"), nested(source));
+        convert_canonical_closure_storage(&mut ctx, module);
+        assert_eq!(
+            ctx.block(block).args[0].attrs.get("storage"),
+            Some(&nested(target))
+        );
+    }
+
+    #[test]
+    fn canonical_closure_storage_conversion_requires_exact_shared_identity() {
+        let mut ctx = IrContext::new();
+        let shared = crate::closure_lower::closure_struct_type_ref(&mut ctx);
+        let target = closure_adt_type(&mut ctx);
+        let generic = intern_type(&mut ctx, Symbol::new("wasm"), Symbol::new("structref"));
+        let mut near = ctx.types.get(shared).clone();
+        near.attrs
+            .insert(Symbol::new("unrelated"), Attribute::Bool(true));
+        let near = ctx.types.intern(near);
+        let converter = wasm_type_converter(&mut ctx);
+        assert_eq!(converter.convert_type_or_identity(&ctx, shared), target);
+        assert_eq!(converter.convert_type_or_identity(&ctx, near), near);
+        assert_eq!(converter.convert_type_or_identity(&ctx, generic), generic);
+        let data = ctx.types.get(target);
+        let Attribute::List(fields) = data.attrs.get("fields").unwrap() else {
+            panic!("fields")
+        };
+        assert!(
+            matches!(&fields[0], Attribute::List(field) if field[0] == Attribute::Symbol(Symbol::new("table_idx")))
+        );
+        let anyref = intern_type(&mut ctx, Symbol::new("wasm"), Symbol::new("anyref"));
+        let i32_ty = intern_type(&mut ctx, Symbol::new("core"), Symbol::new("i32"));
+        assert_eq!(
+            ctx.types.get(target).attrs.get("fields"),
+            Some(&Attribute::List(vec![
+                Attribute::List(vec![
+                    Attribute::Symbol(Symbol::new("table_idx")),
+                    Attribute::Type(i32_ty)
+                ]),
+                Attribute::List(vec![
+                    Attribute::Symbol(Symbol::new("env")),
+                    Attribute::Type(anyref)
+                ]),
+            ]))
+        );
+    }
 }

--- a/crates/trunk-ir-cranelift-backend/src/function.rs
+++ b/crates/trunk-ir-cranelift-backend/src/function.rs
@@ -39,8 +39,7 @@ pub(crate) fn call_conv_for_cps_signature(
 
 fn has_physical_empty_result(ctx: &IrContext, signature: TypeRef) -> bool {
     clif::FuncSig::from_type_ref(ctx, signature)
-        .and_then(|function| function.single_result(ctx))
-        .is_some_and(|result| is_nil_type(ctx, result))
+        .is_some_and(|function| function.results(ctx).is_empty())
 }
 
 pub(crate) fn is_nil_type(ctx: &IrContext, ty: TypeRef) -> bool {
@@ -869,7 +868,12 @@ mod tests {
         let i32_ty = make_core_type(&mut ctx, "i32");
         let nil_ty = make_core_type(&mut ctx, "nil");
         let logical_signature = clif::func_sig(&mut ctx, [i32_ty], [i32_ty]).as_type_ref();
-        let physical_signature = clif::func_sig(&mut ctx, [i32_ty], [nil_ty]).as_type_ref();
+        let physical_signature = clif::func_sig(&mut ctx, [i32_ty], []).as_type_ref();
+        let unit_signature = clif::func_sig(&mut ctx, [i32_ty], [nil_ty]).as_type_ref();
+        assert_eq!(
+            call_conv_for_cps_signature(&ctx, unit_signature, true, CallConv::SystemV),
+            CallConv::SystemV
+        );
 
         assert_eq!(
             call_conv_for_cps_signature(&ctx, logical_signature, true, CallConv::SystemV),

--- a/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
+++ b/crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
@@ -516,7 +516,7 @@ impl RewritePattern for FuncTailCallIndirectPattern {
         let Some(callable) = clif::FuncSig::from_type_ref(ctx, signature) else {
             return false;
         };
-        if callable.single_result(ctx) != Some(core::nil(ctx).as_type_ref())
+        if !callable.results(ctx).is_empty()
             || !TailCallLike::is_resultless(&tail, ctx)
             || callable.inputs(ctx).len() != CallLike::call_args(&tail, ctx).len()
             || callable
@@ -667,14 +667,14 @@ mod tests {
     use trunk_ir::{Attribute, AttributeMap, Symbol};
 
     const TAIL_TRANSFERS: &str = r#"core.module @test {
-  func.func @direct_target(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @direct_target(%value: core.i32) attributes {tribute.calling_convention = 2} {
     func.return
   }
-  func.func @direct_caller(%value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
+  func.func @direct_caller(%value: core.i32) attributes {tribute.calling_convention = 2} {
     func.tail_call %value {callee = @direct_target, tribute.calling_convention = 2}
   }
-  func.func @indirect_caller(%callee: core.ptr, %value: core.i32) -> core.nil attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> core.nil>, tribute.calling_convention = 2}
+  func.func @indirect_caller(%callee: core.ptr, %value: core.i32) attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %value {signature = func.func_sig<(core.i32) -> ()>, tribute.calling_convention = 2}
   }
 }"#;
 
@@ -953,8 +953,8 @@ mod tests {
             &mut ctx,
             r#"core.module @test {
   !evidence = core.array(core.i32)
-  func.func @caller(%callee: core.ptr, %evidence: !evidence) -> core.nil attributes {tribute.calling_convention = 2} {
-    func.tail_call_indirect %callee, %evidence {signature = func.func_sig<(!evidence) -> core.nil>, tribute.calling_convention = 2}
+  func.func @caller(%callee: core.ptr, %evidence: !evidence) attributes {tribute.calling_convention = 2} {
+    func.tail_call_indirect %callee, %evidence {signature = func.func_sig<(!evidence) -> ()>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -970,11 +970,11 @@ mod tests {
         let printed = print_module(&ctx, module.op());
         assert!(
             printed.contains("clif.return_call_indirect")
-                && printed.contains("sig = clif.func_sig<(core.ptr) -> core.nil>"),
+                && printed.contains("sig = clif.func_sig<(core.ptr) -> ()>"),
             "{printed}"
         );
         assert!(
-            !printed.contains("sig = clif.func_sig<(!evidence) -> core.nil>"),
+            !printed.contains("sig = clif.func_sig<(!evidence) -> ()>"),
             "{printed}"
         );
     }

--- a/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
+++ b/crates/trunk-ir-cranelift-backend/src/passes/snapshots/trunk_ir_cranelift_backend__passes__func_to_clif__tests__tail_transfers_to_clif.snap
@@ -3,7 +3,7 @@ source: crates/trunk-ir-cranelift-backend/src/passes/func_to_clif.rs
 expression: result
 ---
 core.module @test {
-  !t0 = clif.func_sig<(core.i32) -> core.nil>
+  !t0 = clif.func_sig<(core.i32) -> ()>
 
   clif.func {sym_name = @direct_target, tribute.calling_convention = 2, type = !t0} {
     ^bb0(%0: core.i32):
@@ -13,7 +13,7 @@ core.module @test {
     ^bb0(%0: core.i32):
       clif.return_call %0 {callee = @direct_target, tribute.calling_convention = 2}
   }
-  clif.func {sym_name = @indirect_caller, tribute.calling_convention = 2, type = clif.func_sig<(core.ptr, core.i32) -> core.nil>} {
+  clif.func {sym_name = @indirect_caller, tribute.calling_convention = 2, type = clif.func_sig<(core.ptr, core.i32) -> ()>} {
     ^bb0(%0: core.ptr, %1: core.i32):
       clif.return_call_indirect %0, %1 {sig = !t0, tribute.calling_convention = 2}
   }

--- a/crates/trunk-ir-cranelift-backend/src/translate.rs
+++ b/crates/trunk-ir-cranelift-backend/src/translate.rs
@@ -763,13 +763,13 @@ mod tests {
       %result = clif.call_indirect %callee, %value, %unit, %last {sig = clif.func_sig<(core.i32, core.nil, core.i64) -> core.i32>} : core.i32
       clif.return %result
   }
-  clif.func {sym_name = @direct_tail, tribute.calling_convention = 2, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
+  clif.func {sym_name = @direct_tail, tribute.calling_convention = 2, type = clif.func_sig<(core.i32, core.nil, core.i64) -> ()>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):
       clif.return_call %value, %unit, %last {callee = @direct_tail}
   }
-  clif.func {sym_name = @indirect_tail, tribute.calling_convention = 2, type = clif.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> core.nil>} {
+  clif.func {sym_name = @indirect_tail, tribute.calling_convention = 2, type = clif.func_sig<(core.ptr, core.i32, core.nil, core.i64) -> ()>} {
     ^entry(%callee: core.ptr, %value: core.i32, %unit: core.nil, %last: core.i64):
-      clif.return_call_indirect %callee, %value, %unit, %last {sig = clif.func_sig<(core.i32, core.nil, core.i64) -> core.nil>}
+      clif.return_call_indirect %callee, %value, %unit, %last {sig = clif.func_sig<(core.i32, core.nil, core.i64) -> ()>}
   }
   clif.func {sym_name = @jump, type = clif.func_sig<(core.i32, core.nil, core.i64) -> core.nil>} {
     ^entry(%value: core.i32, %unit: core.nil, %last: core.i64):

--- a/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
@@ -142,6 +142,29 @@ fn validate_marker_layout(ctx: &IrContext, ty: TypeRef) -> CompilationResult<()>
     Ok(())
 }
 
+/// Register a validated retained declaration for an indexed evidence operation.
+fn register_builtin_evidence_type(
+    ctx: &IrContext,
+    map: &mut HashMap<TypeRef, u32>,
+    index: u32,
+    ty: TypeRef,
+) -> CompilationResult<()> {
+    // Builtins bypass user builders, but retained full declarations still need
+    // local/signature mappings. Abstract refs must not acquire an indexed type.
+    if matches!(index, MARKER_IDX | EVIDENCE_IDX)
+        && crate::passes::wasm_gc_to_wasm::builtin_type_idx(ctx, ty) == Some(index)
+    {
+        let marker = if index == MARKER_IDX {
+            ty
+        } else {
+            ctx.types.get(ty).params[0]
+        };
+        validate_marker_layout(ctx, marker)?;
+        register_type(map, index, ty);
+    }
+    Ok(())
+}
+
 /// Normalize a type for GC struct field comparison.
 ///
 /// Normalizes tribute_rt types and variant instances to their canonical form.
@@ -426,56 +449,6 @@ pub(crate) fn collect_gc_types(
             continue;
         }
 
-        // Builtin layouts do not have builders, but their complete nominal IR
-        // types still need entries for function signatures and local types.
-        // Evidence lookup produces a full Marker declaration, which is distinct
-        // from the name-only declaration registered above. Reuse the typed GC
-        // lowering's builtin identity check; never specialize an abstract ref
-        // merely because an indexed instruction consumes it.
-        let marker_ty = if let Ok(new) = wasm_dialect::StructNew::from_op(ctx, op) {
-            (new.type_idx(ctx) == MARKER_IDX)
-                .then(|| ctx.op_result_types(op).first().copied())
-                .flatten()
-        } else if let Ok(get) = wasm_dialect::StructGet::from_op(ctx, op) {
-            (get.type_idx(ctx) == MARKER_IDX)
-                .then(|| {
-                    ctx.op_operands(op)
-                        .first()
-                        .map(|&v| helpers::value_type(ctx, v))
-                })
-                .flatten()
-        } else if let Ok(set) = wasm_dialect::StructSet::from_op(ctx, op) {
-            (set.type_idx(ctx) == MARKER_IDX)
-                .then(|| {
-                    ctx.op_operands(op)
-                        .first()
-                        .map(|&v| helpers::value_type(ctx, v))
-                })
-                .flatten()
-        } else {
-            None
-        };
-        if let Some(ty) = marker_ty
-            && crate::passes::wasm_gc_to_wasm::builtin_type_idx(ctx, ty) == Some(MARKER_IDX)
-        {
-            validate_marker_layout(ctx, ty)?;
-            register_type(&mut type_idx_by_type, MARKER_IDX, ty);
-        }
-        // The Evidence array retains that same full Marker element type.
-        // Its builtin layout likewise bypasses the user-type builder below.
-        let evidence_idx = wasm_dialect::ArrayNew::from_op(ctx, op)
-            .map(|array| array.type_idx(ctx))
-            .or_else(|_| {
-                wasm_dialect::ArrayNewDefault::from_op(ctx, op).map(|array| array.type_idx(ctx))
-            });
-        if evidence_idx == Ok(EVIDENCE_IDX)
-            && let Some(&ty) = ctx.op_result_types(op).first()
-            && crate::passes::wasm_gc_to_wasm::builtin_type_idx(ctx, ty) == Some(EVIDENCE_IDX)
-        {
-            validate_marker_layout(ctx, ctx.types.get(ty).params[0])?;
-            register_type(&mut type_idx_by_type, EVIDENCE_IDX, ty);
-        }
-
         if wasm_dialect::StructNew::matches(ctx, op) {
             let struct_new =
                 wasm_dialect::StructNew::from_op(ctx, op).expect("matched wasm.struct_new");
@@ -484,6 +457,12 @@ pub(crate) fn collect_gc_types(
             let result_types = ctx.op_result_types(op).to_vec();
             let result_type = result_types.first().copied();
             let type_idx = struct_new.type_idx(ctx);
+
+            if type_idx == MARKER_IDX
+                && let Some(ty) = result_type
+            {
+                register_builtin_evidence_type(ctx, &mut type_idx_by_type, type_idx, ty)?;
+            }
 
             if let Some(builder) = try_get_builder(&mut builders, type_idx) {
                 builder.kind = GcKind::Struct;
@@ -522,6 +501,17 @@ pub(crate) fn collect_gc_types(
                 wasm_dialect::StructGet::from_op(ctx, op).expect("matched wasm.struct_get");
             let type_idx = struct_get.type_idx(ctx);
             let field_idx = struct_get.field_idx(ctx);
+            let operands = ctx.op_operands(op).to_vec();
+            if type_idx == MARKER_IDX
+                && let Some(&value) = operands.first()
+            {
+                register_builtin_evidence_type(
+                    ctx,
+                    &mut type_idx_by_type,
+                    type_idx,
+                    helpers::value_type(ctx, value),
+                )?;
+            }
             if let Some(builder) = try_get_builder(&mut builders, type_idx) {
                 builder.kind = GcKind::Struct;
 
@@ -531,7 +521,6 @@ pub(crate) fn collect_gc_types(
                         "struct type index {type_idx} field index {field_idx} out of bounds (fields: {count})",
                     )));
                 }
-                let operands = ctx.op_operands(op).to_vec();
                 if let Some(&first_operand) = operands.first() {
                     let ty = helpers::value_type(ctx, first_operand);
                     register_type(&mut type_idx_by_type, type_idx, ty);
@@ -554,6 +543,16 @@ pub(crate) fn collect_gc_types(
             let operands = ctx.op_operands(op).to_vec();
             let type_idx = struct_set.type_idx(ctx);
             let field_idx = struct_set.field_idx(ctx);
+            if type_idx == MARKER_IDX
+                && let Some(&value) = operands.first()
+            {
+                register_builtin_evidence_type(
+                    ctx,
+                    &mut type_idx_by_type,
+                    type_idx,
+                    helpers::value_type(ctx, value),
+                )?;
+            }
             if let Some(builder) = try_get_builder(&mut builders, type_idx) {
                 builder.kind = GcKind::Struct;
                 if matches!(builder.field_count, Some(count) if field_idx as usize >= count) {
@@ -581,6 +580,11 @@ pub(crate) fn collect_gc_types(
                     wasm_dialect::ArrayNewDefault::from_op(ctx, op).map(|op| op.type_idx(ctx))
                 })
                 .expect("matched indexed array.new operation");
+            if type_idx == EVIDENCE_IDX
+                && let Some(&ty) = result_types.first()
+            {
+                register_builtin_evidence_type(ctx, &mut type_idx_by_type, type_idx, ty)?;
+            }
             if let Some(builder) = try_get_builder(&mut builders, type_idx) {
                 builder.kind = GcKind::Array;
                 if let Some(&result_ty) = result_types.first() {

--- a/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/gc_types_collection.rs
@@ -84,6 +84,64 @@ fn register_type(type_idx_by_type: &mut HashMap<TypeRef, u32>, idx: u32, ty: Typ
     type_idx_by_type.entry(ty).or_insert(idx);
 }
 
+/// Check retained Marker declarations against the predefined evidence layout.
+/// The nominal builtin lookup selects the layout; it does not validate fields.
+fn validate_marker_layout(ctx: &IrContext, ty: TypeRef) -> CompilationResult<()> {
+    use trunk_ir::Attribute;
+    let data = ctx.types.get(ty);
+    let invalid = || CompilationError::type_error("Marker declaration differs from builtin layout");
+    if data.name != Symbol::new("struct") || !data.params.is_empty() {
+        return Err(invalid());
+    }
+    let Some(fields) = data.attrs.get("fields") else {
+        // Existing name-only builtin references carry no layout declaration.
+        return Ok(());
+    };
+    let Attribute::List(fields) = fields else {
+        return Err(invalid());
+    };
+    let GcTypeDef::Struct(expected) = &gc_types::builtin_types()[MARKER_IDX as usize] else {
+        unreachable!("Marker is a builtin struct")
+    };
+    if fields.len() != expected.len() {
+        return Err(invalid());
+    }
+    for ((field, expected), role) in fields.iter().zip(expected).zip([
+        "ability_id",
+        "prompt_tag",
+        "tr_dispatch_fn",
+        "handler_dispatch",
+    ]) {
+        let Attribute::List(parts) = field else {
+            return Err(invalid());
+        };
+        let [Attribute::Symbol(name), Attribute::Type(ty)] = parts.as_slice() else {
+            return Err(invalid());
+        };
+        let field_type = ctx.types.get(*ty);
+        if *name != Symbol::new(role)
+            || !field_type.params.is_empty()
+            || !field_type.attrs.is_empty()
+            || !(helpers::is_type(ctx, *ty, "core", "i32")
+                || helpers::is_type(ctx, *ty, "core", "ptr")
+                || helpers::is_type(ctx, *ty, "wasm", "anyref"))
+        {
+            return Err(invalid());
+        }
+        // Marker pointer fields are target-owned GC references, as specified
+        // by the builtin layout, even in the retained pre-target declaration.
+        let actual = if helpers::is_type(ctx, *ty, "core", "ptr") {
+            ValType::Ref(wasm_encoder::RefType::ANYREF)
+        } else {
+            helpers::type_to_valtype(ctx, *ty, &HashMap::new())?
+        };
+        if StorageType::Val(actual) != expected.element_type {
+            return Err(invalid());
+        }
+    }
+    Ok(())
+}
+
 /// Normalize a type for GC struct field comparison.
 ///
 /// Normalizes tribute_rt types and variant instances to their canonical form.
@@ -368,6 +426,56 @@ pub(crate) fn collect_gc_types(
             continue;
         }
 
+        // Builtin layouts do not have builders, but their complete nominal IR
+        // types still need entries for function signatures and local types.
+        // Evidence lookup produces a full Marker declaration, which is distinct
+        // from the name-only declaration registered above. Reuse the typed GC
+        // lowering's builtin identity check; never specialize an abstract ref
+        // merely because an indexed instruction consumes it.
+        let marker_ty = if let Ok(new) = wasm_dialect::StructNew::from_op(ctx, op) {
+            (new.type_idx(ctx) == MARKER_IDX)
+                .then(|| ctx.op_result_types(op).first().copied())
+                .flatten()
+        } else if let Ok(get) = wasm_dialect::StructGet::from_op(ctx, op) {
+            (get.type_idx(ctx) == MARKER_IDX)
+                .then(|| {
+                    ctx.op_operands(op)
+                        .first()
+                        .map(|&v| helpers::value_type(ctx, v))
+                })
+                .flatten()
+        } else if let Ok(set) = wasm_dialect::StructSet::from_op(ctx, op) {
+            (set.type_idx(ctx) == MARKER_IDX)
+                .then(|| {
+                    ctx.op_operands(op)
+                        .first()
+                        .map(|&v| helpers::value_type(ctx, v))
+                })
+                .flatten()
+        } else {
+            None
+        };
+        if let Some(ty) = marker_ty
+            && crate::passes::wasm_gc_to_wasm::builtin_type_idx(ctx, ty) == Some(MARKER_IDX)
+        {
+            validate_marker_layout(ctx, ty)?;
+            register_type(&mut type_idx_by_type, MARKER_IDX, ty);
+        }
+        // The Evidence array retains that same full Marker element type.
+        // Its builtin layout likewise bypasses the user-type builder below.
+        let evidence_idx = wasm_dialect::ArrayNew::from_op(ctx, op)
+            .map(|array| array.type_idx(ctx))
+            .or_else(|_| {
+                wasm_dialect::ArrayNewDefault::from_op(ctx, op).map(|array| array.type_idx(ctx))
+            });
+        if evidence_idx == Ok(EVIDENCE_IDX)
+            && let Some(&ty) = ctx.op_result_types(op).first()
+            && crate::passes::wasm_gc_to_wasm::builtin_type_idx(ctx, ty) == Some(EVIDENCE_IDX)
+        {
+            validate_marker_layout(ctx, ctx.types.get(ty).params[0])?;
+            register_type(&mut type_idx_by_type, EVIDENCE_IDX, ty);
+        }
+
         if wasm_dialect::StructNew::matches(ctx, op) {
             let struct_new =
                 wasm_dialect::StructNew::from_op(ctx, op).expect("matched wasm.struct_new");
@@ -598,6 +706,85 @@ pub(crate) fn collect_gc_types(
 mod tests {
     use super::*;
     use trunk_ir::types::{Attribute, TypeDataBuilder};
+
+    #[test]
+    fn incompatible_named_marker_and_evidence_layouts_are_rejected_before_emission() {
+        for field_type in ["core.i64", "wasm.anyref"] {
+            for evidence in [false, true] {
+                let mut ctx = IrContext::new();
+                let producer = if evidence {
+                    "%size = wasm.i32_const {value = 0} : core.i32\n%value = wasm.array_new_default %size {type_idx = 6} : core.array(!Marker)"
+                } else {
+                    "%value = wasm.struct_get %marker {type_idx = 5, field_idx = 0} : core.i32"
+                };
+                let module = trunk_ir::parser::parse_test_module(&mut ctx, &format!(
+                    "core.module @test {{
+                        !Marker = adt.struct() {{name = @_Marker, fields = [[@ability_id, {field_type}], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]]}}
+                        wasm.func @test(%marker: !Marker) -> core.i32 {{
+                            {producer}
+                            wasm.unreachable
+                        }}
+                    }}"
+                ));
+                let error = crate::emit_module_to_wasm(&mut ctx, module)
+                    .err()
+                    .expect("incompatible Marker layout must fail before emission");
+                assert!(
+                    error.to_string().contains("Marker declaration differs"),
+                    "{error}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn indexed_marker_access_does_not_specialize_abstract_or_unrelated_references() {
+        for reference in [
+            "wasm.anyref",
+            "wasm.structref",
+            "wasm.arrayref",
+            "adt.struct() {name = @Other}",
+        ] {
+            let mut ctx = IrContext::new();
+            let module = trunk_ir::parser::parse_test_module(
+                &mut ctx,
+                &format!(
+                    "core.module @test {{
+                    wasm.func @test(%marker: {reference}) -> core.i32 {{
+                        %value = wasm.struct_get %marker {{type_idx = 5, field_idx = 0}} : core.i32
+                        wasm.return %value
+                    }}
+                }}"
+                ),
+            );
+            let function = wasm_dialect::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+            let entry = ctx.region(function.body(&ctx)).blocks[0];
+            let ty = ctx.value_ty(ctx.block_args(entry)[0]);
+            let (_, map) = collect_gc_types(&mut ctx, module).unwrap();
+            // Abstract arrayref retains its existing Evidence mapping; none of
+            // these references may acquire the Marker index from struct_get.
+            let expected = (reference == "wasm.arrayref").then_some(&EVIDENCE_IDX);
+            assert_eq!(map.get(&ty), expected);
+        }
+    }
+
+    #[test]
+    fn marker_declaration_at_a_different_builtin_index_is_not_registered() {
+        let mut ctx = IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+            !Marker = adt.struct() {name = @_Marker, fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]]}
+            wasm.func @test(%marker: !Marker) -> core.i32 {
+                %value = wasm.struct_get %marker {type_idx = 4, field_idx = 0} : core.i32
+                wasm.return %value
+            }
+        }"#,
+        );
+        let ty = ctx.type_alias_by_name(Symbol::new("Marker")).unwrap();
+        let (_, map) = collect_gc_types(&mut ctx, module).unwrap();
+        assert!(!map.contains_key(&ty));
+    }
 
     #[test]
     fn record_struct_field_widens_concrete_to_anyref() {

--- a/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
+++ b/crates/trunk-ir-wasm-backend/src/emit/helpers.rs
@@ -222,7 +222,9 @@ pub(crate) fn exact_return_call_indirect_signature_with(
             "wasm.return_call_indirect signature must be wasm.func_sig",
         )
     })?;
-    if !matches!(results, [result] if is_nil_type(ctx, *result)) {
+    let cps = ctx.op(op).attributes.get("tribute.calling_convention")
+        == Some(&trunk_ir::types::Attribute::Int(2));
+    if !results.is_empty() && (cps || !matches!(results, [result] if is_nil_type(ctx, *result))) {
         return Err(CompilationError::invalid_module(
             "wasm.return_call_indirect signature must have an empty result",
         ));

--- a/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/func_to_wasm.rs
@@ -1019,11 +1019,11 @@ mod tests {
         let module = parse_test_module(
             &mut ctx,
             r#"core.module @test {
-  func.func @physical(%table_index: core.i32, %value: wasm.anyref) -> core.nil {
-    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.anyref) -> core.nil>, table = 7, tribute.calling_convention = 2, type_idx = 9}
+  func.func @physical(%table_index: core.i32, %value: wasm.anyref) {
+    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.anyref) -> ()>, table = 7, tribute.calling_convention = 2, type_idx = 9}
   }
-  func.func @mismatch(%table_index: core.i32, %value: core.i32) -> core.nil {
-    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.float) -> core.nil>, tribute.calling_convention = 2}
+  func.func @mismatch(%table_index: core.i32, %value: core.i32) {
+    func.tail_call_indirect %table_index, %value {signature = func.func_sig<(tribute_rt.float) -> ()>, tribute.calling_convention = 2}
   }
 }"#,
         );
@@ -1050,16 +1050,16 @@ mod tests {
         let output = print_module(&ctx, module.op());
         assert!(
             output.contains(
-                "wasm.return_call_indirect %0, %1 {signature = wasm.func_sig<(wasm.anyref) -> core.nil>"
+                "wasm.return_call_indirect %0, %1 {signature = wasm.func_sig<(wasm.anyref) -> ()>"
             ),
             "{output}"
         );
         assert!(
-            output.contains("wasm.return_call_indirect %0, %1 {signature = wasm.func_sig<(wasm.anyref) -> core.nil>, table = 0, tribute.calling_convention = 2, type_idx = 0}"),
+            output.contains("wasm.return_call_indirect %0, %1 {signature = wasm.func_sig<(wasm.anyref) -> ()>, table = 0, tribute.calling_convention = 2, type_idx = 0}"),
             "the converted transfer must retain its calling convention: {output}"
         );
         assert!(
-            !output.contains("signature = func.func_sig<(tribute_rt.anyref) -> core.nil>"),
+            !output.contains("signature = func.func_sig<(tribute_rt.anyref) -> ()>"),
             "{output}"
         );
         assert!(
@@ -1067,7 +1067,7 @@ mod tests {
             "stale source table metadata must not reach Wasm: {output}"
         );
         assert!(
-            output.contains("func.tail_call_indirect %0, %1 {signature = func.func_sig<(tribute_rt.float) -> core.nil>, tribute.calling_convention = 2}"),
+            output.contains("func.tail_call_indirect %0, %1 {signature = func.func_sig<(tribute_rt.float) -> ()>, tribute.calling_convention = 2}"),
             "the mismatched transfer must remain unchanged: {output}"
         );
     }

--- a/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
+++ b/crates/trunk-ir-wasm-backend/src/passes/wasm_gc_to_wasm.rs
@@ -48,7 +48,7 @@ fn is_evidence_array(ctx: &IrContext, ty: TypeRef) -> bool {
         && named_adt(ctx, array.params[0], "_Marker")
 }
 
-fn builtin_type_idx(ctx: &IrContext, ty: TypeRef) -> Option<u32> {
+pub(crate) fn builtin_type_idx(ctx: &IrContext, ty: TypeRef) -> Option<u32> {
     let data = ctx.types.get(ty);
     if data.dialect == Symbol::new("core") && data.name == Symbol::new("bytes") {
         Some(BYTES_STRUCT_IDX)

--- a/new-plans/cps-effects.md
+++ b/new-plans/cps-effects.md
@@ -220,6 +220,13 @@ control value를 만들지 않는다. Resume하지 않는 handler arm도
 `Escape`를 반환하는 대신 해당 handle의 exit continuation으로 직접 tail
 transfer하므로 completion region과 포기한 suffix를 구조적으로 건너뛴다.
 
+물리화는 전체 callable과 dispatch/frame/R 계약을 검증하고 변환을 계획한 뒤 적용한다.
+실패하면 기존 operation, 타입 참조, attribute와 alias를 변경하지 않는다. Alias,
+closure signature, function constant, exact indirect signature, SSA 결과와 block
+argument, 중첩 타입 attribute를 함께 변환한다. 일반 `never`·`nil` 치환은 하지 않는다.
+Closure tail lowering은 caller·callee·exact indirect signature의 전체 결과 목록을
+비교하여 논리 `[never]`와 물리 `[]`를 각각 지원한다.
+
 Final native/Wasm backend-ready 경계는 `Cps` worker, continuation, `done_k`,
 handler-dispatch의 result vector가 비어 있고 모든 CPS transfer가
 `func.tail_call` 또는 `func.tail_call_indirect`로 끝나는지 검사한다.
@@ -241,61 +248,22 @@ payload, closure environment와 dispatch closure field에 쓰는 일반 `anyref`
   { ability_ref = @Logger, op_name = @log }
 ```
 
-Shared lowering converts it to a target-independent effect ABI operation:
+공통 lowering은 payload packing 전에 exact resume의 frame 입력과 frame metadata에서
+답 타입 `R`을 구하고 evidence·dispatch·resume의 연결을 검증한다.
 
 ```text
 %payload = cast %arg to anyref
-%result = effect.dispatch_tail %ev, %payload
-  { ability_ref = @Logger, op_name = @log }
+effect.dispatch_cps %ev, %dispatch, %resume, %payload
+  { ability_ref = @State, op_name = @get, answer_type = R }
 ```
 
-Native lowering then lowers that ABI operation to the evidence lookup
-and indirect-call representation:
-
-```text
-%marker = ability.evidence_lookup %ev { ability_ref = @Logger }
-%tr_dispatch = adt.struct_get %marker, MarkerField::TrDispatchFn
-%fn = adt.struct_get %tr_dispatch, 0
-%env = adt.struct_get %tr_dispatch, 1
-%op_idx = arith.const <hash(Logger, log)>
-%result = func.call_indirect %fn(%ev, %env, %op_idx, %arg_anyref)
-```
-
-즉 `fn` operation은 CPS 변환, continuation allocation, resume dispatch를
-우회한다.
-
-### `op` operation: tail-call CPS dispatch
-
-직접형 입력은 위 규칙의 `operation_kind = @op` perform이며,
-`tribute_control_to_cps`는 block suffix에서 continuation closure를 구성해
-`ability.perform`으로 내린다.
-
-```text
-ability.perform %continuation, %arg
-  { ability_ref = @State, op_name = @get }
-```
-
-Shared lowering converts it to a target-independent effect ABI operation:
-
-```text
-%payload = cast %arg to anyref
-%cont = cast %continuation to anyref
-effect.dispatch_cps %ev, %cont, %payload
-  { ability_ref = @State, op_name = @get }
-```
-
-Native lowering then finds the `handler_dispatch` closure in evidence and
-tail-calls it:
-
-```text
-%marker = ability.evidence_lookup %ev { ability_ref = @State }
-%handler = adt.struct_get %marker, MarkerField::HandlerDispatch
-%fn = adt.struct_get %handler, 0
-%env = adt.struct_get %handler, 1
-%op_idx = arith.const <hash(State, get)>
-func.tail_call_indirect %fn(
-  %ev, %env, %continuation_anyref, %op_idx, %arg_anyref)
-```
+필수 `answer_type: Type`은 `ContinuationFrame<R>`의 의미적 `R`이다. 호출 결과,
+물리화 완료 marker 또는 callable provenance가 아니며 `ability.perform`에 중복하지
+않는다. Dispatch가 요구하는 resume과 실제 resume의 exact 타입이 같아야 한다.
+같은 `R`을 가진 서로 다른 nominal frame도 호환되지 않는다. Dispatch와 resume의
+convention은 `Cps`, environment 위치는 각각 1과 0이다. 이미 낮춘 closure는
+기존에 인증된 callable provenance만 사용하며 이름이나 저장 형태에서 추론하지 않는다.
+누락되거나 잘못된 attribute 및 frame·R 불일치는 명시적 lowering 오류다.
 
 <!-- markdownlint-disable-next-line MD033 -->
 <a id="dispatch-layers"></a>
@@ -306,11 +274,22 @@ func.tail_call_indirect %fn(
 
 1. `ContinuationFrame<R>`의 내부 `Dispatch<R>`는 resume에서 어휘적 dispatcher를 재구성하는
    CPS closure이며 `(evidence, resume, prompt, ability_id, op_id, payload)`를 받는다.
-2. `effect.dispatch_cps(evidence, continuation, payload)`는 대상 독립적이고
-   result가 없는 effect operation이다.
-3. 대상 handler tail ABI는
-   `(evidence, env, continuation, op_idx, payload)`이며 handler closure를 직접
-   호출한다.
+2. `effect.dispatch_cps(evidence, dispatch, resume, payload)`는 필수
+   `answer_type = R`을 보존하는 결과 없는 대상 독립적 operation이다.
+3. 대상 dispatch ABI는 compiler-owned
+   `(Evidence, Environment, Resume, Prompt, AbilityId, OperationIndex, Payload)`
+   입력과 빈 결과 목록을 갖는다.
+   Native는 canonical shared signature에 기존 Native 변환을 적용하여
+   `(ptr, ptr, ptr, i32, i32, i32, ptr) -> ()`를 얻는다. Wasm은 대상의 canonical
+   evidence/environment/closure 저장 타입, 세 i32와 payload 타입을 사용한다.
+   Closure 입력은 canonical `_closure` ADT이며 일반 `wasm.structref`로 대체하지
+   않는다. 기존 대상 타입 변환은 정확한 공통 closure 저장 타입을 이 ADT로 변환한다.
+
+의미 계약은 closure 타입 소거와 physicalization 변경 전에 검증한다. 최종 target
+lowering은 실제 operand와 독립적으로 고정 signature를 구성하고 operand를 대조한다.
+서로 다른 유효한 `R`도 동일한 물리 ABI를 가지며 resume의 frame은 별도 dispatch
+입력이 아니다. `answer_type`은 일반 재귀 타입 변환에 참여하고 effect operation 제거
+시 소비한다. Raw target call에 복제하지 않으며 legacy dispatch 계약은 유지한다.
 
 정의, lambda, adapter, direct/indirect call, return, suffix, resume, handle은
 ContinuationFrame을 같은 callable provenance로 전달한다. 내부 Dispatch를 effect operation이나
@@ -340,15 +319,13 @@ CPS entry와 `done_k`의 result는 `core.never`이며,
 
 최종 계약에서는 atomic physical CPS switch 이후 target signature lowering이
 이 CPS signature를 native/Wasm empty-result signature로 바꾼 뒤 실제 wrapper와
-ordinary call을 합성한다. 현재 구현은 임시 `[core.nil]` target encoding을 쓴다. Wasm은 nil/void
-machinery처럼 target이 지원하는 표현을 사용한다. Root `done_k`는 source result를
+결과 없는 ordinary call을 합성한다. Root `done_k`는 source result를
 cell에 정확히 한 번 쓰고 terminal dispatch는 root 밖 general operation transfer를
 끝내며, wrapper는 이 둘을 immutable `ContinuationFrame<R>`로 materialize해 worker에
 전달한 뒤 proper-tail-call chain이 끝나면 cell을 읽어 source result로 반환한다.
-Shared `func.func_sig` and `func.call` support zero or one result. Logical CPS
-producers retain `[core.never]`; current target ABI uses temporary `[core.nil]`
-until the later atomic empty-result switch. No second control carrier is
-introduced. 이 adapter는 answer-type polymorphism, trampoline, in-band sentinel 또는
+공통 `func.func_sig`와 `func.call`은 0개 또는 1개 결과를 지원한다. 논리 CPS
+producer는 `[core.never]`를 유지하고 물리화는 정확한 Cps 결과만 `[]`로 바꾼다.
+이 adapter는 answer-type polymorphism, trampoline, in-band sentinel 또는
 control carrier가 아니다.
 
 ### `handle`: evidence extension + handler closures
@@ -483,8 +460,8 @@ Initial operations:
 - `effect.extend(evidence, prompt_tag, tr_dispatch_fn, handler_dispatch)
   { ability_ref } -> evidence`
 - `effect.dispatch_tail(evidence, payload) { ability_ref, op_name } -> result`
-- `effect.dispatch_cps(evidence, continuation, payload)
-  { ability_ref, op_name } -> ()`
+- `effect.dispatch_cps(evidence, dispatch, resume, payload)
+  { ability_ref, op_name, answer_type } -> ()`
 
 Rules:
 

--- a/new-plans/cranelift-backend.md
+++ b/new-plans/cranelift-backend.md
@@ -176,6 +176,12 @@ Effect handling은 tail-call CPS 방식으로 처리된다.
 `lower_ability_perform`과 `lower_handle_dispatch` pass가
 ability 연산을 handler_dispatch 클로저 호출로 변환한다.
 
+물리 CPS 판정은 exact `Cps` convention과 빈 결과 목록의 조합이다. 실제
+Direct/EvidenceDirect Unit 결과와 살아 있는 nil SSA 값의 zero-width 처리는 유지한다.
+최종 dispatch는 operand와 독립적인 compiler-owned canonical shared signature를
+기존 Native 변환으로 낮추며 machine 입력은 `ptr, ptr, ptr, i32, i32, i32, ptr`,
+결과는 빈 목록이다. Operand는 이 고정 계약과 정확히 대조한다.
+
 상세 내용은 [cps-effects.md](cps-effects.md)를 참조.
 
 ---

--- a/new-plans/implementation.md
+++ b/new-plans/implementation.md
@@ -120,8 +120,8 @@ tribute        -> tribute-front + tribute-passes
   조합 계약만 정한다.
 - 최종 계약에서 Native/Wasm signature lowering은 `core.never` CPS signature를
   target empty-result signature로 내린 뒤 external Direct/EvidenceDirect wrapper와
-  ordinary call을 합성한다. 이 atomic physical CPS switch는 후속 작업이며 현재
-  target ABI는 임시 `[core.nil]` encoding을 쓴다.
+  결과 없는 ordinary call을 합성한다. 변환은 모든 callable과 transfer 계약을
+  사전 검증한 뒤 원자적으로 적용하며 Direct/EvidenceDirect의 실제 Unit 결과는 보존한다.
 
 검증 책임은 구현 계층과 분리한다:
 
@@ -489,15 +489,14 @@ entrypoint 전에 거부한다. Frontend는 root body도 direct-style control로
 shared conversion은 typed completion cell과 `core.never` root `done_k`의 추상
 계약을 만든다. 최종 계약에서는 atomic physical CPS switch 이후 target signature
 lowering이 CPS entry를 empty result로 바꾼 뒤에만 Direct/EvidenceDirect export
-wrapper의 ordinary call을 합성한다. 현재 target ABI는 임시 `[core.nil]`을 쓴다. Wrapper는
+wrapper의 결과 없는 ordinary call을 합성한다. Wrapper는
 completion cell을 소유하고 이를 capture한 terminal `Done<R>`와 terminal
 `Dispatch<R>`를 exact nominal `ContinuationFrame<R>`에 materialize해 worker에
 전달한다. `done_k`가 cell을 쓴 뒤 target call이 돌아오면 wrapper가 cell을 읽는다.
 worker frame 계약은 명시적 frame result/layout provenance로 검사하며 closure 이름,
 arity, raw storage, `anyref`에서 추론하지 않는다.
-Shared `func.call` supports zero or one result independently of CPS. Nested-module
-`main` remains ordinary. Target ABI still uses temporary `[core.nil]` encoding
-until the later atomic physical CPS switch.
+공통 `func.call`은 CPS 여부와 독립적으로 0개 또는 1개 결과를 지원한다.
+Nested-module `main`은 일반 함수로 유지한다.
 
 기본 I/O의 embedded `std::io` source wrapper는 target ABI를 직접 호출하지 않는다.
 Frontend shared lowering은 private runtime bridge stub을 `tribute_io.write`와

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -713,8 +713,8 @@ result operand로 이를 추론해서는 안 된다.
 `func.tail_call_indirect`는 callable operand와 argument를 받고 result가 없는
 terminator다. Shared verifier checks complete caller/callee result-list agreement;
 logical CPS callables both retain `[core.never]` despite the resultless transfer
-operation. Final Native/Wasm signature lowering will change these to empty
-result lists; the current target ABI still uses temporary `[core.nil]` encoding.
+operation. 대상 ABI 변환은 검증된 CPS callable의 결과 목록을 원자적으로
+`[]`로 바꾸며 실제 Unit `[core.nil]`은 보존한다.
 
 `scf.*` represents structured control flow, including pattern/case regions and
 region yields. Loop-like forms may be introduced by optimization passes such as

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1808,6 +1808,170 @@ mod tests {
     }
 
     #[test]
+    fn evidence_lookup_preserves_marker_type_in_emitted_binary() {
+        let mut ctx = trunk_ir::IrContext::new();
+        let module = trunk_ir::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+                func.func @__tribute_evidence_lookup(%ev: wasm.arrayref, %id: core.i32) -> core.i32 { func.unreachable }
+            }"#,
+        );
+        tribute_passes::wasm::evidence_to_wasm::prepare_wasm_evidence_runtime(&mut ctx, module);
+        tribute_passes::wasm::lower::finalize_wasm_gc_types(&mut ctx, module).unwrap();
+        let binary = trunk_ir_wasm_backend::emit_module_to_wasm(&mut ctx, module).unwrap();
+        wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
+            .validate_all(&binary.bytes)
+            .expect("evidence lookup must retain concrete Marker locals and return type");
+    }
+
+    #[test]
+    fn root_dispatch_definition_matches_fixed_wasm_tail_signature_and_validates_binary() {
+        use tribute_core::calling_convention::cps_closure_function_type;
+        use tribute_ir::dialect::{ability, effect, tribute_rt};
+        use trunk_ir::dialect::{adt, wasm};
+        use trunk_ir::{Attribute, Symbol, TypeDataBuilder};
+        let (mut ctx, module) = source_logical_cps_root_module();
+        let worker = module
+            .ops(&ctx)
+            .into_iter()
+            .find_map(|op| func_dialect::Func::from_op(&ctx, op).ok())
+            .unwrap();
+        let entry = ctx.region(worker.body(&ctx)).blocks[0];
+        let args = ctx.block_args(entry).to_vec();
+        let frame = ctx.value_ty(args[1]);
+        let layout = ctx
+            .type_alias_by_name(ctx.types.get(frame).attrs.get_symbol("name").unwrap())
+            .unwrap();
+        let Attribute::List(fields) = ctx.types.get(layout).attrs.get("fields").unwrap() else {
+            panic!("frame fields")
+        };
+        let Attribute::List(dispatch_field) = &fields[1] else {
+            panic!("dispatch field")
+        };
+        let Attribute::Type(dispatch_type) = dispatch_field[1] else {
+            panic!("dispatch type")
+        };
+        let signature = cps_closure_function_type(&ctx, dispatch_type).unwrap();
+        let resume_type = func_dialect::FuncSig::from_type_ref(&ctx, signature)
+            .unwrap()
+            .inputs(&ctx)[1];
+        let location = ctx.op(worker.op_ref()).location;
+        let unreachable = ctx.block(entry).ops[0];
+        trunk_ir::rewrite::helpers::erase_op(&mut ctx, unreachable);
+        let dispatch = adt::struct_get(&mut ctx, location, args[1], dispatch_type, layout, 1);
+        ctx.push_op(entry, dispatch.op_ref());
+        let resume = adt::ref_null(&mut ctx, location, resume_type, resume_type);
+        ctx.push_op(entry, resume.op_ref());
+        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
+        let ability_type = ctx.types.intern(
+            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("ability_ref"))
+                .attr("name", Attribute::Symbol(Symbol::new("State")))
+                .build(),
+        );
+        // Match the canonical payload product and erasure used by perform lowering.
+        let payload_type =
+            ability::operation_payload_type_ref(&mut ctx, ability_type, Symbol::new("get"), []);
+        let product = adt::struct_new(&mut ctx, location, [], payload_type, payload_type);
+        ctx.push_op(entry, product.op_ref());
+        let value = product.result(&ctx);
+        let payload = core_dialect::unrealized_conversion_cast(&mut ctx, location, value, anyref);
+        ctx.push_op(entry, payload.op_ref());
+        let nil = core_dialect::nil(&mut ctx).as_type_ref();
+        let values = [
+            dispatch.result(&ctx),
+            resume.result(&ctx),
+            payload.result(&ctx),
+        ];
+        let transfer = effect::dispatch_cps(
+            &mut ctx,
+            location,
+            args[0],
+            values[0],
+            values[1],
+            values[2],
+            ability_type,
+            Symbol::new("get"),
+            nil,
+        );
+        ctx.push_op(entry, transfer.op_ref());
+        let boundary = enter_target_closure_storage_boundary(&mut ctx, module).unwrap();
+        finalize_target_closure_storage(&mut ctx, module, boundary);
+        let binary = compile_to_wasm(&mut ctx, module).unwrap_or_else(|error| {
+            panic!(
+                "{error}\n{}",
+                trunk_ir::printer::print_module(&ctx, module.op())
+            )
+        });
+        let dispatch_definition = module
+            .ops(&ctx)
+            .into_iter()
+            .find_map(|op| {
+                let function = wasm::Func::from_op(&ctx, op).ok()?;
+                (function.sym_name(&ctx) == Symbol::new("__tribute_root_dispatch"))
+                    .then_some(function.r#type(&ctx))
+            })
+            .unwrap();
+        let mut signatures = Vec::new();
+        let _ = trunk_ir::walk::walk_op::<()>(&ctx, module.op(), &mut |op| {
+            if wasm::ReturnCallIndirect::matches(&ctx, op) {
+                signatures.push(
+                    trunk_ir::op_interface::IndirectCallLikeOps::exact_signature(&ctx, op).unwrap(),
+                );
+            }
+            ControlFlow::Continue(WalkAction::Advance)
+        });
+        assert!(signatures.contains(&dispatch_definition));
+        let canonical_closure = tribute_passes::wasm::type_converter::closure_adt_type(&mut ctx);
+        let signature = wasm::FuncSig::from_type_ref(&ctx, dispatch_definition).unwrap();
+        assert_eq!(signature.inputs(&ctx)[2], canonical_closure);
+        assert!(signature.results(&ctx).is_empty());
+        let mut binary_dispatch_signatures = 0;
+        for payload in wasmparser::Parser::new(0).parse_all(&binary.bytes) {
+            if let wasmparser::Payload::TypeSection(types) = payload.unwrap() {
+                for group in types {
+                    for ty in group.unwrap().into_types() {
+                        if let wasmparser::CompositeInnerType::Func(signature) =
+                            ty.composite_type.inner
+                            && signature.params().len() == 7
+                        {
+                            use wasmparser::{RefType, ValType};
+                            let concrete = |index| {
+                                ValType::Ref(
+                                    RefType::new(
+                                        true,
+                                        wasmparser::HeapType::Concrete(
+                                            wasmparser::UnpackedIndex::Module(index),
+                                        ),
+                                    )
+                                    .unwrap(),
+                                )
+                            };
+                            assert_eq!(
+                                signature.params(),
+                                [
+                                    concrete(6),
+                                    ValType::Ref(RefType::ANYREF),
+                                    concrete(4),
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::Ref(RefType::ANYREF)
+                                ]
+                            );
+                            assert!(signature.results().is_empty());
+                            binary_dispatch_signatures += 1;
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(binary_dispatch_signatures, 1);
+        wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
+            .validate_all(&binary.bytes)
+            .expect("canonical root dispatch binary validates");
+    }
+
+    #[test]
     fn native_ownership_plan_options_follow_stage_policy_table() {
         let parameter_elision_only = NativeOptimizationOptions {
             paired_rc_elimination: PairedRcEliminationPolicy::Disabled,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1724,68 +1724,31 @@ mod tests {
     use super::*;
     use salsa_test_macros::salsa_test;
     use std::ops::ControlFlow;
-    use tribute_core::calling_convention::{
-        cps_continuation_frame_layout_type, cps_continuation_frame_ref_type, cps_dispatch_type,
-        cps_done_type,
-    };
     use trunk_ir::dialect::clif;
     use trunk_ir::ops::DialectType;
     use trunk_ir::walk::{WalkAction, walk_region};
 
-    fn source_logical_cps_root_module() -> (IrContext, Module) {
+    fn source_logical_cps_root_module(body: &str) -> (IrContext, Module) {
         let mut ctx = IrContext::new();
-        let module = trunk_ir::parser::parse_test_module(
-            &mut ctx,
-            r#"core.module @test {
-  func.func @main(%evidence: core.i32, %frame: core.i32) -> core.never attributes {tribute.calling_convention = 2} {
-    func.unreachable
-  }
-}"#,
-        );
-        let main = module
-            .ops(&ctx)
-            .into_iter()
-            .find_map(|op| func_dialect::Func::from_op(&ctx, op).ok())
-            .expect("test module must define main");
-        let nil = core_dialect::nil(&mut ctx).as_type_ref();
-        let never = core_dialect::never(&mut ctx).as_type_ref();
-        let evidence = tribute_ir::dialect::ability::evidence_adt_type_ref(&mut ctx);
-        let frame_name = trunk_ir::Symbol::new("__tribute_continuation_frame_root_nil");
-        let frame = cps_continuation_frame_ref_type(&mut ctx, frame_name, nil);
-        let done = cps_done_type(&mut ctx, nil);
-        let anyref = tribute_ir::dialect::tribute_rt::anyref(&mut ctx).as_type_ref();
-        let i32_ty = ctx.types.intern(
-            trunk_ir::TypeDataBuilder::new(
-                trunk_ir::Symbol::new("core"),
-                trunk_ir::Symbol::new("i32"),
-            )
-            .build(),
-        );
-        let dispatch = cps_dispatch_type(&mut ctx, evidence, frame, anyref, i32_ty);
-        let layout = cps_continuation_frame_layout_type(&mut ctx, frame_name, nil, done, dispatch);
-        ctx.register_type_alias(frame_name, layout);
-        let worker = func_dialect::func_sig(&mut ctx, [evidence, frame], [never]).as_type_ref();
-        ctx.op_mut(main.op_ref()).attributes.insert(
-            trunk_ir::Symbol::new("type"),
-            trunk_ir::Attribute::Type(worker),
-        );
-        let entry = ctx.region(main.body(&ctx)).blocks[0];
-        ctx.set_block_arg_type(entry, 0, evidence);
-        ctx.set_block_arg_type(entry, 1, frame);
-        ctx.op_mut(main.op_ref()).attributes.insert(
-            trunk_ir::Symbol::new("tribute.root_export_convention"),
-            trunk_ir::Attribute::Int(0),
-        );
-        ctx.op_mut(main.op_ref()).attributes.insert(
-            trunk_ir::Symbol::new("tribute.root_source_result"),
-            trunk_ir::Attribute::Type(nil),
-        );
+        let source = r#"core.module @test {
+            !Evidence = core.array(adt.struct() {name = @_Marker, fields = [[@ability_id, core.i32], [@prompt_tag, core.i32], [@tr_dispatch_fn, core.ptr], [@handler_dispatch, core.ptr]]})
+            !Frame = adt.typeref() {name = @__tribute_continuation_frame_root_nil, tribute.cps_continuation_frame_result = core.nil}
+            !Done = closure.closure(func.func_sig<(core.nil) -> core.never>) {tribute.calling_convention = 2, tribute.closure_environment_index = 0}
+            !Resume = closure.closure(func.func_sig<(!Evidence, !Frame, tribute_rt.anyref) -> core.never>) {tribute.calling_convention = 2, tribute.closure_environment_index = 0}
+            !Dispatch = closure.closure(func.func_sig<(!Evidence, !Resume, core.i32, core.i32, core.i32, tribute_rt.anyref) -> core.never>) {tribute.calling_convention = 2, tribute.closure_environment_index = 1}
+            !__tribute_continuation_frame_root_nil = adt.struct() {name = @__tribute_continuation_frame_root_nil, tribute.cps_continuation_frame_result = core.nil, fields = [[@done, !Done], [@dispatch, !Dispatch]]}
+            !Payload = adt.struct() {name = @__tribute_ability_payload_7590c57e, fields = []}
+            func.func @main(%evidence: !Evidence, %frame: !Frame) -> core.never attributes {tribute.calling_convention = 2, tribute.root_export_convention = 0, tribute.root_source_result = core.nil} {
+                BODY
+            }
+        }"#.replace("BODY", body);
+        let module = trunk_ir::parser::parse_test_module(&mut ctx, &source);
         (ctx, module)
     }
 
     #[test]
     fn source_logical_root_defers_closure_storage_until_target_finalization() {
-        let (mut ctx, module) = source_logical_cps_root_module();
+        let (mut ctx, module) = source_logical_cps_root_module("func.unreachable");
         let core_module = core_dialect::Module::from_op(&ctx, module.op())
             .expect("test module must be a core.module");
         let before = trunk_ir::printer::print_module(&ctx, module.op());
@@ -1809,46 +1772,14 @@ mod tests {
 
     #[test]
     fn empty_result_cps_root_executes_native_done_continuation() {
-        use tribute_core::calling_convention::cps_closure_function_type;
-        use trunk_ir::dialect::{adt, arith};
-        use trunk_ir::{Attribute, Symbol};
-        let (mut ctx, module) = source_logical_cps_root_module();
-        let worker = module
-            .ops(&ctx)
-            .into_iter()
-            .find_map(|op| func_dialect::Func::from_op(&ctx, op).ok())
-            .unwrap();
-        let entry = ctx.region(worker.body(&ctx)).blocks[0];
-        let frame_value = ctx.block_args(entry)[1];
-        let layout = ctx
-            .type_alias_by_name(Symbol::new("__tribute_continuation_frame_root_nil"))
-            .unwrap();
-        let Attribute::List(fields) = ctx.types.get(layout).attrs.get("fields").unwrap() else {
-            panic!("frame fields")
-        };
-        let Attribute::List(done_field) = &fields[0] else {
-            panic!("Done field")
-        };
-        let Attribute::Type(done_type) = done_field[1] else {
-            panic!("Done type")
-        };
-        let signature = cps_closure_function_type(&ctx, done_type).unwrap();
-        let location = ctx.op(worker.op_ref()).location;
-        let unreachable = ctx.block(entry).ops[0];
-        trunk_ir::rewrite::helpers::erase_op(&mut ctx, unreachable);
-        let done = adt::struct_get(&mut ctx, location, frame_value, done_type, layout, 0);
-        ctx.push_op(entry, done.op_ref());
-        let nil = core_dialect::nil(&mut ctx).as_type_ref();
-        let value = arith::r#const(&mut ctx, location, nil, Attribute::Unit);
-        ctx.push_op(entry, value.op_ref());
-        let callee = done.result(&ctx);
-        let answer = value.result(&ctx);
-        let tail =
-            func_dialect::tail_call_indirect(&mut ctx, location, callee, [answer], Some(signature));
-        ctx.op_mut(tail.op_ref())
-            .attributes
-            .insert(Symbol::new("tribute.calling_convention"), Attribute::Int(2));
-        ctx.push_op(entry, tail.op_ref());
+        use trunk_ir::Symbol;
+        let (mut ctx, module) = source_logical_cps_root_module(
+            r#"
+            %done = adt.struct_get %frame {field = 0, type = !__tribute_continuation_frame_root_nil} : !Done
+            %nil = arith.const {value = unit} : core.nil
+            func.tail_call_indirect %done, %nil {signature = func.func_sig<(core.nil) -> core.never>, tribute.calling_convention = 2}
+        "#,
+        );
 
         run_native_target_pipeline(&mut ctx, module)
             .expect("logical CPS root crosses native boundary");
@@ -1906,7 +1837,8 @@ mod tests {
                 func.func @__tribute_evidence_lookup(%ev: wasm.arrayref, %id: core.i32) -> core.i32 { func.unreachable }
             }"#,
         );
-        tribute_passes::wasm::evidence_to_wasm::prepare_wasm_evidence_runtime(&mut ctx, module);
+        tribute_passes::wasm::evidence_to_wasm::prepare_wasm_evidence_runtime(&mut ctx, module)
+            .unwrap();
         tribute_passes::wasm::lower::finalize_wasm_gc_types(&mut ctx, module).unwrap();
         let binary = trunk_ir_wasm_backend::emit_module_to_wasm(&mut ctx, module).unwrap();
         wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
@@ -1916,74 +1848,17 @@ mod tests {
 
     #[test]
     fn root_dispatch_definition_matches_fixed_wasm_tail_signature_and_validates_binary() {
-        use tribute_core::calling_convention::cps_closure_function_type;
-        use tribute_ir::dialect::{ability, effect, tribute_rt};
-        use trunk_ir::dialect::{adt, wasm};
-        use trunk_ir::{Attribute, Symbol, TypeDataBuilder};
-        let (mut ctx, module) = source_logical_cps_root_module();
-        let worker = module
-            .ops(&ctx)
-            .into_iter()
-            .find_map(|op| func_dialect::Func::from_op(&ctx, op).ok())
-            .unwrap();
-        let entry = ctx.region(worker.body(&ctx)).blocks[0];
-        let args = ctx.block_args(entry).to_vec();
-        let frame = ctx.value_ty(args[1]);
-        let layout = ctx
-            .type_alias_by_name(ctx.types.get(frame).attrs.get_symbol("name").unwrap())
-            .unwrap();
-        let Attribute::List(fields) = ctx.types.get(layout).attrs.get("fields").unwrap() else {
-            panic!("frame fields")
-        };
-        let Attribute::List(dispatch_field) = &fields[1] else {
-            panic!("dispatch field")
-        };
-        let Attribute::Type(dispatch_type) = dispatch_field[1] else {
-            panic!("dispatch type")
-        };
-        let signature = cps_closure_function_type(&ctx, dispatch_type).unwrap();
-        let resume_type = func_dialect::FuncSig::from_type_ref(&ctx, signature)
-            .unwrap()
-            .inputs(&ctx)[1];
-        let location = ctx.op(worker.op_ref()).location;
-        let unreachable = ctx.block(entry).ops[0];
-        trunk_ir::rewrite::helpers::erase_op(&mut ctx, unreachable);
-        let dispatch = adt::struct_get(&mut ctx, location, args[1], dispatch_type, layout, 1);
-        ctx.push_op(entry, dispatch.op_ref());
-        let resume = adt::ref_null(&mut ctx, location, resume_type, resume_type);
-        ctx.push_op(entry, resume.op_ref());
-        let anyref = tribute_rt::anyref(&mut ctx).as_type_ref();
-        let ability_type = ctx.types.intern(
-            TypeDataBuilder::new(Symbol::new("core"), Symbol::new("ability_ref"))
-                .attr("name", Attribute::Symbol(Symbol::new("State")))
-                .build(),
+        use trunk_ir::Symbol;
+        use trunk_ir::dialect::wasm;
+        let (mut ctx, module) = source_logical_cps_root_module(
+            r#"
+            %dispatch = adt.struct_get %frame {field = 1, type = !__tribute_continuation_frame_root_nil} : !Dispatch
+            %resume = adt.ref_null {type = !Resume} : !Resume
+            %product = adt.struct_new {type = !Payload} : !Payload
+            %payload = core.unrealized_conversion_cast %product : tribute_rt.anyref
+            effect.dispatch_cps %evidence, %dispatch, %resume, %payload {ability_ref = core.ability_ref() {name = @State}, op_name = @get, answer_type = core.nil}
+        "#,
         );
-        // Match the canonical payload product and erasure used by perform lowering.
-        let payload_type =
-            ability::operation_payload_type_ref(&mut ctx, ability_type, Symbol::new("get"), []);
-        let product = adt::struct_new(&mut ctx, location, [], payload_type, payload_type);
-        ctx.push_op(entry, product.op_ref());
-        let value = product.result(&ctx);
-        let payload = core_dialect::unrealized_conversion_cast(&mut ctx, location, value, anyref);
-        ctx.push_op(entry, payload.op_ref());
-        let nil = core_dialect::nil(&mut ctx).as_type_ref();
-        let values = [
-            dispatch.result(&ctx),
-            resume.result(&ctx),
-            payload.result(&ctx),
-        ];
-        let transfer = effect::dispatch_cps(
-            &mut ctx,
-            location,
-            args[0],
-            values[0],
-            values[1],
-            values[2],
-            ability_type,
-            Symbol::new("get"),
-            nil,
-        );
-        ctx.push_op(entry, transfer.op_ref());
         let boundary = enter_target_closure_storage_boundary(&mut ctx, module).unwrap();
         finalize_target_closure_storage(&mut ctx, module, boundary);
         let binary = compile_to_wasm(&mut ctx, module).unwrap_or_else(|error| {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1808,6 +1808,96 @@ mod tests {
     }
 
     #[test]
+    fn empty_result_cps_root_executes_native_done_continuation() {
+        use tribute_core::calling_convention::cps_closure_function_type;
+        use trunk_ir::dialect::{adt, arith};
+        use trunk_ir::{Attribute, Symbol};
+        let (mut ctx, module) = source_logical_cps_root_module();
+        let worker = module
+            .ops(&ctx)
+            .into_iter()
+            .find_map(|op| func_dialect::Func::from_op(&ctx, op).ok())
+            .unwrap();
+        let entry = ctx.region(worker.body(&ctx)).blocks[0];
+        let frame_value = ctx.block_args(entry)[1];
+        let layout = ctx
+            .type_alias_by_name(Symbol::new("__tribute_continuation_frame_root_nil"))
+            .unwrap();
+        let Attribute::List(fields) = ctx.types.get(layout).attrs.get("fields").unwrap() else {
+            panic!("frame fields")
+        };
+        let Attribute::List(done_field) = &fields[0] else {
+            panic!("Done field")
+        };
+        let Attribute::Type(done_type) = done_field[1] else {
+            panic!("Done type")
+        };
+        let signature = cps_closure_function_type(&ctx, done_type).unwrap();
+        let location = ctx.op(worker.op_ref()).location;
+        let unreachable = ctx.block(entry).ops[0];
+        trunk_ir::rewrite::helpers::erase_op(&mut ctx, unreachable);
+        let done = adt::struct_get(&mut ctx, location, frame_value, done_type, layout, 0);
+        ctx.push_op(entry, done.op_ref());
+        let nil = core_dialect::nil(&mut ctx).as_type_ref();
+        let value = arith::r#const(&mut ctx, location, nil, Attribute::Unit);
+        ctx.push_op(entry, value.op_ref());
+        let callee = done.result(&ctx);
+        let answer = value.result(&ctx);
+        let tail =
+            func_dialect::tail_call_indirect(&mut ctx, location, callee, [answer], Some(signature));
+        ctx.op_mut(tail.op_ref())
+            .attributes
+            .insert(Symbol::new("tribute.calling_convention"), Attribute::Int(2));
+        ctx.push_op(entry, tail.op_ref());
+
+        run_native_target_pipeline(&mut ctx, module)
+            .expect("logical CPS root crosses native boundary");
+        for name in [
+            "__tribute_cps_main",
+            "__tribute_root_done_k",
+            "__tribute_root_dispatch",
+        ] {
+            let function = module
+                .ops(&ctx)
+                .into_iter()
+                .find_map(|op| {
+                    let function = func_dialect::Func::from_op(&ctx, op).ok()?;
+                    (function.sym_name(&ctx) == Symbol::from_dynamic(name)).then_some(function)
+                })
+                .expect("root bridge function remains present");
+            assert_eq!(
+                tribute_core::get_calling_convention(&ctx, function.op_ref()),
+                Some(tribute_core::CallingConvention::Cps)
+            );
+            assert!(
+                func_dialect::FuncSig::from_type_ref(&ctx, function.r#type(&ctx))
+                    .unwrap()
+                    .results(&ctx)
+                    .is_empty()
+            );
+        }
+        let object = compile_module_to_native(
+            &mut ctx,
+            module,
+            false,
+            NativeOptimizationOptions::production(),
+        )
+        .expect("empty-result root emits native code");
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("empty-result-cps-root");
+        link_native_binary(&object, &executable).expect("empty-result root links");
+        let output = std::process::Command::new(executable)
+            .output()
+            .expect("empty-result root starts");
+        assert!(
+            output.status.success(),
+            "native root failed: {:?}\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
     fn evidence_lookup_preserves_marker_type_in_emitted_binary() {
         let mut ctx = trunk_ir::IrContext::new();
         let module = trunk_ir::parser::parse_test_module(


### PR DESCRIPTION
`effect.dispatch_cps`의 의미적 answer 계약을 검증한 뒤 논리 CPS 결과
`[core.never]`를 물리 ABI의 `[]`로 원자적으로 전환합니다.

- 필수 `answer_type: Type`은 정확한 `ContinuationFrame<R>`의 `R`입니다.
  Payload packing 전에 evidence/dispatch/resume, nominal frame, convention과
  environment 위치를 검증하며, 이미 packed된 payload는 정확한
  `tribute_rt.anyref`여야 합니다.
- Native/Wasm 최종 dispatch signature는 operand에서 추론하지 않고 대상별
  고정 ABI로 구성합니다. 서로 다른 유효한 `R`도 같은 signature를 사용하며,
  `answer_type`은 effect operation 제거 시 소비합니다.
- Root worker/Done/Dispatch, callable metadata, aliases, constants, indirect
  signatures와 재귀 type attributes를 함께 전환합니다. 실제 `[core.nil]`과
  Direct/EvidenceDirect의 빈 결과 목록은 보존합니다. 잘못된 계약은 기존 IR을
  변경하기 전에 거부합니다.

Wasm binary 검증 중 발견한 기존 Marker/Evidence 타입 등록 누락도 제한적으로
수정했습니다. 기준 commit `b2a43db746ea1acd2072dee6831cdf2e82a3b8b4`와 수정 전
작업본에서 동일한 Marker-only harness의 IR/WAT/binary가 일치했고, 두 binary 모두
offset `0xcf`에서 구체 Marker 대신 `anyref` local을 사용하여 검증에 실패했습니다.
Builtin builder를 건너뛰면서 전체 Marker 선언과 이를 원소로 가진 Evidence의
TypeRef 등록이 빠지는 원인입니다. 기존 builtin layout과 field 역할을 검증한 뒤
기존 emitter map에 등록하며, cast 추가나 storage/provenance 재설계는 없습니다.

검증:

- Payload 타입 변조, 누락/잘못된 answer, 다른 nominal frame, convention/environment
  불일치의 사전 거부 및 IR/alias/reference 불변 회귀.
- Direct/EvidenceDirect `[]`, 실제 nil, 논리/물리 closure-tail, 고정 target signature,
  incompatible same-named Marker와 generic reference의 구별 회귀.
- 새 empty-result root 경로가 실제 Native target pipeline을 통과하여
  compile/link/execute에 성공하고 Done continuation을 실행합니다.
- Marker-only 및 root Wasm binary 검증에 성공하며, root definition/indirect
  signature 일치와 최종 7개 입력 및 빈 결과 목록을 직접 확인합니다.
- Workspace 2,136 tests passed, 기존 Wasmtime CLI 요구 테스트 2개 skipped.
  정상 commit hooks도 통과했습니다. 전체 실행에서 일시적인 output-handle
  경고가 발생한 기존 테스트들은 개별 재실행에서 모두 경고 없이 통과했습니다.
- Workspace/all-targets Clippy `-D warnings`, formatting, diff check,
  Markdown lint(40 files) 통과. CI와 coverage 결과는 아직 대기 중입니다.

#825는 이 선행 변경에 의존하는 별도 통합 작업으로 남습니다.

Closes #961


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CPS tail-call handling for functions with no return values.
  - Added stricter validation for effect dispatch operations, callable signatures, and closure contracts.
  - Prevented invalid modules from being partially modified when validation fails.
  - Standardized dispatch signatures across native and WebAssembly targets.
  - Improved WebAssembly validation for Marker and Evidence layouts.

- **Documentation**
  - Updated CPS effects, ABI, intermediate representation, and backend documentation.

- **Tests**
  - Expanded coverage for dispatch signatures, closure storage, WebAssembly output, and empty-result CPS functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->