### PR TITLE
fix(scf): detect callable exits through interface

### DIFF
--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -251,26 +251,11 @@ fn hash_type(ctx: &IrContext, ty: TypeRef) -> u32 {
 
 use trunk_ir::op_interface::{CallableExitModel, CallableExitOps, ControlFlowInterfaceError};
 
-fn resultless_callable_exit(
-    ctx: &trunk_ir::IrContext,
-    op: trunk_ir::OpRef,
-) -> Result<(), ControlFlowInterfaceError> {
-    if !ctx.op_results(op).is_empty() {
-        Err(ControlFlowInterfaceError::new(
-            "CallableExit must not produce SSA results",
-        ))
-    } else if !ctx.op(op).successors.is_empty() {
-        Err(ControlFlowInterfaceError::new(
-            "CallableExit must not have block successors",
-        ))
-    } else {
-        Ok(())
-    }
-}
-
 impl CallableExitModel for Perform {
-    fn exits_callable(self, ctx: &trunk_ir::IrContext) -> Result<(), ControlFlowInterfaceError> {
-        resultless_callable_exit(ctx, self.op_ref())?;
+    fn verify_callable_exit(
+        &self,
+        ctx: &trunk_ir::IrContext,
+    ) -> Result<(), ControlFlowInterfaceError> {
         let data = ctx.op(self.op_ref());
         if data.regions.is_empty()
             && ctx.op_operands(self.op_ref()).len() >= 3
@@ -287,8 +272,14 @@ impl CallableExitModel for Perform {
 }
 
 impl CallableExitModel for HandleDispatch {
-    fn exits_callable(self, ctx: &trunk_ir::IrContext) -> Result<(), ControlFlowInterfaceError> {
-        resultless_callable_exit(ctx, self.op_ref())?;
+    fn allows_nested_regions(&self, _ctx: &trunk_ir::IrContext) -> bool {
+        true
+    }
+
+    fn verify_callable_exit(
+        &self,
+        ctx: &trunk_ir::IrContext,
+    ) -> Result<(), ControlFlowInterfaceError> {
         let data = ctx.op(self.op_ref());
         if data.regions.len() == 1
             && ctx.region(data.regions[0]).blocks.len() == 1

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -249,6 +249,64 @@ fn hash_type(ctx: &IrContext, ty: TypeRef) -> u32 {
 
 // === Pure operation registrations ===
 
+use trunk_ir::op_interface::{CallableExitModel, CallableExitOps, ControlFlowInterfaceError};
+
+fn resultless_callable_exit(
+    ctx: &trunk_ir::IrContext,
+    op: trunk_ir::OpRef,
+) -> Result<(), ControlFlowInterfaceError> {
+    if !ctx.op_results(op).is_empty() {
+        Err(ControlFlowInterfaceError::new(
+            "CallableExit must not produce SSA results",
+        ))
+    } else if !ctx.op(op).successors.is_empty() {
+        Err(ControlFlowInterfaceError::new(
+            "CallableExit must not have block successors",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+impl CallableExitModel for Perform {
+    fn exits_callable(self, ctx: &trunk_ir::IrContext) -> Result<(), ControlFlowInterfaceError> {
+        resultless_callable_exit(ctx, self.op_ref())?;
+        let data = ctx.op(self.op_ref());
+        if data.regions.is_empty()
+            && ctx.op_operands(self.op_ref()).len() >= 3
+            && data.attributes.get_type("ability_ref").is_some()
+            && data.attributes.get_symbol("op_name").is_some()
+        {
+            Ok(())
+        } else {
+            Err(ControlFlowInterfaceError::new(
+                "ability.perform CallableExit has an invalid final CPS shape",
+            ))
+        }
+    }
+}
+
+impl CallableExitModel for HandleDispatch {
+    fn exits_callable(self, ctx: &trunk_ir::IrContext) -> Result<(), ControlFlowInterfaceError> {
+        resultless_callable_exit(ctx, self.op_ref())?;
+        let data = ctx.op(self.op_ref());
+        if data.regions.len() == 1
+            && ctx.region(data.regions[0]).blocks.len() == 1
+            && ctx.op_operands(self.op_ref()).len() >= 2
+            && data.attributes.contains_key("ability_refs")
+        {
+            Ok(())
+        } else {
+            Err(ControlFlowInterfaceError::new(
+                "ability.handle_dispatch CallableExit has an invalid final delimiter shape",
+            ))
+        }
+    }
+}
+
+inventory::submit! { CallableExitOps::register::<Perform>() }
+inventory::submit! { CallableExitOps::register::<HandleDispatch>() }
+
 inventory::submit! { trunk_ir::op_interface::PureOps::register("ability", "evidence_lookup") }
 inventory::submit! { trunk_ir::op_interface::PureOps::register("ability", "evidence_extend") }
 

--- a/crates/tribute-ir/src/dialect/ability.rs
+++ b/crates/tribute-ir/src/dialect/ability.rs
@@ -293,7 +293,14 @@ impl CallableExitModel for HandleDispatch {
         if data.regions.len() == 1
             && ctx.region(data.regions[0]).blocks.len() == 1
             && ctx.op_operands(self.op_ref()).len() >= 2
-            && data.attributes.contains_key("ability_refs")
+            && matches!(
+                data.attributes.get("ability_refs"),
+                Some(trunk_ir::types::Attribute::List(ability_refs))
+                    if ability_refs.iter().all(|ability_ref| matches!(
+                        ability_ref,
+                        trunk_ir::types::Attribute::Type(_)
+                    ))
+            )
         {
             Ok(())
         } else {
@@ -549,6 +556,8 @@ pub fn is_evidence_type_ref(ctx: &IrContext, ty: TypeRef) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use trunk_ir::op_interface::CallableExitOps;
+    use trunk_ir::ops::DialectOp;
 
     #[test]
     fn test_marker_adt_type_ref() {
@@ -698,5 +707,29 @@ mod tests {
         let ev1 = evidence_adt_type_ref(&mut ctx);
         let ev2 = evidence_adt_type_ref(&mut ctx);
         assert_eq!(ev1, ev2, "evidence types should be deduplicated");
+    }
+
+    #[test]
+    fn callable_exit_rejects_malformed_ability_refs_attribute() {
+        for ability_refs in ["@not_a_list", "[1]"] {
+            let mut ctx = IrContext::new();
+            let module = trunk_ir::parser::parse_test_module(
+                &mut ctx,
+                &format!(
+                    r#"core.module @test {{
+  func.func @main(%evidence: core.ptr, %prompt: core.i32) {{
+    ability.handle_dispatch %evidence, %prompt {{ability_refs = {ability_refs}}} {{
+      func.unreachable
+    }}
+  }}
+}}"#
+                ),
+            );
+            let function = trunk_ir::dialect::func::Func::from_op(&ctx, module.ops(&ctx)[0])
+                .expect("function");
+            let handle = ctx.block(ctx.region(function.body(&ctx)).blocks[0]).ops[0];
+
+            assert!(CallableExitOps::exits_callable(&ctx, handle).is_err());
+        }
     }
 }

--- a/crates/tribute-ir/src/dialect/effect.rs
+++ b/crates/tribute-ir/src/dialect/effect.rs
@@ -48,29 +48,11 @@ mod effect {
 
 inventory::submit! { trunk_ir::op_interface::PureOps::register("effect", "extend") }
 
-fn resultless_callable_exit(
-    ctx: &trunk_ir::IrContext,
-    op: trunk_ir::OpRef,
-) -> Result<(), trunk_ir::op_interface::ControlFlowInterfaceError> {
-    if !ctx.op_results(op).is_empty() {
-        Err(trunk_ir::op_interface::ControlFlowInterfaceError::new(
-            "CallableExit must not produce SSA results",
-        ))
-    } else if !ctx.op(op).regions.is_empty() || !ctx.op(op).successors.is_empty() {
-        Err(trunk_ir::op_interface::ControlFlowInterfaceError::new(
-            "CallableExit must not contain nested regions or block successors",
-        ))
-    } else {
-        Ok(())
-    }
-}
-
 impl trunk_ir::op_interface::CallableExitModel for DispatchCps {
-    fn exits_callable(
-        self,
+    fn verify_callable_exit(
+        &self,
         ctx: &trunk_ir::IrContext,
     ) -> Result<(), trunk_ir::op_interface::ControlFlowInterfaceError> {
-        resultless_callable_exit(ctx, self.op_ref())?;
         let data = ctx.op(self.op_ref());
         if ctx.op_operands(self.op_ref()).len() == 4
             && data.attributes.get_type("ability_ref").is_some()

--- a/crates/tribute-ir/src/dialect/effect.rs
+++ b/crates/tribute-ir/src/dialect/effect.rs
@@ -48,6 +48,46 @@ mod effect {
 
 inventory::submit! { trunk_ir::op_interface::PureOps::register("effect", "extend") }
 
+fn resultless_callable_exit(
+    ctx: &trunk_ir::IrContext,
+    op: trunk_ir::OpRef,
+) -> Result<(), trunk_ir::op_interface::ControlFlowInterfaceError> {
+    if !ctx.op_results(op).is_empty() {
+        Err(trunk_ir::op_interface::ControlFlowInterfaceError::new(
+            "CallableExit must not produce SSA results",
+        ))
+    } else if !ctx.op(op).regions.is_empty() || !ctx.op(op).successors.is_empty() {
+        Err(trunk_ir::op_interface::ControlFlowInterfaceError::new(
+            "CallableExit must not contain nested regions or block successors",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+impl trunk_ir::op_interface::CallableExitModel for DispatchCps {
+    fn exits_callable(
+        self,
+        ctx: &trunk_ir::IrContext,
+    ) -> Result<(), trunk_ir::op_interface::ControlFlowInterfaceError> {
+        resultless_callable_exit(ctx, self.op_ref())?;
+        let data = ctx.op(self.op_ref());
+        if ctx.op_operands(self.op_ref()).len() == 4
+            && data.attributes.get_type("ability_ref").is_some()
+            && data.attributes.get_symbol("op_name").is_some()
+            && data.attributes.get_type("answer_type").is_some()
+        {
+            Ok(())
+        } else {
+            Err(trunk_ir::op_interface::ControlFlowInterfaceError::new(
+                "effect.dispatch_cps CallableExit has an invalid final CPS shape",
+            ))
+        }
+    }
+}
+
+inventory::submit! { trunk_ir::op_interface::CallableExitOps::register::<DispatchCps>() }
+
 #[cfg(test)]
 mod tests {
     use trunk_ir::ops::DialectOp;

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -397,9 +397,13 @@ impl CallableExitModel for TailCallIndirect {
                 "func.tail_call_indirect CallableExit requires a callee operand",
             ));
         }
-        match ctx.op(self.op_ref()).attributes.get_type("signature") {
+        match ctx.op(self.op_ref()).attributes.get("signature") {
             None => Ok(()),
-            Some(signature) if FuncSig::from_type_ref(ctx, signature).is_some() => Ok(()),
+            Some(Attribute::Type(signature))
+                if FuncSig::from_type_ref(ctx, *signature).is_some() =>
+            {
+                Ok(())
+            }
             Some(_) => Err(ControlFlowInterfaceError::new(
                 "func.tail_call_indirect CallableExit has an invalid exact signature",
             )),
@@ -696,7 +700,7 @@ inventory::submit! { crate::op_interface::CallableOwnerOps::register::<Func>() }
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::op_interface::IndirectCallLikeOps;
+    use crate::op_interface::{CallableExitOps, IndirectCallLikeOps};
     use crate::ops::DialectOp;
     use crate::parser::parse_test_module;
     use crate::printer::print_module;
@@ -775,6 +779,26 @@ mod tests {
         assert!(IndirectCallLikeOps::get(&ctx, direct_op).is_none());
         assert_eq!(IndirectCallLikeOps::callee(&ctx, direct_op), None);
         assert_eq!(IndirectCallLikeOps::arguments(&ctx, direct_op), None);
+    }
+
+    #[test]
+    fn callable_exit_rejects_wrong_kind_indirect_tail_signature() {
+        let mut ctx = crate::IrContext::new();
+        let module = parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @tail(%callee: func.func_sig<() -> ()>) {
+    func.tail_call_indirect %callee
+  }
+}"#,
+        );
+        let function = Func::from_op(&ctx, module.ops(&ctx)[0]).expect("tail function");
+        let tail = ctx.block(ctx.region(function.body(&ctx)).blocks[0]).ops[0];
+        ctx.op_mut(tail)
+            .attributes
+            .insert(Symbol::new("signature"), Attribute::Int(0));
+
+        assert!(CallableExitOps::exits_callable(&ctx, tail).is_err());
     }
 }
 

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -348,32 +348,13 @@ impl IndirectCallLikeModel for TailCallIndirect {
 
 impl TailCallLike for TailCallIndirect {}
 
-fn resultless_callable_exit(
-    ctx: &crate::IrContext,
-    op: crate::OpRef,
-) -> Result<(), ControlFlowInterfaceError> {
-    if !ctx.op_results(op).is_empty() {
-        Err(ControlFlowInterfaceError::new(
-            "CallableExit must not produce SSA results",
-        ))
-    } else if !ctx.op(op).regions.is_empty() || !ctx.op(op).successors.is_empty() {
-        Err(ControlFlowInterfaceError::new(
-            "CallableExit must not contain nested regions or block successors",
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-impl CallableExitModel for Return {
-    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
-        resultless_callable_exit(ctx, self.op_ref())
-    }
-}
+impl CallableExitModel for Return {}
 
 impl CallableExitModel for TailCall {
-    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
-        resultless_callable_exit(ctx, self.op_ref())?;
+    fn verify_callable_exit(
+        &self,
+        ctx: &crate::IrContext,
+    ) -> Result<(), ControlFlowInterfaceError> {
         if ctx
             .op(self.op_ref())
             .attributes
@@ -390,8 +371,10 @@ impl CallableExitModel for TailCall {
 }
 
 impl CallableExitModel for TailCallIndirect {
-    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
-        resultless_callable_exit(ctx, self.op_ref())?;
+    fn verify_callable_exit(
+        &self,
+        ctx: &crate::IrContext,
+    ) -> Result<(), ControlFlowInterfaceError> {
         if ctx.op_operands(self.op_ref()).is_empty() {
             return Err(ControlFlowInterfaceError::new(
                 "func.tail_call_indirect CallableExit requires a callee operand",
@@ -412,8 +395,10 @@ impl CallableExitModel for TailCallIndirect {
 }
 
 impl CallableExitModel for Unreachable {
-    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
-        resultless_callable_exit(ctx, self.op_ref())?;
+    fn verify_callable_exit(
+        &self,
+        ctx: &crate::IrContext,
+    ) -> Result<(), ControlFlowInterfaceError> {
         if ctx.op_operands(self.op_ref()).is_empty() {
             Ok(())
         } else {

--- a/crates/trunk-ir/src/dialect/func.rs
+++ b/crates/trunk-ir/src/dialect/func.rs
@@ -1,6 +1,9 @@
 //! Arena-based func dialect.
 
-use crate::op_interface::{IndirectCallLikeModel, IndirectCallLikeOps};
+use crate::op_interface::{
+    CallableExitModel, CallableExitOps, ControlFlowInterfaceError, IndirectCallLikeModel,
+    IndirectCallLikeOps,
+};
 use crate::ops::{DialectOp, DialectType};
 use crate::{Attribute, AttributeMap, IrContext, Symbol, TypeDataBuilder, TypeRef};
 
@@ -344,6 +347,83 @@ impl IndirectCallLikeModel for TailCallIndirect {
 }
 
 impl TailCallLike for TailCallIndirect {}
+
+fn resultless_callable_exit(
+    ctx: &crate::IrContext,
+    op: crate::OpRef,
+) -> Result<(), ControlFlowInterfaceError> {
+    if !ctx.op_results(op).is_empty() {
+        Err(ControlFlowInterfaceError::new(
+            "CallableExit must not produce SSA results",
+        ))
+    } else if !ctx.op(op).regions.is_empty() || !ctx.op(op).successors.is_empty() {
+        Err(ControlFlowInterfaceError::new(
+            "CallableExit must not contain nested regions or block successors",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+impl CallableExitModel for Return {
+    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
+        resultless_callable_exit(ctx, self.op_ref())
+    }
+}
+
+impl CallableExitModel for TailCall {
+    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
+        resultless_callable_exit(ctx, self.op_ref())?;
+        if ctx
+            .op(self.op_ref())
+            .attributes
+            .get_symbol("callee")
+            .is_some()
+        {
+            Ok(())
+        } else {
+            Err(ControlFlowInterfaceError::new(
+                "func.tail_call CallableExit requires a callee symbol",
+            ))
+        }
+    }
+}
+
+impl CallableExitModel for TailCallIndirect {
+    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
+        resultless_callable_exit(ctx, self.op_ref())?;
+        if ctx.op_operands(self.op_ref()).is_empty() {
+            return Err(ControlFlowInterfaceError::new(
+                "func.tail_call_indirect CallableExit requires a callee operand",
+            ));
+        }
+        match ctx.op(self.op_ref()).attributes.get_type("signature") {
+            None => Ok(()),
+            Some(signature) if FuncSig::from_type_ref(ctx, signature).is_some() => Ok(()),
+            Some(_) => Err(ControlFlowInterfaceError::new(
+                "func.tail_call_indirect CallableExit has an invalid exact signature",
+            )),
+        }
+    }
+}
+
+impl CallableExitModel for Unreachable {
+    fn exits_callable(self, ctx: &crate::IrContext) -> Result<(), ControlFlowInterfaceError> {
+        resultless_callable_exit(ctx, self.op_ref())?;
+        if ctx.op_operands(self.op_ref()).is_empty() {
+            Ok(())
+        } else {
+            Err(ControlFlowInterfaceError::new(
+                "func.unreachable CallableExit must not have operands",
+            ))
+        }
+    }
+}
+
+inventory::submit! { CallableExitOps::register::<Return>() }
+inventory::submit! { CallableExitOps::register::<TailCall>() }
+inventory::submit! { CallableExitOps::register::<TailCallIndirect>() }
+inventory::submit! { CallableExitOps::register::<Unreachable>() }
 
 inventory::submit! {
     IndirectCallLikeOps::register::<CallIndirect>()

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -456,6 +456,104 @@ impl CallableOwnerOps {
     }
 }
 
+/// Object-safe semantic query for operations that leave the current callable.
+///
+/// Callable exits are distinct from generic structured-region terminators:
+/// a yield, break, or continue can transfer control to an enclosing structured
+/// operation, while a callable exit cannot execute a following operation in
+/// that callable.
+pub trait CallableExit: Sync {
+    fn exits_callable(&self, ctx: &IrContext, op: OpRef) -> Result<(), ControlFlowInterfaceError>;
+}
+
+/// Typed callable-exit semantics supplied by a generated dialect operation
+/// wrapper. Implementations must reject malformed operations rather than
+/// treating registration alone as proof of termination.
+pub trait CallableExitModel: DialectOp {
+    fn exits_callable(self, ctx: &IrContext) -> Result<(), ControlFlowInterfaceError>;
+}
+
+fn callable_exit_model<T: CallableExitModel>(
+    ctx: &IrContext,
+    op: OpRef,
+) -> Result<(), ControlFlowInterfaceError> {
+    let model = T::from_op(ctx, op).map_err(|error| {
+        ControlFlowInterfaceError::new(format!(
+            "malformed {}.{}: {error:?}",
+            T::DIALECT_NAME,
+            T::OP_NAME
+        ))
+    })?;
+    model.exits_callable(ctx)
+}
+
+/// Registry entry for [`CallableExit`].
+pub struct CallableExitRegistration {
+    dialect: &'static str,
+    op_name: &'static str,
+    exits_callable: fn(&IrContext, OpRef) -> Result<(), ControlFlowInterfaceError>,
+}
+
+impl CallableExit for CallableExitRegistration {
+    fn exits_callable(&self, ctx: &IrContext, op: OpRef) -> Result<(), ControlFlowInterfaceError> {
+        (self.exits_callable)(ctx, op)
+    }
+}
+
+inventory::collect!(CallableExitRegistration);
+
+static CALLABLE_EXIT_REGISTRY: LazyLock<
+    HashMap<(Symbol, Symbol), &'static CallableExitRegistration>,
+> = LazyLock::new(|| {
+    let mut registry = HashMap::new();
+    for registration in inventory::iter::<CallableExitRegistration> {
+        let key = (
+            Symbol::from_dynamic(registration.dialect),
+            Symbol::from_dynamic(registration.op_name),
+        );
+        assert!(
+            registry.insert(key, registration).is_none(),
+            "duplicate CallableExit registration for '{}.{}'",
+            registration.dialect,
+            registration.op_name,
+        );
+    }
+    registry
+});
+
+/// Dynamic query and registration entry point for [`CallableExit`].
+pub struct CallableExitOps;
+
+impl CallableExitOps {
+    #[doc(hidden)]
+    pub const fn register<T: CallableExitModel>() -> CallableExitRegistration {
+        CallableExitRegistration {
+            dialect: T::DIALECT_NAME,
+            op_name: T::OP_NAME,
+            exits_callable: callable_exit_model::<T>,
+        }
+    }
+
+    pub fn get(ctx: &IrContext, op: OpRef) -> Option<&'static dyn CallableExit> {
+        let data = ctx.op(op);
+        CALLABLE_EXIT_REGISTRY
+            .get(&(data.dialect, data.name))
+            .map(|registration| *registration as &dyn CallableExit)
+    }
+
+    /// Prove that an operation leaves the current callable.
+    ///
+    /// A missing registration and a failed typed query are both errors so
+    /// generic consumers remain conservative.
+    pub fn exits_callable(ctx: &IrContext, op: OpRef) -> Result<(), ControlFlowInterfaceError> {
+        Self::get(ctx, op)
+            .ok_or_else(|| {
+                ControlFlowInterfaceError::new("operation has no CallableExit registration")
+            })?
+            .exits_callable(ctx, op)
+    }
+}
+
 /// Object-safe semantic accessors for indirect calls.
 ///
 /// An exact signature is optional on otherwise valid ordinary indirect

--- a/crates/trunk-ir/src/op_interface.rs
+++ b/crates/trunk-ir/src/op_interface.rs
@@ -467,10 +467,40 @@ pub trait CallableExit: Sync {
 }
 
 /// Typed callable-exit semantics supplied by a generated dialect operation
-/// wrapper. Implementations must reject malformed operations rather than
-/// treating registration alone as proof of termination.
+/// wrapper. The default contract rejects results, raw block successors, and
+/// nested regions. A model may explicitly permit regions and supplies only
+/// its dialect-specific checks; registration alone is never proof of
+/// termination.
 pub trait CallableExitModel: DialectOp {
-    fn exits_callable(self, ctx: &IrContext) -> Result<(), ControlFlowInterfaceError>;
+    /// Whether this callable exit may own structured regions.
+    fn allows_nested_regions(&self, _ctx: &IrContext) -> bool {
+        false
+    }
+
+    /// Check the dialect-specific part of the callable-exit contract.
+    fn verify_callable_exit(&self, _ctx: &IrContext) -> Result<(), ControlFlowInterfaceError> {
+        Ok(())
+    }
+
+    fn exits_callable(self, ctx: &IrContext) -> Result<(), ControlFlowInterfaceError> {
+        let op = self.op_ref();
+        if !ctx.op_results(op).is_empty() {
+            return Err(ControlFlowInterfaceError::new(
+                "CallableExit must not produce SSA results",
+            ));
+        }
+        if !ctx.op(op).successors.is_empty() {
+            return Err(ControlFlowInterfaceError::new(
+                "CallableExit must not have block successors",
+            ));
+        }
+        if !self.allows_nested_regions(ctx) && !ctx.op(op).regions.is_empty() {
+            return Err(ControlFlowInterfaceError::new(
+                "CallableExit must not contain nested regions",
+            ));
+        }
+        self.verify_callable_exit(ctx)
+    }
 }
 
 fn callable_exit_model<T: CallableExitModel>(

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -724,19 +724,12 @@ mod test_exit_dialect {
 }
 
 #[cfg(test)]
-impl crate::op_interface::CallableExitModel for Exit {
-    fn exits_callable(
-        self,
-        _ctx: &crate::IrContext,
-    ) -> Result<(), crate::op_interface::ControlFlowInterfaceError> {
-        Ok(())
-    }
-}
+impl crate::op_interface::CallableExitModel for Exit {}
 
 #[cfg(test)]
 impl crate::op_interface::CallableExitModel for MalformedExit {
-    fn exits_callable(
-        self,
+    fn verify_callable_exit(
+        &self,
         _ctx: &crate::IrContext,
     ) -> Result<(), crate::op_interface::ControlFlowInterfaceError> {
         Err(crate::op_interface::ControlFlowInterfaceError::new(

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -33,7 +33,7 @@ use smallvec::SmallVec;
 
 use crate::context::{BlockArgData, BlockData, IrContext};
 use crate::dialect::{arith, cf, func, scf};
-use crate::op_interface::{RegionBranchOps, RegionBranchPoint, RegionSuccessor};
+use crate::op_interface::{CallableExitOps, RegionBranchOps, RegionBranchPoint, RegionSuccessor};
 use crate::ops::DialectOp;
 use crate::pass::{Pass, pass_fn};
 use crate::refs::{BlockRef, OpRef, RegionRef, ValueRef};
@@ -131,7 +131,7 @@ fn is_scf_control_flow(ctx: &IrContext, op: OpRef) -> bool {
 }
 
 /// Whether a one-block region has only terminal structured control or a
-/// proper-tail transfer, so lowering it cannot need a continuation block.
+/// registered callable exit, so lowering it cannot need a continuation block.
 fn is_terminal_region(ctx: &IrContext, region: RegionRef) -> bool {
     let [branch] = ctx.region(region).blocks.as_slice() else {
         return false;
@@ -146,7 +146,7 @@ fn is_terminal_region(ctx: &IrContext, region: RegionRef) -> bool {
             && has_only_terminal_region_successors(ctx, terminator)
     } else {
         !is_scf_control_flow(ctx, terminator)
-            && crate::validation::is_proper_tail_terminator(ctx, terminator)
+            && CallableExitOps::exits_callable(ctx, terminator).is_ok()
     }
 }
 
@@ -399,18 +399,8 @@ fn switch_arms(ctx: &IrContext, scf_op: OpRef) -> Option<SwitchArms> {
 
 /// Whether a resultless switch is the final operation in its block and every
 /// selectable arm transfers control, leaving no continuation to merge into.
-fn is_terminal_resultless_switch(
-    ctx: &IrContext,
-    block: BlockRef,
-    scf_op: OpRef,
-    cases: &[(Attribute, RegionRef)],
-    default_region: Option<RegionRef>,
-) -> bool {
-    ctx.block(block).ops.last() == Some(&scf_op)
-        && default_region.is_some_and(|region| is_terminal_region(ctx, region))
-        && cases
-            .iter()
-            .all(|(_, region)| is_terminal_region(ctx, *region))
+fn is_terminal_resultless_switch(ctx: &IrContext, block: BlockRef, scf_op: OpRef) -> bool {
+    ctx.block(block).ops.last() == Some(&scf_op) && has_only_terminal_region_successors(ctx, scf_op)
 }
 
 /// Lower a terminal resultless switch without manufacturing an unreachable
@@ -468,7 +458,7 @@ fn lower_scf_switch(ctx: &mut IrContext, block: BlockRef, scf_op: OpRef, loc: Lo
         return;
     };
 
-    if is_terminal_resultless_switch(ctx, block, scf_op, &arms.cases, arms.default_region) {
+    if is_terminal_resultless_switch(ctx, block, scf_op) {
         lower_terminal_resultless_switch(
             ctx,
             block,
@@ -727,6 +717,41 @@ fn replace_continue_break(
 }
 
 #[cfg(test)]
+#[trunk_ir::dialect]
+mod test_exit_dialect {
+    fn exit() {}
+    fn malformed_exit() {}
+}
+
+#[cfg(test)]
+impl crate::op_interface::CallableExitModel for Exit {
+    fn exits_callable(
+        self,
+        _ctx: &crate::IrContext,
+    ) -> Result<(), crate::op_interface::ControlFlowInterfaceError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl crate::op_interface::CallableExitModel for MalformedExit {
+    fn exits_callable(
+        self,
+        _ctx: &crate::IrContext,
+    ) -> Result<(), crate::op_interface::ControlFlowInterfaceError> {
+        Err(crate::op_interface::ControlFlowInterfaceError::new(
+            "test CallableExit query failed",
+        ))
+    }
+}
+
+#[cfg(test)]
+inventory::submit! { crate::op_interface::CallableExitOps::register::<Exit>() }
+
+#[cfg(test)]
+inventory::submit! { crate::op_interface::CallableExitOps::register::<MalformedExit>() }
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::dialect::{arith, core, func, scf};
@@ -785,6 +810,22 @@ mod tests {
                 .build(ctx);
         let module_op = ctx.create_op(module_data);
         Module::new(ctx, module_op).unwrap()
+    }
+
+    fn first_switch_and_arm_region(ctx: &IrContext, module: Module) -> (OpRef, RegionRef) {
+        let function = func::Func::from_op(ctx, module.ops(ctx)[0]).expect("function");
+        let body = function.body(ctx);
+        let entry = ctx.region(body).blocks[0];
+        let switch = ctx
+            .block(entry)
+            .ops
+            .iter()
+            .copied()
+            .find(|&op| scf::Switch::matches(ctx, op))
+            .expect("switch");
+        let switch_body = ctx.op(switch).regions[0];
+        let arm = ctx.block(ctx.region(switch_body).blocks[0]).ops[0];
+        (switch, ctx.op(arm).regions[0])
     }
 
     /// Collect all op names from a region (dialect.name format).
@@ -1267,6 +1308,223 @@ mod tests {
         assert!(use_chains.is_ok(), "{use_chains}");
         let operation_verifiers = crate::validation::validate_operation_verifiers(&ctx, module);
         assert!(operation_verifiers.is_ok(), "{operation_verifiers}");
+    }
+
+    #[test]
+    fn lower_terminal_scf_switch_with_ordinary_return_preserves_operands() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32, %first: core.i32, %second: core.i32) -> core.i32 {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        func.return %first
+      }
+      scf.default {
+        func.return %second
+      }
+    }
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let function = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        let entry = ctx.region(function.body(&ctx)).blocks[0];
+        let args = ctx.block_args(entry).to_vec();
+
+        lower_scf_to_cf(&mut ctx, module);
+
+        let returns: Vec<_> = ctx
+            .region(function.body(&ctx))
+            .blocks
+            .iter()
+            .flat_map(|&block| ctx.block(block).ops.iter().copied())
+            .filter(|&op| func::Return::matches(&ctx, op))
+            .map(|op| ctx.op_operands(op).to_vec())
+            .collect();
+        assert_eq!(returns, vec![vec![args[1]], vec![args[2]]]);
+        assert_eq!(count_blocks(&ctx, function.body(&ctx)), 3);
+        assert!(crate::validation::validate_all(&ctx, module).is_ok());
+    }
+
+    #[test]
+    fn lower_terminal_scf_switch_with_zero_operand_return_has_no_merge_block() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32) {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        func.return
+      }
+      scf.default {
+        func.unreachable
+      }
+    }
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let function = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+
+        lower_scf_to_cf(&mut ctx, module);
+
+        let returns: Vec<_> = ctx
+            .region(function.body(&ctx))
+            .blocks
+            .iter()
+            .flat_map(|&block| ctx.block(block).ops.iter().copied())
+            .filter(|&op| func::Return::matches(&ctx, op))
+            .collect();
+        assert_eq!(returns.len(), 1);
+        assert!(ctx.op_operands(returns[0]).is_empty());
+        assert_eq!(count_blocks(&ctx, function.body(&ctx)), 3);
+        assert!(crate::validation::validate_all(&ctx, module).is_ok());
+    }
+
+    #[test]
+    fn callable_exit_interface_drives_terminal_switch_lowering() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        test_exit_dialect.exit
+      }
+      scf.default {
+        func.unreachable
+      }
+    }
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let function = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+
+        lower_scf_to_cf(&mut ctx, module);
+
+        assert_eq!(count_blocks(&ctx, function.body(&ctx)), 3);
+        assert!(
+            !collect_op_names(&ctx, function.body(&ctx))
+                .iter()
+                .any(|name| name.starts_with("scf."))
+        );
+        assert!(crate::validation::validate_use_chains(&ctx, module).is_ok());
+    }
+
+    #[test]
+    fn terminal_detection_fails_closed_for_non_exit_and_incomplete_paths() {
+        for (input, arm_must_be_nonterminal) in [
+            (
+                r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} { scf.yield }
+      scf.default { func.unreachable }
+    }
+  }
+}"#,
+                true,
+            ),
+            (
+                r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} { func.unreachable }
+    }
+  }
+}"#,
+                false,
+            ),
+            (
+                r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        func.return
+        arith.const {value = 0} : core.nil
+      }
+      scf.default { func.unreachable }
+    }
+  }
+}"#,
+                true,
+            ),
+            (
+                r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        ^first:
+          cf.br [^second]
+        ^second:
+          func.unreachable
+      }
+      scf.default { func.unreachable }
+    }
+  }
+}"#,
+                true,
+            ),
+            (
+                r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} { test_exit_dialect.malformed_exit }
+      scf.default { func.unreachable }
+    }
+  }
+}"#,
+                true,
+            ),
+        ] {
+            let mut ctx = IrContext::new();
+            let module = crate::parser::parse_test_module(&mut ctx, input);
+            let (switch, arm) = first_switch_and_arm_region(&ctx, module);
+            assert_eq!(
+                is_terminal_region(&ctx, arm),
+                !arm_must_be_nonterminal,
+                "unexpected arm termination proof: {input}"
+            );
+            let function = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+            let entry = ctx.region(function.body(&ctx)).blocks[0];
+            assert!(
+                !is_terminal_resultless_switch(&ctx, entry, switch),
+                "switch must retain a continuation: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn callable_exit_query_rejects_unregistered_and_malformed_operations() {
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(
+            &mut ctx,
+            r#"core.module @test {
+  func.func @main(%choice: core.i32) -> core.nil {
+    scf.switch %choice {
+      scf.case {value = 0} { arith.const {value = 0} : core.nil }
+      scf.default { test_exit_dialect.malformed_exit }
+    }
+  }
+}"#,
+        );
+        let (switch, arm) = first_switch_and_arm_region(&ctx, module);
+        let unregistered = ctx.block(ctx.region(arm).blocks[0]).ops[0];
+        let switch_body = ctx.op(switch).regions[0];
+        let malformed_wrapper = ctx.block(ctx.region(switch_body).blocks[0]).ops[1];
+        let malformed_region = ctx.op(malformed_wrapper).regions[0];
+        let malformed = ctx.block(ctx.region(malformed_region).blocks[0]).ops[0];
+        let malformed_func_exit_data = OperationDataBuilder::new(
+            ctx.op(unregistered).location,
+            Symbol::new("func"),
+            Symbol::new("unreachable"),
+        )
+        .result(ctx.value_ty(ctx.op_results(unregistered)[0]))
+        .build(&mut ctx);
+        let malformed_func_exit = ctx.create_op(malformed_func_exit_data);
+
+        assert!(crate::op_interface::CallableExitOps::exits_callable(&ctx, unregistered).is_err());
+        assert!(crate::op_interface::CallableExitOps::exits_callable(&ctx, malformed).is_err());
+        assert!(
+            crate::op_interface::CallableExitOps::exits_callable(&ctx, malformed_func_exit)
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/trunk-ir/src/transforms/scf_to_cf.rs
+++ b/crates/trunk-ir/src/transforms/scf_to_cf.rs
@@ -1346,6 +1346,48 @@ mod tests {
     }
 
     #[test]
+    fn lower_nested_terminal_scf_switch_with_ordinary_returns_has_no_merge_blocks() {
+        let input = r#"core.module @test {
+  func.func @main(%choice: core.i32, %nested_choice: core.i32, %first: core.i32, %second: core.i32, %third: core.i32) -> core.i32 {
+    scf.switch %choice {
+      scf.case {value = 0} {
+        scf.switch %nested_choice {
+          scf.case {value = 0} {
+            func.return %first
+          }
+          scf.default {
+            func.return %second
+          }
+        }
+      }
+      scf.default {
+        func.return %third
+      }
+    }
+  }
+}"#;
+        let mut ctx = IrContext::new();
+        let module = crate::parser::parse_test_module(&mut ctx, input);
+        let function = func::Func::from_op(&ctx, module.ops(&ctx)[0]).unwrap();
+        let entry = ctx.region(function.body(&ctx)).blocks[0];
+        let args = ctx.block_args(entry).to_vec();
+
+        lower_scf_to_cf(&mut ctx, module);
+
+        let returns: Vec<_> = ctx
+            .region(function.body(&ctx))
+            .blocks
+            .iter()
+            .flat_map(|&block| ctx.block(block).ops.iter().copied())
+            .filter(|&op| func::Return::matches(&ctx, op))
+            .map(|op| ctx.op_operands(op).to_vec())
+            .collect();
+        assert_eq!(returns, vec![vec![args[2]], vec![args[3]], vec![args[4]]]);
+        assert_eq!(count_blocks(&ctx, function.body(&ctx)), 5);
+        assert!(crate::validation::validate_all(&ctx, module).is_ok());
+    }
+
+    #[test]
     fn lower_terminal_scf_switch_with_zero_operand_return_has_no_merge_block() {
         let input = r#"core.module @test {
   func.func @main(%choice: core.i32) {

--- a/new-plans/ir.md
+++ b/new-plans/ir.md
@@ -112,6 +112,24 @@ and successors are explicit values: a point is either `Parent` or a concrete
 nested-region terminator, and a successor is either a concrete region or
 `Parent`.
 
+`CallableExit` is a separate dialect-registered operation interface for an
+operation that ends execution of the current callable and therefore cannot
+continue after its enclosing structured region. It is not a generic
+terminator marker: `scf.yield`, `scf.break`, and `scf.continue` transfer within
+structured control flow and do not satisfy it. Dialects register only their
+verified callable exits, including ordinary `func.return`, proper tail
+transfers, and unreachable control flow. The typed model and its dynamic query
+are fallible. An unregistered operation, malformed registered operation, or
+query error is never evidence that a region is terminal.
+
+Structured-to-CFG lowering may use `CallableExit` only after preserving its
+own structural rules: the region must have one block, the exit must be that
+block's final operation, and a nested structured operation must expose every
+possible entry successor through `RegionBranch`. A `Parent` successor, a
+missing mapping, or an incomplete query leaves a reachable continuation and
+must retain the merge path. This does not imply arbitrary multi-block or loop
+CFG termination analysis.
+
 These interfaces are queried through TrunkIR's operation registry and remain
 object-safe. Their dyn-facing methods return named concrete small collections;
 they do not use RPITIT, GATs, caller-visible tuples, or dialect-specific


### PR DESCRIPTION
## Summary
- avoid manufacturing an unreachable empty merge block when a resultless SCF switch exits through ordinary return, tail transfer, unreachable, or final CPS dispatch
- add a fallible dialect-owned CallableExit interface and use complete RegionBranch entry successors to prove all structured paths exit
- fail closed for missing defaults, nonterminal structured transfers, malformed operations, invalid attributes, and unregistered interfaces

## Validation
- cargo nextest run --workspace: 2152 passed
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check
- markdownlint-cli2 new-plans/ir.md

Coverage intentionally excluded. This PR does not include the #825 integration or a Never repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added callable-exit validation for function returns, tail calls, unreachable operations, ability operations, and effect dispatches.
  * Added conservative detection of operations that end the current callable during structured-to-control-flow lowering.
  * Malformed or unregistered callable exits now fail safely rather than being treated as terminal.

* **Documentation**
  * Documented callable-exit behavior and its distinction from structured-control-flow terminators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->